### PR TITLE
[FEATURE] Ajout la possibilité  de filtrer une liste d’étudiants  SUP par numéro étudiant (PIX-2417).

### DIFF
--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -33,12 +33,15 @@ function _toUserWithSchoolingRegistrationDTO(BookshelfSchoolingRegistration) {
   });
 }
 
-function _setSchoolingRegistrationFilters(qb, { lastName, firstName, connexionType } = {}) {
+function _setSchoolingRegistrationFilters(qb, { lastName, firstName, studentNumber, connexionType } = {}) {
   if (lastName) {
     qb.whereRaw('LOWER("schooling-registrations"."lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
   }
   if (firstName) {
     qb.whereRaw('LOWER("schooling-registrations"."firstName") LIKE ?', `%${firstName.toLowerCase()}%`);
+  }
+  if (studentNumber) {
+    qb.whereRaw('LOWER("schooling-registrations"."studentNumber") LIKE ?', `%${studentNumber.toLowerCase()}%`);
   }
   if (connexionType === 'none') {
     qb.whereRaw('"users"."username" IS NULL');

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1532,6 +1532,25 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         expect(_.map(data, 'firstName')).to.deep.equal(['Bar', 'Baz']);
       });
 
+      it('should return school registrations filtered by student number', async () => {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, firstName: 'Foo', lastName: '1', studentNumber: 'FOO123' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, firstName: 'Bar', lastName: '2', studentNumber: 'BAR123' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, firstName: 'Baz', lastName: '3', studentNumber: 'BAZ123' });
+        await databaseBuilder.commit();
+
+        // when
+        const { data } = await schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations({
+          organizationId: organization.id,
+          filter: { studentNumber: 'ba' },
+        });
+
+        // then
+        expect(_.map(data, 'studentNumber')).to.deep.equal(['BAR123', 'BAZ123']);
+      });
+
       it('should return school registrations filtered by firstname AND lastname', async () => {
         // given
         const organization = databaseBuilder.factory.buildOrganization();

--- a/orga/app/components/edit-student-number-modal.hbs
+++ b/orga/app/components/edit-student-number-modal.hbs
@@ -4,10 +4,10 @@
       {{#if @student.studentNumber}}
         <p class="content-text">{{t "pages.students-sup.edit-student-number-modal.form.student-number" firstName=@student.firstName  lastName=@student.lastName }}<span class=" content-text--info">{{@student.studentNumber}}</span></p>
       {{/if}}
-      <label for="studentNumber" class="content-text">{{t "pages.students-sup.edit-student-number-modal.form.new-student-number-label"}}</label>
+      <label for="editStudentNumber" class="content-text">{{t "pages.students-sup.edit-student-number-modal.form.new-student-number-label"}}</label>
       <div class="input-container">
         <Input
-          id="studentNumber"
+          id="editStudentNumber"
           type="text"
           @value={{this.newStudentNumber}}
           class="input"

--- a/orga/app/components/routes/authenticated/sup-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.hbs
@@ -25,7 +25,13 @@
           <Table::Header />
         </tr>
         <tr>
-          <Table::Header/>
+          <Table::HeaderFilterInput
+            @field="studentNumber"
+            @value={{@studentNumberFilter}}
+            @placeholder={{t "pages.students-sup.table.filter.student-number.label"}}
+            @ariaLabel={{t "pages.students-sup.table.filter.student-number.aria-label"}}
+            @triggerFiltering={{@triggerFiltering}}
+          />
           <Table::HeaderFilterInput
             @field="lastName"
             @value={{@lastNameFilter}}

--- a/orga/app/controllers/authenticated/sup-students/list.js
+++ b/orga/app/controllers/authenticated/sup-students/list.js
@@ -16,6 +16,7 @@ export default class ListController extends Controller {
 
   @tracked lastName = null;
   @tracked firstName = null;
+  @tracked studentNumber = null;
   @tracked pageNumber = null;
   @tracked pageSize = null;
 

--- a/orga/app/routes/authenticated/sup-students/list.js
+++ b/orga/app/routes/authenticated/sup-students/list.js
@@ -8,6 +8,7 @@ export default class ListRoute extends Route {
   queryParams = {
     lastName: { refreshModel: true },
     firstName: { refreshModel: true },
+    studentNumber: { refreshModel: true },
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
   };
@@ -20,6 +21,7 @@ export default class ListRoute extends Route {
         organizationId: this.currentUser.organization.id,
         lastName: params.lastName,
         firstName: params.firstName,
+        studentNumber: params.studentNumber,
       },
       page: {
         number: params.pageNumber,
@@ -32,6 +34,7 @@ export default class ListRoute extends Route {
     if (isExiting) {
       controller.lastName = null;
       controller.firstName = null;
+      controller.studentNumber = null;
       controller.pageNumber = null;
       controller.pageSize = null;
     }

--- a/orga/app/templates/authenticated/sup-students/list.hbs
+++ b/orga/app/templates/authenticated/sup-students/list.hbs
@@ -6,5 +6,6 @@
     @triggerFiltering={{this.triggerFiltering}}
     @lastNameFilter={{this.lastName}}
     @firstNameFilter={{this.firstName}}
+    @studentNumberFilter={{this.studentNumber}}
   />
 </div>

--- a/orga/tests/acceptance/sup-student-list-test.js
+++ b/orga/tests/acceptance/sup-student-list-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { find, triggerEvent, visit, typeIn } from '@ember/test-helpers';
+import { find, triggerEvent, visit } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
@@ -92,7 +93,7 @@ module('Acceptance | Sup Student List', function(hooks) {
         // when
         await clickByLabel('Afficher les actions');
         await clickByLabel('Éditer le numéro étudiant');
-        await typeIn('#studentNumber', '1234');
+        await fillInByLabel('Nouveau numéro étudiant', '1234');
         await clickByLabel('Mettre à jour');
 
         // then
@@ -106,7 +107,7 @@ module('Acceptance | Sup Student List', function(hooks) {
         // when
         await clickByLabel('Afficher les actions');
         await clickByLabel('Éditer le numéro étudiant');
-        await typeIn('#studentNumber', '321');
+        await fillInByLabel('Nouveau numéro étudiant', '321');
         await clickByLabel('Mettre à jour');
 
         // then

--- a/orga/tests/integration/components/edit-student-number-modal-test.js
+++ b/orga/tests/integration/components/edit-student-number-modal-test.js
@@ -53,14 +53,6 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       });
     });
 
-    test('should render component with student number input', async function(assert) {
-      assert.dom('#studentNumber').exists();
-    });
-
-    test('should render component with update button', async function(assert) {
-      assert.contains('Mettre à jour');
-    });
-
     module('When a student number is entered', function() {
 
       test('should have the update button enable', async function(assert) {
@@ -92,7 +84,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
         onSaveStudentNumberStub.withArgs(123456).resolves();
 
         // when
-        await fillInByLabel('Nouveau numéro étudiant', 123456);
+        await fillInByLabel('Nouveau numéro étudiant', '123456');
         await clickByLabel('Mettre à jour');
 
         // then
@@ -125,7 +117,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
         onSaveStudentNumberStub.rejects(error);
 
         // when
-        await fillInByLabel('Nouveau numéro étudiant', 77107);
+        await fillInByLabel('Nouveau numéro étudiant', '77107');
         await clickByLabel('Mettre à jour');
 
         // then
@@ -145,9 +137,9 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
         onSaveStudentNumberStub.onFirstCall().rejects(error).onSecondCall().resolves();
 
         // when
-        await fillInByLabel('Nouveau numéro étudiant', 77107);
+        await fillInByLabel('Nouveau numéro étudiant', '77107');
         await clickByLabel('Mettre à jour');
-        await fillInByLabel('Nouveau numéro étudiant', 65432);
+        await fillInByLabel('Nouveau numéro étudiant', '65432');
         await clickByLabel('Mettre à jour');
 
         // then

--- a/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
@@ -105,9 +105,9 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
     assert.dom('[aria-label="Étudiant"]').exists({ count: 2 });
   });
 
-  test('it should display the firstName, lastName and birthdate of student', async function(assert) {
+  test('it should display the student number, firstName, lastName and birthdate of student', async function(assert) {
     // given
-    const students = [{ lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') }];
+    const students = [{ studentNumber: 'LATERREURGIGI123', lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') }];
 
     this.set('students', students);
 
@@ -115,6 +115,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
     await render(hbs`<Routes::Authenticated::SupStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
     // then
+    assert.contains('LATERREURGIGI123');
     assert.contains('La Terreur');
     assert.contains('Gigi');
     assert.contains('01/02/2010');
@@ -153,6 +154,23 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       assert.equal(call.args[0], 'firstName');
       assert.equal(call.args[1], true);
       assert.equal(call.args[2].target.value, 'bob');
+    });
+
+    test('it should trigger filtering with student number', async function(assert) {
+      const triggerFiltering = sinon.spy();
+      this.set('triggerFiltering', triggerFiltering);
+      this.set('students', []);
+
+      // when
+      await render(hbs`<Routes::Authenticated::SupStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
+
+      await fillInByLabel('Entrer un numéro étudiant', 'LATERREURGIGI123');
+
+      // then
+      const call = triggerFiltering.getCall(0);
+      assert.equal(call.args[0], 'studentNumber');
+      assert.equal(call.args[1], true);
+      assert.equal(call.args[2].target.value, 'LATERREURGIGI123');
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -547,6 +547,10 @@
           "last-name": {
             "aria-label": "Enter a last name",
             "label": "Search by last name"
+          },
+          "student-number": {
+            "aria-label": "Enter a student number",
+            "label": "Search by student number"
           }
         },
         "row-title": "Student"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -372,11 +372,11 @@
         "button": "S'inscrire",
         "fields": {
           "first-name": {
-            "label":"Prénom",
+            "label": "Prénom",
             "error": "Votre prénom n’est pas renseigné."
           },
           "last-name": {
-            "label":"Nom",
+            "label": "Nom",
             "error": "Votre nom n’est pas renseigné."
           },
           "email": {
@@ -547,6 +547,10 @@
           "last-name": {
             "aria-label": "Entrer un nom",
             "label": "Rechercher par nom"
+          },
+          "student-number": {
+            "aria-label": "Entrer un numéro étudiant",
+            "label": "Rechercher par numéro étudiant"
           }
         },
         "row-title": "Étudiant"
@@ -588,9 +592,9 @@
       },
       "table": {
         "column": {
-          "first-name":"Prénom",
-          "last-name":"Nom",
-          "organization-membership-role":"Rôle"
+          "first-name": "Prénom",
+          "last-name": "Nom",
+          "organization-membership-role": "Rôle"
         },
         "empty": "En attente de membres",
         "row-title": "Membre"
@@ -615,7 +619,7 @@
       "invited-members": "À la réception de l'e-mail, les invités pourront choisir de se créer un compte Pix ou de se connecter avec un compte Pix existant.",
       "errors": {
         "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
-        "status" : {
+        "status": {
           "400": "Le format de l'adresse e-mail est incorrect.",
           "404": "Cet email n'appartient à aucun utilisateur.",
           "412": "Ce membre a déjà été ajouté.",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous pouvons filtrer la liste des étudiants uniquement par nom et prénom, il y a une nouvelle demande pour ajouter la possibilité de filtrer également par numéro d'étudiant.

## :robot: Solution
Permettre l’utilisateur de filtrer sur le numéro étudiant au sein de l’onglet étudiant pour une orga SUP is mananging student

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Orga avec un compte SUP
- Allez sur le menu étudiant
- Nous pouvons voir le filtrage par numero étudiant sur la première colonne, tapez un numéro d’étudiant pour filtrer.