### PR TITLE
[FEATURE] Ajouter les mentions concernant les certifications Pix+ Droit dans les csv de résultats de certification (PIX-2443)

### DIFF
--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -57,6 +57,10 @@ class CertificationResult {
       this.juryId = undefined;
     }
   }
+
+  hasTakenClea() {
+    return this.cleaCertificationResult.isTaken();
+  }
 }
 
 module.exports = CertificationResult;

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -14,6 +14,8 @@ class CertificationResult {
     isPublished,
     isV2Certification,
     cleaCertificationResult,
+    pixPlusDroitMaitreCertificationResult,
+    pixPlusDroitExpertCertificationResult,
     certificationIssueReports,
     hasSeenEndTestScreen,
     assessmentId,
@@ -30,6 +32,8 @@ class CertificationResult {
     this.isPublished = isPublished;
     this.isV2Certification = isV2Certification;
     this.cleaCertificationResult = cleaCertificationResult;
+    this.pixPlusDroitMaitreCertificationResult = pixPlusDroitMaitreCertificationResult;
+    this.pixPlusDroitExpertCertificationResult = pixPlusDroitExpertCertificationResult;
     this.certificationIssueReports = certificationIssueReports;
     this.hasSeenEndTestScreen = hasSeenEndTestScreen;
     this.assessmentId = assessmentId;
@@ -60,6 +64,14 @@ class CertificationResult {
 
   hasTakenClea() {
     return this.cleaCertificationResult.isTaken();
+  }
+
+  hasTakenPixPlusDroitMaitre() {
+    return this.pixPlusDroitMaitreCertificationResult.isTaken();
+  }
+
+  hasTakenPixPlusDroitExpert() {
+    return this.pixPlusDroitExpertCertificationResult.isTaken();
   }
 }
 

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -1,25 +1,24 @@
 const Assessment = require('./Assessment');
 
 class CertificationResult {
-  constructor(
-    {
-      id,
-      lastAssessmentResult,
-      firstName,
-      lastName,
-      birthplace,
-      birthdate,
-      externalId,
-      completedAt,
-      createdAt,
-      isPublished,
-      isV2Certification,
-      cleaCertificationStatus,
-      certificationIssueReports,
-      hasSeenEndTestScreen,
-      assessmentId,
-      sessionId,
-    } = {}) {
+  constructor({
+    id,
+    lastAssessmentResult,
+    firstName,
+    lastName,
+    birthplace,
+    birthdate,
+    externalId,
+    completedAt,
+    createdAt,
+    isPublished,
+    isV2Certification,
+    cleaCertificationResult,
+    certificationIssueReports,
+    hasSeenEndTestScreen,
+    assessmentId,
+    sessionId,
+  } = {}) {
     this.id = id;
     this.lastName = lastName;
     this.firstName = firstName;
@@ -30,7 +29,7 @@ class CertificationResult {
     this.createdAt = createdAt;
     this.isPublished = isPublished;
     this.isV2Certification = isV2Certification;
-    this.cleaCertificationStatus = cleaCertificationStatus;
+    this.cleaCertificationResult = cleaCertificationResult;
     this.certificationIssueReports = certificationIssueReports;
     this.hasSeenEndTestScreen = hasSeenEndTestScreen;
     this.assessmentId = assessmentId;

--- a/api/lib/domain/models/CleaCertificationResult.js
+++ b/api/lib/domain/models/CleaCertificationResult.js
@@ -1,0 +1,29 @@
+const cleaStatuses = {
+  ACQUIRED: 'acquired',
+  REJECTED: 'rejected',
+  NOT_PASSED: 'not_passed',
+};
+
+class CleaCertificationResult {
+
+  constructor({
+    status,
+  } = {}) {
+    this.status = status;
+  }
+
+  static from({ acquired }) {
+    return new CleaCertificationResult({
+      status: acquired ? cleaStatuses.ACQUIRED : cleaStatuses.REJECTED,
+    });
+  }
+
+  static buildNotPassed() {
+    return new CleaCertificationResult({
+      status: cleaStatuses.NOT_PASSED,
+    });
+  }
+}
+
+CleaCertificationResult.cleaStatuses = cleaStatuses;
+module.exports = CleaCertificationResult;

--- a/api/lib/domain/models/CleaCertificationResult.js
+++ b/api/lib/domain/models/CleaCertificationResult.js
@@ -15,7 +15,7 @@ class CleaCertificationResult {
     this.status = status;
   }
 
-  static from({ acquired }) {
+  static buildFrom({ acquired }) {
     return new CleaCertificationResult({
       status: acquired ? cleaStatuses.ACQUIRED : cleaStatuses.REJECTED,
     });

--- a/api/lib/domain/models/CleaCertificationResult.js
+++ b/api/lib/domain/models/CleaCertificationResult.js
@@ -3,7 +3,7 @@ const { keys } = require('./Badge');
 const cleaStatuses = {
   ACQUIRED: 'acquired',
   REJECTED: 'rejected',
-  NOT_PASSED: 'not_passed',
+  NOT_TAKEN: 'not_taken',
 };
 const badgeKey = keys.PIX_EMPLOI_CLEA;
 
@@ -21,9 +21,9 @@ class CleaCertificationResult {
     });
   }
 
-  static buildNotPassed() {
+  static buildNotTaken() {
     return new CleaCertificationResult({
-      status: cleaStatuses.NOT_PASSED,
+      status: cleaStatuses.NOT_TAKEN,
     });
   }
 }

--- a/api/lib/domain/models/CleaCertificationResult.js
+++ b/api/lib/domain/models/CleaCertificationResult.js
@@ -1,8 +1,11 @@
+const { keys } = require('./Badge');
+
 const cleaStatuses = {
   ACQUIRED: 'acquired',
   REJECTED: 'rejected',
   NOT_PASSED: 'not_passed',
 };
+const badgeKey = keys.PIX_EMPLOI_CLEA;
 
 class CleaCertificationResult {
 
@@ -26,4 +29,5 @@ class CleaCertificationResult {
 }
 
 CleaCertificationResult.cleaStatuses = cleaStatuses;
+CleaCertificationResult.badgeKey = badgeKey;
 module.exports = CleaCertificationResult;

--- a/api/lib/domain/models/CleaCertificationResult.js
+++ b/api/lib/domain/models/CleaCertificationResult.js
@@ -26,6 +26,10 @@ class CleaCertificationResult {
       status: cleaStatuses.NOT_TAKEN,
     });
   }
+
+  isTaken() {
+    return this.status !== cleaStatuses.NOT_TAKEN;
+  }
 }
 
 CleaCertificationResult.cleaStatuses = cleaStatuses;

--- a/api/lib/domain/models/PixPlusDroitExpertCertificationResult.js
+++ b/api/lib/domain/models/PixPlusDroitExpertCertificationResult.js
@@ -1,0 +1,36 @@
+const statuses = {
+  ACQUIRED: 'acquired',
+  REJECTED: 'rejected',
+  NOT_TAKEN: 'not_taken',
+};
+
+const badgeKey = 'PIX_DROIT_EXPERT_CERTIF';
+
+class PixPlusDroitExpertCertificationResult {
+
+  constructor({
+    status,
+  } = {}) {
+    this.status = status;
+  }
+
+  static from({ acquired }) {
+    return new PixPlusDroitExpertCertificationResult({
+      status: acquired ? statuses.ACQUIRED : statuses.REJECTED,
+    });
+  }
+
+  static buildNotTaken() {
+    return new PixPlusDroitExpertCertificationResult({
+      status: statuses.NOT_TAKEN,
+    });
+  }
+
+  isTaken() {
+    return this.status !== statuses.NOT_TAKEN;
+  }
+}
+
+PixPlusDroitExpertCertificationResult.statuses = statuses;
+PixPlusDroitExpertCertificationResult.badgeKey = badgeKey;
+module.exports = PixPlusDroitExpertCertificationResult;

--- a/api/lib/domain/models/PixPlusDroitExpertCertificationResult.js
+++ b/api/lib/domain/models/PixPlusDroitExpertCertificationResult.js
@@ -14,7 +14,7 @@ class PixPlusDroitExpertCertificationResult {
     this.status = status;
   }
 
-  static from({ acquired }) {
+  static buildFrom({ acquired }) {
     return new PixPlusDroitExpertCertificationResult({
       status: acquired ? statuses.ACQUIRED : statuses.REJECTED,
     });

--- a/api/lib/domain/models/PixPlusDroitMaitreCertificationResult.js
+++ b/api/lib/domain/models/PixPlusDroitMaitreCertificationResult.js
@@ -14,7 +14,7 @@ class PixPlusDroitMaitreCertificationResult {
     this.status = status;
   }
 
-  static from({ acquired }) {
+  static buildFrom({ acquired }) {
     return new PixPlusDroitMaitreCertificationResult({
       status: acquired ? statuses.ACQUIRED : statuses.REJECTED,
     });

--- a/api/lib/domain/models/PixPlusDroitMaitreCertificationResult.js
+++ b/api/lib/domain/models/PixPlusDroitMaitreCertificationResult.js
@@ -1,0 +1,36 @@
+const statuses = {
+  ACQUIRED: 'acquired',
+  REJECTED: 'rejected',
+  NOT_TAKEN: 'not_taken',
+};
+
+const badgeKey = 'PIX_DROIT_MAITRE_CERTIF';
+
+class PixPlusDroitMaitreCertificationResult {
+
+  constructor({
+    status,
+  } = {}) {
+    this.status = status;
+  }
+
+  static from({ acquired }) {
+    return new PixPlusDroitMaitreCertificationResult({
+      status: acquired ? statuses.ACQUIRED : statuses.REJECTED,
+    });
+  }
+
+  static buildNotTaken() {
+    return new PixPlusDroitMaitreCertificationResult({
+      status: statuses.NOT_TAKEN,
+    });
+  }
+
+  isTaken() {
+    return this.status !== statuses.NOT_TAKEN;
+  }
+}
+
+PixPlusDroitMaitreCertificationResult.statuses = statuses;
+PixPlusDroitMaitreCertificationResult.badgeKey = badgeKey;
+module.exports = PixPlusDroitMaitreCertificationResult;

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -2,7 +2,7 @@ const CertificationResult = require('../models/CertificationResult');
 const assessmentRepository = require('../../../lib/infrastructure/repositories/assessment-repository');
 const certificationAssessmentRepository = require('../../../lib/infrastructure/repositories/certification-assessment-repository');
 const assessmentResultRepository = require('../../infrastructure/repositories/assessment-result-repository');
-const cleaCertificationStatusRepository = require('../../infrastructure/repositories/clea-certification-status-repository');
+const cleaCertificationResultRepository = require('../../infrastructure/repositories/clea-certification-result-repository');
 const certificationResultService = require('./certification-result-service');
 
 async function calculateCertificationResultByCertificationCourseId(certificationCourseId) {
@@ -12,7 +12,7 @@ async function calculateCertificationResultByCertificationCourseId(certification
 
 async function getCertificationResultByCertifCourse({ certificationCourse }) {
   const certificationCourseId = certificationCourse.id;
-  const cleaCertificationStatus = await cleaCertificationStatusRepository.getCleaCertificationStatus(certificationCourseId);
+  const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
   const lastAssessmentResult = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
   const assessmentId = await assessmentRepository.getIdByCertificationCourseId(certificationCourseId);
 
@@ -29,7 +29,7 @@ async function getCertificationResultByCertifCourse({ certificationCourse }) {
     createdAt: certificationCourse.createdAt,
     isPublished: certificationCourse.isPublished,
     isV2Certification: certificationCourse.isV2Certification,
-    cleaCertificationStatus,
+    cleaCertificationResult,
     certificationIssueReports: certificationCourse.certificationIssueReports,
     hasSeenEndTestScreen: certificationCourse.hasSeenEndTestScreen,
     sessionId: certificationCourse.sessionId,

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -3,6 +3,8 @@ const assessmentRepository = require('../../../lib/infrastructure/repositories/a
 const certificationAssessmentRepository = require('../../../lib/infrastructure/repositories/certification-assessment-repository');
 const assessmentResultRepository = require('../../infrastructure/repositories/assessment-result-repository');
 const cleaCertificationResultRepository = require('../../infrastructure/repositories/clea-certification-result-repository');
+const pixPlusDroitMaitreCertificationResultRepository = require('../../infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository');
+const pixPlusDroitExpertCertificationResultRepository = require('../../infrastructure/repositories/pix-plus-droit-expert-certification-result-repository');
 const certificationResultService = require('./certification-result-service');
 
 async function calculateCertificationResultByCertificationCourseId(certificationCourseId) {
@@ -13,6 +15,8 @@ async function calculateCertificationResultByCertificationCourseId(certification
 async function getCertificationResultByCertifCourse({ certificationCourse }) {
   const certificationCourseId = certificationCourse.id;
   const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
+  const pixPlusDroitMaitreCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId });
+  const pixPlusDroitExpertCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId });
   const lastAssessmentResult = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
   const assessmentId = await assessmentRepository.getIdByCertificationCourseId(certificationCourseId);
 
@@ -30,6 +34,8 @@ async function getCertificationResultByCertifCourse({ certificationCourse }) {
     isPublished: certificationCourse.isPublished,
     isV2Certification: certificationCourse.isV2Certification,
     cleaCertificationResult,
+    pixPlusDroitMaitreCertificationResult,
+    pixPlusDroitExpertCertificationResult,
     certificationIssueReports: certificationCourse.certificationIssueReports,
     hasSeenEndTestScreen: certificationCourse.hasSeenEndTestScreen,
     sessionId: certificationCourse.sessionId,

--- a/api/lib/infrastructure/repositories/clea-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/clea-certification-result-repository.js
@@ -12,6 +12,6 @@ module.exports = {
     if (!result) {
       return CleaCertificationResult.buildNotTaken();
     }
-    return CleaCertificationResult.from(result);
+    return CleaCertificationResult.buildFrom(result);
   },
 };

--- a/api/lib/infrastructure/repositories/clea-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/clea-certification-result-repository.js
@@ -10,7 +10,7 @@ module.exports = {
       .first();
 
     if (!result) {
-      return CleaCertificationResult.buildNotPassed();
+      return CleaCertificationResult.buildNotTaken();
     }
     return CleaCertificationResult.from(result);
   },

--- a/api/lib/infrastructure/repositories/clea-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/clea-certification-result-repository.js
@@ -1,0 +1,17 @@
+const { knex } = require('../bookshelf');
+const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
+
+module.exports = {
+  async get({ certificationCourseId }) {
+    const result = await knex
+      .select('acquired')
+      .from('partner-certifications')
+      .where({ certificationCourseId, partnerKey: CleaCertificationResult.badgeKey })
+      .first();
+
+    if (!result) {
+      return CleaCertificationResult.buildNotPassed();
+    }
+    return CleaCertificationResult.from(result);
+  },
+};

--- a/api/lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository.js
@@ -1,0 +1,17 @@
+const { knex } = require('../bookshelf');
+const PixPlusDroitExpertCertificationResult = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+
+module.exports = {
+  async get({ certificationCourseId }) {
+    const result = await knex
+      .select('acquired')
+      .from('partner-certifications')
+      .where({ certificationCourseId, partnerKey: PixPlusDroitExpertCertificationResult.badgeKey })
+      .first();
+
+    if (!result) {
+      return PixPlusDroitExpertCertificationResult.buildNotTaken();
+    }
+    return PixPlusDroitExpertCertificationResult.from(result);
+  },
+};

--- a/api/lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository.js
@@ -12,6 +12,6 @@ module.exports = {
     if (!result) {
       return PixPlusDroitExpertCertificationResult.buildNotTaken();
     }
-    return PixPlusDroitExpertCertificationResult.from(result);
+    return PixPlusDroitExpertCertificationResult.buildFrom(result);
   },
 };

--- a/api/lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository.js
@@ -1,0 +1,17 @@
+const { knex } = require('../bookshelf');
+const PixPlusDroitMaitreCertificationResult = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+
+module.exports = {
+  async get({ certificationCourseId }) {
+    const result = await knex
+      .select('acquired')
+      .from('partner-certifications')
+      .where({ certificationCourseId, partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey })
+      .first();
+
+    if (!result) {
+      return PixPlusDroitMaitreCertificationResult.buildNotTaken();
+    }
+    return PixPlusDroitMaitreCertificationResult.from(result);
+  },
+};

--- a/api/lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository.js
@@ -12,6 +12,6 @@ module.exports = {
     if (!result) {
       return PixPlusDroitMaitreCertificationResult.buildNotTaken();
     }
-    return PixPlusDroitMaitreCertificationResult.from(result);
+    return PixPlusDroitMaitreCertificationResult.buildFrom(result);
   },
 };

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -1,6 +1,6 @@
 const { getCsvContent } = require('./write-csv-utils');
 const { status: assessmentResultStatuses } = require('../../../domain/models/AssessmentResult');
-const { statuses: cleaStatuses } = require('../../../infrastructure/repositories/clea-certification-status-repository');
+const { cleaStatuses } = require('../../../domain/models/CleaCertificationResult');
 
 const _ = require('lodash');
 const moment = require('moment');
@@ -26,11 +26,11 @@ async function getSessionCertificationResultsCsv({
 }
 
 function _didAtLeastOneCandidateTakeClea(certificationResults) {
-  return certificationResults.some((result) => _hasPassedClea(result.cleaCertificationStatus));
+  return certificationResults.some((result) => _hasPassedClea(result.cleaCertificationResult));
 }
 
-function _hasPassedClea(cleaCertificationStatus) {
-  return [cleaStatuses.REJECTED, cleaStatuses.ACQUIRED].includes(cleaCertificationStatus);
+function _hasPassedClea(cleaCertificationResult) {
+  return [cleaStatuses.REJECTED, cleaStatuses.ACQUIRED].includes(cleaCertificationResult.status);
 }
 
 function _buildCertificationResultsFileDataWithoutCertificationCenterName({ certificationResults }) {
@@ -123,7 +123,7 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
     [_headers.BIRTHDATE]: _formatDate(certificationResult.birthdate),
     [_headers.BIRTHPLACE]: certificationResult.birthplace,
     [_headers.EXTERNAL_ID]: certificationResult.externalId,
-    [_headers.CLEA_STATUS]: CLEA_STATUS_LABEL_FOR_CSV[certificationResult.cleaCertificationStatus],
+    [_headers.CLEA_STATUS]: CLEA_STATUS_LABEL_FOR_CSV[certificationResult.cleaCertificationResult.status],
     [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
     [_headers.SESSION_ID]: session.id,
     [_headers.CERTIFICATION_CENTER]: session.certificationCenter,

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -110,7 +110,7 @@ function _buildFileHeaders({ shouldIncludeClea }) {
 }
 
 const CLEA_STATUS_LABEL_FOR_CSV = {
-  [cleaStatuses.NOT_PASSED]: 'Non passée',
+  [cleaStatuses.NOT_TAKEN]: 'Non passée',
   [cleaStatuses.ACQUIRED]: 'Validée',
   [cleaStatuses.REJECTED]: 'Rejetée',
 };

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -8,8 +8,8 @@ const moment = require('moment');
 async function getDivisionCertificationResultsCsv({
   certificationResults,
 }) {
-  const data = _buildCertificationResultsFileDataWithoutCertificationCenterName({ certificationResults });
-  const fileHeaders = _buildCertificationResultsFileHeadersWithoutCertificationCenterName();
+  const data = _buildFileDataWithoutCertificationCenterName({ certificationResults });
+  const fileHeaders = _buildFileHeadersWithoutCertificationCenterName();
 
   return getCsvContent({ data, fileHeaders });
 }
@@ -19,8 +19,8 @@ async function getSessionCertificationResultsCsv({
   certificationResults,
 }) {
 
-  const data = _buildCertificationResultsFileDataWithCertificationCenterName({ session, certificationResults });
-  const fileHeaders = _buildCertificationResultsFileHeadersWithCertificationCenterName({ shouldIncludeClea: _didAtLeastOneCandidateTakeClea(certificationResults) });
+  const data = _buildFileData({ session, certificationResults });
+  const fileHeaders = _buildFileHeaders({ shouldIncludeClea: _didAtLeastOneCandidateTakeClea(certificationResults) });
 
   return getCsvContent({ data, fileHeaders });
 }
@@ -33,7 +33,7 @@ function _hasPassedClea(cleaCertificationResult) {
   return [cleaStatuses.REJECTED, cleaStatuses.ACQUIRED].includes(cleaCertificationResult.status);
 }
 
-function _buildCertificationResultsFileDataWithoutCertificationCenterName({ certificationResults }) {
+function _buildFileDataWithoutCertificationCenterName({ certificationResults }) {
   return certificationResults.map(_getRowItemsFromResults);
 }
 
@@ -60,7 +60,7 @@ function _getRowItemsFromResults(certificationResult) {
   return { ...rowWithoutCompetences, ...competencesRow };
 }
 
-function _buildCertificationResultsFileHeadersWithoutCertificationCenterName() {
+function _buildFileHeadersWithoutCertificationCenterName() {
   return _.concat(
     [
       _headers.CERTIFICATION_NUMBER,
@@ -79,11 +79,11 @@ function _buildCertificationResultsFileHeadersWithoutCertificationCenterName() {
   );
 }
 
-function _buildCertificationResultsFileDataWithCertificationCenterName({ session, certificationResults }) {
+function _buildFileData({ session, certificationResults }) {
   return certificationResults.map(_getRowItemsFromSessionAndResults(session));
 }
 
-function _buildCertificationResultsFileHeadersWithCertificationCenterName({ shouldIncludeClea }) {
+function _buildFileHeaders({ shouldIncludeClea }) {
 
   const cleaHeader = shouldIncludeClea
     ? [_headers.CLEA_STATUS]

--- a/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
@@ -8,13 +8,13 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
 
     context('when there is no clea certification result for a given certification id', () => {
 
-      it('should return a not_passed result', async () => {
+      it('should return a not_taken result', async () => {
         // when
         const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId: 123 });
 
         // then
         expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
-        expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.NOT_PASSED);
+        expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.NOT_TAKEN);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
@@ -9,8 +9,12 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
     context('when there is no clea certification result for a given certification id', () => {
 
       it('should return a not_taken result', async () => {
+        // given
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        await databaseBuilder.commit();
+
         // when
-        const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId: 123 });
+        const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
 
         // then
         const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();

--- a/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const cleaCertificationResultRepository = require('../../../../lib/infrastructure/repositories/clea-certification-result-repository');
 const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
 
@@ -13,8 +13,9 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
         const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId: 123 });
 
         // then
+        const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
         expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
-        expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.NOT_TAKEN);
+        expect(cleaCertificationResult).to.deep.equal(expectedCleaCertificationResult);
       });
     });
 
@@ -31,8 +32,9 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
         const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
 
         // then
+        const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
         expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
-        expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.ACQUIRED);
+        expect(cleaCertificationResult).to.deep.equal(expectedCleaCertificationResult);
       });
     });
 
@@ -49,8 +51,9 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
         const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
 
         // then
+        const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.rejected();
         expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
-        expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.REJECTED);
+        expect(cleaCertificationResult).to.deep.equal(expectedCleaCertificationResult);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
@@ -1,0 +1,57 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const cleaCertificationResultRepository = require('../../../../lib/infrastructure/repositories/clea-certification-result-repository');
+const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
+
+describe('Integration | Infrastructure | Repositories | clea-certification-result-repository', () => {
+
+  describe('#get', () => {
+
+    context('when there is no clea certification result for a given certification id', () => {
+
+      it('should return a not_passed result', async () => {
+        // when
+        const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId: 123 });
+
+        // then
+        expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
+        expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.NOT_PASSED);
+      });
+    });
+
+    context('when there is a acquired clea certification result for a given certification id', () => {
+
+      it('should return a acquired result', async () => {
+        // given
+        databaseBuilder.factory.buildBadge({ key: CleaCertificationResult.badgeKey });
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: CleaCertificationResult.badgeKey, acquired: true });
+        await databaseBuilder.commit();
+
+        // when
+        const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
+
+        // then
+        expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
+        expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.ACQUIRED);
+      });
+    });
+
+    context('when there is a rejected clea certification result for a given certification id', () => {
+
+      it('should return a rejected result', async () => {
+        // given
+        databaseBuilder.factory.buildBadge({ key: CleaCertificationResult.badgeKey });
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: CleaCertificationResult.badgeKey, acquired: false });
+        await databaseBuilder.commit();
+
+        // when
+        const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
+
+        // then
+        expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
+        expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.REJECTED);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const pixPlusDroitExpertCertificationResultRepository = require('../../../../lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository');
 const PixPlusDroitExpertCertificationResult = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
 
@@ -13,8 +13,9 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-expert-ce
         const pixPlusCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId: 123 });
 
         // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
         expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitExpertCertificationResult);
-        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitExpertCertificationResult.statuses.NOT_TAKEN);
+        expect(pixPlusCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
       });
     });
 
@@ -31,8 +32,9 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-expert-ce
         const pixPlusCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId });
 
         // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
         expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitExpertCertificationResult);
-        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitExpertCertificationResult.statuses.ACQUIRED);
+        expect(pixPlusCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
       });
     });
 
