### PR TITLE
[TECH] Compléter la colonne CampaignParticipationId dans les BadgesAcquisitions (PIX-2288).

### DIFF
--- a/api/db/database-builder/factory/build-badge-acquisition.js
+++ b/api/db/database-builder/factory/build-badge-acquisition.js
@@ -5,6 +5,7 @@ module.exports = function buildBadgeAcquisition({
   badgeId,
   userId,
   campaignParticipationId,
+  createdAt,
 } = {}) {
 
   return databaseBuffer.pushInsertable({
@@ -14,6 +15,7 @@ module.exports = function buildBadgeAcquisition({
       badgeId,
       userId,
       campaignParticipationId,
+      createdAt,
     },
   });
 };

--- a/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
+++ b/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
@@ -1,16 +1,18 @@
-const _ = require('lodash');
 const { knex } = require('../db/knex-database-connection');
-const BadgeAcquisitonsRepository = require('../lib/infrastructure/repositories/badge-acquisition-repository');
 
-async function fillCampaignParticipationIdInBadgeAcquisitions() {
+async function getAllBadgeAcquistionsWithoutCampaignParticipation() {
   return knex('badge-acquisitions').select().where({ campaignParticipationId: null });
 }
 
 async function getCampaignParticipationFromBadgeAcquisition(badgeAcquisition) {
   const dateBeforeBadgeAcquisition = new Date(badgeAcquisition.createdAt);
-  dateBeforeBadgeAcquisition.setDate(badgeAcquisition.createdAt.getDate() - 1);
+  dateBeforeBadgeAcquisition.setHours(badgeAcquisition.createdAt.getHours() - 1);
+
+  const dateAfterBadgeAcquisition = new Date(badgeAcquisition.createdAt);
+  dateAfterBadgeAcquisition.setHours(badgeAcquisition.createdAt.getHours() + 1);
 
   const badge = await knex('badges').select('targetProfileId').where({ id: badgeAcquisition.badgeId }).first();
+
   return knex('campaign-participations')
     .select('campaign-participations.id')
     .innerJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
@@ -20,7 +22,16 @@ async function getCampaignParticipationFromBadgeAcquisition(badgeAcquisition) {
       'campaigns.targetProfileId': badge.targetProfileId,
       'assessments.state': 'completed',
     })
-    .whereBetween('assessments.updatedAt', [dateBeforeBadgeAcquisition, badgeAcquisition.createdAt]);
+    .whereBetween('assessments.updatedAt', [dateBeforeBadgeAcquisition, dateAfterBadgeAcquisition]);
+}
+
+async function updateBadgeAcquisitionWithCampaignParticipationId(badgeAcquisition, campaignParticipations) {
+  if (campaignParticipations.length === 1) {
+    const campaignParticipationId = campaignParticipations[0].id;
+    await knex('badge-acquisitions').update({ campaignParticipationId }).where({ id: badgeAcquisition.id });
+    return;
+  }
+  console.log(`ERROR with badgeAcquisition #${badgeAcquisition.id} : campaignParticipations has ${campaignParticipations.length} possibilities.`)
 }
 
 async function main() {
@@ -28,7 +39,7 @@ async function main() {
     console.log('Coucou');
 
     // Récupérer les badges acquisitions sans campaignParticipationid
-    const badgeAcquisitionsWithoutCPI = await fillCampaignParticipationIdInBadgeAcquisitions();
+    const badgeAcquisitionsWithoutCPI = await getAllBadgeAcquistionsWithoutCampaignParticipation();
     // Récupérer pour chacun la campagne qui va bien
 
     // Update chaque ligne avec sa campagne qui va bien
@@ -50,6 +61,7 @@ if (require.main === module) {
 }
 
 module.exports = {
-  fillCampaignParticipationIdInBadgeAcquisitions,
+  getAllBadgeAcquistionsWithoutCampaignParticipation,
   getCampaignParticipationFromBadgeAcquisition,
+  updateBadgeAcquisitionWithCampaignParticipationId
 };

--- a/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
+++ b/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
@@ -3,12 +3,20 @@ const { knex } = require('../db/knex-database-connection');
 const BadgeAcquisitonsRepository = require('../lib/infrastructure/repositories/badge-acquisition-repository');
 
 async function fillCampaignParticipationIdInBadgeAcquisitions() {
-  return knex('badge-acquisitions').select().where({ campaignParticipationId : null });
+  return knex('badge-acquisitions').select().where({ campaignParticipationId: null });
+}
+
+async function getCampaignParticipationFromBadgeAcquisition(badgeAcquisition) {
+  const badge = await knex('badges').select('targetProfileId').where({ id: badgeAcquisition.badgeId }).first();
+  return knex('campaign-participations')
+    .select('campaign-participations.id')
+    .innerJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .where({ 'campaign-participations.userId': badgeAcquisition.userId, 'campaigns.targetProfileId': badge.targetProfileId });
 }
 
 async function main() {
   try {
-    console.log("Coucou")
+    console.log('Coucou');
 
     // Récupérer les badges acquisitions sans campaignParticipationid
     const badgeAcquisitionsWithoutCPI = await fillCampaignParticipationIdInBadgeAcquisitions();
@@ -33,5 +41,6 @@ if (require.main === module) {
 }
 
 module.exports = {
-  fillCampaignParticipationIdInBadgeAcquisitions
-}
+  fillCampaignParticipationIdInBadgeAcquisitions,
+  getCampaignParticipationFromBadgeAcquisition,
+};

--- a/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
+++ b/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
@@ -1,0 +1,37 @@
+const _ = require('lodash');
+const { knex } = require('../db/knex-database-connection');
+const BadgeAcquisitonsRepository = require('../lib/infrastructure/repositories/badge-acquisition-repository');
+
+async function fillCampaignParticipationIdInBadgeAcquisitions() {
+  return knex('badge-acquisitions').select().where({ campaignParticipationId : null });
+}
+
+async function main() {
+  try {
+    console.log("Coucou")
+
+    // Récupérer les badges acquisitions sans campaignParticipationid
+    const badgeAcquisitionsWithoutCPI = await fillCampaignParticipationIdInBadgeAcquisitions();
+    // Récupérer pour chacun la campagne qui va bien
+
+    // Update chaque ligne avec sa campagne qui va bien
+
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}
+
+module.exports = {
+  fillCampaignParticipationIdInBadgeAcquisitions
+}

--- a/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
@@ -1,13 +1,17 @@
-const { expect, databaseBuilder, knex } = require('../../test-helper');
+const { expect, databaseBuilder, knex, sinon } = require('../../test-helper');
 
 const {
   main,
-  getAllBadgeAcquistionsWithoutCampaignParticipation,
+  getAllBadgeAcquistionsWithoutCampaignParticipationId,
   getCampaignParticipationFromBadgeAcquisition,
   updateBadgeAcquisitionWithCampaignParticipationId,
 } = require('../../../scripts/fill-campaign-participation-id-in-badge-acquisitions');
 
 describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions', () => {
+
+  beforeEach(() => {
+    sinon.stub(console, 'log');
+  });
 
   afterEach(() => {
     databaseBuilder.clean();
@@ -45,7 +49,7 @@ describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions
       expect(result[0].campaignParticipationId).to.equal(campaignParticipation.id);
     });
   });
-  describe('#getAllBadgeAcquistionsWithoutCampaignParticipation', () => {
+  describe('#getAllBadgeAcquistionsWithoutCampaignParticipationId', () => {
 
     it('should return badge-acquisitions without campaignParticipationId', async () => {
       // given
@@ -65,7 +69,7 @@ describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions
       await databaseBuilder.commit();
 
       // when
-      const result = await getAllBadgeAcquistionsWithoutCampaignParticipation();
+      const result = await getAllBadgeAcquistionsWithoutCampaignParticipationId();
 
       // then
       expect(result).to.have.lengthOf(1);

--- a/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
@@ -1,0 +1,36 @@
+const { expect, databaseBuilder } = require('../../test-helper');
+
+const {
+  fillCampaignParticipationIdInBadgeAcquisitions,
+} = require('../../../scripts/fill-campaign-participation-id-in-badge-acquisitions');
+
+describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions', () => {
+
+  describe('#fillCampaignParticipationIdInBadgeAcquisitions', () => {
+
+    it('should return badge-acquisitions without campaignParticipationId', async () => {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const badge = databaseBuilder.factory.buildBadge();
+      const badgeAcquisitionWithoutCampaignId = databaseBuilder.factory.buildBadgeAcquisition({
+        userId: user.id,
+        badgeId: badge.id,
+        campaignParticipationId: null
+      });
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+      const badgeAcquisitionWithCampaignId = databaseBuilder.factory.buildBadgeAcquisition({
+        userId: user.id,
+        badgeId: badge.id,
+        campaignParticipationId: campaignParticipation.id
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await fillCampaignParticipationIdInBadgeAcquisitions();
+
+      // then
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].campaignParticipationId).to.equal(null);
+    });
+  });
+});

--- a/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
@@ -43,11 +43,17 @@ describe.only('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisi
         userId: user.id,
         badgeId: badge.id,
         campaignParticipationId: null,
+        createdAt: new Date('2020-01-01'),
       });
       const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         userId: user.id,
+      });
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: campaignParticipation.id,
+        updatedAt: new Date('2020-01-01'),
+        state: 'completed',
       });
       await databaseBuilder.commit();
 
@@ -56,6 +62,59 @@ describe.only('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisi
 
       // then
       expect(result).to.deep.equal([{ id: campaignParticipation.id }]);
+    });
+
+    it('should return only campaignParticipations whose assessment has completed on same date as badge was acquired', async () => {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const badge = databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id });
+      const badgeAcquisitionWithoutCampaignId = databaseBuilder.factory.buildBadgeAcquisition({
+        userId: user.id,
+        badgeId: badge.id,
+        campaignParticipationId: null,
+        createdAt: new Date('2020-01-01'),
+      });
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId: user.id,
+      });
+
+      const secondCampaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      const secondCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: secondCampaign.id,
+        userId: user.id,
+      });
+
+      const thirdCampaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      const thirdCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: thirdCampaign.id,
+        userId: user.id,
+      });
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: campaignParticipation.id,
+        updatedAt: new Date('2020-01-01'),
+        state: 'completed',
+      });
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: secondCampaignParticipation.id,
+        updatedAt: new Date('2020-02-01'),
+        state: 'completed',
+      });
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: thirdCampaignParticipation.id,
+        updatedAt: new Date('2020-01-01'),
+        state: 'started',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await getCampaignParticipationFromBadgeAcquisition(badgeAcquisitionWithoutCampaignId);
+
+      // then
+      expect(result).to.deep.equal([ { id: campaignParticipation.id } ]);
     });
   });
 });

