### PR TITLE
[BUGFIX] Gérer les erreurs produites lors d'un appel POST /api/pole-emploi/token (PIX-2490).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -88,6 +88,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CampaignCodeError) {
     return new HttpErrors.NotFoundError(error.message);
   }
+  if (error instanceof DomainErrors.GeneratePoleEmploiTokensError) {
+    return new HttpErrors.InternalServerError(error.message, error.title);
+  }
   if (error instanceof DomainErrors.UserAccountNotFoundForPoleEmploiError) {
     return new HttpErrors.UnauthorizedError(error.message, error.responseCode, { authenticationKey: error.authenticationKey });
   }

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -1,4 +1,5 @@
 const JSONAPIError = require('jsonapi-serializer').Error;
+
 class BaseHttpError extends Error {
   constructor(message) {
     super(message);
@@ -125,6 +126,14 @@ class SessionPublicationBatchError extends BaseHttpError {
   }
 }
 
+class InternalServerError extends BaseHttpError {
+  constructor(message, title) {
+    super(message);
+    this.title = title || 'Internal Server Error';
+    this.status = 500;
+  }
+}
+
 function sendJsonApiError(httpError, h) {
   const jsonApiError = new JSONAPIError({
     status: httpError.status.toString(),
@@ -142,6 +151,7 @@ module.exports = {
   ConflictError,
   ForbiddenError,
   ImproveCompetenceEvaluationForbiddenError,
+  InternalServerError,
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,
@@ -149,7 +159,7 @@ module.exports = {
   PreconditionFailedError,
   sendJsonApiError,
   ServiceUnavailableError,
+  SessionPublicationBatchError,
   UnauthorizedError,
   UnprocessableEntityError,
-  SessionPublicationBatchError,
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -768,6 +768,14 @@ class NotImplementedError extends Error {
   }
 }
 
+class GeneratePoleEmploiTokensError extends DomainError {
+  constructor(message, status) {
+    super(message);
+    this.status = parseInt(status, 10);
+    this.title = 'Pole emploi tokens generation fails.';
+  }
+}
+
 module.exports = {
   AlreadyExistingEntityError,
   AlreadyExistingCampaignParticipationError,
@@ -811,6 +819,7 @@ module.exports = {
   EntityValidationError,
   FileValidationError,
   ForbiddenAccess,
+  GeneratePoleEmploiTokensError,
   ImproveCompetenceEvaluationForbiddenError,
   InvalidCertificationCandidate,
   InvalidCertificationReportForFinalization,

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,6 +1,5 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
-const logger = require('../logger');
 
 class HttpResponse {
   constructor({
@@ -26,24 +25,20 @@ module.exports = {
         isSuccessful: true,
       });
     } catch (httpErr) {
-      const isSuccessful = false;
-
-      let code;
+      let code = null;
       let data;
 
       if (httpErr.response) {
         code = httpErr.response.status;
         data = httpErr.response.data;
       } else {
-        code = '500';
-        data = null;
+        data = httpErr.message;
       }
 
-      logger.error({ err: httpErr }, `Error while post ${url}`);
       return new HttpResponse({
         code,
         data,
-        isSuccessful,
+        isSuccessful: false,
       });
     }
   },

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -56,7 +56,6 @@ describe('Unit | Infrastructure | http | http-agent', () => {
           const actualResponse = await post({ url, payload, headers });
 
           // then
-          expect(logger.error).to.have.been.calledOnce;
           expect(actualResponse).to.deep.equal({
             isSuccessful: false,
             code: axiosError.response.status,
@@ -76,21 +75,23 @@ describe('Unit | Infrastructure | http | http-agent', () => {
           const headers = { a: 'someHeaderInfo' };
 
           const axiosError = {
-            name: 'error name',
+            response: {
+              data: { error: 'HTTP error' },
+              status: 400,
+            },
           };
           sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
 
           const expectedResponse = {
             isSuccessful: false,
-            code: '500',
-            data: null,
+            code: axiosError.response.status,
+            data: axiosError.response.data,
           };
 
           // when
           const actualResponse = await post({ url, payload, headers });
 
           // then
-          expect(logger.error).to.have.been.calledOnce;
           expect(actualResponse).to.deep.equal(expectedResponse);
         });
       });

--- a/mon-pix/app/routes/login-pe.js
+++ b/mon-pix/app/routes/login-pe.js
@@ -60,6 +60,7 @@ export default class LoginPeRoute extends Route {
       if (shouldValidateCgu && authenticationKey) {
         return this.replaceWith('terms-of-service-pe', { queryParams: { authenticationKey } });
       }
+      throw new Error(JSON.stringify(response.errors));
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
cf. [Erreur Sentry](https://sentry.io/organizations/pix/issues/2137374557/?project=1398749&referrer=slack)
Lors des tentatives d’obtention de tokens Pôle-emploi, certaines requêtes axios.post() échouent et retournent des Erreurs non catchées.

## :robot: Solution
* Améliorer la gestion des erreurs en se basant sur la documentation d'Axios : https://github.com/axios/axios#handling-errors
* Voir la [documentation Pôle-emploi](https://pole-emploi.io/data/documentation/erreurs) concernant les erreurs fréquentes
* Utiliser le `http-agent`
* Dans `pole-emploi-notofier` logger les erreurs
* En cas d'erreurs, dans Pix App rediriger vers la page Oups
<p align="center">
<img src="https://user-images.githubusercontent.com/88607/116396846-218c5280-a826-11eb-8e84-811c5b59b3e7.png" width="600" />
</p>

## :rainbow: Remarques
* Un test d'acceptance (utilisant [nock.js](https://github.com/nock/nock#replying-with-errors)) a été créé spécifiquement

## :100: Pour tester
* Tester la connexion avec PE (env recette)