### PR TITLE
[FEATURE] Résilience Pôle emploi - Ajout d'un script de création a posteriori des pole-emploi-sendings (Pix-2483).

### DIFF
--- a/api/db/database-builder/factory/build-pole-emploi-sending.js
+++ b/api/db/database-builder/factory/build-pole-emploi-sending.js
@@ -1,0 +1,30 @@
+const buildCampaignParticipation = require('./build-campaign-participation');
+const databaseBuffer = require('../database-buffer');
+const _ = require('lodash');
+
+module.exports = function buildPoleEmploiSending({
+  id = databaseBuffer.getNextId(),
+  isSuccessful = true,
+  responseCode = '200',
+  type = 'CAMPAIGN_PARTICIPATION_START',
+  payload = {},
+  createdAt = new Date('2020-01-01'),
+  campaignParticipationId,
+} = {}) {
+
+  campaignParticipationId = _.isNil(campaignParticipationId) ? buildCampaignParticipation().id : campaignParticipationId;
+
+  const values = {
+    id,
+    isSuccessful,
+    responseCode,
+    type,
+    payload,
+    createdAt,
+    campaignParticipationId,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'pole-emploi-sendings',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -37,6 +37,7 @@ module.exports = {
   buildOrganizationTag: require('./build-organization-tag'),
   buildMembership: require('./build-membership'),
   buildPixRole: require('./build-pix-role'),
+  buildPoleEmploiSending: require('./build-pole-emploi-sending'),
   buildResetPasswordDemand: require('./build-reset-password-demand'),
   buildSession: require('./build-session'),
   buildSchoolingRegistration: require('./build-schooling-registration'),

--- a/api/scripts/prod/compute-pole-emploi-sendings.js
+++ b/api/scripts/prod/compute-pole-emploi-sendings.js
@@ -1,0 +1,172 @@
+// Usage: node compute-pole-emploi-sendings PIXEMPLOI 10
+const campaignRepository = require('../../lib/infrastructure/repositories/campaign-repository');
+const campaignParticipationResultRepository = require('../../lib/infrastructure/repositories/campaign-participation-result-repository');
+const targetProfileRepository = require('../../lib/infrastructure/repositories/target-profile-repository');
+const poleEmploiSendingRepository = require('../../lib/infrastructure/repositories/pole-emploi-sending-repository');
+const userRepository = require('../../lib/infrastructure/repositories/user-repository');
+const PoleEmploiPayload = require('../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload');
+const PoleEmploiSending = require('../../lib/domain/models/PoleEmploiSending');
+const { knex } = require('../../db/knex-database-connection');
+const bluebird = require('bluebird');
+let count;
+let total;
+
+async function computePoleEmploiSendings(campaignCode, concurrency) {
+  const campaignParticipationsStarted = await knex('campaign-participations')
+    .select('campaign-participations.id', 'campaign-participations.createdAt', 'campaign-participations.userId', 'campaign-participations.campaignId')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .join('organization-tags', 'organization-tags.organizationId', 'campaigns.organizationId')
+    .join('tags', 'tags.id', 'organization-tags.tagId')
+    .leftJoin('pole-emploi-sendings', function() {
+      this.on({ 'pole-emploi-sendings.campaignParticipationId': 'campaign-participations.id' })
+        .andOnVal('pole-emploi-sendings.type', PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START);
+    })
+    .where({ 'pole-emploi-sendings.id': null, 'tags.name': 'POLE EMPLOI', 'campaigns.code': campaignCode });
+  count = 0;
+  total = campaignParticipationsStarted.length;
+  console.log(`Participations commencées à traiter : ${total}`);
+
+  await bluebird.map(campaignParticipationsStarted, _computeStartedPoleEmploiSendings, { concurrency });
+
+  const campaignParticipationsCompleted = await knex('campaign-participations')
+    .select('campaign-participations.id', 'campaign-participations.createdAt', 'campaign-participations.userId', 'campaign-participations.campaignId', 'assessments.updatedAt as assessmentUpdatedAt')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .join('organization-tags', 'organization-tags.organizationId', 'campaigns.organizationId')
+    .join('tags', 'tags.id', 'organization-tags.tagId')
+    .join('assessments', 'assessments.campaignParticipationId', 'campaign-participations.id')
+    .leftJoin('pole-emploi-sendings', function() {
+      this.on({ 'pole-emploi-sendings.campaignParticipationId': 'campaign-participations.id' })
+        .andOnVal('pole-emploi-sendings.type', PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION);
+    })
+    .where({ 'pole-emploi-sendings.id': null, 'tags.name': 'POLE EMPLOI', 'campaigns.code': campaignCode, 'assessments.state': 'completed' });
+  count = 0;
+  total = campaignParticipationsCompleted.length;
+  console.log(`Participations terminées à traiter : ${total}`);
+
+  await bluebird.map(campaignParticipationsCompleted, _computeCompletedPoleEmploiSendings, { concurrency });
+
+  const campaignParticipationsShared = await knex('campaign-participations')
+    .select('campaign-participations.id', 'campaign-participations.createdAt', 'campaign-participations.userId', 'campaign-participations.campaignId', 'campaign-participations.sharedAt')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .join('organization-tags', 'organization-tags.organizationId', 'campaigns.organizationId')
+    .join('tags', 'tags.id', 'organization-tags.tagId')
+    .leftJoin('pole-emploi-sendings', function() {
+      this.on({ 'pole-emploi-sendings.campaignParticipationId': 'campaign-participations.id' })
+        .andOnVal('pole-emploi-sendings.type', PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING);
+    })
+    .where({ 'pole-emploi-sendings.id': null, 'tags.name': 'POLE EMPLOI', 'campaigns.code': campaignCode })
+    .whereNotNull('campaign-participations.sharedAt');
+  count = 0;
+  total = campaignParticipationsShared.length;
+  console.log(`Participations partagées à traiter : ${total}`);
+
+  await bluebird.map(campaignParticipationsShared, _computeSharedPoleEmploiSendings, { concurrency });
+}
+
+async function _computeStartedPoleEmploiSendings(participation) {
+  const user = await userRepository.get(participation.userId);
+  const campaign = await campaignRepository.get(participation.campaignId);
+  const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
+
+  const payload = PoleEmploiPayload.buildForParticipationStarted({
+    user,
+    campaign,
+    targetProfile,
+    participation,
+  });
+
+  const poleEmploiSending = PoleEmploiSending.buildForParticipationStarted({
+    campaignParticipationId: participation.id,
+    payload: payload.toString(),
+    isSuccessful: false,
+    responseCode: 'NOT_SENT',
+  });
+
+  await poleEmploiSendingRepository.create({ poleEmploiSending });
+
+  count++;
+  console.log(`${count} / ${total}`);
+}
+
+async function _computeCompletedPoleEmploiSendings(participation) {
+  const user = await userRepository.get(participation.userId);
+  const campaign = await campaignRepository.get(participation.campaignId);
+  const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
+  const assessment = { updatedAt: participation.assessmentUpdatedAt };
+
+  const payload = PoleEmploiPayload.buildForParticipationFinished({
+    user,
+    campaign,
+    targetProfile,
+    participation,
+    assessment,
+  });
+
+  const poleEmploiSending = PoleEmploiSending.buildForParticipationFinished({
+    campaignParticipationId: participation.id,
+    payload: payload.toString(),
+    isSuccessful: false,
+    responseCode: 'NOT_SENT',
+  });
+
+  await poleEmploiSendingRepository.create({ poleEmploiSending });
+
+  count++;
+  console.log(`${count} / ${total}`);
+}
+
+async function _computeSharedPoleEmploiSendings(participation) {
+  const user = await userRepository.get(participation.userId);
+  const campaign = await campaignRepository.get(participation.campaignId);
+  const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
+  const participationResult = await campaignParticipationResultRepository.getByParticipationId(participation.id);
+
+  const payload = PoleEmploiPayload.buildForParticipationShared({
+    user,
+    campaign,
+    targetProfile,
+    participation,
+    participationResult,
+  });
+
+  const poleEmploiSending = PoleEmploiSending.buildForParticipationShared({
+    campaignParticipationId: participation.id,
+    payload: payload.toString(),
+    isSuccessful: false,
+    responseCode: 'NOT_SENT',
+  });
+
+  await poleEmploiSendingRepository.create({ poleEmploiSending });
+
+  count++;
+  console.log(`${count} / ${total}`);
+}
+
+let exitCode;
+const SUCCESS = 0;
+const FAILURE = 1;
+const campaignCode = process.argv[2];
+const concurrency = parseInt(process.argv[3]);
+
+if (require.main === module) {
+  computePoleEmploiSendings(campaignCode, concurrency)
+    .then(handleSuccess)
+    .catch(handleError)
+    .finally(exit);
+}
+
+function handleSuccess() {
+  exitCode = SUCCESS;
+}
+
+function handleError(err) {
+  console.error(err);
+  exitCode = FAILURE;
+}
+
+function exit() {
+  console.log('code', exitCode);
+  process.exit(exitCode);
+}
+
+module.exports = computePoleEmploiSendings;

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
@@ -29,11 +29,11 @@ describe('Integration | Repository | Campaign Participation Result', () => {
           { id: 'recTube2', competenceId: 'rec2' },
         ],
         skills: [
-          { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1' },
-          { id: 'skill2', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1' },
-          { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
-          { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
-          { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
+          { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1' }, // skill previously validated in competence 1
+          { id: 'skill2', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1' }, // skill validated in competence 1
+          { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' }, // skill invalidated in competence 2
+          { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' }, // skill not tested
+          { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' }, // skill not in target profile
         ],
       };
 
@@ -71,7 +71,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
         sharedAt: new Date('2020-01-02'),
       });
 
-      databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed' });
+      const { id: assessmentId } = databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed', type: 'CAMPAIGN' });
       const knowledgeElementsAttributes = [
         {
           userId,
@@ -82,8 +82,9 @@ describe('Integration | Repository | Campaign Participation Result', () => {
         },
         {
           userId,
-          skillId: 'skill2',
-          competenceId: 'rec1',
+          assessmentId,
+          skillId: 'skill3',
+          competenceId: 'rec2',
           createdAt: new Date('2020-01-01'),
           status: KnowledgeElement.StatusType.INVALIDATED,
         },
@@ -125,7 +126,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
         sharedAt: new Date('2020-01-02'),
       });
 
-      databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed' });
+      const { id: assessmentId } = databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed', type: 'CAMPAIGN' });
 
       const knowledgeElementsAttributes = [
         {
@@ -137,6 +138,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
         },
         {
           userId,
+          assessmentId,
           skillId: 'skill2',
           competenceId: 'rec1',
           createdAt: new Date('2020-01-01'),
@@ -144,17 +146,11 @@ describe('Integration | Repository | Campaign Participation Result', () => {
         },
         {
           userId,
+          assessmentId,
           skillId: 'skill3',
           competenceId: 'rec2',
           createdAt: new Date('2020-01-01'),
           status: KnowledgeElement.StatusType.INVALIDATED,
-        },
-        {
-          userId,
-          skillId: 'skill4',
-          competenceId: 'rec2',
-          createdAt: new Date('2020-01-01'),
-          status: KnowledgeElement.StatusType.VALIDATED,
         },
       ];
 
@@ -186,9 +182,9 @@ describe('Integration | Repository | Campaign Participation Result', () => {
           index: '2.1',
           areaName: 'area2',
           areaColor: 'colorArea2',
-          testedSkillsCount: 2,
+          testedSkillsCount: 1,
           totalSkillsCount: 2,
-          validatedSkillsCount: 1,
+          validatedSkillsCount: 0,
         },
       ]);
     });
@@ -204,7 +200,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
           sharedAt: null,
         });
 
-        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed' });
+        const { id: assessmentId } = databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed', type: 'CAMPAIGN' });
         const knowledgeElementsAttributes = [
           {
             userId,
@@ -215,6 +211,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
           },
           {
             userId,
+            assessmentId,
             skillId: 'skill2',
             competenceId: 'rec1',
             createdAt: new Date('2020-01-01'),
@@ -253,7 +250,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
           sharedAt: new Date('2020-01-02'),
         });
 
-        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed' });
+        const { id: assessmentId } = databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed', type: 'CAMPAIGN' });
         databaseBuilder.factory.buildStage({ id: 10, title: 'StageO', message: 'Message0', targetProfileId, threshold: 0 });
         databaseBuilder.factory.buildStage({ id: 1, title: 'Stage1', message: 'Message1', targetProfileId, threshold: 10 });
         databaseBuilder.factory.buildStage({ id: 2, title: 'Stage2', message: 'Message2', targetProfileId, threshold: 50 });
@@ -269,6 +266,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
           },
           {
             userId,
+            assessmentId,
             skillId: 'skill2',
             competenceId: 'rec1',
             createdAt: new Date('2020-01-01'),
@@ -276,17 +274,11 @@ describe('Integration | Repository | Campaign Participation Result', () => {
           },
           {
             userId,
+            assessmentId,
             skillId: 'skill3',
             competenceId: 'rec2',
             createdAt: new Date('2020-01-01'),
             status: KnowledgeElement.StatusType.INVALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skill4',
-            competenceId: 'rec2',
-            createdAt: new Date('2020-01-01'),
-            status: KnowledgeElement.StatusType.VALIDATED,
           },
         ];
 
@@ -415,13 +407,6 @@ describe('Integration | Repository | Campaign Participation Result', () => {
               createdAt: new Date('2020-01-01'),
               status: KnowledgeElement.StatusType.INVALIDATED,
             },
-            {
-              userId,
-              skillId: 'skill4',
-              competenceId: 'rec2',
-              createdAt: new Date('2020-01-01'),
-              status: KnowledgeElement.StatusType.VALIDATED,
-            },
           ];
 
           databaseBuilder
@@ -456,9 +441,9 @@ describe('Integration | Repository | Campaign Participation Result', () => {
             areaName: undefined,
             index: undefined,
             name: 'BadgeCompt2',
-            testedSkillsCount: 2,
+            testedSkillsCount: 1,
             totalSkillsCount: 2,
-            validatedSkillsCount: 1,
+            validatedSkillsCount: 0,
           });
         });
       });

--- a/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
+++ b/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
@@ -1,0 +1,297 @@
+const _ = require('lodash');
+const { expect, databaseBuilder, domainBuilder, knex, learningContentBuilder, mockLearningContent, sinon } = require('../../../test-helper');
+const computePoleEmploiSendings = require('../../../../scripts/prod/compute-pole-emploi-sendings');
+const Campaign = require('../../../../lib/domain/models/Campaign');
+const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSending');
+
+function setLearningContent(learningContent) {
+  const learningObjects = learningContentBuilder.buildLearningContent(learningContent);
+  mockLearningContent(learningObjects);
+}
+
+describe('computePoleEmploiSendings', () => {
+
+  const code = 'CODEPE123';
+  let campaignParticipationId, userId, campaignId;
+  let skill1, skill2, competence1, competence2;
+
+  beforeEach(() => {
+    sinon.stub(console, 'log');
+
+    skill1 = domainBuilder.buildSkill({ id: 'skill1Id' }); // skill invalidated in assessment
+    skill2 = domainBuilder.buildSkill({ id: 'skill2Id' }); // skill validated in assessment
+    competence1 = domainBuilder.buildCompetence({ id: 'competence1Id', name: 'Competence 1', skillIds: [skill1.id] });
+    competence2 = domainBuilder.buildCompetence({ id: 'competence2Id', name: 'Competence 2', skillIds: [skill2.id] });
+    const learningContent = [{
+      id: 'areaId',
+      name: 'Area',
+      competences: [
+        {
+          id: competence1.id,
+          name: competence1.name,
+          tubes: [{
+            id: 'tube1Id',
+            skills: [
+              { id: skill1.id, nom: '@web1' },
+            ],
+          }],
+        },
+        {
+          id: competence2.id,
+          name: competence2.name,
+          tubes: [{
+            id: 'tube2Id',
+            skills: [
+              { id: skill2.id, nom: '@file1' },
+            ],
+          }],
+        },
+      ],
+    }];
+    setLearningContent(learningContent);
+
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const tagId = databaseBuilder.factory.buildTag({ name: 'POLE EMPLOI' }).id;
+    databaseBuilder.factory.buildOrganizationTag({ tagId, organizationId });
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile({ name: 'Diagnostic initial' }).id;
+    [skill1, skill2].forEach((skill) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skill.id }));
+    campaignId = databaseBuilder.factory.buildCampaign({ name: 'Campagne Pôle Emploi', code, type: Campaign.types.ASSESSMENT, organizationId, targetProfileId }).id;
+    userId = databaseBuilder.factory.buildUser({ firstName: 'Martin', lastName: 'Tamare' }).id;
+    return databaseBuilder.commit();
+  });
+
+  afterEach(() => {
+    return knex('pole-emploi-sendings').delete();
+  });
+
+  context('when pole emploi sendings is missing for status CAMPAIGN_PARTICIPATION_START', () => {
+    beforeEach(() => {
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isShared: false, sharedAt: null }).id;
+      databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'started', type: 'CAMPAIGN' });
+      return databaseBuilder.commit();
+    });
+
+    it('should create pole emploi sending', async () => {
+      const payload = {
+        campagne: {
+          nom: 'Campagne Pôle Emploi',
+          dateDebut: '2020-01-01T00:00:00.000Z',
+          dateFin: null,
+          type: 'EVALUATION',
+          codeCampagne: 'CODEPE123',
+          urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
+          nomOrganisme: 'Pix',
+          typeOrganisme: 'externe',
+        },
+        individu: {
+          nom: 'Tamare',
+          prenom: 'Martin',
+        },
+        test: {
+          etat: 2,
+          progression: 0,
+          typeTest: 'DI',
+          referenceExterne: campaignParticipationId,
+          dateDebut: '2020-01-01T00:00:00.000Z',
+          dateProgression: null,
+          dateValidation: null,
+          evaluation: null,
+          uniteEvaluation: 'A',
+          elementsEvalues: [],
+        },
+      };
+      const expectedResults = {
+        campaignParticipationId,
+        type: 'CAMPAIGN_PARTICIPATION_START',
+        isSuccessful: false,
+        responseCode: 'NOT_SENT',
+        payload,
+      };
+
+      await computePoleEmploiSendings(code, 1);
+
+      const [ poleEmploiSending ] = await knex('pole-emploi-sendings').where({ type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START });
+      expect(_.omit(poleEmploiSending, ['id', 'createdAt'])).to.deep.equal(expectedResults);
+    });
+  });
+
+  context('when pole emploi sendings is missing for status CAMPAIGN_PARTICIPATION_COMPLETION', () => {
+    beforeEach(() => {
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isShared: false, sharedAt: null }).id;
+      databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'completed', type: 'CAMPAIGN' });
+      return databaseBuilder.commit();
+    });
+
+    it('should create pole emploi sending', async () => {
+      const payload = {
+        campagne: {
+          nom: 'Campagne Pôle Emploi',
+          dateDebut: '2020-01-01T00:00:00.000Z',
+          dateFin: null,
+          type: 'EVALUATION',
+          codeCampagne: 'CODEPE123',
+          urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
+          nomOrganisme: 'Pix',
+          typeOrganisme: 'externe',
+        },
+        individu: {
+          nom: 'Tamare',
+          prenom: 'Martin',
+        },
+        test: {
+          etat: 3,
+          progression: 100,
+          typeTest: 'DI',
+          referenceExterne: campaignParticipationId,
+          dateDebut: '2020-01-01T00:00:00.000Z',
+          dateProgression: '2020-01-02T00:00:00.000Z',
+          dateValidation: null,
+          evaluation: null,
+          uniteEvaluation: 'A',
+          elementsEvalues: [],
+        },
+      };
+      const expectedResults = {
+        campaignParticipationId,
+        type: 'CAMPAIGN_PARTICIPATION_COMPLETION',
+        isSuccessful: false,
+        responseCode: 'NOT_SENT',
+        payload,
+      };
+
+      await computePoleEmploiSendings(code, 1);
+
+      const [ poleEmploiSending ] = await knex('pole-emploi-sendings').where({ type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION });
+      expect(_.omit(poleEmploiSending, ['id', 'createdAt'])).to.deep.equal(expectedResults);
+    });
+  });
+
+  context('when pole emploi sendings is missing for status CAMPAIGN_PARTICIPATION_COMPLETION and assessment has been improved', () => {
+    let oldAssessment, assessmentImproving;
+
+    beforeEach(() => {
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isShared: false, sharedAt: null }).id;
+      oldAssessment = databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'completed', type: 'CAMPAIGN', updatedAt: new Date('2020-10-10') });
+      assessmentImproving = databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'completed', type: 'CAMPAIGN', updatedAt: new Date('2020-12-12'), isImproving: true });
+      return databaseBuilder.commit();
+    });
+
+    it('should create pole emploi sending', async () => {
+      await computePoleEmploiSendings(code, 1);
+
+      const poleEmploiSendings = await knex('pole-emploi-sendings').where({ type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION });
+      expect(poleEmploiSendings).to.have.lengthOf(2);
+      expect(_.map(poleEmploiSendings, 'payload.test.dateProgression')).to.have.members([oldAssessment.updatedAt.toISOString(), assessmentImproving.updatedAt.toISOString()]);
+    });
+  });
+
+  context('when pole emploi sendings is missing for status CAMPAIGN_PARTICIPATION_SHARING', () => {
+    beforeEach(() => {
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isShared: true, sharedAt: new Date('2021-10-10') }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'completed', type: 'CAMPAIGN' }).id;
+      const ke1 = databaseBuilder.factory.buildKnowledgeElement({ status: 'validated', skillId: skill1.id, assessmentId, userId, competenceId: competence1.id });
+      const ke2 = databaseBuilder.factory.buildKnowledgeElement({ status: 'invalidated', skillId: skill2.id, assessmentId, userId, competenceId: competence1.id });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId, snappedAt: new Date('2021-10-10'), snapshot: JSON.stringify([ke1, ke2]) });
+      return databaseBuilder.commit();
+    });
+
+    it('should create pole emploi sending', async () => {
+      const payload = {
+        campagne: {
+          nom: 'Campagne Pôle Emploi',
+          dateDebut: '2020-01-01T00:00:00.000Z',
+          dateFin: null,
+          type: 'EVALUATION',
+          codeCampagne: 'CODEPE123',
+          urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
+          nomOrganisme: 'Pix',
+          typeOrganisme: 'externe',
+        },
+        individu: {
+          nom: 'Tamare',
+          prenom: 'Martin',
+        },
+        test: {
+          etat: 4,
+          progression: 100,
+          typeTest: 'DI',
+          referenceExterne: campaignParticipationId,
+          dateDebut: '2020-01-01T00:00:00.000Z',
+          dateProgression: '2021-10-10T00:00:00.000Z',
+          dateValidation: '2021-10-10T00:00:00.000Z',
+          evaluation: 50,
+          uniteEvaluation: 'A',
+          elementsEvalues: [{
+            libelle: 'Competence 1',
+            categorie: 'competence',
+            type: 'competence Pix',
+            domaineRattachement: 'Area',
+            nbSousElements: 1,
+            evaluation: {
+              scoreObtenu: 100,
+              uniteScore: 'A',
+              nbSousElementValide: 1,
+            },
+          }, {
+            libelle: 'Competence 2',
+            categorie: 'competence',
+            type: 'competence Pix',
+            domaineRattachement: 'Area',
+            nbSousElements: 1,
+            evaluation: {
+              scoreObtenu: 0,
+              uniteScore: 'A',
+              nbSousElementValide: 0,
+            },
+          }],
+        },
+      };
+      const expectedResults = {
+        campaignParticipationId,
+        type: 'CAMPAIGN_PARTICIPATION_SHARING',
+        isSuccessful: false,
+        responseCode: 'NOT_SENT',
+        payload,
+      };
+
+      await computePoleEmploiSendings(code, 1);
+
+      const [ poleEmploiSending ] = await knex('pole-emploi-sendings').where({ type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING });
+      expect(_.omit(poleEmploiSending, ['id', 'createdAt'])).to.deep.equal(expectedResults);
+    });
+  });
+
+  context('when pole emploi sendings is missing for all statuses', () => {
+    beforeEach(() => {
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isShared: true, sharedAt: new Date('2021-10-10') }).id;
+      databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'completed', type: 'CAMPAIGN' });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId, snappedAt: new Date('2021-10-10'), snapshot: JSON.stringify([]) });
+      return databaseBuilder.commit();
+    });
+
+    it('should create 3 pole emploi sendings', async () => {
+      await computePoleEmploiSendings(code, 1);
+
+      const poleEmploiSendings = await knex('pole-emploi-sendings');
+      expect(poleEmploiSendings).to.have.lengthOf(3);
+    });
+  });
+
+  context('when only one pole emploi sendings is missing', () => {
+    beforeEach(() => {
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isShared: true, sharedAt: new Date('2021-10-10') }).id;
+      databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId, type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START });
+      databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId, type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION });
+      databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'completed', type: 'CAMPAIGN' });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId, snappedAt: new Date('2021-10-10'), snapshot: JSON.stringify([]) });
+      return databaseBuilder.commit();
+    });
+
+    it('should only create pole emploi sending missing', async () => {
+      await computePoleEmploiSendings(code, 1);
+
+      const poleEmploiSendings = await knex('pole-emploi-sendings');
+      expect(poleEmploiSendings).to.have.lengthOf(3);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Afin d'être résilient quant à l'envoi des données à Pôle emploi, il est nécéssaire de mettre en place certaines choses.

## :robot: Solution
Etape 1 : Créer les enregistrements pole-emploi-sendings en base a posteriori.

## :rainbow: Remarques
Rien à signaler

## :100: Pour tester
- rajouter le tag "POLE EMPLOI" à la campagne AZERTY123 (car elle a déjà tout plein de participations)
- lancer le script `node compite-pole-emploi-sendings AZERTY123 <concurrency>`