--- a/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
@@ -2,9 +2,10 @@ const { expect, databaseBuilder } = require('../../test-helper');
 
 const {
   fillCampaignParticipationIdInBadgeAcquisitions,
+  getCampaignParticipationFromBadgeAcquisition,
 } = require('../../../scripts/fill-campaign-participation-id-in-badge-acquisitions');
 
-describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions', () => {
+describe.only('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions', () => {
 
   describe('#fillCampaignParticipationIdInBadgeAcquisitions', () => {
 
@@ -12,16 +13,16 @@ describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions
       // given
       const user = databaseBuilder.factory.buildUser();
       const badge = databaseBuilder.factory.buildBadge();
-      const badgeAcquisitionWithoutCampaignId = databaseBuilder.factory.buildBadgeAcquisition({
+      databaseBuilder.factory.buildBadgeAcquisition({
         userId: user.id,
         badgeId: badge.id,
-        campaignParticipationId: null
+        campaignParticipationId: null,
       });
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
-      const badgeAcquisitionWithCampaignId = databaseBuilder.factory.buildBadgeAcquisition({
+      databaseBuilder.factory.buildBadgeAcquisition({
         userId: user.id,
         badgeId: badge.id,
-        campaignParticipationId: campaignParticipation.id
+        campaignParticipationId: campaignParticipation.id,
       });
       await databaseBuilder.commit();
 
@@ -31,6 +32,30 @@ describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions
       // then
       expect(result).to.have.lengthOf(1);
       expect(result[0].campaignParticipationId).to.equal(null);
+    });
+
+    it('should return possible campaignParticipations for one badge', async () => {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const badge = databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id });
+      const badgeAcquisitionWithoutCampaignId = databaseBuilder.factory.buildBadgeAcquisition({
+        userId: user.id,
+        badgeId: badge.id,
+        campaignParticipationId: null,
+      });
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId: user.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await getCampaignParticipationFromBadgeAcquisition(badgeAcquisitionWithoutCampaignId);
+
+      // then
+      expect(result).to.deep.equal([{ id: campaignParticipation.id }]);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La table `badge-acquisitions` a une colonne `campaignParticipationId` qui n'est pas remplit pour les anciennes acquisitions.

## :robot: Solution
Création d'un script permettant de les remplir.

## :rainbow: Remarques
- On affiche un message si on a un doute sur la campaignParticipation à ajouter
- On affiche un message si on n'a pas de campaignParticipation à ajouter (Cléa Num)
- 3 soucis remontés : Les anciens cléa num n'auront pas de CampaignParticipationId, des users ont gagné 2 fois dans la même journées les badges (à faire à la main), 4 cas étranges de gains de badge à analyser

## :100: Pour tester
A tester sur une base de test