### PR TITLE
[TECH] Expliciter la stratégie de test du routeur dans les tests API.

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -62,7 +62,6 @@ const loadConfiguration = function() {
 };
 
 const setupErrorHandling = function(server) {
-
   server.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
 };
 

--- a/api/tests/integration/application/.eslintrc.js
+++ b/api/tests/integration/application/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  extends: '../../.eslintrc.yaml',
+  rules: {
+    'no-restricted-modules': ['error', {
+      'paths': [{
+        'name': '../../../server',
+        'message': 'Please use http-server-test instead.',
+      },
+      {
+        'name': '../../../../server',
+        'message': 'Please use http-server-test instead.',
+      },
+      ],
+    }],
+  },
+};

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -1,20 +1,20 @@
+const querystring = require('querystring');
+
 const {
   expect,
-  HttpTestServer,
   sinon,
 } = require('../../../test-helper');
 
-const querystring = require('querystring');
-
-const moduleUnderTest = require('../../../../lib/application/authentication');
+// eslint-disable-next-line no-restricted-modules
+const createServer = require('../../../../server');
 
 const authenticationController = require('../../../../lib/application/authentication/authentication-controller');
 
 describe('Integration | Application | Route | AuthenticationRouter', () => {
 
-  let httpTestServer;
+  let server;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(authenticationController, 'authenticateUser').callsFake((request, h) => h.response({
       token_type: 'bearer',
       access_token: 'some-jwt-access-token',
@@ -22,8 +22,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
     }));
     sinon.stub(authenticationController, 'authenticatePoleEmploiUser').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(authenticationController, 'authenticateAnonymousUser').callsFake((request, h) => h.response('ok').code(200));
-
-    httpTestServer = new HttpTestServer(moduleUnderTest, true);
+    server = await createServer();
   });
 
   describe('POST /api/token', () => {
@@ -54,7 +53,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -69,7 +68,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -83,7 +82,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -97,7 +96,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -112,7 +111,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -123,7 +122,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       headers['content-type'] = 'text/html';
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(415);
@@ -149,7 +148,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
 
     it('should return a response with HTTP status code 204 when route handler (a.k.a. controller) is successful', async () => {
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(204);
@@ -163,7 +162,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -176,7 +175,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -189,7 +188,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(204);
@@ -200,7 +199,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       headers['content-type'] = 'text/html';
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(415);
@@ -233,7 +232,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       payload.data.attributes.username = undefined;
 
       // when
-      const response = await httpTestServer.request(method, url, payload);
+      const response = await server.inject({ method, url, payload });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -244,7 +243,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       payload.data.attributes.password = undefined;
 
       // when
-      const response = await httpTestServer.request(method, url, payload);
+      const response = await server.inject({ method, url, payload });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -255,7 +254,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       payload.data.attributes['external-user-token'] = undefined;
 
       // when
-      const response = await httpTestServer.request(method, url, payload);
+      const response = await server.inject({ method, url, payload });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -266,7 +265,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       payload.data.attributes['expected-user-id'] = undefined;
 
       // when
-      const response = await httpTestServer.request(method, url, payload);
+      const response = await server.inject({ method, url, payload });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -297,7 +296,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
 
     it('should return a response with HTTP status code 200', async () => {
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -308,7 +307,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       headers['content-type'] = 'application/json';
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(415);
@@ -319,7 +318,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       payload = undefined;
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -333,7 +332,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -347,7 +346,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -361,7 +360,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       });
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -388,7 +387,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
 
     it('should return a response with HTTP status code 200', async () => {
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -399,7 +398,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       payload = querystring.stringify({});
 
       // when
-      const response = await httpTestServer.request(method, url, payload, null, headers);
+      const response = await server.inject({ method, url, payload, auth: null, headers });
 
       // then
       expect(response.statusCode).to.equal(400);

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-modules
-const createServer = require('../../../server');
 const { expect, sinon, HttpTestServer } = require('../../test-helper');
 const DomainErrors = require('../../../lib/domain/errors');
 
@@ -652,18 +650,14 @@ describe('Integration | API | Controller Error', () => {
   context('500 Internal Server Error', () => {
 
     const INTERNAL_SERVER_ERROR = 500;
-    let heavyweightServer;
-
-    beforeEach(async () => {
-      heavyweightServer = await createServer();
-      heavyweightServer.route({ method: 'GET', path: '/test_route', handler: routeHandler, config: { auth: false } });
-    });
 
     it('responds Internal Server Error error when another error occurs', async () => {
       routeHandler.throws(new Error('Unexpected Error'));
-      const response = await heavyweightServer.inject(request);
-      const payload = JSON.parse(response.payload);
+      // when
+      const response = await server.requestObject(request);
 
+      // then
+      const payload = JSON.parse(response.payload);
       expect(response.statusCode).to.equal(INTERNAL_SERVER_ERROR);
       expect(payload.message).to.equal('An internal server error occurred');
     });

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -7,7 +7,9 @@ describe('Integration | API | Controller Error', () => {
 
   let server;
   const routeHandler = sinon.stub();
-  const options = { method: 'GET', url: '/test_route' };
+
+  const routeUrl = '/test_route';
+  const request = { method: 'GET', url: routeUrl };
 
   function responseDetail(response) {
     const payload = JSON.parse(response.payload);
@@ -25,7 +27,7 @@ describe('Integration | API | Controller Error', () => {
       register: async function(server) {
         server.route([{
           method: 'GET',
-          path: '/test_route',
+          path: routeUrl,
           handler: routeHandler,
           config: {
             auth: false,
@@ -41,7 +43,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Precondition Failed when a AlreadyExistingEntityError occurs', async () => {
       routeHandler.throws(new DomainErrors.AlreadyExistingEntityError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
       expect(responseDetail(response)).to.equal('L’entité existe déjà.');
@@ -49,7 +51,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Precondition Failed when a AlreadyRatedAssessmentError error occurs', async () => {
       routeHandler.throws(new DomainErrors.AlreadyRatedAssessmentError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
       expect(responseDetail(response)).to.equal('Assessment is already rated.');
@@ -57,7 +59,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Precondition Failed when a CompetenceResetError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CompetenceResetError(2));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
       expect(responseDetail(response)).to.equal('Il reste 2 jours avant de pouvoir réinitiliser la compétence.');
@@ -65,7 +67,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Precondition Failed when a AlreadyExistingMembershipError error occurs', async () => {
       routeHandler.throws(new DomainErrors.AlreadyExistingMembershipError('Le membership existe déjà.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
       expect(responseDetail(response)).to.equal('Le membership existe déjà.');
@@ -73,7 +75,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Precondition Failed when a AlreadyExistingOrganizationInvitationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.AlreadyExistingOrganizationInvitationError('L\'invitation de l\'organisation existe déjà.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
       expect(responseDetail(response)).to.equal('L\'invitation de l\'organisation existe déjà.');
@@ -81,7 +83,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Precondition Failed when a AlreadySharedCampaignParticipationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.AlreadySharedCampaignParticipationError('Ces résultats de campagne ont déjà été partagés.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
       expect(responseDetail(response)).to.equal('Ces résultats de campagne ont déjà été partagés.');
@@ -89,28 +91,28 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Precondition Failed when a AlreadyExistingCampaignParticipationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.AlreadyExistingCampaignParticipationError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
     });
 
     it('responds Precondition Failed when a CsvImportError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CsvImportError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
     });
 
     it('responds Precondition Failed when a SiecleXmlImportError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SiecleXmlImportError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
     });
 
     it('responds Precondition Failed when a TargetProfileInvalidError error occurs', async () => {
       routeHandler.throws(new DomainErrors.TargetProfileInvalidError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
     });
@@ -121,7 +123,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Not Found when a DomainError.NotFoundError error occurs', async () => {
       routeHandler.throws(new DomainErrors.NotFoundError('Entity Not Found'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('Entity Not Found');
@@ -129,7 +131,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Not Found when a CampaignCodeError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CampaignCodeError('Campaign Code Error'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('Campaign Code Error');
@@ -137,7 +139,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Not Found when a CertificationCandidateByPersonalInfoNotFoundError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CertificationCandidateByPersonalInfoNotFoundError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('Aucun candidat de certification ne correspond aux informations d\'identité fournies.');
@@ -145,7 +147,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Not Found when a UserNotFoundError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotFoundError('Ce compte est introuvable.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('Ce compte est introuvable.');
@@ -153,7 +155,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Not Found when a PasswordResetDemandNotFoundError error occurs', async () => {
       routeHandler.throws(new DomainErrors.PasswordResetDemandNotFoundError('La demande de réinitialisation de mot de passe n\'existe pas.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('La demande de réinitialisation de mot de passe n\'existe pas.');
@@ -161,7 +163,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Not Found when a NoCertificationResultForDivision error occurs', async () => {
       routeHandler.throws(new DomainErrors.NoCertificationResultForDivision());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('Aucun résultat de certification pour cette classe.');
@@ -169,7 +171,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Not Found when a ChallengeToBeNeutralizedNotFoundError error occurs', async () => {
       routeHandler.throws(new DomainErrors.ChallengeToBeNeutralizedNotFoundError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('La question à neutraliser n\'a pas été posée lors du test de certification');
@@ -189,7 +191,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Conflict when a CertificationCandidateByPersonalInfoTooManyMatchesError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CertificationCandidateByPersonalInfoTooManyMatchesError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(CONFLICT_ERROR);
       expect(responseDetail(response)).to.equal('Plus d\'un candidat de certification correspondent aux informations d\'identité fournies.');
@@ -197,7 +199,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Conflict when a ChallengeAlreadyAnsweredError error occurs', async () => {
       routeHandler.throws(new DomainErrors.ChallengeAlreadyAnsweredError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(CONFLICT_ERROR);
       expect(responseDetail(response)).to.equal('This challenge has already been answered.');
@@ -205,7 +207,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Conflict when a AssessmentNotCompletedError error occurs', async () => {
       routeHandler.throws(new DomainErrors.AssessmentNotCompletedError('Cette évaluation n\'est pas terminée.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(CONFLICT_ERROR);
       expect(responseDetail(response)).to.equal('Cette évaluation n\'est pas terminée.');
@@ -213,7 +215,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Conflict when a SchoolingRegistrationAlreadyLinkedToUserError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SchoolingRegistrationAlreadyLinkedToUserError('L\'élève est déjà rattaché à un compte utilisateur.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(CONFLICT_ERROR);
       expect(responseDetail(response)).to.equal('L\'élève est déjà rattaché à un compte utilisateur.');
@@ -221,7 +223,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Conflict when a SameNationalStudentIdInOrganizationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SameNationalStudentIdInOrganizationError('(ABC123)'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(CONFLICT_ERROR);
       expect(responseDetail(response)).to.equal('The INE ABC123 is already in use for this organization.');
@@ -229,7 +231,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Conflict when a SameNationalApprenticeIdInOrganizationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SameNationalApprenticeIdInOrganizationError('(ABC123)'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(CONFLICT_ERROR);
       expect(responseDetail(response)).to.equal('The INA ABC123 is already in use for this organization.');
@@ -241,7 +243,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserNotAuthorizedToAccessEntityError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotAuthorizedToAccessEntityError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Utilisateur non autorisé à accéder à la ressource');
@@ -249,7 +251,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserNotAuthorizedToUpdateResourceError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotAuthorizedToUpdateResourceError('Utilisateur non autorisé à mettre à jour à la ressource'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Utilisateur non autorisé à mettre à jour à la ressource');
@@ -257,7 +259,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserNotAuthorizedToCreateCampaignError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotAuthorizedToCreateCampaignError('Utilisateur non autorisé à créer une campagne'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Utilisateur non autorisé à créer une campagne');
@@ -265,7 +267,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserNotAuthorizedToGetCertificationCoursesError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotAuthorizedToGetCertificationCoursesError('Cet utilisateur n\'est pas autorisé à récupérer ces certification courses.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Cet utilisateur n\'est pas autorisé à récupérer ces certification courses.');
@@ -273,7 +275,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a CertificationCandidateAlreadyLinkedToUserError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CertificationCandidateAlreadyLinkedToUserError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Le candidat de certification est déjà lié à un utilisateur.');
@@ -281,7 +283,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a CertificationCandidateForbiddenDeletionError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CertificationCandidateForbiddenDeletionError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Il est interdit de supprimer un candidat de certification déjà lié à un utilisateur.');
@@ -289,7 +291,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a ForbiddenAccess error occurs', async () => {
       routeHandler.throws(new DomainErrors.ForbiddenAccess('Accès non autorisé.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Accès non autorisé.');
@@ -297,7 +299,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserAlreadyLinkedToCandidateInSessionError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserAlreadyLinkedToCandidateInSessionError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('L\'utilisateur est déjà lié à un candidat dans cette session.');
@@ -305,7 +307,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserNotAuthorizedToCertifyError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotAuthorizedToCertifyError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('The user cannot be certified.');
@@ -313,7 +315,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserNotAuthorizedToGetCampaignResultsError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotAuthorizedToGetCampaignResultsError('Cet utilisateur n\'est pas autorisé à récupérer les résultats de la campagne.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Cet utilisateur n\'est pas autorisé à récupérer les résultats de la campagne.');
@@ -321,7 +323,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserNotAuthorizedToUpdatePasswordError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotAuthorizedToUpdatePasswordError('Cet utilisateur n\'est pas autorisé à récupérer les résultats de la campagne.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Cet utilisateur n\'est pas autorisé à récupérer les résultats de la campagne.');
@@ -329,7 +331,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a UserNotAuthorizedToCreateResourceError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotAuthorizedToCreateResourceError('Cet utilisateur n\'est pas autorisé à créer la ressource.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Cet utilisateur n\'est pas autorisé à créer la ressource.');
@@ -337,7 +339,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a ImproveCompetenceEvaluationForbiddenError error occurs', async () => {
       routeHandler.throws(new DomainErrors.ImproveCompetenceEvaluationForbiddenError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Le niveau maximum est déjà atteint pour cette compétence.');
@@ -346,7 +348,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Forbidden when a ApplicationScopeNotAllowedError error occurs', async () => {
       routeHandler.throws(new DomainErrors.ApplicationScopeNotAllowedError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('The scope is not allowed.');
@@ -359,7 +361,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a CertificationCandidatePersonalInfoFieldMissingError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CertificationCandidatePersonalInfoFieldMissingError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Un ou plusieurs champs d\'informations d\'identité sont manquants.');
@@ -367,7 +369,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a CertificationCandidatePersonalInfoWrongFormat error occurs', async () => {
       routeHandler.throws(new DomainErrors.CertificationCandidatePersonalInfoWrongFormat());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Un ou plusieurs champs d\'informations d\'identité sont au mauvais format.');
@@ -375,7 +377,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a CertificationCenterMembershipCreationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.CertificationCenterMembershipCreationError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Le membre ou le centre de certification n\'existe pas.');
@@ -383,7 +385,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a InvalidCertificationReportForFinalization error occurs', async () => {
       routeHandler.throws(new DomainErrors.InvalidCertificationReportForFinalization('Echec lors de la validation du certification course'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Echec lors de la validation du certification course');
@@ -391,7 +393,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a MembershipCreationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.MembershipCreationError('Erreur lors de la création du membership à une organisation.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Erreur lors de la création du membership à une organisation.');
@@ -399,7 +401,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a MembershipUpdateError error occurs', async () => {
       routeHandler.throws(new DomainErrors.MembershipUpdateError('Erreur lors de la mise à jour du membership à une organisation.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Erreur lors de la mise à jour du membership à une organisation.');
@@ -407,7 +409,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a SchoolingRegistrationsCouldNotBeSavedError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SchoolingRegistrationsCouldNotBeSavedError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('An error occurred during process');
@@ -415,7 +417,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a WrongDateFormatError error occurs', async () => {
       routeHandler.throws(new DomainErrors.WrongDateFormatError('Format de date invalide.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Format de date invalide.');
@@ -423,7 +425,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a SessionAlreadyFinalizedError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SessionAlreadyFinalizedError('Erreur, tentatives de finalisation multiples de la session.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Erreur, tentatives de finalisation multiples de la session.');
@@ -431,7 +433,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a SessionAlreadyPublishedError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SessionAlreadyPublishedError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('La session est déjà publiée.');
@@ -439,7 +441,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Bad Request when a UserOrgaSettingsCreationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserOrgaSettingsCreationError('Erreur lors de la création des paramètres utilisateur relatifs à Pix Orga.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
       expect(responseDetail(response)).to.equal('Erreur lors de la création des paramètres utilisateur relatifs à Pix Orga.');
@@ -451,7 +453,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unprocessable Entity when a ObjectValidationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.ObjectValidationError('Erreur, objet non valide.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
       expect(responseDetail(response)).to.equal('Erreur, objet non valide.');
@@ -460,7 +462,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unprocessable Entity when a FileValidationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.FileValidationError('Erreur, fichier non valide.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
       expect(responseDetail(response)).to.equal('An error occurred, file is invalid');
@@ -468,7 +470,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unprocessable Entity when a UserNotMemberOfOrganizationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserNotMemberOfOrganizationError('L\'utilisateur n\'est pas membre de l\'organisation.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
       expect(responseDetail(response)).to.equal('L\'utilisateur n\'est pas membre de l\'organisation.');
@@ -483,7 +485,7 @@ describe('Integration | API | Controller Error', () => {
       routeHandler.throws(new DomainErrors.EntityValidationError({ invalidAttributes }));
 
       // when
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
@@ -507,7 +509,7 @@ describe('Integration | API | Controller Error', () => {
       routeHandler.throws(new DomainErrors.EntityValidationError({ invalidAttributes }));
 
       // when
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
@@ -531,7 +533,7 @@ describe('Integration | API | Controller Error', () => {
       routeHandler.throws(new DomainErrors.EntityValidationError({ invalidAttributes }));
 
       // when
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
@@ -561,7 +563,7 @@ describe('Integration | API | Controller Error', () => {
       routeHandler.throws(new DomainErrors.EntityValidationError({ invalidAttributes }));
 
       // when
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       // then
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
@@ -572,7 +574,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds UnprocessableEntity when a CertificationCandidatesImportError occurs', async () => {
       routeHandler.throws(new DomainErrors.CertificationCandidatesImportError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
     });
@@ -583,7 +585,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unauthorized when a MissingOrInvalidCredentialsError error occurs', async () => {
       routeHandler.throws(new DomainErrors.MissingOrInvalidCredentialsError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal('L\'adresse e-mail et/ou le mot de passe saisis sont incorrects.');
@@ -591,7 +593,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unauthorized when a InvalidTemporaryKeyError error occurs', async () => {
       routeHandler.throws(new DomainErrors.InvalidTemporaryKeyError('Demande de réinitialisation invalide.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal('Demande de réinitialisation invalide.');
@@ -599,7 +601,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unauthorized when a InvalidResultRecipientTokenError error occurs', async () => {
       routeHandler.throws(new DomainErrors.InvalidResultRecipientTokenError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal('Le token de récupération des résultats de la session de certification est invalide.');
@@ -607,7 +609,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unauthorized when a UserShouldChangePasswordError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserShouldChangePasswordError('Erreur, vous devez changer votre mot de passe.'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal('Erreur, vous devez changer votre mot de passe.');
@@ -616,7 +618,7 @@ describe('Integration | API | Controller Error', () => {
     it('when a UserShouldChangePasswordError error is thrown', async () => {
       const expectedMessage = 'L\'utilisateur n\'a pas de compte Pix';
       routeHandler.throws(new DomainErrors.UserAccountNotFoundForPoleEmploiError(expectedMessage));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal(expectedMessage);
@@ -624,7 +626,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unauthorized when a UserCantBeCreatedError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserCantBeCreatedError('L\'utilisateur ne peut pas être créé'));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal('L\'utilisateur ne peut pas être créé');
@@ -632,7 +634,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unauthorized when a ApplicationWithInvalidClientSecretError error occurs', async () => {
       routeHandler.throws(new DomainErrors.ApplicationWithInvalidClientSecretError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal('The client secret is invalid.');
@@ -640,7 +642,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Unauthorized when a ApplicationWithInvalidClientIdError error occurs', async () => {
       routeHandler.throws(new DomainErrors.ApplicationWithInvalidClientIdError());
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal('The client ID is invalid.');
@@ -659,7 +661,7 @@ describe('Integration | API | Controller Error', () => {
 
     it('responds Internal Server Error error when another error occurs', async () => {
       routeHandler.throws(new Error('Unexpected Error'));
-      const response = await heavyweightServer.inject(options);
+      const response = await heavyweightServer.inject(request);
       const payload = JSON.parse(response.payload);
 
       expect(response.statusCode).to.equal(INTERNAL_SERVER_ERROR);
@@ -671,7 +673,7 @@ describe('Integration | API | Controller Error', () => {
     const SERVICE_UNAVAILABLE_ERROR = 503;
     it('responds ServiceUnavailable when a SendingEmailToResultRecipientError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SendingEmailToResultRecipientError(['toto@pix.fr', 'titi@pix.fr']));
-      const response = await server.inject(options);
+      const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
       expect(responseDetail(response)).to.equal('Échec lors de l\'envoi des résultats au(x) destinataire(s) : toto@pix.fr, titi@pix.fr');

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -1,7 +1,5 @@
 const Hapi = require('@hapi/hapi');
 
-const authentication = require('../../../lib/infrastructure/authentication');
-
 const preResponseUtils = require('../../../lib/application/pre-response-utils');
 const { handleFailAction } = require('../../../lib/validate');
 
@@ -26,7 +24,7 @@ const routesConfig = {
  */
 class HttpTestServer {
 
-  constructor(moduleUnderTest, enableAuthentication = false) {
+  constructor(moduleUnderTest) {
     this.hapiServer = Hapi.server(routesConfig);
 
     this.hapiServer.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -27,12 +27,16 @@ class HttpTestServer {
   constructor(moduleUnderTest) {
     this.hapiServer = Hapi.server(routesConfig);
 
-    this.hapiServer.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
+    this._setupErrorHandling();
 
     // register returns a promise, which is ignored
     // TODO: extract register in a separate async method
     // https://stackoverflow.com/questions/43431550/async-await-class-constructor
     this.hapiServer.register(moduleUnderTest);
+  }
+
+  _setupErrorHandling() {
+    this.hapiServer.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
   }
 
   request(method, url, payload, auth, headers) {

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -50,6 +50,11 @@ class HttpTestServer {
   request(method, url, payload, auth, headers) {
     return this.hapiServer.inject({ method, url, payload, auth, headers });
   }
+
+  inject({ method, url, payload, auth, headers }) {
+    return this.hapiServer.inject({ method, url, payload, auth, headers });
+  }
+
 }
 
 module.exports = HttpTestServer;

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -51,7 +51,7 @@ class HttpTestServer {
     return this.hapiServer.inject({ method, url, payload, auth, headers });
   }
 
-  inject({ method, url, payload, auth, headers }) {
+  requestObject({ method, url, payload, auth, headers }) {
     return this.hapiServer.inject({ method, url, payload, auth, headers });
   }
 

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -28,10 +28,6 @@ class HttpTestServer {
     this.hapiServer = Hapi.server(routesConfig);
 
     this.hapiServer.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
-    this.hapiServer.events.on({ name: 'request', channels: 'error' }, (request, event) => {
-      // eslint-disable-next-line no-console
-      console.error(event.error);
-    });
 
     // register returns a promise, which is ignored
     // TODO: extract register in a separate async method

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -33,13 +33,9 @@ class HttpTestServer {
       console.error(event.error);
     });
 
-    if (enableAuthentication) {
-      this.hapiServer.auth.scheme(authentication.schemeName, authentication.scheme);
-      authentication.strategies.map((strategy) => {
-        this.hapiServer.auth.strategy(strategy.name, authentication.schemeName, strategy.configuration);
-      });
-      this.hapiServer.auth.default(authentication.defaultStrategy);
-    }
+    // register returns a promise, which is ignored
+    // TODO: extract register in a separate async method
+    // https://stackoverflow.com/questions/43431550/async-await-class-constructor
     this.hapiServer.register(moduleUnderTest);
   }
 

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -1,5 +1,4 @@
 const Hapi = require('@hapi/hapi');
-const Inert = require('@hapi/inert');
 
 const authentication = require('../../../lib/infrastructure/authentication');
 
@@ -43,7 +42,6 @@ class HttpTestServer {
       });
       this.hapiServer.auth.default(authentication.defaultStrategy);
     }
-    this.hapiServer.register(Inert);
     this.hapiServer.register(moduleUnderTest);
   }
 

--- a/api/tests/unit/tooling/http-test-server_test.js
+++ b/api/tests/unit/tooling/http-test-server_test.js
@@ -1,4 +1,4 @@
-const { expect, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const { expect } = require('../../test-helper');
 
 const HttpTestServer = require('../../tooling/server/http-test-server');
 
@@ -21,73 +21,5 @@ describe('Unit | Tooling | Http-test-server', () => {
       expect(httpTestServer.hapiServer._core.extensions.route.onPreResponse.nodes[0].func.name).to.equal('handleDomainAndHttpErrors');
     });
 
-    describe('when authentication is enabled, using default strategy', async () => {
-
-      let httpTestServerWithAuthentication;
-
-      before(() => {
-        const moduleUnderTest = {
-          name: 'foo-route',
-          register: async function(server) {
-            server.route([{
-              method: 'GET',
-              path: '/foo',
-              config: {
-                handler: () => {
-                  return 'bar';
-                },
-              },
-            }]);
-          },
-        };
-        httpTestServerWithAuthentication = new HttpTestServer(moduleUnderTest, true);
-      });
-
-      it('should answer unauthorized if no authentication is provided', async () => {
-
-        // given
-        const request = {
-          method: 'GET',
-          url: '/foo',
-        };
-
-        // when
-        const response = await httpTestServerWithAuthentication.request(request.method, request.url, null, null);
-
-        // then
-        expect(response.statusCode).to.equal(401);
-      });
-
-      it('should answer unauthorized if authentication is invalid', async () => {
-
-        // given
-        const request = {
-          method: 'GET',
-          url: '/foo',
-          headers: { authorization: 'invalidToken' },
-        };
-
-        // when
-        const response = await httpTestServerWithAuthentication.request(request.method, request.url, null, null, request.headers);
-
-        // then
-        expect(response.statusCode).to.equal(401);
-      });
-
-      it('should answer OK if authentication is valid', async () => {
-        // given
-        const request = {
-          method: 'GET',
-          url: '/foo',
-          headers: { authorization: generateValidRequestAuthorizationHeader() },
-        };
-
-        // when
-        const response = await httpTestServerWithAuthentication.request(request.method, request.url, null, null, request.headers);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-      });
-    });
   });
 });

--- a/docs/adr/0024-tester-routeur-api.md
+++ b/docs/adr/0024-tester-routeur-api.md
@@ -1,0 +1,93 @@
+# 24. Comment tester le routeur API ?
+
+Date : 2021-04-16
+
+## État
+Adopté
+
+## Contexte 
+
+### Général
+Nous avons besoin de tests qui :
+- empêchent les régressions
+- fournissent un feedback rapide (s'exécutent rapidement)
+- ne causent pas de faux positifs
+- soient simples à comprendre, pour être facilement modifiés
+
+Le routeur de l'API (fourni par HAPI) accepte la configuration suivante pour chaque route:
+- le nom de la route (path) et son verbe
+- une validation syntaxique de la requête (effectué par JOI)
+- une validation de sécurité de la requête (authentification)
+- le controller à appeler si requête est validée 
+
+Les tests du routeur, c’est-à-dire configuré avec les routes Pix, ont pour but de tester 
+ces configurations en satisfaisant les critères (tous ne pouvant être satisfaits en même temps).
+
+### Spécifique
+
+HAPI [préconise](https://hapi.dev/tutorials/testing/) 
+- de ne pas faire de tests depuis l'extérieur (appel HTTP)
+- mais d'utiliser la fonction `server.inject`
+
+Cette pratique est déjà en place. 
+La question à traiter ici est : quel type de serveur démarrer ? 
+
+### Type de test
+Le routeur est soumis à deux types de test :
+- intégration avec le contrôleur : vérifier que la valeur de retour du handler est renvoyée par le routeur au client
+- acceptance : vérifier que le routeur effectue les vérifications, appelle le handler et renvoie la valeur de retour
+
+Le test d'intégration n'a pas besoin que le routeur transmette des valeurs au controlleur, car celui-ci est stubbé pour renvoyer une valeur.
+On peut donc se passer des vérifications syntaxiques et de sécurité. 
+
+Dans les tests d'acceptance, les tests utilisent les composants réels (controller, use-case/repository). Comme l'identification du client se 
+fait via le token, il n'est pas possible de désactiver l'authentification, sinon le `userId` n'est pas disponible dans `request.auth.credentials`.
+De plus, les tests d'acceptance ont pour but premier de prévenir des régressions, ce qui suppose d'utiliser une configuration proche de la production.
+
+**On ne peut donc pas se passer des vérifications syntaxiques et de sécurité.**
+
+### Type de serveurs
+
+#### Serveur de production (lourd)
+Appellé [server.js](../../api/server.js), il est démarré en un appel par le [script racine](../../api/bin/www). 
+
+Avantages :
+- protège complètement des régressions
+
+Inconvénients :
+- feedback moins rapide qu'un serveur léger (démarrage plus lent)
+- n'attire pas l'attention du développeur sur les routes en cours de tests
+
+#### Serveur de test (léger) 
+Appelé [http-test-server](../../api/tests/tooling/http-test-server.js), il ne contient uniquement instance Hapi sans routes.
+Aucun plugin n'est chargé. La route à tester doit lui être indiqué, auquel cas il appliquera la validation syntaxique.
+
+Avantages :
+- focalisation du développeur sur la route à tester
+- feedback plus rapide qu'un serveur lourd (démarrage plus rapide)
+
+Inconvénients :
+- protège moins des régressions (ne permet pas de tester les plugins et la validation de sécurité)
+
+### Solution n°1 : Utiliser un serveur de production (lourd) partout
+Avantages :
+- protège complètement des régressions
+- simplifie le choix pour le développeur
+
+Inconvénients :
+- feedback moins rapide qu'un serveur léger
+- n'attire pas l'attention du développeur sur les routes en cours de tests
+
+### Solution n°2 : Utiliser un serveur de test (léger) dans les tests d'intégration
+Avantages pour les tests d'intégration :
+- exécution plus rapide
+- facilite l'écriture en permettant de ne pas utiliser de token 
+
+Inconvénients :
+- le développeur doit connaître le serveur de test et où l'utiliser
+
+## Décision
+La solution n°2 est adoptée, car elle est déjà largement utilisée.
+
+## Conséquences
+Ajouter une règle de lint pour indiquer le serveur à utiliser dans les tests d'intégration.


### PR DESCRIPTION
## :unicorn: Problème
Les raisons de l'usage du serveur de test  léger `http-test-server` ne sont pas explicites.

## :robot: Solution
Documenter les raisons dans un ADR

## :rainbow: Remarques
Ajout d'une règle de lint pour préconiser son usage

Suppression des fonctionnalités inutiles
- authentification
- plugin Inert
- log des erreurs

## :100: Pour tester
Vérifier que la CI passe
