### PR TITLE
[FEATURE] Correction de l'affichage dans le burger menu sur Pix App (PIX-2469).

### DIFF
--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -44,11 +44,13 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    padding: 6px 32px;
+    color: $grey-70;
+    margin: 0 0 20px 0;
   }
 
   &__logout {
-    font-size: 0.938rem;
-    text-decoration: underline;
+    font-size: 1rem;
     margin: 10px 0;
 
     &:hover {

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -46,15 +46,6 @@
     overflow: hidden;
   }
 
-  &__email {
-    font-size: 0.75rem;
-    font-weight: $font-light;
-    padding: 0;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-
   &__logout {
     font-size: 0.938rem;
     text-decoration: underline;

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -60,6 +60,13 @@
   }
 }
 
+.navbar-burger-menu-user-info-item-logout {
+
+  &__icon {
+    margin-right: 6px;
+  }
+}
+
 .navbar-burger-menu-navigation {
   margin-bottom: auto;
 

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -1,15 +1,16 @@
 .navbar-burger-menu {
-  padding: 20px 0;
 
   &__user-info {
     display: flex;
     flex-direction: column;
     background-color: $light-blue;
+    padding: 20px 0;
   }
 
   &__navigation {
     display: flex;
     flex-direction: column;
+    padding: 20px 0;
   }
 }
 
@@ -21,9 +22,23 @@
 
 .navbar-burger-menu-user-info {
 
+  &__list {
+    padding-left: 0;
+    margin: 0;
+  }
+
   &__item {
+    list-style: none;
     margin: 5px 0;
-    padding: 6px 32px;
+    padding: 10px 0;
+  }
+}
+
+.navbar-burger-menu-user-info-item {
+
+  &__link {
+    margin: 5px 0;
+    padding: 10px 32px;
     color: $white;
     font-size: 1rem;
     font-family: $font-open-sans;
@@ -33,20 +48,6 @@
       color: $white;
       text-decoration: none;
     }
-  }
-}
-
-.navbar-burger-menu-user-info-item {
-
-  &__name {
-    font-size: 1.25rem;
-    font-weight: $font-semi-bold;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    padding: 6px 32px;
-    color: $grey-70;
-    margin: 0 0 20px 0;
   }
 
   &__logout {
@@ -68,13 +69,37 @@
 }
 
 .navbar-burger-menu-navigation {
-  margin-bottom: auto;
+
+  &__name {
+    font-size: 1.25rem;
+    font-weight: $font-semi-bold;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    padding: 6px 32px;
+    color: $grey-70;
+    margin: 0 0 20px 0;
+  }
+
+  &__list {
+    padding-left: 0;
+    margin: 0;
+  }
 
   &__item {
+    list-style: none;
+    padding: 12px 0;
     margin: 5px 0;
-    padding: 10px 32px;
+  }
+}
+
+.navbar-burger-menu-navigation-item {
+  margin-bottom: auto;
+
+  &__link {
     color: $grey-35;
     font-size: 1.125rem;
+    padding: 12px 32px;
     font-family: $font-roboto;
 
     &.active {
@@ -99,5 +124,6 @@
     margin-bottom: 21px;
     display: flex;
     flex-direction: column;
+    padding: 10px 32px;
   }
 }

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -1,11 +1,34 @@
-<div class="navbar-burger-menu navbar-burger-menu__user-info">
+<div class="navbar-burger-menu navbar-burger-menu__navigation">
+
   {{#if this.currentUser.user}}
-    <div class="navbar-burger-menu-user-info__item">
-      <p class="navbar-burger-menu-user-info-item__name">
-        {{this.currentUser.user.fullName}}
-      </p>
-    </div>
+    <p class="navbar-burger-menu-user-info-item__name">
+      {{this.currentUser.user.fullName}}
+    </p>
   {{/if}}
+
+  <LinkTo @route="user-dashboard" class="navbar-burger-menu-navigation__item">
+    {{t 'navigation.main.dashboard'}}
+  </LinkTo>
+  <LinkTo @route="profile" class="navbar-burger-menu-navigation__item">
+    {{t 'navigation.main.skills'}}
+  </LinkTo>
+
+  <LinkTo @route="certifications" class="navbar-burger-menu-navigation__item">
+    {{t 'navigation.main.start-certification'}}
+  </LinkTo>
+
+  <LinkTo @route="user-tutorials" class="navbar-burger-menu-navigation__item">
+    {{t 'navigation.main.tutorials'}}
+  </LinkTo>
+
+</div>
+<div class="navbar-burger-menu-navigation__item navbar-burger-menu-navigation__bottom-item">
+  <LinkTo @route="fill-in-campaign-code" class="button button--thin">
+    {{t 'navigation.main.code'}}
+  </LinkTo>
+</div>
+
+<div class="navbar-burger-menu navbar-burger-menu__user-info">
 
   {{#if this.showMyTestsLink}}
     <LinkTo @route="user-tests" class="navbar-burger-menu-user-info__item">
@@ -27,28 +50,5 @@
 
   <LinkTo @route="logout" class="navbar-burger-menu-user-info__item navbar-burger-menu-user-info-item__logout">
     {{t 'navigation.user.sign-out'}}
-  </LinkTo>
-</div>
-
-<div class="navbar-burger-menu navbar-burger-menu__navigation">
-  <LinkTo @route="user-dashboard" class="navbar-burger-menu-navigation__item">
-    {{t 'navigation.main.dashboard'}}
-  </LinkTo>
-  <LinkTo @route="profile" class="navbar-burger-menu-navigation__item">
-    {{t 'navigation.main.skills'}}
-  </LinkTo>
-
-  <LinkTo @route="certifications" class="navbar-burger-menu-navigation__item">
-    {{t 'navigation.main.start-certification'}}
-  </LinkTo>
-
-  <LinkTo @route="user-tutorials" class="navbar-burger-menu-navigation__item">
-    {{t 'navigation.main.tutorials'}}
-  </LinkTo>
-
-</div>
-<div class="navbar-burger-menu-navigation__item navbar-burger-menu-navigation__bottom-item">
-  <LinkTo @route="fill-in-campaign-code" class="button button--thin">
-    {{t 'navigation.main.code'}}
   </LinkTo>
 </div>

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -49,6 +49,7 @@
   </a>
 
   <LinkTo @route="logout" class="navbar-burger-menu-user-info__item navbar-burger-menu-user-info-item__logout">
+    <FaIcon @icon="power-off" class="navbar-burger-menu-user-info-item-logout__icon"/>
     {{t 'navigation.user.sign-out'}}
   </LinkTo>
 </div>

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -1,55 +1,69 @@
-<div class="navbar-burger-menu navbar-burger-menu__navigation">
+<nav class="navbar-burger-menu">
+  <div class="navbar-burger-menu__navigation">
 
-  {{#if this.currentUser.user}}
-    <p class="navbar-burger-menu-user-info-item__name">
-      {{this.currentUser.user.fullName}}
-    </p>
-  {{/if}}
-
-  <LinkTo @route="user-dashboard" class="navbar-burger-menu-navigation__item">
-    {{t 'navigation.main.dashboard'}}
-  </LinkTo>
-  <LinkTo @route="profile" class="navbar-burger-menu-navigation__item">
-    {{t 'navigation.main.skills'}}
-  </LinkTo>
-
-  <LinkTo @route="certifications" class="navbar-burger-menu-navigation__item">
-    {{t 'navigation.main.start-certification'}}
-  </LinkTo>
-
-  <LinkTo @route="user-tutorials" class="navbar-burger-menu-navigation__item">
-    {{t 'navigation.main.tutorials'}}
-  </LinkTo>
-
-</div>
-<div class="navbar-burger-menu-navigation__item navbar-burger-menu-navigation__bottom-item">
-  <LinkTo @route="fill-in-campaign-code" class="button button--thin">
-    {{t 'navigation.main.code'}}
-  </LinkTo>
-</div>
-
-<div class="navbar-burger-menu navbar-burger-menu__user-info">
-
-  {{#if this.showMyTestsLink}}
-    <LinkTo @route="user-tests" class="navbar-burger-menu-user-info__item">
-      {{t 'navigation.user.tests'}}
+    {{#if this.currentUser.user}}
+      <p class="navbar-burger-menu-navigation__name">
+        {{this.currentUser.user.fullName}}
+      </p>
+    {{/if}}
+    <ul class="navbar-burger-menu-navigation__list">
+      <li class="navbar-burger-menu-navigation__item">
+        <LinkTo @route="user-dashboard" class="navbar-burger-menu-navigation-item__link">
+          {{t 'navigation.main.dashboard'}}
+        </LinkTo>
+      </li>
+      <li class="navbar-burger-menu-navigation__item">
+        <LinkTo @route="profile" class="navbar-burger-menu-navigation-item__link">
+          {{t 'navigation.main.skills'}}
+        </LinkTo>
+      </li>
+      <li class="navbar-burger-menu-navigation__item">
+        <LinkTo @route="certifications" class="navbar-burger-menu-navigation-item__link">
+          {{t 'navigation.main.start-certification'}}
+        </LinkTo>
+      </li>
+      <li class="navbar-burger-menu-navigation__item">
+        <LinkTo @route="user-tutorials" class="navbar-burger-menu-navigation-item__link">
+          {{t 'navigation.main.tutorials'}}
+        </LinkTo>
+      </li>
+    </ul>
+  </div>
+  <div class="navbar-burger-menu-navigation__item navbar-burger-menu-navigation-item__bottom-item">
+    <LinkTo @route="fill-in-campaign-code" class="button button--thin">
+      {{t 'navigation.main.code'}}
     </LinkTo>
-  {{/if}}
-
-  <LinkTo @route="user-account" class="navbar-burger-menu-user-info__item" >
-    {{t 'navigation.user.account'}}
-  </LinkTo>
-
-  <LinkTo @route="user-certifications" class="navbar-burger-menu-user-info__item">
-    {{t 'navigation.user.certifications'}}
-  </LinkTo>
-
-  <a href="{{t 'navigation.main.link-help'}}" target="_blank" class="navbar-burger-menu-user-info__item" rel="noopener noreferrer">
-    {{t 'navigation.main.help'}}
-  </a>
-
-  <LinkTo @route="logout" class="navbar-burger-menu-user-info__item navbar-burger-menu-user-info-item__logout">
-    <FaIcon @icon="power-off" class="navbar-burger-menu-user-info-item-logout__icon"/>
-    {{t 'navigation.user.sign-out'}}
-  </LinkTo>
-</div>
+  </div>
+  <div class="navbar-burger-menu__user-info">
+    <ul class="navbar-burger-menu-user-info__list">
+      {{#if this.showMyTestsLink}}
+        <li class="navbar-burger-menu-user-info__item">
+          <LinkTo @route="user-tests" class="navbar-burger-menu-user-info-item__link">
+            {{t 'navigation.user.tests'}}
+          </LinkTo>
+        </li>
+      {{/if}}
+      <li class="navbar-burger-menu-user-info__item">
+        <LinkTo @route="user-account" class="navbar-burger-menu-user-info-item__link" >
+          {{t 'navigation.user.account'}}
+        </LinkTo>
+      </li>
+      <li class="navbar-burger-menu-user-info__item">
+        <LinkTo @route="user-certifications" class="navbar-burger-menu-user-info-item__link">
+          {{t 'navigation.user.certifications'}}
+        </LinkTo>
+      </li>
+      <li class="navbar-burger-menu-user-info__item">
+        <a href="{{t 'navigation.main.link-help'}}" target="_blank" class="navbar-burger-menu-user-info-item__link" rel="noopener noreferrer">
+          {{t 'navigation.main.help'}}
+        </a>
+      </li>
+      <li class="navbar-burger-menu-user-info__item">
+        <LinkTo @route="logout" class="navbar-burger-menu-user-info-item__link navbar-burger-menu-user-info-item__logout">
+          <FaIcon @icon="power-off" class="navbar-burger-menu-user-info-item-logout__icon"/>
+          {{t 'navigation.user.sign-out'}}
+        </LinkTo>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -16,6 +16,10 @@
     </LinkTo>
   {{/if}}
 
+  <LinkTo @route="user-account" class="navbar-burger-menu-user-info__item" >
+    {{t 'navigation.user.account'}}
+  </LinkTo>
+
   <LinkTo @route="user-certifications" class="navbar-burger-menu-user-info__item">
     {{t 'navigation.user.certifications'}}
   </LinkTo>
@@ -32,9 +36,6 @@
 <div class="navbar-burger-menu navbar-burger-menu__navigation">
   <LinkTo @route="user-dashboard" class="navbar-burger-menu-navigation__item">
     {{t 'navigation.main.dashboard'}}
-  </LinkTo>
-  <LinkTo @route="user-account" class="navbar-burger-menu-navigation__item" >
-    {{t 'navigation.user.account'}}
   </LinkTo>
   <LinkTo @route="profile" class="navbar-burger-menu-navigation__item">
     {{t 'navigation.main.skills'}}

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -4,9 +4,6 @@
       <p class="navbar-burger-menu-user-info-item__name">
         {{this.currentUser.user.fullName}}
       </p>
-      <p class="navbar-burger-menu-user-info-item__email">
-        {{this.currentUser.user.email}}
-      </p>
     </div>
   {{/if}}
 

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -26,13 +26,25 @@ describe('Integration | Component | navbar-burger-menu', function() {
     // then
     expect(find('.navbar-burger-menu__navigation')).to.exist;
 
-    expect(findAll('.navbar-burger-menu-navigation__item')).to.have.lengthOf(6);
+    expect(findAll('.navbar-burger-menu-navigation__item')).to.have.lengthOf(5);
     expect(contains('Accueil')).to.exist;
-    expect(contains('Mon compte')).to.exist;
     expect(contains('Compétences')).to.exist;
     expect(contains('Certification')).to.exist;
     expect(contains('Mes tutos')).to.exist;
     expect(contains('J\'ai un code')).to.exist;
+  });
+
+  it('should display the user menu with expected elements', async function() {
+    // when
+    await render(hbs`<NavbarBurgerMenu />`);
+
+    // then
+    expect(find('.navbar-burger-menu__user-info')).to.exist;
+
+    expect(contains(this.intl.t('navigation.user.account'))).to.exist;
+    expect(contains(this.intl.t('navigation.user.certifications'))).to.exist;
+    expect(contains(this.intl.t('navigation.main.help'))).to.exist;
+    expect(contains(this.intl.t('navigation.user.sign-out'))).to.exist;
   });
 
   context('when user has participations', function() {

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -18,6 +18,14 @@ describe('Integration | Component | navbar-burger-menu', function() {
 
   });
 
+  it('should display the user\'s fullname', async function() {
+    // when
+    await render(hbs`<NavbarBurgerMenu />`);
+
+    // then
+    expect(contains('Bobby Carotte')).to.exist;
+  });
+
   it('should display the navigation menu with expected elements outside of campaign results', async function() {
     // when
     await render(hbs`<NavbarBurgerMenu />`);

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -27,11 +27,11 @@ describe('Integration | Component | navbar-burger-menu', function() {
     expect(find('.navbar-burger-menu__navigation')).to.exist;
 
     expect(findAll('.navbar-burger-menu-navigation__item')).to.have.lengthOf(5);
-    expect(contains('Accueil')).to.exist;
-    expect(contains('Compétences')).to.exist;
-    expect(contains('Certification')).to.exist;
-    expect(contains('Mes tutos')).to.exist;
-    expect(contains('J\'ai un code')).to.exist;
+    expect(contains(this.intl.t('navigation.main.dashboard'))).to.exist;
+    expect(contains(this.intl.t('navigation.main.skills'))).to.exist;
+    expect(contains(this.intl.t('navigation.main.start-certification'))).to.exist;
+    expect(contains(this.intl.t('navigation.main.tutorials'))).to.exist;
+    expect(contains(this.intl.t('navigation.main.code'))).to.exist;
   });
 
   it('should display the user menu with expected elements', async function() {
@@ -63,7 +63,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
       await render(hbs`<NavbarBurgerMenu />`);
 
       // then
-      expect(contains('Mes parcours')).to.exist;
+      expect(contains(this.intl.t('navigation.user.tests'))).to.exist;
     });
   });
 
@@ -83,7 +83,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
       await render(hbs`<NavbarBurgerMenu />`);
 
       // then
-      expect(contains('Mes parcours')).to.not.exist;
+      expect(contains(this.intl.t('navigation.user.tests'))).to.not.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -12,7 +12,6 @@ describe('Integration | Component | navbar-burger-menu', function() {
 
   beforeEach(async function() {
     class currentUser extends Service { user = {
-      email: 'bobby.carotte@example.net',
       fullName: 'Bobby Carotte',
     }}
     this.owner.register('service:currentUser', currentUser);

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -26,7 +26,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
     expect(contains('Bobby Carotte')).to.exist;
   });
 
-  it('should display the navigation menu with expected elements outside of campaign results', async function() {
+  it('should display the navigation menu with "Home", "Skills", "Certification", "My tutorials" and "I have a code" links', async function() {
     // when
     await render(hbs`<NavbarBurgerMenu />`);
 
@@ -41,7 +41,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
     expect(contains(this.intl.t('navigation.main.code'))).to.exist;
   });
 
-  it('should display the user menu with expected elements', async function() {
+  it('should display the user menu with "My account", "My certifications", "Help", "Log-out" links', async function() {
     // when
     await render(hbs`<NavbarBurgerMenu />`);
 


### PR DESCRIPTION
## :unicorn: Problème
Le lien "Mon compte" a été ajouté dans le mauvais sous-menu du burger menu (version mobile) de Pix App.

## :robot: Solution
Afficher le lien dans le sous-menu adéquat.

## :rainbow: Remarques
Plusieurs modifications sont incluses dans ce ticket : 
- L'adresse e-mail affichée dans le burger menu est retirée.
- Inversion d'affichage des deux sous-menus, on affiche d'abord le menu de navigation.
- Ajout d'une icône pour le lien de déconnexion, pour qu'il soit similaire au lien en version desktop.


## :100: Pour tester
Aller sur Pix App en version mobile et cliquer sur le burger menu 
