### PR TITLE
[FEATURE] Affichage des certifications complémentaires dans la liste des certifications sur PixAdmin (PIX-2373)

### DIFF
--- a/admin/app/components/certification/certification-info-field.hbs
+++ b/admin/app/components/certification/certification-info-field.hbs
@@ -28,7 +28,7 @@
 {{else}}
   <div class="row certification-info-field">
     <div class="certification-info-field__label">{{@label}}</div>
-    <div class="certification-info-value">
+    <div class="certification-info-value {{@class}}">
       {{#if @linkRoute}}
         <LinkTo @route={{@linkRoute}} @model={{@value}}>
           {{this.valueWithSuffix}}

--- a/admin/app/components/certification/certification-list.js
+++ b/admin/app/components/certification/certification-list.js
@@ -33,8 +33,8 @@ export default class CertificationList extends Component {
       className: 'certification-list-page__cell--important',
     },
     {
-      propertyName: 'cleaStatus',
-      title: 'Certification CléA numérique',
+      propertyName: 'complementaryCertificationsLabel',
+      title: 'Autres certifications',
     },
     {
       propertyName: 'pixScore',

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -5,15 +5,7 @@ import Model, { attr } from '@ember-data/model';
 import find from 'lodash/find';
 import { certificationStatuses } from 'pix-admin/models/certification';
 
-const ACQUIRED = 'acquired';
-const REJECTED = 'rejected';
-const NOT_PASSED = 'not_passed';
-
-const partnerCertificationStatusToDisplayName = {
-  [ACQUIRED]: 'Validée',
-  [REJECTED]: 'Rejetée',
-  [NOT_PASSED]: 'Non passée',
-};
+const NOT_TAKEN = 'not_taken';
 
 export default class JuryCertificationSummary extends Model {
 
@@ -27,6 +19,8 @@ export default class JuryCertificationSummary extends Model {
   @attr() examinerComment;
   @attr() hasSeenEndTestScreen;
   @attr() cleaCertificationStatus;
+  @attr() pixPlusDroitMaitreCertificationStatus;
+  @attr() pixPlusDroitExpertCertificationStatus;
   @attr() numberOfCertificationIssueReports;
   @attr() numberOfCertificationIssueReportsWithRequiredAction;
 
@@ -40,9 +34,12 @@ export default class JuryCertificationSummary extends Model {
     return (new Date(this.completedAt)).toLocaleString('fr-FR');
   }
 
-  @computed('cleaCertificationStatus')
-  get cleaStatus() {
-    return partnerCertificationStatusToDisplayName[this.cleaCertificationStatus];
+  get complementaryCertificationsLabel() {
+    const certifications = [];
+    if (this.cleaCertificationStatus !== NOT_TAKEN) certifications.push('CléA Numérique');
+    if (this.pixPlusDroitMaitreCertificationStatus !== NOT_TAKEN) certifications.push('Pix+ Droit Maître');
+    if (this.pixPlusDroitExpertCertificationStatus !== NOT_TAKEN) certifications.push('Pix+ Droit Expert');
+    return certifications.join('\n');
   }
 
   @computed('numberOfCertificationIssueReportsWithRequiredAction')

--- a/admin/tests/integration/components/certification/certification-list-test.js
+++ b/admin/tests/integration/components/certification/certification-list-test.js
@@ -1,12 +1,19 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | <Certification::CertificationList/>', function(hooks) {
+module('Integration | Component | CertificationList', function(hooks) {
 
   setupRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(async function() {
+    store = this.owner.lookup('service:store');
+  });
 
   test('should display many certifications', async function(assert) {
     // given
@@ -34,5 +41,23 @@ module('Integration | Component | <Certification::CertificationList/>', function
 
     const numberOfCertificationIssueReportsWithRequiredAction = this.element.querySelector('tbody > tr td:nth-child(5)');
     assert.dom(numberOfCertificationIssueReportsWithRequiredAction).hasText('2');
+  });
+
+  test('should display the complementary certifications if any', async function(assert) {
+    // given
+    const juryCertificationSummaryProcessed = run(() => {
+      return store.createRecord('jury-certification-summary', {
+        cleaCertificationStatus: 'taken',
+        pixPlusDroitMaitreCertificationStatus: 'taken',
+        pixPlusDroitExpertCertificationStatus: 'not_taken',
+      });
+    });
+    this.certifications = [juryCertificationSummaryProcessed];
+
+    // when
+    await render(hbs`<Certification::CertificationList @certifications={{certifications}} />`);
+
+    // then
+    assert.contains('CléA Numérique\nPix+ Droit Maître');
   });
 });

--- a/admin/tests/unit/models/jury-certification-summary-test.js
+++ b/admin/tests/unit/models/jury-certification-summary-test.js
@@ -31,7 +31,151 @@ module('Unit | Model | jury-certification-summary', function(hooks) {
         });
       });
     });
-
   });
 
+  module('#hasSeenEndTestScreenLabel', function() {
+
+    test('it returns an empty string when it has seen end test screen', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', { hasSeenEndTestScreen: true });
+      });
+
+      // when
+      const hasSeenEndTestScreenLabel = juryCertificationSummaryProcessed.hasSeenEndTestScreenLabel;
+
+      // then
+      assert.equal(hasSeenEndTestScreenLabel, '');
+    });
+
+    test('it returns \'non\' when it has not seen end test screen', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', { hasSeenEndTestScreen: false });
+      });
+
+      // when
+      const hasSeenEndTestScreenLabel = juryCertificationSummaryProcessed.hasSeenEndTestScreenLabel;
+
+      // then
+      assert.equal(hasSeenEndTestScreenLabel, 'non');
+    });
+  });
+
+  module('#numberOfCertificationIssueReportsWithRequiredActionLabel', function() {
+
+    test('it returns an empty string when there are no issue reports', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', { numberOfCertificationIssueReportsWithRequiredAction: 0 });
+      });
+
+      // when
+      const numberOfCertificationIssueReportsWithRequiredActionLabel = juryCertificationSummaryProcessed.numberOfCertificationIssueReportsWithRequiredActionLabel;
+
+      // then
+      assert.equal(numberOfCertificationIssueReportsWithRequiredActionLabel, '');
+    });
+
+    test('it returns the count of issue reports when there are some', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', { numberOfCertificationIssueReportsWithRequiredAction: 4 });
+      });
+
+      // when
+      const numberOfCertificationIssueReportsWithRequiredActionLabel = juryCertificationSummaryProcessed.numberOfCertificationIssueReportsWithRequiredActionLabel;
+
+      // then
+      assert.equal(numberOfCertificationIssueReportsWithRequiredActionLabel, 4);
+    });
+  });
+
+  module('#complementaryCertificationsLabel', function() {
+
+    test('it returns an empty string when there are no complementary certifications taken', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', {
+          cleaCertificationStatus: 'not_taken',
+          pixPlusDroitMaitreCertificationStatus: 'not_taken',
+          pixPlusDroitExpertCertificationStatus: 'not_taken',
+        });
+      });
+
+      // when
+      const complementaryCertificationsLabel = juryCertificationSummaryProcessed.complementaryCertificationsLabel;
+
+      // then
+      assert.equal(complementaryCertificationsLabel, '');
+    });
+
+    test('it returns CléA Numérique when Clea has been taken as complementary certification', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', {
+          cleaCertificationStatus: 'taken',
+          pixPlusDroitMaitreCertificationStatus: 'not_taken',
+          pixPlusDroitExpertCertificationStatus: 'not_taken',
+        });
+      });
+
+      // when
+      const complementaryCertificationsLabel = juryCertificationSummaryProcessed.complementaryCertificationsLabel;
+
+      // then
+      assert.equal(complementaryCertificationsLabel, 'CléA Numérique');
+    });
+
+    test('it returns Pix+ Droit Maître when pix+ droit maitre has been taken as complementary certification', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', {
+          cleaCertificationStatus: 'not_taken',
+          pixPlusDroitMaitreCertificationStatus: 'taken',
+          pixPlusDroitExpertCertificationStatus: 'not_taken',
+        });
+      });
+
+      // when
+      const complementaryCertificationsLabel = juryCertificationSummaryProcessed.complementaryCertificationsLabel;
+
+      // then
+      assert.equal(complementaryCertificationsLabel, 'Pix+ Droit Maître');
+    });
+
+    test('it returns Pix+ Droit Expert when pix+ droit expert has been taken as complementary certification', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', {
+          cleaCertificationStatus: 'not_taken',
+          pixPlusDroitMaitreCertificationStatus: 'not_taken',
+          pixPlusDroitExpertCertificationStatus: 'taken',
+        });
+      });
+
+      // when
+      const complementaryCertificationsLabel = juryCertificationSummaryProcessed.complementaryCertificationsLabel;
+
+      // then
+      assert.equal(complementaryCertificationsLabel, 'Pix+ Droit Expert');
+    });
+
+    test('it returns all complementary certifications taken separated by carriage return where there are some', function(assert) {
+      // given
+      const juryCertificationSummaryProcessed = run(() => {
+        return store.createRecord('jury-certification-summary', {
+          cleaCertificationStatus: 'taken',
+          pixPlusDroitMaitreCertificationStatus: 'not_taken',
+          pixPlusDroitExpertCertificationStatus: 'taken',
+        });
+      });
+
+      // when
+      const complementaryCertificationsLabel = juryCertificationSummaryProcessed.complementaryCertificationsLabel;
+
+      // then
+      assert.equal(complementaryCertificationsLabel, 'CléA Numérique\nPix+ Droit Expert');
+    });
+  });
 });

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -14,6 +14,8 @@ class JuryCertificationSummary {
     isPublished,
     hasSeenEndTestScreen,
     cleaCertificationResult,
+    pixPlusDroitMaitreCertificationResult,
+    pixPlusDroitExpertCertificationResult,
     certificationIssueReports,
   } = {}) {
     this.id = id;
@@ -25,6 +27,8 @@ class JuryCertificationSummary {
     }
     this.pixScore = pixScore;
     this.cleaCertificationResult = cleaCertificationResult;
+    this.pixPlusDroitMaitreCertificationResult = pixPlusDroitMaitreCertificationResult;
+    this.pixPlusDroitExpertCertificationResult = pixPlusDroitExpertCertificationResult;
     this.createdAt = createdAt;
     this.completedAt = completedAt;
     this.isPublished = isPublished;

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -2,16 +2,6 @@ const { status: assessmentResultStatuses } = require('../models/AssessmentResult
 
 const STARTED = 'started';
 
-const ACQUIRED = true;
-const REJECTED = false;
-const NOT_PASSED = null;
-
-const statuses = {
-  [ACQUIRED]: 'acquired',
-  [REJECTED]: 'rejected',
-  [NOT_PASSED]: 'not_passed',
-};
-
 class JuryCertificationSummary {
   constructor({
     id,
@@ -23,7 +13,7 @@ class JuryCertificationSummary {
     completedAt,
     isPublished,
     hasSeenEndTestScreen,
-    cleaCertificationStatus,
+    cleaCertificationResult,
     certificationIssueReports,
   } = {}) {
     this.id = id;
@@ -34,7 +24,7 @@ class JuryCertificationSummary {
       this.status = STARTED;
     }
     this.pixScore = pixScore;
-    this.cleaCertificationStatus = statuses[cleaCertificationStatus];
+    this.cleaCertificationResult = cleaCertificationResult;
     this.createdAt = createdAt;
     this.completedAt = completedAt;
     this.isPublished = isPublished;

--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -35,9 +35,7 @@ module.exports = {
       juryCertificationSummaryRows,
       certificationIssueReportRows);
 
-    const juryCertificationSummaries = _.map(juryCertificationSummaryDTOs, _toDomain);
-
-    return juryCertificationSummaries;
+    return _.map(juryCertificationSummaryDTOs, _toDomain);
   },
 };
 

--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const { knex } = require('../bookshelf');
 const JuryCertificationSummary = require('../../domain/read-models/JuryCertificationSummary');
 const CertificationIssueReport = require('../../domain/models/CertificationIssueReport');
+const CleaCertificationResult = require('../../domain/models/CleaCertificationResult');
 
 module.exports = {
 
@@ -57,9 +58,13 @@ function _toDomain(juryCertificationSummaryDTO) {
       return new CertificationIssueReport(certificationIssueReportDTO);
     });
 
+  let cleaCertificationResult = CleaCertificationResult.buildNotTaken();
+  if (_.isBoolean(juryCertificationSummaryDTO.acquired)) {
+    cleaCertificationResult = CleaCertificationResult.buildFrom({ acquired: juryCertificationSummaryDTO.acquired });
+  }
   return new JuryCertificationSummary({
     ...juryCertificationSummaryDTO,
     certificationIssueReports,
-    cleaCertificationStatus: juryCertificationSummaryDTO.acquired,
+    cleaCertificationResult,
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer.js
@@ -13,6 +13,7 @@ module.exports = {
           get(juryCertificationSummary, 'certificationIssueReports[0].description');
         result.numberOfCertificationIssueReports = juryCertificationSummary.certificationIssueReports.length;
         result.numberOfCertificationIssueReportsWithRequiredAction = juryCertificationSummary.certificationIssueReports.filter((issueReport) => issueReport.isActionRequired).length;
+        result.cleaCertificationStatus = result.cleaCertificationResult.status;
         return result;
       },
       attributes: [

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer.js
@@ -14,6 +14,8 @@ module.exports = {
         result.numberOfCertificationIssueReports = juryCertificationSummary.certificationIssueReports.length;
         result.numberOfCertificationIssueReportsWithRequiredAction = juryCertificationSummary.certificationIssueReports.filter((issueReport) => issueReport.isActionRequired).length;
         result.cleaCertificationStatus = result.cleaCertificationResult.status;
+        result.pixPlusDroitMaitreCertificationStatus = result.pixPlusDroitMaitreCertificationResult.status;
+        result.pixPlusDroitExpertCertificationStatus = result.pixPlusDroitExpertCertificationResult.status;
         return result;
       },
       attributes: [
@@ -29,6 +31,8 @@ module.exports = {
         'numberOfCertificationIssueReportsWithRequiredAction',
         'hasSeenEndTestScreen',
         'cleaCertificationStatus',
+        'pixPlusDroitMaitreCertificationStatus',
+        'pixPlusDroitExpertCertificationStatus',
       ],
     }).serialize(juryCertificationSummary);
   },

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -88,7 +88,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           'created-at': certif2.createdAt,
           'number-of-certification-issue-reports': 0,
           'number-of-certification-issue-reports-with-required-action': 0,
-          'clea-certification-status': 'not_passed',
+          'clea-certification-status': 'not_taken',
           'completed-at': certif2.completedAt,
           'examiner-comment': undefined,
           'has-seen-end-test-screen': certif2.hasSeenEndTestScreen,

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -76,6 +76,8 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           'number-of-certification-issue-reports': 0,
           'number-of-certification-issue-reports-with-required-action': 0,
           'clea-certification-status': 'acquired',
+          'pix-plus-droit-maitre-certification-status': 'not_taken',
+          'pix-plus-droit-expert-certification-status': 'not_taken',
           'examiner-comment': undefined,
           'has-seen-end-test-screen': certif1.hasSeenEndTestScreen,
         };
@@ -89,6 +91,8 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           'number-of-certification-issue-reports': 0,
           'number-of-certification-issue-reports-with-required-action': 0,
           'clea-certification-status': 'not_taken',
+          'pix-plus-droit-maitre-certification-status': 'not_taken',
+          'pix-plus-droit-expert-certification-status': 'not_taken',
           'completed-at': certif2.completedAt,
           'examiner-comment': undefined,
           'has-seen-end-test-screen': certif2.hasSeenEndTestScreen,
@@ -122,9 +126,6 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
         expect(response.result.data[1].attributes).to.deep.equal(expectedJuryCertifSumm2);
         expect(response.result.data[1].id).to.deep.equal(certif2.id.toString());
       });
-
     });
