### PR TITLE
[TECH] Généraliser l'encapsulation des appels http sortant de l'API.

### DIFF
--- a/api/lib/.eslintrc.js
+++ b/api/lib/.eslintrc.js
@@ -1,0 +1,12 @@
+
+module.exports = {
+  extends: '../.eslintrc.yaml',
+  rules: {
+    'no-restricted-modules': ['error', {
+      'paths': [{
+        'name': 'axios',
+        'message': 'Please use http-agent instead (ADR 23)',
+      }],
+    }],
+  },
+};

--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
 const querystring = require('querystring');
 

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -25,12 +25,10 @@ module.exports = {
         client_id: settings.poleEmploi.clientId,
       };
 
-      const tokenResponse = await httpAgent.post(
-        settings.poleEmploi.tokenUrl,
-        querystring.stringify(data),
-        {
-          headers: { 'content-type': 'application/x-www-form-urlencoded' },
-        },
+      const tokenResponse = await httpAgent.post({
+        url: settings.poleEmploi.tokenUrl,
+        payload: querystring.stringify(data),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' } },
       );
 
       if (!tokenResponse.isSuccessful) {
@@ -56,7 +54,8 @@ module.exports = {
       'Accept': 'application/json',
       'Service-source': 'Pix',
     };
-    const httpResponse = await httpAgent.post(url, payload, headers);
+
+    const httpResponse = await httpAgent.post({ url, payload, headers });
 
     return {
       isSuccessful: httpResponse.isSuccessful,

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -46,4 +46,34 @@ module.exports = {
       });
     }
   },
+  async get({ url, payload, headers }) {
+    try {
+      const config = { data: payload, headers };
+      const httpResponse = await axios.get(url, config);
+      return new HttpResponse({
+        code: httpResponse.status,
+        data: httpResponse.data,
+        isSuccessful: true,
+      });
+    } catch (httpErr) {
+      const isSuccessful = false;
+
+      let code;
+      let data;
+
+      if (httpErr.response) {
+        code = httpErr.response.status;
+        data = httpErr.response.data;
+      } else {
+        code = '500';
+        data = null;
+      }
+
+      return new HttpResponse({
+        code,
+        data,
+        isSuccessful,
+      });
+    }
+  },
 };

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -14,7 +14,7 @@ class HttpResponse {
 }
 
 module.exports = {
-  async post(url, payload, headers) {
+  async post({ url, payload, headers }) {
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
 const logger = require('../logger');
 

--- a/api/lib/infrastructure/lcms.js
+++ b/api/lib/infrastructure/lcms.js
@@ -1,12 +1,15 @@
-const axios = require('axios');
+const httpAgent = require('./http/http-agent');
+
 const { lcms } = require('../config');
 
 module.exports = {
   async getCurrentContent() {
-    const response = await axios.get('/releases/latest', {
-      baseURL: lcms.url,
-      headers: { Authorization: `Bearer ${lcms.apiKey}` },
-    });
+    const response = await httpAgent.get(
+      {
+        url: lcms.url + '/releases/latest',
+        headers: { Authorization: `Bearer ${lcms.apiKey}` },
+      },
+    );
     return response.data.content;
   },
 };

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -80,12 +80,12 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         await notify(userId, payload, poleEmploiSending);
 
         // then
-        expect(httpAgent.post).to.have.been.calledWithExactly(settings.poleEmploi.sendingUrl, payload, {
+        expect(httpAgent.post).to.have.been.calledWithExactly({ url: settings.poleEmploi.sendingUrl, payload, headers: {
           'Authorization': `Bearer ${authenticationMethod.authenticationComplement.accessToken}`,
           'Content-type': 'application/json',
           'Accept': 'application/json',
           'Service-source': 'Pix',
-        });
+        } });
       });
     });
 
@@ -108,9 +108,8 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         await notify(userId, payload, poleEmploiSending);
 
         // then
