### PR TITLE
[SR] Supprimer les .get et .set dans les tests unitaires des models de Pix-App.

### DIFF
--- a/mon-pix/tests/unit/models/answer-test.js
+++ b/mon-pix/tests/unit/models/answer-test.js
@@ -26,7 +26,7 @@ describe('Unit | Model | Answer', function() {
       const answer = run(() => store.createRecord('answer', { 'result': 'ok' }));
 
       // when
-      const result = answer.get('isResultOk');
+      const result = answer.isResultOk;
 
       expect(result).to.be.true;
     });
@@ -36,7 +36,7 @@ describe('Unit | Model | Answer', function() {
       const answer = run(() => store.createRecord('answer', { 'result': 'ko' }));
 
       // when
-      const result = answer.get('isResultOk');
+      const result = answer.isResultOk;
 
       expect(result).to.be.false;
     });
@@ -48,7 +48,7 @@ describe('Unit | Model | Answer', function() {
       const answer = run(() => store.createRecord('answer', { 'result': 'ok' }));
 
       // when
-      const result = answer.get('isResultNotOk');
+      const result = answer.isResultNotOk;
 
       expect(result).to.be.false;
     });
@@ -58,7 +58,7 @@ describe('Unit | Model | Answer', function() {
       const answer = run(() => store.createRecord('answer', { 'result': 'ko' }));
 
       // when
-      const result = answer.get('isResultNotOk');
+      const result = answer.isResultNotOk;
 
       expect(result).to.be.true;
     });