-
   });
-
 });

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -1,4 +1,4 @@
-const { databaseBuilder, expect } = require('../../../test-helper');
+const { databaseBuilder, expect, domainBuilder } = require('../../../test-helper');
 const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
@@ -66,8 +66,9 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
 
         // then
+        const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
         const expectedJuryCertificationSummary = new JuryCertificationSummary({
-          cleaCertificationStatus: null,
+          cleaCertificationResult: expectedCleaCertificationResult,
           completedAt: manyAsrCertification.completedAt,
           createdAt: manyAsrCertification.createdAt,
           firstName: manyAsrCertification.firstName,
@@ -194,8 +195,9 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
 
         // then
+        const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
         expect(juryCertificationSummaries).to.have.lengthOf(1);
-        expect(juryCertificationSummaries[0].cleaCertificationStatus).to.equal(CleaCertificationResult.cleaStatuses.ACQUIRED);
+        expect(juryCertificationSummaries[0].cleaCertificationResult).to.deep.equal(expectedCleaCertificationResult);
       });
 
       it('should have the status rejected when clea certification is rejected', async () => {
@@ -211,14 +213,15 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
 
         // then
+        const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.rejected();
         expect(juryCertificationSummaries).to.have.lengthOf(1);
-        expect(juryCertificationSummaries[0].cleaCertificationStatus).to.equal(CleaCertificationResult.cleaStatuses.REJECTED);
+        expect(juryCertificationSummaries[0].cleaCertificationResult).to.deep.equal(expectedCleaCertificationResult);
       });
     });
 
     context('when a summary has a no Clea certification', () => {
 
-      it('should have the status not_passed when clea certification has not be taken', async () => {
+      it('should have the status notTaken when clea certification has not be taken', async () => {
         // given
         const dbf = databaseBuilder.factory;
         const sessionId = dbf.buildSession().id;
@@ -229,8 +232,9 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
 
         // then
+        const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
         expect(juryCertificationSummaries).to.have.lengthOf(1);
-        expect(juryCertificationSummaries[0].cleaCertificationStatus).to.equal('not_passed');
+        expect(juryCertificationSummaries[0].cleaCertificationResult).to.deep.equal(expectedCleaCertificationResult);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -2,6 +2,8 @@ const { databaseBuilder, expect, domainBuilder } = require('../../../test-helper
 const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
+const PixPlusDroitMaitreCertificationResult = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+const PixPlusDroitExpertCertificationResult = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
 const { CertificationIssueReportCategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
 const juryCertificationSummaryRepository = require('../../../../lib/infrastructure/repositories/jury-certification-summary-repository');
@@ -67,8 +69,12 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
 
         // then
         const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
+        const expectedPixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
+        const expectedPixPlusDroitExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
         const expectedJuryCertificationSummary = new JuryCertificationSummary({
           cleaCertificationResult: expectedCleaCertificationResult,
+          pixPlusDroitMaitreCertificationResult: expectedPixPlusDroitMaitreCertificationResult,
+          pixPlusDroitExpertCertificationResult: expectedPixPlusDroitExpertCertificationResult,
           completedAt: manyAsrCertification.completedAt,
           createdAt: manyAsrCertification.createdAt,
           firstName: manyAsrCertification.firstName,
@@ -225,7 +231,7 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
         // given
         const dbf = databaseBuilder.factory;
         const sessionId = dbf.buildSession().id;
-        dbf.buildCertificationCourse({ sessionId }).id;
+        dbf.buildCertificationCourse({ sessionId });
         await databaseBuilder.commit();
 
         // when
@@ -235,6 +241,151 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
         const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
         expect(juryCertificationSummaries).to.have.lengthOf(1);
         expect(juryCertificationSummaries[0].cleaCertificationResult).to.deep.equal(expectedCleaCertificationResult);
+      });
+    });
+
+    context('when a summary has a Pix plus droit maitre certification', () => {
+
+      it('should have the status acquired when Pix plus droit maitre certification is acquired', async () => {
+        // given
+        const dbf = databaseBuilder.factory;
+        const sessionId = dbf.buildSession().id;
+        const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
+        dbf.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+        dbf.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey, acquired: true });
+        await databaseBuilder.commit();
+
+        // when
+        const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
+
+        // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
+        expect(juryCertificationSummaries).to.have.lengthOf(1);
+        expect(juryCertificationSummaries[0].pixPlusDroitMaitreCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
+      });
+
+      it('should have the status rejected when Pix plus droit maitre certification is rejected', async () => {
+        // given
+        const dbf = databaseBuilder.factory;
+        const sessionId = dbf.buildSession().id;
+        const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
+        dbf.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+        dbf.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey, acquired: false });
+        await databaseBuilder.commit();
+
+        // when
+        const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
+
+        // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();
+        expect(juryCertificationSummaries).to.have.lengthOf(1);
+        expect(juryCertificationSummaries[0].pixPlusDroitMaitreCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
+      });
+    });
+
+    context('when a summary has a no Pix plus droit maitre certification', () => {
+
+      it('should have the status notTaken when pix plus droit maitre certification has not be taken', async () => {
+        // given
+        const dbf = databaseBuilder.factory;
+        const sessionId = dbf.buildSession().id;
+        dbf.buildCertificationCourse({ sessionId });
+        await databaseBuilder.commit();
+
+        // when
+        const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
+
+        // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
+        expect(juryCertificationSummaries).to.have.lengthOf(1);
+        expect(juryCertificationSummaries[0].pixPlusDroitMaitreCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
+      });
+    });
+
+    context('when a summary has a Pix plus droit expert certification', () => {
+
+      it('should have the status acquired when Pix plus droit expert certification is acquired', async () => {
+        // given
+        const dbf = databaseBuilder.factory;
+        const sessionId = dbf.buildSession().id;
+        const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
+        dbf.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+        dbf.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitExpertCertificationResult.badgeKey, acquired: true });
+        await databaseBuilder.commit();
+
+        // when
+        const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
+
+        // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
+        expect(juryCertificationSummaries).to.have.lengthOf(1);
+        expect(juryCertificationSummaries[0].pixPlusDroitExpertCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
+      });
+
+      it('should have the status rejected when Pix plus droit expert certification is rejected', async () => {
+        // given
+        const dbf = databaseBuilder.factory;
+        const sessionId = dbf.buildSession().id;
+        const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
+        dbf.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+        dbf.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitExpertCertificationResult.badgeKey, acquired: false });
+        await databaseBuilder.commit();
+
+        // when
+        const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
+
+        // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected();
+        expect(juryCertificationSummaries).to.have.lengthOf(1);
+        expect(juryCertificationSummaries[0].pixPlusDroitExpertCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
+      });
+    });
+
+    context('when a summary has a no Pix plus droit expert certification', () => {
+
+      it('should have the status notTaken when pix plus droit expert certification has not be taken', async () => {
+        // given
+        const dbf = databaseBuilder.factory;
+        const sessionId = dbf.buildSession().id;
+        dbf.buildCertificationCourse({ sessionId });
+        await databaseBuilder.commit();
+
+        // when
+        const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
+
+        // then
+        const expectedPixPlusCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
+        expect(juryCertificationSummaries).to.have.lengthOf(1);
+        expect(juryCertificationSummaries[0].pixPlusDroitExpertCertificationResult).to.deep.equal(expectedPixPlusCertificationResult);
+      });
+    });
+
+    context('when a summary has several partner certifications', () => {
+
+      it('should return only one exemplary of the summary with appropriate info on partner certification', async () => {
+        // given
+        const dbf = databaseBuilder.factory;
+        const sessionId = dbf.buildSession().id;
+        const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
+        dbf.buildBadge({ key: CleaCertificationResult.badgeKey });
+        dbf.buildPartnerCertification({ certificationCourseId, partnerKey: CleaCertificationResult.badgeKey, acquired: true });
+        dbf.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+        dbf.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey, acquired: false });
+        dbf.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+        dbf.buildPartnerCertification({ certificationCourseId, partnerKey: PixPlusDroitExpertCertificationResult.badgeKey, acquired: true });
+        await databaseBuilder.commit();
+
+        // when
+        const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
+
+        // then
+        const expectedCleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
+        const expectedPixPlusMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();
+        const expectedPixPlusExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
+        expect(juryCertificationSummaries).to.have.lengthOf(1);
+        expect(juryCertificationSummaries[0].cleaCertificationResult).to.deep.equal(expectedCleaCertificationResult);
+        expect(juryCertificationSummaries[0].pixPlusDroitMaitreCertificationResult).to.deep.equal(expectedPixPlusMaitreCertificationResult);
+        expect(juryCertificationSummaries[0].pixPlusDroitExpertCertificationResult).to.deep.equal(expectedPixPlusExpertCertificationResult);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-summary-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-summary-serializer_test.js
@@ -18,6 +18,8 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
         category: CertificationIssueReportCategories.OTHER,
       });
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
+      const pixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();
+      const pixPlusDroitExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
       modelJuryCertifSummary = new JuryCertificationSummary({
         id: 1,
         firstName: 'someFirstName',
@@ -30,6 +32,8 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
         certificationIssueReports: [issueReport],
         hasSeenEndTestScreen: false,
         cleaCertificationResult,
+        pixPlusDroitMaitreCertificationResult,
+        pixPlusDroitExpertCertificationResult,
       });
 
       expectedJsonApi = {
@@ -49,6 +53,8 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
             'number-of-certification-issue-reports-with-required-action': 1,
             'has-seen-end-test-screen': modelJuryCertifSummary.hasSeenEndTestScreen,
             'clea-certification-status': 'acquired',
+            'pix-plus-droit-maitre-certification-status': 'rejected',
+            'pix-plus-droit-expert-certification-status': 'not_taken',
           },
         },
       };
@@ -62,5 +68,4 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
       expect(json).to.deep.equal(expectedJsonApi);
     });
   });
