### PR TITLE
[FEATURE] Permettre de recommencer un parcours dont les résultats ont été partagés (Pix-2464)

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -12,7 +12,7 @@ module.exports = function buildCampaignParticipation({
   userId,
   participantExternalId = 'participantExternalId',
   validatedSkillsCount,
-  isImproved,
+  isImproved = false,
 } = {}) {
 
   userId = _.isUndefined(userId) ? buildUser().id : userId;

--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -24,8 +24,7 @@ module.exports = function buildCampaign({
   customResultPageText,
   customResultPageButtonText,
   customResultPageButtonUrl,
-  multipleSendings,
-
+  multipleSendings = false,
 } = {}) {
 
   if (type === Campaign.types.ASSESSMENT) {

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -6,3 +6,4 @@ require('fs').readdirSync(__dirname).forEach(function(file) {
 
   module.exports[path.basename(file, '.js')] = require(path.join(__dirname, file));
 });
+

--- a/api/lib/domain/read-models/CampaignToJoin.js
+++ b/api/lib/domain/read-models/CampaignToJoin.js
@@ -24,6 +24,7 @@ class CampaignToJoin {
     customResultPageText,
     customResultPageButtonText,
     customResultPageButtonUrl,
+    multipleSendings,
   } = {}) {
     this.id = id;
     this.code = code;
@@ -47,6 +48,7 @@ class CampaignToJoin {
     this.customResultPageText = customResultPageText;
     this.customResultPageButtonText = customResultPageButtonText;
     this.customResultPageButtonUrl = customResultPageButtonUrl;
+    this.multipleSendings = multipleSendings;
   }
 
   get isAssessment() {

--- a/api/lib/domain/services/improvement-service.js
+++ b/api/lib/domain/services/improvement-service.js
@@ -5,9 +5,9 @@ function _keepKnowledgeElementsRecentOrValidated({ currentUserKnowledgeElements,
   const startedDateOfAssessment = assessment.createdAt;
 
   return currentUserKnowledgeElements.filter((knowledgeElement) => {
-    const isOldEnoughToBeImproved = moment(startedDateOfAssessment)
+    const isNotOldEnoughToBeImproved = moment(startedDateOfAssessment)
       .diff(knowledgeElement.createdAt, 'days', true) < constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
-    return knowledgeElement.isValidated || isOldEnoughToBeImproved;
+    return knowledgeElement.isValidated || isNotOldEnoughToBeImproved;
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
       attributes: ['code', 'title', 'type', 'idPixLabel', 'customLandingPageText',
         'externalIdHelpImageUrl', 'alternativeTextToExternalIdHelpImage', 'isArchived', 'isForAbsoluteNovice',
         'isRestricted', 'isSimplifiedAccess', 'organizationName', 'organizationType', 'organizationLogoUrl',
-        'organizationIsPoleEmploi', 'targetProfileName', 'targetProfileImageUrl', 'customResultPageText', 'customResultPageButtonText', 'customResultPageButtonUrl'],
+        'organizationIsPoleEmploi', 'targetProfileName', 'targetProfileImageUrl', 'customResultPageText', 'customResultPageButtonText', 'customResultPageButtonUrl', 'multipleSendings'],
     }).serialize(campaignsToJoin);
   },
 };

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -671,4 +671,5 @@ describe('Integration | Repository | Campaign Participation', () => {
       expect(isAssessmentCompleted).to.be.false;
     });
   });
+
 });

--- a/api/tests/tooling/domain-builder/factory/build-campaign-to-join.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-to-join.js
@@ -21,6 +21,7 @@ module.exports = function buildCampaignToJoin({
   organizationIsPoleEmploi = false,
   targetProfileName = 'Le profil cible',
   targetProfileImageUrl = 'targetProfileImageUrl',
+  multipleSendings = false,
 } = {}) {
   return new CampaignToJoin({
     id,
@@ -41,5 +42,6 @@ module.exports = function buildCampaignToJoin({
     organizationIsPoleEmploi,
     targetProfileName,
     targetProfileImageUrl,
+    multipleSendings,
   });
 };

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -227,6 +227,7 @@ describe('Unit | Application | Controller | Campaign', () => {
           'custom-result-page-text': campaignToJoin.customResultPageText,
           'custom-result-page-button-text': campaignToJoin.customResultPageButtonText,
           'custom-result-page-button-url': campaignToJoin.customResultPageButtonUrl,
+          'multiple-sendings': campaignToJoin.multipleSendings,
         },
       });
     });

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -1,71 +1,32 @@
-const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const usecases = require('../../../../lib/domain/usecases');
 const CampaignParticipationStarted = require('../../../../lib/domain/events/CampaignParticipationStarted');
