### PR TITLE
[BUGFIX] Gérer les QROCM avec des clés d'input à une lettre (PIX-2502).

### DIFF
--- a/mon-pix/app/utils/proposals-as-blocks.js
+++ b/mon-pix/app/utils/proposals-as-blocks.js
@@ -2,11 +2,11 @@ import isEmpty from 'lodash/isEmpty';
 
 const MINIMUM_SIZE_FOR_LABEL = 6;
 function stringHasPlaceholder(input) {
-  return 1 < input.indexOf('#');
+  return input.includes('#');
 }
 
 function stringHasAriaLabel(input) {
-  return 1 < input.indexOf('§');
+  return input.includes('§');
 }
 
 function _isInput(block) {
@@ -20,7 +20,7 @@ function buildLineFrom(textBlock, challengeResponseTemplate) {
   if (isInput) {
     challengeResponseTemplate.incrementInputCount();
     const blockToTemplate = new InputBlock({ input: block, inputIndex: challengeResponseTemplate.inputCount });
-    blockToTemplate.attachInputAndPlaceholderIfExist();
+    blockToTemplate.addPlaceHolderAndAriaLabelIfExist();
     challengeResponseTemplate.add(blockToTemplate);
 
   } else {
@@ -83,19 +83,15 @@ class InputBlock {
     this._type = 'input';
   }
 
-  attachInputAndPlaceholderIfExist() {
+  addPlaceHolderAndAriaLabelIfExist() {
     if (stringHasPlaceholder(this._input)) {
-      const inputParts = this._input.split('#');
-      if (stringHasAriaLabel(this._input)) {
-        const informations = inputParts[1].split('§');
-        this._placeholder = informations[0];
-        this._ariaLabel = informations[1];
-        this._autoAriaLabel = false;
-      } else {
-        this._placeholder = inputParts[1];
-      }
-      this._input = inputParts[0];
+      this._placeholder = this._input.split('#')[1].split('§')[0];
     }
+    if (stringHasAriaLabel(this._input)) {
+      this._ariaLabel = this._input.split('§')[1];
+      this._autoAriaLabel = false;
+    }
+    this._input = this._input.split(/#|§/)[0];
   }
 
   get input() {

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -34,6 +34,24 @@ describe('Unit | Utility | proposals as blocks', function() {
       ],
     },
     {
+      data: '${a#PlaceHolder§AriaLabel}',
+      expected: [
+        { input: 'a', text: null, placeholder: 'PlaceHolder', ariaLabel: 'AriaLabel', type: 'input', autoAriaLabel: false },
+      ],
+    },
+    {
+      data: '${a#PlaceHolder}',
+      expected: [
+        { input: 'a', text: null, placeholder: 'PlaceHolder', ariaLabel: '1', type: 'input', autoAriaLabel: true },
+      ],
+    },
+    {
+      data: '${a§AriaLabel}',
+      expected: [
+        { input: 'a', text: null, placeholder: null, ariaLabel: 'AriaLabel', type: 'input', autoAriaLabel: false },
+      ],
+    },
+    {
       data: '${annee#19XX§Année de construction}',
       expected: [
         { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Année de construction', type: 'input', autoAriaLabel: false },


### PR DESCRIPTION
## :unicorn: Problème
Dans la version actuelle, les QROCM avec des inputs notés comme : `${a#PlaceHolder}` ne fonctionne pas, car la clé `a` ne fait qu'un seul caractère.

## :robot: Solution
- Modifier le code pour gérer les clés à une lettre
- BSR sur la gestion des placeholder et aria-label dans les qrocm

## :rainbow: Remarques


## :100: Pour tester
Tester l'épreuve recTZjDgEo6kNH8Wr
