### PR TITLE
[FEATURE] Afficher la dernière participation à la campagne dans le cas d'une campagne à envois multiples (Pix-2463).

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -12,6 +12,7 @@ module.exports = function buildCampaignParticipation({
   userId,
   participantExternalId = 'participantExternalId',
   validatedSkillsCount,
+  isImproved,
 } = {}) {
 
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -27,6 +28,7 @@ module.exports = function buildCampaignParticipation({
     sharedAt,
     participantExternalId,
     validatedSkillsCount,
+    isImproved,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'campaign-participations',

--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -24,6 +24,7 @@ module.exports = function buildCampaign({
   customResultPageText,
   customResultPageButtonText,
   customResultPageButtonUrl,
+  multipleSendings,
 
 } = {}) {
 
@@ -53,6 +54,7 @@ module.exports = function buildCampaign({
     customResultPageText,
     customResultPageButtonText,
     customResultPageButtonUrl,
+    multipleSendings,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'campaigns',

--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -257,15 +257,16 @@ __Plus d'infos :)__
 
   databaseBuilder.factory.buildCampaign({
     id: 16,
-    name: 'Pro - Campagne d’évaluation PIC - Terrminé & partagé.',
+    name: 'Pro - Campagne d’évaluation PIC - Terrminé & partagé - Envois multiple',
     code: 'FINISHED3',
     type: 'ASSESSMENT',
-    title: 'Parcours terminé partagé',
+    title: 'Parcours terminé partagé - Envois multiple',
     customLandingPageText: '',
     organizationId: PRO_COMPANY_ID,
     creatorId: 2,
     targetProfileId: TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
     idPixLabel: 'identifiant entreprise',
+    multipleSendings: true,
   });
 
   databaseBuilder.factory.buildCampaign({

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -112,6 +112,7 @@ module.exports = {
       .query((qb) => {
         qb.innerJoin('campaign-participations', 'campaign-participations.id', 'assessments.campaignParticipationId');
         qb.innerJoin('campaigns', 'campaign-participations.campaignId', 'campaigns.id');
+        qb.where('campaign-participations.isImproved', false);
       })
       .orderBy('createdAt', 'desc')
       .fetch({ require: false, withRelated: includeCampaign ? ['campaignParticipation', 'campaignParticipation.campaign'] : [] })

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -49,6 +49,7 @@ function _findByUserId({ userId }) {
         .innerJoin('assessments', 'assessments.campaignParticipationId', 'campaign-participations.id')
         .modify(_filterMostRecentAssessments)
         .where('campaign-participations.userId', userId)
+        .where('campaign-participations.isImproved', false)
         .whereNot('campaigns.isForAbsoluteNovice', true);
     })
     .from('campaign-participation-overviews')

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -109,7 +109,7 @@ module.exports = {
 
   findOneByCampaignIdAndUserId({ campaignId, userId }) {
     return BookshelfCampaignParticipation
-      .where({ campaignId, userId })
+      .where({ campaignId, userId, isImproved: false })
       .fetch({ require: false })
       .then((campaignParticipation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCampaignParticipation, campaignParticipation));
   },

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -90,6 +90,19 @@ describe('Integration | Repository | Campaign Participation Overview', () => {
         expect(campaignParticipationUserIds).to.exactlyContain([participation1Id, participation2Id]);
       });
 
+      it('retrieves information about the most recent campaign participation of multipleSending campaign', async () => {
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, multipleSendings: true });
+        const { id: oldParticipationId } = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isImproved: true });
+        const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId });
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId: oldParticipationId, state: Assessment.states.COMPLETED, createdAt: new Date('2020-01-01') });
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId: participationId, state: Assessment.states.COMPLETED, createdAt: new Date('2020-01-03') });
+        await databaseBuilder.commit();
+
+        const { campaignParticipationOverviews: [campaignParticipation] } = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+
+        expect(campaignParticipation.id).to.equal(participationId);
+      });
+
       it('retrieves information about the most recent assessment of campaign participation', async () => {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -435,7 +435,29 @@ describe('Integration | Repository | Campaign Participation', () => {
 
       // then
       expect(response).to.be.instanceOf(CampaignParticipation);
-      expect(response.id).to.deep.equal(campaignParticipation.id);
+      expect(response.id).to.equal(campaignParticipation.id);
+    });
+
+    it('should return the non improved campaign participation found', async () => {
+      // given
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+        isImproved: true,
+      });
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await campaignParticipationRepository.findOneByCampaignIdAndUserId({ campaignId, userId });
+
+      // then
+      expect(response).to.be.instanceOf(CampaignParticipation);
+      expect(response.id).to.equal(campaignParticipation.id);
     });
 
     it('should return no campaign participation', async () => {
@@ -476,7 +498,7 @@ describe('Integration | Repository | Campaign Participation', () => {
         const campaignParticipationFound = await campaignParticipationRepository.findOneByAssessmentIdWithSkillIds(assessmentId);
 
         // then
-        expect(campaignParticipationFound.assessmentId).to.deep.equal(assessmentId);
+        expect(campaignParticipationFound.assessmentId).to.equal(assessmentId);
         expect(campaignParticipationFound.campaign.targetProfile.skills).to.have.lengthOf(2);
         expect(campaignParticipationFound.campaign.targetProfile.skills[0]).to.be.instanceOf(Skill);
         expect(campaignParticipationFound.campaign.targetProfile.skills[0].id).to.equal(skillId1);


### PR DESCRIPTION
## :unicorn: Problème
Nous avons introduit le concept de campagne à envoi muliple. Même après avoir envoyé le résultat d'une campagne, nous pouvons à nouveau participer à cette campagne. A condition d'avoir le champs `multipleSendings` activé.

Doublon de campagne dans la page mes parcours. et remonter aléatoire de la participation de campagne dans la page de résultat.

## :robot: Solution
Filter sur les campagnes participations qui ne sont pas en `isImproved` à `true`, afin  de ne remonter que le campagne participation en cours.

## :rainbow: Remarques

## :100: Pour tester
Jaune Attend à passé deux fois sa campagne _Pro - Campagne d’évaluation PIC - Terrminé & partagé._ `FINISHED3` . nous devons voir le résultat de la seconde participation dans la page mes parcours.

La page résultat de `FINISHED3` doit bien cibler le bon assessment qui correspond à la dernière `campaign-participation` . A Vérifier sur le Adminer de la RA ? 