### PR TITLE
[BUGFIX] Corrige la récupération des badges

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -1,5 +1,8 @@
 extends: '../.eslintrc.yaml'
 
+parserOptions:
+  ecmaVersion: 2020
+
 globals:
   include: true
 

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -30,7 +30,7 @@ module.exports = {
       },
       transform(record) {
         record.badgeCriteria.forEach((badgeCriterion) => {
-          badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds.map((partnerCompetenceId) => {
+          badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds?.map((partnerCompetenceId) => {
             return { id: partnerCompetenceId };
           });
         });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -16,6 +16,66 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
         title: 'Banana',
         targetProfileId: '1',
         isCertifiable: false,
+        badgeCriteria: [
+          domainBuilder.buildBadgeCriterion({ partnerCompetenceIds: null }),
+        ],
+        badgePartnerCompetences: [],
+      });
+
+      const expectedSerializedBadge = {
+        data: {
+          attributes: {
+            'alt-message': 'You won a banana badge',
+            'image-url': '/img/banana.svg',
+            'is-certifiable': false,
+            message: 'Congrats, you won a banana badge',
+            title: 'Banana',
+            key: 'BANANA',
+          },
+          id: '1',
+          type: 'badges',
+          relationships: {
+            'badge-criteria': {
+              'data': [{
+                id: '1',
+                type: 'badge-criterion',
+              }],
+            },
+            'badge-partner-competences': {
+              'data': [],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              scope: 'CampaignParticipation',
+              threshold: 40,
+            },
+            id: '1',
+            type: 'badge-criterion',
+          },
+        ],
+      };
+
+      // when
+      const json = serializer.serialize(badge);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedBadge);
+    });
+
+    it('should convert a Badge model with badge partner competence object into JSON API data', function() {
+      // given
+      const badge = domainBuilder.buildBadge({
+        id: '1',
+        altMessage: 'You won a banana badge',
+        imageUrl: '/img/banana.svg',
+        message: 'Congrats, you won a banana badge',
+        key: 'BANANA',
+        title: 'Banana',
+        targetProfileId: '1',
+        isCertifiable: false,
       });
 
       const expectedSerializedBadge = {


### PR DESCRIPTION
## :unicorn: Problème
Certains badges n'ont pas de partnerCompetenceIds dans les critères, ce qui déclenche une erreur:
https://sentry.io/organizations/pix/issues/2343563801/

## :robot: Solution
S'assurer de ne pas itérer lorsque partnerCompetenceIds est null (avec le chainage optionnel).

## :rainbow: Remarques
Nous avons du changer la version ecma du linter pour que ca passe.

## :100: Pour tester