### PR TITLE
[BUGFIX] L'affichage du score dans la page de détails d'une certification sur PixAdmin pouvait être erroné (PIX-2507)

### DIFF
--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -23,19 +23,26 @@ module.exports = {
   },
 
   async findByCertificationCourseId(certificationCourseId) {
-    const competenceMarks = await knex('competence-marks')
+    const competenceMarks = await knex
       .select(
         'competence-marks.id',
-        'area_code',
-        'competence_code',
+        'competence-marks.area_code',
+        'competence-marks.competence_code',
         'competence-marks.competenceId',
         'competence-marks.level',
         'competence-marks.score',
         'competence-marks.assessmentResultId',
       )
-      .join('assessment-results', 'assessmentResultId', 'assessment-results.id')
-      .join('assessments', 'assessmentId', 'assessments.id')
-      .where({ certificationCourseId });
+      .from('assessments')
+      .join('assessment-results', 'assessments.id', 'assessment-results.assessmentId')
+      .leftJoin({ 'latest-assessment-results': 'assessment-results' }, function() {
+        this.on('assessments.id', 'latest-assessment-results.assessmentId')
+          .andOn('assessment-results.createdAt', '<', 'latest-assessment-results.createdAt');
+      })
+      .join('competence-marks', 'assessment-results.id', 'competence-marks.assessmentResultId')
+      .whereNull('latest-assessment-results.id')
+      .where('assessments.certificationCourseId', certificationCourseId)
+      .orderBy('competence-marks.id');
 
     return competenceMarks.map(_toDomain);
   },

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -87,19 +87,67 @@ describe('Integration | Repository | CompetenceMark', () => {
 
   describe('#findByCertificationCourseId', () => {
 
-    it('should return all competence-marks for one certificationCourseId', async () => {
+    it('should return an empty array when there are no competence-marks for a certificationCourseId', async () => {
+      // given
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+      databaseBuilder.factory.buildAssessmentResult({ assessmentId });
+      databaseBuilder.factory.buildCompetenceMark();
+      await databaseBuilder.commit();
 
+      // when
+      const competenceMarks = await competenceMarkRepository.findByCertificationCourseId(certificationCourseId);
+
+      // then
+      expect(competenceMarks).to.be.empty;
+    });
+
+    it('should return all competence-marks for a certificationCourseId', async () => {
+      // given
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
+      const anotherAssessmentResultId = databaseBuilder.factory.buildAssessmentResult().id;
+      _.map([
+        { id: 1, score: 13, level: 2, area_code: '4', competence_code: '4.2', competenceId: 'recABC', assessmentResultId },
+        { id: 2, score: 10, level: 1, area_code: '3', competence_code: '3.1', competenceId: 'recDEF', assessmentResultId: anotherAssessmentResultId },
+        { id: 3, score: 24, level: 3, area_code: '3', competence_code: '3.1', competenceId: 'recGHI', assessmentResultId },
+      ], (mark) => {
+        return databaseBuilder.factory.buildCompetenceMark(mark).id;
+      });
+      const expectedCompetenceMarks = [
+        domainBuilder.buildCompetenceMark({ id: 1, score: 13, level: 2, area_code: '4', competence_code: '4.2', competenceId: 'recABC', assessmentResultId }),
+        domainBuilder.buildCompetenceMark({ id: 3, score: 24, level: 3, area_code: '3', competence_code: '3.1', competenceId: 'recGHI', assessmentResultId }),
+      ];
+      await databaseBuilder.commit();
+
+      // when
+      const competenceMarks = await competenceMarkRepository.findByCertificationCourseId(certificationCourseId);
+
+      // then
+      expect(competenceMarks[0]).to.be.instanceOf(CompetenceMark);
+      expect(competenceMarks).to.deep.equal(expectedCompetenceMarks);
+    });
+
+    it('should only take into account competence-marks of the latest assessment-results if there are more than one', async () => {
       // given
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({}).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
-      const anotherAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({}).id;
-      const competenceMarkIds = _.map([
-        { score: 13, level: 2, area_code: '4', competence_code: '4.2', assessmentResultId },
-        { score: 10, level: 1, area_code: '3', competence_code: '3.1', assessmentResultId: anotherAssessmentResultId },
-        { score: 24, level: 3, area_code: '3', competence_code: '3.1', assessmentResultId },
+      const olderAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId, createdAt: new Date('2020-01-01') }).id;
+      const latestAssessmentResult = databaseBuilder.factory.buildAssessmentResult({ assessmentId, createdAt: new Date('2021-01-01') }).id;
+      _.map([
+        { id: 1, score: 13, level: 2, area_code: '4', competence_code: '4.2', competenceId: 'recXYZ', assessmentResultId: olderAssessmentResultId },
       ], (mark) => {
         return databaseBuilder.factory.buildCompetenceMark(mark).id;
+      });
+      const expectedCompetenceMarks =
+      _.map([
+        { id: 4, score: 13, level: 2, area_code: '4', competence_code: '4.2', competenceId: 'recABC', assessmentResultId: latestAssessmentResult },
+        { id: 5, score: 10, level: 1, area_code: '3', competence_code: '3.1', competenceId: 'recDEF', assessmentResultId: latestAssessmentResult },
+        { id: 6, score: 24, level: 3, area_code: '3', competence_code: '3.1', competenceId: 'recGHI', assessmentResultId: latestAssessmentResult },
+      ], (mark) => {
+        databaseBuilder.factory.buildCompetenceMark(mark);
+        return domainBuilder.buildCompetenceMark(mark);
       });
       await databaseBuilder.commit();
 
@@ -107,11 +155,7 @@ describe('Integration | Repository | CompetenceMark', () => {
       const competenceMarks = await competenceMarkRepository.findByCertificationCourseId(certificationCourseId);
 
       // then
-      const sortedCompetenceMarks = _.sortBy(competenceMarks, [(mark) => { return mark.id; }]);
-      expect(sortedCompetenceMarks[0]).to.be.instanceOf(CompetenceMark);
-      expect(sortedCompetenceMarks[0].id).to.equal(competenceMarkIds[0]);
-      expect(sortedCompetenceMarks[1].id).to.equal(competenceMarkIds[2]);
-      expect(sortedCompetenceMarks.length).to.equal(2);
+      expect(competenceMarks).to.deep.equal(expectedCompetenceMarks);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Pour reproduire : Quand FT_IS_NEUTRALIZATION_AUTO_ENABLED est activé, la page de détails d'une certification dans PixAdmin ne provoque pas un dry re-scoring mais récupère le score déjà calculé et stocké en BDD. Si l'on provoque un vrai re-scoring sur une certif (via la neutralisation par exemple), on s'aperçoit en retournant à la page de détails que le score affiché est faux. En fait, il s'agit de la somme de l'ancien scoring et du nouveau scoring 😬 

En fait, côté API, on récupère tous les competence-marks, alors qu'il ne faut récupérer que ceux du dernier assessment-result (soit du dernier scoring)

## :robot: Solution
Corriger la méthode de repository qui récupère les competence marks afin qu'elle ne récupère que ceux du dernier scoring

## :100: Pour tester
** Peut nécessiter nécessite pas de reset des seeds **
- Se connecter à PixAdmin avec : pixmaster@example.net / pix123
- Se rendre dans l'entrée de menu "Sessions de certification"
- Dans l'onglet "Sessions à publier", choisir la session 5
- Se rendre dans l'onglet "Certifications" et choisir la certification 104123
- Se rendre dans l'onglet "Détails" puis retenir le score inscrit
- Se rendre dans l'onglet "Neutralisation" puis neutraliser une ou plusieurs questions
- Retourner sur l'onglet "Détails" et constate que le score n'a pas triplé / quadruplé
