### PR TITLE
[FEATURE] Donner accès à Pix Certif à l'administrateur SCO lors de la modification du rôle dans PixOrga (PIX-2454).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -301,6 +301,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
 
+  if (error instanceof DomainErrors.InvalidMembershipRoleError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -301,7 +301,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
 
-  if (error instanceof DomainErrors.InvalidMembershipRoleError) {
+  if (error instanceof DomainErrors.InvalidMembershipOrganizationRoleError) {
     return new HttpErrors.BadRequestError(error.message);
   }
 

--- a/api/lib/application/memberships/membership-controller.js
+++ b/api/lib/application/memberships/membership-controller.js
@@ -1,6 +1,7 @@
 const membershipSerializer = require('../../infrastructure/serializers/jsonapi/membership-serializer');
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 const usecases = require('../../domain/usecases');
+const { BadRequestError } = require('../http-errors');
 
 module.exports = {
 
@@ -18,6 +19,9 @@ module.exports = {
     const membershipId = request.params.id;
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
     const membership = membershipSerializer.deserialize(request.payload);
+    if (membershipId != membership.id) {
+      throw new BadRequestError();
+    }
     membership.updatedByUserId = userId;
 
     const updatedMembership = await usecases.updateMembership({ membership });

--- a/api/lib/application/memberships/membership-controller.js
+++ b/api/lib/application/memberships/membership-controller.js
@@ -20,8 +20,9 @@ module.exports = {
     const membership = membershipSerializer.deserialize(request.payload);
     membership.updatedByUserId = userId;
 
-    const updateMembership = await usecases.updateMembership({ membershipId, membership });
-    return h.response(membershipSerializer.serialize(updateMembership));
+    const updatedMembership = await usecases.updateMembership({ membership });
+
+    return h.response(membershipSerializer.serialize(updatedMembership));
   },
 
   async disable(request, h) {

--- a/api/lib/application/memberships/membership-controller.js
+++ b/api/lib/application/memberships/membership-controller.js
@@ -14,17 +14,14 @@ module.exports = {
       });
   },
 
-  update(request, h) {
-
+  async update(request, h) {
     const membershipId = request.params.id;
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const membershipAttributes = membershipSerializer.deserialize(request.payload);
-    membershipAttributes.updatedByUserId = userId;
+    const membership = membershipSerializer.deserialize(request.payload);
+    membership.updatedByUserId = userId;
 
-    return usecases.updateMembership({ membershipId, membershipAttributes })
-      .then((membership) => {
-        return h.response(membershipSerializer.serialize(membership));
-      });
+    const updateMembership = await usecases.updateMembership({ membershipId, membership });
+    return h.response(membershipSerializer.serialize(updateMembership));
   },
 
   async disable(request, h) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -776,7 +776,7 @@ class GeneratePoleEmploiTokensError extends DomainError {
   }
 }
 
-class InvalidMembershipRoleError extends DomainError {
+class InvalidMembershipOrganizationRoleError extends DomainError {
   constructor(message = 'Le rôle du membre est invalide.') {
     super(message);
   }
@@ -831,7 +831,7 @@ module.exports = {
   InvalidCertificationReportForFinalization,
   InvalidCertificationIssueReportForSaving,
   InvalidExternalUserTokenError,
-  InvalidMembershipRoleError,
+  InvalidMembershipOrganizationRoleError,
   InvalidPasswordForUpdateEmailError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -776,6 +776,12 @@ class GeneratePoleEmploiTokensError extends DomainError {
   }
 }
 
+class InvalidMembershipRoleError extends DomainError {
+  constructor(message = 'Le rôle du membre est invalide.') {
+    super(message);
+  }
+}
+
 module.exports = {
   AlreadyExistingEntityError,
   AlreadyExistingCampaignParticipationError,
@@ -825,6 +831,7 @@ module.exports = {
   InvalidCertificationReportForFinalization,
   InvalidCertificationIssueReportForSaving,
   InvalidExternalUserTokenError,
+  InvalidMembershipRoleError,
   InvalidPasswordForUpdateEmailError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultError,

--- a/api/lib/domain/models/Membership.js
+++ b/api/lib/domain/models/Membership.js
@@ -1,3 +1,4 @@
+const { InvalidMembershipRoleError } = require('../errors');
 const roles = {
   ADMIN: 'ADMIN',
   MEMBER: 'MEMBER',
@@ -21,6 +22,13 @@ class Membership {
 
   get isAdmin() {
     return this.organizationRole === roles.ADMIN;
+  }
+
+  validateRole() {
+    const isRoleValid = Object.values(roles).includes(this.organizationRole);
+    if (!isRoleValid) {
+      throw new InvalidMembershipRoleError();
+    }
   }
 }
 

--- a/api/lib/domain/models/Membership.js
+++ b/api/lib/domain/models/Membership.js
@@ -1,4 +1,4 @@
-const { InvalidMembershipRoleError } = require('../errors');
+const { InvalidMembershipOrganizationRoleError } = require('../errors');
 const roles = {
   ADMIN: 'ADMIN',
   MEMBER: 'MEMBER',
@@ -27,7 +27,7 @@ class Membership {
   validateRole() {
     const isRoleValid = Object.values(roles).includes(this.organizationRole);
     if (!isRoleValid) {
-      throw new InvalidMembershipRoleError();
+      throw new InvalidMembershipOrganizationRoleError();
     }
   }
 }

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -1,3 +1,11 @@
+async function createCertificationCenterMembership(certificationCenterMembershipRepository, existingMembership, existingCertificationCenter) {
+  const isAlreadyMemberOfCertificationCenter = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(existingMembership.user.id, existingCertificationCenter.id);
+
+  if (!isAlreadyMemberOfCertificationCenter) {
+    certificationCenterMembershipRepository.save(existingMembership.user.id, existingCertificationCenter.id);
+  }
+}
+
 module.exports = async function updateMembership({
   membershipId,
   membership,
@@ -12,7 +20,7 @@ module.exports = async function updateMembership({
     const existingCertificationCenter = await certificationCenterRepository.findByExternalId({ externalId: existingMembership.organization.externalId });
 
     if (existingCertificationCenter) {
-      certificationCenterMembershipRepository.save(existingMembership.user.id, existingCertificationCenter.id);
+      await createCertificationCenterMembership(certificationCenterMembershipRepository, existingMembership, existingCertificationCenter);
     }
   }
 

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -1,6 +1,20 @@
-module.exports = async function updateMembership({ membershipRepository, membershipId, membership }) {
-
+module.exports = async function updateMembership({
+  membershipId,
+  membership,
+  membershipRepository,
+  certificationCenterRepository,
+  certificationCenterMembershipRepository,
+}) {
   membership.validateRole();
+
+  if (membership.isAdmin) {
+    const existingMembership = await membershipRepository.get(membershipId);
+    const existingCertificationCenter = await certificationCenterRepository.getByExternalId({ externalId: existingMembership.organization.externalId });
+
+    if (existingCertificationCenter) {
+      certificationCenterMembershipRepository.save(existingMembership.user.id, existingCertificationCenter.id);
+    }
+  }
 
   return membershipRepository.updateById({ id: membershipId, membership });
 };

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -1,10 +1,4 @@
-async function createCertificationCenterMembership(certificationCenterMembershipRepository, existingMembership, existingCertificationCenter) {
-  const isAlreadyMemberOfCertificationCenter = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(existingMembership.user.id, existingCertificationCenter.id);
-
-  if (!isAlreadyMemberOfCertificationCenter) {
-    certificationCenterMembershipRepository.save(existingMembership.user.id, existingCertificationCenter.id);
-  }
-}
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = async function updateMembership({
   membershipId,
@@ -20,7 +14,14 @@ module.exports = async function updateMembership({
     const existingCertificationCenter = await certificationCenterRepository.findByExternalId({ externalId: existingMembership.organization.externalId });
 
     if (existingCertificationCenter) {
-      await createCertificationCenterMembership(certificationCenterMembershipRepository, existingMembership, existingCertificationCenter);
+      const isAlreadyMemberOfCertificationCenter = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(existingMembership.user.id, existingCertificationCenter.id);
+
+      if (!isAlreadyMemberOfCertificationCenter) {
+        return DomainTransaction.execute(async (domainTransaction) => {
+          await certificationCenterMembershipRepository.save(existingMembership.user.id, existingCertificationCenter.id, domainTransaction);
+          return membershipRepository.updateById({ id: membershipId, membership }, domainTransaction);
+        });
+      }
     }
   }
 

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -9,7 +9,7 @@ module.exports = async function updateMembership({
 
   if (membership.isAdmin) {
     const existingMembership = await membershipRepository.get(membershipId);
-    const existingCertificationCenter = await certificationCenterRepository.getByExternalId({ externalId: existingMembership.organization.externalId });
+    const existingCertificationCenter = await certificationCenterRepository.findByExternalId({ externalId: existingMembership.organization.externalId });
 
     if (existingCertificationCenter) {
       certificationCenterMembershipRepository.save(existingMembership.user.id, existingCertificationCenter.id);

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -1,4 +1,3 @@
-
-module.exports = async function updateMembership({ membershipRepository, membershipId, membershipAttributes }) {
-  return membershipRepository.updateById({ id: membershipId, membershipAttributes });
+module.exports = async function updateMembership({ membershipRepository, membershipId, membership }) {
+  return membershipRepository.updateById({ id: membershipId, membership });
 };

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -1,3 +1,4 @@
+const OrganizationTypes = require('../models/Organization').types;
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = async function updateMembership({
@@ -7,10 +8,12 @@ module.exports = async function updateMembership({
   certificationCenterRepository,
   certificationCenterMembershipRepository,
 }) {
-  membership.validateRole();
 
-  if (membership.isAdmin) {
-    const existingMembership = await membershipRepository.get(membershipId);
+  membership.validateRole();
+  const existingMembership = await membershipRepository.get(membershipId);
+
+  if (existingMembership.organization.type === OrganizationTypes.SCO && membership.isAdmin) {
+
     const existingCertificationCenter = await certificationCenterRepository.findByExternalId({ externalId: existingMembership.organization.externalId });
 
     if (existingCertificationCenter) {

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -2,16 +2,13 @@ const OrganizationTypes = require('../models/Organization').types;
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = async function updateMembership({
-  membershipId,
   membership,
   membershipRepository,
   certificationCenterRepository,
   certificationCenterMembershipRepository,
 }) {
-
   membership.validateRole();
-  const existingMembership = await membershipRepository.get(membershipId);
-
+  const existingMembership = await membershipRepository.get(membership.id);
   if (existingMembership.organization.type === OrganizationTypes.SCO && membership.isAdmin) {
 
     const existingCertificationCenter = await certificationCenterRepository.findByExternalId({ externalId: existingMembership.organization.externalId });
@@ -21,12 +18,13 @@ module.exports = async function updateMembership({
 
       if (!isAlreadyMemberOfCertificationCenter) {
         return DomainTransaction.execute(async (domainTransaction) => {
-          await certificationCenterMembershipRepository.save(existingMembership.user.id, existingCertificationCenter.id, domainTransaction);
-          return membershipRepository.updateById({ id: membershipId, membership }, domainTransaction);
+          await certificationCenterMembershipRepository
+            .save(existingMembership.user.id, existingCertificationCenter.id, domainTransaction);
+          return membershipRepository.updateById({ id: existingMembership.id, membership }, domainTransaction);
         });
       }
     }
   }
 
-  return membershipRepository.updateById({ id: membershipId, membership });
+  return membershipRepository.updateById({ id: existingMembership.id, membership });
 };

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -1,3 +1,6 @@
 module.exports = async function updateMembership({ membershipRepository, membershipId, membership }) {
+
+  membership.validateRole();
+
   return membershipRepository.updateById({ id: membershipId, membership });
 };

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -76,4 +76,12 @@ module.exports = {
     const { models, pagination } = certificationCenterBookshelf;
     return { models: models.map(_toDomain), pagination };
   },
+
+  async getByExternalId({ externalId }) {
+    const certificationCenterBookshelf = await BookshelfCertificationCenter
+      .where({ externalId })
+      .fetch({ require: false });
+
+    return certificationCenterBookshelf ? _toDomain(certificationCenterBookshelf) : null;
+  },
 };

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -77,7 +77,7 @@ module.exports = {
     return { models: models.map(_toDomain), pagination };
   },
 
-  async getByExternalId({ externalId }) {
+  async findByExternalId({ externalId }) {
     const certificationCenterBookshelf = await BookshelfCertificationCenter
       .where({ externalId })
       .fetch({ require: false });

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -61,7 +61,7 @@ module.exports = {
       bookshelfMembership = await BookshelfMembership.where('id', membershipId).fetch({ withRelated: ['user', 'organization'] });
     } catch (error) {
       if (error instanceof BookshelfMembership.NotFoundError) {
-        throw new NotFoundError(`Not found membership for ID ${membershipId}`);
+        throw new NotFoundError(`Membership ${membershipId} not found`);
       }
       throw error;
     }
@@ -119,8 +119,8 @@ module.exports = {
       throw new MembershipUpdateError(err.message);
     }
 
-    updatedMembership = await updatedMembership.refresh({ withRelated: ['user', 'organization'], transacting: domainTransaction.knexTransaction });
-    return bookshelfToDomainConverter.buildDomainObject(BookshelfMembership, updatedMembership);
+    const updatedMembershipWithUserAndOrganization = await updatedMembership.refresh({ withRelated: ['user', 'organization'], transacting: domainTransaction.knexTransaction });
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfMembership, updatedMembershipWithUserAndOrganization);
   },
 
 };

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -88,18 +88,17 @@ module.exports = {
       .then((memberships) => bookshelfToDomainConverter.buildDomainObjects(BookshelfMembership, memberships));
   },
 
-  updateById({ id, membershipAttributes }) {
-    return new BookshelfMembership({ id })
-      .save(membershipAttributes, { patch: true, method: 'update', require: true })
-      .then((updatedMembership) => updatedMembership.refresh({
-        withRelated: ['user', 'organization'],
-      }))
-      .then(
-        (membership) => bookshelfToDomainConverter.buildDomainObject(BookshelfMembership, membership),
-        (err) => {
-          throw new MembershipUpdateError(err.message);
-        },
-      );
+  async updateById({ id, membership }) {
+    let updatedMembership;
+    try {
+      updatedMembership = await new BookshelfMembership({ id })
+        .save(membership, { patch: true, method: 'update', require: true });
+    } catch (err) {
+      throw new MembershipUpdateError(err.message);
+    }
+
+    updatedMembership = await updatedMembership.refresh({ withRelated: ['user', 'organization'] });
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfMembership, updatedMembership);
   },
 
 };

--- a/api/tests/acceptance/application/membership-controller_test.js
+++ b/api/tests/acceptance/application/membership-controller_test.js
@@ -184,7 +184,7 @@ describe('Acceptance | Controller | membership-controller', () => {
         await knex('certification-center-memberships').delete();
       });
 
-      it('should return the updated membership', async () => {
+      it('should return the updated membership and add certification center membership', async () => {
         // given
         const expectedMembership = {
           data: {

--- a/api/tests/acceptance/application/membership-controller_test.js
+++ b/api/tests/acceptance/application/membership-controller_test.js
@@ -127,7 +127,8 @@ describe('Acceptance | Controller | membership-controller', () => {
     let newOrganizationRole;
 
     beforeEach(async () => {
-      organizationId = databaseBuilder.factory.buildOrganization().id;
+      const externalId = 'externalId';
+      organizationId = databaseBuilder.factory.buildOrganization({ externalId }).id;
       const adminUserId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildMembership({
         organizationId,
@@ -140,6 +141,7 @@ describe('Acceptance | Controller | membership-controller', () => {
         organizationId, userId,
         organizationRole: Membership.roles.MEMBER,
       }).id;
+      databaseBuilder.factory.buildCertificationCenter({ externalId });
 
       await databaseBuilder.commit();
 
@@ -177,6 +179,10 @@ describe('Acceptance | Controller | membership-controller', () => {
     });
 
     context('Success cases', () => {
+
+      afterEach(async () => {
+        await knex('certification-center-memberships').delete();
+      });
 
       it('should return the updated membership', async () => {
         // given

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -32,14 +32,13 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
     context('Success cases', () => {
 
-      beforeEach(() => {
+      it('should resolve a 201 HTTP response', async () => {
+        // given
         const membership = domainBuilder.buildMembership();
         usecases.createMembership.resolves(membership);
 
         securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
-      });
 
-      it('should resolve a 201 HTTP response', async () => {
         // when
         const response = await httpTestServer.request('POST', '/api/memberships', payload);
 
@@ -48,6 +47,12 @@ describe('Integration | Application | Memberships | membership-controller', () =
       });
 
       it('should return a JSON API membership', async () => {
+        // given
+        const membership = domainBuilder.buildMembership();
+        usecases.createMembership.resolves(membership);
+
+        securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
+
         // when
         const response = await httpTestServer.request('POST', '/api/memberships', payload);
 
@@ -60,13 +65,12 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
       context('when user is not allowed to access resource', () => {
 
-        beforeEach(() => {
+        it('should resolve a 403 HTTP response', () => {
+          // given
           securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => {
             return Promise.resolve(h.response().code(403).takeover());
           });
-        });
 
-        it('should resolve a 403 HTTP response', () => {
           // when
           const promise = httpTestServer.request('POST', '/api/memberships', payload);
 
@@ -94,15 +98,14 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
     context('Success cases', () => {
 
-      beforeEach(() => {
+      it('should return a 200 HTTP response', async () => {
+        // given
         const membership = domainBuilder.buildMembership({
           organizationRole: Membership.roles.MEMBER,
         });
         usecases.updateMembership.resolves(membership);
         securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
-      });
 
-      it('should return a 200 HTTP response', async () => {
         // when
         const response = await httpTestServer.request('PATCH', '/api/memberships/1', payload);
 
@@ -115,13 +118,12 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
       context('when user is not allowed to access resource', () => {
 
-        beforeEach(() => {
+        it('should resolve a 403 HTTP response', async () => {
+          // given
           securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => {
             return Promise.resolve(h.response().code(403).takeover());
           });
-        });
 
-        it('should resolve a 403 HTTP response', async () => {
           // when
           const response = await httpTestServer.request('PATCH', '/api/memberships/1');
 
@@ -149,17 +151,14 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
   describe('#disable', () => {
 
-    let membershipId;
-
     context('Success cases', () => {
 
-      beforeEach(() => {
-        membershipId = domainBuilder.buildMembership().id;
+      it('should return a 200 HTTP response', async () => {
+        // given
+        const membershipId = domainBuilder.buildMembership().id;
         usecases.disableMembership.resolves();
         securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
-      });
 
-      it('should return a 200 HTTP response', async () => {
         // when
         const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/disable`);
 
@@ -172,13 +171,13 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
       context('when user is not admin of the organization nor has pix master role', () => {
 
-        beforeEach(() => {
+        it('should resolve a 403 HTTP response', async () => {
+          // given
+          const membershipId = domainBuilder.buildMembership({ organizationRole: Membership.roles.MEMBER }).id;
           securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => {
             return Promise.resolve(h.response().code(403).takeover());
           });
-        });
 
-        it('should resolve a 403 HTTP response', async () => {
           // when
           const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/disable`);
 

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -3,7 +3,7 @@ const usecases = require('../../../../lib/domain/usecases');
 const Membership = require('../../../../lib/domain/models/Membership');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const moduleUnderTest = require('../../../../lib/application/memberships');
-const { InvalidMembershipRoleError } = require('../../../../lib/domain/errors');
+const { InvalidMembershipOrganizationRoleError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Application | Memberships | membership-controller', () => {
 
@@ -145,7 +145,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
         it('should resolve a 400 HTTP response', async () => {
           // given
           securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
-          usecases.updateMembership.throws(new InvalidMembershipRoleError());
+          usecases.updateMembership.throws(new InvalidMembershipOrganizationRoleError());
 
           // when
           const response = await httpTestServer.request('PATCH', '/api/memberships/1', payload);

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -129,6 +129,51 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
     context('Error cases', () => {
 
+      context('when request is not valid', () => {
+
+        it('should resolve a 400 HTTP response', async () => {
+          // given
+          securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
+          const idGivenInRequestParams = 1;
+          const idGivenInPayload = 44;
+
+          const membership = new Membership({
+            id: idGivenInPayload,
+            organizationRole: Membership.roles.ADMIN,
+            updatedByUserId: null,
+          });
+          const updatedMembership = domainBuilder.buildMembership({
+            organizationRole: Membership.roles.ADMIN,
+          });
+          usecases.updateMembership
+            .withArgs({ membership })
+            .resolves(updatedMembership);
+
+          // when
+          const payload = {
+            data: {
+              type: 'memberships',
+              id: idGivenInPayload,
+              attributes: {
+                'organization-role': Membership.roles.ADMIN,
+              },
+              relationships: {
+                organization: {
+                  data: {
+                    id: '1',
+                    type: 'organizations',
+                  },
+                },
+              },
+            },
+          };
+          const response = await httpTestServer.request('PATCH', `/api/memberships/${idGivenInRequestParams}`, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+
       context('when user is not allowed to access resource', () => {
 
         it('should resolve a 403 HTTP response', async () => {

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -91,7 +91,15 @@ describe('Integration | Application | Memberships | membership-controller', () =
       data: {
         type: 'memberships',
         attributes: {
-          'organaization-role': organizationRole,
+          'organization-role': organizationRole,
+        },
+        relationships: {
+          organization: {
+            data: {
+              id: '1',
+              type: 'organizations',
+            },
+          },
         },
       },
     };

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -3,6 +3,7 @@ const usecases = require('../../../../lib/domain/usecases');
 const Membership = require('../../../../lib/domain/models/Membership');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const moduleUnderTest = require('../../../../lib/application/memberships');
+const { InvalidMembershipRoleError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Application | Memberships | membership-controller', () => {
 
@@ -126,6 +127,21 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
           // then
           expect(response.statusCode).to.equal(403);
+        });
+      });
+
+      context('when organization role is not valid', () => {
+
+        it('should resolve a 400 HTTP response', async () => {
+          // given
+          securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
+          usecases.updateMembership.throws(new InvalidMembershipRoleError());
+
+          // when
+          const response = await httpTestServer.request('PATCH', '/api/memberships/1', payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
         });
       });
     });

--- a/api/tests/integration/domain/usecases/update-membership_test.js
+++ b/api/tests/integration/domain/usecases/update-membership_test.js
@@ -25,12 +25,12 @@ describe('Integration | UseCases | update-membership', () => {
       organizationRole: Membership.roles.MEMBER,
     }).id;
     const newOrganizationRole = Membership.roles.ADMIN;
-    const membershipAttributes = { organizationRole: newOrganizationRole, updatedByUserId };
+    const membership = { organizationRole: newOrganizationRole, updatedByUserId };
 
     await databaseBuilder.commit();
 
     // when
-    const result = await updateMembership({ membershipRepository, membershipId, membershipAttributes });
+    const result = await updateMembership({ membershipRepository, membershipId, membership });
 
     // then
     expect(result).to.be.an.instanceOf(Membership);

--- a/api/tests/integration/domain/usecases/update-membership_test.js
+++ b/api/tests/integration/domain/usecases/update-membership_test.js
@@ -1,25 +1,55 @@
-const { expect, databaseBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
 
 const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+const certificationCenterRepository = require('../../../../lib/infrastructure/repositories/certification-center-repository');
+const certificationCenterMembershipRepository = require('../../../../lib/infrastructure/repositories/certification-center-membership-repository');
 const Membership = require('../../../../lib/domain/models/Membership');
 
 const updateMembership = require('../../../../lib/domain/usecases/update-membership');
 
 describe('Integration | UseCases | update-membership', () => {
 
-  let userId;
-  let updatedByUserId;
-  let organizationId;
-
-  beforeEach(async () => {
-    organizationId = databaseBuilder.factory.buildOrganization().id;
-    userId = databaseBuilder.factory.buildUser().id;
-    updatedByUserId = databaseBuilder.factory.buildUser().id;
-    await databaseBuilder.commit();
+  afterEach(() => {
+    return knex('certification-center-memberships').delete();
   });
 
   it('should update membership', async () => {
     // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    const updatedByUserId = databaseBuilder.factory.buildUser().id;
+
+    const membershipId = databaseBuilder.factory.buildMembership({
+      organizationId, userId,
+      organizationRole: Membership.roles.MEMBER,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const newOrganizationRole = Membership.roles.ADMIN;
+    const membership = new Membership({ id: membershipId, organizationRole: newOrganizationRole, updatedByUserId });
+
+    // when
+    const result = await updateMembership({
+      membershipId,
+      membership,
+      membershipRepository,
+      certificationCenterRepository,
+      certificationCenterMembershipRepository,
+    });
+
+    // then
+    expect(result).to.be.an.instanceOf(Membership);
+    expect(result.organizationRole).equal(newOrganizationRole);
+    expect(result.updatedByUserId).equal(updatedByUserId);
+  });
+
+  it('if the organization has a certification center and he role to update is set to administrator, it should create a certification center membership ', async () => {
+    // given
+    const externalId = 'foo';
+    const organizationId = databaseBuilder.factory.buildOrganization({ externalId }).id;
+    const userId = databaseBuilder.factory.buildUser().id;
+    const updatedByUserId = databaseBuilder.factory.buildUser().id;
     const membershipId = databaseBuilder.factory.buildMembership({
       organizationId, userId,
       organizationRole: Membership.roles.MEMBER,
@@ -27,15 +57,27 @@ describe('Integration | UseCases | update-membership', () => {
     const newOrganizationRole = Membership.roles.ADMIN;
     const membership = new Membership({ id: membershipId, organizationRole: newOrganizationRole, updatedByUserId });
 
+    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ externalId }).id;
+
     await databaseBuilder.commit();
 
     // when
-    const result = await updateMembership({ membershipRepository, membershipId, membership });
+    await updateMembership({
+      membershipId,
+      membership,
+      membershipRepository,
+      certificationCenterRepository,
+      certificationCenterMembershipRepository,
+    });
 
     // then
-    expect(result).to.be.an.instanceOf(Membership);
-    expect(result.organizationRole).equal(newOrganizationRole);
-    expect(result.updatedByUserId).equal(updatedByUserId);
+    const certificationCenterMembership = await knex('certification-center-memberships').where({
+      userId,
+      certificationCenterId,
+    }).first();
+
+    expect(certificationCenterMembership).not.to.be.undefined;
+
   });
 
 });

--- a/api/tests/integration/domain/usecases/update-membership_test.js
+++ b/api/tests/integration/domain/usecases/update-membership_test.js
@@ -3,6 +3,7 @@ const { expect, databaseBuilder, knex } = require('../../../test-helper');
 const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
 const certificationCenterRepository = require('../../../../lib/infrastructure/repositories/certification-center-repository');
 const certificationCenterMembershipRepository = require('../../../../lib/infrastructure/repositories/certification-center-membership-repository');
+
 const Membership = require('../../../../lib/domain/models/Membership');
 
 const updateMembership = require('../../../../lib/domain/usecases/update-membership');
@@ -47,7 +48,7 @@ describe('Integration | UseCases | update-membership', () => {
   it('if the organization has a certification center and the role to update is set to administrator, it should create a certification center membership ', async () => {
     // given
     const externalId = 'foo';
-    const organizationId = databaseBuilder.factory.buildOrganization({ externalId }).id;
+    const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', externalId }).id;
     const userId = databaseBuilder.factory.buildUser().id;
     const updatedByUserId = databaseBuilder.factory.buildUser().id;
     const membershipId = databaseBuilder.factory.buildMembership({

--- a/api/tests/integration/domain/usecases/update-membership_test.js
+++ b/api/tests/integration/domain/usecases/update-membership_test.js
@@ -44,7 +44,7 @@ describe('Integration | UseCases | update-membership', () => {
     expect(result.updatedByUserId).equal(updatedByUserId);
   });
 
-  it('if the organization has a certification center and he role to update is set to administrator, it should create a certification center membership ', async () => {
+  it('if the organization has a certification center and the role to update is set to administrator, it should create a certification center membership ', async () => {
     // given
     const externalId = 'foo';
     const organizationId = databaseBuilder.factory.buildOrganization({ externalId }).id;

--- a/api/tests/integration/domain/usecases/update-membership_test.js
+++ b/api/tests/integration/domain/usecases/update-membership_test.js
@@ -25,7 +25,7 @@ describe('Integration | UseCases | update-membership', () => {
       organizationRole: Membership.roles.MEMBER,
     }).id;
     const newOrganizationRole = Membership.roles.ADMIN;
-    const membership = { organizationRole: newOrganizationRole, updatedByUserId };
+    const membership = new Membership({ id: membershipId, organizationRole: newOrganizationRole, updatedByUserId });
 
     await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -296,7 +296,7 @@ describe('Integration | Repository | Certification Center', () => {
     });
   });
 
-  describe('#getByExternalId', () => {
+  describe('#findByExternalId', () => {
 
     context('the certification center is found', () => {
 
@@ -309,7 +309,7 @@ describe('Integration | Repository | Certification Center', () => {
 
       it('should return the certification center', async () => {
         // when
-        const certificationCenter = await certificationCenterRepository.getByExternalId({ externalId });
+        const certificationCenter = await certificationCenterRepository.findByExternalId({ externalId });
 
         // then
         expect(certificationCenter).to.be.an.instanceOf(CertificationCenter);
@@ -321,7 +321,7 @@ describe('Integration | Repository | Certification Center', () => {
       it('should return null', async () => {
         // when
         const externalId = 'nonExistentExternalId';
-        const certificationCenter = await certificationCenterRepository.getByExternalId({ externalId });
+        const certificationCenter = await certificationCenterRepository.findByExternalId({ externalId });
 
         // then
         expect(certificationCenter).to.be.null;

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -10,7 +10,8 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('the certification center is found', () => {
 
-      beforeEach(async () => {
+      it('should return the certification center of the given id with the right properties', async () => {
+        // given
         databaseBuilder.factory.buildCertificationCenter({
           id: 1,
           name: 'certificationCenterName',
@@ -19,9 +20,7 @@ describe('Integration | Repository | Certification Center', () => {
         databaseBuilder.factory.buildCertificationCenter({ id: 2 });
 
         await databaseBuilder.commit();
-      });
 
-      it('should return the certification center of the given id with the right properties', async () => {
         // when
         const certificationCenter = await certificationCenterRepository.get(1);
 
@@ -117,14 +116,11 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('when there are CertificationCenters in the database', () => {
 
-      beforeEach(() => {
-        _.times(3, databaseBuilder.factory.buildCertificationCenter);
-
-        return databaseBuilder.commit();
-      });
-
       it('should return an Array of CertificationCenters', async () => {
         // given
+        _.times(3, databaseBuilder.factory.buildCertificationCenter);
+        await databaseBuilder.commit();
+
         const filter = {};
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
@@ -143,13 +139,11 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('when there are lots of CertificationCenters (> 10) in the database', () => {
 
-      beforeEach(() => {
-        _.times(12, databaseBuilder.factory.buildCertificationCenter);
-        return databaseBuilder.commit();
-      });
-
       it('should return paginated matching CertificationCenters', async () => {
         // given
+        _.times(12, databaseBuilder.factory.buildCertificationCenter);
+        await databaseBuilder.commit();
+
         const filter = {};
         const page = { number: 1, size: 3 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 4, rowCount: 12 };
@@ -165,16 +159,14 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('when there are multiple CertificationCenters matching the same "name" search pattern', () => {
 
-      beforeEach(() => {
+      it('should return only CertificationCenters matching "name" if given in filters', async () => {
+        // given
         databaseBuilder.factory.buildCertificationCenter({ name: 'Dragon & co center' });
         databaseBuilder.factory.buildCertificationCenter({ name: 'Dragonades & co center' });
         databaseBuilder.factory.buildCertificationCenter({ name: 'Broca & co center' });
         databaseBuilder.factory.buildCertificationCenter({ name: 'Donnie & co center' });
-        return databaseBuilder.commit();
-      });
+        await databaseBuilder.commit();
 
-      it('should return only CertificationCenters matching "name" if given in filters', async () => {
-        // given
         const filter = { name: 'dra' };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
@@ -191,16 +183,14 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('when there are multiple CertificationCenters matching the same "type" search pattern', () => {
 
-      beforeEach(() => {
+      it('should return only CertificationCenters matching "type" if given in filters', async () => {
+        // given
         databaseBuilder.factory.buildCertificationCenter({ type: 'PRO' });
         databaseBuilder.factory.buildCertificationCenter({ type: 'PRO' });
         databaseBuilder.factory.buildCertificationCenter({ type: 'SUP' });
         databaseBuilder.factory.buildCertificationCenter({ type: 'SCO' });
-        return databaseBuilder.commit();
-      });
+        await databaseBuilder.commit();
 
-      it('should return only CertificationCenters matching "type" if given in filters', async () => {
-        // given
         const filter = { type: 'S' };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
@@ -216,15 +206,13 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('when there are multiple CertificationCenters matching the same "externalId" search pattern', () => {
 
-      beforeEach(() => {
+      it('should return only CertificationCenters matching "externalId" if given in filters', async () => {
+        // given
         databaseBuilder.factory.buildCertificationCenter({ externalId: 'AZH578' });
         databaseBuilder.factory.buildCertificationCenter({ externalId: 'BFR842' });
         databaseBuilder.factory.buildCertificationCenter({ externalId: 'AZH002' });
-        return databaseBuilder.commit();
-      });
+        await databaseBuilder.commit();
 
-      it('should return only CertificationCenters matching "externalId" if given in filters', async () => {
-        // given
         const filter = { externalId: 'AZ' };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
@@ -240,22 +228,12 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('when there are multiple CertificationCenters matching the fields "first name", "last name" and "email" search pattern', () => {
 
-      beforeEach(() => {
-        // Matching users
-        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_1', type: 'SCO', externalId: 'c_ok_1' });
-        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_2', type: 'SCO', externalId: 'c_ok_2' });
-        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_3', type: 'SCO', externalId: 'c_ok_3' });
-
-        // Unmatching users
-        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ko_4', type: 'SCO', externalId: 'c_ok_4' });
-        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_5', type: 'SUP', externalId: 'c_ok_5' });
-        databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_6', type: 'SCO', externalId: 'c_ko_1' });
-
-        return databaseBuilder.commit();
-      });
-
       it('should return only CertificationCenters matching "name" AND "type" AND "externalId" if given in filters', async () => {
         // given
+        _buildThreeCertificationCenterMatchingNameTypeAndExternalId({ databaseBuilder, numberOfBuild: 3 });
+        _buildThreeCertificationCenterUnmatchingNameTypeOrExternalId({ databaseBuilder, numberOfBuild: 3 });
+        await databaseBuilder.commit();
+
         const filter = { name: 'name_ok', type: 'SCO', externalId: 'c_ok' };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
@@ -273,15 +251,12 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('when there are filters that should be ignored', () => {
 
-      beforeEach(() => {
-        databaseBuilder.factory.buildCertificationCenter({ id: 1 });
-        databaseBuilder.factory.buildCertificationCenter({ id: 2 });
-
-        return databaseBuilder.commit();
-      });
-
       it('should ignore the filters and retrieve all certificationCenters', async () => {
         // given
+        databaseBuilder.factory.buildCertificationCenter({ id: 1 });
+        databaseBuilder.factory.buildCertificationCenter({ id: 2 });
+        await databaseBuilder.commit();
+
         const filter = { foo: 1 };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
@@ -300,14 +275,12 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('the certification center is found', () => {
 
-      const externalId = 'EXTERNAL_ID';
-
-      beforeEach(async () => {
+      it('should return the certification center', async () => {
+        // given
+        const externalId = 'EXTERNAL_ID';
         databaseBuilder.factory.buildCertificationCenter({ externalId });
         await databaseBuilder.commit();
-      });
 
-      it('should return the certification center', async () => {
         // when
         const certificationCenter = await certificationCenterRepository.findByExternalId({ externalId });
 
@@ -331,3 +304,15 @@ describe('Integration | Repository | Certification Center', () => {
 
   });
 });
+
+function _buildThreeCertificationCenterMatchingNameTypeAndExternalId({ databaseBuilder }) {
+  databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_1', type: 'SCO', externalId: 'c_ok_1' });
+  databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_2', type: 'SCO', externalId: 'c_ok_2' });
+  databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_3', type: 'SCO', externalId: 'c_ok_3' });
+}
+
+function _buildThreeCertificationCenterUnmatchingNameTypeOrExternalId({ databaseBuilder }) {
+  databaseBuilder.factory.buildCertificationCenter({ name: 'name_ko_4', type: 'SCO', externalId: 'c_ok_4' });
+  databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_5', type: 'SUP', externalId: 'c_ok_5' });
+  databaseBuilder.factory.buildCertificationCenter({ name: 'name_ok_6', type: 'SCO', externalId: 'c_ko_1' });
+}

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -313,10 +313,11 @@ describe('Integration | Repository | Certification Center', () => {
 
         // then
         expect(certificationCenter).to.be.an.instanceOf(CertificationCenter);
+        expect(certificationCenter.externalId).to.equal(externalId);
       });
     });
 
-    context('the certification center could not be found', () => {
+    context('the certification center is not found', () => {
 
       it('should return null', async () => {
         // when

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -295,4 +295,38 @@ describe('Integration | Repository | Certification Center', () => {
       });
     });
   });
+
+  describe('#getByExternalId', () => {
+
+    context('the certification center is found', () => {
+
+      const externalId = 'EXTERNAL_ID';
+
+      beforeEach(async () => {
+        databaseBuilder.factory.buildCertificationCenter({ externalId });
+        await databaseBuilder.commit();
+      });
+
+      it('should return the certification center', async () => {
+        // when
+        const certificationCenter = await certificationCenterRepository.getByExternalId({ externalId });
+
+        // then
+        expect(certificationCenter).to.be.an.instanceOf(CertificationCenter);
+      });
+    });
+
+    context('the certification center could not be found', () => {
+
+      it('should return null', async () => {
+        // when
+        const externalId = 'nonExistentExternalId';
+        const certificationCenter = await certificationCenterRepository.getByExternalId({ externalId });
+
+        // then
+        expect(certificationCenter).to.be.null;
+      });
+    });
+
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | Repository | Certification Center', () => {
 
   describe('#get', () => {
 
-    context('the certification center is found', () => {
+    context('when the certification center is found', () => {
 
       it('should return the certification center of the given id with the right properties', async () => {
         // given

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -1,7 +1,7 @@
 const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
 const _ = require('lodash');
 const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
-const { MembershipCreationError, MembershipUpdateError } = require('../../../../lib/domain/errors');
+const { MembershipCreationError, MembershipUpdateError, NotFoundError } = require('../../../../lib/domain/errors');
 const Membership = require('../../../../lib/domain/models/Membership');
 const Organization = require('../../../../lib/domain/models/Organization');
 const User = require('../../../../lib/domain/models/User');
@@ -87,11 +87,14 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
     context('when membership does not exist', () => {
 
       it('should throw a NotFoundError', async () => {
+        // given
+        const nonExistingMembership = existingMembershipId + 1;
+
         // when
-        const result = await membershipRepository.get(existingMembershipId);
+        const error = await catchErr(membershipRepository.get)(nonExistingMembership);
 
         // then
-        expect(result).to.be.an.instanceOf(Membership);
+        expect(error).to.be.an.instanceOf(NotFoundError);
       });
     });
   });
@@ -540,7 +543,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
 
     context('When membership exist', () => {
 
-      it('should update membership attributes', async () => {
+      it('should return the updated membership', async () => {
         // given
         const membership = { organizationRole: Membership.roles.ADMIN, updatedByUserId };
 
@@ -562,8 +565,6 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
 
         // then
         expect(updatedMembership).to.be.an.instanceOf(Membership);
-        expect(updatedMembership.user).be.an.instanceOf(User);
-        expect(updatedMembership.organization).to.be.an.instanceOf(Organization);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -62,12 +62,12 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
 
   describe('#get', () => {
 
-    let existingMembership;
+    let existingMembershipId;
 
     beforeEach(async () => {
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      existingMembership = databaseBuilder.factory.buildMembership({ userId, organizationId });
+      existingMembershipId = databaseBuilder.factory.buildMembership({ userId, organizationId }).id;
       await databaseBuilder.commit();
     });
 
@@ -75,7 +75,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
 
       it('should return the membership', async () => {
         // when
-        const result = await membershipRepository.get(existingMembership.id);
+        const result = await membershipRepository.get(existingMembershipId);
 
         // then
         expect(result).to.be.an.instanceOf(Membership);
@@ -88,7 +88,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
 
       it('should throw a NotFoundError', async () => {
         // when
-        const result = await membershipRepository.get(existingMembership.id);
+        const result = await membershipRepository.get(existingMembershipId);
 
         // then
         expect(result).to.be.an.instanceOf(Membership);

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -4,6 +4,7 @@ const membershipRepository = require('../../../../lib/infrastructure/repositorie
 const { MembershipCreationError, MembershipUpdateError } = require('../../../../lib/domain/errors');
 const Membership = require('../../../../lib/domain/models/Membership');
 const Organization = require('../../../../lib/domain/models/Organization');
+const User = require('../../../../lib/domain/models/User');
 
 describe('Integration | Infrastructure | Repository | membership-repository', () => {
 
@@ -505,51 +506,28 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
 
       it('should update membership attributes', async () => {
         // given
-        const membershipAttributes = { organizationRole: Membership.roles.ADMIN, updatedByUserId };
+        const membership = { organizationRole: Membership.roles.ADMIN, updatedByUserId };
 
         // when
-        const membership = await membershipRepository.updateById({ id: existingMembershipId, membershipAttributes });
+        const updatedMembership = await membershipRepository.updateById({ id: existingMembershipId, membership });
 
         // then
-        expect(membership).to.be.an.instanceOf(Membership);
-        expect(membership.organizationRole).to.equal(membershipAttributes.organizationRole);
-        expect(membership.updatedByUserId).to.equal(membershipAttributes.updatedByUserId);
+        expect(updatedMembership).to.be.an.instanceOf(Membership);
+        expect(updatedMembership.organizationRole).to.equal(updatedMembership.organizationRole);
+        expect(updatedMembership.updatedByUserId).to.equal(updatedMembership.updatedByUserId);
       });
 
-      it('should update organization role with admin role', async () => {
+      it('should return the organization and user linked to this membership', async () => {
         // given
-        const membershipAttributes = { organizationRole: Membership.roles.ADMIN };
+        const membership = { organizationRole: Membership.roles.ADMIN, updatedByUserId };
 
         // when
-        const membership = await membershipRepository.updateById({ id: existingMembershipId, membershipAttributes });
+        const updatedMembership = await membershipRepository.updateById({ id: existingMembershipId, membership });
 
         // then
-        expect(membership).to.be.an.instanceOf(Membership);
-        expect(membership.organizationRole).to.equal(membershipAttributes.organizationRole);
-      });
-
-      it('should update organization role with member role', async () => {
-        // given
-        const organizationRole = Membership.roles.MEMBER;
-        const membershipAttributes = { organizationRole };
-
-        // when
-        const membership = await membershipRepository.updateById({ id: existingMembershipId, membershipAttributes });
-        // then
-        expect(membership.organizationRole).to.equal(organizationRole);
-      });
-
-      it('should save the user identifier who changes the organization role ', async () => {
-        // given
-        const membershipAttributes = { organizationRole: Membership.roles.ADMIN, updatedByUserId };
-
-        // when
-        const membership = await membershipRepository.updateById({ id: existingMembershipId, membershipAttributes });
-
-        // then
-        expect(membership).to.be.an.instanceOf(Membership);
-        expect(membership.organizationRole).to.equal(membershipAttributes.organizationRole);
-        expect(membership.updatedByUserId).to.equal(membershipAttributes.updatedByUserId);
+        expect(updatedMembership).to.be.an.instanceOf(Membership);
+        expect(updatedMembership.user).be.an.instanceOf(User);
+        expect(updatedMembership.organization).to.be.an.instanceOf(Organization);
       });
     });
 
@@ -560,10 +538,10 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
         const organizationRole = Membership.roles.ADMIN;
         const messageNotRowUpdated = 'No Rows Updated';
         const notExistingMembershipId = 9898977;
-        const membershipAttributes = { organizationRole, updatedByUserId };
+        const membership = { organizationRole, updatedByUserId };
 
         // when
-        const error = await catchErr(membershipRepository.updateById)({ id: notExistingMembershipId, membershipAttributes });
+        const error = await catchErr(membershipRepository.updateById)({ id: notExistingMembershipId, membership });
 
         // then
         expect(error).to.be.an.instanceOf(MembershipUpdateError);

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -60,6 +60,42 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
     });
   });
 
+  describe('#get', () => {
+
+    let existingMembership;
+
+    beforeEach(async () => {
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      existingMembership = databaseBuilder.factory.buildMembership({ userId, organizationId });
+      await databaseBuilder.commit();
+    });
+
+    context('when membership exists', () => {
+
+      it('should return the membership', async () => {
+        // when
+        const result = await membershipRepository.get(existingMembership.id);
+
+        // then
+        expect(result).to.be.an.instanceOf(Membership);
+        expect(result.user).to.be.an.instanceOf(User);
+        expect(result.organization).to.be.an.instanceOf(Organization);
+      });
+    });
+
+    context('when membership does not exist', () => {
+
+      it('should throw a NotFoundError', async () => {
+        // when
+        const result = await membershipRepository.get(existingMembership.id);
+
+        // then
+        expect(result).to.be.an.instanceOf(Membership);
+      });
+    });
+  });
+
   describe('#findByOrganizationId', () => {
 
     it('should return all the memberships for a given organization ID with only required relationships', async () => {

--- a/api/tests/unit/domain/models/Membership_test.js
+++ b/api/tests/unit/domain/models/Membership_test.js
@@ -13,9 +13,6 @@ describe('Unit | Domain | Models | Membership', () => {
         const membership = new Membership({
           id: 'bbb12aa3',
           organizationRole: 'ADMIN',
-          updatedByUserId: undefined,
-          organization: undefined,
-          user: undefined,
         });
 
         // then
@@ -30,9 +27,6 @@ describe('Unit | Domain | Models | Membership', () => {
         const membership = new Membership({
           id: '123',
           organizationRole: 'SUPERADMIN',
-          updatedByUserId: null,
-          organization: null,
-          user: null,
         });
 
         // then

--- a/api/tests/unit/domain/models/Membership_test.js
+++ b/api/tests/unit/domain/models/Membership_test.js
@@ -1,0 +1,45 @@
+const { expect } = require('../../../test-helper');
+const Membership = require('../../../../lib/domain/models/Membership');
+const { InvalidMembershipRoleError } = require('../../../../lib/domain/errors');
+
+describe('Unit | Domain | Models | Membership', () => {
+
+  describe('#validateRole', () => {
+
+    context('when organizationRole is valid', () => {
+
+      it('should not throw an error', () => {
+        // given / when
+        const membership = new Membership({
+          id: 'bbb12aa3',
+          organizationRole: 'ADMIN',
+          updatedByUserId: undefined,
+          organization: undefined,
+          user: undefined,
+        });
+
+        // then
+        expect(() => membership.validateRole()).not.to.throw();
+      });
+    });
+
+    context('when organizationRole is invalid', () => {
+
+      it('should throw an InvalidMembershipRoleError error', async () => {
+        // given / when
+        const membership = new Membership({
+          id: '123',
+          organizationRole: 'SUPERADMIN',
+          updatedByUserId: null,
+          organization: null,
+          user: null,
+        });
+
+        // then
+        expect(() => membership.validateRole()).to.throw(InvalidMembershipRoleError);
+      });
+
+    });
+
+  });
+});

--- a/api/tests/unit/domain/models/Membership_test.js
+++ b/api/tests/unit/domain/models/Membership_test.js
@@ -1,6 +1,6 @@
 const { expect } = require('../../../test-helper');
 const Membership = require('../../../../lib/domain/models/Membership');
-const { InvalidMembershipRoleError } = require('../../../../lib/domain/errors');
+const { InvalidMembershipOrganizationRoleError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | Models | Membership', () => {
 
@@ -22,7 +22,7 @@ describe('Unit | Domain | Models | Membership', () => {
 
     context('when organizationRole is invalid', () => {
 
-      it('should throw an InvalidMembershipRoleError error', async () => {
+      it('should throw an InvalidMembershipOrganizationRoleError error', async () => {
         // given / when
         const membership = new Membership({
           id: '123',
@@ -30,7 +30,7 @@ describe('Unit | Domain | Models | Membership', () => {
         });
 
         // then
-        expect(() => membership.validateRole()).to.throw(InvalidMembershipRoleError);
+        expect(() => membership.validateRole()).to.throw(InvalidMembershipOrganizationRoleError);
       });
 
     });

--- a/api/tests/unit/domain/usecases/update-membership_test.js
+++ b/api/tests/unit/domain/usecases/update-membership_test.js
@@ -2,7 +2,7 @@ const { expect, sinon } = require('../../../test-helper');
 const { updateMembership } = require('../../../../lib/domain/usecases');
 const Membership = require('../../../../lib/domain/models/Membership');
 
-describe('Unit | UseCase | update-membership-attributes', () => {
+describe('Unit | UseCase | update-membership', () => {
 
   let membershipRepository;
 
@@ -18,13 +18,13 @@ describe('Unit | UseCase | update-membership-attributes', () => {
       // given
       const membershipId = 100;
       const organizationRole = Membership.roles.ADMIN;
-      const membershipAttributes = { id: membershipId, organizationRole, updatedByUserId: 12345 };
+      const membership = { id: membershipId, organizationRole, updatedByUserId: 12345 };
 
       // when
-      await updateMembership({ membershipId, membershipAttributes, membershipRepository });
+      await updateMembership({ membershipId, membership, membershipRepository });
 
       // then
-      expect(membershipRepository.updateById).to.has.been.calledWith({ id: membershipId, membershipAttributes });
+      expect(membershipRepository.updateById).to.has.been.calledWith({ id: membershipId, membership });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/update-membership_test.js
+++ b/api/tests/unit/domain/usecases/update-membership_test.js
@@ -15,7 +15,7 @@ describe('Unit | UseCase | update-membership', () => {
       get: sinon.stub(),
     };
     certificationCenterRepository = {
-      getByExternalId: sinon.stub(),
+      findByExternalId: sinon.stub(),
     };
     certificationCenterMembershipRepository = {
       save: sinon.stub(),
@@ -28,7 +28,7 @@ describe('Unit | UseCase | update-membership', () => {
     const organizationRole = Membership.roles.ADMIN;
     const membership = new Membership({ id: membershipId, organizationRole, updatedByUserId: 12345 });
     membershipRepository.get.resolves(domainBuilder.buildMembership());
-    certificationCenterRepository.getByExternalId.resolves(null);
+    certificationCenterRepository.findByExternalId.resolves(null);
 
     // when
     await updateMembership({
@@ -79,7 +79,7 @@ describe('Unit | UseCase | update-membership', () => {
         });
 
         membershipRepository.get.withArgs(membershipId).resolves(existingMembership);
-        certificationCenterRepository.getByExternalId.withArgs({ externalId }).resolves(existingCertificationCenter);
+        certificationCenterRepository.findByExternalId.withArgs({ externalId }).resolves(existingCertificationCenter);
 
         // when
         await updateMembership({
@@ -109,7 +109,7 @@ describe('Unit | UseCase | update-membership', () => {
         });
 
         membershipRepository.get.withArgs(membershipId).resolves(existingMembership);
-        certificationCenterRepository.getByExternalId.withArgs({ externalId }).resolves(null);
+        certificationCenterRepository.findByExternalId.withArgs({ externalId }).resolves(null);
 
         // when
         await updateMembership({

--- a/api/tests/unit/domain/usecases/update-membership_test.js
+++ b/api/tests/unit/domain/usecases/update-membership_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const { updateMembership } = require('../../../../lib/domain/usecases');
 const Membership = require('../../../../lib/domain/models/Membership');
-const { InvalidMembershipRoleError } = require('../../../../lib/domain/errors');
+const { InvalidMembershipOrganizationRoleError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | update-membership', () => {
 
@@ -48,7 +48,7 @@ describe('Unit | UseCase | update-membership', () => {
     expect(membershipRepository.updateById).to.has.been.calledWith({ id: membershipId, membership });
   });
 
-  it('should throw a InvalidMembershipRoleError if role is not valid', async () => {
+  it('should throw a InvalidMembershipOrganizationRoleError if role is not valid', async () => {
     // given
     const organization = domainBuilder.buildOrganization({ type: 'SUP' });
     const membershipId = 100;
@@ -65,7 +65,7 @@ describe('Unit | UseCase | update-membership', () => {
     });
 
     // then
-    expect(error).to.an.instanceOf(InvalidMembershipRoleError);
+    expect(error).to.an.instanceOf(InvalidMembershipOrganizationRoleError);
   });
 
   context('when the role to update is set to administrator', () => {

--- a/api/tests/unit/domain/usecases/update-membership_test.js
+++ b/api/tests/unit/domain/usecases/update-membership_test.js
@@ -1,4 +1,4 @@
-const { expect, sinon, catchErr } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const { updateMembership } = require('../../../../lib/domain/usecases');
 const Membership = require('../../../../lib/domain/models/Membership');
 const { InvalidMembershipRoleError } = require('../../../../lib/domain/errors');
@@ -6,39 +6,145 @@ const { InvalidMembershipRoleError } = require('../../../../lib/domain/errors');
 describe('Unit | UseCase | update-membership', () => {
 
   let membershipRepository;
+  let certificationCenterRepository;
+  let certificationCenterMembershipRepository;
 
   beforeEach(() => {
     membershipRepository = {
-      updateById: sinon.stub().resolves(),
+      updateById: sinon.stub(),
+      get: sinon.stub(),
+    };
+    certificationCenterRepository = {
+      getByExternalId: sinon.stub(),
+    };
+    certificationCenterMembershipRepository = {
+      save: sinon.stub(),
     };
   });
 
-  context('when membership exists', () => {
+  it('should update the membership', async () => {
+    // given
+    const membershipId = 100;
+    const organizationRole = Membership.roles.ADMIN;
+    const membership = new Membership({ id: membershipId, organizationRole, updatedByUserId: 12345 });
+    membershipRepository.get.resolves(domainBuilder.buildMembership());
+    certificationCenterRepository.getByExternalId.resolves(null);
 
-    it('should update membership attributes', async () => {
-      // given
-      const membershipId = 100;
-      const organizationRole = Membership.roles.ADMIN;
-      const membership = new Membership({ id: membershipId, organizationRole, updatedByUserId: 12345 });
-
-      // when
-      await updateMembership({ membershipId, membership, membershipRepository });
-
-      // then
-      expect(membershipRepository.updateById).to.has.been.calledWith({ id: membershipId, membership });
+    // when
+    await updateMembership({
+      membershipId,
+      membership,
+      membershipRepository,
+      certificationCenterRepository,
+      certificationCenterMembershipRepository,
     });
 
-    it('should throw a InvalidMembershipRoleError if role is not valid', async () => {
-      // given
-      const membershipId = 100;
-      const organizationRole = 'NOT_VALID_ROLE';
-      const membership = new Membership({ id: membershipId, organizationRole, updatedByUserId: 12345 });
+    // then
+    expect(membershipRepository.updateById).to.has.been.calledWith({ id: membershipId, membership });
+  });
 
-      // when
-      const error = await catchErr(updateMembership)({ membershipId, membership, membershipRepository });
+  it('should throw a InvalidMembershipRoleError if role is not valid', async () => {
+    // given
+    const membershipId = 100;
+    const organizationRole = 'NOT_VALID_ROLE';
+    const membership = new Membership({ id: membershipId, organizationRole, updatedByUserId: 12345 });
 
-      // then
-      expect(error).to.an.instanceOf(InvalidMembershipRoleError);
+    // when
+    const error = await catchErr(updateMembership)({
+      membershipId,
+      membership,
+      membershipRepository,
+      certificationCenterRepository,
+      certificationCenterMembershipRepository,
+    });
+
+    // then
+    expect(error).to.an.instanceOf(InvalidMembershipRoleError);
+  });
+
+  context('when the role to update is set to administrator', () => {
+
+    context('when the membership\'s organization has a certification center', () => {
+      it('should create a certification center membership', async () => {
+        // given
+        const membershipId = 1;
+        const externalId = 'externalId';
+        const membership = new Membership({ organizationRole: Membership.roles.ADMIN });
+        const existingOrganization = domainBuilder.buildOrganization({ externalId });
+        const existingUser = domainBuilder.buildUser();
+        const existingCertificationCenter = domainBuilder.buildCertificationCenter({ externalId });
+        const existingMembership = domainBuilder.buildMembership({
+          organization: existingOrganization,
+          user: existingUser,
+        });
+
+        membershipRepository.get.withArgs(membershipId).resolves(existingMembership);
+        certificationCenterRepository.getByExternalId.withArgs({ externalId }).resolves(existingCertificationCenter);
+
+        // when
+        await updateMembership({
+          membershipId,
+          membership,
+          membershipRepository,
+          certificationCenterRepository,
+          certificationCenterMembershipRepository,
+        });
+
+        // then
+        expect(certificationCenterMembershipRepository.save).to.have.been.calledWith(existingUser.id, existingCertificationCenter.id);
+      });
+    });
+
+    context('when the membership\'s organization has no certification center', () => {
+      it('should not create a certification center membership', async () => {
+        // given
+        const membershipId = 1;
+        const externalId = 'externalId';
+        const membership = new Membership({ organizationRole: Membership.roles.ADMIN });
+        const existingOrganization = domainBuilder.buildOrganization({ externalId });
+        const existingUser = domainBuilder.buildUser();
+        const existingMembership = domainBuilder.buildMembership({
+          organization: existingOrganization,
+          user: existingUser,
+        });
+
+        membershipRepository.get.withArgs(membershipId).resolves(existingMembership);
+        certificationCenterRepository.getByExternalId.withArgs({ externalId }).resolves(null);
+
+        // when
+        await updateMembership({
+          membershipId,
+          membership,
+          membershipRepository,
+          certificationCenterRepository,
+          certificationCenterMembershipRepository,
+        });
+
+        // then
+        expect(certificationCenterMembershipRepository.save).to.not.have.been.called;
+      });
     });
   });
+
+  context('when the role to update is set to member', () => {
+    it('should not create a certification center membership', async () => {
+      // given
+      const membershipId = 1;
+      const membership = new Membership({ organizationRole: Membership.roles.MEMBER });
+
+      // when
+      await updateMembership({
+        membershipId,
+        membership,
+        membershipRepository,
+        certificationCenterRepository,
+        certificationCenterMembershipRepository,
+      });
+
+      // then
+      expect(certificationCenterMembershipRepository.save).to.not.have.been.called;
+    });
+  });
+
 });
+

--- a/api/tests/unit/domain/usecases/update-membership_test.js
+++ b/api/tests/unit/domain/usecases/update-membership_test.js
@@ -1,6 +1,7 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 const { updateMembership } = require('../../../../lib/domain/usecases');
 const Membership = require('../../../../lib/domain/models/Membership');
+const { InvalidMembershipRoleError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | update-membership', () => {
 
@@ -18,13 +19,26 @@ describe('Unit | UseCase | update-membership', () => {
       // given
       const membershipId = 100;
       const organizationRole = Membership.roles.ADMIN;
-      const membership = { id: membershipId, organizationRole, updatedByUserId: 12345 };
+      const membership = new Membership({ id: membershipId, organizationRole, updatedByUserId: 12345 });
 
       // when
       await updateMembership({ membershipId, membership, membershipRepository });
 
       // then
       expect(membershipRepository.updateById).to.has.been.calledWith({ id: membershipId, membership });
+    });
+
+    it('should throw a InvalidMembershipRoleError if role is not valid', async () => {
+      // given
+      const membershipId = 100;
+      const organizationRole = 'NOT_VALID_ROLE';
+      const membership = new Membership({ id: membershipId, organizationRole, updatedByUserId: 12345 });
+
+      // when
+      const error = await catchErr(updateMembership)({ membershipId, membership, membershipRepository });
+
+      // then
+      expect(error).to.an.instanceOf(InvalidMembershipRoleError);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Un utilisateur: 
- ayant un rôle d'administrateur sur PixOrga;
- sur une organisation de type SCO;
- ayant un centre de certification associé;
- souhaite pouvoir accéder à PixCertif. 

La gestion des autorisations existante sépare: 
- l'accès à PixOrga (table memberships); 
- l'accès à PixCertif (table certification-center-memberships).

L'utilisateur ne peut donc pas y accéder.

## :robot: Solution
Aujourd'hui, un script est exécuté à la main tous les mardi et vendredi afin de créer les espaces Pix Certif aux Administrateurs des organisations.

Par ailleurs, il existe actuellement, la possibilité pour un administrateur d'une organisation de changer le rôle d'un autre membre pour qu'il devienne à son tour administrateur. La même fonctionnalité existe sur Pix Admin.

Il serait donc logique que la création d'un espace Pix Certif pour un membre se fasse au moment où il devient administrateur, que ce soit fait par l’intermédiaire d'un admin de Pix Orga ou bien d'un admin de Pix Admin.

SI le rôle d'un membre d'une Orga est modifié pour qu'il devienne "ADMIN" et SI l'orga a un centre de certif associé, ALORS on lui crée automatiquement un espace Pix Certif.

A l'inverse, si on passe un administrateur à "membre", on ne supprime pas l’accès à Pix Certif.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

## Création du membership
Sur Pix Admin :
- Trouver un membre d'une organisation SCO. 
- Changer son rôle de "membre" à "admin"
- Vérifier en base si la table "certification-center-membership" contient un record contenant l'userId du membre en question

Sur Pix Orga :
- Trouver une orga SCO (`sco.admin@exemple.net` > Collège The Night Watch associé au CDC Centre SCO des Anne-Étoiles (1237457A))
- Changer le rôle d'un membre à "admin"
- Vérifier en base si la table "certification-center-membership" contient un record contenant l'userId du membre en question

## Non-création du membership

### Pas de centre de certification
Sur Pix Orga ou Admin : 
- Trouver une orga à laquelle n'est relié aucun centre de certif
- Changer le rôle d'un membre à "admin"
- Constater qu'aucune erreur apparaît
- La table "certification-center-membership" ne devrait pas avoir de nouveau record

### Organisation non SCO
Sur Pix Orga :
- Trouver une orga non SCO (`sup.admin@example.net`)
- Changer le rôle d'un membre à "admin"
- Vérifier en base que la table "certification-center-membership" ne contient pas d'enregistrement sur l'userId du membre en question