### PR TITLE
[FEATURE] Toujours renvoyer un niveau de competence positif pour le livret scolaire

### DIFF
--- a/api/lib/domain/read-models/livret-scolaire/Certificate.js
+++ b/api/lib/domain/read-models/livret-scolaire/Certificate.js
@@ -84,7 +84,9 @@ function _isValidated(status) {
 }
 
 function _getExtractValidatedCompetenceResults(competenceResultsJson) {
-  const competenceResults = JSON.parse(competenceResultsJson);
+  const competenceResults = JSON
+    .parse(competenceResultsJson)
+    .map(({ competenceId, level }) => ({ competenceId, level: Math.max(0, level) }));
   return sortBy(competenceResults, 'competenceId');
 }
 


### PR DESCRIPTION
## :unicorn: Problème
En interne on gère des niveaux négatifs pour les certifications (passage de la certif sur un niveau 0 avec echec => -1)

## :robot: Solution
Renvoyer 0 si le level est négatif.

## :100: Pour tester
- Passer une certification avec une echec sur une competence positionnée à 0
- Le retour via l'endpoint livret-scolaire devrait renvoyé 0 au lieu de -1
(on peut aussi tout simplement mettre à jour en BDD un competenceMarks.level à -1 et verifier qu'il ressort à 0)
