### PR TITLE
[FEATURE] Ajout d'un bouton pour Dé-neutraliser une épreuve neutralisée sur PixAdmin (PIX-2509)

### DIFF
--- a/admin/app/adapters/certification-details.js
+++ b/admin/app/adapters/certification-details.js
@@ -13,7 +13,7 @@ export default class CertificationDetails extends ApplicationAdapter {
     requestType,
     query,
   ) {
-    if (requestType === 'neutralize-challenge') {
+    if (requestType === 'challenge-neutralization') {
       return `${this.host}/${this.namespace}/admin/certification/`;
     } else {
       return super.buildURL(

--- a/admin/app/controllers/authenticated/certifications/certification/neutralization.js
+++ b/admin/app/controllers/authenticated/certifications/certification/neutralization.js
@@ -16,17 +16,31 @@ export default class NeutralizationController extends Controller {
         certificationCourseId: this.certificationDetails.id,
         challengeRecId,
       });
-      this._updateModel(challengeRecId);
+      this._updateModel(challengeRecId, true);
       return this.notifications.success(`La question n°${questionIndex} a été neutralisée avec succès.`);
     } catch (e) {
       return this.notifications.error(`Une erreur est survenue lors de la neutralisation de la question n°${questionIndex}.`);
     }
   }
 
-  _updateModel(challengeRecId) {
+  @action
+  async deneutralize(challengeRecId, questionIndex) {
+    try {
+      await this.certificationDetails.deneutralizeChallenge({
+        certificationCourseId: this.certificationDetails.id,
+        challengeRecId,
+      });
+      this._updateModel(challengeRecId, false);
+      return this.notifications.success(`La question n°${questionIndex} a été dé-neutralisée avec succès.`);
+    } catch (e) {
+      return this.notifications.error(`Une erreur est survenue lors de la dé-neutralisation de la question n°${questionIndex}.`);
+    }
+  }
+
+  _updateModel(challengeRecId, neutralized) {
     const neutralizedChallenge = this.certificationDetails.listChallengesAndAnswers.find((challengeAndAnswer) => {
       return challengeAndAnswer.challengeId === challengeRecId;
     });
-    set(neutralizedChallenge, 'isNeutralized', true);
+    set(neutralizedChallenge, 'isNeutralized', neutralized);
   }
 }

--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -61,7 +61,20 @@ export default class CertificationDetails extends Model {
   neutralizeChallenge = memberAction({
     path: 'neutralize-challenge',
     type: 'post',
-    urlType: 'neutralize-challenge',
+    urlType: 'challenge-neutralization',
+    before(attributes) {
+      return {
+        data: {
+          attributes,
+        },
+      };
+    },
+  });
+
+  deneutralizeChallenge = memberAction({
+    path: 'deneutralize-challenge',
+    type: 'post',
+    urlType: 'challenge-neutralization',
     before(attributes) {
       return {
         data: {

--- a/admin/app/styles/authenticated/certifications/certification/neutralization.scss
+++ b/admin/app/styles/authenticated/certifications/certification/neutralization.scss
@@ -1,4 +1,5 @@
 .neutralization__neutralize-button {
   padding: 6px 8px;
   font-weight: normal;
+  width: 128px;
 }

--- a/admin/app/templates/authenticated/certifications/certification/neutralization.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/neutralization.hbs
@@ -23,15 +23,25 @@
             {{answer.challengeId}}
           </td>
           <td>
-            <PixButton
-                @triggerAction={{fn this.neutralize answer.challengeId answer.order}}
-                @backgroundColor="blue"
-                @loading-color="grey"
-                class="neutralization__neutralize-button"
-                @isDisabled={{ answer.isNeutralized }}
-            >
-              Neutraliser
-            </PixButton>
+            {{#if answer.isNeutralized}}
+              <PixButton
+                      @triggerAction={{fn this.deneutralize answer.challengeId answer.order}}
+                      @backgroundColor="transparent"
+                      @loading-color="grey"
+                      class="neutralization__neutralize-button"
+              >
+                Dé-neutraliser
+              </PixButton>
+            {{else}}
+              <PixButton
+                      @triggerAction={{fn this.neutralize answer.challengeId answer.order}}
+                      @backgroundColor="blue"
+                      @loading-color="grey"
+                      class="neutralization__neutralize-button"
+              >
+                Neutraliser
+              </PixButton>
+            {{/if}}
           </td>
         </tr>
       {{/each}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -118,6 +118,14 @@ export default function() {
     return schema.certificationDetails.find(id);
   });
 
+  this.post('/admin/certification/neutralize-challenge', () => {
+    return new Response(204);
+  });
+
+  this.post('/admin/certification/deneutralize-challenge', () => {
+    return new Response(204);
+  });
+
   this.get('/admin/sessions/:id/generate-results-download-link', { sessionResultsLink: 'http://link-to-results.fr' });
 
   this.post('/organizations/:id/invitations', (schema, request) => {

--- a/admin/tests/unit/adapters/certification-details-test.js
+++ b/admin/tests/unit/adapters/certification-details-test.js
@@ -16,10 +16,10 @@ module('Unit | Adapter | certification details', function(hooks) {
   });
 
   module('#buildURL', function() {
-    test('should build neutralize-challenge base URL when called with according requestType', function(assert) {
+    test('should build challenge neutralization base URL when called with according requestType', function(assert) {
       // when
       const adapter = this.owner.lookup('adapter:certification-details');
-      const url = adapter.buildURL(123, 'certification-details', null, 'neutralize-challenge');
+      const url = adapter.buildURL(123, 'certification-details', null, 'challenge-neutralization');
 
       // then
       assert.ok(url.endsWith('/admin/certification/'));

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/neutralization-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/neutralization-test.js
@@ -4,7 +4,9 @@ import { setupTest } from 'ember-qunit';
 
 module('Unit | Controller | authenticated/certifications/certification/neutralization', function(hooks) {
   setupTest(hooks);
+
   module('#neutralizeChallenge', async function() {
+
     test('neutralizes a challenge', async function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/certifications/certification/neutralization');
@@ -69,6 +71,76 @@ module('Unit | Controller | authenticated/certifications/certification/neutraliz
       // then
       assert.ok(controller.notifications.error.calledOnceWithExactly(
         'Une erreur est survenue lors de la neutralisation de la question n°2.',
+      ));
+    });
+  });
+
+  module('#deneutralizeChallenge', async function() {
+
+    test('deneutralizes a challenge', async function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications/certification/neutralization');
+      controller.certificationDetails = {
+        id: 'certificationCourseId',
+        deneutralizeChallenge: sinon.stub(),
+        listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],
+      };
+      controller.certificationDetails.deneutralizeChallenge.resolves({});
+
+      // when
+      await controller.deneutralize('challengeRecId123', 2);
+
+      // then
+      assert.ok(controller.certificationDetails.deneutralizeChallenge.calledOnceWithExactly({
+        certificationCourseId: 'certificationCourseId',
+        challengeRecId: 'challengeRecId123',
+      }));
+    });
+
+    test('notifies a successful deneutralization and updates model', async function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications/certification/neutralization');
+      controller.certificationDetails = {
+        id: 'certificationCourseId',
+        deneutralizeChallenge: sinon.stub(),
+        listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],
+      };
+      controller.certificationDetails.deneutralizeChallenge.resolves({});
+      const notifications = {
+        success: sinon.stub(),
+      };
+      controller.notifications = notifications;
+
+      // when
+      await controller.deneutralize('challengeRecId123', 2);
+
+      // then
+      assert.ok(controller.notifications.success.calledOnceWithExactly(
+        'La question n°2 a été dé-neutralisée avec succès.',
+      ));
+      assert.equal(controller.certificationDetails.listChallengesAndAnswers[0].isNeutralized, false);
+    });
+
+    test('notifies a failed deneutralization', async function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications/certification/neutralization');
+      controller.certificationDetails = {
+        id: 'certificationCourseId',
+        deneutralizeChallenge: sinon.stub(),
+        listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],
+      };
+      controller.certificationDetails.deneutralizeChallenge.rejects({});
+      const notifications = {
+        error: sinon.stub(),
+      };
+      controller.notifications = notifications;
+
+      // when
+      await controller.deneutralize('challengeRecId123', 2);
+
+      // then
+      assert.ok(controller.notifications.error.calledOnceWithExactly(
+        'Une erreur est survenue lors de la dé-neutralisation de la question n°2.',
       ));
     });
   });

--- a/admin/tests/unit/models/certification-details-test.js
+++ b/admin/tests/unit/models/certification-details-test.js
@@ -68,4 +68,42 @@ module('Unit | Model | certification details', function(hooks) {
       assert.ok(adapter.ajax.calledWithExactly(url, 'POST', payload));
     });
   });
+
+  module('#deneutralizeChallenge', function() {
+
+    test('deneutralizes a challenge', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('certification-details');
+      sinon.stub(adapter, 'ajax');
+
+      const url = `${ENV.APP.API_HOST}/api/admin/certification/deneutralize-challenge`;
+      const payload = {
+        data: {
+          data: {
+            attributes: {
+              certificationCourseId: 123,
+              challengeRecId: 'rec123',
+            },
+          },
+        },
+      };
+      adapter.ajax.resolves({});
+
+      const certification = run(() => store.createRecord('certification-details', {
+        listChallengesAndAnswers: [],
+      }));
+
+      // when
+      await certification.deneutralizeChallenge(
+        {
+          certificationCourseId: 123,
+          challengeRecId: 'rec123',
+        },
+      );
+
+      // then
+      assert.ok(adapter.ajax.calledWithExactly(url, 'POST', payload));
+    });
+  });
 });

--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -61,11 +61,12 @@ module.exports = {
     const challengeRecId = request.payload.data.attributes.challengeRecId;
     const certificationCourseId = request.payload.data.attributes.certificationCourseId;
     const juryId = request.auth.credentials.userId;
-    await usecases.deneutralizeChallenge({
+    const event = await usecases.deneutralizeChallenge({
       challengeRecId,
       certificationCourseId,
       juryId,
     });
+    await events.eventDispatcher.dispatch(event);
     return h.response().code(204);
   },
 };

--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -56,4 +56,16 @@ module.exports = {
     await events.eventDispatcher.dispatch(event);
     return h.response().code(204);
   },
+
+  async deneutralizeChallenge(request, h) {
+    const challengeRecId = request.payload.data.attributes.challengeRecId;
+    const certificationCourseId = request.payload.data.attributes.certificationCourseId;
+    const juryId = request.auth.credentials.userId;
+    await usecases.deneutralizeChallenge({
+      challengeRecId,
+      certificationCourseId,
+      juryId,
+    });
+    return h.response().code(204);
+  },
 };

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -90,6 +90,28 @@ exports.register = async function(server) {
         tags: ['api'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/certification/deneutralize-challenge',
+      config: {
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                certificationCourseId: identifiersType.certificationCourseId,
+                challengeRecId: Joi.string().required(),
+              },
+            },
+          }),
+        },
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: certificationController.deneutralizeChallenge,
+        tags: ['api'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -79,6 +79,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.ChallengeToBeNeutralizedNotFoundError) {
     return new HttpErrors.NotFoundError(error.message);
   }
+  if (error instanceof DomainErrors.ChallengeToBeDeneutralizedNotFoundError) {
+    return new HttpErrors.NotFoundError(error.message);
+  }
   if (error instanceof DomainErrors.NotFoundError) {
     return new HttpErrors.NotFoundError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -405,6 +405,12 @@ class ChallengeToBeNeutralizedNotFoundError extends DomainError {
   }
 }
 
+class ChallengeToBeDeneutralizedNotFoundError extends DomainError {
+  constructor() {
+    super('La question à dé-neutraliser n\'a pas été posée lors du test de certification');
+  }
+}
+
 class CsvParsingError extends DomainError {
   constructor(message = 'Les données n\'ont pas pu être parsées.') {
     super(message);
@@ -797,6 +803,7 @@ module.exports = {
   CertificationCourseUpdateError,
   ChallengeAlreadyAnsweredError,
   ChallengeToBeNeutralizedNotFoundError,
+  ChallengeToBeDeneutralizedNotFoundError,
   CompetenceResetError,
   CsvImportError,
   CsvParsingError,

--- a/api/lib/domain/events/ChallengeDeneutralized.js
+++ b/api/lib/domain/events/ChallengeDeneutralized.js
@@ -1,0 +1,8 @@
+class ChallengeDeneutralized {
+  constructor({ certificationCourseId, juryId }) {
+    this.certificationCourseId = certificationCourseId;
+    this.juryId = juryId;
+  }
+}
+
+module.exports = ChallengeDeneutralized;

--- a/api/lib/domain/events/check-event-type.js
+++ b/api/lib/domain/events/check-event-type.js
@@ -1,7 +1,0 @@
-module.exports = {
-  checkEventType(event, eventType) {
-    if (!(event instanceof eventType)) {
-      throw new Error(`event must be of type ${eventType.name}`);
-    }
-  },
-};

--- a/api/lib/domain/events/check-event-types.js
+++ b/api/lib/domain/events/check-event-types.js
@@ -1,0 +1,11 @@
+const _ = require('lodash');
+module.exports = {
+  checkEventTypes(receivedEvent, acceptedEventTypes) {
+    if (!_.some(acceptedEventTypes, (acceptedEventType) => {
+      return receivedEvent instanceof acceptedEventType;
+    })) {
+      const acceptedEventNames = acceptedEventTypes.map((acceptedEventType) => acceptedEventType.name);
+      throw new Error(`event must be one of types ${acceptedEventNames.join(', ')}`);
+    }
+  },
+};

--- a/api/lib/domain/events/compute-validated-skills-count.js
+++ b/api/lib/domain/events/compute-validated-skills-count.js
@@ -18,4 +18,4 @@ async function _countValidatedSkills(campaignParticipation, knowledgeElementRepo
   return _(validatedSkillsCountByCompetence).values().sum();
 }
 
-module.exports.eventType = CampaignParticipationResultShared;
+module.exports.eventTypes = [ CampaignParticipationResultShared ];

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const AssessmentCompleted = require('../events/AssessmentCompleted');
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 
 const eventType = AssessmentCompleted;
 
@@ -11,7 +11,7 @@ const handleBadgeAcquisition = async function({
   badgeRepository,
   campaignParticipationResultRepository,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
 
   if (event.isCampaignType) {
     const badges = await _fetchPossibleCampaignAssociatedBadges(event, badgeRepository);

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const AssessmentCompleted = require('../events/AssessmentCompleted');
 const { checkEventTypes } = require('./check-event-types');
 
-const eventType = AssessmentCompleted;
+const eventTypes = [ AssessmentCompleted ];
 
 const handleBadgeAcquisition = async function({
   event,
@@ -11,7 +11,7 @@ const handleBadgeAcquisition = async function({
   badgeRepository,
   campaignParticipationResultRepository,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, eventTypes);
 
   if (event.isCampaignType) {
     const badges = await _fetchPossibleCampaignAssociatedBadges(event, badgeRepository);
@@ -45,5 +45,5 @@ function _isBadgeAcquired(campaignParticipationResult, badge, badgeCriteriaServi
   return badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badge });
 }
 
-handleBadgeAcquisition.eventType = eventType;
+handleBadgeAcquisition.eventTypes = eventTypes;
 module.exports = handleBadgeAcquisition;

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -5,7 +5,7 @@ const {
   CertificationComputeError,
 } = require('../errors');
 const ChallengeNeutralized = require('./ChallengeNeutralized');
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 
 const eventType = ChallengeNeutralized;
 const EMITTER = 'PIX-ALGO-NEUTRALIZATION'; // to be refined according to rescoring reason
@@ -17,7 +17,7 @@ async function handleCertificationRescoring({
   competenceMarkRepository,
   scoringCertificationService,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
 
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: event.certificationCourseId });
   await _calculateCertificationScore({

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -5,9 +5,10 @@ const {
   CertificationComputeError,
 } = require('../errors');
 const ChallengeNeutralized = require('./ChallengeNeutralized');
+const ChallengeDeneutralized = require('./ChallengeDeneutralized');
 const { checkEventTypes } = require('./check-event-types');
 
-const eventType = ChallengeNeutralized;
+const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized];
 const EMITTER = 'PIX-ALGO-NEUTRALIZATION'; // to be refined according to rescoring reason
 
 async function handleCertificationRescoring({
@@ -17,7 +18,7 @@ async function handleCertificationRescoring({
   competenceMarkRepository,
   scoringCertificationService,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, [eventTypes]);
 
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: event.certificationCourseId });
   await _calculateCertificationScore({
@@ -105,5 +106,5 @@ async function _saveResultAfterCertificationComputeError({
   await assessmentResultRepository.save(assessmentResult);
 }
 
-handleCertificationRescoring.eventType = eventType;
+handleCertificationRescoring.eventTypes = eventTypes;
 module.exports = handleCertificationRescoring;

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -9,7 +9,7 @@ const ChallengeDeneutralized = require('./ChallengeDeneutralized');
 const { checkEventTypes } = require('./check-event-types');
 
 const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized];
-const EMITTER = 'PIX-ALGO-NEUTRALIZATION'; // to be refined according to rescoring reason
+const EMITTER = 'PIX-ALGO-NEUTRALIZATION';
 
 async function handleCertificationRescoring({
   event,
@@ -18,7 +18,7 @@ async function handleCertificationRescoring({
   competenceMarkRepository,
   scoringCertificationService,
 }) {
-  checkEventTypes(event, [eventTypes]);
+  checkEventTypes(event, eventTypes);
 
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: event.certificationCourseId });
   await _calculateCertificationScore({

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -6,7 +6,7 @@ const {
   CertificationComputeError,
 } = require('../errors');
 const AssessmentCompleted = require('./AssessmentCompleted');
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 
 const eventType = AssessmentCompleted;
 const EMITTER = 'PIX-ALGO';
@@ -20,7 +20,7 @@ async function handleCertificationScoring({
   competenceMarkRepository,
   scoringCertificationService,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
 
   if (event.isCertificationType) {
     const certificationAssessment = await certificationAssessmentRepository.get(event.assessmentId);

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -8,7 +8,7 @@ const {
 const AssessmentCompleted = require('./AssessmentCompleted');
 const { checkEventTypes } = require('./check-event-types');
 
-const eventType = AssessmentCompleted;
+const eventTypes = [ AssessmentCompleted ];
 const EMITTER = 'PIX-ALGO';
 
 async function handleCertificationScoring({
@@ -20,7 +20,7 @@ async function handleCertificationScoring({
   competenceMarkRepository,
   scoringCertificationService,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, eventTypes);
 
   if (event.isCertificationType) {
     const certificationAssessment = await certificationAssessmentRepository.get(event.assessmentId);
@@ -118,5 +118,5 @@ async function _saveResultAfterCertificationComputeError({
   await assessmentResultRepository.save(assessmentResult);
   return certificationCourseRepository.changeCompletionDate(certificationAssessment.certificationCourseId, new Date());
 }
-handleCertificationScoring.eventType = eventType;
+handleCertificationScoring.eventTypes = eventTypes;
 module.exports = handleCertificationScoring;

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -1,4 +1,4 @@
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 const CertificationScoringCompleted = require('./CertificationScoringCompleted');
 
 const eventType = CertificationScoringCompleted;
@@ -7,7 +7,7 @@ async function handleCleaCertificationScoring({
   event,
   partnerCertificationScoringRepository,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
   const cleaCertificationScoring = await partnerCertificationScoringRepository.buildCleaCertificationScoring({
     certificationCourseId: event.certificationCourseId,
     userId: event.userId,

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -1,13 +1,13 @@
 const { checkEventTypes } = require('./check-event-types');
 const CertificationScoringCompleted = require('./CertificationScoringCompleted');
 
-const eventType = CertificationScoringCompleted;
+const eventTypes = [ CertificationScoringCompleted ];
 
 async function handleCleaCertificationScoring({
   event,
   partnerCertificationScoringRepository,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, eventTypes);
   const cleaCertificationScoring = await partnerCertificationScoringRepository.buildCleaCertificationScoring({
     certificationCourseId: event.certificationCourseId,
     userId: event.userId,
@@ -19,5 +19,5 @@ async function handleCleaCertificationScoring({
   }
 }
 
-handleCleaCertificationScoring.eventType = eventType;
+handleCleaCertificationScoring.eventTypes = eventTypes;
 module.exports = handleCleaCertificationScoring;

--- a/api/lib/domain/events/handle-pix-plus-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-certifications-scoring.js
@@ -1,4 +1,4 @@
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 const CertificationScoringCompleted = require('./CertificationScoringCompleted');
 const PixPlusCertificationScoring = require('../models/PixPlusCertificationScoring');
 const { ReproducibilityRate } = require('../models/ReproducibilityRate');
@@ -11,7 +11,7 @@ async function handlePixPlusCertificationsScoring({
   certificationAssessmentRepository,
   partnerCertificationScoringRepository,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
   const certificationCourseId = event.certificationCourseId;
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId, domainTransaction });
   const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgeKeysTaken();

--- a/api/lib/domain/events/handle-pix-plus-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-certifications-scoring.js
@@ -3,7 +3,7 @@ const CertificationScoringCompleted = require('./CertificationScoringCompleted')
 const PixPlusCertificationScoring = require('../models/PixPlusCertificationScoring');
 const { ReproducibilityRate } = require('../models/ReproducibilityRate');
 
-const eventType = CertificationScoringCompleted;
+const eventTypes = [ CertificationScoringCompleted ];
 
 async function handlePixPlusCertificationsScoring({
   event,
@@ -11,7 +11,7 @@ async function handlePixPlusCertificationsScoring({
   certificationAssessmentRepository,
   partnerCertificationScoringRepository,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, eventTypes);
   const certificationCourseId = event.certificationCourseId;
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId, domainTransaction });
   const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgeKeysTaken();
@@ -32,5 +32,5 @@ function _buildPixPlusCertificationScoring(event, answers, certifiableBadgeKey) 
   });
 }
 
-handlePixPlusCertificationsScoring.eventType = eventType;
+handlePixPlusCertificationsScoring.eventTypes = eventTypes;
 module.exports = handlePixPlusCertificationsScoring;

--- a/api/lib/domain/events/handle-pole-emploi-participation-finished.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-finished.js
@@ -3,7 +3,7 @@ const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/Po
 const AssessmentCompleted = require('./AssessmentCompleted');
 const PoleEmploiSending = require('../models/PoleEmploiSending');
 
-const eventType = AssessmentCompleted;
+const eventTypes = [ AssessmentCompleted ];
 
 async function handlePoleEmploiParticipationFinished({
   event,
@@ -16,7 +16,7 @@ async function handlePoleEmploiParticipationFinished({
   userRepository,
   poleEmploiNotifier,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, eventTypes);
 
   const { campaignParticipationId } = event;
 
@@ -53,5 +53,5 @@ async function handlePoleEmploiParticipationFinished({
   }
 }
 
-handlePoleEmploiParticipationFinished.eventType = eventType;
+handlePoleEmploiParticipationFinished.eventTypes = eventTypes;
 module.exports = handlePoleEmploiParticipationFinished;

--- a/api/lib/domain/events/handle-pole-emploi-participation-finished.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-finished.js
@@ -1,4 +1,4 @@
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
 const AssessmentCompleted = require('./AssessmentCompleted');
 const PoleEmploiSending = require('../models/PoleEmploiSending');
@@ -16,7 +16,7 @@ async function handlePoleEmploiParticipationFinished({
   userRepository,
   poleEmploiNotifier,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
 
   const { campaignParticipationId } = event;
 

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -1,4 +1,4 @@
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 const CampaignParticipationResultsShared = require('./CampaignParticipationResultsShared');
 const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
 const PoleEmploiSending = require('../models/PoleEmploiSending');
@@ -16,7 +16,7 @@ async function handlePoleEmploiParticipationShared({
   userRepository,
   poleEmploiNotifier,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
 
   const { campaignParticipationId } = event;
 

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -3,7 +3,7 @@ const CampaignParticipationResultsShared = require('./CampaignParticipationResul
 const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
 const PoleEmploiSending = require('../models/PoleEmploiSending');
 
-const eventType = CampaignParticipationResultsShared;
+const eventTypes = [ CampaignParticipationResultsShared ];
 
 async function handlePoleEmploiParticipationShared({
   event,
@@ -16,7 +16,7 @@ async function handlePoleEmploiParticipationShared({
   userRepository,
   poleEmploiNotifier,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, eventTypes);
 
   const { campaignParticipationId } = event;
 
@@ -51,5 +51,5 @@ async function handlePoleEmploiParticipationShared({
   }
 }
 
-handlePoleEmploiParticipationShared.eventType = eventType;
+handlePoleEmploiParticipationShared.eventTypes = eventTypes;
 module.exports = handlePoleEmploiParticipationShared;

--- a/api/lib/domain/events/handle-pole-emploi-participation-started.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-started.js
@@ -3,7 +3,7 @@ const CampaignParticipationStarted = require('./CampaignParticipationStarted');
 const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
 const PoleEmploiSending = require('../models/PoleEmploiSending');
 
-const eventType = CampaignParticipationStarted;
+const eventTypes = [ CampaignParticipationStarted ];
 
 async function handlePoleEmploiParticipationStarted({
   event,
@@ -15,7 +15,7 @@ async function handlePoleEmploiParticipationStarted({
   userRepository,
   poleEmploiNotifier,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, eventTypes);
 
   const { campaignParticipationId } = event;
 
@@ -48,5 +48,5 @@ async function handlePoleEmploiParticipationStarted({
   }
 }
 
-handlePoleEmploiParticipationStarted.eventType = eventType;
+handlePoleEmploiParticipationStarted.eventTypes = eventTypes;
 module.exports = handlePoleEmploiParticipationStarted;

--- a/api/lib/domain/events/handle-pole-emploi-participation-started.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-started.js
@@ -1,4 +1,4 @@
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 const CampaignParticipationStarted = require('./CampaignParticipationStarted');
 const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
 const PoleEmploiSending = require('../models/PoleEmploiSending');
@@ -15,7 +15,7 @@ async function handlePoleEmploiParticipationStarted({
   userRepository,
   poleEmploiNotifier,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
 
   const { campaignParticipationId } = event;
 

--- a/api/lib/domain/events/handle-session-finalized.js
+++ b/api/lib/domain/events/handle-session-finalized.js
@@ -1,5 +1,5 @@
 const FinalizedSession = require('../models/FinalizedSession');
-const { checkEventType } = require('./check-event-type');
+const { checkEventTypes } = require('./check-event-types');
 const SessionFinalized = require('./SessionFinalized');
 
 const eventType = SessionFinalized;
@@ -9,7 +9,7 @@ async function handleSessionFinalized({
   juryCertificationSummaryRepository,
   finalizedSessionRepository,
 }) {
-  checkEventType(event, eventType);
+  checkEventTypes(event, [eventType]);
   const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(event.sessionId);
 
   const finalizedSession = FinalizedSession.from({

--- a/api/lib/domain/events/handle-session-finalized.js
+++ b/api/lib/domain/events/handle-session-finalized.js
@@ -2,14 +2,14 @@ const FinalizedSession = require('../models/FinalizedSession');
 const { checkEventTypes } = require('./check-event-types');
 const SessionFinalized = require('./SessionFinalized');
 
-const eventType = SessionFinalized;
+const eventTypes = [ SessionFinalized ];
 
 async function handleSessionFinalized({
   event,
   juryCertificationSummaryRepository,
   finalizedSessionRepository,
 }) {
-  checkEventTypes(event, [eventType]);
+  checkEventTypes(event, eventTypes);
   const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(event.sessionId);
 
   const finalizedSession = FinalizedSession.from({
@@ -25,6 +25,6 @@ async function handleSessionFinalized({
   await finalizedSessionRepository.save(finalizedSession);
 }
 
-handleSessionFinalized.eventType = eventType;
+handleSessionFinalized.eventTypes = eventTypes;
 module.exports = handleSessionFinalized;
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -53,7 +53,10 @@ function buildEventDispatcher(handlersStubs) {
 
   for (const key in handlers) {
     const inject = _.partial(injectDefaults, dependencies);
-    eventDispatcher.subscribe(handlersToBeInjected[key].eventType, inject(handlers[key]));
+    const injectedHandler = inject(handlers[key]);
+    for (const eventType of handlersToBeInjected[key].eventTypes) {
+      eventDispatcher.subscribe(eventType, injectedHandler);
+    }
   }
 
   return eventDispatcher;

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -3,7 +3,7 @@ const Joi = require('joi')
 const { validateEntity } = require('../validators/entity-validator');
 const { states } = require('./Assessment');
 const _ = require('lodash');
-const { ChallengeToBeNeutralizedNotFoundError } = require('../errors');
+const { ChallengeToBeNeutralizedNotFoundError, ChallengeToBeDeneutralizedNotFoundError } = require('../errors');
 
 const certificationAssessmentSchema = Joi.object({
   id: Joi.number().integer().required(),
@@ -53,6 +53,15 @@ class CertificationAssessment {
       challengeToBeNeutralized.neutralize();
     } else {
       throw new ChallengeToBeNeutralizedNotFoundError();
+    }
+  }
+
+  deneutralizeChallengeByRecId(recId) {
+    const challengeToBeDeneutralized = _.find(this.certificationChallenges, { challengeId: recId });
+    if (challengeToBeDeneutralized) {
+      challengeToBeDeneutralized.deneutralize();
+    } else {
+      throw new ChallengeToBeDeneutralizedNotFoundError();
     }
   }
 

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -60,6 +60,10 @@ class CertificationChallenge {
     this.isNeutralized = true;
   }
 
+  deneutralize() {
+    this.isNeutralized = false;
+  }
+
   isPixPlus() {
     return Boolean(this.certifiableBadgeKey);
   }

--- a/api/lib/domain/usecases/deneutralize-challenge.js
+++ b/api/lib/domain/usecases/deneutralize-challenge.js
@@ -1,0 +1,13 @@
+const ChallengeDeneutralized = require('../events/ChallengeDeneutralized');
+
+module.exports = async function deneutralizeChallenge({
+  certificationAssessmentRepository,
+  certificationCourseId,
+  challengeRecId,
+  juryId,
+}) {
+  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId });
+  certificationAssessment.deneutralizeChallengeByRecId(challengeRecId);
+  await certificationAssessmentRepository.save(certificationAssessment);
+  return new ChallengeDeneutralized({ certificationCourseId, juryId });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -266,6 +266,7 @@ module.exports = injectDependencies({
   publishSession: require('./publish-session'),
   unpublishSession: require('./unpublish-session'),
   neutralizeChallenge: require('./neutralize-challenge'),
+  deneutralizeChallenge: require('./deneutralize-challenge'),
   publishSessionsInBatch: require('./publish-sessions-in-batch'),
   updateSchoolingRegistrationDependentUserPassword: require('./update-schooling-registration-dependent-user-password'),
   updateSession: require('./update-session'),

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -162,6 +162,14 @@ describe('Integration | API | Controller Error', () => {
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('La question à neutraliser n\'a pas été posée lors du test de certification');
     });
+
+    it('responds Not Found when a ChallengeToBeDeneutralizedNotFoundError error occurs', async () => {
+      routeHandler.throws(new DomainErrors.ChallengeToBeDeneutralizedNotFoundError());
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
+      expect(responseDetail(response)).to.equal('La question à dé-neutraliser n\'a pas été posée lors du test de certification');
+    });
   });
 
   context('409 Conflict', () => {

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -143,12 +143,36 @@ describe('Unit | Controller | certifications-controller', () => {
         },
         auth: { credentials: { userId: 7 } },
       };
-      const eventToBeDispatched = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
-      sinon.stub(usecases, 'neutralizeChallenge').withArgs({
+      sinon.stub(usecases, 'neutralizeChallenge');
+      sinon.stub(events, 'eventDispatcher').value({
+        dispatch: sinon.stub(),
+      });
+
+      // when
+      await certificationController.neutralizeChallenge(request, hFake);
+
+      // then
+      expect(usecases.neutralizeChallenge).to.have.been.calledWith({
         certificationCourseId: 1,
         challengeRecId: 'rec43mpMIR5dUzdjh',
         juryId: 7,
-      }).resolves(eventToBeDispatched);
+      });
+    });
+
+    it('returns 204', async () => {
+      // given
+      const request = {
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: 1,
+              challengeRecId: 'rec43mpMIR5dUzdjh',
+            },
+          },
+        },
+        auth: { credentials: { userId: 7 } },
+      };
+      sinon.stub(usecases, 'neutralizeChallenge');
       sinon.stub(events, 'eventDispatcher').value({
         dispatch: sinon.stub(),
       });
@@ -157,8 +181,33 @@ describe('Unit | Controller | certifications-controller', () => {
       const response = await certificationController.neutralizeChallenge(request, hFake);
 
       // then
-      expect(events.eventDispatcher.dispatch).to.have.been.calledWithExactly(eventToBeDispatched);
       expect(response.statusCode).to.equal(204);
+    });
+
+    it('dispatches an event', async () => {
+      // given
+      const request = {
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: 1,
+              challengeRecId: 'rec43mpMIR5dUzdjh',
+            },
+          },
+        },
+        auth: { credentials: { userId: 7 } },
+      };
+      const eventToBeDispatched = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+      sinon.stub(usecases, 'neutralizeChallenge').resolves(eventToBeDispatched);
+      sinon.stub(events, 'eventDispatcher').value({
+        dispatch: sinon.stub(),
+      });
+
+      // when
+      await certificationController.neutralizeChallenge(request, hFake);
+
+      // then
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWithExactly(eventToBeDispatched);
     });
   });
 

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -160,4 +160,55 @@ describe('Unit | Controller | certifications-controller', () => {
       expect(response.statusCode).to.equal(204);
     });
   });
+
+  describe('#deneutralizeChallenge', () => {
+    it('deneutralizes the challenge', async () => {
+      // given
+      const request = {
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: 1,
+              challengeRecId: 'rec43mpMIR5dUzdjh',
+            },
+          },
+        },
+        auth: { credentials: { userId: 7 } },
+      };
+      sinon.stub(usecases, 'deneutralizeChallenge');
+
+      // when
+      await certificationController.deneutralizeChallenge(request, hFake);
+
+      // then
+      expect(usecases.deneutralizeChallenge).to.have.been.calledWith({
+        certificationCourseId: 1,
+        challengeRecId: 'rec43mpMIR5dUzdjh',
+        juryId: 7,
+      });
+    });
+
+    it('returns 204', async () => {
+      // given
+      const request = {
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: 1,
+              challengeRecId: 'rec43mpMIR5dUzdjh',
+            },
+          },
+        },
+        auth: { credentials: { userId: 7 } },
+      };
+      sinon.stub(usecases, 'deneutralizeChallenge');
+
+      // when
+      const response = await certificationController.deneutralizeChallenge(request, hFake);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+  });
 });

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -6,6 +6,7 @@ const certificationSerializer = require('../../../../lib/infrastructure/serializ
 const certificationAttestationPdf = require('../../../../lib/infrastructure/utils/pdf/certification-attestation-pdf');
 const events = require('../../../../lib/domain/events');
 const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
+const ChallengeDeneutralized = require('../../../../lib/domain/events/ChallengeDeneutralized');
 
 describe('Unit | Controller | certifications-controller', () => {
 
@@ -176,6 +177,7 @@ describe('Unit | Controller | certifications-controller', () => {
         auth: { credentials: { userId: 7 } },
       };
       sinon.stub(usecases, 'deneutralizeChallenge');
+      sinon.stub(events, 'eventDispatcher');
 
       // when
       await certificationController.deneutralizeChallenge(request, hFake);
@@ -202,12 +204,40 @@ describe('Unit | Controller | certifications-controller', () => {
         auth: { credentials: { userId: 7 } },
       };
       sinon.stub(usecases, 'deneutralizeChallenge');
+      sinon.stub(events, 'eventDispatcher');
 
       // when
       const response = await certificationController.deneutralizeChallenge(request, hFake);
 
       // then
       expect(response.statusCode).to.equal(204);
+    });
+
+    it('dispatches the event', async () => {
+      // given
+      const request = {
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: 1,
+              challengeRecId: 'rec43mpMIR5dUzdjh',
+            },
+          },
+        },
+        auth: { credentials: { userId: 7 } },
+      };
+      const eventToBeDispatched = new ChallengeDeneutralized({ certificationCourseId: 1, juryId: 7 });
+
+      sinon.stub(usecases, 'deneutralizeChallenge').resolves(eventToBeDispatched);
+      sinon.stub(events, 'eventDispatcher').value({
+        dispatch: sinon.stub(),
+      });
+
+      // when
+      await certificationController.deneutralizeChallenge(request, hFake);
+
+      // then
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(eventToBeDispatched);
     });
 
   });

--- a/api/tests/unit/application/certifications/index_test.js
+++ b/api/tests/unit/application/certifications/index_test.js
@@ -74,4 +74,73 @@ describe('Unit | Application | Certification | Routes', () => {
       expect(response.statusCode).to.equal(400);
     });
   });
+
+  context('POST /api/admin/certification/deneutralize-challenge', () => {
+
+    it('rejects access if the logged user is not a Pix Master', async () => {
+      // given
+      sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
+      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const payload = {
+        data: {
+          attributes: {
+            certificationCourseId: 1,
+            challengeRecId: 'rec43mpMIR5dUzdjh',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/certification/deneutralize-challenge', payload);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('checks that a valid certification-course id is given', async () => {
+      // given
+      sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
+      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const payload = {
+        data: {
+          attributes: {
+            certificationCourseId: 'invalide',
+            challengeRecId: 'rec43mpMIR5dUzdjh',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/certification/deneutralize-challenge', payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('checks that a challenge recId is given', async() => {
+      // given
+      sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
+      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const payload = {
+        data: {
+          attributes: {
+            certificationCourseId: 1,
+            challengeRecId: null,
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/certification/deneutralize-challenge', payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/unit/domain/events/check-event-type_test.js
+++ b/api/tests/unit/domain/events/check-event-type_test.js
@@ -1,17 +1,29 @@
 const { expect, catchErr } = require('../../../test-helper');
-const { checkEventType } = require('../../../../lib/domain/events/check-event-type');
+const { checkEventTypes } = require('../../../../lib/domain/events/check-event-types');
 
-describe('Unit | Domain | Events | check-event-type', () => {
-  it('throw with right message when event of wront type ', async () => {
+describe('Unit | Domain | Events | check-event-types', () => {
+  it('throw with right message when event of wrong type ', async () => {
     // given
     const wrongTypeEvent = 'Event of wrong type';
 
     // when
-    const error = await catchErr(checkEventType)(wrongTypeEvent, TestEvent);
+    const error = await catchErr(checkEventTypes)(wrongTypeEvent, [TestEvent1, TestEvent2]);
 
     // then
-    expect(error.message).to.equal('event must be of type TestEvent');
+    expect(error.message).to.equal('event must be one of types TestEvent1, TestEvent2');
+  });
+
+  it('accepts an event of correct type ', async () => {
+    // given
+    const correctTypeEvent = new TestEvent1();
+
+    // when / then
+    expect(() => {
+      checkEventTypes(correctTypeEvent, [TestEvent1, TestEvent2]);
+    }).not.to.throw();
   });
 });
 
-class TestEvent {}
+class TestEvent1 {}
+
+class TestEvent2 {}

--- a/api/tests/unit/domain/events/compute-validated-skills-count_test.js
+++ b/api/tests/unit/domain/events/compute-validated-skills-count_test.js
@@ -4,11 +4,11 @@ const CampaignParticipationResultsShared = require('./../../../../lib/domain/eve
 
 describe('Unit | Domain | Events | compute-validated-skills-count', function() {
 
-  describe('eventType', () => {
+  describe('eventTypes', () => {
     it('returns the CampaignParticipationResultsShared', () => {
-      const eventType = computeValidatedSkillsCount.eventType;
+      const eventTypes = computeValidatedSkillsCount.eventTypes;
 
-      expect(eventType).to.equals(CampaignParticipationResultsShared);
+      expect(eventTypes).to.deep.equal([CampaignParticipationResultsShared]);
     });
   });
 

--- a/api/tests/unit/domain/events/event-choreography-rescore-certification_test.js
+++ b/api/tests/unit/domain/events/event-choreography-rescore-certification_test.js
@@ -1,0 +1,30 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
+const ChallengeDeneutralized = require('../../../../lib/domain/events/ChallengeDeneutralized');
+
+describe('Event Choreography | Rescore Certification', function() {
+  it('Should trigger Certification Rescoring handler on ChallengeNeutralized event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+
+    // when
+    await eventDispatcher.dispatch(event);
+
+    // then
+    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWith({ domainTransaction: undefined, event });
+  });
+
+  it('Should trigger Certification Rescoring handler on ChallengeDeneutralized event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new ChallengeDeneutralized({ certificationCourseId: 1, juryId: 7 });
+
+    // when
+    await eventDispatcher.dispatch(event);
+
+    // then
+    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWith({ domainTransaction: undefined, event });
+  });
+});

--- a/api/tests/unit/domain/events/handle-pix-plus-certifications-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-pix-plus-certifications-scoring_test.js
@@ -31,7 +31,7 @@ describe('Unit | Domain | Events | handle-pix-plus-certifications-scoring', () =
     );
 
     // then
-    expect(error.message).to.equal('event must be of type CertificationScoringCompleted');
+    expect(error.message).to.equal('event must be one of types CertificationScoringCompleted');
   });
 
   context('when user was not asked any pix plus challenges', () => {

--- a/api/tests/unit/domain/models/CertificationChallenge_test.js
+++ b/api/tests/unit/domain/models/CertificationChallenge_test.js
@@ -28,6 +28,31 @@ describe('Unit | Domain | Models | CertificationChallenge', () => {
     });
   });
 
+  describe('#deneutralize', () => {
+
+    it('should deneutralize a neutralized certification challenge', () => {
+      // given
+      const certificationChallenge = domainBuilder.buildCertificationChallenge({ isNeutralized: true });
+
+      // when
+      certificationChallenge.deneutralize();
+
+      // then
+      expect(certificationChallenge.isNeutralized).to.be.false;
+    });
+
+    it('should leave a deneutralized certification challenge if it was deneutralized already', () => {
+      // given
+      const certificationChallenge = domainBuilder.buildCertificationChallenge({ isNeutralized: false });
+
+      // when
+      certificationChallenge.deneutralize();
+
+      // then
+      expect(certificationChallenge.isNeutralized).to.be.false;
+    });
+  });
+
   describe('#static createForPixCertification', () => {
 
     it('should build a certificationChallenge for pix certification', () => {

--- a/api/tests/unit/domain/usecases/deneutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/deneutralize-challenge_test.js
@@ -1,0 +1,92 @@
+const {
+  sinon,
+  expect,
+  domainBuilder,
+} = require('../../../test-helper');
+const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
+const deneutralizeChallenge = require('../../../../lib/domain/usecases/deneutralize-challenge');
+const ChallengeDeneutralized = require('../../../../lib/domain/events/ChallengeDeneutralized');
+
+describe('Unit | UseCase | deneutralize-challenge', () => {
+  it('deneutralizes a challenge by its recId', async () => {
+    // given
+    const certificationCourseId = 1;
+    const certificationAssessmentRepository = {
+      getByCertificationCourseId: sinon.stub(),
+      save: sinon.stub(),
+    };
+    const dependencies = {
+      certificationAssessmentRepository,
+    };
+
+    const challengeToBeDeneutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: true });
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
+      certificationChallenges: [
+        challengeToBeDeneutralized,
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+      ],
+    });
+    sinon.stub(certificationAssessment, 'deneutralizeChallengeByRecId');
+
+    certificationAssessmentRepository.getByCertificationCourseId
+      .withArgs({ certificationCourseId })
+      .resolves(certificationAssessment);
+
+    // when
+    await deneutralizeChallenge({
+      ...dependencies,
+      certificationCourseId,
+      challengeRecId: challengeToBeDeneutralized.challengeId,
+      juryId: 7,
+    });
+
+    // then
+    expect(certificationAssessment.deneutralizeChallengeByRecId).to.have.been.calledWith(challengeToBeDeneutralized.challengeId);
+    expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
+  });
+
+  it('return a ChallengeDeneutralized event', async () => {
+    // given
+    const certificationCourseId = 1;
+    const certificationAssessmentRepository = {
+      getByCertificationCourseId: sinon.stub(),
+      save: sinon.stub(),
+    };
+    const dependencies = {
+      certificationAssessmentRepository,
+    };
+
+    const challengeToBeDeneutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: true });
+    const certificationAssessment = new CertificationAssessment({
+      id: 123,
+      userId: 123,
+      certificationCourseId: 1,
+      createdAt: new Date('2020-01-01'),
+      completedAt: new Date('2020-01-01'),
+      state: CertificationAssessment.states.STARTED,
+      isV2Certification: true,
+      certificationChallenges: [
+        challengeToBeDeneutralized,
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+      ],
+      certificationAnswersByDate: ['answer'],
+    });
+    certificationAssessmentRepository.getByCertificationCourseId
+      .withArgs({ certificationCourseId })
+      .resolves(certificationAssessment);
+
+    // when
+    const event = await deneutralizeChallenge({
+      ...dependencies,
+      certificationCourseId,
+      challengeRecId: challengeToBeDeneutralized.challengeId,
+      juryId: 7,
+    });
+
+    // then
+    expect(event).to.be.an.instanceof(ChallengeDeneutralized);
+    expect(event).to.deep.equal({ certificationCourseId, juryId: 7 });
+  });
+});

--- a/api/tests/unit/domain/usecases/neutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/neutralize-challenge_test.js
@@ -13,7 +13,7 @@ describe('Unit | UseCase | neutralize-challenge', () => {
     const certificationCourseId = 1;
     const certificationAssessmentRepository = {
       getByCertificationCourseId: sinon.stub(),
-      save: sinon.spy(), // FIXME : do it without a spy ?
+      save: sinon.stub(),
     };
     const dependencies = {
       certificationAssessmentRepository,
@@ -35,6 +35,7 @@ describe('Unit | UseCase | neutralize-challenge', () => {
       ],
       certificationAnswersByDate: ['answer'],
     });
+    sinon.stub(certificationAssessment, 'neutralizeChallengeByRecId');
     certificationAssessmentRepository.getByCertificationCourseId
       .withArgs({ certificationCourseId })
       .resolves(certificationAssessment);
@@ -48,12 +49,8 @@ describe('Unit | UseCase | neutralize-challenge', () => {
     });
 
     // then
-    expect(
-      certificationAssessmentRepository.save
-        .getCall(0)
-        .args[0]
-        .certificationChallenges[0].isNeutralized,
-    ).to.be.true;
+    expect(certificationAssessment.neutralizeChallengeByRecId).to.have.been.calledWith(challengeToBeNeutralized.challengeId);
+    expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
   });
 
   it('return a ChallengeNeutralized event', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui le Pôle Certif peut neutraliser des épreuves, ce qui entraîne un rescoring automatique pour la certification concernée. Néanmoins le Pôle Certif devrait pourvoir annuler la neutralisation d’une épreuve en cas d’erreur ou autre.

## :robot: Solution
On enlève la désactivation du bouton Neutraliser lorsque l'épreuve est déjà neutralisée. A la place, on change la couleur du bouton pour un joli transparent grisou et on met le label "Dé-neutraliser". Cliquer sur ce bouton permet de déneutraliser l'épreuve.

## :rainbow: Remarques


## :100: Pour tester
- Se connecter à PixAdmin : pixmaster@example.net / pix123
- Se rendre sur la session de certification 5
- Se rendre sur la certification 104123
- Aller dans l'onglet Neutralisation
- Neutraliser une épreuve -> constater le changement du bouton. 
- Constater les effets attendus sur le score (mieux vaut neutraliser plusieurs épreuves pour voir un changement sur le score)
- Dé-neutraliser les épreuves neutralisées précédemment -> constater le retour du bouton "Neutraliser"
- Constater le retour à la normal du score
