### PR TITLE
[TECH] Généraliser un serveur léger dans les tests API.

### DIFF
--- a/api/lib/swaggers.js
+++ b/api/lib/swaggers.js
@@ -39,7 +39,7 @@ function _buildSwaggerArgs(swaggerOptions)
   }, {
     routes: { prefix: '/' + swaggerOptions.routeTag },
   }];
-};
+}
 
 const swaggers = [ swaggerOptionsAuthorizationServer, swaggerOptionsLivretScolaire, swaggerOptionsIn ].map(_buildSwaggerArgs);
 

--- a/api/lib/swaggers.js
+++ b/api/lib/swaggers.js
@@ -39,7 +39,11 @@ function _buildSwaggerArgs(swaggerOptions)
   }, {
     routes: { prefix: '/' + swaggerOptions.routeTag },
   }];
-}
+};
+
+const swaggers = [ swaggerOptionsAuthorizationServer, swaggerOptionsLivretScolaire, swaggerOptionsIn ].map(_buildSwaggerArgs);
+
+module.exports = swaggers;
 
 const swaggers = [ swaggerOptionsAuthorizationServer, swaggerOptionsLivretScolaire, swaggerOptionsIn ].map(_buildSwaggerArgs);
 

--- a/api/server.js
+++ b/api/server.js
@@ -27,6 +27,8 @@ const setupServer = async () => {
 
   await setupOpenApiSpecification(server);
 
+  validateEnvironmentVariables();
+
   return server;
 };
 

--- a/api/server.js
+++ b/api/server.js
@@ -32,7 +32,7 @@ const setupServer = async () => {
   return server;
 };
 