@@ -49,8 +51,9 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-expert-ce
         const pixPlusCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId });
 
         // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected();
         expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitExpertCertificationResult);
-        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitExpertCertificationResult.statuses.REJECTED);
+        expect(pixPlusCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository_test.js
@@ -9,8 +9,12 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-expert-ce
     context('when there is no pix plus droit expert certification result for a given certification id', () => {
 
       it('should return a not_taken result', async () => {
+        // given
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        await databaseBuilder.commit();
+
         // when
-        const pixPlusCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId: 123 });
+        const pixPlusCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId });
 
         // then
         const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();

--- a/api/tests/integration/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository_test.js
@@ -1,0 +1,57 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const pixPlusDroitExpertCertificationResultRepository = require('../../../../lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository');
+const PixPlusDroitExpertCertificationResult = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+
+describe('Integration | Infrastructure | Repositories | pix-plus-droit-expert-certification-result-repository', () => {
+
+  describe('#get', () => {
+
+    context('when there is no pix plus droit expert certification result for a given certification id', () => {
+
+      it('should return a not_taken result', async () => {
+        // when
+        const pixPlusCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId: 123 });
+
+        // then
+        expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitExpertCertificationResult);
+        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitExpertCertificationResult.statuses.NOT_TAKEN);
+      });
+    });
+
+    context('when there is a acquired pix plus droit expert certification result for a given certification id', () => {
+
+      it('should return a acquired result', async () => {
+        // given
+        databaseBuilder.factory.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitExpertCertificationResult.badgeKey, acquired: true });
+        await databaseBuilder.commit();
+
+        // when
+        const pixPlusCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId });
+
+        // then
+        expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitExpertCertificationResult);
+        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitExpertCertificationResult.statuses.ACQUIRED);
+      });
+    });
+
+    context('when there is a rejected pix plus droit expert certification result for a given certification id', () => {
+
+      it('should return a rejected result', async () => {
+        // given
+        databaseBuilder.factory.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitExpertCertificationResult.badgeKey, acquired: false });
+        await databaseBuilder.commit();
+
+        // when
+        const pixPlusCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({ certificationCourseId });
+
+        // then
+        expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitExpertCertificationResult);
+        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitExpertCertificationResult.statuses.REJECTED);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository_test.js
@@ -1,0 +1,57 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const pixPlusDroitMaitreCertificationResultRepository = require('../../../../lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository');
+const PixPlusDroitMaitreCertificationResult = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+
+describe('Integration | Infrastructure | Repositories | pix-plus-droit-maitre-certification-result-repository', () => {
+
+  describe('#get', () => {
+
+    context('when there is no pix plus droit maitre certification result for a given certification id', () => {
+
+      it('should return a not_taken result', async () => {
+        // when
+        const pixPlusCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId: 123 });
+
+        // then
+        expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitMaitreCertificationResult);
+        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitMaitreCertificationResult.statuses.NOT_TAKEN);
+      });
+    });
+
+    context('when there is a acquired pix plus droit maitre certification result for a given certification id', () => {
+
+      it('should return a acquired result', async () => {
+        // given
+        databaseBuilder.factory.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey, acquired: true });
+        await databaseBuilder.commit();
+
+        // when
+        const pixPlusCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId });
+
+        // then
+        expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitMaitreCertificationResult);
+        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitMaitreCertificationResult.statuses.ACQUIRED);
+      });
+    });
+
+    context('when there is a rejected pix plus droit maitre certification result for a given certification id', () => {
+
+      it('should return a rejected result', async () => {
+        // given
+        databaseBuilder.factory.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey, acquired: false });
+        await databaseBuilder.commit();
+
+        // when
+        const pixPlusCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId });
+
+        // then
+        expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitMaitreCertificationResult);
+        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitMaitreCertificationResult.statuses.REJECTED);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const pixPlusDroitMaitreCertificationResultRepository = require('../../../../lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository');
 const PixPlusDroitMaitreCertificationResult = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 
