### PR TITLE
[REFACTO] Calculer le résultat d'un résultat thématique en dehors d'une campagne (PIX-2488).

### DIFF
--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -16,16 +16,17 @@ const handleBadgeAcquisition = async function({
 
   if (event.isCampaignType) {
 
-    const badgeList = await _fetchPossibleCampaignAssociatedBadges(event, badgeRepository);
-    if (_.isEmpty(badgeList)) {
+    const associatedBadges = await _fetchPossibleCampaignAssociatedBadges(event, badgeRepository);
+    if (_.isEmpty(associatedBadges)) {
       return;
     }
     const targetProfile = await targetProfileRepository.getByCampaignParticipationId(event.campaignParticipationId);
     const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: event.userId });
 
-    const badgesBeingAcquired = badgeList.filter((badge) =>
-      _isBadgeAcquired({ knowledgeElements, targetProfile, badge, badgeCriteriaService }));
-    const badgesAcquisitionToCreate = badgesBeingAcquired.map((badge) => {
+    const validatedBadgesByUser = associatedBadges.filter((badge) =>
+      badgeCriteriaService.areBadgeCriteriaFulfilled({ knowledgeElements, targetProfile, badge }));
+
+    const badgesAcquisitionToCreate = validatedBadgesByUser.map((badge) => {
       return {
         badgeId: badge.id,
         userId: event.userId,
@@ -41,10 +42,6 @@ const handleBadgeAcquisition = async function({
 
 function _fetchPossibleCampaignAssociatedBadges(event, badgeRepository) {
   return badgeRepository.findByCampaignParticipationId(event.campaignParticipationId);
-}
-
-function _isBadgeAcquired({ knowledgeElements, targetProfile, badge, badgeCriteriaService }) {
-  return badgeCriteriaService.isBadgeAcquired({ knowledgeElements, targetProfile, badge });
 }
 
 handleBadgeAcquisition.eventTypes = eventTypes;

--- a/api/lib/domain/services/badge-criteria-service.js
+++ b/api/lib/domain/services/badge-criteria-service.js
@@ -1,60 +1,47 @@
 const _ = require('lodash');
 const BadgeCriterion = require('../../../lib/domain/models/BadgeCriterion');
 
-function areBadgeCriteriaFulfilled({ campaignParticipationResult, badge }) {
-  return _.every(badge.badgeCriteria, (criterion) => {
-    let isBadgeCriterionFulfilled = false;
-    let campaignParticipationBadge;
+function isBadgeAcquired({ knowledgeElements, targetProfile, badge }) {
+  const { masteryPercentage, partnerCompetenceResults } =
+    computeAllMasteryPercentages({ knowledgeElements, targetProfile, badge });
 
+  return areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+}
+
+function computeAllMasteryPercentages({ knowledgeElements, targetProfile, badge }) {
+  const targetProfileSkillsIds = targetProfile.getSkillIds();
+  const targetedKnowledgeElements = _removeUntargetedKnowledgeElements(knowledgeElements, targetProfileSkillsIds);
+
+  const partnerCompetenceResults = _computePartnerCompetenceResults(badge, targetProfileSkillsIds, targetedKnowledgeElements);
+
+  const validatedSkillsCount = targetedKnowledgeElements.filter((targetedKnowledgeElement) => targetedKnowledgeElement.isValidated).length;
+  const totalSkillsCount = targetProfileSkillsIds.length;
+  const masteryPercentage = _computeMasteryPercentage({ totalSkillsCount, validatedSkillsCount });
+
+  return { masteryPercentage, partnerCompetenceResults };
+}
+
+function areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge }) {
+  return _.every(badge.badgeCriteria, (criterion) => {
     switch (criterion.scope) {
       case BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION:
-        isBadgeCriterionFulfilled = _verifyCampaignParticipationResultMasteryPercentageCriterion(
-          campaignParticipationResult,
-          criterion.threshold,
-        );
-        break;
+        return masteryPercentage >= criterion.threshold;
 
       case BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE:
-        campaignParticipationBadge = _findBadgeMatchingWithTheReference(campaignParticipationResult, badge);
-
-        if (campaignParticipationBadge) {
-          isBadgeCriterionFulfilled = _verifyEveryPartnerCompetenceResultMasteryPercentageCriterion(
-            campaignParticipationBadge.partnerCompetenceResults,
-            criterion.threshold,
-          );
-        }
-        break;
+        return _verifyEveryPartnerCompetenceResultMasteryPercentageCriterion(
+          partnerCompetenceResults,
+          criterion.threshold,
+        );
 
       case BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES:
-        campaignParticipationBadge = _findBadgeMatchingWithTheReference(campaignParticipationResult, badge);
-
-        if (campaignParticipationBadge && criterion.partnerCompetenceIds) {
-          isBadgeCriterionFulfilled = _verifySomePartnerCompetenceResultsMasteryPercentageCriterion(
-            campaignParticipationBadge.partnerCompetenceResults,
-            criterion.threshold,
-            criterion.partnerCompetenceIds,
-          );
-        }
-        break;
-
-      default:
-        isBadgeCriterionFulfilled = false;
-        break;
+        return _verifySomePartnerCompetenceResultsMasteryPercentageCriterion(
+          partnerCompetenceResults,
+          criterion.threshold,
+          criterion.partnerCompetenceIds,
+        );
     }
-
-    return isBadgeCriterionFulfilled;
+    return false;
   });
-}
-
-function _findBadgeMatchingWithTheReference(campaignParticipationResult, badge) {
-  return _.find(
-    campaignParticipationResult.campaignParticipationBadges,
-    (campaignParticipationBadge) => campaignParticipationBadge.id === badge.id,
-  );
-}
-
-function _verifyCampaignParticipationResultMasteryPercentageCriterion(campaignParticipationResult, threshold) {
-  return campaignParticipationResult.masteryPercentage >= threshold;
 }
 
 function _verifyEveryPartnerCompetenceResultMasteryPercentageCriterion(partnerCompetenceResults, threshold) {
@@ -70,6 +57,60 @@ function _verifySomePartnerCompetenceResultsMasteryPercentageCriterion(partnerCo
   return !_.isEmpty(filteredPartnerCompetenceResults);
 }
 
+function _removeUntargetedKnowledgeElements(knowledgeElements, targetProfileSkillsIds) {
+  return _.filter(knowledgeElements, (ke) => targetProfileSkillsIds.some((skillId) => skillId === ke.skillId));
+}
+
+function _computePartnerCompetenceResults(badge, targetProfileSkillsIds, targetedKnowledgeElements) {
+  if (_.isEmpty(badge.badgePartnerCompetences)) {
+    return [];
+  }
+
+  const validTargetedPartnerCompetences = _keepValidTargetedPartnerCompetences(badge.badgePartnerCompetences, targetProfileSkillsIds);
+  return _.map(validTargetedPartnerCompetences, (badgePartnerCompetence) => _getTestedCompetenceResults(badgePartnerCompetence, targetedKnowledgeElements));
+}
+
+function _keepValidTargetedPartnerCompetences(badgePartnerCompetences, targetProfileSkillsIds) {
+  const targetedCompetences = _removeUntargetedSkillIdsFromPartnerCompetences(badgePartnerCompetences, targetProfileSkillsIds);
+  return _removePartnerCompetencesWithoutAnyTargetedSkillsLeft(targetedCompetences);
+}
+
+function _removeUntargetedSkillIdsFromPartnerCompetences(badgePartnerCompetences, targetProfileSkillsIds) {
+  return _.map(badgePartnerCompetences, (badgePartnerCompetence) => {
+    badgePartnerCompetence.skillIds = _.intersection(badgePartnerCompetence.skillIds, targetProfileSkillsIds);
+    return badgePartnerCompetence;
+  });
+}
+
+function _removePartnerCompetencesWithoutAnyTargetedSkillsLeft(badgePartnerCompetences) {
+  return _.filter(badgePartnerCompetences, (badgePartnerCompetence) => !_.isEmpty(badgePartnerCompetence.skillIds));
+}
+
+function _computeMasteryPercentage({ totalSkillsCount, validatedSkillsCount }) {
+  if (totalSkillsCount !== 0) {
+    return Math.round(validatedSkillsCount * 100 / totalSkillsCount);
+  } else {
+    return 0;
+  }
+}
+
+function _getTestedCompetenceResults(badgePartnerCompetence, targetedKnowledgeElements) {
+  const targetedKnowledgeElementsForCompetence = _.filter(targetedKnowledgeElements, (ke) => _.includes(badgePartnerCompetence.skillIds, ke.skillId));
+  const validatedKnowledgeElementsForCompetence = _.filter(targetedKnowledgeElementsForCompetence, 'isValidated');
+
+  const validatedSkillsCount = validatedKnowledgeElementsForCompetence.length;
+  const totalSkillsCount = badgePartnerCompetence.skillIds.length;
+
+  const masteryPercentage = _computeMasteryPercentage({ totalSkillsCount, validatedSkillsCount });
+
+  return {
+    id: badgePartnerCompetence.id,
+    masteryPercentage,
+  };
+}
+
 module.exports = {
   areBadgeCriteriaFulfilled,
+  isBadgeAcquired,
+  computeAllMasteryPercentages,
 };

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -9,21 +9,26 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
     const badgeRepository = {
       findByCampaignParticipationId: _.noop,
     };
+    const targetProfileRepository = {
+      getByCampaignParticipationId: _.noop,
+    };
+    const knowledgeElementRepository = {
+      findUniqByUserId: _.noop,
+    };
     const badgeAcquisitionRepository = {
       create: _.noop,
     };
-    const campaignParticipationResultRepository = {
-      getByParticipationId: _.noop,
-    };
+
     const badgeCriteriaService = {
-      areBadgeCriteriaFulfilled: _.noop,
+      isBadgeAcquired: _.noop,
     };
 
     const dependencies = {
       badgeAcquisitionRepository,
-      badgeRepository,
-      campaignParticipationResultRepository,
       badgeCriteriaService,
+      badgeRepository,
+      knowledgeElementRepository,
+      targetProfileRepository,
     };
 
     it('fails when event is not of correct type', async () => {
@@ -48,7 +53,8 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
         let badge;
         const badgeId = Symbol('badgeId');
-        const campaignParticipationResult = Symbol('campaignParticipationResult');
+        const targetProfile = Symbol('targetProfile');
+        const knowledgeElements = Symbol('knowledgeElements');
 
         beforeEach(() => {
           sinon.stub(badgeRepository, 'findByCampaignParticipationId');
@@ -58,20 +64,19 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           };
           badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId).resolves([badge]);
 
+          sinon.stub(targetProfileRepository, 'getByCampaignParticipationId');
+          targetProfileRepository.getByCampaignParticipationId.withArgs(event.campaignParticipationId).resolves(targetProfile);
+
+          sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
+          knowledgeElementRepository.findUniqByUserId.withArgs({ userId: event.userId }).resolves(knowledgeElements);
+          sinon.stub(badgeCriteriaService, 'isBadgeAcquired');
           sinon.stub(badgeAcquisitionRepository, 'create');
-
-          sinon.stub(campaignParticipationResultRepository, 'getByParticipationId');
-          campaignParticipationResultRepository.getByParticipationId.withArgs(event.campaignParticipationId, [badge], []).resolves(
-            campaignParticipationResult,
-          );
-
-          sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
         });
 
         it('should create a badge when badge requirements are fulfilled', async () => {
           // given
-          badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ campaignParticipationResult, badge })
+          badgeCriteriaService.isBadgeAcquired
+            .withArgs({ targetProfile, knowledgeElements, badge })
             .returns(true);
 
           // when
@@ -87,8 +92,8 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
         it('should not create a badge when badge requirements are not fulfilled', async () => {
           // given
-          badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ campaignParticipationResult, badge })
+          badgeCriteriaService.isBadgeAcquired
+            .withArgs({ targetProfile, knowledgeElements, badge })
             .returns(false);
           // when
           await handleBadgeAcquisition({ event, ...dependencies });
@@ -103,8 +108,8 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
         let badge1, badge2;
         const badgeId_1 = Symbol('badgeId_1');
         const badgeId_2 = Symbol('badgeId_2');
-
-        const campaignParticipationResult = Symbol('campaignParticipationResult');
+        const targetProfile = Symbol('targetProfile');
+        const knowledgeElements = Symbol('knowledgeElements');
 
         beforeEach(() => {
           sinon.stub(badgeRepository, 'findByCampaignParticipationId');
@@ -118,23 +123,23 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           };
           badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId).resolves([badge1, badge2]);
 
+          sinon.stub(targetProfileRepository, 'getByCampaignParticipationId');
+          targetProfileRepository.getByCampaignParticipationId.withArgs(event.campaignParticipationId).resolves(targetProfile);
+
+          sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
+          knowledgeElementRepository.findUniqByUserId.withArgs({ userId: event.userId }).resolves(knowledgeElements);
+
+          sinon.stub(badgeCriteriaService, 'isBadgeAcquired');
           sinon.stub(badgeAcquisitionRepository, 'create');
-
-          sinon.stub(campaignParticipationResultRepository, 'getByParticipationId');
-          campaignParticipationResultRepository.getByParticipationId.withArgs(event.campaignParticipationId, [badge1, badge2], []).resolves(
-            campaignParticipationResult,
-          );
-
-          sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
         });
 
         it('should create one badge when only one badge requirements are fulfilled', async () => {
           // given
-          badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ campaignParticipationResult, badge: badge1 })
+          badgeCriteriaService.isBadgeAcquired
+            .withArgs({ targetProfile, knowledgeElements, badge: badge1 })
             .returns(true);
-          badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ campaignParticipationResult, badge: badge2 })
+          badgeCriteriaService.isBadgeAcquired
+            .withArgs({ targetProfile, knowledgeElements, badge: badge2 })
             .returns(false);
 
           // when
@@ -150,11 +155,11 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
         it('should create two badges when both badges requirements are fulfilled', async () => {
           // given
-          badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ campaignParticipationResult, badge: badge1 })
+          badgeCriteriaService.isBadgeAcquired
+            .withArgs({ targetProfile, knowledgeElements, badge: badge1 })
             .returns(true);
-          badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ campaignParticipationResult, badge: badge2 })
+          badgeCriteriaService.isBadgeAcquired
+            .withArgs({ targetProfile, knowledgeElements, badge: badge2 })
             .returns(true);
 
           // when

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -20,7 +20,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
     };
 
     const badgeCriteriaService = {
-      isBadgeAcquired: _.noop,
+      areBadgeCriteriaFulfilled: _.noop,
     };
 
     const dependencies = {
@@ -69,13 +69,13 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
           sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
           knowledgeElementRepository.findUniqByUserId.withArgs({ userId: event.userId }).resolves(knowledgeElements);
-          sinon.stub(badgeCriteriaService, 'isBadgeAcquired');
+          sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
           sinon.stub(badgeAcquisitionRepository, 'create');
         });
 
         it('should create a badge when badge requirements are fulfilled', async () => {
           // given
-          badgeCriteriaService.isBadgeAcquired
+          badgeCriteriaService.areBadgeCriteriaFulfilled
             .withArgs({ targetProfile, knowledgeElements, badge })
             .returns(true);
 
@@ -92,7 +92,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
         it('should not create a badge when badge requirements are not fulfilled', async () => {
           // given
-          badgeCriteriaService.isBadgeAcquired
+          badgeCriteriaService.areBadgeCriteriaFulfilled
             .withArgs({ targetProfile, knowledgeElements, badge })
             .returns(false);
           // when
@@ -129,16 +129,16 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
           knowledgeElementRepository.findUniqByUserId.withArgs({ userId: event.userId }).resolves(knowledgeElements);
 
-          sinon.stub(badgeCriteriaService, 'isBadgeAcquired');
+          sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
           sinon.stub(badgeAcquisitionRepository, 'create');
         });
 
         it('should create one badge when only one badge requirements are fulfilled', async () => {
           // given
-          badgeCriteriaService.isBadgeAcquired
+          badgeCriteriaService.areBadgeCriteriaFulfilled
             .withArgs({ targetProfile, knowledgeElements, badge: badge1 })
             .returns(true);
-          badgeCriteriaService.isBadgeAcquired
+          badgeCriteriaService.areBadgeCriteriaFulfilled
             .withArgs({ targetProfile, knowledgeElements, badge: badge2 })
             .returns(false);
 
@@ -155,10 +155,10 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
         it('should create two badges when both badges requirements are fulfilled', async () => {
           // given
-          badgeCriteriaService.isBadgeAcquired
+          badgeCriteriaService.areBadgeCriteriaFulfilled
             .withArgs({ targetProfile, knowledgeElements, badge: badge1 })
             .returns(true);
-          badgeCriteriaService.isBadgeAcquired
+          badgeCriteriaService.areBadgeCriteriaFulfilled
             .withArgs({ targetProfile, knowledgeElements, badge: badge2 })
             .returns(true);
 

--- a/api/tests/unit/domain/services/badge-criteria-service_test.js
+++ b/api/tests/unit/domain/services/badge-criteria-service_test.js
@@ -17,7 +17,7 @@ const COMPETENCE_RESULT_ID = {
 
 describe('Unit | Domain | Services | badge-criteria', () => {
 
-  describe('#areBadgeCriteriaFulfilled', () => {
+  describe('#verifyCriteriaFulfilment', () => {
 
     context('when there is multiple badge criteria to acquire one badge', function() {
       const badgeCriteria = [
@@ -49,7 +49,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(true);
@@ -64,7 +64,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -79,7 +79,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -103,7 +103,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         const partnerCompetenceResults = [];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(true);
@@ -115,7 +115,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         const partnerCompetenceResults = [];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -142,7 +142,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(true);
@@ -157,7 +157,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -184,7 +184,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(true);
@@ -199,7 +199,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -207,7 +207,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
     });
   });
 
-  describe('#isBadgeAcquired', () => {
+  describe('#areBadgeCriteriaFulfilled', () => {
 
     it('should return false if badge is not acquired', () => {
       // given
@@ -248,7 +248,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
       });
 
       // when
-      const badgeAcquired = badgeCriteriaService.isBadgeAcquired({ knowledgeElements, targetProfile, badge: yellowBadge });
+      const badgeAcquired = badgeCriteriaService.areBadgeCriteriaFulfilled({ knowledgeElements, targetProfile, badge: yellowBadge });
 
       // then
       expect(badgeAcquired).to.equal(false);
@@ -293,26 +293,26 @@ describe('Unit | Domain | Services | badge-criteria', () => {
       });
 
       // when
-      const badgeAcquired = badgeCriteriaService.isBadgeAcquired({ knowledgeElements, targetProfile, badge: yellowBadge });
+      const badgeAcquired = badgeCriteriaService.areBadgeCriteriaFulfilled({ knowledgeElements, targetProfile, badge: yellowBadge });
 
       // then
       expect(badgeAcquired).to.equal(true);
     });
   });
 
-  describe('#computeAllMasteryPercentages', () => {
+  describe('#getMasteryPercentageForAllPartnerCompetences', () => {
 
-    it('should return global mastery percentage', () => {
+    it('should return an empty array when there is not badgePartnerCompetences', () => {
       // given
-      const knowledgeElements = [
+      const targetedKnowledgeElements = [
         new KnowledgeElement({ skillId: 1, status: 'validated' }),
         new KnowledgeElement({ skillId: 2, status: 'invalidated' }),
         new KnowledgeElement({ skillId: 7, status: 'validated' }),
       ];
-      const skills = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const targetProfileSkillsIds = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
       const targetProfile = domainBuilder.buildTargetProfile({
         id: 1,
-        skills,
+        skills: targetProfileSkillsIds,
       });
       const yellowBadge = domainBuilder.buildBadge({
         id: 1,
@@ -320,13 +320,10 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         badgePartnerCompetences: [],
         targetProfileId: targetProfile.id,
       });
-      const expectedMasteryPercentages = {
-        masteryPercentage: 25,
-        partnerCompetenceResults: [],
-      };
+      const expectedMasteryPercentages = [];
 
       // when
-      const masteryPercentages = badgeCriteriaService.computeAllMasteryPercentages({ knowledgeElements, targetProfile, badge: yellowBadge });
+      const masteryPercentages = badgeCriteriaService.getMasteryPercentageForAllPartnerCompetences({ targetedKnowledgeElements, targetProfileSkillsIds, badge: yellowBadge });
 
       // then
       expect(masteryPercentages).to.deep.equal(expectedMasteryPercentages);
@@ -334,7 +331,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
     it('should return correct mastery percentages for all badgePartnerCompetences', () => {
       // given
-      const knowledgeElements = [
+      const targetedKnowledgeElements = [
         new KnowledgeElement({ skillId: 1, status: 'validated' }),
         new KnowledgeElement({ skillId: 2, status: 'invalidated' }),
         new KnowledgeElement({ skillId: 3, status: 'validated' }),
@@ -342,16 +339,17 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         new KnowledgeElement({ skillId: 7, status: 'validated' }),
         new KnowledgeElement({ skillId: 8, status: 'validated' }),
       ];
-      const skills = [
+      const skillsIds = [
         { id: 1 },
         { id: 2 },
         { id: 3 },
         { id: 4 },
         { id: 5 },
       ];
+      const targetProfileSkillsIds = [1, 2, 3, 4, 5];
       const targetProfile = domainBuilder.buildTargetProfile({
         id: 1,
-        skills,
+        skills: skillsIds,
       });
       const yellowBadge = domainBuilder.buildBadge({
         id: 1,
@@ -376,21 +374,38 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         ],
         targetProfileId: targetProfile.id,
       });
-      const expectedMasteryPercentages = {
-        masteryPercentage: 40,
-        partnerCompetenceResults: [
-          { id: 1, masteryPercentage: 67 },
-          { id: 2, masteryPercentage: 33 },
-          { id: 3, masteryPercentage: 40 },
-          { id: 4, masteryPercentage: 50 },
-        ],
-      };
-
+      const expectedMasteryPercentages = [
+        { id: 1, masteryPercentage: 67 },
+        { id: 2, masteryPercentage: 33 },
+        { id: 3, masteryPercentage: 40 },
+        { id: 4, masteryPercentage: 50 },
+      ];
       // when
-      const masteryPercentages = badgeCriteriaService.computeAllMasteryPercentages({ knowledgeElements, targetProfile, badge: yellowBadge });
+      const masteryPercentages = badgeCriteriaService.getMasteryPercentageForAllPartnerCompetences({ targetedKnowledgeElements, targetProfileSkillsIds, badge: yellowBadge });
 
       // then
       expect(masteryPercentages).to.deep.equal(expectedMasteryPercentages);
     });
   });
+
+  describe('#getMasteryPercentageForTargetProfile', () => {
+
+    it('should return global mastery percentage', () => {
+      // given
+      const targetedKnowledgeElements = [
+        new KnowledgeElement({ skillId: 1, status: 'validated' }),
+        new KnowledgeElement({ skillId: 2, status: 'invalidated' }),
+      ];
+      const targetProfileSkillsIds = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+
+      const expectedMasteryPercentage = 25;
+
+      // when
+      const masteryPercentages = badgeCriteriaService.getMasteryPercentageForTargetProfile({ targetedKnowledgeElements, targetProfileSkillsIds });
+
+      // then
+      expect(masteryPercentages).to.deep.equal(expectedMasteryPercentage);
+    });
+  });
+
 });

--- a/api/tests/unit/domain/services/badge-criteria-service_test.js
+++ b/api/tests/unit/domain/services/badge-criteria-service_test.js
@@ -2,6 +2,7 @@ const { domainBuilder, expect } = require('../../../test-helper');
 
 const BadgeCriterion = require('../../../../lib/domain/models/BadgeCriterion');
 const badgeCriteriaService = require('../../../../lib/domain/services/badge-criteria-service');
+const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 
 const CRITERION_THRESHOLD = {
   CAMPAIGN_PARTICIPATION: 70,
@@ -41,15 +42,14 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return true when all the badge criteria are fulfilled', async () => {
         // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 9,
-          secondCompetenceResult: 9,
-          campaignParticipationResult: 9,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+        const masteryPercentage = 90;
+        const partnerCompetenceResults = [
+          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 90 },
+          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 90 },
+        ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(true);
@@ -57,15 +57,14 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return false when no badge criterion is fulfilled', async () => {
         // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 1,
-          secondCompetenceResult: 3,
-          campaignParticipationResult: 2,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+        const masteryPercentage = 20;
+        const partnerCompetenceResults = [
+          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 10 },
+          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 30 },
+        ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -73,15 +72,14 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return false when at least one badge criterion is not fulfilled', async () => {
         // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 9,
-          secondCompetenceResult: 3,
-          campaignParticipationResult: 9,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+        const masteryPercentage = 90;
+        const partnerCompetenceResults = [
+          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 90 },
+          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 30 },
+        ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -101,15 +99,11 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return true when fulfilled', async () => {
         // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 1,
-          secondCompetenceResult: 1,
-          campaignParticipationResult: 9,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+        const masteryPercentage = 90;
+        const partnerCompetenceResults = [];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(true);
@@ -117,15 +111,11 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return false when not fulfilled', async () => {
         // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 1,
-          secondCompetenceResult: 1,
-          campaignParticipationResult: 2,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+        const masteryPercentage = 20;
+        const partnerCompetenceResults = [];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -145,15 +135,14 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return true when fulfilled', async () => {
         // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 4,
-          secondCompetenceResult: 4,
-          campaignParticipationResult: 1,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+        const masteryPercentage = 10;
+        const partnerCompetenceResults = [
+          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 40 },
+          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 40 },
+        ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(true);
@@ -161,15 +150,14 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return false when not fulfilled', async () => {
         // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 3,
-          secondCompetenceResult: 4,
-          campaignParticipationResult: 1,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+        const masteryPercentage = 10;
+        const partnerCompetenceResults = [
+          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 30 },
+          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 40 },
+        ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
@@ -189,63 +177,220 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return true when fulfilled', async () => {
         // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 1,
-          secondCompetenceResult: 6,
-          campaignParticipationResult: 1,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+        const masteryPercentage = 10;
+        const partnerCompetenceResults = [
+          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 10 },
+          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 60 },
+        ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(true);
       });
 
       it('should return false when not fulfilled', async () => {
-        // given
-        const validatedSkillsCount = {
-          firstCompetenceResult: 1,
-          secondCompetenceResult: 5,
-          campaignParticipationResult: 1,
-        };
-        const campaignParticipationResult = _buildCampaignParticipationResult(validatedSkillsCount, badge);
+
+        const masteryPercentage = 10;
+        const partnerCompetenceResults = [
+          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 10 },
+          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 50 },
+        ];
 
         // when
-        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ masteryPercentage, partnerCompetenceResults, badge });
 
         // then
         expect(result).to.be.equal(false);
       });
     });
   });
+
+  describe('#isBadgeAcquired', () => {
+
+    it('should return false if badge is not acquired', () => {
+      // given
+      const knowledgeElements = [
+        new KnowledgeElement({ skillId: 1, status: 'validated' }),
+        new KnowledgeElement({ skillId: 2, status: 'invalidated' }),
+        new KnowledgeElement({ skillId: 7, status: 'validated' }),
+      ];
+      const skills = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const targetProfile = domainBuilder.buildTargetProfile({
+        id: 1,
+        skills,
+      });
+      const yellowBadge = domainBuilder.buildBadge({
+        id: 1,
+        altMessage: 'You won the Yellow badge',
+        imageUrl: '/img/yellow.svg',
+        message: 'Congrats, you won the Yellow badge!',
+        title: 'Yellow',
+        key: 'YELLOW',
+        isCertifiable: false,
+        badgeCriteria: [
+          domainBuilder.buildBadgeCriterion({
+            id: 17,
+            scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+            threshold: 54,
+          }),
+        ],
+        badgePartnerCompetences: [
+          domainBuilder.buildBadgePartnerCompetence({
+            id: 18,
+            name: 'Yellow',
+            color: 'emerald',
+            skillIds: [1, 2, 4],
+          }),
+        ],
+        targetProfileId: targetProfile.id,
+      });
+
+      // when
+      const badgeAcquired = badgeCriteriaService.isBadgeAcquired({ knowledgeElements, targetProfile, badge: yellowBadge });
+
+      // then
+      expect(badgeAcquired).to.equal(false);
+    });
+
+    it('should return true if badge is acquired', () => {
+      // given
+      const knowledgeElements = [
+        new KnowledgeElement({ skillId: 1, status: 'validated' }),
+        new KnowledgeElement({ skillId: 2, status: 'validated' }),
+        new KnowledgeElement({ skillId: 7, status: 'validated' }),
+      ];
+      const skills = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const targetProfile = domainBuilder.buildTargetProfile({
+        id: 1,
+        skills,
+      });
+      const yellowBadge = domainBuilder.buildBadge({
+        id: 1,
+        altMessage: 'You won the Yellow badge',
+        imageUrl: '/img/yellow.svg',
+        message: 'Congrats, you won the Yellow badge!',
+        title: 'Yellow',
+        key: 'YELLOW',
+        isCertifiable: false,
+        badgeCriteria: [
+          domainBuilder.buildBadgeCriterion({
+            id: 17,
+            scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+            threshold: 54,
+          }),
+        ],
+        badgePartnerCompetences: [
+          domainBuilder.buildBadgePartnerCompetence({
+            id: 18,
+            name: 'Yellow',
+            color: 'emerald',
+            skillIds: [1, 2, 4],
+          }),
+        ],
+        targetProfileId: targetProfile.id,
+      });
+
+      // when
+      const badgeAcquired = badgeCriteriaService.isBadgeAcquired({ knowledgeElements, targetProfile, badge: yellowBadge });
+
+      // then
+      expect(badgeAcquired).to.equal(true);
+    });
+  });
+
+  describe('#computeAllMasteryPercentages', () => {
+
+    it('should return global mastery percentage', () => {
+      // given
+      const knowledgeElements = [
+        new KnowledgeElement({ skillId: 1, status: 'validated' }),
+        new KnowledgeElement({ skillId: 2, status: 'invalidated' }),
+        new KnowledgeElement({ skillId: 7, status: 'validated' }),
+      ];
+      const skills = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const targetProfile = domainBuilder.buildTargetProfile({
+        id: 1,
+        skills,
+      });
+      const yellowBadge = domainBuilder.buildBadge({
+        id: 1,
+        badgeCriteria: [],
+        badgePartnerCompetences: [],
+        targetProfileId: targetProfile.id,
+      });
+      const expectedMasteryPercentages = {
+        masteryPercentage: 25,
+        partnerCompetenceResults: [],
+      };
+
+      // when
+      const masteryPercentages = badgeCriteriaService.computeAllMasteryPercentages({ knowledgeElements, targetProfile, badge: yellowBadge });
+
+      // then
+      expect(masteryPercentages).to.deep.equal(expectedMasteryPercentages);
+    });
+
+    it('should return correct mastery percentages for all badgePartnerCompetences', () => {
+      // given
+      const knowledgeElements = [
+        new KnowledgeElement({ skillId: 1, status: 'validated' }),
+        new KnowledgeElement({ skillId: 2, status: 'invalidated' }),
+        new KnowledgeElement({ skillId: 3, status: 'validated' }),
+        new KnowledgeElement({ skillId: 4, status: 'invalidated' }),
+        new KnowledgeElement({ skillId: 7, status: 'validated' }),
+        new KnowledgeElement({ skillId: 8, status: 'validated' }),
+      ];
+      const skills = [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+        { id: 5 },
+      ];
+      const targetProfile = domainBuilder.buildTargetProfile({
+        id: 1,
+        skills,
+      });
+      const yellowBadge = domainBuilder.buildBadge({
+        id: 1,
+        badgeCriteria: [],
+        badgePartnerCompetences: [
+          domainBuilder.buildBadgePartnerCompetence({
+            id: 1,
+            skillIds: [1, 2, 3],
+          }),
+          domainBuilder.buildBadgePartnerCompetence({
+            id: 2,
+            skillIds: [3, 4, 5],
+          }),
+          domainBuilder.buildBadgePartnerCompetence({
+            id: 3,
+            skillIds: [1, 2, 3, 4, 5],
+          }),
+          domainBuilder.buildBadgePartnerCompetence({
+            id: 4,
+            skillIds: [1, 2, 7],
+          }),
+        ],
+        targetProfileId: targetProfile.id,
+      });
+      const expectedMasteryPercentages = {
+        masteryPercentage: 40,
+        partnerCompetenceResults: [
+          { id: 1, masteryPercentage: 67 },
+          { id: 2, masteryPercentage: 33 },
+          { id: 3, masteryPercentage: 40 },
+          { id: 4, masteryPercentage: 50 },
+        ],
+      };
+
+      // when
+      const masteryPercentages = badgeCriteriaService.computeAllMasteryPercentages({ knowledgeElements, targetProfile, badge: yellowBadge });
+
+      // then
+      expect(masteryPercentages).to.deep.equal(expectedMasteryPercentages);
+    });
+  });
 });
-
-function _buildCampaignParticipationResult(validatedSkillsCount, badge) {
-  const partnerCompetenceResults = [
-    domainBuilder.buildCompetenceResult({
-      id: COMPETENCE_RESULT_ID.FIRST,
-      validatedSkillsCount: validatedSkillsCount.firstCompetenceResult,
-      totalSkillsCount: 10,
-      badgeId: badge.id,
-    }),
-    domainBuilder.buildCompetenceResult({
-      id: COMPETENCE_RESULT_ID.SECOND,
-      validatedSkillsCount: validatedSkillsCount.secondCompetenceResult,
-      totalSkillsCount: 10,
-      badgeId: badge.id,
-    }),
-  ];
-
-  const campaignParticipationBadge = domainBuilder.buildCampaignParticipationBadge({
-    id: badge.id,
-    partnerCompetenceResults,
-  });
-
-  return domainBuilder.buildCampaignParticipationResult({
-    campaignParticipationBadges: [campaignParticipationBadge],
-    validatedSkillsCount: validatedSkillsCount.campaignParticipationResult,
-    totalSkillsCount: 10,
-  });
-}


### PR DESCRIPTION
## :unicorn: Problème
Le calcul d'un résultat d'un badge dépend d'un object CampaignParticipationResult qui n'existe pas en dehors d'une campagne, comme au début d'une certification.

## :robot: Solution
Modifier le `BadgeCriteriaService` pour y ajouter une méthode permettant de calculer le résultat d'un badge avec une liste de knowledge-elements et des informations sur le badge et le targetProfile

## :rainbow: Remarques
- TODO : nettoyer ce qui reste du calcul des badge dans le CampaignParticipationResult

## :100: Pour tester
Passer des campagnes avec des RT.