### PR TITLE
[FEATURE] Autoriser l'envoi multiple pour une campagne de collecte de profils (Pix-2466).

### DIFF
--- a/api/db/seeds/data/campaign-participations-builder.js
+++ b/api/db/seeds/data/campaign-participations-builder.js
@@ -107,15 +107,33 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
     }
   };
 
-  const participateToCampaignOfTypeProfilesCollection = (userId, isShared) => {
-    const sharedAt = isShared ? new Date() : null;
+  const participateToCampaignOfTypeProfilesCollection = (campaignId, userId, isShared, isImproved = false) => {
+    const today = new Date();
+
+    const sharedAt = isShared ? today : null;
+
     databaseBuilder.factory.buildCampaignParticipation({
-      campaignId: 6,
+      campaignId,
       userId,
       participantExternalId: userId,
       isShared,
       sharedAt,
     });
+
+    if (isImproved) {
+      const yesterday = new Date();
+      yesterday.setDate(today.getDate() - 1);
+      const oldSharedAt = isShared ? yesterday : null;
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+        participantExternalId: userId,
+        isShared,
+        sharedAt: oldSharedAt,
+        isImproved,
+      });
+    }
   };
 
   usersNotCompleted.forEach((user) => participateComplexAssessmentCampaign(1, user, 'STARTED', false));
@@ -129,9 +147,11 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
   participateComplexAssessmentCampaign(15, users[0], 'COMPLETED', true);
   participateComplexAssessmentCampaign(16, users[0], 'COMPLETED', true, true);
 
-  usersNotCompleted.forEach((user) => participateToCampaignOfTypeProfilesCollection(user.id, false));
-  usersNotShared.forEach((user) => participateToCampaignOfTypeProfilesCollection(user.id, false));
-  usersCompletedShared.forEach((user) => participateToCampaignOfTypeProfilesCollection(user.id, true));
-  [CERTIF_REGULAR_USER1_ID, CERTIF_REGULAR_USER2_ID, CERTIF_REGULAR_USER3_ID].forEach((userId) => participateToCampaignOfTypeProfilesCollection(userId, true));
-  [CERTIF_REGULAR_USER4_ID, CERTIF_REGULAR_USER5_ID].forEach((userId) => participateToCampaignOfTypeProfilesCollection(userId, false));
+  participateToCampaignOfTypeProfilesCollection(18, users[0].id, true, true);
+
+  usersNotCompleted.forEach((user) => participateToCampaignOfTypeProfilesCollection(6, user.id, false));
+  usersNotShared.forEach((user) => participateToCampaignOfTypeProfilesCollection(6, user.id, false));
+  usersCompletedShared.forEach((user) => participateToCampaignOfTypeProfilesCollection(6, user.id, true));
+  [CERTIF_REGULAR_USER1_ID, CERTIF_REGULAR_USER2_ID, CERTIF_REGULAR_USER3_ID].forEach((userId) => participateToCampaignOfTypeProfilesCollection(6, userId, true));
+  [CERTIF_REGULAR_USER4_ID, CERTIF_REGULAR_USER5_ID].forEach((userId) => participateToCampaignOfTypeProfilesCollection(6, userId, false));
 };

--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -283,4 +283,16 @@ __Plus d'infos :)__
     isForAbsoluteNovice: true,
   });
 
+  databaseBuilder.factory.buildCampaign({
+    id: 18,
+    name: 'Pro - Campagne de collecte de profils - envois multiple',
+    code: 'SNAPMU789',
+    type: 'PROFILES_COLLECTION',
+    organizationId: PRO_COMPANY_ID,
+    creatorId: 2,
+    idPixLabel: 'identifiant entreprise',
+    title: null,
+    customLandingPageText: null,
+    multipleSendings: true,
+  });
 }


### PR DESCRIPTION
## :unicorn: Problème

## :robot: Solution
Rajouter un seeds en local pour avoir un jeu de données collecte de profile en envoi multiple

## :rainbow: Remarques

## :100: Pour tester
Se connecter avec `jaune.attend@example.net`
Aller sur la campagne `SNA789` Campagne de collecte d eprofile a envoi multiple. vérifier que vous avez bien le dernier envoi sur la page` /campagnes/SNA789/collecte/deja-envoye`