@@ -13,8 +13,9 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-maitre-ce
         const pixPlusCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId: 123 });
 
         // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
         expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitMaitreCertificationResult);
-        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitMaitreCertificationResult.statuses.NOT_TAKEN);
+        expect(pixPlusCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
       });
     });
 
@@ -31,8 +32,9 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-maitre-ce
         const pixPlusCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId });
 
         // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
         expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitMaitreCertificationResult);
-        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitMaitreCertificationResult.statuses.ACQUIRED);
+        expect(pixPlusCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
       });
     });
 
@@ -49,8 +51,9 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-maitre-ce
         const pixPlusCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId });
 
         // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();
         expect(pixPlusCertificationResult).to.be.instanceOf(PixPlusDroitMaitreCertificationResult);
-        expect(pixPlusCertificationResult.status).to.equal(PixPlusDroitMaitreCertificationResult.statuses.REJECTED);
+        expect(pixPlusCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository_test.js
@@ -9,8 +9,12 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-maitre-ce
     context('when there is no pix plus droit maitre certification result for a given certification id', () => {
 
       it('should return a not_taken result', async () => {
+        // given
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        await databaseBuilder.commit();
+
         // when
-        const pixPlusCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId: 123 });
+        const pixPlusCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({ certificationCourseId });
 
         // then
         const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -1,6 +1,5 @@
 const { expect, domainBuilder, databaseBuilder } = require('../../../../test-helper');
 const { getSessionCertificationResultsCsv, getDivisionCertificationResultsCsv } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
-const { statuses: cleaStatuses } = require('../../../../../lib/infrastructure/repositories/clea-certification-status-repository');
 
 describe('Integration | Infrastructure | Utils | csv | certification-results', () => {
 
@@ -36,13 +35,14 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           firstName: 'Lili',
           birthdate,
           createdAt,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notPassed(),
         });
         const certifResult2 = domainBuilder.buildCertificationResult({
           lastAssessmentResult: lastAssessmentResult2,
           firstName: 'Tom',
           birthdate,
           createdAt,
-          cleaCertificationStatus: cleaStatuses.NOT_PASSED,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notPassed(),
         });
 
         const certificationResults = [ certifResult1, certifResult2 ];
@@ -91,14 +91,14 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           firstName: 'Lili',
           birthdate,
           createdAt,
-          cleaCertificationStatus: cleaStatuses.NOT_PASSED,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notPassed(),
         });
         const certifResult2 = domainBuilder.buildCertificationResult({
           lastAssessmentResult: lastAssessmentResult2,
           firstName: 'Tom',
           birthdate,
           createdAt,
-          cleaCertificationStatus: cleaStatuses.ACQUIRED,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
         });
 
         const certificationResults = [ certifResult1, certifResult2 ];

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -61,7 +61,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
           `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
           `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
-        expect(result).to.deep.equal(expectedResult);
+        expect(result).to.equal(expectedResult);
       });
     });
 