-
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-summary-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-summary-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../../test-helper');
+const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer');
 const JuryCertificationSummary = require('../../../../../lib/domain/read-models/JuryCertificationSummary');
 const CertificationIssueReport = require('../../../../../lib/domain/models/CertificationIssueReport');
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
         description: 'someComment',
         category: CertificationIssueReportCategories.OTHER,
       });
+      const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
       modelJuryCertifSummary = new JuryCertificationSummary({
         id: 1,
         firstName: 'someFirstName',
@@ -28,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
         isPublished: true,
         certificationIssueReports: [issueReport],
         hasSeenEndTestScreen: false,
-        cleaCertificationStatus: true,
+        cleaCertificationResult,
       });
 
       expectedJsonApi = {


### PR DESCRIPTION
## :unicorn: Problème
Certains candidats en certification peuvent passer une double certification : aujourd’hui, il est par exemple possible de passer la double certif Pix/CléA numérique, et bientôt Pix/Pix+ Droit puis Pix/Pix+ Prof. Le pôle certification en charge du traitement des sessions de certification doit donc être informé si un candidat a passé une autre certification en plus de sa certif Pix.

## :robot: Solution
Dans Pix Admin > liste des certifications d’une session : on modifie le libellé de la colonne “Certification CléA numérique” pour “Autres certifications”.
Dans la colonne, on affiche la liste des certifications complémentaires passées séparées par des retours chariot.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Trouver ou créer une certification pour laquelle une ou plusieurs certifications complémentaires ont été passées (session 8 certif 200 y'a cléa dedans 🤷🏿 )
constater le bon affichage dans la liste des certifications
