### PR TITLE
[BUGFIX][i18n] Modification du terme "En attente" afin de le rendre plus compréhensible par le prescripteur (Pix-2486)

### DIFF
--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
@@ -101,7 +101,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
       // then
       assert.contains('Doe2');
       assert.contains('John');
-      assert.contains('En attente');
+      assert.contains('En attente d\'envoi');
     });
 
     test('it should not display badge neither tooltip', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
@@ -58,7 +58,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
       assert.contains('Doe');
       assert.contains('Doe2');
       assert.contains('John');
-      assert.contains('En attente');
+      assert.contains('En attente d\'envoi');
     });
 
     test('it should display the profile list with external id', async function(assert) {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -128,7 +128,7 @@
           "last-name": "Prénom",
           "results": {
             "label": "Résultats",
-            "on-hold": " En attente",
+            "on-hold": " En attente d'envoi",
             "under-test": "En cours de test"
           }
         },
@@ -251,7 +251,7 @@
           },
           "sending-date": {
             "label": "Date d'envoi",
-            "on-hold": "En attente"
+            "on-hold": "En attente d'envoi"
           }
         },
         "empty": "En attente de profils",


### PR DESCRIPTION
## :unicorn: Problème
Le terme "En attente" est trop vague pour le prescripteur, pour les différentes campagnes.

## :robot: Solution
"En attente d'envoi" est suggéré afin que le prescripteur sache ce qu'il attend.

## :rainbow: Remarques
Pas de modification pour la partie `en.json`

## :100: Pour tester
Se connecter sur `pro.admin@example.net` vérifier que les deux types de campagnes affiche bien "en attente d'envoi" .