@@ -117,7 +117,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
           `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
           `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
-        expect(result).to.deep.equal(expectedResult);
+        expect(result).to.equal(expectedResult);
       });
     });
 
@@ -173,7 +173,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification Pix+ Droit Maître";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
           `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
           `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
-        expect(result).to.deep.equal(expectedResult);
+        expect(result).to.equal(expectedResult);
       });
     });
 
@@ -229,7 +229,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification Pix+ Droit Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
           `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
           `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
-        expect(result).to.deep.equal(expectedResult);
+        expect(result).to.equal(expectedResult);
       });
     });
 
@@ -298,7 +298,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Non passée";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
           `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Non passée";"Non passée";"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
         `"${certifResult3.id}";"Bob";"${certifResult3.lastName}";"${expectedBirthDate}";"${certifResult3.birthplace}";"${certifResult3.externalId}";"Validée";"Non passée";"Non passée";31;"-";"-";"-";"-";"-";"-";"-";"-";3;"-";"-";"-";"-";"-";"-";"-";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
-        expect(result).to.deep.equal(expectedResult);
+        expect(result).to.equal(expectedResult);
       });
     });
   });
@@ -352,7 +352,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Date de passage de la certification"\n' +
         `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"${certifResult1.sessionId}";"${expectedCreatedAt}"\n` +
         `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"${certifResult2.sessionId}";"${expectedCreatedAt}"`;
