### PR TITLE
[FEATURE] Afficher les tags de chaque organisation sur Pix Admin (PIX-197).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -119,6 +119,17 @@
     {{else}}
     <div class="organization__data">
       <h1 class="organization__name">{{@organization.name}}</h1>
+
+      {{#if @organization.tags}}
+        <ul class="organization-tags-list">
+          {{#each @organization.tags as |tag|}}
+            <li class="organization-tags-list__tag">
+              <PixTag @compact="true" @color="purple-light">{{tag.name}}</PixTag>
+            </li>
+          {{/each}}
+        </ul>
+      {{/if}}
+
       <div class="organization-information-section__content">
         <div>
           <p>

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -21,6 +21,7 @@ export default class Organization extends Model {
 
   @hasMany('membership') memberships;
   @hasMany('targetProfile') targetProfiles;
+  @hasMany('tag') tags;
 
   async hasMember(userEmail) {
     const memberships = await this.memberships;

--- a/admin/app/models/tag.js
+++ b/admin/app/models/tag.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Tag extends Model {
+  @attr('string') name;
+}

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -38,11 +38,23 @@
     }
 
     .organization__data {
+      max-width: 100%;
 
       .organization__name {
         font-size: 1.5rem;
         font-weight: 600;
         margin-bottom: 20px;
+      }
+
+      .organization-tags-list {
+        list-style: none;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+
+        &__tag {
+          margin-right: 6px;
+        }
       }
     }
 

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -43,6 +43,20 @@ module('Integration | Component | organization-information-section', function(ho
     assert.dom('.organization__canCollectProfiles').hasText('Oui');
   });
 
+  test('it should display tags', async function(assert) {
+    // given
+    const organization = EmberObject.create({ tags: [{ id: 1, name: 'CFA' }, { id: 2, name: 'PRIVE' }, { id: 3, name: 'AGRICULTURE' }] });
+    this.set('organization', organization);
+
+    // when
+    await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);
+
+    // expect
+    assert.contains('CFA');
+    assert.contains('PRIVE');
+    assert.contains('AGRICULTURE');
+  });
+
   module('Edit organization', function(hooks) {
 
     let organization;

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
 
   serialize(organizations, meta) {
     return new Serializer('organizations', {
-      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'canCollectProfiles', 'email', 'memberships', 'students', 'targetProfiles'],
+      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'canCollectProfiles', 'email', 'memberships', 'students', 'targetProfiles', 'tags'],
       memberships: {
         ref: 'id',
         ignoreRelationshipData: true,
@@ -33,6 +33,11 @@ module.exports = {
             return `/api/organizations/${parent.id}/target-profiles`;
           },
         },
+      },
+      tags: {
+        ref: 'id',
+        included: true,
+        attributes: ['id', 'name'],
       },
       meta,
     }).serialize(organizations);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -547,6 +547,10 @@ describe('Acceptance | Application | organization-controller', () => {
 
       it('should return the matching organization as JSON API', async () => {
         // given
+        const tag = databaseBuilder.factory.buildTag({ id: 7, name: 'AEFE' });
+        databaseBuilder.factory.buildOrganizationTag({ tagId: tag.id, organizationId: organization.id });
+        await databaseBuilder.commit();
+
         const expectedResult = {
           'data': {
             'attributes': {
@@ -572,6 +576,14 @@ describe('Acceptance | Application | organization-controller', () => {
                   'related': `/api/organizations/${organization.id}/students`,
                 },
               },
+              'tags': {
+                'data': [
+                  {
+                    'id': tag.id.toString(),
+                    'type': 'tags',
+                  },
+                ],
+              },
               'target-profiles': {
                 'links': {
                   'related': `/api/organizations/${organization.id}/target-profiles`,
@@ -580,6 +592,16 @@ describe('Acceptance | Application | organization-controller', () => {
             },
             'type': 'organizations',
           },
+          'included': [
+            {
+              'attributes': {
+                'id': tag.id,
+                'name': tag.name,
+              },
+              'id': tag.id.toString(),
+              'type': 'tags',
+            },
+          ],
         };
 
         // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -7,8 +7,13 @@ describe('Unit | Serializer | organization-serializer', () => {
 
     it('should return a JSON API serialized organization', () => {
       // given
-      const organization = domainBuilder.buildOrganization({ email: 'sco.generic.account@example.net' });
+      const tags = [
+        domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
+        domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
+      ];
+      const organization = domainBuilder.buildOrganization({ email: 'sco.generic.account@example.net', tags });
       const meta = { some: 'meta' };
+
       // when
       const serializedOrganization = serializer.serialize(organization, meta);
 
@@ -44,8 +49,38 @@ describe('Unit | Serializer | organization-serializer', () => {
                 related: `/api/organizations/${organization.id}/target-profiles`,
               },
             },
+            'tags': {
+              'data': [
+                {
+                  'id': tags[0].id.toString(),
+                  'type': 'tags',
+                },
+                {
+                  'id': tags[1].id.toString(),
+                  'type': 'tags',
+                },
+              ],
+            },
           },
         },
+        'included': [
+          {
+            'attributes': {
+              'id': tags[0].id,
+              'name': tags[0].name,
+            },
+            'id': tags[0].id.toString(),
+            'type': 'tags',
+          },
+          {
+            'attributes': {
+              'id': tags[1].id,
+              'name': tags[1].name,
+            },
+            'id': tags[1].id.toString(),
+            'type': 'tags',
+          },
+        ],
         meta: {
           some: 'meta',
         },


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, dans la page de détails d'une organisation, on ne voit pas les tags associés à cette dernière.

## :robot: Solution
Afficher les tags associés, sous le nom de l'organisation.

## :100: Pour tester
Se connecter sur Pix Admin, aller sur l'organisation Dragon & Co ( `id = 1` ) et vérifier que rien n'est affiché ( orga sans tags )
Aller sur l'orga avec  CFA Agricole ( `id = 8` ), et vérifier que deux tags sont affichés (AGRI et CFA)