-const { AlreadyExistingCampaignParticipationError, ForbiddenAccess } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | start-campaign-participation', () => {
 
   const userId = 19837482;
   const campaignParticipation = domainBuilder.buildCampaignParticipation();
-  const campaignToJoinRepository = { get: () => undefined, isCampaignJoinableByUser: () => undefined };
-  const campaignParticipationRepository = { save: () => undefined, findOneByCampaignIdAndUserId: () => undefined };
+  const campaignToJoinRepository = { get: () => undefined, checkCampaignIsJoinableByUser: () => undefined };
+  const campaignParticipationRepository = { save: () => undefined, findOneByCampaignIdAndUserId: () => undefined, hasAlreadyParticipated: () => {}, markPreviousParticipationsAsImproved: () => {} };
   const assessmentRepository = { save: () => undefined };
   const domainTransaction = Symbol('DomainTransaction');
-  const dependencies = {
-    campaignParticipationRepository,
-    campaignToJoinRepository,
-    assessmentRepository,
-    domainTransaction,
-  };
 
   beforeEach(() => {
     sinon.stub(campaignToJoinRepository, 'get');
-    sinon.stub(campaignToJoinRepository, 'isCampaignJoinableByUser');
+    sinon.stub(campaignToJoinRepository, 'checkCampaignIsJoinableByUser');
     sinon.stub(campaignParticipationRepository, 'save');
     sinon.stub(campaignParticipationRepository, 'findOneByCampaignIdAndUserId');
+    sinon.stub(campaignParticipationRepository, 'hasAlreadyParticipated');
+    sinon.stub(campaignParticipationRepository, 'markPreviousParticipationsAsImproved');
     sinon.stub(assessmentRepository, 'save');
-  });
-
-  it('should throw a ForbiddenAccess if the campaign is not joinable by the user', async () => {
-    // given
-    const campaignToJoin = domainBuilder.buildCampaignToJoin({ id: campaignParticipation.campaignId });
-    campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId).resolves(campaignToJoin);
-    campaignToJoinRepository.isCampaignJoinableByUser.withArgs(campaignToJoin, userId).resolves(false);
-
-    // when
-    const error = await catchErr(usecases.startCampaignParticipation)({ campaignParticipation, userId, ...dependencies });
-
-    // then
-    return expect(error).to.be.instanceOf(ForbiddenAccess);
-  });
-
-  it('should throw an AlreadyExistingCampaignParticipationError if the user has already participated to the campaign', async () => {
-    // given
-    const campaignToJoin = domainBuilder.buildCampaignToJoin({ id: campaignParticipation.campaignId, organizationIsManagingStudents: false });
-    campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId).resolves(campaignToJoin);
-    campaignToJoinRepository.isCampaignJoinableByUser.withArgs(campaignToJoin, userId).resolves(true);
-    const alreadyStartedParticipation = domainBuilder.buildCampaignParticipation();
-    campaignParticipationRepository.findOneByCampaignIdAndUserId
-      .withArgs({ campaignId: campaignToJoin.id, userId })
-      .resolves(alreadyStartedParticipation);
-
-    // when
-    const error = await catchErr(usecases.startCampaignParticipation)({ campaignParticipation, userId, ...dependencies });
-
-    // then
-    return expect(error).to.be.instanceOf(AlreadyExistingCampaignParticipationError);
   });
 
   it('should return the saved campaign participation', async () => {
     // given
     const campaignToJoin = domainBuilder.buildCampaignToJoin({ id: campaignParticipation.campaignId, organizationIsManagingStudents: false });
-    campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId).resolves(campaignToJoin);
-    campaignToJoinRepository.isCampaignJoinableByUser.withArgs(campaignToJoin, userId).resolves(true);
-    campaignParticipationRepository.findOneByCampaignIdAndUserId
-      .withArgs({ campaignId: campaignToJoin.id, userId })
-      .resolves(null);
+    campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId, domainTransaction).resolves(campaignToJoin);
     assessmentRepository.save.resolves();
     const campaignParticipationToSave = domainBuilder.buildCampaignParticipation({
       ...campaignParticipation,
@@ -73,11 +34,14 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     });
     const savedCampaignParticipation = Symbol('savedCampaignParticipation');
     campaignParticipationRepository.save.withArgs(campaignParticipationToSave).resolves(savedCampaignParticipation);