-        expect(httpAgent.post).to.have.been.calledWithExactly(settings.poleEmploi.tokenUrl, querystring.stringify(params), {
-          headers: { 'content-type': 'application/x-www-form-urlencoded' },
-        });
+        expect(httpAgent.post).to.have.been.calledWithExactly({ url: settings.poleEmploi.tokenUrl, payload: querystring.stringify(params),
+          headers: { 'content-type': 'application/x-www-form-urlencoded' } });
       });
 
       context('when it succeeds', () => {
@@ -158,12 +157,12 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           await notify(userId, payload, poleEmploiSending);
 
           // then
-          expect(httpAgent.post).to.have.been.calledWithExactly(settings.poleEmploi.sendingUrl, payload, {
+          expect(httpAgent.post).to.have.been.calledWithExactly({ url: settings.poleEmploi.sendingUrl, payload, headers: {
             'Authorization': `Bearer ${authenticationComplement.accessToken}`,
             'Content-type': 'application/json',
             'Accept': 'application/json',
             'Service-source': 'Pix',
-          });
+          } });
         });
       });
 

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -23,7 +23,7 @@ describe('Unit | Infrastructure | http | http-agent', () => {
       sinon.stub(axios, 'post').withArgs(url, payload, { headers }).resolves(axiosResponse);
 
       // when
-      const actualResponse = await post(url, payload, headers);
+      const actualResponse = await post({ url, payload, headers });
 
       // then
       expect(actualResponse).to.deep.equal({
@@ -53,7 +53,7 @@ describe('Unit | Infrastructure | http | http-agent', () => {
           sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
 
           // when
-          const actualResponse = await post(url, payload, headers);
+          const actualResponse = await post({ url, payload, headers });
 
           // then
           expect(logger.error).to.have.been.calledOnce;
@@ -87,7 +87,7 @@ describe('Unit | Infrastructure | http | http-agent', () => {
           };
 
           // when
-          const actualResponse = await post(url, payload, headers);
+          const actualResponse = await post({ url, payload, headers });
 
           // then
           expect(logger.error).to.have.been.calledOnce;

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon } = require('../../../test-helper');
 const axios = require('axios');
 const logger = require('../../../../lib/infrastructure/logger');
-const { post } = require('../../../../lib/infrastructure/http/http-agent');
+const { post, get } = require('../../../../lib/infrastructure/http/http-agent');
 
 describe('Unit | Infrastructure | http | http-agent', () => {
 
@@ -91,6 +91,91 @@ describe('Unit | Infrastructure | http | http-agent', () => {
 
           // then
           expect(logger.error).to.have.been.calledOnce;
+          expect(actualResponse).to.deep.equal(expectedResponse);
+        });
+      });
+    });
+  });
+  describe('#get', () => {
+
+    afterEach(() => {
+      axios.get.restore();
+    });
+
+    it('should return the response status and success from the http call when successful', async () => {
+      // given
+      const url = 'someUrl';
+      const payload = 'somePayload';
+      const headers = { a: 'someHeaderInfo' };
+      const axiosResponse = {
+        data: Symbol('data'),
+        status: 'someStatus',
+      };
+      sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).resolves(axiosResponse);
+
+      // when
+      const actualResponse = await get({ url, payload, headers });
+
+      // then
+      expect(actualResponse).to.deep.equal({
+        isSuccessful: true,
+        code: axiosResponse.status,
+        data: axiosResponse.data,
+      });
+    });
+
+    context('when an error occurs', () => {
+
+      context('when error.response exists', () => {
+
+        it('should return the error\'s response status and data from the http call when failed', async () => {
+          // given
+          const url = 'someUrl';
+          const payload = 'somePayload';
+          const headers = { a: 'someHeaderInfo' };
+          const axiosError = {
+            response: {
+              data: Symbol('data'),
+              status: 'someStatus',
+            },
+          };
+          sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
+
+          // when
+          const actualResponse = await get({ url, payload, headers });
+
+          // then
+          expect(actualResponse).to.deep.equal({
+            isSuccessful: false,
+            code: axiosError.response.status,
+            data: axiosError.response.data,
+          });
+        });
+      });
+
+      context('when error.response doesn\'t exists', () => {
+
+        it('should return the error\'s response status and success from the http call when failed', async () => {
+          // given
+          const url = 'someUrl';
+          const payload = 'somePayload';
+          const headers = { a: 'someHeaderInfo' };
+
+          const axiosError = {
+            name: 'error name',
+          };
+          sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
+
+          const expectedResponse = {
+            isSuccessful: false,
+            code: '500',
+            data: null,
+          };
+
+          // when
+          const actualResponse = await get({ url, payload, headers });
+
+          // then
           expect(actualResponse).to.deep.equal(expectedResponse);
         });
       });

--- a/docs/adr/0023-encapsuler-appel-http.md
+++ b/docs/adr/0023-encapsuler-appel-http.md
@@ -1,0 +1,59 @@
+# 23. Faut-il encapsuler les appels http dans l'API ?
+
+Date : 2020-04-22
+
+## État
+Adopté
+
+## Contexte 
+L'API effectue des appels http:
+- vers des services Pix (ex: LCMS);
+- vers des API externes à Pix (ex: Pole Emploi).
+
+La librairie standard node permet de faire des appels http avec [http.request()](https://nodejs.org/api/http.html#http_http_request_options_callback).
+
+Il existe des librairies bâties au-dessus de la librairie standard, qui offrent :
+- une interface (API) simplifiée (ex: pour traiter une réponse, la librairie standard prend en argument un callback et émet des évènements, alors que `axios` renvoie une promesse);
+- des fonctionnalités supplémentaires.
+
+La plupart des contributeurs de ces librairies sont bénévoles.
+Il y a donc un risque que leur maintenance ne soit un jour plus assurée.
+De plus, toutes n'offrent pas les mêmes fonctionnalités.
+
+Pour ces deux raisons, nous pourrions être amenés à vouloir changer de librairie.
+Dans ce cas, le coût de migration (réécriture du code) est un facteur à prendre en compte.
+
+Cette encapsulation a déjà été réalisée sur le logging avec [logger](./../../api/lib/infrastructure/logger.js).
+À la question "Quels sont les cas pertinents pour encapsuler ?", les appels http sont régulièrement [cités](https://levelup.gitconnected.com/why-you-should-often-wrap-your-dependencies-5fced2999616).
+
+### Solution n°1 : Encapsuler les appels à la librairie http dans un composant
+
+Un composant, [http-agent](../../api/lib/infrastructure/http/http-agent.js), appelle la librairie (ex: `axios`).
+
+Le code de production fait appel à ce composant uniquement pour tout appel http.
+
+Avantages :
+- diminution du coût de migration: seul ce composant doit être modifié.
+
+Inconvénients :
+- le développeur doit retenir l'usage et le nom et du composant (ce coût est partiellement mitigeable avec de la documentation et des règles de lint, mais ne peut être totalement supprimé) ;
+- le développeur doit retenir son API et le mapping avec la librairie appelée.
+
+### Solution n°2 : Appeler directement la librairie
+
+Le code de production fait directement appel à la librairie.
+
+Avantages :
+- montée en compétences facilitée : le développeur connait probablement déjà la librairie de par ses expériences précédentes
+
+Inconvénients :
+- augmentation du coût de migration : tous les appels doivent être modifiés
+
+## Décision
+La solution n°1 est adoptée
+
+## Conséquences
+En dehors des API externes proposant une librairie dédiée (ex: [mailjet](https://github.com/mailjet/mailjet-apiv3-nodejs)), 
+appeler le composant `http-agent` à la place de la librairie (ex: `axios`).
+
+Ajouter une règle de lint pour empêcher l'usage direct et non-intentionnel de la librairie (ex: `axios`).


### PR DESCRIPTION
## :unicorn: Problème
Le composant [http-agent](https://github.com/1024pix/pix/blob/dev/api/lib/infrastructure/http/http-agent.js) a été créé pour encapsuler les requêtes http.
Son existence n'est pas connue de tous, ni les raisons de sa création.

## :robot: Solution
Documenter les raisons du choix dans un ADR.
Ajouter une règle de lint pour expliciter le choix par défaut.
Modifier le code existant pour l'utiliser.

## :rainbow: Remarques
La méthode `post` comporte 3 paramètres: passage en objet pour faciliter l'appel.

Avant
```
const tokenResponse = await httpAgent.post(
  settings.poleEmploi.tokenUrl,
  querystring.stringify(data),
  {
    headers: { 'content-type': 'application/x-www-form-urlencoded' },
  },
);
```

Après
```
const tokenResponse = await httpAgent.post({
  url: settings.poleEmploi.tokenUrl,
  payload: querystring.stringify(data),
  headers: { 'content-type': 'application/x-www-form-urlencoded' } },
);
```

## :100: Pour tester
Essayer d'utiliser la librairie `axios` et vérifier qu'une erreur de lint apparaît.