--- a/mon-pix/tests/unit/models/assessment-test.js
+++ b/mon-pix/tests/unit/models/assessment-test.js
@@ -25,9 +25,10 @@ describe('Unit | Model | Assessment', function() {
       // given
       const assessment = store.createRecord('assessment');
       assessment.set('answers', []);
+      assessment.answers = [];
 
       // when
-      const answersSinceLastCheckpoints = assessment.get('answersSinceLastCheckpoints');
+      const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
 
       // then
       expect(answersSinceLastCheckpoints).to.deep.equal([]);
@@ -41,7 +42,7 @@ describe('Unit | Model | Assessment', function() {
       run(() => assessment.set('answers', answers));
 
       // when
-      const answersSinceLastCheckpoints = assessment.get('answersSinceLastCheckpoints');
+      const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
 
       // then
       expect(answersSinceLastCheckpoints).to.deep.equal(answers);
@@ -55,7 +56,7 @@ describe('Unit | Model | Assessment', function() {
       run(() => assessment.set('answers', answers));
 
       // when
-      const answersSinceLastCheckpoints = assessment.get('answersSinceLastCheckpoints');
+      const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
 
       // then
       expect(answersSinceLastCheckpoints).to.deep.equal([answer6, answer7]);
@@ -69,7 +70,7 @@ describe('Unit | Model | Assessment', function() {
       run(() => assessment.set('answers', answers));
 
       // when
-      const answersSinceLastCheckpoints = assessment.get('answersSinceLastCheckpoints');
+      const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
 
       // then
       expect(answersSinceLastCheckpoints).to.deep.equal([answer6, answer7, answer8, answer9, answer10]);
@@ -83,7 +84,7 @@ describe('Unit | Model | Assessment', function() {
       run(() => assessment.set('answers', answers));
 
       // when
-      const answersSinceLastCheckpoints = assessment.get('answersSinceLastCheckpoints');
+      const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
 
       // then
       expect(answersSinceLastCheckpoints).to.deep.equal([answer11]);

--- a/mon-pix/tests/unit/models/assessment-test.js
+++ b/mon-pix/tests/unit/models/assessment-test.js
@@ -24,7 +24,6 @@ describe('Unit | Model | Assessment', function() {
     it('should return an empty array when no answers has been given', function() {
       // given
       const assessment = store.createRecord('assessment');
-      assessment.set('answers', []);
       assessment.answers = [];
 
       // when
@@ -39,7 +38,7 @@ describe('Unit | Model | Assessment', function() {
       const answer = run(() => store.createRecord('answer'));
       const assessment = store.createRecord('assessment');
       const answers = [answer];
-      run(() => assessment.set('answers', answers));
+      run(() => assessment.answers = answers);
 
       // when
       const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
@@ -53,7 +52,7 @@ describe('Unit | Model | Assessment', function() {
       const answers = newAnswers(store, 7);
       const [answer6, answer7] = answers.slice(5);
       const assessment = store.createRecord('assessment');
-      run(() => assessment.set('answers', answers));
+      run(() => assessment.answers = answers);
 
       // when
       const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
@@ -67,7 +66,7 @@ describe('Unit | Model | Assessment', function() {
       const answers = newAnswers(store, 10);
       const [answer6, answer7, answer8, answer9, answer10] = answers.slice(5);
       const assessment = store.createRecord('assessment');
-      run(() => assessment.set('answers', answers));
+      run(() => assessment.answers = answers);
 
       // when
       const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
@@ -81,7 +80,7 @@ describe('Unit | Model | Assessment', function() {
       const answers = newAnswers(store, 11);
       const answer11 = answers[10];
       const assessment = store.createRecord('assessment');
-      run(() => assessment.set('answers', answers));
+      run(() => assessment.answers = answers);
 
       // when
       const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
@@ -97,7 +96,7 @@ describe('Unit | Model | Assessment', function() {
       const model = store.createRecord('assessment');
 
       // when
-      model.set('type', 'CAMPAIGN');
+      model.type = 'CAMPAIGN';
 
       //then
       expect(model.isForCampaign).to.be.true;
@@ -107,7 +106,7 @@ describe('Unit | Model | Assessment', function() {
       const model = store.createRecord('assessment');
 
       // when
-      model.set('type', '_');
+      model.type = '_';
 
       //then
       expect(model.isForCampaign).to.be.false;
@@ -120,7 +119,7 @@ describe('Unit | Model | Assessment', function() {
       const model = store.createRecord('assessment');
 
       // when
-      model.set('type', 'CERTIFICATION');
+      model.type = 'CERTIFICATION';
 
       //then
       expect(model.isCertification).to.be.true;
@@ -130,7 +129,7 @@ describe('Unit | Model | Assessment', function() {
       const model = store.createRecord('assessment');
 
       // when
-      model.set('type', '_');
+      model.type = '_';
 
       //then
       expect(model.isCertification).to.be.false;
@@ -143,7 +142,7 @@ describe('Unit | Model | Assessment', function() {
       const model = store.createRecord('assessment');
 
       // when
-      model.set('type', 'DEMO');
+      model.type = 'DEMO';
 
       //then
       expect(model.isDemo).to.be.true;
@@ -153,7 +152,7 @@ describe('Unit | Model | Assessment', function() {
       const model = store.createRecord('assessment');
 
       // when
-      model.set('type', '_');
+      model.type = '_';
 
       //then
       expect(model.isDemo).to.be.false;
@@ -166,7 +165,7 @@ describe('Unit | Model | Assessment', function() {
       const model = store.createRecord('assessment');
 
       // when
-      model.set('type', 'PREVIEW');
+      model.type = 'PREVIEW';
 
       //then
       expect(model.isPreview).to.be.true;
@@ -176,7 +175,7 @@ describe('Unit | Model | Assessment', function() {
       const model = store.createRecord('assessment');
 
       // when
-      model.set('type', '_');
+      model.type = '_';
 
       //then
       expect(model.isPreview).to.be.false;

--- a/mon-pix/tests/unit/models/campaign-participation-badge-test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-badge-test.js
@@ -28,7 +28,7 @@ describe('Unit | Model | CampaignParticipationBadge', function() {
       });
 
       const model = store.createRecord('campaign-participation-badge');
-      model.set('partnerCompetenceResults', [partnerCompetenceResult1, partnerCompetenceResult2]);
+      model.partnerCompetenceResults = [partnerCompetenceResult1, partnerCompetenceResult2];
 
       // when
       const maxTotalSkillsCountInPartnerCompetences = model.maxTotalSkillsCountInPartnerCompetences;

--- a/mon-pix/tests/unit/models/campaign-participation-badge-test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-badge-test.js
@@ -31,7 +31,7 @@ describe('Unit | Model | CampaignParticipationBadge', function() {
       model.set('partnerCompetenceResults', [partnerCompetenceResult1, partnerCompetenceResult2]);
 
       // when
-      const maxTotalSkillsCountInPartnerCompetences = model.get('maxTotalSkillsCountInPartnerCompetences');
+      const maxTotalSkillsCountInPartnerCompetences = model.maxTotalSkillsCountInPartnerCompetences;
 
       // then
       expect(maxTotalSkillsCountInPartnerCompetences).to.equal(10);

--- a/mon-pix/tests/unit/models/campaign-participation-result-test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-result-test.js
@@ -33,7 +33,7 @@ describe('Unit | Model | Campaign-Participation-Result', function() {
       model.set('competenceResults', [competenceResult1, competenceResult2, competenceResult3]);
 
       // when
-      const maxTotalSkillsCountInCompetences = model.get('maxTotalSkillsCountInCompetences');
+      const maxTotalSkillsCountInCompetences = model.maxTotalSkillsCountInCompetences;
 
       // then
       expect(maxTotalSkillsCountInCompetences).to.equal(11);

--- a/mon-pix/tests/unit/models/campaign-participation-result-test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-result-test.js
@@ -30,7 +30,7 @@ describe('Unit | Model | Campaign-Participation-Result', function() {
       });
 
       const model = store.createRecord('campaign-participation-result');
-      model.set('competenceResults', [competenceResult1, competenceResult2, competenceResult3]);
+      model.competenceResults = [competenceResult1, competenceResult2, competenceResult3];
 
       // when
       const maxTotalSkillsCountInCompetences = model.maxTotalSkillsCountInCompetences;

--- a/mon-pix/tests/unit/models/challenge-test.js
+++ b/mon-pix/tests/unit/models/challenge-test.js
@@ -25,7 +25,7 @@ describe('Unit | Model | Challenge', function() {
         const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
         // when
-        const hasAttachment = challenge.get('hasAttachment');
+        const hasAttachment = challenge.hasAttachment;
 
         // then
         expect(hasAttachment).to.be.true;
@@ -39,7 +39,7 @@ describe('Unit | Model | Challenge', function() {
         const challenge = store.createRecord('challenge', { attachments: [] });
 
         // when
-        const hasAttachment = challenge.get('hasAttachment');
+        const hasAttachment = challenge.hasAttachment;
 
         // then
         expect(hasAttachment).to.be.false;
@@ -56,7 +56,7 @@ describe('Unit | Model | Challenge', function() {
         const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
         // when
-        const hasSingleAttachment = challenge.get('hasSingleAttachment');
+        const hasSingleAttachment = challenge.hasSingleAttachment;
 
         // then
         expect(hasSingleAttachment).to.be.true;
@@ -70,7 +70,7 @@ describe('Unit | Model | Challenge', function() {
         const challenge = store.createRecord('challenge', { attachments: ['file.url', 'file.1.url', 'file.2.url'] });
 
         // when
-        const hasSingleAttachment = challenge.get('hasSingleAttachment');
+        const hasSingleAttachment = challenge.hasSingleAttachment;
 
         // then
         expect(hasSingleAttachment).to.be.false;
@@ -87,7 +87,7 @@ describe('Unit | Model | Challenge', function() {
         const challenge = store.createRecord('challenge', { attachments: [] });
 
         // when
-        const hasMultipleAttachments = challenge.get('hasMultipleAttachments');
+        const hasMultipleAttachments = challenge.hasMultipleAttachments;
 
         // then
         expect(hasMultipleAttachments).to.be.false;
@@ -101,7 +101,7 @@ describe('Unit | Model | Challenge', function() {
         const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
         // when
-        const hasMultipleAttachments = challenge.get('hasMultipleAttachments');
+        const hasMultipleAttachments = challenge.hasMultipleAttachments;
 
         // then
         expect(hasMultipleAttachments).to.be.false;
@@ -115,7 +115,7 @@ describe('Unit | Model | Challenge', function() {
         const challenge = store.createRecord('challenge', { attachments: ['file.url', 'file.1.url', 'file.2.url'] });
 
         // when
-        const hasMultipleAttachments = challenge.get('hasMultipleAttachments');
+        const hasMultipleAttachments = challenge.hasMultipleAttachments;
 
         // then
         expect(hasMultipleAttachments).to.be.true;
@@ -141,7 +141,7 @@ describe('Unit | Model | Challenge', function() {
       const challenge = store.createRecord('challenge', embedOptions);
 
       // when
-      const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
+      const hasValidEmbedDocument = challenge.hasValidEmbedDocument;
 
       // then
       expect(hasValidEmbedDocument).to.be.true;
@@ -153,7 +153,7 @@ describe('Unit | Model | Challenge', function() {
       const challenge = store.createRecord('challenge', embedOptions);
 
       // when
-      const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
+      const hasValidEmbedDocument = challenge.hasValidEmbedDocument;
 
       // then
       expect(hasValidEmbedDocument).to.be.false;
@@ -165,7 +165,7 @@ describe('Unit | Model | Challenge', function() {
       const challenge = store.createRecord('challenge', embedOptions);
 
       // when
-      const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
+      const hasValidEmbedDocument = challenge.hasValidEmbedDocument;
 
       // then
       expect(hasValidEmbedDocument).to.be.false;
@@ -177,7 +177,7 @@ describe('Unit | Model | Challenge', function() {
       const challenge = store.createRecord('challenge', embedOptions);
 
       // when
-      const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
+      const hasValidEmbedDocument = challenge.hasValidEmbedDocument;
 
       // then
       expect(hasValidEmbedDocument).to.be.false;
@@ -189,7 +189,7 @@ describe('Unit | Model | Challenge', function() {
       const challenge = store.createRecord('challenge', embedOptions);
 
       // when
-      const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
+      const hasValidEmbedDocument = challenge.hasValidEmbedDocument;
 
       // then
       expect(hasValidEmbedDocument).to.be.false;

--- a/mon-pix/tests/unit/models/competence-result-test.js
+++ b/mon-pix/tests/unit/models/competence-result-test.js
@@ -29,8 +29,8 @@ describe('Unit | Model | Competence-Result', function() {
         competenceResults: [otherCompetenceResult, competenceResult],
       });
 
-      competenceResult.set('totalSkillsCount', 2);
-      competenceResult.set('campaignParticipationResult', campaignParticipationResult);
+      competenceResult.totalSkillsCount = 2;
+      competenceResult.campaignParticipationResult = campaignParticipationResult;
 
       // when
       const totalSkillsCountPercentage = competenceResult.totalSkillsCountPercentage;
@@ -48,8 +48,8 @@ describe('Unit | Model | Competence-Result', function() {
         competenceResults: [otherCompetenceResult, competenceResult],
       });
 
-      competenceResult.set('totalSkillsCount', 1);
-      competenceResult.set('campaignParticipationResult', campaignParticipationResult);
+      competenceResult.totalSkillsCount = 1;
+      competenceResult.campaignParticipationResult = campaignParticipationResult;
 
       // when
       const totalSkillsCountPercentage = competenceResult.totalSkillsCountPercentage;

--- a/mon-pix/tests/unit/models/competence-result-test.js
+++ b/mon-pix/tests/unit/models/competence-result-test.js
@@ -33,7 +33,7 @@ describe('Unit | Model | Competence-Result', function() {
       competenceResult.set('campaignParticipationResult', campaignParticipationResult);
 
       // when
-      const totalSkillsCountPercentage = competenceResult.get('totalSkillsCountPercentage');
+      const totalSkillsCountPercentage = competenceResult.totalSkillsCountPercentage;
 
       // then
       expect(totalSkillsCountPercentage).to.equal(100);
@@ -52,7 +52,7 @@ describe('Unit | Model | Competence-Result', function() {
       competenceResult.set('campaignParticipationResult', campaignParticipationResult);
 
       // when
-      const totalSkillsCountPercentage = competenceResult.get('totalSkillsCountPercentage');
+      const totalSkillsCountPercentage = competenceResult.totalSkillsCountPercentage;
 
       // then
       expect(totalSkillsCountPercentage).to.equal(25);

--- a/mon-pix/tests/unit/models/correction-test.js
+++ b/mon-pix/tests/unit/models/correction-test.js
@@ -32,7 +32,7 @@ describe('Unit | Model | correction', function() {
       model = store.createRecord('correction', defaultAttributes);
 
       // when
-      const result = model.get('noHintsNorTutorialsAtAll');
+      const result = model.noHintsNorTutorialsAtAll;
 
       // then
       expect(result).to.be.true;
@@ -45,7 +45,7 @@ describe('Unit | Model | correction', function() {
       }));
 
       // when
-      const result = model.get('noHintsNorTutorialsAtAll');
+      const result = model.noHintsNorTutorialsAtAll;
 
       // then
       expect(result).to.be.false;
@@ -59,7 +59,7 @@ describe('Unit | Model | correction', function() {
       }));
 
       // when
-      const result = model.get('noHintsNorTutorialsAtAll');
+      const result = model.noHintsNorTutorialsAtAll;
 
       // then
       expect(result).to.be.false;
@@ -73,7 +73,7 @@ describe('Unit | Model | correction', function() {
       }));
 
       // when
-      const result = model.get('noHintsNorTutorialsAtAll');
+      const result = model.noHintsNorTutorialsAtAll;
 
       // then
       expect(result).to.be.false;

--- a/mon-pix/tests/unit/models/profile-test.js
+++ b/mon-pix/tests/unit/models/profile-test.js
@@ -30,7 +30,7 @@ describe('Unit | Model | Profile model', function() {
         const scorecard3 = store.createRecord('scorecard', { area: area2 });
 
         const model = store.createRecord('profile');
-        model.set('scorecards', [scorecard1, scorecard2, scorecard3]);
+        model.scorecards = [scorecard1, scorecard2, scorecard3];
 
         // when
         const areasCode = model.areasCode;

--- a/mon-pix/tests/unit/models/profile-test.js
+++ b/mon-pix/tests/unit/models/profile-test.js
@@ -33,7 +33,7 @@ describe('Unit | Model | Profile model', function() {
         model.set('scorecards', [scorecard1, scorecard2, scorecard3]);
 
         // when
-        const areasCode = model.get('areasCode');
+        const areasCode = model.areasCode;
 
         // then
         expect(areasCode).to.deep.equal([1, 2]);

--- a/mon-pix/tests/unit/models/progression-test.js
+++ b/mon-pix/tests/unit/models/progression-test.js
@@ -25,7 +25,7 @@ describe('Unit | Model | Progression', function() {
         const progression = store.createRecord('progression', { completionRate: 0.06815 });
 
         // when
-        const completionPercentage = progression.get('completionPercentage');
+        const completionPercentage = progression.completionPercentage;
 
         // then
         expect(completionPercentage).to.equal(7);

--- a/mon-pix/tests/unit/models/scorecard-test.js
+++ b/mon-pix/tests/unit/models/scorecard-test.js
@@ -53,7 +53,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('level', maxReachableLevel);
 
       // when
-      const isMaxLevel = scorecard.get('isMaxLevel');
+      const isMaxLevel = scorecard.isMaxLevel;
 
       // then
       expect(isMaxLevel).to.be.true;
@@ -64,7 +64,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('level', 2);
 
       // when
-      const isMaxLevel = scorecard.get('isMaxLevel');
+      const isMaxLevel = scorecard.isMaxLevel;
 
       // then
       expect(isMaxLevel).to.be.false;
@@ -79,7 +79,7 @@ describe('Unit | Model | Scorecard model', function() {
         scorecard.set('status', 'COMPLETED');
 
         // when
-        const isFinishedWithMaxLevel = scorecard.get('isFinishedWithMaxLevel');
+        const isFinishedWithMaxLevel = scorecard.isFinishedWithMaxLevel;
 
         // then
         expect(isFinishedWithMaxLevel).to.be.true;
@@ -91,7 +91,7 @@ describe('Unit | Model | Scorecard model', function() {
         scorecard.set('status', 'STARTED');
 
         // when
-        const isFinishedWithMaxLevel = scorecard.get('isFinishedWithMaxLevel');
+        const isFinishedWithMaxLevel = scorecard.isFinishedWithMaxLevel;
 
         // then
         expect(isFinishedWithMaxLevel).to.be.false;
@@ -105,7 +105,7 @@ describe('Unit | Model | Scorecard model', function() {
         scorecard.set('status', 'COMPLETED');
 
         // when
-        const isFinishedWithMaxLevel = scorecard.get('isFinishedWithMaxLevel');
+        const isFinishedWithMaxLevel = scorecard.isFinishedWithMaxLevel;
 
         // then
         expect(isFinishedWithMaxLevel).to.be.false;
@@ -117,7 +117,7 @@ describe('Unit | Model | Scorecard model', function() {
         scorecard.set('status', 'STARTED');
 
         // when
-        const isFinishedWithMaxLevel = scorecard.get('isFinishedWithMaxLevel');
+        const isFinishedWithMaxLevel = scorecard.isFinishedWithMaxLevel;
 
         // then
         expect(isFinishedWithMaxLevel).to.be.false;
@@ -134,7 +134,7 @@ describe('Unit | Model | Scorecard model', function() {
         scorecard.set('remainingDaysBeforeImproving', 0);
 
         // when
-        const isImprovable = scorecard.get('isImprovable');
+        const isImprovable = scorecard.isImprovable;
 
         // then
         expect(isImprovable).to.be.false;
@@ -149,7 +149,7 @@ describe('Unit | Model | Scorecard model', function() {
         scorecard.set('remainingDaysBeforeImproving', 0);
 
         // when
-        const isImprovable = scorecard.get('isImprovable');
+        const isImprovable = scorecard.isImprovable;
 
         // then
         expect(isImprovable).to.be.false;
@@ -164,7 +164,7 @@ describe('Unit | Model | Scorecard model', function() {
         scorecard.set('remainingDaysBeforeImproving', 1);
 
         // when
-        const isImprovable = scorecard.get('isImprovable');
+        const isImprovable = scorecard.isImprovable;
 
         // then
         expect(isImprovable).to.be.false;
@@ -179,7 +179,7 @@ describe('Unit | Model | Scorecard model', function() {
         scorecard.set('remainingDaysBeforeImproving', 0);
 
         // when
-        const isImprovable = scorecard.get('isImprovable');
+        const isImprovable = scorecard.isImprovable;
 
         // then
         expect(isImprovable).to.be.true;
@@ -193,7 +193,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('earnedPix', 0);
 
       // when
-      const hasNotEarnAnything = scorecard.get('hasNotEarnAnything');
+      const hasNotEarnAnything = scorecard.hasNotEarnAnything;
 
       // then
       expect(hasNotEarnAnything).to.be.true;
@@ -204,7 +204,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('earnedPix', 2);
 
       // when
-      const hasNotEarnAnything = scorecard.get('hasNotEarnAnything');
+      const hasNotEarnAnything = scorecard.hasNotEarnAnything;
 
       // then
       expect(hasNotEarnAnything).to.be.false;
@@ -217,7 +217,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('level', 0);
 
       // when
-      const hasNotReachLevelOne = scorecard.get('hasNotReachLevelOne');
+      const hasNotReachLevelOne = scorecard.hasNotReachLevelOne;
 
       // then
       expect(hasNotReachLevelOne).to.be.true;
@@ -228,7 +228,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('level', 1);
 
       // when
-      const hasNotReachLevelOne = scorecard.get('hasNotReachLevelOne');
+      const hasNotReachLevelOne = scorecard.hasNotReachLevelOne;
 
       // then
       expect(hasNotReachLevelOne).to.be.false;
@@ -239,7 +239,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('level', 2);
 
       // when
-      const hasNotReachLevelOne = scorecard.get('hasNotReachLevelOne');
+      const hasNotReachLevelOne = scorecard.hasNotReachLevelOne;
 
       // then
       expect(hasNotReachLevelOne).to.be.false;
@@ -252,7 +252,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('level', 1);
 
       // when
-      const hasReachAtLeastLevelOne = scorecard.get('hasReachAtLeastLevelOne');
+      const hasReachAtLeastLevelOne = scorecard.hasReachAtLeastLevelOne;
 
       // then
       expect(hasReachAtLeastLevelOne).to.be.true;
@@ -263,7 +263,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('level', 4);
 
       // when
-      const hasReachAtLeastLevelOne = scorecard.get('hasReachAtLeastLevelOne');
+      const hasReachAtLeastLevelOne = scorecard.hasReachAtLeastLevelOne;
 
       // then
       expect(hasReachAtLeastLevelOne).to.be.true;
@@ -274,7 +274,7 @@ describe('Unit | Model | Scorecard model', function() {
       scorecard.set('level', 0);
 
       // when
-      const hasReachAtLeastLevelOne = scorecard.get('hasReachAtLeastLevelOne');
+      const hasReachAtLeastLevelOne = scorecard.hasReachAtLeastLevelOne;
 
       // then
       expect(hasReachAtLeastLevelOne).to.be.false;

--- a/mon-pix/tests/unit/models/scorecard-test.js
+++ b/mon-pix/tests/unit/models/scorecard-test.js
@@ -23,7 +23,7 @@ describe('Unit | Model | Scorecard model', function() {
     ].forEach((data) => {
       it(`should return ${data.expectedPercentageAheadOfNextLevel} when pixScoreAheadOfNextLevel is ${data.pixScoreAheadOfNextLevel}`, function() {
         // given
-        scorecard.set('pixScoreAheadOfNextLevel', data.pixScoreAheadOfNextLevel);
+        scorecard.pixScoreAheadOfNextLevel = data.pixScoreAheadOfNextLevel;
 
         // when
         const percentageAheadOfNextLevel = scorecard.percentageAheadOfNextLevel;
@@ -37,7 +37,7 @@ describe('Unit | Model | Scorecard model', function() {
   describe('remainingPixToNextLevel', function() {
     it('should return 2 remaining Pix to next level', function() {
       // given
-      scorecard.set('pixScoreAheadOfNextLevel', 3);
+      scorecard.pixScoreAheadOfNextLevel = 3;
 
       // when
       const remainingPixToNextLevel = scorecard.remainingPixToNextLevel;
@@ -50,7 +50,7 @@ describe('Unit | Model | Scorecard model', function() {
   describe('isMaxLevel', function() {
     it('should return true', function() {
       // given
-      scorecard.set('level', maxReachableLevel);
+      scorecard.level = maxReachableLevel;
 
       // when
       const isMaxLevel = scorecard.isMaxLevel;
@@ -61,7 +61,7 @@ describe('Unit | Model | Scorecard model', function() {
 
     it('should return false', function() {
       // given
-      scorecard.set('level', 2);
+      scorecard.level = 2;
 
       // when
       const isMaxLevel = scorecard.isMaxLevel;
@@ -75,8 +75,8 @@ describe('Unit | Model | Scorecard model', function() {
     context('when max level is reached', function() {
       it('should return true', function() {
         // given
-        scorecard.set('level', maxReachableLevel);
-        scorecard.set('status', 'COMPLETED');
+        scorecard.level = maxReachableLevel;
+        scorecard.status = 'COMPLETED';
 
         // when
         const isFinishedWithMaxLevel = scorecard.isFinishedWithMaxLevel;
@@ -87,8 +87,8 @@ describe('Unit | Model | Scorecard model', function() {
 
       it('should return false', function() {
         // given
-        scorecard.set('level', maxReachableLevel);
-        scorecard.set('status', 'STARTED');
+        scorecard.level = maxReachableLevel;
+        scorecard.status = 'STARTED';
 
         // when
         const isFinishedWithMaxLevel = scorecard.isFinishedWithMaxLevel;
@@ -101,8 +101,8 @@ describe('Unit | Model | Scorecard model', function() {
     context('when max level is not reached', function() {
       it('should return true', function() {
         // given
-        scorecard.set('level', 3);
-        scorecard.set('status', 'COMPLETED');
+        scorecard.level = 3;
+        scorecard.status = 'COMPLETED';
 
         // when
         const isFinishedWithMaxLevel = scorecard.isFinishedWithMaxLevel;
@@ -113,8 +113,8 @@ describe('Unit | Model | Scorecard model', function() {
 
       it('should return false', function() {
         // given
-        scorecard.set('level', 3);
-        scorecard.set('status', 'STARTED');
+        scorecard.level = 3;
+        scorecard.status = 'STARTED';
 
         // when
         const isFinishedWithMaxLevel = scorecard.isFinishedWithMaxLevel;
@@ -129,9 +129,9 @@ describe('Unit | Model | Scorecard model', function() {
     context('when the competence is finished with max level', function() {
       it('should return false', function() {
         // given
-        scorecard.set('level', maxReachableLevel);
-        scorecard.set('status', 'COMPLETED');
-        scorecard.set('remainingDaysBeforeImproving', 0);
+        scorecard.level = maxReachableLevel;
+        scorecard.status = 'COMPLETED';
+        scorecard.remainingDaysBeforeImproving = 0;
 
         // when
         const isImprovable = scorecard.isImprovable;
@@ -144,9 +144,9 @@ describe('Unit | Model | Scorecard model', function() {
     context('when the competence is not finished', function() {
       it('should return false', function() {
         // given
-        scorecard.set('level', maxReachableLevel);
-        scorecard.set('status', 'STARTED');
-        scorecard.set('remainingDaysBeforeImproving', 0);
+        scorecard.level = maxReachableLevel;
+        scorecard.status = 'STARTED';
+        scorecard.remainingDaysBeforeImproving = 0;
 
         // when
         const isImprovable = scorecard.isImprovable;
@@ -159,9 +159,9 @@ describe('Unit | Model | Scorecard model', function() {
     context('when there are remaining days before improving', function() {
       it('should return false', function() {
         // given
-        scorecard.set('level', maxReachableLevel);
-        scorecard.set('status', 'COMPLETED');
-        scorecard.set('remainingDaysBeforeImproving', 1);
+        scorecard.level = maxReachableLevel;
+        scorecard.status = 'COMPLETED';
+        scorecard.remainingDaysBeforeImproving = 1;
 
         // when
         const isImprovable = scorecard.isImprovable;
@@ -174,9 +174,9 @@ describe('Unit | Model | Scorecard model', function() {
     context('when the competence is finished without reaching the max level and there are no remaining days before improving', function() {
       it('should return true', function() {
         // given
-        scorecard.set('level', 3);
-        scorecard.set('status', 'COMPLETED');
-        scorecard.set('remainingDaysBeforeImproving', 0);
+        scorecard.level = 3;
+        scorecard.status = 'COMPLETED';
+        scorecard.remainingDaysBeforeImproving = 0;
 
         // when
         const isImprovable = scorecard.isImprovable;
@@ -190,7 +190,7 @@ describe('Unit | Model | Scorecard model', function() {
   describe('hasNotEarnAnything', function() {
     it('should return true', function() {
       // given
-      scorecard.set('earnedPix', 0);
+      scorecard.earnedPix = 0;
 
       // when
       const hasNotEarnAnything = scorecard.hasNotEarnAnything;
@@ -201,7 +201,7 @@ describe('Unit | Model | Scorecard model', function() {
 
     it('should return false', function() {
       // given
-      scorecard.set('earnedPix', 2);
+      scorecard.earnedPix = 2;
 
       // when
       const hasNotEarnAnything = scorecard.hasNotEarnAnything;
@@ -214,7 +214,7 @@ describe('Unit | Model | Scorecard model', function() {
   describe('hasNotReachLevelOne', function() {
     it('should return true', function() {
       // given
-      scorecard.set('level', 0);
+      scorecard.level = 0;
 
       // when
       const hasNotReachLevelOne = scorecard.hasNotReachLevelOne;
@@ -225,7 +225,7 @@ describe('Unit | Model | Scorecard model', function() {
 
     it('should return false if level is 1', function() {
       // given
-      scorecard.set('level', 1);
+      scorecard.level = 1;
 
       // when
       const hasNotReachLevelOne = scorecard.hasNotReachLevelOne;
@@ -236,7 +236,7 @@ describe('Unit | Model | Scorecard model', function() {
 
     it('should return false if level > 1', function() {
       // given
-      scorecard.set('level', 2);
+      scorecard.level = 2;
 
       // when
       const hasNotReachLevelOne = scorecard.hasNotReachLevelOne;
@@ -249,7 +249,7 @@ describe('Unit | Model | Scorecard model', function() {
   describe('hasReachAtLeastLevelOne', function() {
     it('should return true if level is 1', function() {
       // given
-      scorecard.set('level', 1);
+      scorecard.level = 1;
 
       // when
       const hasReachAtLeastLevelOne = scorecard.hasReachAtLeastLevelOne;
@@ -260,7 +260,7 @@ describe('Unit | Model | Scorecard model', function() {
 
     it('should return true if level is 4', function() {
       // given
-      scorecard.set('level', 4);
+      scorecard.level = 4;
 
       // when
       const hasReachAtLeastLevelOne = scorecard.hasReachAtLeastLevelOne;
@@ -271,7 +271,7 @@ describe('Unit | Model | Scorecard model', function() {
 
     it('should return false', function() {
       // given
-      scorecard.set('level', 0);
+      scorecard.level = 0;
 
       // when
       const hasReachAtLeastLevelOne = scorecard.hasReachAtLeastLevelOne;

--- a/mon-pix/tests/unit/models/shared-profile-for-campaign-test.js
+++ b/mon-pix/tests/unit/models/shared-profile-for-campaign-test.js
@@ -24,7 +24,7 @@ describe('Unit | Model | SharedProfileForCampaign model', function() {
     model.set('scorecards', [scorecard1, scorecard2, scorecard3]);
 
     // when
-    const areasCode = model.get('areasCode');
+    const areasCode = model.areasCode;
 
     // then
     expect(areasCode).to.deep.equal([1, 2]);

--- a/mon-pix/tests/unit/models/shared-profile-for-campaign-test.js
+++ b/mon-pix/tests/unit/models/shared-profile-for-campaign-test.js
@@ -21,7 +21,7 @@ describe('Unit | Model | SharedProfileForCampaign model', function() {
     const scorecard3 = store.createRecord('scorecard', { area: area2 });
 
     const model = store.createRecord('sharedProfileForCampaign');
-    model.set('scorecards', [scorecard1, scorecard2, scorecard3]);
+    model.scorecards = [scorecard1, scorecard2, scorecard3];
 
     // when
     const areasCode = model.areasCode;

--- a/mon-pix/tests/unit/models/user-test.js
+++ b/mon-pix/tests/unit/models/user-test.js
@@ -20,8 +20,8 @@ describe('Unit | Model | user model', function() {
     it('should concatenate user first and last name', function() {
       // given
       const model = store.createRecord('user');
-      model.set('firstName', 'Manu');
-      model.set('lastName', 'Phillip');
+      model.firstName = 'Manu';
+      model.lastName = 'Phillip';
 
       // when
       const fullName = model.fullName;
@@ -36,9 +36,9 @@ describe('Unit | Model | user model', function() {
       // given
       const campaign = store.createRecord('campaign', { type: 'ASSESSMENT' });
       const participation = store.createRecord('campaign-participation');
-      participation.set('campaign', campaign);
+      participation.campaign = campaign;
       const model = store.createRecord('user');
-      model.set('campaignParticipations', [participation]);
+      model.campaignParticipations = [participation];
 
       // when
       const hasAssessmentParticipations = model.hasAssessmentParticipations;
@@ -51,9 +51,9 @@ describe('Unit | Model | user model', function() {
       // given
       const campaign = store.createRecord('campaign', { type: 'PROFILE_COLLECTION' });
       const participation = store.createRecord('campaign-participation');
-      participation.set('campaign', campaign);
+      participation.campaign = campaign;
       const model = store.createRecord('user');
-      model.set('campaignParticipations', [participation]);
+      model.campaignParticipations = [participation];
 
       // when
       const hasAssessmentParticipations = model.hasAssessmentParticipations;

--- a/mon-pix/tests/unit/models/user-test.js
+++ b/mon-pix/tests/unit/models/user-test.js
@@ -24,7 +24,7 @@ describe('Unit | Model | user model', function() {
       model.set('lastName', 'Phillip');
 
       // when
-      const fullName = model.get('fullName');
+      const fullName = model.fullName;
 
       // then
       expect(fullName).to.equal('Manu Phillip');
@@ -41,7 +41,7 @@ describe('Unit | Model | user model', function() {
       model.set('campaignParticipations', [participation]);
 
       // when
-      const hasAssessmentParticipations = model.get('hasAssessmentParticipations');
+      const hasAssessmentParticipations = model.hasAssessmentParticipations;
 
       // then
       expect(hasAssessmentParticipations).to.equal(true);
@@ -56,7 +56,7 @@ describe('Unit | Model | user model', function() {
       model.set('campaignParticipations', [participation]);
 
       // when
-      const hasAssessmentParticipations = model.get('hasAssessmentParticipations');
+      const hasAssessmentParticipations = model.hasAssessmentParticipations;
 
       // then
       expect(hasAssessmentParticipations).to.equal(false);
@@ -67,7 +67,7 @@ describe('Unit | Model | user model', function() {
       const model = store.createRecord('user');
 
       // when
-      const hasAssessmentParticipations = model.get('hasAssessmentParticipations');
+      const hasAssessmentParticipations = model.hasAssessmentParticipations;
 
       // then
       expect(hasAssessmentParticipations).to.equal(false);


### PR DESCRIPTION
## :unicorn: Problème
Depuis le passage à Octane, il n'est plus nécessaire d'utiliser les `.get` et `.set` sur les models.

## :robot: Solution
On les remplace par l'accès direct.

## :rainbow: Remarques
Pour les `.get`, on remplace `get\(['"](.*)['"]\)` par `$1`.
Pour les `.set`, on remplace `set\(['"](.*)['"],\s*(.*)\)` par `$1 = $2`.

## :100: Pour tester
Lancer les tests 🥳