+    campaignParticipationRepository.hasAlreadyParticipated.withArgs(campaignToJoin.id, userId).resolves(false);
+    campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId, domainTransaction).resolves(campaignToJoin);
 
     // when
     const { campaignParticipation: actualSavedCampaignParticipation } = await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository, domainTransaction });
 
     // then
+    expect(campaignToJoinRepository.checkCampaignIsJoinableByUser).to.have.been.calledWith(campaignToJoin, userId, domainTransaction);
     expect(actualSavedCampaignParticipation).to.deep.equal(savedCampaignParticipation);
   });
 
@@ -88,11 +52,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
       id: campaignParticipation.campaignId,
       organizationIsManagingStudents: false,
     });
-    campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId).resolves(campaignToJoin);
-    campaignToJoinRepository.isCampaignJoinableByUser.withArgs(campaignToJoin, userId).resolves(true);
-    campaignParticipationRepository.findOneByCampaignIdAndUserId
-      .withArgs({ campaignId: campaignToJoin.id, userId })
-      .resolves(null);
+    campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId, domainTransaction).resolves(campaignToJoin);
     const assessmentId = 987654321;
     const campaignParticipationStartedEvent = new CampaignParticipationStarted({ campaignParticipationId: campaignParticipation.id });
     assessmentRepository.save.resolves({ id: assessmentId });
