### PR TITLE
[INFRA] Ajouter une passe non intrusive de vérification de types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,10 @@ jobs:
           paths:
             - ~/.npm
       - run:
-          name: Lint and test
+          name: Lint, typecheck and test
           command: |
             npm run lint
+            npm run typecheck
             npm test
           environment:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci

--- a/api/.depcheckrc
+++ b/api/.depcheckrc
@@ -1,4 +1,4 @@
-ignores: ["bookshelf-validate", "mocha-junit-reporter", "eslint-plugin-mocha", "@types/node",]
+ignores: ["bookshelf-validate", "mocha-junit-reporter", "eslint-plugin-mocha", "@types/node", "@types/bookshelf",]
 
 # "bookshelf-validate" is used in ./lib/infrastructure/bookshelf.js
 # code => bookshelf.plugin('bookshelf-validate',
@@ -12,4 +12,5 @@ ignores: ["bookshelf-validate", "mocha-junit-reporter", "eslint-plugin-mocha", "
 # code =>  plugins: - mocha
 # see https://github.com/lo1tuma/eslint-plugin-mocha#install-and-configure
 
+# "@types/bookshelf" is used by typechecker
 # "@types/node" is used by typechecker

--- a/api/.depcheckrc
+++ b/api/.depcheckrc
@@ -1,4 +1,4 @@
-ignores: ["bookshelf-validate", "mocha-junit-reporter", "eslint-plugin-mocha"]
+ignores: ["bookshelf-validate", "mocha-junit-reporter", "eslint-plugin-mocha", "@types/node",]
 
 # "bookshelf-validate" is used in ./lib/infrastructure/bookshelf.js
 # code => bookshelf.plugin('bookshelf-validate',
@@ -11,3 +11,5 @@ ignores: ["bookshelf-validate", "mocha-junit-reporter", "eslint-plugin-mocha"]
 # "eslint-plugin-mocha" is used in ../.eslintrc.yaml
 # code =>  plugins: - mocha
 # see https://github.com/lo1tuma/eslint-plugin-mocha#install-and-configure
+
+# "@types/node" is used by typechecker

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const settings = require('../config');
 
 const PIX_COUNT_BY_LEVEL = 8;

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -1,10 +1,17 @@
+// @ts-check
+
 const _ = require('lodash');
+
+/** @typedef {import('./CertificationCandidate')} CertificationCandidate */
 
 const CREATED = 'created';
 const FINALIZED = 'finalized';
 const IN_PROCESS = 'in_process';
 const PROCESSED = 'processed';
 
+/**
+ * @enum {string}
+ */
 const statuses = {
   CREATED,
   FINALIZED,
@@ -15,6 +22,25 @@ const statuses = {
 const NO_EXAMINER_GLOBAL_COMMENT = null;
 
 class Session {
+  /**
+   * @param {Object} obj
+   * @param {number} [obj.id]
+   * @param {string} [obj.accessCode]
+   * @param {string} [obj.address]
+   * @param {string} [obj.certificationCenter]
+   * @param {string} [obj.date]
+   * @param {string} [obj.description]
+   * @param {string} [obj.examiner]
+   * @param {string} [obj.room]
+   * @param {string} [obj.time]
+   * @param {string | null} [obj.examinerGlobalComment]
+   * @param {Date | null} [obj.finalizedAt]
+   * @param {Date | null} [obj.resultsSentToPrescriberAt]
+   * @param {Date | null} [obj.publishedAt]
+   * @param {CertificationCandidate[]} [obj.certificationCandidates]
+   * @param {number} [obj.certificationCenterId]
+   * @param {number | null} [obj.assignedCertificationOfficerId]
+   */
   constructor({
     id,
     accessCode,
@@ -51,10 +77,12 @@ class Session {
     this.assignedCertificationOfficerId = assignedCertificationOfficerId;
   }
 
+  /** @returns {Boolean} */
   areResultsFlaggedAsSent() {
     return !_.isNil(this.resultsSentToPrescriberAt);
   }
 
+  /** @returns {statuses} */
   get status() {
     if (this.publishedAt) {
       return statuses.PROCESSED;
@@ -68,6 +96,7 @@ class Session {
     return statuses.CREATED;
   }
 
+  /** @returns {Boolean} */
   isPublished() {
     return this.publishedAt !== null;
   }

--- a/api/lib/domain/models/SessionRepository.js
+++ b/api/lib/domain/models/SessionRepository.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+const { NotImplementedError } = require('../errors');
+
+/** @typedef {import('./Session')} Session */
+
+/** @interface */
+class SessionRepository {
+  /**
+   * @param {number} _sessionId
+   *
+   * @returns {Promise<Session>}
+   */
+  async get(_sessionId) {
+    throw new NotImplementedError();
+  }
+}
+
+module.exports = SessionRepository;

--- a/api/lib/domain/services/session-authorization-service.js
+++ b/api/lib/domain/services/session-authorization-service.js
@@ -1,4 +1,4 @@
-const sessionRepository = require('../../infrastructure/repositories/session-repository');
+const sessionRepository = require('../../infrastructure/repositories/session-sql-repository');
 const userRepository = require('../../infrastructure/repositories/user-repository');
 
 module.exports = {

--- a/api/lib/domain/services/session-code-service.js
+++ b/api/lib/domain/services/session-code-service.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const sessionRepository = require('../../infrastructure/repositories/session-repository');
+const sessionRepository = require('../../infrastructure/repositories/session-sql-repository');
 
 function _randomLetter() {
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXZ'.split('');

--- a/api/lib/domain/usecases/get-session.js
+++ b/api/lib/domain/usecases/get-session.js
@@ -1,3 +1,15 @@
+// @ts-check
+
+/** @typedef {import('../models/SessionRepository')} SessionRepository */
+/** @typedef {import('../../domain/models/Session')} Session */
+
+/**
+ * @param {Object} obj
+ * @param {number} obj.sessionId
+ * @param {SessionRepository} obj.sessionRepository
+ *
+ * @returns {Promise<Session>}
+ */
 module.exports = function getSession({ sessionId, sessionRepository }) {
   return sessionRepository.get(sessionId);
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -96,7 +96,7 @@ const dependencies = {
   scoringCertificationService: require('../../domain/services/scoring/scoring-certification-service'),
   sessionAuthorizationService: require('../../domain/services/session-authorization-service'),
   sessionPublicationService: require('../../domain/services/session-publication-service'),
-  sessionRepository: require('../../infrastructure/repositories/session-repository'),
+  sessionRepository: require('../../infrastructure/repositories/session-sql-repository'),
   sessionSummaryRepository: require('../../infrastructure/repositories/session-summary-repository'),
   settings: require('../../config'),
   shareableCertificateRepository: require('../../infrastructure/repositories/shareable-certificate-repository'),

--- a/api/lib/infrastructure/repositories/session-sql-repository.js
+++ b/api/lib/infrastructure/repositories/session-sql-repository.js
@@ -20,17 +20,15 @@ class SessionSQLRepository {
   }
 
   async isSessionCodeAvailable(accessCode) {
-    const sessionWithAccessCode = await BookshelfSession
-      .where({ accessCode })
+    const sessionWithAccessCode = await new BookshelfSession({ accessCode })
       .fetch({ require: false });
 
     return !sessionWithAccessCode;
   }
 
   async isFinalized(id) {
-    const session = await BookshelfSession
+    const session = await new BookshelfSession({ id })
       .query((qb) => {
-        qb.where({ id });
         qb.whereRaw('?? IS NOT NULL', ['finalizedAt']);
       })
       .fetch({ require: false, columns: 'id' });

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1163,10 +1163,16 @@
       "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
+      "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+      "dev": true
+    },
     "@types/node": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
-      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
+      "version": "14.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
+      "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -8258,6 +8264,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.13.8",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1152,10 +1152,83 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
+    "@types/bluebird": {
+      "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
+      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
+      "dev": true
+    },
+    "@types/bookshelf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/bookshelf/-/bookshelf-1.2.3.tgz",
+      "integrity": "sha512-uQEGn0qzty+45L42VLh7Ze1GuTvlZNOORbBjTY7+0cfFJqKbPXph/tSznFboqOkALLMZfwta+t9CWAAAd0nHag==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/create-error": "*",
+        "@types/lodash": "*",
+        "knex": "^0.21.12"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "knex": {
+          "version": "0.21.21",
+          "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.21.tgz",
+          "integrity": "sha512-cjw5qO1EzVKjbywcVa61IQJMLt7PfYBRI/2NwCA/B9beXgbw652wDNLz+JM+UKKNsfwprq0ugYqBYc9q4JN36A==",
+          "dev": true,
+          "requires": {
+            "colorette": "1.2.1",
+            "commander": "^6.2.0",
+            "debug": "4.3.1",
+            "esm": "^3.2.25",
+            "getopts": "2.2.5",
+            "interpret": "^2.2.0",
+            "liftoff": "3.1.0",
+            "lodash": "^4.17.20",
+            "pg-connection-string": "2.4.0",
+            "tarn": "^3.0.1",
+            "tildify": "2.0.0",
+            "v8flags": "^3.2.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@types/create-error": {
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@types/create-error/-/create-error-0.3.30.tgz",
+      "integrity": "sha1-3GkqKwpdcNhdvwH+8vbUEjIlXfM=",
+      "dev": true
+    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+    },
+    "@types/lodash": {
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.4",
@@ -1164,15 +1237,15 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
-      "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
-      "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw=="
+      "version": "14.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.14.tgz",
+      "integrity": "sha512-rsAj2u8Xkqfc332iXV12SqIsjVi07H479bOP4q94NAcjzmAvapumEhuVIt53koEf7JFrpjgNKjBga5Pnn/GL8A=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -1548,10 +1621,40 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-differ": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
       "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+      "dev": true
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
       "dev": true
     },
     "array-union": {
@@ -1564,6 +1667,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
       "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0="
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
     },
     "arrify": {
       "version": "2.0.1",
@@ -1587,6 +1696,12 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -1597,6 +1712,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "auto-bind": {
       "version": "4.0.0",
@@ -1626,6 +1747,61 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "base64-js": {
       "version": "1.5.1",
@@ -1912,6 +2088,35 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -1946,6 +2151,23 @@
         "moment": "^2.19.3",
         "mv": "~2",
         "safe-json-stringify": "~1"
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "cacheable-request": {
@@ -2148,6 +2370,29 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -2343,6 +2588,16 @@
         }
       }
     },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
     "color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
@@ -2461,6 +2716,12 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
@@ -2566,6 +2827,12 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -2626,6 +2893,47 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -2911,6 +3219,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
       "integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "detect-libc": {
@@ -3548,15 +3862,145 @@
       "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
       "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -3610,6 +4054,29 @@
         "token-types": "^2.0.0"
       }
     },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -3630,6 +4097,37 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "findup-sync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
+      }
+    },
+    "fined": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
+      }
+    },
+    "flagged-respawn": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+      "dev": true
     },
     "flat": {
       "version": "5.0.2",
@@ -3657,6 +4155,21 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
       "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -3709,6 +4222,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
       "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
     },
     "fromentries": {
       "version": "1.2.1",
@@ -3821,6 +4343,12 @@
         }
       }
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "getopts": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
@@ -3876,6 +4404,41 @@
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
           "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
           "dev": true
+        }
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -4004,6 +4567,38 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "has-yarn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
@@ -4036,6 +4631,15 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -4422,6 +5026,36 @@
       "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4460,6 +5094,51 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -4500,6 +5179,26 @@
       "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
       "dev": true
     },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -4518,6 +5217,24 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -4528,6 +5245,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -4550,6 +5276,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
@@ -4996,6 +5728,12 @@
         "json-buffer": "3.0.0"
       }
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
     "knex": {
       "version": "0.95.6",
       "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.6.tgz",
@@ -5066,6 +5804,33 @@
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "requires": {
         "immediate": "~3.0.5"
+      }
+    },
+    "liftoff": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+      "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "findup-sync": "^3.0.0",
+        "fined": "^1.0.1",
+        "flagged-respawn": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.0",
+        "rechoir": "^0.6.2",
+        "resolve": "^1.1.7"
+      },
+      "dependencies": {
+        "rechoir": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        }
       }
     },
     "lines-and-columns": {
@@ -5312,10 +6077,34 @@
         }
       }
     },
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
     "make-plural": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
       "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA=="
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
     },
     "math-interval-parser": {
       "version": "2.0.1",
@@ -5376,6 +6165,27 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -5442,6 +6252,27 @@
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "mkdirp": {
@@ -5756,9 +6587,9 @@
       }
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
       "optional": true
     },
     "nanoid": {
@@ -5766,6 +6597,25 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
       "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
       "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -6209,11 +7059,82 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "object-hash": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
       "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
+      "requires": {
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -6365,6 +7286,17 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -6376,6 +7308,18 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
     },
     "patch-console": {
       "version": "1.0.0",
@@ -6404,6 +7348,21 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -6548,6 +7507,12 @@
       "requires": {
         "irregular-plurals": "^1.0.0"
       }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "postcss": {
       "version": "8.2.15",
@@ -7005,6 +7970,16 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -7037,6 +8012,18 @@
       "requires": {
         "es6-error": "^4.0.1"
       }
+    },
+    "repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.88.2",
@@ -7159,10 +8146,26 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "responselike": {
@@ -7183,6 +8186,12 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
@@ -7217,6 +8226,15 @@
       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "optional": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -7348,6 +8366,29 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "sharp": {
       "version": "0.28.3",
@@ -7566,10 +8607,142 @@
         }
       }
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
     },
     "sourcemap-codec": {
       "version": "1.4.8",
@@ -7623,6 +8796,15 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
       }
     },
     "split2": {
@@ -7701,6 +8883,27 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
+        }
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
         }
       }
     },