-const createServer = async function() {
+const createServer = async function () {
 
   const serverConfiguration = {
     compression: false,
@@ -58,12 +58,12 @@ const createServer = async function() {
   return new Hapi.server(serverConfiguration);
 };
 
-const loadConfiguration = function() {
+const loadConfiguration = function () {
   validateEnvironmentVariables();
   config = require('./lib/config');
 };
 
-const setupErrorHandling = function(server) {
+const setupErrorHandling = function (server) {
 
   server.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
 };
@@ -76,12 +76,12 @@ const setupAuthentication = function(server) {
   server.auth.default(authentication.defaultStrategy);
 };
 
-const setupRoutesAndPlugins = async function(server) {
+const setupRoutesAndPlugins = async function (server) {
   const configuration = [].concat(plugins, routes);
   await server.register(configuration);
 };
 
-const setupOpenApiSpecification = async function(server) {
+const setupOpenApiSpecification = async function (server) {
   for (const swaggerRegisterArgs of swaggers) {
     await server.register(...swaggerRegisterArgs);
   }

--- a/api/server.js
+++ b/api/server.js
@@ -32,7 +32,7 @@ const setupServer = async () => {
   return server;
 };
 
-const createServer = async function () {
+const createServer = async function() {
 
   const serverConfiguration = {
     compression: false,
@@ -58,12 +58,12 @@ const createServer = async function () {
   return new Hapi.server(serverConfiguration);
 };
 
-const loadConfiguration = function () {
+const loadConfiguration = function() {
   validateEnvironmentVariables();
   config = require('./lib/config');
 };
 
-const setupErrorHandling = function (server) {
+const setupErrorHandling = function(server) {
 
   server.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
 };
@@ -76,12 +76,12 @@ const setupAuthentication = function(server) {
   server.auth.default(authentication.defaultStrategy);
 };
 
-const setupRoutesAndPlugins = async function (server) {
+const setupRoutesAndPlugins = async function(server) {
   const configuration = [].concat(plugins, routes);
   await server.register(configuration);
 };
 
-const setupOpenApiSpecification = async function (server) {
+const setupOpenApiSpecification = async function(server) {
   for (const swaggerRegisterArgs of swaggers) {
     await server.register(...swaggerRegisterArgs);
   }

--- a/api/tests/acceptance/application/.eslintrc.js
+++ b/api/tests/acceptance/application/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  extends: '../../.eslintrc.yaml',
+  rules: {
+    'no-restricted-modules': ['error', {
+      'paths': [{
+        'name': '../../../server',
+        'message': 'Please use http-server-test instead.',
+      },
+      {
+        'name': '../../../../server',
+        'message': 'Please use http-server-test instead.',
+      },
+      ],
+    }],
+  },
+};

--- a/api/tests/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-find_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | answer-controller-find', () => {

--- a/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, mockLearningContent } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const { FRENCH_FRANCE } = require('../../../../lib/domain/constants').LOCALE;
 

--- a/api/tests/acceptance/application/answers/answer-controller-get_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | answer-controller-get', () => {

--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -1,4 +1,5 @@
 const { expect, knex, databaseBuilder, mockLearningContent, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const BookshelfAnswer = require('../../../../lib/infrastructure/data/answer');
 const { FRENCH_FRANCE, ENGLISH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;

--- a/api/tests/acceptance/application/answers/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-update_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | answer-controller-update', () => {

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, knex, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -3,6 +3,7 @@ const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, knex, 
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const Badge = require('../../../../lib/domain/models/Badge');
 const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-find-competence-evaluations_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-find-competence-evaluations_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | API | assessment-controller-find-competence-evaluations', () => {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, mockLearningContent, learningContentBuilder, knex, sinon } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, mockLearningContent, learningContentBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo', function() {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -1,4 +1,5 @@
 const { learningContentBuilder, mockLearningContent, databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 const Assessment = require('../../../../lib/domain/models/Assessment');

--- a/api/tests/acceptance/application/assessments/assessment-controller-post_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-post_test.js
@@ -1,4 +1,5 @@
 const { expect, knex, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const BookshelfAssessment = require('../../../../lib/infrastructure/data/assessment');
 

--- a/api/tests/acceptance/application/authentication-controller_test.js
+++ b/api/tests/acceptance/application/authentication-controller_test.js
@@ -21,8 +21,11 @@ describe('Acceptance | Controller | authentication-controller', () => {
   let server;
   let userId;
 
-  beforeEach(async () => {
+  before(async () => {
     server = await createServer();
+  });
+
+  beforeEach(async () => {
 
     userId = databaseBuilder.factory.buildUser.withRawPassword({
       email: userEmailAddress,

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
 

--- a/api/tests/acceptance/application/cache-controller_test.js
+++ b/api/tests/acceptance/application/cache-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | cache-controller', () => {

--- a/api/tests/acceptance/application/cache-controller_test.js
+++ b/api/tests/acceptance/application/cache-controller_test.js
@@ -1,21 +1,21 @@
-const { expect, generateValidRequestAuthorizationHeader } = require('../../test-helper');
-// eslint-disable-next-line no-restricted-modules
-const createServer = require('../../../server');
+const { expect, generateValidRequestAuthorizationHeader, HttpTestServer } = require('../../test-helper');
+
+const moduleUnderTest = require('../../../lib/application/cache');
 
 describe('Acceptance | Controller | cache-controller', () => {
 
   let server;
 
-  beforeEach(async () => {
-    server = await createServer();
+  before(async () => {
+    server = new HttpTestServer(moduleUnderTest, true);
   });
 
   describe('PATCH /api/cache/{model}/{id}', () => {
 
-    let options;
+    let request;
 
     beforeEach(() => {
-      options = {
+      request = {
         method: 'PATCH',
         url: '/api/cache/challenges/recChallengeId',
         headers: {},
@@ -29,10 +29,10 @@ describe('Acceptance | Controller | cache-controller', () => {
     describe('Resource access management', () => {
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
         // given
-        options.headers.authorization = 'invalid.access.token';
+        request.headers.authorization = 'invalid.access.token';
 
         // when
-        const response = await server.inject(options);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -41,10 +41,10 @@ describe('Acceptance | Controller | cache-controller', () => {
       it('should respond with a 403 - forbidden access - if user has not role PIX_MASTER', async () => {
         // given
         const nonPixMasterUserId = 9999;
-        options.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMasterUserId);
+        request.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMasterUserId);
 
         // when
-        const response = await server.inject(options);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -54,10 +54,10 @@ describe('Acceptance | Controller | cache-controller', () => {
 
   describe('PATCH /api/cache', () => {
 
-    let options;
+    let request;
 
     beforeEach(() => {
-      options = {
+      request = {
         method: 'PATCH',
         url: '/api/cache',
         headers: {},
@@ -68,10 +68,10 @@ describe('Acceptance | Controller | cache-controller', () => {
 
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
         // given
-        options.headers.authorization = 'invalid.access.token';
+        request.headers.authorization = 'invalid.access.token';
 
         // when
-        const response = await server.inject(options);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -80,10 +80,10 @@ describe('Acceptance | Controller | cache-controller', () => {
       it('should respond with a 403 - forbidden access - if user has not role PIX_MASTER', async () => {
         // given
         const nonPixMAsterUserId = 9999;
-        options.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMAsterUserId);
+        request.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMAsterUserId);
 
         // when
-        const response = await server.inject(options);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(403);

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -11,6 +11,7 @@ const {
 
 const settings = require('../../../lib/config');
 const Membership = require('../../../lib/domain/models/Membership');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | API | Campaign Controller', () => {

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const Assessment = require('../../../lib/domain/models/Assessment');
 const { expect, databaseBuilder, mockLearningContent, learningContentBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../test-helper');

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -1,7 +1,7 @@
-// eslint-disable-next-line no-restricted-modules
-const createServer = require('../../../server');
-const { expect, databaseBuilder, mockLearningContent, learningContentBuilder, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const { expect, databaseBuilder, mockLearningContent, learningContentBuilder, generateValidRequestAuthorizationHeader, HttpTestServer } = require('../../test-helper');
 const _ = require('lodash');
+
+const moduleUnderTest = require('../../../lib/application/campaign-participation-results');
 
 describe('Acceptance | API | Campaign Participation Result', () => {
 
@@ -18,8 +18,13 @@ describe('Acceptance | API | Campaign Participation Result', () => {
 
   let server, badge, badgePartnerCompetence, stage;
 
+  const authenticationEnabled = true;
+
+  before(async () => {
+    server = new HttpTestServer(moduleUnderTest, authenticationEnabled);
+  });
+
   beforeEach(async () => {
-    server = await createServer();
 
     const oldDate = new Date('2018-02-03');
     const recentDate = new Date('2018-05-06');
@@ -166,10 +171,10 @@ describe('Acceptance | API | Campaign Participation Result', () => {
   });
 
   describe('GET /api/campaign-participations/{id}/campaign-participation-result', () => {
-    let options;
+    let request;
 
     beforeEach(async () => {
-      options = {
+      request = {
         method: 'GET',
         url: `/api/campaign-participations/${campaignParticipation.id}/campaign-participation-result`,
         headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
@@ -298,7 +303,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
       };
 
       // when
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.result).to.deep.equal(expectedResponse);

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const { expect, databaseBuilder, mockLearningContent, learningContentBuilder, generateValidRequestAuthorizationHeader } = require('../../test-helper');
 const _ = require('lodash');

--- a/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-analyses_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-analyses_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const Membership = require('../../../../lib/domain/models/Membership');
 const { expect, databaseBuilder, mockLearningContent, learningContentBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -8,6 +8,7 @@ const {
   knex,
 } = require('../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | API | Certification Center', () => {

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -1,22 +1,26 @@
 const _ = require('lodash');
 
+const moduleUnderTest = require('../../../lib/application/certification-centers');
+
 const {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
   insertUserWithRolePixMaster,
   knex,
+  HttpTestServer,
 } = require('../../test-helper');
-
-// eslint-disable-next-line no-restricted-modules
-const createServer = require('../../../server');
 
 describe('Acceptance | API | Certification Center', () => {
 
   let server, request;
 
+  before(async () => {
+    const authenticationEnabled = true;
+    server = new HttpTestServer(moduleUnderTest, authenticationEnabled);
+  });
+
   beforeEach(async () => {
-    server = await createServer();
     await insertUserWithRolePixMaster();
   });
 
@@ -38,7 +42,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 200 HTTP status', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -46,7 +50,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return a list of certificationCenter, with their name and id', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.result.data).to.have.lengthOf(5);
@@ -61,7 +65,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 403 HTTP status code ', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -71,7 +75,7 @@ describe('Acceptance | API | Certification Center', () => {
     context('when user is not connected', () => {
       it('should return 401 HTTP status code if user is not authenticated', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -107,7 +111,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 200 HTTP status', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -115,7 +119,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return the certification center created', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.result.data.attributes.name).to.equal('Nouveau Centre de Certif');
@@ -131,7 +135,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 403 HTTP status code ', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -141,7 +145,7 @@ describe('Acceptance | API | Certification Center', () => {
     context('when user is not connected', () => {
       it('should return 401 HTTP status code if user is not authenticated', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -169,7 +173,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 200 HTTP status', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -177,7 +181,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return the certification center asked', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.result.data.id).to.equal(expectedCertificationCenter.id.toString());
@@ -189,7 +193,7 @@ describe('Acceptance | API | Certification Center', () => {
         request.url = '/api/certification-centers/112334';
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(404);
@@ -206,7 +210,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 403 HTTP status code ', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -216,7 +220,7 @@ describe('Acceptance | API | Certification Center', () => {
     context('when user is not connected', () => {
       it('should return 401 HTTP status code if user is not authenticated', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -248,7 +252,7 @@ describe('Acceptance | API | Certification Center', () => {
       };
 
       // when
-      const response = await server.inject(request);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -287,7 +291,7 @@ describe('Acceptance | API | Certification Center', () => {
         const request = _buildSchoolinRegistrationsWithConnectedUserRequest(user, certificationCenter, session);
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -311,7 +315,7 @@ describe('Acceptance | API | Certification Center', () => {
         const request = _buildSchoolinRegistrationsWithConnectedUserRequest(user, certificationCenter, session);
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(_.map(response.result.data, 'id')).to.deep.equal(['3', '2', '5', '4', '1']);
@@ -331,7 +335,7 @@ describe('Acceptance | API | Certification Center', () => {
         request = _buildSchoolinRegistrationsNotConnectedUserRequest(certificationCenterWhereUserDoesNotHaveAccess, session);
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -368,7 +372,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 200 HTTP status', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -376,7 +380,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return the list of sessions', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.result.data).to.have.lengthOf(expectedSessions.length);
@@ -393,7 +397,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 403 HTTP status code ', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -403,7 +407,7 @@ describe('Acceptance | API | Certification Center', () => {
     context('when user is not connected', () => {
       it('should return 401 HTTP status code if user is not authenticated', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -446,7 +450,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       it('should return 200 HTTP status', async () => {
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -491,7 +495,7 @@ describe('Acceptance | API | Certification Center', () => {
         ];
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.result.data[0].id)
@@ -538,7 +542,7 @@ describe('Acceptance | API | Certification Center', () => {
 
     it('should return 201 HTTP status', async () => {
       // when
-      const response = await server.inject(request);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.statusCode).to.equal(201);
@@ -551,7 +555,7 @@ describe('Acceptance | API | Certification Center', () => {
         request.headers.authorization = generateValidRequestAuthorizationHeader(1111);
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -565,7 +569,7 @@ describe('Acceptance | API | Certification Center', () => {
         request.headers.authorization = 'invalid.access.token';
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -579,7 +583,7 @@ describe('Acceptance | API | Certification Center', () => {
         request.url = '/api/certification-centers/1/certification-center-memberships';
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(400);
@@ -593,7 +597,7 @@ describe('Acceptance | API | Certification Center', () => {
         request.payload.email = 'notexist@example.net';
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(404);
@@ -615,7 +619,7 @@ describe('Acceptance | API | Certification Center', () => {
         await databaseBuilder.commit();
 
         // when
-        const response = await server.inject(request);
+        const response = await server.requestObject(request);
 
         // then
         expect(response.statusCode).to.equal(412);

--- a/api/tests/acceptance/application/certification-center-membership-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-membership-controller_test.js
@@ -2,6 +2,7 @@ const {
   expect, generateValidRequestAuthorizationHeader,
   insertUserWithRolePixMaster, databaseBuilder, knex,
 } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | API | Certification Center Membership', () => {

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, knex, learningContentBuilder, mockLearningContent, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const config = require('../../../lib/config');
 

--- a/api/tests/acceptance/application/certification-issue-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-issue-report-controller_test.js
@@ -3,6 +3,7 @@ const {
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
 } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | certification-issue-report-controller', () => {

--- a/api/tests/acceptance/application/certification-issue-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-issue-report-controller_test.js
@@ -1,18 +1,25 @@
+const moduleUnderTest = require('../../../lib/application/certification-issue-reports');
+
 const {
   expect,
   databaseBuilder,
+  HttpTestServer,
   generateValidRequestAuthorizationHeader,
 } = require('../../test-helper');
-// eslint-disable-next-line no-restricted-modules
-const createServer = require('../../../server');
 
 describe('Acceptance | Controller | certification-issue-report-controller', () => {
+
+  let server;
+
+  before(async () => {
+    const authenticationEnabled = true;
+    server = new HttpTestServer(moduleUnderTest, authenticationEnabled);
+  });
 
   describe('DELETE /api/certification-issue-reports/{id}', () => {
 
     it('should return 204 HTTP status code', async () => {
       // given
-      const server = await createServer();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       const userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId }).id;
@@ -29,7 +36,7 @@ describe('Acceptance | Controller | certification-issue-report-controller', () =
       await databaseBuilder.commit();
 
       // when
-      const response = await server.inject(request);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.statusCode).to.equal(204);

--- a/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
+++ b/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Route | CertificationPointOfContact', () => {

--- a/api/tests/acceptance/application/certification-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-report-controller_test.js
@@ -4,6 +4,7 @@ const {
   knex,
   generateValidRequestAuthorizationHeader,
 } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | certification-report-controller', () => {

--- a/api/tests/acceptance/application/certification-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-report-controller_test.js
@@ -3,11 +3,19 @@ const {
   databaseBuilder,
   knex,
   generateValidRequestAuthorizationHeader,
+  HttpTestServer,
 } = require('../../test-helper');
-// eslint-disable-next-line no-restricted-modules
-const createServer = require('../../../server');
+
+const moduleUnderTest = require('../../../lib/application/certification-reports');
 
 describe('Acceptance | Controller | certification-report-controller', () => {
+
+  let server;
+
+  before(async () => {
+    const authenticationEnabled = true;
+    server = new HttpTestServer(moduleUnderTest, authenticationEnabled);
+  });
 
   describe('POST /api/certification-reports/{id}/certification-issue-reports', () => {
 
@@ -17,7 +25,6 @@ describe('Acceptance | Controller | certification-report-controller', () => {
 
     it('should return 201 HTTP status code', async () => {
       // given
-      const server = await createServer();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       const userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId }).id;
@@ -50,7 +57,7 @@ describe('Acceptance | Controller | certification-report-controller', () => {
       await databaseBuilder.commit();
 
       // when
-      const response = await server.inject(request);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.statusCode).to.equal(201);

--- a/api/tests/acceptance/application/certifications-livret-scolaire/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications-livret-scolaire/certification-controller_test.js
@@ -3,10 +3,12 @@ const {
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
   generateValidRequestAuthorizationHeaderForApplication,
+  HttpTestServer,
 } = require('../../../test-helper');
-const createServer = require('../../../../server');
+
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const { buildOrganization, buildValidatedPublishedCertificationData, mockLearningContentCompetences, buildUser, buildSchoolingRegistration } = require('../../../../tests/tooling/domain-builder/factory/build-certifications-results-for-ls');
+const moduleUnderTest = require('../../../../lib/application/certification-livret-scolaire');
 
 describe('Acceptance | API | Certifications', () => {
 
@@ -14,6 +16,10 @@ describe('Acceptance | API | Certifications', () => {
   const OSMOSE_CLIENT_ID = 'graviteeOsmoseClientId';
   const OSMOSE_SCOPE = 'organizations-certifications-result';
   const OSMOSE_SOURCE = 'osmose';
+
+  before(()=>{
+    server = new HttpTestServer(moduleUnderTest, true);
+  });
 
   describe('GET /api/organizations/:id/certifications', () => {
     const pixScore = 400;
@@ -191,7 +197,6 @@ describe('Acceptance | API | Certifications', () => {
     beforeEach(() => {
       organizationId = buildOrganization(uai).id;
       mockLearningContentCompetences();
-
     });
 
     context('when the given uai is correct', () => {
@@ -199,7 +204,6 @@ describe('Acceptance | API | Certifications', () => {
       it('should return 200 HTTP status code with the certifications results and referential of competences', async () => {
 
         // given
-        server = await createServer();
         const user = buildUser();
         const schoolingRegistration = buildSchoolingRegistration({ userId: user.id, organizationId });
         const { session, certificationCourse }
@@ -223,11 +227,10 @@ describe('Acceptance | API | Certifications', () => {
           method: 'GET',
           url: `/api/organizations/${uai}/certifications`,
           headers: { authorization: generateValidRequestAuthorizationHeaderForApplication(OSMOSE_CLIENT_ID, OSMOSE_SOURCE, OSMOSE_SCOPE) },
-
         };
 
         // when
-        const response = await server.inject(options);
+        const response = await server.request(options.method, options.url, null, null, options.headers);
 
         // then
         const expectedCertificationResult = {
@@ -274,7 +277,6 @@ describe('Acceptance | API | Certifications', () => {
       it('should return 200 HTTP status code with the referential of competences only', async () => {
 
         // given
-        server = await createServer();
         options = {
           method: 'GET',
           url: '/api/organizations/9999/certifications',
@@ -282,7 +284,7 @@ describe('Acceptance | API | Certifications', () => {
         };
 
         // when
-        const response = await server.inject(options);
+        const response = await server.request(options.method, options.url, null, null, options.headers);
 
         // then
         const expectedCertificationResult = {
@@ -309,7 +311,6 @@ describe('Acceptance | API | Certifications', () => {
       it('should return unauthorized status code', async () => {
 
         // given
-        server = await createServer();
         options = {
           method: 'GET',
           url: '/api/organizations/9999/certifications',
@@ -317,7 +318,7 @@ describe('Acceptance | API | Certifications', () => {
         };
 
         // when
-        const response = await server.inject(options);
+        const response = await server.request(options.method, options.url, null, null, options.headers);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -329,7 +330,6 @@ describe('Acceptance | API | Certifications', () => {
       it('should return unauthorized status code', async () => {
 
         // given
-        server = await createServer();
         options = {
           method: 'GET',
           url: '/api/organizations/9999/certifications',
@@ -337,7 +337,7 @@ describe('Acceptance | API | Certifications', () => {
         };
 
         // when
-        const response = await server.inject(options);
+        const response = await server.request(options.method, options.url, null, null, options.headers);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -349,7 +349,6 @@ describe('Acceptance | API | Certifications', () => {
       it('should return Forbidden access status code', async () => {
 
         // given
-        server = await createServer();
         options = {
           method: 'GET',
           url: '/api/organizations/9999/certifications',
@@ -357,7 +356,7 @@ describe('Acceptance | API | Certifications', () => {
         };
 
         // when
-        const response = await server.inject(options);
+        const response = await server.request(options.method, options.url, null, null, options.headers);
 
         // then
         expect(response.statusCode).to.equal(403);

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -5,6 +5,7 @@ const {
   mockLearningContent,
   learningContentBuilder,
 } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 

--- a/api/tests/acceptance/application/challenge-controller_test.js
+++ b/api/tests/acceptance/application/challenge-controller_test.js
@@ -1,13 +1,12 @@
-const { learningContentBuilder, expect, mockLearningContent } = require('../../test-helper');
-// eslint-disable-next-line no-restricted-modules
-const createServer = require('../../../server');
+const { learningContentBuilder, expect, mockLearningContent, HttpTestServer } = require('../../test-helper');
+const moduleUnderTest = require('../../../lib/application/challenges');
 
 describe('Acceptance | API | ChallengeController', () => {
 
   let server;
-
-  beforeEach(async () => {
-    server = await createServer();
+  before(async () => {
+    const authenticationEnabled = false;
+    server = new HttpTestServer(moduleUnderTest, authenticationEnabled);
   });
 
   describe('GET /api/challenges/:challenge_id', () => {
@@ -47,44 +46,40 @@ describe('Acceptance | API | ChallengeController', () => {
       mockLearningContent(learningContentObjects);
     });
 
-    const options = {
+    const request = {
       method: 'GET',
       url: `/api/challenges/${challengeId}`,
     };
 
-    it('should return 200 HTTP status code', () => {
+    it('should return 200 HTTP status code', async() => {
       // when
-      const promise = server.inject(options);
+      const response = await server.requestObject(request);
 
       // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
 
-    it('should return application/json', () => {
+    it('should return application/json', async() => {
       // when
-      const promise = server.inject(options);
+      const response = await server.requestObject(request);
 
       // then
-      return promise.then((response) => {
-        const contentType = response.headers['content-type'];
-        expect(contentType).to.contain('application/json');
-      });
+      const contentType = response.headers['content-type'];
+      expect(contentType).to.contain('application/json');
     });
 
-    it('should return the expected challenge', () => {
+    it('should return the expected challenge', async() => {
       // when
-      const promise = server.inject(options);
+      const response = await server.requestObject(request);
 
       // then
-      return promise.then((response) => {
-        const challenge = response.result.data;
-        expect(challenge.id).to.equal(challengeId);
-        expect(challenge.attributes.instruction).to.equal(instruction);
-        expect(challenge.attributes.proposals).to.equal(proposals);
-        expect(challenge.attributes.type).to.equal(challengeType);
-      });
+
+      const challenge = response.result.data;
+      expect(challenge.id).to.equal(challengeId);
+      expect(challenge.attributes.instruction).to.equal(instruction);
+      expect(challenge.attributes.proposals).to.equal(proposals);
+      expect(challenge.attributes.type).to.equal(challengeType);
+
     });
   });
 });

--- a/api/tests/acceptance/application/challenge-controller_test.js
+++ b/api/tests/acceptance/application/challenge-controller_test.js
@@ -1,4 +1,5 @@
 const { learningContentBuilder, expect, mockLearningContent } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | API | ChallengeController', () => {

--- a/api/tests/acceptance/application/competence-evaluation-controller-improve_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller-improve_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex } = require('../../test-helper');
 const { MAX_REACHABLE_PIX_BY_COMPETENCE } = require('../../../lib/domain/constants');

--- a/api/tests/acceptance/application/competence-evaluation-controller_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex, mockLearningContent, learningContentBuilder } = require('../../test-helper');
 

--- a/api/tests/acceptance/application/course-controller_test.js
+++ b/api/tests/acceptance/application/course-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, nock, generateValidRequestAuthorizationHeader, mockLearningContent, learningContentBuilder } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | API | Courses', () => {

--- a/api/tests/acceptance/application/course-controller_test.js
+++ b/api/tests/acceptance/application/course-controller_test.js
@@ -1,14 +1,14 @@
-const { expect, nock, generateValidRequestAuthorizationHeader, mockLearningContent, learningContentBuilder } = require('../../test-helper');
-// eslint-disable-next-line no-restricted-modules
-const createServer = require('../../../server');
+const { expect, nock, generateValidRequestAuthorizationHeader, mockLearningContent, learningContentBuilder, HttpTestServer } = require('../../test-helper');
+const moduleUnderTest = require('../../../lib/application/courses');
 
 describe('Acceptance | API | Courses', () => {
 
   let server;
   const userId = 42;
 
-  beforeEach(async () => {
-    server = await createServer();
+  before(async () => {
+    const authenticationEnabled = false;
+    server = new HttpTestServer(moduleUnderTest, authenticationEnabled);
   });
 
   describe('GET /api/courses/:course_id', () => {
@@ -46,10 +46,10 @@ describe('Acceptance | API | Courses', () => {
     });
 
     context('when the course exists', () => {
-      let options;
+      let request;
 
       beforeEach(() => {
-        options = {
+        request = {
           method: 'GET',
           url: '/api/courses/rec_course_id',
           headers: {
@@ -58,60 +58,56 @@ describe('Acceptance | API | Courses', () => {
         };
       });
 
-      it('should return 200 HTTP status code', () => {
+      it('should return 200 HTTP status code', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.requestObject(request);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
+
       });
 
-      it('should return application/json', () => {
+      it('should return application/json', async() => {
         // when
-        const promise = server.inject(options);
+        const response = await server.requestObject(request);
 
         // then
-        return promise.then((response) => {
-          const contentType = response.headers['content-type'];
-          expect(contentType).to.contain('application/json');
-        });
+        const contentType = response.headers['content-type'];
+        expect(contentType).to.contain('application/json');
+
       });
 
-      it('should return the expected course', () => {
+      it('should return the expected course', async() => {
         // when
-        const promise = server.inject(options);
+        const response = await server.requestObject(request);
 
         // then
-        return promise.then((response) => {
-          const course = response.result.data;
-          expect(course.id).to.equal('rec_course_id');
-          expect(course.attributes.name).to.equal('A la recherche de l\'information #01');
-          expect(course.attributes.description).to.equal('Mener une recherche et une veille d\'information');
-        });
+        const course = response.result.data;
+        expect(course.id).to.equal('rec_course_id');
+        expect(course.attributes.name).to.equal('A la recherche de l\'information #01');
+        expect(course.attributes.description).to.equal('Mener une recherche et une veille d\'information');
+
       });
 
     });
 
-    context('when the course does not exist', () => {
-      let options;
+    context('when the course does not exist', async() => {
+      let request;
 
       beforeEach(() => {
-        options = {
+        request = {
           method: 'GET',
           url: '/api/courses/rec_i_dont_exist',
         };
       });
 
-      it('should return 404 HTTP status code', () => {
+      it('should return 404 HTTP status code', async() => {
         // when
-        const promise = server.inject(options);
+        const response = await server.requestObject(request);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(404);
-        });
+        expect(response.statusCode).to.equal(404);
+
       });
     });
   });

--- a/api/tests/acceptance/application/error-controller_test.js
+++ b/api/tests/acceptance/application/error-controller_test.js
@@ -1,4 +1,5 @@
 const { expect } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | error-controller', () => {

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -1,5 +1,6 @@
 const { expect } = require('../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | feature-toggle-controller', () => {

--- a/api/tests/acceptance/application/feedback-controller_test.js
+++ b/api/tests/acceptance/application/feedback-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, knex, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const Feedback = require('../../../lib/infrastructure/data/feedback');
 

--- a/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-to-publish_test.js
+++ b/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-to-publish_test.js
@@ -1,6 +1,7 @@
 const {
   expect, generateValidRequestAuthorizationHeader, databaseBuilder, insertUserWithRolePixMaster,
 } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | finalized-session-controller-find-finalized-sessions-to-publish', () => {

--- a/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-with-required-action_test.js
+++ b/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-with-required-action_test.js
@@ -1,6 +1,7 @@
 const {
   expect, generateValidRequestAuthorizationHeader, databaseBuilder, insertUserWithRolePixMaster,
 } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | finalized-session-controller-find-finalized-sessions-with-required-action', () => {

--- a/api/tests/acceptance/application/membership-controller_test.js
+++ b/api/tests/acceptance/application/membership-controller_test.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, knex } = require('../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const Membership = require('../../../lib/domain/models/Membership');
 

--- a/api/tests/acceptance/application/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitation-controller_test.js
@@ -3,6 +3,7 @@ const { expect, knex, databaseBuilder } = require('../../test-helper');
 const Membership = require('../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../lib/domain/models/OrganizationInvitation');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Application | organization-invitation-controller', () => {

--- a/api/tests/acceptance/application/organizations/organization-controller-import-higher-schooling-registration_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-higher-schooling-registration_test.js
@@ -3,6 +3,7 @@ const Membership = require('../../../../lib/domain/models/Membership');
 const HigherSchoolingRegistrationColumns = require('../../../../lib/infrastructure/serializers/csv/higher-schooling-registration-columns');
 
 const { getI18n } = require('../../../../tests/tooling/i18n/i18n');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 const i18n = getI18n();

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -5,6 +5,7 @@ const {
   generateValidRequestAuthorizationHeader,
 } = require('../../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 require('events').EventEmitter.defaultMaxListeners = 60;
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -5,6 +5,7 @@ const {
   generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster,
 } = require('../../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 const Membership = require('../../../../lib/domain/models/Membership');

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -5,6 +5,7 @@ const resetPasswordDemandRepository = require('../../../lib/infrastructure/repos
 
 const config = require('../../../lib/config');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | password-controller', () => {

--- a/api/tests/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/acceptance/application/pole-emploi-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, knex } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const authenticationCache = require('../../../lib/infrastructure/caches/authentication-cache');
 const jsonwebtoken = require('jsonwebtoken');

--- a/api/tests/acceptance/application/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescriber-controller_test.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | Prescriber-controller', () => {

--- a/api/tests/acceptance/application/progression-controller_test.js
+++ b/api/tests/acceptance/application/progression-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, mockLearningContent, learningContentBuilder } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | API | Progressions', () => {

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const { databaseBuilder, expect, sinon } = require('../../test-helper');
 
 const samlify = require('samlify');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const settings = require('../../../lib/config');
 

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
@@ -5,6 +5,7 @@ const {
   generateValidRequestAuthorizationHeader,
 } = require('../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | Schooling-registration-dependent-user', () => {

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -7,6 +7,7 @@ const {
   knex,
 } = require('../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const Membership = require('../../../lib/domain/models/Membership');
 const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -2,6 +2,7 @@ const { databaseBuilder, expect, knex, generateValidRequestAuthorizationHeader, 
 const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
 const { FRENCH_SPOKEN } = require('../../../lib/domain/constants').LOCALE;
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | scorecard-controller', () => {

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 const Membership = require('../../../lib/domain/models/Membership');
 const securityPreHandlers = require('../../../lib/application/security-pre-handlers');

--- a/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
+++ b/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const _ = require('lodash');
 

--- a/api/tests/acceptance/application/session/session-controller-delete-certification-candidate_test.js
+++ b/api/tests/acceptance/application/session/session-controller-delete-certification-candidate_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-delete-certification-candidate', () => {

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -1,4 +1,5 @@
 const { sinon, expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-enroll-students-to-session', () => {

--- a/api/tests/acceptance/application/session/session-controller-generate-session-results-download-link_test.js
+++ b/api/tests/acceptance/application/session/session-controller-generate-session-results-download-link_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-generate-session-results-download-link', () => {

--- a/api/tests/acceptance/application/session/session-controller-get-attendance-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-attendance-sheet_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-get-attendance-sheet', () => {

--- a/api/tests/acceptance/application/session/session-controller-get-candidates-import-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-candidates-import-sheet_test.js
@@ -1,5 +1,6 @@
 
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-get-candidates-import-sheet', () => {

--- a/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const _ = require('lodash');
 

--- a/api/tests/acceptance/application/session/session-controller-get-certification-reports_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-reports_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-get-certification-reports', () => {

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const Badge = require('../../../../lib/domain/models/Badge');
 

--- a/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-get-jury-session', () => {

--- a/api/tests/acceptance/application/session/session-controller-get-session-results-by-result-recipient-email_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-session-results-by-result-recipient-email_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const jsonwebtoken = require('jsonwebtoken');
 const settings = require('../../../../lib/config');

--- a/api/tests/acceptance/application/session/session-controller-get-session-results-to-download_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-session-results-to-download_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const jsonwebtoken = require('jsonwebtoken');
 const settings = require('../../../../lib/config');

--- a/api/tests/acceptance/application/session/session-controller-get-session-results_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-session-results_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const moment = require('moment');
 

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-get', () => {

--- a/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_reports_categorization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_reports_categorization_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const fs = require('fs');
 const { stat } = require('fs').promises;

--- a/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
@@ -1,6 +1,7 @@
 const {
   expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex,
 } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('PATCH /api/admin/sessions/:id/publish', () => {

--- a/api/tests/acceptance/application/session/session-controller-patch-unpublish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-unpublish-session_test.js
@@ -1,6 +1,7 @@
 const {
   expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex,
 } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('PATCH /api/admin/sessions/:id/unpublish', () => {

--- a/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
@@ -1,6 +1,7 @@
 const {
   expect, generateValidRequestAuthorizationHeader, databaseBuilder,
 } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('PATCH /api/admin/sessions/:id/certification-officer-assignment', () => {

--- a/api/tests/acceptance/application/session/session-controller-patch_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-patch', () => {

--- a/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const { expect, databaseBuilder, domainBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-post-certification-candidates', () => {

--- a/api/tests/acceptance/application/session/session-controller-post_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post_test.js
@@ -1,4 +1,5 @@
 const { expect, knex, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | session-controller-post', () => {

--- a/api/tests/acceptance/application/session/session-controller-publish-session-in-batch_test.js
+++ b/api/tests/acceptance/application/session/session-controller-publish-session-in-batch_test.js
@@ -1,6 +1,7 @@
 const {
   expect, generateValidRequestAuthorizationHeader, databaseBuilder,
 } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('POST /api/admin/sessions/publish-in-batch', () => {

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -1,4 +1,5 @@
 const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | sessions-controller', () => {

--- a/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
@@ -1,6 +1,7 @@
 const {
   expect, generateValidRequestAuthorizationHeader, databaseBuilder,
 } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('PUT /api/admin/sessions/:id/results-sent-to-prescriber', () => {

--- a/api/tests/acceptance/application/swagger_test.js
+++ b/api/tests/acceptance/application/swagger_test.js
@@ -1,4 +1,5 @@
 const { expect } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | lib | swagger', () => {

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex, mockLearningContent, learningContentBuilder } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | target-profile-controller', () => {

--- a/api/tests/acceptance/application/tutorials/tutorial-evaluations-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/tutorial-evaluations-controller_test.js
@@ -1,4 +1,5 @@
 const { mockLearningContent, databaseBuilder, expect, knex, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | tutorial-evaluations-controller', () => {

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, mockLearningContent, databaseBuilder, knex } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | user-tutorial-controller', () => {

--- a/api/tests/acceptance/application/user-orga-settings-controller_test.js
+++ b/api/tests/acceptance/application/user-orga-settings-controller_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | user-orga-settings-controller', () => {

--- a/api/tests/acceptance/application/users/accept-pix-certif-terms-of-service_test.js
+++ b/api/tests/acceptance/application/users/accept-pix-certif-terms-of-service_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-accept-pix-certif-terms-of-service', () => {

--- a/api/tests/acceptance/application/users/accept-pix-orga-terms-of-service_test.js
+++ b/api/tests/acceptance/application/users/accept-pix-orga-terms-of-service_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-accept-pix-orga-terms-of-service', () => {

--- a/api/tests/acceptance/application/users/accept-pix-terms-of-service_test.js
+++ b/api/tests/acceptance/application/users/accept-pix-terms-of-service_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-accept-pix-terms-of-service', () => {

--- a/api/tests/acceptance/application/users/change-lang_test.js
+++ b/api/tests/acceptance/application/users/change-lang_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | change-lang', () => {

--- a/api/tests/acceptance/application/users/get-user-campaign-participation-to-campaign_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-participation-to-campaign_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Route | GET /users/id/campaigns/id/campaign-participations', () => {

--- a/api/tests/acceptance/application/users/remember-user-has-seen-assessment-instructions_test.js
+++ b/api/tests/acceptance/application/users/remember-user-has-seen-assessment-instructions_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-remember-user-has-seen-assessment-instructions', () => {

--- a/api/tests/acceptance/application/users/remember-user-has-seen-new-dashboard-info_test.js
+++ b/api/tests/acceptance/application/users/remember-user-has-seen-new-dashboard-info_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-has-seen-new-dashboard-info', () => {

--- a/api/tests/acceptance/application/users/update-user-details-for-administration_test.js
+++ b/api/tests/acceptance/application/users/update-user-details-for-administration_test.js
@@ -1,5 +1,6 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, knex } = require('../../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-update-user-details-for-administration', () => {

--- a/api/tests/acceptance/application/users/users-controller-anonymize-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-anonymize-user_test.js
@@ -1,4 +1,5 @@
 const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, knex } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-anonymize-user', () => {

--- a/api/tests/acceptance/application/users/users-controller-dissociate-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/users/users-controller-dissociate-schooling-registrations_test.js
@@ -5,6 +5,7 @@ const {
   insertUserWithRolePixMaster,
 } = require('../../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-dissociate-schooling-registrations-by-user', () => {

--- a/api/tests/acceptance/application/users/users-controller-find-users_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-users_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | users-controller-find-users', () => {

--- a/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, mockLearningContent, learningContentBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-get-campaign-participation-overviews', () => {

--- a/api/tests/acceptance/application/users/users-controller-get-campaign-participations_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-campaign-participations_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | GET /user/id/campaign-participations', () => {

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -4,6 +4,7 @@ const {
   generateValidRequestAuthorizationHeader,
 } = require('../../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-get-current-user', () => {

--- a/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 const Membership = require('../../../../lib/domain/models/Membership');

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile_test.js
@@ -1,5 +1,6 @@
 const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, mockLearningContent } = require('../../../test-helper');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-get-user-profile', () => {

--- a/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
+++ b/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
@@ -1,4 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, mockLearningContent } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | users-controller-is-certifiable', () => {

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -1,4 +1,5 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, sinon } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const mailer = require('../../../../lib/infrastructure/mailers/mailer');
 

--- a/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
+++ b/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
@@ -1,4 +1,5 @@
 const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, knex } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -1,6 +1,7 @@
 const { knex, databaseBuilder, expect, generateValidRequestAuthorizationHeader, sinon, mockLearningContent } = require('../../../test-helper');
 const _ = require('lodash');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-reset-scorecard', () => {

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -9,6 +9,7 @@ const {
 
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller', () => {

--- a/api/tests/acceptance/application/users/users-controller-update-password_test.js
+++ b/api/tests/acceptance/application/users/users-controller-update-password_test.js
@@ -1,6 +1,7 @@
 const { expect, hFake, knex, databaseBuilder } = require('../../../test-helper');
 
 const authenticationController = require('../../../../lib/application/authentication/authentication-controller');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-update-password', () => {

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, mockLearningContent } = require('../../../test-helper');
+// eslint-disable-next-line no-restricted-modules
 const createServer = require('../../../../server');
 
 describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profile', () => {

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -50,6 +50,10 @@ class HttpTestServer {
   request(method, url, payload, auth, headers) {
     return this.hapiServer.inject({ method, url, payload, auth, headers });
   }
+
+  requestObject({ method, url, payload, auth, headers }) {
+    return this.hapiServer.inject({ method, url, payload, auth, headers });
+  }
 }
 
 module.exports = HttpTestServer;

--- a/docs/adr/0024-tester-routeur-api.md
+++ b/docs/adr/0024-tester-routeur-api.md
@@ -1,0 +1,66 @@
+# 24. Comment tester le routeur API ?
+
+Date : 2021-04-16
+
+## État
+Adopté
+
+## Contexte 
+
+### Général
+Nous avons besoin de tests qui :
+- empêchent les régressions
+- fournissent un feedback rapide (en s'exécutant rapidement)
+- ne causent pas de faux positifs lors du refactoring
+- soient simples à comprendre, pour être facilement modifiés
+
+Le routeur de l'API (fourni par HAPI) accepte la configuration suivante pour chaque route :
+- le nom de la route (path) et son verbe
+- une validation syntaxique de la requête (effectué par JOI)
+- une validation de sécurité de la requête (authentification)
+- le controller à appeler si requête est validée 
+
+Les tests du routeur ont pour but de :  
+- tester ces configurations ;
+- en satisfaisant les critères (tous ne pouvant être satisfaits en même temps).
+
+### Spécifique
+
+HAPI [préconise](https://hapi.dev/tutorials/testing/) 
+- de ne pas faire de tests depuis l'extérieur (appel HTTP)
+- mais d'utiliser la fonction `server.inject`
+
+Cette pratique est déjà en place. 
+La question à traiter ici est: quel type de serveur démarrer ? 
+
+### Solution n°1 : Utiliser le serveur de production (lourd)
+Cette solution utilise le serveur démarré par les [conteneurs](../../api/bin/www), à savoir [server.js](../../api/server.js)
+
+Avantages :
+- protège complètement des régressions
+
+Inconvénients :
+- feedback moins rapide qu'un serveur léger 
+- n'attire pas l'attention du développeur sur les routes en cours de tests
+
+### Solution n°2 : Utiliser un serveur de test (léger)
+Cette solution utilise [un serveur](../../api/tests/tooling/http-test-server.js) dédié au test:
+- il ne contient pas de route par défaut, elles doivent lui être indiquées
+- il contient les stratégies de validation (syntaxique et de sécurité)  
+- il ne contient pas tous les plugins (ex: documentation avec Swagger)   
+
+Avantages :
+- focalisation du développeur sur la route à tester
+- feedback plus rapide qu'un serveur lourd
+
+Inconvénients :
+- protège moins des régressions
+- ne permet pas de tester les plugins
+
+## Décision
+La solution n°2 est adoptée, sauf dans le cas où la fonctionnalité n'est pas offerte 
+par le serveur de test léger.
+
+## Conséquences
+Ajouter une règle de lint pour prévenir l'utilisation non-intentionelle du serveur lourd.
+Créer le serveur léger une seule fois par fichier de test.


### PR DESCRIPTION
## :unicorn: Problème
Le serveur de test  léger `http-test-server` n'embarque pas automatiquement l'ensembles des routes, ce qui permet d'exécuter les tests plus rapidement, mais il n'est pas utilisé partout. [Une PR](https://github.com/1024pix/pix/pull/2843) mergée récemment lève les limitations liées à l'authentification.

## :robot: Solution
Généraliser son usage partout ou cela est possible

## :rainbow: Remarques
Ajout d'une règle de lint pour préconiser son usage
Documenter les raisons de son choix dans une ADR

## :100: Pour tester
Vérifier que la CI passe