@@ -107,51 +67,104 @@ describe('Unit | UseCase | start-campaign-participation', () => {
 
   context('when campaign is of type ASSESSMENT', () => {
 
-    it('should create a campaign assessment', async () => {
-      // given
-      const campaignToJoin = domainBuilder.buildCampaignToJoin({
-        id: campaignParticipation.campaignId,
-        organizationIsManagingStudents: false,
-        type: Campaign.types.ASSESSMENT,
+    context('when the campaign does not allow retry', () => {
+      it('should create a campaign assessment', async () => {
+        // given
+        const campaignToJoin = domainBuilder.buildCampaignToJoin({
+          id: campaignParticipation.campaignId,
+          organizationIsManagingStudents: false,
+          type: Campaign.types.ASSESSMENT,
+        });
+        campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId, domainTransaction).resolves(campaignToJoin);
+        assessmentRepository.save.resolves();
+        campaignParticipationRepository.save.resolves({ id: 1 });
+
+        // when
+        await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository, domainTransaction });
+
+        // then
+        const createdAssessment = Assessment.createForCampaign({ userId, campaignParticipationId: 1 });
+        expect(assessmentRepository.save).to.have.been.calledWith({ assessment: createdAssessment, domainTransaction });
       });
-      campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId).resolves(campaignToJoin);
-      campaignToJoinRepository.isCampaignJoinableByUser.withArgs(campaignToJoin, userId).resolves(true);
-      campaignParticipationRepository.findOneByCampaignIdAndUserId
-        .withArgs({ campaignId: campaignToJoin.id, userId })
-        .resolves(null);
-      assessmentRepository.save.resolves();
-      campaignParticipationRepository.save.resolves({ id: 1 });
+    });
 
-      // when
-      await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository, domainTransaction });
+    context('when the campaign allows retry', () => {
+      it('should create an improving assessment', async () => {
+        // given
+        const campaignToJoin = domainBuilder.buildCampaignToJoin({
+          id: campaignParticipation.campaignId,
+          organizationIsManagingStudents: false,
+          type: Campaign.types.ASSESSMENT,
+        });
+        campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId, domainTransaction).resolves(campaignToJoin);
+        assessmentRepository.save.resolves();
+        campaignParticipationRepository.save.resolves({ id: 1 });
+        campaignParticipationRepository.markPreviousParticipationsAsImproved.resolves(campaignToJoin.id, userId);
+        campaignParticipationRepository.hasAlreadyParticipated.withArgs(campaignToJoin.id, userId, domainTransaction).resolves(true);
 
-      // then
-      const createdAssessment = Assessment.createForCampaign({ userId, campaignParticipationId: 1 });
-      expect(assessmentRepository.save).to.have.been.calledWith({ assessment: createdAssessment, domainTransaction });
+        // when
+        await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository, domainTransaction });
+
+        // then
+        const createdAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId: 1 });
+        expect(assessmentRepository.save).to.have.been.calledWith({ assessment: createdAssessment, domainTransaction });
+        expect(campaignParticipationRepository.markPreviousParticipationsAsImproved).to.have.been.calledWith(campaignToJoin.id, userId, domainTransaction);
+      });
     });
   });
 
   context('when campaign is of type PROFILES_COLLECTION', () => {
 
-    it('should not create a campaign assessment', async () => {
-      // given
-      const campaignToJoin = domainBuilder.buildCampaignToJoin({
-        id: campaignParticipation.campaignId,
-        organizationIsManagingStudents: false,
-        type: Campaign.types.PROFILES_COLLECTION,
+    context('when the campaign does not allow retry', () => {
+      it('should not create a campaign assessment', async () => {
+        // given
+        const campaignToJoin = domainBuilder.buildCampaignToJoin({
+          id: campaignParticipation.campaignId,
+          organizationIsManagingStudents: false,
+          type: Campaign.types.PROFILES_COLLECTION,
+        });
+        campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId, domainTransaction).resolves(campaignToJoin);
+        campaignParticipationRepository.save.resolves({ id: 1 });
+
+        // when
+        await usecases.startCampaignParticipation({
+          campaignParticipation,
+          userId,
+          campaignParticipationRepository,
+          assessmentRepository,
+          campaignToJoinRepository,
+          domainTransaction,
+        });
+
+        // then
+        expect(assessmentRepository.save).to.not.have.been.called;
       });
-      campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId).resolves(campaignToJoin);
-      campaignToJoinRepository.isCampaignJoinableByUser.withArgs(campaignToJoin, userId).resolves(true);
-      campaignParticipationRepository.findOneByCampaignIdAndUserId
-        .withArgs({ campaignId: campaignToJoin.id, userId })
-        .resolves(null);
-      campaignParticipationRepository.save.resolves({ id: 1 });
+    });
 
-      // when
-      await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository, domainTransaction });
+    context('when the campaign allows retry', () => {
+      it('should not create a campaign assessment', async () => {
+        // given
+        const campaignToJoin = domainBuilder.buildCampaignToJoin({
+          id: campaignParticipation.campaignId,
+          organizationIsManagingStudents: false,
+          type: Campaign.types.PROFILES_COLLECTION,
+        });
+        campaignToJoinRepository.get.withArgs(campaignParticipation.campaignId, domainTransaction).resolves(campaignToJoin);
+        campaignParticipationRepository.save.resolves({ id: 1 });
 
-      // then
-      expect(assessmentRepository.save).to.not.have.been.called;
+        // when
+        await usecases.startCampaignParticipation({
+          campaignParticipation,
+          userId,
+          campaignParticipationRepository,
+          assessmentRepository,
+          campaignToJoinRepository,
+          domainTransaction,
+        });
+
+        // then
+        expect(assessmentRepository.save).to.not.have.been.called;
+      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
@@ -38,6 +38,7 @@ describe('Unit | Serializer | JSONAPI | campaign-to-join-serializer', () => {
             'custom-result-page-text': campaignToJoin.customResultPageText,
             'custom-result-page-button-text': campaignToJoin.customResultPageButtonText,
             'custom-result-page-button-url': campaignToJoin.customResultPageButtonUrl,
+            'multiple-sendings': campaignToJoin.multipleSendings,
           },
         },
       });

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -74,6 +74,15 @@
         </div>
       </div>
     </div>
+    {{#if this.retryAllowed }}
+      <div class="skill-review__retry">
+        <p class="skill-review-retry__message">{{t 'pages.skill-review.retry.message' organizationName=this.organizationName}}</p>
+        <LinkTo @route="campaigns.start-or-resume"
+                @model={{@model.campaignParticipation.campaign.code}}
+                @query={{hash retry=true}}
+                class="skill-review-retry__button button button--big button--link">{{t 'pages.skill-review.retry.button'}}</LinkTo>
+      </div>
+    {{/if}}
   </PixBlock>
 {{/if}}
 {{#if this.displayOrganizationCustomMessage}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -113,6 +113,10 @@ export default class SkillReview extends Component {
     }
   }
 
+  get retryAllowed() {
+    return this.isShared && this.masteryPercentage < 100 && this.args.model.campaignParticipation.campaign.get('multipleSendings');
+  }
+
   get customButtonText() {
     return this.args.model.campaignParticipation.campaign.get('customResultPageButtonText');
   }

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -21,6 +21,7 @@ export default class Campaign extends Model {
   @attr('string') customResultPageText;
   @attr('string') customResultPageButtonText;
   @attr('string') customResultPageButtonUrl;
+  @attr('boolean') multipleSendings;
 
   get isAssessment() {
     return this.type === 'ASSESSMENT';

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -63,7 +63,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     return this.modelFor('campaigns');
   }
 
-  async redirect(campaign) {
+  async redirect(campaign, transition) {
     if (campaign.isArchived) {
       this.isLoading = false;
       return;
@@ -79,7 +79,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       return this.replaceWith('campaigns.fill-in-participant-external-id', campaign);
     }
 
-    if (this._shouldStartCampaignParticipation) {
+    if (this._shouldStartCampaignParticipation(campaign, transition.to.queryParams)) {
       await this._createCampaignParticipation(campaign);
     }
 
@@ -224,8 +224,8 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       && !this.state.doesUserHaveOngoingParticipation;
   }
 
-  get _shouldStartCampaignParticipation() {
-    return !this.state.doesUserHaveOngoingParticipation;
+  _shouldStartCampaignParticipation(campaign, queryParams) {
+    return !this.state.doesUserHaveOngoingParticipation || (campaign.multipleSendings && queryParams.retry);
   }
 
   _handleQueryParamBoolean(value, defaultValue) {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -3,6 +3,8 @@
   &__banner {
     width: 100%;
     margin-bottom: 30px;
+    display: flex;
+    flex-direction: column;
   }
 
   &__result-and-action {
@@ -13,6 +15,21 @@
 
     @include device-is('tablet') {
       flex-direction: row;
+    }
+  }
+
+  &__retry {
+    border-top: 1px dashed $grey-22;
+    color: $grey-100;
+    text-align: center;
+    font-size: 1.125rem;
+    font-family: $font-open-sans;
+    font-weight: $font-light;
+
+    @include device-is('tablet') {
+      margin-top: 32px;
+      padding: 0 32px;
+      font-size: 1.5rem;
     }
   }
 
@@ -84,6 +101,14 @@
 
   &__improvement-button {
     height: 50px;
+  }
+}
+
+.skill-review-retry {
+
+  &__button {
+    font-size: 0.875rem;
+    padding: 10px;
   }
 }
 

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -326,6 +326,38 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           expect(currentURL()).to.contains('/assessments');
         });
       });
+
+      context('When the participation is shared', () => {
+        context('when the campaign allows multiple participations', function() {
+
+          beforeEach(async function() {
+            campaign = server.create('campaign', { type: ASSESSMENT, multipleSendings: true });
+            const assessment = server.create('assessment', { type: 'CAMPAIGN', state: 'completed', codeCampaign: campaign.code });
+            server.create('campaign-participation', { sharedAt: new Date('2020-01-01'), isShared: true, createdAt: new Date('2020-01-01'), assessment, campaign });
+            await visit(`campagnes/${campaign.code}?retry=true`);
+          });
+
+          it('should redirect to assessment when retrying the campaign', async function() {
+            // then
+            expect(currentURL()).to.contains('/evaluation');
+          });
+        });
+
+        context('when the campaign does not allow multiple participations', () => {
+          beforeEach(async function() {
+            campaign = server.create('campaign', { type: ASSESSMENT, multipleSendings: false });
+            const assessment = server.create('assessment', { type: 'CAMPAIGN', state: 'completed', codeCampaign: campaign.code });
+            const campaignParticipationResult = server.create('campaign-participation-result', {});
+            server.create('campaign-participation', { sharedAt: new Date('2020-01-01'), isShared: true, createdAt: new Date('2020-01-01'), user: prescritUser, campaign, assessment, campaignParticipationResult });
+            await visit(`campagnes/${campaign.code}?retry=true&hasUserSeenLandingPage=true`);
+          });
+
+          it('should redirect to assessment results when retrying the campaign', async function() {
+            // then
+            expect(currentURL()).to.contains('/evaluation/resultats/');
+          });
+        });
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -4,6 +4,7 @@ import { click, find, render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 import { reject } from 'rsvp';
+import EmberObject from '@ember/object';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
@@ -112,6 +113,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
     });
   });
+
   context('When campaign is for Absolute Novice', function() {
     beforeEach(async function() {
       // Given
@@ -449,6 +451,75 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         // Then
         expect(contains('J\'envoie mes résultats')).to.exist;
         expect(contains('Message de votre organisation')).to.not.exist;
+      });
+    });
+  });
+
+  describe('The retry block', function() {
+    let clock;
+    const now = new Date('2021-09-25');
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(now.getTime());
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    context('show the retry block', function() {
+      beforeEach(function() {
+        // Given
+        const model = {
+          campaignParticipation: EmberObject.create({
+            isShared: true,
+            campaignParticipationResult: EmberObject.create({
+              campaignParticipationBadges: [],
+              masteryPercentage: 56,
+            }),
+            campaign: EmberObject.create({
+              multipleSendings: true,
+            }),
+          }),
+
+        };
+        this.set('model', model);
+      });
+
+      it('should display the block for the message', async function() {
+        // When
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+            @model={{model}}/>`);
+        // Then
+        expect(contains(this.intl.t('pages.skill-review.retry.button'))).to.exist;
+      });
+    });
+
+    context('Does not show the retry block', function() {
+      beforeEach(function() {
+        // Given
+        const model = {
+          campaignParticipation: EmberObject.create({
+            isShared: true,
+            campaignParticipationResult: EmberObject.create({
+              campaignParticipationBadges: [],
+              masteryPercentage: 56,
+            }),
+            campaign: EmberObject.create({
+              multipleSendings: false,
+            }),
+          }),
+
+        };
+        this.set('model', model);
+      });
+
+      it('should display the block for the message', async function() {
+        // When
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+            @model={{model}}/>`);
+        // Then
+        expect(contains(this.intl.t('pages.skill-review.retry.button'))).to.not.exist;
       });
     });
   });

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
@@ -423,10 +423,10 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
       component.args.model.campaignParticipation.campaign.customResultPageButtonText = 'Next step';
 
       // when
-      const url = component.customButtonText;
+      const result = component.customButtonText;
 
       // then
-      expect(url).to.equal('Next step');
+      expect(result).to.equal('Next step');
     });
   });
 