@@ -8166,11 +9369,53 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
     },
     "token-types": {
       "version": "2.1.1",
@@ -8266,16 +9511,22 @@
       }
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
-      "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
+      "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
       "optional": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
     },
     "undefsafe": {
       "version": "2.0.3",
@@ -8292,6 +9543,18 @@
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -8299,6 +9562,46 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
       }
     },
     "update-notifier": {
@@ -8388,6 +9691,12 @@
         }
       }
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -8396,6 +9705,12 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -8412,6 +9727,15 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "v8flags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
     },
     "validator": {
       "version": "13.6.0",

--- a/api/package.json
+++ b/api/package.json
@@ -80,6 +80,8 @@
   },
   "devDependencies": {
     "@ls-lint/ls-lint": "^1.9.2",
+    "@types/mocha": "^8.2.2",
+    "@types/node": "^14.14.41",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "chai-sorted": "^0.2.0",
@@ -96,7 +98,8 @@
     "nyc": "^15.1.0",
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
-    "stream-to-promise": "^3.0.0"
+    "stream-to-promise": "^3.0.0",
+    "typescript": "^4.2.4"
   },
   "scripts": {
     "clean": "rm -rf node_modules",
@@ -119,6 +122,7 @@
     "lint:code": "eslint .",
     "lint:fix": "eslint --fix .",
     "lint:json": "eslint --fix --ext .json translations/",
+    "typecheck": "tsc --project tsconfig.json",
     "postdeploy": "npm run db:migrate",
     "preinstall": "npx check-engine",
     "scalingo-background-job": "node scripts/reload-cache-everyday.js",

--- a/api/package.json
+++ b/api/package.json
@@ -80,6 +80,7 @@
   },
   "devDependencies": {
     "@ls-lint/ls-lint": "^1.9.2",
+    "@types/bookshelf": "^1.2.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.14.41",
     "chai": "^4.3.4",

--- a/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
+++ b/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
@@ -2,7 +2,7 @@ const { unlink, writeFile } = require('fs').promises;
 const _ = require('lodash');
 const { expect, databaseBuilder } = require('../../../../test-helper');
 const readOdsUtils = require('../../../../../lib/infrastructure/utils/ods/read-ods-utils');
-const sessionRepository = require('../../../../../lib/infrastructure/repositories/session-repository');
+const sessionRepository = require('../../../../../lib/infrastructure/repositories/session-sql-repository');
 const getAttendanceSheet = require('../../../../../lib/domain/usecases/get-attendance-sheet');
 
 describe('Integration | UseCases | getAttendanceSheet', function() {

--- a/api/tests/integration/infrastructure/repositories/session-sql-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-sql-repository_test.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const Session = require('../../../../lib/domain/models/Session');
 const { statuses } = require('../../../../lib/domain/models/Session');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');
+const sessionSQLRepository = require('../../../../lib/infrastructure/repositories/session-sql-repository');
 
 describe('Integration | Repository | Session', function() {
 
@@ -32,7 +32,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should persist the session in db', async function() {
       // when
-      await sessionRepository.save(session);
+      await sessionSQLRepository.save(session);
 
       // then
       const sessionSaved = await knex('sessions').select();
@@ -41,7 +41,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return the saved Session', async function() {
       // when
-      const savedSession = await sessionRepository.save(session);
+      const savedSession = await sessionSQLRepository.save(session);
 
       // then
       expect(savedSession).to.be.an.instanceOf(Session);
@@ -73,7 +73,7 @@ describe('Integration | Repository | Session', function() {
       const accessCode = 'DEF123';
 
       // when
-      const isAvailable = await sessionRepository.isSessionCodeAvailable(accessCode);
+      const isAvailable = await sessionSQLRepository.isSessionCodeAvailable(accessCode);
 
       // then
       expect(isAvailable).to.be.equal(true);
@@ -84,7 +84,7 @@ describe('Integration | Repository | Session', function() {
       const accessCode = 'ABC123';
 
       // when
-      const isAvailable = await sessionRepository.isSessionCodeAvailable(accessCode);
+      const isAvailable = await sessionSQLRepository.isSessionCodeAvailable(accessCode);
 
       // then
       expect(isAvailable).to.be.equal(false);
@@ -105,7 +105,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return true if the session status is finalized', async function() {
       // when
-      const isFinalized = await sessionRepository.isFinalized(finalizedSessionId);
+      const isFinalized = await sessionSQLRepository.isFinalized(finalizedSessionId);
 
       // then
       expect(isFinalized).to.be.equal(true);
@@ -113,7 +113,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return false if the session status is not finalized', async function() {
       // when
-      const isFinalized = await sessionRepository.isFinalized(notFinalizedSessionId);
+      const isFinalized = await sessionSQLRepository.isFinalized(notFinalizedSessionId);
 
       // then
       expect(isFinalized).to.be.equal(false);
@@ -152,7 +152,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return session informations in a session Object', async function() {
       // when
-      const actualSession = await sessionRepository.get(session.id);
+      const actualSession = await sessionSQLRepository.get(session.id);
 
       // then
       expect(actualSession).to.be.instanceOf(Session);
@@ -161,7 +161,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return a Not found error when no session was found', async function() {
       // when
-      const error = await catchErr(sessionRepository.get)(2);
+      const error = await catchErr(sessionSQLRepository.get)(2);
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
@@ -204,7 +204,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return session informations in a session Object', async function() {
       // when
-      const actualSession = await sessionRepository.getWithCertificationCandidates(session.id);
+      const actualSession = await sessionSQLRepository.getWithCertificationCandidates(session.id);
 
       // then
       expect(actualSession).to.be.instanceOf(Session);
@@ -213,7 +213,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return associated certifications candidates ordered by lastname and firstname', async function() {
       // when
-      const actualSession = await sessionRepository.getWithCertificationCandidates(session.id);
+      const actualSession = await sessionSQLRepository.getWithCertificationCandidates(session.id);
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) => _.pick(item, ['sessionId', 'lastName', 'firstName']));
@@ -226,7 +226,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return a Not found error when no session was found', async function() {
       // when
-      const error = await catchErr(sessionRepository.get)(session.id + 1);
+      const error = await catchErr(sessionSQLRepository.get)(session.id + 1);
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
@@ -252,7 +252,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return a Session domain object', async function() {
       // when
-      const sessionSaved = await sessionRepository.updateSessionInfo(session);
+      const sessionSaved = await sessionSQLRepository.updateSessionInfo(session);
 
       // then
       expect(sessionSaved).to.be.an.instanceof(Session);
@@ -262,7 +262,7 @@ describe('Integration | Repository | Session', function() {
       // given
 
       // when
-      const sessionSaved = await sessionRepository.updateSessionInfo(session);
+      const sessionSaved = await sessionSQLRepository.updateSessionInfo(session);
 
       // then
       expect(sessionSaved.id).to.equal(session.id);
@@ -298,7 +298,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return true if user has membership in the certification center that originated the session', async function() {
       // when
-      const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
+      const hasMembership = await sessionSQLRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
 
       // then
       expect(hasMembership).to.be.true;
@@ -306,7 +306,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return false if user has no membership in the certification center that originated the session', async function() {
       // when
-      const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userIdNotAllowed, sessionId);
+      const hasMembership = await sessionSQLRepository.doesUserHaveCertificationCenterMembershipForSession(userIdNotAllowed, sessionId);
 
       // then
       expect(hasMembership).to.be.false;
@@ -327,7 +327,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return an updated Session domain object', async function() {
       // when
-      const sessionSaved = await sessionRepository.finalize({ id, examinerGlobalComment, finalizedAt });
+      const sessionSaved = await sessionSQLRepository.finalize({ id, examinerGlobalComment, finalizedAt });
 
       // then
       expect(sessionSaved).to.be.an.instanceof(Session);
@@ -349,7 +349,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return a flagged Session domain object', async function() {
       // when
-      const sessionFlagged = await sessionRepository.flagResultsAsSentToPrescriber({ id, resultsSentToPrescriberAt });
+      const sessionFlagged = await sessionSQLRepository.flagResultsAsSentToPrescriber({ id, resultsSentToPrescriberAt });
 
       // then
       expect(sessionFlagged).to.be.an.instanceof(Session);
@@ -370,7 +370,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return a updated Session domain object', async function() {
       // when
-      const sessionFlagged = await sessionRepository.updatePublishedAt({ id, publishedAt });
+      const sessionFlagged = await sessionSQLRepository.updatePublishedAt({ id, publishedAt });
 
       // then
       expect(sessionFlagged).to.be.an.instanceof(Session);

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -1,11 +1,36 @@
+// ts-check
+
 const Session = require('../../../../lib/domain/models/Session');
 
+/** @typedef {import('../../../../lib/domain/models/CertificationCandidate')} CertificationCandidate */
+
+/**
+ * @param {Object} obj
+ * @param {number} [obj.id]
+ * @param {string} [obj.accessCode]
+ * @param {string} [obj.address]
+ * @param {string} [obj.certificationCenter]
+ * @param {number} [obj.certificationCenterId]
+ * @param {string} [obj.date]
+ * @param {string} [obj.description]
+ * @param {string} [obj.examiner]
+ * @param {string} [obj.room]
+ * @param {string} [obj.time]
+ * @param {string | null} [obj.examinerGlobalComment]
+ * @param {Date | null} [obj.finalizedAt]
+ * @param {Date | null} [obj.resultsSentToPrescriberAt]
+ * @param {Date | null} [obj.publishedAt]
+ * @param {number | null} [obj.assignedCertificationOfficerId]
+ * @param {CertificationCandidate[]} [obj.certificationCandidates]
+ *
+ * @returns {Session}
+ */
 const buildSession = function({
   id = 123,
   accessCode = 'ABCD123',
   address = '4 avenue du général perlimpimpim',
   certificationCenter = 'Centre de certif pix',
-  certificationCenterId,
+  certificationCenterId = 1234,
   date = '2021-01-01',
   description = 'Bonne année',
   examiner = 'Flute',
@@ -15,7 +40,7 @@ const buildSession = function({
   finalizedAt = null,
   resultsSentToPrescriberAt = null,
   publishedAt = null,
-  assignedCertificationOfficerId,
+  assignedCertificationOfficerId = null,
   certificationCandidates = [],
 } = {}) {
   return new Session({
@@ -38,6 +63,27 @@ const buildSession = function({
   });
 };
 
+/**
+ * @param {Object} obj
+ * @param {number} [obj.id]
+ * @param {string} [obj.accessCode]
+ * @param {string} [obj.address]
+ * @param {string} [obj.certificationCenter]
+ * @param {number} [obj.certificationCenterId]
+ * @param {string} [obj.date]
+ * @param {string} [obj.description]
+ * @param {string} [obj.examiner]
+ * @param {string} [obj.room]
+ * @param {string} [obj.time]
+ * @param {string} [obj.examinerGlobalComment]
+ * @param {Date | null} [obj.finalizedAt]
+ * @param {Date | null} [obj.resultsSentToPrescriberAt]
+ * @param {Date | null} [obj.publishedAt]
+ * @param {number | null} [obj.assignedCertificationOfficerId]
+ * @param {CertificationCandidate[]} [obj.certificationCandidates]
+ *
+ * @returns {Session}
+ */
 buildSession.created = function({
   id,
   accessCode,
@@ -63,7 +109,7 @@ buildSession.created = function({
     room,
     time,
     certificationCandidates,
-    examinerGlobalComment: null,
+    examinerGlobalComment: Session.NO_EXAMINER_GLOBAL_COMMENT,
     finalizedAt: null,
     resultsSentToPrescriberAt: null,
     publishedAt: null,
@@ -71,6 +117,22 @@ buildSession.created = function({
   });
 };
 
+/**
+ * @param {Object} obj
+ * @param {number} [obj.id]
+ * @param {string} [obj.accessCode]
+ * @param {string} [obj.address]
+ * @param {string} [obj.certificationCenter]
+ * @param {number} [obj.certificationCenterId]
+ * @param {string} [obj.date]
+ * @param {string} [obj.description]
+ * @param {string} [obj.examiner]
+ * @param {string} [obj.room]
+ * @param {string} [obj.time]
+ * @param {CertificationCandidate[]} [obj.certificationCandidates]
+ *
+ * @returns {Session}
+ */
 buildSession.finalized = function({
   id,
   accessCode,
@@ -96,7 +158,7 @@ buildSession.finalized = function({
     room,
     time,
     certificationCandidates,
-    examinerGlobalComment: null,
+    examinerGlobalComment: Session.NO_EXAMINER_GLOBAL_COMMENT,
     finalizedAt: new Date('2020-01-01'),
     resultsSentToPrescriberAt: null,
     publishedAt: null,
@@ -104,6 +166,22 @@ buildSession.finalized = function({
   });
 };
 
+/**
+ * @param {Object} obj
+ * @param {number} [obj.id]
+ * @param {string} [obj.accessCode]
+ * @param {string} [obj.address]
+ * @param {string} [obj.certificationCenter]
+ * @param {number} [obj.certificationCenterId]
+ * @param {string} [obj.date]
+ * @param {string} [obj.description]
+ * @param {string} [obj.examiner]
+ * @param {string} [obj.room]
+ * @param {string} [obj.time]
+ * @param {CertificationCandidate[]} [obj.certificationCandidates]
+ *
+ * @returns {Session}
+ */
 buildSession.inProcess = function({
   id,
   accessCode,
@@ -129,7 +207,7 @@ buildSession.inProcess = function({
     room,
     time,
     certificationCandidates,
-    examinerGlobalComment: null,
+    examinerGlobalComment: Session.NO_EXAMINER_GLOBAL_COMMENT,
     finalizedAt: new Date('2020-01-01'),
     resultsSentToPrescriberAt: null,
     publishedAt: null,
@@ -137,6 +215,22 @@ buildSession.inProcess = function({
   });
 };
 
+/**
+ * @param {Object} obj
+ * @param {number} [obj.id]
+ * @param {string} [obj.accessCode]
+ * @param {string} [obj.address]
+ * @param {string} [obj.certificationCenter]
+ * @param {number} [obj.certificationCenterId]
+ * @param {string} [obj.date]
+ * @param {string} [obj.description]
+ * @param {string} [obj.examiner]
+ * @param {string} [obj.room]
+ * @param {string} [obj.time]
+ * @param {CertificationCandidate[]} [obj.certificationCandidates]
+ *
+ * @returns {Session}
+ */
 buildSession.processed = function({
   id,
   accessCode,
@@ -162,7 +256,7 @@ buildSession.processed = function({
     room,
     time,
     certificationCandidates,
-    examinerGlobalComment: null,
+    examinerGlobalComment: Session.NO_EXAMINER_GLOBAL_COMMENT,
     finalizedAt: new Date('2020-01-01'),
     resultsSentToPrescriberAt: new Date('2020-01-02'),
     publishedAt: new Date('2020-01-02'),

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const Session = require('../../../../lib/domain/models/Session');
 const { expect } = require('../../../test-helper');
 const _ = require('lodash');
@@ -27,7 +29,7 @@ describe('Unit | Domain | Models | Session', function() {
 
   beforeEach(function() {
     session = new Session({
-      id: 'id',
+      id: 1234,
       accessCode: '',
       address: '',
       certificationCenter: '',
@@ -37,14 +39,12 @@ describe('Unit | Domain | Models | Session', function() {
       room: '',
       time: '',
       examinerGlobalComment: '',
-      finalizedAt: '',
-      resultsSentToPrescriberAt: '',
-      publishedAt: '',
-      // includes
+      finalizedAt: null,
+      resultsSentToPrescriberAt: null,
+      publishedAt: null,
       certificationCandidates: [],
-      // references
-      certificationCenterId: '',
-      assignedCertificationOfficerId: '',
+      certificationCenterId: 2345,
+      assignedCertificationOfficerId: null,
     });
   });
 

--- a/api/tests/unit/domain/services/session-authorization-service_test.js
+++ b/api/tests/unit/domain/services/session-authorization-service_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon } = require('../../../test-helper');
 const sessionAuthorizationService = require('../../../../lib/domain/services/session-authorization-service');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');
+const sessionSQLRepository = require('../../../../lib/infrastructure/repositories/session-sql-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | Service | SessionAuthorizationService', function() {
@@ -15,14 +15,14 @@ describe('Unit | Service | SessionAuthorizationService', function() {
 
     beforeEach(function() {
       sinon.stub(userRepository, 'isPixMaster');
-      sinon.stub(sessionRepository, 'doesUserHaveCertificationCenterMembershipForSession');
+      sinon.stub(sessionSQLRepository, 'doesUserHaveCertificationCenterMembershipForSession');
     });
 
     context('when user has membership for session', function() {
 
       it('should return', async function() {
         // given
-        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, sessionId).returns(true);
+        sessionSQLRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, sessionId).returns(true);
 
         // when
         const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });
@@ -35,7 +35,7 @@ describe('Unit | Service | SessionAuthorizationService', function() {
     context('when user has no membership for session', function() {
 
       beforeEach(function() {
-        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, sessionId).returns(false);
+        sessionSQLRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, sessionId).returns(false);
       });
 
       context('when user is PixMaster', function() {

--- a/api/tests/unit/domain/services/session-code-service_test.js
+++ b/api/tests/unit/domain/services/session-code-service_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon } = require('../../../test-helper');
 const sessionCodeService = require('../../../../lib/domain/services/session-code-service');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');
+const sessionSQLRepository = require('../../../../lib/infrastructure/repositories/session-sql-repository');
 const _ = require('lodash');
 
 describe('Unit | Service | CodeSession', function() {
@@ -9,7 +9,7 @@ describe('Unit | Service | CodeSession', function() {
 
     it('should return a session code with 4 random capital letters and 2 random numbers', async function() {
       // given
-      sinon.stub(sessionRepository, 'isSessionCodeAvailable').resolves(true);
+      sinon.stub(sessionSQLRepository, 'isSessionCodeAvailable').resolves(true);
 
       // when
       const result = await sessionCodeService.getNewSessionCode();
@@ -20,7 +20,7 @@ describe('Unit | Service | CodeSession', function() {
 
     it('should return a new code if first code was not unique', async function() {
       // given
-      sinon.stub(sessionRepository, 'isSessionCodeAvailable')
+      sinon.stub(sessionSQLRepository, 'isSessionCodeAvailable')
         .onCall(0).resolves(false)
         .onCall(1).resolves(true);
       sinon.stub(_, 'sample')

--- a/api/tests/unit/domain/usecases/get-session_test.js
+++ b/api/tests/unit/domain/usecases/get-session_test.js
@@ -1,25 +1,28 @@
+// @ts-check
+
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const getSession = require('../../../../lib/domain/usecases/get-session');
 const { NotFoundError } = require('../../../../lib/domain/errors');
+const Session = require('../../../../lib/domain/models/Session');
+const SessionRepository = require('../../../../lib/domain/models/SessionRepository');
 
 describe('Unit | UseCase | get-session', function() {
 
-  const sessionId = 'sessionId';
+  const sessionId = 123;
+  /** @type {SessionRepository} */
   let sessionRepository;
 
   beforeEach(function() {
-    sessionRepository = {
-      get: sinon.stub(),
-    };
+    sessionRepository = new SessionRepository();
   });
 
   context('when the session exists', function() {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line mocha/no-setup-in-describe
-    const sessionToFind = Symbol('sessionToFind');
+    const sessionToFind = new Session({ id: sessionId });
 
     beforeEach(function() {
-      sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
+      sinon.stub(sessionRepository, 'get').withArgs(sessionId).resolves(sessionToFind);
     });
 
     it('should get the session', async function() {
@@ -34,7 +37,7 @@ describe('Unit | UseCase | get-session', function() {
   context('when the session does not exist', function() {
 
     beforeEach(function() {
-      sessionRepository.get.withArgs(sessionId).rejects(new NotFoundError());
+      sinon.stub(sessionRepository, 'get').rejects(new NotFoundError());
     });
 
     it('should throw an error the session', async function() {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,17 @@
+ {
+   "compilerOptions": {
+       "allowJs": true,
+       "module": "commonjs",
+       "noEmit": true,
+       "skipLibCheck": true,
+       "strictNullChecks": true,
+       "target": "es2020"
+     },
+   "exclude": [
+       "node_modules"
+     ],
+   "compileOnSave": true,
+   "typingOptions": {
+       "enableAutoDiscovery": true
+     }
+ }

--- a/docs/adr/0004-traitement-type-date-sans-horaire-dans-pix.md
+++ b/docs/adr/0004-traitement-type-date-sans-horaire-dans-pix.md
@@ -45,7 +45,7 @@ Exemple de résultats dans les tests en local avant mise en application des reco
       -[Date: 2018-02-22T23:00:00.000Z]
       +[Date: 2018-02-23T00:00:00.000Z]
 
-      at Context.it.only (tests/integration/infrastructure/repositories/session-repository_test.js:193:37)
+      at Context.it.only (tests/integration/infrastructure/repositories/session-sql-repository_test.js:193:37)
 ```
 
 ## Décision


### PR DESCRIPTION
## :unicorn: Problème

Dans la base de code il est parfois difficile de tracer les types des arguments de fonction, qui peuvent venir de plusieurs appels de fonction supérieures.

Également, dans nos IDEs certains refactorings automatisés sont limités car ils n'arrivent pas bien à interpréter les types des variables.

Autre point, JavaScript ne nous permet pas de définir d'interface, pour nos repositories par exemple, ce qui fait que des règles comme "le domaine ne dépend pas du code extérieur au domaine" sont difficiles à voir.

## :robot: Solution

Ajouter une vérification de types non intrusive et progressive sur une partie du projet api.

On resterait en JS pur de bout en bout, mais on profiterait de la vérification de types de TypeScript dans l’IDE et en CI sur une partie du projet api.

Note : cette expérimentation se limite pour l'instant à du code géré par l'équipe certif, afin de ne pas trop diluer l'expérience et en limiter l'impact dans un premier temps.

## :rainbow: Remarques

Cette PR sert à évaluer l'intérêt d'une vérification de types dans le contexte de Pix, elle sert à recueillir les conversations sur ce sujet, et à concrétiser l'expérimentation sous forme de code. Si l'expérimentation est concluante, cette PR pourrait être mergée.

La première expérimentation hors projet est documentée ici :

- https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2603221009/2021-04-15+Plan+pour+ajouter+progressivement+de+la+v+rification+de+types+non+intrusive+dans+api+lib+domain
