### PR TITLE
[FEATURE] Ajouter une documentation pour orga.pix.org (PIX-2477).

### DIFF
--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -3,9 +3,14 @@ import Component from '@glimmer/component';
 
 export default class SidebarMenu extends Component {
   @service currentUser;
+  @service url;
   @service featureToggles;
 
   get documentationUrl() {
+    if (!this.url.isFrenchDomainExtension) {
+      return 'https://cloud.pix.fr/s/HxpfpBnY47nYBkz';
+    }
+
     if (this.currentUser.isSCOManagingStudents && this.currentUser.isAgriculture) {
       return 'https://view.genial.ly/5f85a0b87812e90d12b7b593';
     }

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -224,9 +224,10 @@ module('Acceptance | authentication', function(hooks) {
         // when
         await visit('/');
         // then
-        assert.dom('.sidebar-menu a').exists({ count: 2 });
+        assert.dom('.sidebar-menu a').exists({ count: 3 });
         assert.dom('.sidebar-menu').containsText('Campagnes');
         assert.dom('.sidebar-menu').containsText('Équipe');
+        assert.dom('.sidebar-menu').containsText('Documentation');
         assert.dom('.sidebar-menu a:first-child').hasClass('active');
       });
 
@@ -365,8 +366,9 @@ module('Acceptance | authentication', function(hooks) {
         await visit('/');
 
         // then
-        assert.dom('.sidebar-menu a').exists({ count: 1 });
+        assert.dom('.sidebar-menu a').exists({ count: 2 });
         assert.dom('.sidebar-menu').containsText('Campagnes');
+        assert.dom('.sidebar-menu').containsText('Documentation');
         assert.dom('.sidebar-menu a:first-child ').hasClass('active');
       });
 

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -7,113 +7,149 @@ import Service from '@ember/service';
 module('Integration | Component | sidebar-menu', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display documentation for a pro organization', async function(assert) {
-    class CurrentUserStub extends Service {
-      organization = Object.create({ id: 1, isPro: true });
+  module('when the user is authenticated on orga.pix.fr', function(hooks) {
+    class UrlServiceStub extends Service {
+      get isFrenchDomainExtension() {
+        return true;
+      }
     }
-    this.owner.register('service:current-user', CurrentUserStub);
 
-    // when
-    await render(hbs`<SidebarMenu />`);
+    hooks.beforeEach(function() {
+      this.owner.register('service:url', UrlServiceStub);
+    });
 
-    // then
-    assert.dom('a[href="https://cloud.pix.fr/s/cwZN2GAbqSPGnw4"]').exists();
+    test('it should display documentation for a pro organization', async function(assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, isPro: true });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<SidebarMenu />`);
+
+      // then
+      assert.dom('a[href="https://cloud.pix.fr/s/cwZN2GAbqSPGnw4"]').exists();
+    });
+
+    test('it should display documentation for a pro mediation numerique organization', async function(assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1 });
+        isMediationNumerique = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<SidebarMenu />`);
+
+      // then
+      assert.dom('a[href="https://view.genial.ly/6048a0d3757f980dc010d6d4"]').exists();
+    });
+
+    test('it should display documentation for a sco organization', async function(assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, type: 'SCO' });
+        isSCOManagingStudents = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<SidebarMenu />`);
+
+      // then
+      assert.dom('a[href="https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f"]').exists();
+    });
+
+    test('it should display documentation for a sco agriculture organization', async function(assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, type: 'SCO' });
+        isSCOManagingStudents = true;
+        isAgriculture = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<SidebarMenu />`);
+
+      // then
+      assert.dom('a[href="https://view.genial.ly/5f85a0b87812e90d12b7b593"]').exists();
+    });
+
+    test('it should display documentation for a sco AEFE organization', async function(assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, type: 'SCO' });
+        isAEFE = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<SidebarMenu />`);
+
+      // then
+      assert.dom('a[href="https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8"]').exists();
+    });
+
+    test('it should display documentation for a sco MLF organization', async function(assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, type: 'SCO' });
+        isMLF = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<SidebarMenu />`);
+      // then
+      assert.dom('a[href="https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8"]').exists();
+    });
+
+    test('it should display documentation for a SUP organization', async function(assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, isSup: true });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<SidebarMenu />`);
+      // then
+      assert.dom('a[href="https://cloud.pix.fr/s/DTTo7Lp7p6Ktceo"]').exists();
+    });
+
+    test('it should not display documentation for a sco organization that does not managed students', async function(assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, type: 'SCO' });
+        isSCOManagingStudents = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<SidebarMenu />`);
+
+      // then
+      assert.dom('.sidebar-menu__documentation-item').doesNotExist();
+    });
   });
 
