### PR TITLE
[BUGFIX] Calcul du résultat de certification : compter le nombre d'épreuves proposées (PIX-2493)

### DIFF
--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -9,19 +9,23 @@ class CertifiedLevel {
   }
 
   static from({
-    numberOfChallengesAnswered,
+    numberOfChallenges,
     numberOfNeutralizedAnswers,
     numberOfCorrectAnswers,
     estimatedLevel,
     reproducibilityRate,
   }) {
     const rule = _rules.findRuleFor({
-      numberOfChallengesAnswered,
+      numberOfChallenges,
       numberOfCorrectAnswers,
       numberOfNeutralizedAnswers,
     });
     if (!rule) {
-      throw new Error('Règle de calcul de niveau certifié manquante.');
+      throw new MissingCertifiedLevelRuleError({
+        numberOfChallenges,
+        numberOfNeutralizedAnswers,
+        numberOfCorrectAnswers,
+      });
     } else {
       return rule.apply({ reproducibilityRate, estimatedLevel });
     }
@@ -60,14 +64,14 @@ module.exports = {
 
 class Rule {
   constructor({
-    numberOfChallengesAnswered,
+    numberOfChallenges,
     numberOfCorrectAnswers,
     numberOfNeutralizedAnswers,
     actionWhenReproducibilityRateEqualOrAbove80,
     actionWhenReproducibilityBetween70And80,
     actionWhenReproducibilityBelow70,
   }) {
-    this.numberOfChallengesAnswered = numberOfChallengesAnswered;
+    this.numberOfChallenges = numberOfChallenges;
     this.numberOfCorrectAnswers = numberOfCorrectAnswers;
     this.numberOfNeutralizedAnswers = numberOfNeutralizedAnswers;
     this.actionWhenReproducibilityRateEqualOrAbove80 = actionWhenReproducibilityRateEqualOrAbove80;
@@ -76,11 +80,11 @@ class Rule {
   }
 
   isApplicable({
-    numberOfChallengesAnswered,
+    numberOfChallenges,
     numberOfCorrectAnswers,
     numberOfNeutralizedAnswers,
   }) {
-    return (numberOfChallengesAnswered === this.numberOfChallengesAnswered
+    return (numberOfChallenges === this.numberOfChallenges
       && numberOfCorrectAnswers === this.numberOfCorrectAnswers
       && numberOfNeutralizedAnswers === this.numberOfNeutralizedAnswers);
   }
@@ -99,7 +103,7 @@ class Rule {
 class Rule1 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 3,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -112,7 +116,7 @@ class Rule1 extends Rule {
 class Rule2 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 2,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -125,7 +129,7 @@ class Rule2 extends Rule {
 class Rule3 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 2,
       numberOfNeutralizedAnswers: 1,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -138,7 +142,7 @@ class Rule3 extends Rule {
 class Rule4 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 1,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -151,7 +155,7 @@ class Rule4 extends Rule {
 class Rule5 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 1,
       numberOfNeutralizedAnswers: 1,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -164,7 +168,7 @@ class Rule5 extends Rule {
 class Rule6 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 1,
       numberOfNeutralizedAnswers: 2,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -177,7 +181,7 @@ class Rule6 extends Rule {
 class Rule7 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -190,7 +194,7 @@ class Rule7 extends Rule {
 class Rule8 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 1,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -203,7 +207,7 @@ class Rule8 extends Rule {
 class Rule9 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 2,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -216,7 +220,7 @@ class Rule9 extends Rule {
 class Rule10 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 3,
+      numberOfChallenges: 3,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 3,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -229,7 +233,7 @@ class Rule10 extends Rule {
 class Rule11 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 2,
+      numberOfChallenges: 2,
       numberOfCorrectAnswers: 2,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -242,7 +246,7 @@ class Rule11 extends Rule {
 class Rule12 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 2,
+      numberOfChallenges: 2,
       numberOfCorrectAnswers: 1,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -255,7 +259,7 @@ class Rule12 extends Rule {
 class Rule13 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 2,
+      numberOfChallenges: 2,
       numberOfCorrectAnswers: 1,
       numberOfNeutralizedAnswers: 1,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -268,7 +272,7 @@ class Rule13 extends Rule {
 class Rule14 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 2,
+      numberOfChallenges: 2,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -281,7 +285,7 @@ class Rule14 extends Rule {
 class Rule15 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 2,
+      numberOfChallenges: 2,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 1,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -294,7 +298,7 @@ class Rule15 extends Rule {
 class Rule16 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 2,
+      numberOfChallenges: 2,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 2,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -307,7 +311,7 @@ class Rule16 extends Rule {
 class Rule17 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 1,
+      numberOfChallenges: 1,
       numberOfCorrectAnswers: 1,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
@@ -320,7 +324,7 @@ class Rule17 extends Rule {
 class Rule18 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 1,
+      numberOfChallenges: 1,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 1,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -333,7 +337,7 @@ class Rule18 extends Rule {
 class Rule19 extends Rule {
   constructor() {
     super({
-      numberOfChallengesAnswered: 1,
+      numberOfChallenges: 1,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
@@ -366,14 +370,28 @@ const _rules = {
     new Rule19(),
   ],
   findRuleFor({
-    numberOfChallengesAnswered,
+    numberOfChallenges,
     numberOfCorrectAnswers,
     numberOfNeutralizedAnswers,
   }) {
     return this.rules.find((rule) => rule.isApplicable({
-      numberOfChallengesAnswered,
+      numberOfChallenges,
       numberOfCorrectAnswers,
       numberOfNeutralizedAnswers,
     }));
   },
 };
+
+class MissingCertifiedLevelRuleError extends Error {
+  constructor({
+    numberOfChallenges,
+    numberOfCorrectAnswers,
+    numberOfNeutralizedAnswers,
+  }) {
+    const message = 'Règle de calcul de niveau certifié manquante pour ' +
+      `${numberOfChallenges} épreuves proposées ` +
+      `${numberOfCorrectAnswers} réponses correctes et ` +
+      `${numberOfNeutralizedAnswers} épreuves neutralisées`;
+    super(message);
+  }
+}

--- a/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
+++ b/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
@@ -8,8 +8,8 @@ module.exports = class CompetenceAnswerCollection {
   }
 
   static from({ answersForCompetence, challengesForCompetence }) {
-    const answersForScoring = answersForCompetence.map((answer) => {
-      const challenge = _.find(challengesForCompetence, { challengeId: answer.challengeId });
+    const answersForScoring = challengesForCompetence.map((challenge) => {
+      const answer = _.find(answersForCompetence, { challengeId: challenge.challengeId });
       return new AnswerForScoring(answer, challenge);
     });
     return new CompetenceAnswerCollection(answersForScoring);
@@ -30,7 +30,7 @@ module.exports = class CompetenceAnswerCollection {
     return nbOfCorrectAnswers;
   }
 
-  numberOfChallengesAnswered() {
+  numberOfChallenges() {
     const numberOfChallenges = _(this.answers).map((answer) => {
       if (this.answers.length < 3 && answer.isQROCMdep()) {
         return 2;
@@ -68,14 +68,15 @@ class AnswerForScoring {
   }
 
   isCorrect() {
-    return this.answer.isOk();
+    return Boolean(this?.answer.isOk());
   }
 
   isAFullyCorrectQROCMdep() {
-    return this.isQROCMdep() && this.answer.isOk();
+    return this.isQROCMdep() && this.isCorrect();
   }
 
   isAPartiallyCorrectQROCMdep() {
-    return this.isQROCMdep() && this.answer.isPartially();
+    return this.isQROCMdep()
+      && Boolean(this.answer) && this.answer.isPartially();
   }
 }

--- a/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
+++ b/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
@@ -68,7 +68,7 @@ class AnswerForScoring {
   }
 
   isCorrect() {
-    return Boolean(this?.answer.isOk());
+    return Boolean(this.answer?.isOk());
   }
 
   isAFullyCorrectQROCMdep() {

--- a/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
+++ b/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
@@ -43,7 +43,7 @@ module.exports = class CompetenceAnswerCollection {
 
   numberOfNeutralizedChallenges() {
     return _(this.answers).map((answer) => {
-      if (answer.challenge.isNeutralized) {
+      if (answer.isNeutralized()) {
         if (this.answers.length < 3 && answer.isQROCMdep()) {
           return 2;
         } else {
@@ -78,5 +78,9 @@ class AnswerForScoring {
   isAPartiallyCorrectQROCMdep() {
     return this.isQROCMdep()
       && Boolean(this.answer) && this.answer.isPartially();
+  }
+
+  isNeutralized() {
+    return this.challenge.isNeutralized;
   }
 }

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -40,7 +40,7 @@ function _getCompetencesWithCertifiedLevelAndScore(answers, listCompetences, rep
     const competenceAnswerCollection = CompetenceAnswerCollectionForScoring.from({ answersForCompetence, challengesForCompetence });
 
     const certifiedLevel = CertifiedLevel.from({
-      numberOfChallengesAnswered: competenceAnswerCollection.numberOfChallengesAnswered(),
+      numberOfChallenges: competenceAnswerCollection.numberOfChallenges(),
       numberOfCorrectAnswers: competenceAnswerCollection.numberOfCorrectAnswers(),
       numberOfNeutralizedAnswers: competenceAnswerCollection.numberOfNeutralizedChallenges(),
       estimatedLevel: competence.estimatedLevel,

--- a/api/tests/unit/domain/models/CertifiedLevel_test.js
+++ b/api/tests/unit/domain/models/CertifiedLevel_test.js
@@ -15,7 +15,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies the estimated level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 3,
           numberOfNeutralizedAnswers: 0,
           estimatedLevel: 3,
@@ -34,7 +34,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it(`certifies the estimated level when reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 2,
           estimatedLevel: 3,
@@ -48,7 +48,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it(`certifies a level below the estimated level when reproducibility rate < ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 2,
           estimatedLevel: 3,
@@ -66,7 +66,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies the estimated level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfNeutralizedAnswers: 1,
           numberOfCorrectAnswers: 2,
           estimatedLevel: 3,
@@ -85,7 +85,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify a level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
@@ -103,7 +103,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it(`certifies the estimated level is reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 1,
           numberOfNeutralizedAnswers: 1,
           estimatedLevel: 3,
@@ -119,7 +119,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it(`certifies a level below the estimated on if reproducibility rate >= 70% and < ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 1,
           numberOfNeutralizedAnswers: 1,
           estimatedLevel: 3,
@@ -135,7 +135,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify a level if reproducibility level < 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 1,
           numberOfNeutralizedAnswers: 1,
           estimatedLevel: 3,
@@ -153,7 +153,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies the estimated level if reproducibility rate is >= 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 1,
           numberOfNeutralizedAnswers: 2,
           estimatedLevel: 3,
@@ -169,7 +169,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies a level below the estimated on if reproducibility rate < 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 1,
           numberOfNeutralizedAnswers: 2,
           estimatedLevel: 3,
@@ -188,7 +188,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 0,
           numberOfNeutralizedAnswers: 0,
           estimatedLevel: 3, // unimportant
@@ -207,7 +207,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 0,
           numberOfNeutralizedAnswers: 1,
           estimatedLevel: 3, // unimportant
@@ -226,7 +226,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 0,
           numberOfNeutralizedAnswers: 2,
           estimatedLevel: 3, // unimportant
@@ -245,7 +245,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 3,
+          numberOfChallenges: 3,
           numberOfCorrectAnswers: 0,
           numberOfNeutralizedAnswers: 3,
           estimatedLevel: 3, // unimportant
@@ -267,7 +267,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies the estimated level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 2,
           estimatedLevel: 3,
@@ -286,7 +286,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it(`certifies the estimated level when reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
@@ -302,7 +302,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it(`certifies a level below the estimated level when reproducibility rate >= 70% and < ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
@@ -318,7 +318,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify a level when reproducibility rate < 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
@@ -337,7 +337,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies the estimated level when reproducibility rate >= 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 1,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
@@ -353,7 +353,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies a level below the estimated level when reproducibility rate < 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 1,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
@@ -372,7 +372,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 0,
           estimatedLevel: 3, // unimportant
@@ -391,7 +391,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 1,
           numberOfCorrectAnswers: 0,
           estimatedLevel: 3, // unimportant
@@ -410,7 +410,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 2,
+          numberOfChallenges: 2,
           numberOfNeutralizedAnswers: 2,
           numberOfCorrectAnswers: 0,
           estimatedLevel: 3, // unimportant
@@ -433,7 +433,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies the estimated level when reproducibility rate >= 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 1,
+          numberOfChallenges: 1,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
@@ -449,7 +449,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('certifies a level below the estimated level when reproducibility rate < 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 1,
+          numberOfChallenges: 1,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
@@ -468,7 +468,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 1,
+          numberOfChallenges: 1,
           numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 0,
           estimatedLevel: 3, // unimportant
@@ -487,7 +487,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       it('does not certify any level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
-          numberOfChallengesAnswered: 1,
+          numberOfChallenges: 1,
           numberOfNeutralizedAnswers: 1,
           numberOfCorrectAnswers: 0,
           estimatedLevel: 3, // unimportant
@@ -504,14 +504,19 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
 
   context('when no rule is applicable', () => {
     it('throws', () => {
+      // given
+      const expectedMessage = 'Règle de calcul de niveau certifié manquante pour ' +
+        '1000 épreuves proposées ' +
+        '1000 réponses correctes ' +
+        'et 1000 épreuves neutralisées';
       // when
       expect(() => CertifiedLevel.from({
-        numberOfChallengesAnswered: 1000,
+        numberOfChallenges: 1000,
         numberOfNeutralizedAnswers: 1000,
         numberOfCorrectAnswers: 1000,
         estimatedLevel: 0, // unimportant
         reproducibilityRate: 0, // unimportant
-      })).to.throw();
+      })).to.throw(expectedMessage);
     });
   });
 });

--- a/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
@@ -3,8 +3,10 @@ const CompetenceAnswerCollectionForScoring = require('../../../../lib/domain/mod
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 
 describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', function() {
-  context('#numberOfChallengesAnswered', () => {
-    it('equals 0 when no answers', () => {
+
+  context('#numberOfChallenges', () => {
+
+    it('equals 0 when no challenges asked', () => {
       // given
       const answerCollection = CompetenceAnswerCollectionForScoring.from({
         answersForCompetence: [],
@@ -12,10 +14,10 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfChallengesAnswered();
+      const numberOfChallenges = answerCollection.numberOfChallenges();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(0);
+      expect(numberOfChallenges).to.equal(0);
     });
 
     it('equals the number of challenges when no QROCMDep', () => {
@@ -32,13 +34,13 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfChallengesAnswered();
+      const numberOfChallenges = answerCollection.numberOfChallenges();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(3);
+      expect(numberOfChallenges).to.equal(3);
     });
 
-    it('counts QROCMDeps as double if only two answers or less', () => {
+    it('counts QROCMDeps as double if only two challenges or less', () => {
       // given
       const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1', type: 'QCM' });
       const qROCMDepChallenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', type: 'QROCM-dep' });
@@ -50,13 +52,13 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfChallengesAnswered();
+      const numberOfChallenges = answerCollection.numberOfChallenges();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(3);
+      expect(numberOfChallenges).to.equal(3);
     });
 
-    it('counts QROCMDeps as single if more than two answers', () => {
+    it('counts QROCMDeps as single if more than two challenges', () => {
       // given
       const challenge1 = _buildDecoratedCertificationChallenge({ type: 'QCM' });
       const challenge2 = _buildDecoratedCertificationChallenge({ type: 'QCM' });
@@ -70,13 +72,32 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfChallengesAnswered();
+      const numberOfChallenges = answerCollection.numberOfChallenges();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(3);
+      expect(numberOfChallenges).to.equal(3);
+    });
+
+    it('counts answered as well as unanswered challenges indifferently', () => {
+      // given
+      const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1', type: 'QCM' });
+      const challenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', type: 'QCM' });
+      const challenge3 = _buildDecoratedCertificationChallenge({ challengeId: 'chal3', type: 'QCM' });
+      const noAnswers = [];
+      const answerCollection = CompetenceAnswerCollectionForScoring.from({
+        answersForCompetence: noAnswers,
+        challengesForCompetence: [challenge1, challenge2, challenge3],
+      });
+
+      // when
+      const numberOfChallenges = answerCollection.numberOfChallenges();
+
+      // then
+      expect(numberOfChallenges).to.equal(3);
     });
   });
   context('#numberOfCorrectAnswers', () => {
+
     it('equals 0 when no answers', () => {
       // given
       const answerCollection = CompetenceAnswerCollectionForScoring.from({
@@ -85,10 +106,10 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfCorrectAnswers();
+      const numberOfCorrectAnswers = answerCollection.numberOfCorrectAnswers();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(0);
+      expect(numberOfCorrectAnswers).to.equal(0);
     });
 
     it('equals 0 when no correct answers', () => {
@@ -105,10 +126,10 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfCorrectAnswers();
+      const numberOfCorrectAnswers = answerCollection.numberOfCorrectAnswers();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(0);
+      expect(numberOfCorrectAnswers).to.equal(0);
     });
 
     it('equals the number of answers when they are all correct', () => {
@@ -125,10 +146,10 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfCorrectAnswers();
+      const numberOfCorrectAnswers = answerCollection.numberOfCorrectAnswers();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(3);
+      expect(numberOfCorrectAnswers).to.equal(3);
     });
 
     it('counts QROCMDeps as 1 when partially correct', () => {
@@ -143,10 +164,10 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfCorrectAnswers();
+      const numberOfCorrectAnswers = answerCollection.numberOfCorrectAnswers();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(2);
+      expect(numberOfCorrectAnswers).to.equal(2);
     });
 
     it('counts QROCMDeps as 2 when fully correct', () => {
@@ -161,13 +182,15 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfChallengesAnswered = answerCollection.numberOfCorrectAnswers();
+      const numberOfCorrectAnswers = answerCollection.numberOfCorrectAnswers();
 
       // then
-      expect(numberOfChallengesAnswered).to.equal(3);
+      expect(numberOfCorrectAnswers).to.equal(3);
     });
   });
+
   context('#numberOfNeutralizedChallenges', () => {
+
     it('equals 0 when there are no answers', () => {
       // given
       const answerCollection = CompetenceAnswerCollectionForScoring.from({
@@ -176,11 +199,12 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfNeutralizeChallenges = answerCollection.numberOfNeutralizedChallenges();
+      const numberOfNeutralizedChallenges = answerCollection.numberOfNeutralizedChallenges();
 
       // then
-      expect(numberOfNeutralizeChallenges).to.equal(0);
+      expect(numberOfNeutralizedChallenges).to.equal(0);
     });
+
     it('equals the number of challenges when there are all neutralized and none of them are QROCMDep', () => {
       // given
       const challenge1 = _buildDecoratedCertificationChallenge({ type: 'QCM', isNeutralized: true });
@@ -195,11 +219,12 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfNeutralizeChallenges = answerCollection.numberOfNeutralizedChallenges();
+      const numberOfNeutralizedChallenges = answerCollection.numberOfNeutralizedChallenges();
 
       // then
-      expect(numberOfNeutralizeChallenges).to.equal(3);
+      expect(numberOfNeutralizedChallenges).to.equal(3);
     });
+
     it('counts a neutralized QROCMDep challenge as two neutralized challenges when less than 3 challenges', () => {
       // given
       const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'rec1234', type: 'QCM', isNeutralized: true });
@@ -212,10 +237,10 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfNeutralizeChallenges = answerCollection.numberOfNeutralizedChallenges();
+      const numberOfNeutralizedChallenges = answerCollection.numberOfNeutralizedChallenges();
 
       // then
-      expect(numberOfNeutralizeChallenges).to.equal(3);
+      expect(numberOfNeutralizedChallenges).to.equal(3);
     });
 
     it('counts a neutralized QROCMDep challenge as a single neutralized challenge when 3 challenges', () => {
@@ -233,10 +258,10 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       });
 
       // when
-      const numberOfNeutralizeChallenges = answerCollection.numberOfNeutralizedChallenges();
+      const numberOfNeutralizedChallenges = answerCollection.numberOfNeutralizedChallenges();
 
       // then
-      expect(numberOfNeutralizeChallenges).to.equal(3);
+      expect(numberOfNeutralizedChallenges).to.equal(3);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Suite à la #2811 la visualisation des certification commencée non-terminées ne fonctionne plus dans Pix-Admin.
En effet le calcul du nombre de questions proposées est erronée, il se base sur le nombre de réponses données. Or dans le cas d'une certification non terminée, il se peut qu'il n'y ait aucune réponses pour une compétence donnée, ce qui faisait crasher l’algorithme du choix de la règle à appliquer. 

## :robot: Solution
Se baser sur le nombre d'épreuves sélectionnées pour une compétence et non plus sur le nombre de réponses apportées.

## :rainbow: Remarques
- Le message d'erreur en cas de règle non trouvée a été revue pour être plus facilement investigué.

## :100: Pour tester
- Commencer une certification, faire en sorte d'avoir un taux de repro > 50%
- Ne pas répondre aux questions de la dernière compétence
- Vérifier qu'il est possible de visualiser le détail dans Pix-Admin
