### PR TITLE
[FEATURE] Modifier la bannière Pix certif pour la reprogrammation de sessions du SCO (PIX-2500)

### DIFF
--- a/certif/app/styles/globals/colors.scss
+++ b/certif/app/styles/globals/colors.scss
@@ -10,7 +10,8 @@ $black: #07142E;
 $pix-orga: #00DDFF;
 $pix-purplie: #6B20DC;
 $pix-purple: #8A49FF;
-$pix-certif-banner: #187F7C;
+$pix-certif-banner: #C4E8FF;
+$pix-certif-banner-text: #0069AB;
 // gradients
 $pix-green-gradient: linear-gradient(-45deg, #52D987 0%, #1A8C89 100%);
 // light

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -21,6 +21,7 @@
       justify-content: space-between;
 
       .sco-temporary-banner__informations-text {
+        color: $pix-certif-banner-text;
         display: flex;
         align-items: center;
         line-height: 22px;
@@ -34,8 +35,8 @@
           margin: 0;
 
           a {
-            font-weight: bold;
-            color: $white;
+            font-weight: bolder;
+            color: $pix-certif-banner-text;
           }
         }
       }

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -23,7 +23,6 @@
         </li>
       </ul>
     </nav>
-
     
   </aside>
 
@@ -36,10 +35,10 @@
     {{#if this.showBanner}}
       <PixBanner class="sco-temporary-banner">
         <span class="sco-temporary-banner__informations-text">
-          <FaIcon @icon="exclamation-triangle" class="sco-temporary-banner-informations-text__triangle-icon" />
+          <FaIcon @icon="info-circle" class="sco-temporary-banner-informations-text__triangle-icon" />
           <p>
-            Il est important de vérifier que les élèves soient certifiables avant de les inscrire en session de certification. <br>
-            Vous pouvez faire une <a href="https://view.genial.ly/5fda0b5aebe82c0d17f177ea " target="_blank" rel="noopener noreferrer">campagne de collecte de profil <FaIcon @icon="external-link-alt"/></a> pour vous en assurer.
+            La certification en collège et lycée est possible jusqu'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ».<br>
+            <a href="https://view.genial.ly/6077017b8b37870d98620200" target="_blank" rel="noopener noreferrer"> En savoir plus <FaIcon @icon="external-link-alt"/></a>
           </p>
         </span>
         <button type="button" class="sco-temporary-banner-button" {{on 'click' this.closeBanner}}>

--- a/certif/tests/acceptance/authenticated-test.js
+++ b/certif/tests/acceptance/authenticated-test.js
@@ -3,6 +3,7 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   createCertificationPointOfContactWithTermsOfServiceAccepted,
+  createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted,
   authenticateSession,
 } from '../helpers/test-init';
 
@@ -42,6 +43,32 @@ module('Acceptance | authenticated', function(hooks) {
 
       // then
       assert.equal(currentURL(), '/sessions/liste');
+    });
+  });
+
+  module('Sco temporary banner', function() {
+    test('it should display the banner when User is SCO isManagingStudent', async function(assert) {
+      // given
+      const certificationPointOfContact = createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted();
+      await authenticateSession(certificationPointOfContact.id);
+
+      // when
+      await visit('/sessions/liste');
+
+      // then
+      assert.dom('.sco-temporary-banner').hasText('La certification en collège et lycée est possible jusqu\'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ». En savoir plus');
+    });
+
+    test('it should not display the banner when User is NOT SCO isManagingStudent', async function(assert) {
+      // given
+      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+      await authenticateSession(certificationPointOfContact.id);
+
+      // when
+      await visit('/sessions/liste');
+
+      // then
+      assert.dom('.sco-temporary-banner').doesNotExist();
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Des sessions de certification ont été planifiées pour début avril dans des établissements scolaires. Ces sessions n’ont pas pu avoir lieu à cause de la fermeture des collèges et lycées. Pour ne pas pénaliser les élèves, le calendrier de certification Pix a été rallongé puisque les établissements scolaires peuvent maintenant organiser des sessions jusqu’au 25 juin 2021 (à la place du 20 mai). Il s’agit donc d’informer depuis Pix Certif les utilisateurs Pix certif du SCO de cette modification de date, ainsi que de les inciter à modifier les sessions planifiées mais n’ayant pas pu avoir lieu, plutôt que d’en créer de nouvelles.

## :robot: Solution
Dans Pix certif UNIQUEMENT pour les CDC liés à des orgas de type SCO isManagingStudent, sur la page “Sessions de certification”, 

- supprimer le bandeau “Il est important de vérifier que les élèves soient certifiables […]”

- remplacer par un autre bandeau d’information avec un nouveau texte : 
texte à afficher : La certification en collège et lycée est possible jusqu'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ». En savoir plus” cliquer sur “En savoir plus” ouvre la page suivante dans un nouvel onglet

## 💯  Pour tester
- Se connecter en tant que membre d'un centre de certification SCO isManagingStudent et vérifier la présence le contenu du bandeau.
- Se connecter en tant que membre d'un centre de certification non-SCO et vérifier l'absence du bandeau.