-  test('it should display documentation for a pro mediation numerique organization', async function(assert) {
+  module('when the user is authenticated on orga.pix.org', function(hooks) {
+    class UrlServiceStub extends Service {
+      get isFrenchDomainExtension() {
+        return false;
+      }
+    }
     class CurrentUserStub extends Service {
       organization = Object.create({ id: 1 });
-      isMediationNumerique = true;
     }
-    this.owner.register('service:current-user', CurrentUserStub);
 
-    // when
-    await render(hbs`<SidebarMenu />`);
+    hooks.beforeEach(function() {
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.owner.register('service:url', UrlServiceStub);
+    });
 
-    // then
-    assert.dom('a[href="https://view.genial.ly/6048a0d3757f980dc010d6d4"]').exists();
-  });
+    test('it should display documentation', async function(assert) {
+      // when
+      await render(hbs`<SidebarMenu />`);
 
-  test('it should display documentation for a sco organization', async function(assert) {
-    class CurrentUserStub extends Service {
-      organization = Object.create({ id: 1, type: 'SCO' });
-      isSCOManagingStudents = true;
-    }
-    this.owner.register('service:current-user', CurrentUserStub);
-
-    // when
-    await render(hbs`<SidebarMenu />`);
-
-    // then
-    assert.dom('a[href="https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f"]').exists();
-  });
-
-  test('it should display documentation for a sco agriculture organization', async function(assert) {
-    class CurrentUserStub extends Service {
-      organization = Object.create({ id: 1, type: 'SCO' });
-      isSCOManagingStudents = true;
-      isAgriculture = true;
-    }
-    this.owner.register('service:current-user', CurrentUserStub);
-
-    // when
-    await render(hbs`<SidebarMenu />`);
-
-    // then
-    assert.dom('a[href="https://view.genial.ly/5f85a0b87812e90d12b7b593"]').exists();
-  });
-
-  test('it should display documentation for a sco AEFE organization', async function(assert) {
-    class CurrentUserStub extends Service {
-      organization = Object.create({ id: 1, type: 'SCO' });
-      isAEFE = true;
-    }
-    this.owner.register('service:current-user', CurrentUserStub);
-
-    // when
-    await render(hbs`<SidebarMenu />`);
-
-    // then
-    assert.dom('a[href="https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8"]').exists();
-  });
-
-  test('it should display documentation for a sco MLF organization', async function(assert) {
-    class CurrentUserStub extends Service {
-      organization = Object.create({ id: 1, type: 'SCO' });
-      isMLF = true;
-    }
-    this.owner.register('service:current-user', CurrentUserStub);
-
-    // when
-    await render(hbs`<SidebarMenu />`);
-    // then
-    assert.dom('a[href="https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8"]').exists();
-  });
-
-  test('it should display documentation for a SUP organization', async function(assert) {
-    class CurrentUserStub extends Service {
-      organization = Object.create({ id: 1, isSup: true });
-    }
-    this.owner.register('service:current-user', CurrentUserStub);
-
-    // when
-    await render(hbs`<SidebarMenu />`);
-    // then
-    assert.dom('a[href="https://cloud.pix.fr/s/DTTo7Lp7p6Ktceo"]').exists();
-  });
-
-  test('it should not display documentation for a sco organization that does not managed students', async function(assert) {
-    class CurrentUserStub extends Service {
-      organization = Object.create({ id: 1, type: 'SCO' });
-      isSCOManagingStudents = false;
-    }
-    this.owner.register('service:current-user', CurrentUserStub);
-
-    // when
-    await render(hbs`<SidebarMenu />`);
-
-    // then
-    assert.dom('.sidebar-menu__documentation-item').doesNotExist();
+      // then
+      assert.dom('a[href="https://cloud.pix.fr/s/HxpfpBnY47nYBkz"]').exists();
+    });
   });
 
   test('it should display Certifications menu in the sidebar-menu when FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED is true and user is SCOManagingStudents', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs de orga.pix.org n'ont pas de documentation qui leur est propre et utilisent celle de orga.pix.fr.

## :robot: Solution
Afficher une documentation spécifique si l'utilisateur est connecté sur orga.pix.org

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
En local on dois avoir la nouvelle documantation
Sur la review app il doit y avoir les documentations en fonction type d'organisation
