### PR TITLE
[BUGFIX] Correction des conditions d'affichage du bandeau sur l'adresse email du destinataire des résultats (PIX-2491)

### DIFF
--- a/api/db/seeds/data/certification/certification-center-memberships-builder.js
+++ b/api/db/seeds/data/certification/certification-center-memberships-builder.js
@@ -4,6 +4,7 @@ const {
   SUP_CERTIF_CENTER_ID,
   NONE_CERTIF_CENTER_ID,
   DROIT_CERTIF_CENTER_ID,
+  SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID,
 } = require('./certification-centers-builder');
 const {
   PIX_SCO_CERTIF_USER_ID,
@@ -17,6 +18,10 @@ const {
 module.exports = function certificationCenterMembershipsBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildCertificationCenterMembership({
     certificationCenterId: SCO_CERTIF_CENTER_ID,
+    userId: PIX_SCO_CERTIF_USER_ID,
+  });
+  databaseBuilder.factory.buildCertificationCenterMembership({
+    certificationCenterId: SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID,
     userId: PIX_SCO_CERTIF_USER_ID,
   });
   databaseBuilder.factory.buildCertificationCenterMembership({

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -9,7 +9,10 @@ const NONE_CERTIF_CENTER_ID = 4;
 const NONE_CERTIF_CENTER_NAME = 'Centre NOTYPE des Anne-Étoiles';
 const DROIT_CERTIF_CENTER_ID = 5;
 const DROIT_CERTIF_CENTER_NAME = 'Centre DROIT des Anne-Étoiles';
+const SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID = 6;
+const SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_NAME = 'Centre SCO NO MANAGING STUDENTS des Anne-Étoiles';
 const SCO_EXTERNAL_ID = '1237457A';
+const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = 'AEFE';
 
 function certificationCentersBuilder({ databaseBuilder }) {
 
@@ -17,6 +20,13 @@ function certificationCentersBuilder({ databaseBuilder }) {
     id: SCO_CERTIF_CENTER_ID,
     name: SCO_CERTIF_CENTER_NAME,
     externalId: SCO_EXTERNAL_ID,
+    type: 'SCO',
+  });
+
+  databaseBuilder.factory.buildCertificationCenter({
+    id: SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID,
+    name: SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_NAME,
+    externalId: SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID,
     type: 'SCO',
   });
 
@@ -65,4 +75,6 @@ module.exports = {
   NONE_CERTIF_CENTER_NAME,
   DROIT_CERTIF_CENTER_ID,
   DROIT_CERTIF_CENTER_NAME,
+  SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID,
+  SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_NAME,
 };

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -2,7 +2,7 @@
 
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { notEmpty, sort } from '@ember/object/computed';
 
 const SORTING_ORDER = ['date:desc', 'time:desc'];
@@ -21,7 +21,6 @@ export default class SessionsListController extends Controller {
     this.transitionToRoute('authenticated.sessions.details', session.id);
   }
 
-  @computed('currentUser.currentCertificationCenter.isScoManagingStudents')
   get shouldDisplayResultRecipientInfoMessage() {
     return !this.currentUser.currentCertificationCenter.isScoManagingStudents;
   }

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -8,14 +8,20 @@ QUnit.assert.notContains = notContains;
 
 export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepted = false, certificationCenterType, certificationCenterName = 'Centre de certification du pix', isRelatedOrganizationManagingStudents = false, certificationCenterCount = 1) {
   const certificationCenters = _createCertificationCenters(certificationCenterCount, { certificationCenterName, certificationCenterType, isRelatedOrganizationManagingStudents });
+  return createCertificationPointOfContactWithCustomCenters({ pixCertifTermsOfServiceAccepted, certificationCenters });
+}
 
+export function createCertificationPointOfContactWithCustomCenters({
+  pixCertifTermsOfServiceAccepted = false,
+  certificationCenters = [],
+}) {
   const certificationPointOfContact = server.create('certification-point-of-contact', {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
     pixCertifTermsOfServiceAccepted,
     certificationCenters,
-    currentCertificationCenterId: 1,
+    currentCertificationCenterId: parseInt(certificationCenters[0].id),
   });
   certificationPointOfContact.save();
 
@@ -33,7 +39,6 @@ function _createCertificationCenters(certificationCenterCount, certificationCent
 
 export function createCertificationCenter({ certificationCenterName, certificationCenterType, isRelatedOrganizationManagingStudents }) {
   const certificationCenter = server.create('certification-center', {
-    id: 1,
     name: certificationCenterName,
     type: certificationCenterType,
     externalId: 'ABC123',

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -10,14 +10,7 @@ export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepte
   const certificationCenters = [];
 
   times(certificationCenterCount, () => {
-    const certificationCenter = server.create('certification-center', {
-      id: 1,
-      name: certificationCenterName,
-      type: certificationCenterType,
-      externalId: 'ABC123',
-      isRelatedOrganizationManagingStudents,
-    });
-    certificationCenter.save();
+    const certificationCenter = createCertificationCenter({ certificationCenterName, certificationCenterType, isRelatedOrganizationManagingStudents });
     certificationCenters.push(certificationCenter);
   });
 
@@ -32,6 +25,18 @@ export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepte
   certificationPointOfContact.save();
 
   return certificationPointOfContact;
+}
+
+export function createCertificationCenter({ certificationCenterName, certificationCenterType, isRelatedOrganizationManagingStudents }) {
+  const certificationCenter = server.create('certification-center', {
+    id: 1,
+    name: certificationCenterName,
+    type: certificationCenterType,
+    externalId: 'ABC123',
+    isRelatedOrganizationManagingStudents,
+  });
+  certificationCenter.save();
+  return certificationCenter;
 }
 
 export function createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted() {

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -7,12 +7,7 @@ QUnit.assert.contains = contains;
 QUnit.assert.notContains = notContains;
 
 export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepted = false, certificationCenterType, certificationCenterName = 'Centre de certification du pix', isRelatedOrganizationManagingStudents = false, certificationCenterCount = 1) {
-  const certificationCenters = [];
-
-  times(certificationCenterCount, () => {
-    const certificationCenter = createCertificationCenter({ certificationCenterName, certificationCenterType, isRelatedOrganizationManagingStudents });
-    certificationCenters.push(certificationCenter);
-  });
+  const certificationCenters = _createCertificationCenters(certificationCenterCount, { certificationCenterName, certificationCenterType, isRelatedOrganizationManagingStudents });
 
   const certificationPointOfContact = server.create('certification-point-of-contact', {
     firstName: 'Harry',
@@ -25,6 +20,15 @@ export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepte
   certificationPointOfContact.save();
 
   return certificationPointOfContact;
+}
+
+function _createCertificationCenters(certificationCenterCount, certificationCenterTemplate) {
+  const certificationCenters = [];
+  times(certificationCenterCount, () => {
+    const certificationCenter = createCertificationCenter(certificationCenterTemplate);
+    certificationCenters.push(certificationCenter);
+  });
+  return certificationCenters;
 }
 
 export function createCertificationCenter({ certificationCenterName, certificationCenterType, isRelatedOrganizationManagingStudents }) {


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Admin, la notif concernant l’adresse email du destinataire des résultats est parfois visible alors qu'elle ne devrait pas. Le problème semble survenir lorsqu'un utilisateur est membre de plusieurs centres de certif dont certains devraient déclencher l'affichage la bannière et d'autres non. Lorsque l'utilisateur change son centre de certif, les conditions d'affichage du bandeau ne sont pas mises à jour. 

## :robot: Solution

Vérifier et corriger le rafraichissement des conditions d'affichage du bandeau.

## :rainbow: Remarques

- Le bug a peu de chance de se produire en production mais il embêtait notre chère PO pendant ses tests.
- Pour le tirer, j'ai retiré un décorateur `@computed`. Je pense que le bug a été introduit par la récente montée de version de Ember, ce qui expliquerait pourquoi il ne se produisait pas plutôt.

## :100: Pour tester

- Se connecter à Pix Certif avec un utilisateur associé à au moins un centre de certif SCO gérant des élèves, et un centre de certif non SCO.
- Basculer d'un centre de certif à l'autre et constater que le bandeau apparaît pour le centre non SCO et disparaît pour l'autre.
