### PR TITLE
[BUGFIX] Serialise tout les badgeParnerCompetences dans le critère lorsque son scope est EveryPartnerCompetence

### DIFF
--- a/api/db/seeds/data/badges-builder.js
+++ b/api/db/seeds/data/badges-builder.js
@@ -224,35 +224,33 @@ function _returnIds(...builders) {
 }
 
 function _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIds, badge) {
-  return _returnIds(
-    databaseBuilder.factory.buildBadgePartnerCompetence({
-      name: 'Rechercher des informations sur internet',
-      color: null,
-      skillIds: targetProfileSkillIds[0].map((id) => id),
-      badgeId: badge.id,
-    }),
+  databaseBuilder.factory.buildBadgePartnerCompetence({
+    name: 'Rechercher des informations sur internet',
+    color: null,
+    skillIds: targetProfileSkillIds[0].map((id) => id),
+    badgeId: badge.id,
+  });
 
-    databaseBuilder.factory.buildBadgePartnerCompetence({
-      name: 'Utiliser des outils informatiques',
-      color: null,
-      skillIds: targetProfileSkillIds[1].map((id) => id),
-      badgeId: badge.id,
-    }),
+  databaseBuilder.factory.buildBadgePartnerCompetence({
+    name: 'Utiliser des outils informatiques',
+    color: null,
+    skillIds: targetProfileSkillIds[1].map((id) => id),
+    badgeId: badge.id,
+  });
 
-    databaseBuilder.factory.buildBadgePartnerCompetence({
-      name: 'Naviguer sur internet',
-      color: null,
-      skillIds: targetProfileSkillIds[2].map((id) => id),
-      badgeId: badge.id,
-    }),
+  databaseBuilder.factory.buildBadgePartnerCompetence({
+    name: 'Naviguer sur internet',
+    color: null,
+    skillIds: targetProfileSkillIds[2].map((id) => id),
+    badgeId: badge.id,
+  });
 
-    databaseBuilder.factory.buildBadgePartnerCompetence({
-      name: 'Partager sur les réseaux sociaux',
-      color: null,
-      skillIds: targetProfileSkillIds[3].map((id) => id),
-      badgeId: badge.id,
-    }),
-  );
+  databaseBuilder.factory.buildBadgePartnerCompetence({
+    name: 'Partager sur les réseaux sociaux',
+    color: null,
+    skillIds: targetProfileSkillIds[3].map((id) => id),
+    badgeId: badge.id,
+  });
 }
 
 function _associateBadgeCriteria(databaseBuilder, badge, badgePartnerCompetencesIds = []) {

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -1,4 +1,5 @@
 const { Serializer } = require('jsonapi-serializer');
+const BadgeCriterion = require('../../../domain/models/BadgeCriterion');
 
 const mapType = {
   badgeCriteria: 'badge-criterion',
@@ -30,9 +31,15 @@ module.exports = {
       },
       transform(record) {
         record.badgeCriteria.forEach((badgeCriterion) => {
-          badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds?.map((partnerCompetenceId) => {
-            return { id: partnerCompetenceId };
-          });
+          if (badgeCriterion.scope === BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE) {
+            badgeCriterion.partnerCompetences = record.badgePartnerCompetences.map(({ id }) => {
+              return { id };
+            });
+          } else {
+            badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds?.map((partnerCompetenceId) => {
+              return { id: partnerCompetenceId };
+            });
+          }
         });
         return record;
       },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/badge-serializer');
+const BadgeCriterion = require('../../../../../lib/domain/models/BadgeCriterion');
 
 describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
 
@@ -142,6 +143,99 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
               },
             },
             id: '2',
+            type: 'badge-criterion',
+          },
+          {
+            attributes: {
+              name: 'name',
+            },
+            id: '1',
+            type: 'badge-partner-competence',
+          },
+          {
+            attributes: {
+              name: 'name',
+            },
+            id: '2',
+            type: 'badge-partner-competence',
+          },
+        ],
+      };
+
+      // when
+      const json = serializer.serialize(badge);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedBadge);
+    });
+
+    it('should convert a Badge model and scope with every partner competence badge criteria scope into JSON API data', function() {
+      // given
+      const badge = domainBuilder.buildBadge({
+        id: '1',
+        altMessage: 'You won a banana badge',
+        imageUrl: '/img/banana.svg',
+        message: 'Congrats, you won a banana badge',
+        key: 'BANANA',
+        title: 'Banana',
+        targetProfileId: '1',
+        isCertifiable: false,
+        badgeCriteria: [
+          domainBuilder.buildBadgeCriterion({
+            scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+            partnerCompetenceIds: null,
+          }),
+        ],
+      });
+
+      const expectedSerializedBadge = {
+        data: {
+          attributes: {
+            'alt-message': 'You won a banana badge',
+            'image-url': '/img/banana.svg',
+            'is-certifiable': false,
+            message: 'Congrats, you won a banana badge',
+            title: 'Banana',
+            key: 'BANANA',
+          },
+          id: '1',
+          type: 'badges',
+          relationships: {
+            'badge-criteria': {
+              'data': [{
+                id: '1',
+                type: 'badge-criterion',
+              }],
+            },
+            'badge-partner-competences': {
+              'data': [{
+                id: '1',
+                type: 'badge-partner-competence',
+              }, {
+                id: '2',
+                type: 'badge-partner-competence',
+              }],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              scope: 'EveryPartnerCompetence',
+              threshold: 40,
+            },
+            relationships: {
+              'partner-competences': {
+                data: [{
+                  id: '1',
+                  type: 'badge-partner-competence',
+                }, {
+                  id: '2',
+                  type: 'badge-partner-competence',
+                }],
+              },
+            },
+            id: '1',
             type: 'badge-criterion',
           },
           {


### PR DESCRIPTION
## :unicorn: Problème
Dans #2842, nous avions sérialisé les badgePartnerCompetences associé au critère du badge. Lorsque le scope est EveryPartnerCompetence, le champ `partnerCompetenceIds` est vide en base de données puisqu'il faut alors chercher tout les BadgePartnerCompetences du badge.

## :robot: Solution
Lors de de la sérialisation, lorsque le critère a un scope EveryPartnerCompetence, on sérialise aussi tout les badgePartnerCompetences.

## :rainbow: Remarques
J'ai re-corrigé les seeds que nous avions modifié sans vraiment comprendre.

## :100: Pour tester

1. Se rendre sur Pix Admin.
2. Aller dans l'onglet Profils cibles.
3. Sélectionner un profil cible.
4. Sélectionner l'onglet Clé de lecture.
5. Cliquer sur le bouton Voir détail d’un résultat thématique.
6. Vérifier que que les noms du groupe de critères associé est affiché dans le tableau