-      expect(result).to.deep.equal(expectedResult);
+      expect(result).to.equal(expectedResult);
     });
   });
 });

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -9,7 +9,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
 
       it('should return correct csvContent without clea informations', async () => {
         // given
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
         const session = databaseBuilder.factory.buildSession({ certificationCenterId });
 
         const birthdate = new Date('1990-01-01');

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -3,11 +3,11 @@ const { getSessionCertificationResultsCsv, getDivisionCertificationResultsCsv } 
 
 describe('Integration | Infrastructure | Utils | csv | certification-results', () => {
 
-  describe('#getSessionCertificationResultsCsv', () => {
+  context('#getSessionCertificationResultsCsv', () => {
 
-    describe('when no certification has passed clea', () => {
+    context('when no certification has passed complementary certifications', () => {
 
-      it('should return correct csvContent without clea informations', async () => {
+      it('should return correct csvContent without complementary certification informations', async () => {
         // given
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
         const session = databaseBuilder.factory.buildSession({ certificationCenterId });
@@ -36,6 +36,8 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           birthdate,
           createdAt,
           cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
         });
         const certifResult2 = domainBuilder.buildCertificationResult({
           lastAssessmentResult: lastAssessmentResult2,
@@ -43,6 +45,8 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           birthdate,
           createdAt,
           cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
+          pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         });
 
         const certificationResults = [ certifResult1, certifResult2 ];
@@ -61,7 +65,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
       });
     });
 
-    describe('when at least one candidate has passed CleA certification', () => {
+    context('when at least one candidate has passed CleA certification', () => {
 
       it('should return correct csvContent with the CleA information', async () => {
         // given
@@ -116,9 +120,190 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         expect(result).to.deep.equal(expectedResult);
       });
     });
+
+    context('when at least one candidate has passed Pix plus maitre certification', () => {
+
+      it('should return correct csvContent with the Pix plus maitre information', async () => {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
+        const session = databaseBuilder.factory.buildSession({ certificationCenterId });
+
+        const birthdate = new Date('1990-01-01');
+        const createdAt = new Date('2020-01-01');
+
+        const competencesWithMark1 = [
+          { competence_code: '1.1', level: 0 }, { competence_code: '1.2', level: 1 }, { competence_code: '1.3', level: 5 },
+          { competence_code: '5.1', level: 0 }, { competence_code: '5.2', level: -1 },
+        ];
+        const competencesWithMark2 = [ { competence_code: '5.1', level: 3 }, { competence_code: '5.2', level: -1 } ];
+
+        const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
+          status: 'validated',
+          competenceMarks: competencesWithMark1,
+        });
+        const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
+          status: 'rejected',
+          competenceMarks: competencesWithMark2,
+        });
+
+        const certifResult1 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult1,
+          firstName: 'Lili',
+          birthdate,
+          createdAt,
+          pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
+        });
+        const certifResult2 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult2,
+          firstName: 'Tom',
+          birthdate,
+          createdAt,
+          pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired(),
+        });
+
+        const certificationResults = [ certifResult1, certifResult2 ];
+
+        // when
+        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+
+        // then
+        const expectedBirthDate = '01/01/1990';
+        const expectedCreatedAt = '01/01/2020';
+        const expectedResult = '\uFEFF' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification Pix+ Droit Maître";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
+
+    context('when at least one candidate has passed Pix plus expert certification', () => {
+
+      it('should return correct csvContent with the Pix plus expert information', async () => {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
+        const session = databaseBuilder.factory.buildSession({ certificationCenterId });
+
+        const birthdate = new Date('1990-01-01');
+        const createdAt = new Date('2020-01-01');
+
+        const competencesWithMark1 = [
+          { competence_code: '1.1', level: 0 }, { competence_code: '1.2', level: 1 }, { competence_code: '1.3', level: 5 },
+          { competence_code: '5.1', level: 0 }, { competence_code: '5.2', level: -1 },
+        ];
+        const competencesWithMark2 = [ { competence_code: '5.1', level: 3 }, { competence_code: '5.2', level: -1 } ];
+
+        const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
+          status: 'validated',
+          competenceMarks: competencesWithMark1,
+        });
+        const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
+          status: 'rejected',
+          competenceMarks: competencesWithMark2,
+        });
+
+        const certifResult1 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult1,
+          firstName: 'Lili',
+          birthdate,
+          createdAt,
+          pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
+        });
+        const certifResult2 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult2,
+          firstName: 'Tom',
+          birthdate,
+          createdAt,
+          pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired(),
+        });
+
+        const certificationResults = [ certifResult1, certifResult2 ];
+
+        // when
+        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+
+        // then
+        const expectedBirthDate = '01/01/1990';
+        const expectedCreatedAt = '01/01/2020';
+        const expectedResult = '\uFEFF' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification Pix+ Droit Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
+
+    context('when there are several complementary certifications', () => {
+
+      it('should return correct csvContent with complementary informations', async () => {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const session = databaseBuilder.factory.buildSession({ certificationCenterId });
+
+        const birthdate = new Date('1990-01-01');
+        const createdAt = new Date('2020-01-01');
+
+        const competencesWithMark1 = [
+          { competence_code: '1.1', level: 0 }, { competence_code: '1.2', level: 1 }, { competence_code: '1.3', level: 5 },
+          { competence_code: '5.1', level: 0 }, { competence_code: '5.2', level: -1 },
+        ];
+        const competencesWithMark2 = [ { competence_code: '5.1', level: 3 }, { competence_code: '5.2', level: -1 } ];
+        const competencesWithMark3 = [ { competence_code: '3.2', level: 3 } ];
+
+        const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
+          status: 'validated',
+          competenceMarks: competencesWithMark1,
+        });
+        const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
+          status: 'rejected',
+          competenceMarks: competencesWithMark2,
+        });
+        const lastAssessmentResult3 = domainBuilder.buildAssessmentResult({
+          status: 'validated',
+          competenceMarks: competencesWithMark3,
+        });
+
+        const certifResult1 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult1,
+          firstName: 'Lili',
+          birthdate,
+          createdAt,
+          pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired(),
+        });
+        const certifResult2 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult2,
+          firstName: 'Tom',
+          birthdate,
+          createdAt,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.rejected(),
+        });
+        const certifResult3 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult3,
+          firstName: 'Bob',
+          birthdate,
+          createdAt,
+          pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired(),
+        });
+
+        const certificationResults = [ certifResult1, certifResult2, certifResult3 ];
+
+        // when
+        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+
+        // then
+        const expectedBirthDate = '01/01/1990';
+        const expectedCreatedAt = '01/01/2020';
+        const expectedResult = '\uFEFF' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Non passée";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Non passée";"Non passée";"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+        `"${certifResult3.id}";"Bob";"${certifResult3.lastName}";"${expectedBirthDate}";"${certifResult3.birthplace}";"${certifResult3.externalId}";"Validée";"Non passée";"Non passée";31;"-";"-";"-";"-";"-";"-";"-";"-";3;"-";"-";"-";"-";"-";"-";"-";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
   });
 