@@ -474,6 +474,59 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
       component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = null;
       // when
       const result = component.displayPixLink;
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('#retryAllowed', function() {
+
+    it('should return false when masteryPercentage equals to 100 ', function() {
+      // given
+      component.args.model.campaignParticipation.isShared = true;
+      component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 100;
+      component.args.model.campaignParticipation.campaign.multipleSendings = true;
+      // when
+      const result = component.retryAllowed;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return false when isShared is false', function() {
+      // given
+      component.args.model.campaignParticipation.isShared = false;
+      component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 56;
+      component.args.model.campaignParticipation.campaign.multipleSendings = true;
+
+      // when
+      const result = component.retryAllowed;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return false when multipleSendings is false', function() {
+      // given
+      component.args.model.campaignParticipation.isShared = true;
+      component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 56;
+      component.args.model.campaignParticipation.campaign.multipleSendings = false;
+
+      // when
+      const result = component.retryAllowed;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return true when multipleSendings and isShared are true,  masteryPercentage is less than 100', function() {
+      // given
+      component.args.model.campaignParticipation.isShared = true;
+      component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 56;
+      component.args.model.campaignParticipation.campaign.multipleSendings = true;
+      // when
+      const result = component.retryAllowed;
 
       // then
       expect(result).to.be.true;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -930,7 +930,11 @@
             },
             "information": "If you have already completed personalised tests on Pix, questions you have previously answered have not been asked again. However, the result shown here is based on all of your answers.",
             "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
-            "organization-message": "Message of your organisation",
+            "organization-message" : "Message of your organization",
+            "retry": {
+                "button": "Retake my personalised test",
+                "message": "{organizationName} encourages you to retake your test to measure your progress."
+            },
             "send-results": "Don't forget to submit your results.",
             "send-status": {
                 "in-progress": "Results are being shared..."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -931,6 +931,10 @@
             "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
             "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
             "organization-message" : "Message de votre organisation",
+            "retry": {
+                "button": "Repasser mon parcours",
+                "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser."
+            },
             "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
             "send-status": {
                 "in-progress": "Envoi en cours"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il est impossible de repasser un parcours quand les résultats de ce dernier ont été envoyés. Ceci empêche de mesurer la progression d'un participant sur un même parcours.

## :robot: Solution
Permettre de recommencer un parcours.

## :rainbow: Remarques

## :100: Pour tester
Aller sur le profil de jaune.attend@example.net, et aller sur la campagne `FINISHED3`, et recommencer la campagne.
