### PR TITLE
[BUGFIX] Valider le paramètre filter[id] de la route GET /api/organizations (PIX-2497).

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -36,7 +36,7 @@ exports.register = async (server) => {
             allowUnknown: true,
           },
           query: Joi.object({
-            'filter[id]': Joi.number().integer().empty('').allow(null).optional(),
+            'filter[id]': identifiersType.organizationId.empty('').allow(null).optional(),
             'filter[name]': Joi.string().empty('').allow(null).optional(),
             'page[number]': Joi.number().integer().empty('').allow(null).optional(),
             'page[size]': Joi.number().integer().empty('').allow(null).optional(),

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -54,4 +54,9 @@ _assignValueToExport(typesPositiveInteger32bits, implementationType.positiveInte
 _assignValueToExport(typesAlphanumeric, implementationType.alphanumeric);
 _assignValueToExport(typesAlphanumeric255, implementationType.alphanumeric255);
 
+valuesToExport.positiveInteger32bits = {
+  min: postgreSQLSequenceDefaultStart,
+  max: postgreSQLSequenceEnd,
+};
+
 module.exports = valuesToExport;


### PR DESCRIPTION
## :unicorn: Problème
cf. [Erreur Sentry](https://sentry.io/organizations/pix/issues/2350035133/?project=1398749&referrer=slack)

Dans Pix Admin, sur la page des organisations, il est possible de filtrer la liste en précisant un ID (celui d’une organisation).
Côté front, il n’y a pas de validation numérique de ce champ.
Identiquement, côté API, la validation numérique de cet ID n’est pas borné (min et max).

## :robot: Solution
* Utiliser le type Joi correspondant : `identifiersType.organizationId` 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter à Pix Admin
Visiter la page https://admin-pr2882.review.pix.fr/organizations/list?id=11111111111111111111111111111111111111
Vérifier que l'API renvoie une 400

```
{
	"errors": [
		{
			"status": "400",
			"title": "Bad Request",
			"detail": "Un des champs de recherche saisis est invalide."
		}
	]
}
```