-  describe('#getDivisionCertificationResultsCsv', () => {
+  context('#getDivisionCertificationResultsCsv', () => {
 
     it('returns a csv without session informations', async () => {
       // given

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -35,14 +35,14 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           firstName: 'Lili',
           birthdate,
           createdAt,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notPassed(),
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
         });
         const certifResult2 = domainBuilder.buildCertificationResult({
           lastAssessmentResult: lastAssessmentResult2,
           firstName: 'Tom',
           birthdate,
           createdAt,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notPassed(),
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
         });
 
         const certificationResults = [ certifResult1, certifResult2 ];
@@ -91,7 +91,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           firstName: 'Lili',
           birthdate,
           createdAt,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notPassed(),
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
         });
         const certifResult2 = domainBuilder.buildCertificationResult({
           lastAssessmentResult: lastAssessmentResult2,

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -1,6 +1,6 @@
 const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
-const { statuses: cleaStatuses } = require('../../../../lib/infrastructure/repositories/clea-certification-status-repository');
 const buildAssessmentResult = require('./build-assessment-result');
+const buildCleaCertificationResult = require('./build-clea-certification-result');
 
 module.exports = function buildCertificationResult({
   id = '123',
@@ -15,7 +15,7 @@ module.exports = function buildCertificationResult({
   completedAt = new Date('2020-05-05'),
   isPublished = true,
   isV2Certification = true,
-  cleaCertificationStatus = cleaStatuses.NOT_PASSED,
+  cleaCertificationResult = buildCleaCertificationResult.notPassed(),
   hasSeenEndTestScreen = true,
   assessmentId,
   sessionId,
@@ -33,7 +33,7 @@ module.exports = function buildCertificationResult({
     createdAt,
     isPublished,
     isV2Certification,
-    cleaCertificationStatus,
+    cleaCertificationResult,
     certificationIssueReports,
     hasSeenEndTestScreen,
     assessmentId,

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -1,6 +1,7 @@
 const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
 const buildAssessmentResult = require('./build-assessment-result');
 const buildCleaCertificationResult = require('./build-clea-certification-result');
+const buildPixPlusDroitCertificationResult = require('./build-pix-plus-droit-certification-result');
 
 module.exports = function buildCertificationResult({
   id = '123',
@@ -16,6 +17,8 @@ module.exports = function buildCertificationResult({
   isPublished = true,
   isV2Certification = true,
   cleaCertificationResult = buildCleaCertificationResult.notTaken(),
+  pixPlusDroitMaitreCertificationResult = buildPixPlusDroitCertificationResult.maitre.notTaken(),
+  pixPlusDroitExpertCertificationResult = buildPixPlusDroitCertificationResult.expert.notTaken(),
   hasSeenEndTestScreen = true,
   assessmentId,
   sessionId,
@@ -34,6 +37,8 @@ module.exports = function buildCertificationResult({
     isPublished,
     isV2Certification,
     cleaCertificationResult,
+    pixPlusDroitMaitreCertificationResult,
+    pixPlusDroitExpertCertificationResult,
     certificationIssueReports,
     hasSeenEndTestScreen,
     assessmentId,

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -15,7 +15,7 @@ module.exports = function buildCertificationResult({
   completedAt = new Date('2020-05-05'),
   isPublished = true,
   isV2Certification = true,
-  cleaCertificationResult = buildCleaCertificationResult.notPassed(),
+  cleaCertificationResult = buildCleaCertificationResult.notTaken(),
   hasSeenEndTestScreen = true,
   assessmentId,
   sessionId,

--- a/api/tests/tooling/domain-builder/factory/build-clea-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certification-result.js
@@ -1,0 +1,29 @@
+const CleaCertificationResult = require('./../../../../lib/domain/models/CleaCertificationResult');
+
+const buildCleaCertificationResult = function({
+  status = CleaCertificationResult.cleaStatuses.ACQUIRED,
+} = {}) {
+  return new CleaCertificationResult({
+    status,
+  });
+};
+
+buildCleaCertificationResult.acquired = function() {
+  return new CleaCertificationResult({
+    status: CleaCertificationResult.cleaStatuses.ACQUIRED,
+  });
+};
+
+buildCleaCertificationResult.rejected = function() {
+  return new CleaCertificationResult({
+    status: CleaCertificationResult.cleaStatuses.REJECTED,
+  });
+};
+
+buildCleaCertificationResult.notPassed = function() {
+  return new CleaCertificationResult({
+    status: CleaCertificationResult.cleaStatuses.NOT_PASSED,
+  });
+};
+
+module.exports = buildCleaCertificationResult;

--- a/api/tests/tooling/domain-builder/factory/build-clea-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certification-result.js
@@ -20,9 +20,9 @@ buildCleaCertificationResult.rejected = function() {
   });
 };
 
-buildCleaCertificationResult.notPassed = function() {
+buildCleaCertificationResult.notTaken = function() {
   return new CleaCertificationResult({
-    status: CleaCertificationResult.cleaStatuses.NOT_PASSED,
+    status: CleaCertificationResult.cleaStatuses.NOT_TAKEN,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-pix-plus-droit-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-pix-plus-droit-certification-result.js
@@ -1,0 +1,64 @@
+const PixPlusDroitMaitreCertificationResult = require('./../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+const PixPlusDroitExpertCertificationResult = require('./../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+
+const buildPixPlusDroitCertificationResult = function({
+  status = PixPlusDroitMaitreCertificationResult.statuses.ACQUIRED,
+} = {}) {
+  return new PixPlusDroitMaitreCertificationResult({
+    status,
+  });
+};
+
+buildPixPlusDroitCertificationResult.maitre = function({
+  status = PixPlusDroitMaitreCertificationResult.statuses.ACQUIRED,
+}) {
+  return new PixPlusDroitMaitreCertificationResult({
+    status,
+  });
+};
+
+buildPixPlusDroitCertificationResult.expert = function({
+  status = PixPlusDroitExpertCertificationResult.statuses.ACQUIRED,
+}) {
+  return new PixPlusDroitExpertCertificationResult({
+    status,
+  });
+};
+
+buildPixPlusDroitCertificationResult.maitre.acquired = function() {
+  return new PixPlusDroitMaitreCertificationResult({
+    status: PixPlusDroitMaitreCertificationResult.statuses.ACQUIRED,
+  });
+};
+
+buildPixPlusDroitCertificationResult.maitre.rejected = function() {
+  return new PixPlusDroitMaitreCertificationResult({
+    status: PixPlusDroitMaitreCertificationResult.statuses.REJECTED,
+  });
+};
+
+buildPixPlusDroitCertificationResult.maitre.notTaken = function() {
+  return new PixPlusDroitMaitreCertificationResult({
+    status: PixPlusDroitMaitreCertificationResult.statuses.NOT_TAKEN,
+  });
+};
+
+buildPixPlusDroitCertificationResult.expert.acquired = function() {
+  return new PixPlusDroitExpertCertificationResult({
+    status: PixPlusDroitExpertCertificationResult.statuses.ACQUIRED,
+  });
+};
+
+buildPixPlusDroitCertificationResult.expert.rejected = function() {
+  return new PixPlusDroitExpertCertificationResult({
+    status: PixPlusDroitExpertCertificationResult.statuses.REJECTED,
+  });
+};
+
+buildPixPlusDroitCertificationResult.expert.notTaken = function() {
+  return new PixPlusDroitExpertCertificationResult({
+    status: PixPlusDroitExpertCertificationResult.statuses.NOT_TAKEN,
+  });
+};
+
+module.exports = buildPixPlusDroitCertificationResult;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -36,6 +36,7 @@ module.exports = {
   buildCertifiedTube: require('./build-certified-tube'),
   buildChallenge: require('./build-challenge'),
   buildChallengeLearningContentDataObject: require('./build-challenge-learning-content-data-object'),
+  buildCleaCertificationResult: require('./build-clea-certification-result'),
   buildCleaCertificationScoring: require('./build-clea-certification-scoring'),
   buildCompetence: require('./build-competence'),
   buildCompetenceEvaluation: require('./build-competence-evaluation'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -53,6 +53,7 @@ module.exports = {
   buildOrganization: require('./build-organization'),
   buildOrganizationInvitation: require('./build-organization-invitation'),
   buildOrganizationTag: require('./build-organization-tag'),
+  buildPixPlusDroitCertificationResult: require('./build-pix-plus-droit-certification-result'),
   buildPixPlusCertificationScoring: require('./build-pix-plus-certification-scoring'),
   buildPixRole: require('./build-pix-role'),
   buildPlacementProfile: require('./build-placement-profile'),

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -1,0 +1,31 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | CertificationResult', () => {
+
+  context('#hasTakenClea', () => {
+
+    it('returns true when Clea certification has been taken in the certification', async () => {
+      // given
+      const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
+      const certificationResult = domainBuilder.buildCertificationResult({ cleaCertificationResult });
+
+      // when
+      const hasTakenClea = certificationResult.hasTakenClea();
+
+      // then
+      expect(hasTakenClea).to.be.true;
+    });
+
+    it('returns false when Clea certification has not been taken in the certification', async () => {
+      // given
+      const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
+      const certificationResult = domainBuilder.buildCertificationResult({ cleaCertificationResult });
+
+      // when
+      const hasTakenClea = certificationResult.hasTakenClea();
+
+      // then
+      expect(hasTakenClea).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -28,4 +28,58 @@ describe('Unit | Domain | Models | CertificationResult', () => {
       expect(hasTakenClea).to.be.false;
     });
   });
+
+  context('#hasTakenPixPlusDroitMaitre', () => {
+
+    it('returns true when Pix plus maitre certification has been taken in the certification', async () => {
+      // given
+      const pixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
+      const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitMaitreCertificationResult });
+
+      // when
+      const hasTakenPixPlusDroitMaitre = certificationResult.hasTakenPixPlusDroitMaitre();
+
+      // then
+      expect(hasTakenPixPlusDroitMaitre).to.be.true;
+    });
+
+    it('returns false when Pix plus maitre certification has not been taken in the certification', async () => {
+      // given
+      const pixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
+      const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitMaitreCertificationResult });
+
+      // when
+      const hasTakenPixPlusDroitMaitre = certificationResult.hasTakenPixPlusDroitMaitre();
+
+      // then
+      expect(hasTakenPixPlusDroitMaitre).to.be.false;
+    });
+  });
+
+  context('#hasTakenPixPlusDroitExpert', () => {
+
+    it('returns true when Pix plus droit expert certification has been taken in the certification', async () => {
+      // given
+      const pixPlusDroitExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
+      const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitExpertCertificationResult });
+
+      // when
+      const hasTakenPixPlusDroitExpert = certificationResult.hasTakenPixPlusDroitExpert();
+
+      // then
+      expect(hasTakenPixPlusDroitExpert).to.be.true;
+    });
+
+    it('returns false when Pix plus droit expert certification has not been taken in the certification', async () => {
+      // given
+      const pixPlusDroitExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
+      const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitExpertCertificationResult });
+
+      // when
+      const hasTakenPixPlusDroitExpert = certificationResult.hasTakenPixPlusDroitExpert();
+
+      // then
+      expect(hasTakenPixPlusDroitExpert).to.be.false;
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CleaCertificationResult_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationResult_test.js
@@ -24,15 +24,15 @@ describe('Unit | Domain | Models | CleaCertificationResult', () => {
     });
   });
 
-  context('#static buildNotPassed', () => {
+  context('#static buildNotTaken', () => {
 
-    it('builds a CleaCertificationResult not_passed', async () => {
+    it('builds a CleaCertificationResult not_taken', async () => {
       // when
-      const cleaCertificationResult = CleaCertificationResult.buildNotPassed();
+      const cleaCertificationResult = CleaCertificationResult.buildNotTaken();
 
       // then
       expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
-      expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.NOT_PASSED);
+      expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.NOT_TAKEN);
     });
   });
 });

--- a/api/tests/unit/domain/models/CleaCertificationResult_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationResult_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
 
 describe('Unit | Domain | Models | CleaCertificationResult', () => {
@@ -33,6 +33,42 @@ describe('Unit | Domain | Models | CleaCertificationResult', () => {
       // then
       expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
       expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.NOT_TAKEN);
+    });
+  });
+
+  context('#isTaken', () => {
+
+    it('returns true when CleaCertificationResult has a status acquired', async () => {
+      // given
+      const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
+
+      // when
+      const isTaken = cleaCertificationResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.true;
+    });
+
+    it('returns true when CleaCertificationResult has a status rejected', async () => {
+      // given
+      const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.rejected();
+
+      // when
+      const isTaken = cleaCertificationResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.true;
+    });
+
+    it('returns false when CleaCertificationResult has a status not_taken', async () => {
+      // given
+      const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
+
+      // when
+      const isTaken = cleaCertificationResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.false;
     });
   });
 });

--- a/api/tests/unit/domain/models/CleaCertificationResult_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationResult_test.js
@@ -3,11 +3,11 @@ const CleaCertificationResult = require('../../../../lib/domain/models/CleaCerti
 
 describe('Unit | Domain | Models | CleaCertificationResult', () => {
 
-  context('#static from', () => {
+  context('#static buildFrom', () => {
 
     it('builds a CleaCertificationResult acquired', async () => {
       // when
-      const cleaCertificationResult = CleaCertificationResult.from({ acquired: true });
+      const cleaCertificationResult = CleaCertificationResult.buildFrom({ acquired: true });
 
       // then
       expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
@@ -16,7 +16,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', () => {
 
     it('builds a CleaCertificationResult rejected', async () => {
       // when
-      const cleaCertificationResult = CleaCertificationResult.from({ acquired: false });
+      const cleaCertificationResult = CleaCertificationResult.buildFrom({ acquired: false });
 
       // then
       expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);

--- a/api/tests/unit/domain/models/CleaCertificationResult_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationResult_test.js
@@ -1,0 +1,38 @@
+const { expect } = require('../../../test-helper');
+const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
+
+describe('Unit | Domain | Models | CleaCertificationResult', () => {
+
+  context('#static from', () => {
+
+    it('builds a CleaCertificationResult acquired', async () => {
+      // when
+      const cleaCertificationResult = CleaCertificationResult.from({ acquired: true });
+
+      // then
+      expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
+      expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.ACQUIRED);
+    });
+
+    it('builds a CleaCertificationResult rejected', async () => {
+      // when
+      const cleaCertificationResult = CleaCertificationResult.from({ acquired: false });
+
+      // then
+      expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
+      expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.REJECTED);
+    });
+  });
+
+  context('#static buildNotPassed', () => {
+
+    it('builds a CleaCertificationResult not_passed', async () => {
+      // when
+      const cleaCertificationResult = CleaCertificationResult.buildNotPassed();
+
+      // then
+      expect(cleaCertificationResult).to.be.instanceOf(CleaCertificationResult);
+      expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.NOT_PASSED);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/PixPlusDroitExpertCertificationResult_test.js
+++ b/api/tests/unit/domain/models/PixPlusDroitExpertCertificationResult_test.js
@@ -1,0 +1,74 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+const PixPlusExpertCertificationResult = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+
+describe('Unit | Domain | Models | PixPlusExpertCertificationResult', () => {
+
+  context('#static from', () => {
+
+    it('builds a PixPlusExpertCertificationResult acquired', async () => {
+      // when
+      const pixPlusResult = PixPlusExpertCertificationResult.from({ acquired: true });
+
+      // then
+      expect(pixPlusResult).to.be.instanceOf(PixPlusExpertCertificationResult);
+      expect(pixPlusResult.status).to.equal(PixPlusExpertCertificationResult.statuses.ACQUIRED);
+    });
+
+    it('builds a PixPlusExpertCertificationResult rejected', async () => {
+      // when
+      const pixPlusResult = PixPlusExpertCertificationResult.from({ acquired: false });
+
+      // then
+      expect(pixPlusResult).to.be.instanceOf(PixPlusExpertCertificationResult);
+      expect(pixPlusResult.status).to.equal(PixPlusExpertCertificationResult.statuses.REJECTED);
+    });
+  });
+
+  context('#static buildNotTaken', () => {
+
+    it('builds a PixPlusExpertCertificationResult not_taken', async () => {
+      // when
+      const pixPlusResult = PixPlusExpertCertificationResult.buildNotTaken();
+
+      // then
+      expect(pixPlusResult).to.be.instanceOf(PixPlusExpertCertificationResult);
+      expect(pixPlusResult.status).to.equal(PixPlusExpertCertificationResult.statuses.NOT_TAKEN);
+    });
+  });
+
+  context('#isTaken', () => {
+
+    it('returns true when PixPlusExpertCertificationResult has a status acquired', async () => {
+      // given
+      const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
+
+      // when
+      const isTaken = pixPlusResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.true;
+    });
+
+    it('returns true when PixPlusExpertCertificationResult has a status rejected', async () => {
+      // given
+      const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected();
+
+      // when
+      const isTaken = pixPlusResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.true;
+    });
+
+    it('returns false when PixPlusExpertCertificationResult has a status not_taken', async () => {
+      // given
+      const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
+
+      // when
+      const isTaken = pixPlusResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/models/PixPlusDroitExpertCertificationResult_test.js
+++ b/api/tests/unit/domain/models/PixPlusDroitExpertCertificationResult_test.js
@@ -3,11 +3,11 @@ const PixPlusExpertCertificationResult = require('../../../../lib/domain/models/
 
 describe('Unit | Domain | Models | PixPlusExpertCertificationResult', () => {
 
-  context('#static from', () => {
+  context('#static buildFrom', () => {
 
     it('builds a PixPlusExpertCertificationResult acquired', async () => {
       // when
-      const pixPlusResult = PixPlusExpertCertificationResult.from({ acquired: true });
+      const pixPlusResult = PixPlusExpertCertificationResult.buildFrom({ acquired: true });
 
       // then
       expect(pixPlusResult).to.be.instanceOf(PixPlusExpertCertificationResult);
@@ -16,7 +16,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', () => {
 
     it('builds a PixPlusExpertCertificationResult rejected', async () => {
       // when
-      const pixPlusResult = PixPlusExpertCertificationResult.from({ acquired: false });
+      const pixPlusResult = PixPlusExpertCertificationResult.buildFrom({ acquired: false });
 
       // then
       expect(pixPlusResult).to.be.instanceOf(PixPlusExpertCertificationResult);

--- a/api/tests/unit/domain/models/PixPlusDroitMaitreCertificationResult_test.js
+++ b/api/tests/unit/domain/models/PixPlusDroitMaitreCertificationResult_test.js
@@ -1,0 +1,74 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+const PixPlusMaitreCertificationResult = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+
+describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', () => {
+
+  context('#static from', () => {
+
+    it('builds a PixPlusMaitreCertificationResult acquired', async () => {
+      // when
+      const pixPlusResult = PixPlusMaitreCertificationResult.from({ acquired: true });
+
+      // then
+      expect(pixPlusResult).to.be.instanceOf(PixPlusMaitreCertificationResult);
+      expect(pixPlusResult.status).to.equal(PixPlusMaitreCertificationResult.statuses.ACQUIRED);
+    });
+
+    it('builds a PixPlusMaitreCertificationResult rejected', async () => {
+      // when
+      const pixPlusResult = PixPlusMaitreCertificationResult.from({ acquired: false });
+
+      // then
+      expect(pixPlusResult).to.be.instanceOf(PixPlusMaitreCertificationResult);
+      expect(pixPlusResult.status).to.equal(PixPlusMaitreCertificationResult.statuses.REJECTED);
+    });
+  });
+
+  context('#static buildNotTaken', () => {
+
+    it('builds a PixPlusMaitreCertificationResult not_taken', async () => {
+      // when
+      const pixPlusResult = PixPlusMaitreCertificationResult.buildNotTaken();
+
+      // then
+      expect(pixPlusResult).to.be.instanceOf(PixPlusMaitreCertificationResult);
+      expect(pixPlusResult.status).to.equal(PixPlusMaitreCertificationResult.statuses.NOT_TAKEN);
+    });
+  });
+
+  context('#isTaken', () => {
+
+    it('returns true when PixPlusMaitreCertificationResult has a status acquired', async () => {
+      // given
+      const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
+
+      // when
+      const isTaken = pixPlusResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.true;
+    });
+
+    it('returns true when PixPlusMaitreCertificationResult has a status rejected', async () => {
+      // given
+      const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();
+
+      // when
+      const isTaken = pixPlusResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.true;
+    });
+
+    it('returns false when PixPlusMaitreCertificationResult has a status not_taken', async () => {
+      // given
+      const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
+
+      // when
+      const isTaken = pixPlusResult.isTaken();
+
+      // then
+      expect(isTaken).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/models/PixPlusDroitMaitreCertificationResult_test.js
+++ b/api/tests/unit/domain/models/PixPlusDroitMaitreCertificationResult_test.js
@@ -3,11 +3,11 @@ const PixPlusMaitreCertificationResult = require('../../../../lib/domain/models/
 
 describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', () => {
 
-  context('#static from', () => {
+  context('#static buildFrom', () => {
 
     it('builds a PixPlusMaitreCertificationResult acquired', async () => {
       // when
-      const pixPlusResult = PixPlusMaitreCertificationResult.from({ acquired: true });
+      const pixPlusResult = PixPlusMaitreCertificationResult.buildFrom({ acquired: true });
 
       // then
       expect(pixPlusResult).to.be.instanceOf(PixPlusMaitreCertificationResult);
@@ -16,7 +16,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', () => {
 
     it('builds a PixPlusMaitreCertificationResult rejected', async () => {
       // when
-      const pixPlusResult = PixPlusMaitreCertificationResult.from({ acquired: false });
+      const pixPlusResult = PixPlusMaitreCertificationResult.buildFrom({ acquired: false });
 
       // then
       expect(pixPlusResult).to.be.instanceOf(PixPlusMaitreCertificationResult);

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -1,5 +1,7 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const cleaCertificationResultRepository = require('../../../../lib/infrastructure/repositories/clea-certification-result-repository');
+const pixPlusMaitreCertificationResultRepository = require('../../../../lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository');
+const pixPlusExpertCertificationResultRepository = require('../../../../lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const assessmentResultRepository = require('../../../../lib/infrastructure/repositories/assessment-result-repository');
 const getSessionResults = require('../../../../lib/domain/usecases/get-session-results');
@@ -19,15 +21,25 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
     domainBuilder.buildCleaCertificationResult.rejected(),
     domainBuilder.buildCleaCertificationResult.notTaken(),
   ];
+  const pixPlusDroitMaitreCertificationResults = [
+    domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired(),
+    domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected(),
+    domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
+  ];
+  const pixPlusDroitExpertCertificationResults = [
+    domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired(),
+    domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected(),
+    domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
+  ];
   const assessmentsIds = [ 1, 2, 3 ];
 
   const assessmentResult1 = domainBuilder.buildAssessmentResult({ pixScore: 500, competenceMarks: [], createdAt: 'lundi', assessmentId: assessmentsIds[0] });
   const assessmentResult2 = domainBuilder.buildAssessmentResult({ pixScore: 10, competenceMarks: [], createdAt: 'mardi', assessmentId: assessmentsIds[1], commentForCandidate: 'Son ordinateur a explosé' });
   const assessmentResult3 = domainBuilder.buildAssessmentResult({ pixScore: 400, competenceMarks: [], createdAt: 'mercredi', assessmentId: assessmentsIds[2] });
 
-  const firstCertifResult = _buildCertificationResult(certifCourse1, assessmentResult1, cleaCertificationResults[0]);
-  const secondCertifResult = _buildCertificationResult(certifCourse2, assessmentResult2, cleaCertificationResults[1]);
-  const thirdCertifResult = _buildCertificationResult(certifCourse3, assessmentResult3, cleaCertificationResults[2]);
+  const firstCertifResult = _buildCertificationResult(certifCourse1, assessmentResult1, cleaCertificationResults[0], pixPlusDroitMaitreCertificationResults[0], pixPlusDroitExpertCertificationResults[0]);
+  const secondCertifResult = _buildCertificationResult(certifCourse2, assessmentResult2, cleaCertificationResults[1], pixPlusDroitMaitreCertificationResults[1], pixPlusDroitExpertCertificationResults[1]);
+  const thirdCertifResult = _buildCertificationResult(certifCourse3, assessmentResult3, cleaCertificationResults[2], pixPlusDroitMaitreCertificationResults[2], pixPlusDroitExpertCertificationResults[2]);
 
   beforeEach(() => {
     // given
@@ -39,6 +51,16 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
     cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.id }).resolves(cleaCertificationResults[0]);
     cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.id }).resolves(cleaCertificationResults[1]);
     cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.id }).resolves(cleaCertificationResults[2]);
+
+    const pixPlusMaitreCertificationResultRepositoryStub = sinon.stub(pixPlusMaitreCertificationResultRepository, 'get');
+    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.id }).resolves(pixPlusDroitMaitreCertificationResults[0]);
+    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.id }).resolves(pixPlusDroitMaitreCertificationResults[1]);
+    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.id }).resolves(pixPlusDroitMaitreCertificationResults[2]);
+
+    const pixPlusExpertCertificationResultRepositoryStub = sinon.stub(pixPlusExpertCertificationResultRepository, 'get');
+    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.id }).resolves(pixPlusDroitExpertCertificationResults[0]);
+    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.id }).resolves(pixPlusDroitExpertCertificationResults[1]);
+    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.id }).resolves(pixPlusDroitExpertCertificationResults[2]);
 
     const assessmentRepositoryStub = sinon.stub(assessmentRepository, 'getIdByCertificationCourseId');
     assessmentRepositoryStub.withArgs(certifCourse1.id).resolves(assessmentsIds[0]);
@@ -92,13 +114,15 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
 
 });
 
-function _buildCertificationResult(certifCourse, lastAssessmentResult, cleaCertificationResult) {
+function _buildCertificationResult(certifCourse, lastAssessmentResult, cleaCertificationResult, pixPlusDroitMaitreCertificationResult, pixPlusDroitExpertCertificationResult) {
   return domainBuilder.buildCertificationResult({
     ...certifCourse,
     certificationIssueReports: certifCourse.certificationIssueReports,
     lastAssessmentResult,
     assessmentId: lastAssessmentResult.assessmentId,
     cleaCertificationResult,
+    pixPlusDroitMaitreCertificationResult,
+    pixPlusDroitExpertCertificationResult,
     competencesWithMark: [],
   });
 }

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -1,5 +1,5 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
-const cleaCertificationStatusRepository = require('../../../../lib/infrastructure/repositories/clea-certification-status-repository');
+const cleaCertificationResultRepository = require('../../../../lib/infrastructure/repositories/clea-certification-result-repository');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const assessmentResultRepository = require('../../../../lib/infrastructure/repositories/assessment-result-repository');
 const getSessionResults = require('../../../../lib/domain/usecases/get-session-results');
@@ -14,16 +14,20 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
   const certifCourse2 = domainBuilder.buildCertificationCourse({ id: 2 });
   const certifCourse3 = domainBuilder.buildCertificationCourse({ id: 3 });
 
-  const cleaCertifications = [ 'acquired', 'rejected', 'not_passed'];
+  const cleaCertificationResults = [
+    domainBuilder.buildCleaCertificationResult.acquired(),
+    domainBuilder.buildCleaCertificationResult.rejected(),
+    domainBuilder.buildCleaCertificationResult.notPassed(),
+  ];
   const assessmentsIds = [ 1, 2, 3 ];
 
   const assessmentResult1 = domainBuilder.buildAssessmentResult({ pixScore: 500, competenceMarks: [], createdAt: 'lundi', assessmentId: assessmentsIds[0] });
   const assessmentResult2 = domainBuilder.buildAssessmentResult({ pixScore: 10, competenceMarks: [], createdAt: 'mardi', assessmentId: assessmentsIds[1], commentForCandidate: 'Son ordinateur a explosé' });
   const assessmentResult3 = domainBuilder.buildAssessmentResult({ pixScore: 400, competenceMarks: [], createdAt: 'mercredi', assessmentId: assessmentsIds[2] });
 
-  const firstCertifResult = _buildCertificationResult(certifCourse1, assessmentResult1, cleaCertifications[0]);
-  const secondCertifResult = _buildCertificationResult(certifCourse2, assessmentResult2, cleaCertifications[1]);
-  const thirdCertifResult = _buildCertificationResult(certifCourse3, assessmentResult3, cleaCertifications[2]);
+  const firstCertifResult = _buildCertificationResult(certifCourse1, assessmentResult1, cleaCertificationResults[0]);
+  const secondCertifResult = _buildCertificationResult(certifCourse2, assessmentResult2, cleaCertificationResults[1]);
+  const thirdCertifResult = _buildCertificationResult(certifCourse3, assessmentResult3, cleaCertificationResults[2]);
 
   beforeEach(() => {
     // given
@@ -31,10 +35,10 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
 
     certificationCourseRepository.findCertificationCoursesBySessionId = sinon.stub().withArgs({ sessionId }).resolves([certifCourse1, certifCourse2, certifCourse3]);
 
-    const cleaCertificationStatusRepositoryStub = sinon.stub(cleaCertificationStatusRepository, 'getCleaCertificationStatus');
-    cleaCertificationStatusRepositoryStub.withArgs(certifCourse1.id).resolves(cleaCertifications[0]);
-    cleaCertificationStatusRepositoryStub.withArgs(certifCourse2.id).resolves(cleaCertifications[1]);
-    cleaCertificationStatusRepositoryStub.withArgs(certifCourse3.id).resolves(cleaCertifications[2]);
+    const cleaCertificationResultRepositoryStub = sinon.stub(cleaCertificationResultRepository, 'get');
+    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.id }).resolves(cleaCertificationResults[0]);
+    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.id }).resolves(cleaCertificationResults[1]);
+    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.id }).resolves(cleaCertificationResults[2]);
 
     const assessmentRepositoryStub = sinon.stub(assessmentRepository, 'getIdByCertificationCourseId');
     assessmentRepositoryStub.withArgs(certifCourse1.id).resolves(assessmentsIds[0]);
@@ -88,13 +92,13 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
 
 });
 
-function _buildCertificationResult(certifCourse, lastAssessmentResult, cleaCertification) {
+function _buildCertificationResult(certifCourse, lastAssessmentResult, cleaCertificationResult) {
   return domainBuilder.buildCertificationResult({
     ...certifCourse,
     certificationIssueReports: certifCourse.certificationIssueReports,
     lastAssessmentResult,
     assessmentId: lastAssessmentResult.assessmentId,
-    cleaCertificationStatus: cleaCertification,
+    cleaCertificationResult,
     competencesWithMark: [],
   });
 }

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -17,7 +17,7 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
   const cleaCertificationResults = [
     domainBuilder.buildCleaCertificationResult.acquired(),
     domainBuilder.buildCleaCertificationResult.rejected(),
-    domainBuilder.buildCleaCertificationResult.notPassed(),
+    domainBuilder.buildCleaCertificationResult.notTaken(),
   ];
   const assessmentsIds = [ 1, 2, 3 ];
 


### PR DESCRIPTION
## :unicorn: Problème
Certains étudiants en droit vont pouvoir passer une double certif Pix / Pix + Droit. Il s’agit maintenant de permettre à leur professeurs de savoir si ils ont obtenu ou non cette certification depuis le fichier des résultats.

## :robot: Solution
Dans le fichier csv des résultats de certification, UNIQUEMENT pour les sessions ayant au moins 1 certification Pix+ Droit :
- ajouter deux colonnes “Certification Pix+ Droit Maître” puis “Certification Pix+ Droit Expert” avec les valeur “Validée”, “Rejetée” ou “Non passée” (si certains candidats de la session n’ont pas passé la double certif)
- colonne à placer après la colonne “Identifiant Externe”
Cette modification s'applique à la fois pour le CSV téléchargé par le destinataire des résultats de certification, mais aussi par un admin Pix en utilisant un lien de téléchargement obtenu sur PixAdmin

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Préparer une session de certification avec idéalement un panachage Cléa / Pix+Droit
- Visualiser le CSV et constater que les mentions des certifications complémentaires sont bien présentes
