### PR TITLE
[FEATURE] Générer les identifiants via les informations de l'élève présent en base sur la double mire Pix App (PIX-1785).

### DIFF
--- a/api/lib/domain/usecases/generate-username.js
+++ b/api/lib/domain/usecases/generate-username.js
@@ -23,6 +23,12 @@ module.exports = async function generateUsername({
   const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
   await checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository, obfuscationService);
 
+  studentInformation = {
+    firstName: matchedSchoolingRegistration.firstName,
+    lastName: matchedSchoolingRegistration.lastName,
+    birthdate: matchedSchoolingRegistration.birthdate,
+  };
+
   return userReconciliationService.createUsernameByUser({ user: studentInformation, userRepository });
 
 };

--- a/api/tests/unit/domain/usecases/generate-username-test.js
+++ b/api/tests/unit/domain/usecases/generate-username-test.js
@@ -196,15 +196,19 @@ describe('Unit | UseCase | generate-username', () => {
 
   context('When schoolingRegistration matched and student is not already reconciled', () => {
 
-    it('should return username', async () => {
+    it('should call createUsernameByUser with student information from database', async () => {
       // given
-      const username = studentInformation.firstName + '.' + studentInformation.lastName + '0112';
       schoolingRegistrationRepository.findByOrganizationIdAndBirthdate.resolves([schoolingRegistration]);
       userReconciliationService.findMatchingCandidateIdForGivenUser.resolves(schoolingRegistration.id);
-      userReconciliationService.createUsernameByUser.resolves(username);
+
+      studentInformation = {
+        firstName: schoolingRegistration.firstName,
+        lastName: schoolingRegistration.lastName,
+        birthdate: schoolingRegistration.birthdate,
+      };
 
       // when
-      const result = await generateUsername({
+      await generateUsername({
         studentInformation,
         campaignCode,
         campaignRepository,
@@ -216,7 +220,8 @@ describe('Unit | UseCase | generate-username', () => {
       });
 
       // then
-      expect(result).to.be.equal(username);
+      expect(userReconciliationService.createUsernameByUser).calledWith({ user: studentInformation, userRepository });
+
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans la double mire Pix App, lorsqu'un élève se créer un compte via un identifiant, celui-ci est généré sur ce que l'élève a saisi dans les champs prénom et nom. 

Or si l'élève à fait une faute de frappe (et qu'on parvient à le retrouver) cette faute va apparaître dans son identifiant.

<img width="329" alt="Capture d’écran 2021-04-15 à 11 19 16" src="https://user-images.githubusercontent.com/58915422/114845878-71a5f680-9ddc-11eb-8c9c-f84d79bbb603.png">
<img width="590" alt="Capture d’écran 2021-04-15 à 11 15 27" src="https://user-images.githubusercontent.com/58915422/114845891-74085080-9ddc-11eb-8573-d305921dfe5a.png">


## :robot: Solution
Générer l'identifiant en se basant sur les informations de l'élève existant en base (table `schooling-registrations`)

## :rainbow: Remarques
La génération d'identifiant se fait également sur Pix Orga, qui se base déjà sur les infos de la table `schooling-registrations`. 
Il n'est pas impacté par ce ticket.

## :100: Pour tester
Aller sur la page campagnes > `BAGDES123` > Entrer l'utilisateur : `First` `Laast` `10/10/2010`
L'identifiant généré sera `first.last1010`
