### PR TITLE
[FEATURE] Ajout de l'info de neutralisation dans l'affichage du détail d'une certification dans Pix Admin (PIX-2380)

### DIFF
--- a/api/lib/domain/read-models/CertificationDetails.js
+++ b/api/lib/domain/read-models/CertificationDetails.js
@@ -79,6 +79,7 @@ function _buildListChallengesAndAnswers({
     return {
       challengeId: challengeForAnswer.challengeId,
       competence: competenceIndex,
+      isNeutralized: challengeForAnswer.isNeutralized,
       result: certificationAnswer.result.status,
       skill: challengeForAnswer.associatedSkillName,
       value: certificationAnswer.value,

--- a/api/tests/unit/domain/read-models/CertificationDetails_test.js
+++ b/api/tests/unit/domain/read-models/CertificationDetails_test.js
@@ -127,9 +127,9 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
 
       it('should create listChallengesAndAnswers', () => {
         // given
-        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue' });
+        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: true });
         const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
-        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit' });
+        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit', isNeutralized: false });
         const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456', value: 'bidule' });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge1, certificationChallenge2],
@@ -153,6 +153,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
           {
             challengeId: 'rec123',
             competence: '1.1',
+            isNeutralized: true,
             result: 'ok',
             skill: 'manger une mangue',
             value: 'prout',
@@ -160,6 +161,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
           {
             challengeId: 'rec456',
             competence: '2.2',
+            isNeutralized: false,
             result: 'ko',
             skill: 'faire son lit',
             value: 'bidule',
@@ -169,9 +171,9 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
 
       it('should ignore challenges that do not have answer', () => {
         // given
-        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue' });
+        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: true });
         const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
-        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit' });
+        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit', isNeutralized: true });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge1, certificationChallenge2],
           certificationAnswersByDate: [answer1],
@@ -194,6 +196,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
           {
             challengeId: 'rec123',
             competence: '1.1',
+            isNeutralized: true,
             result: 'ok',
             skill: 'manger une mangue',
             value: 'prout',

--- a/api/tests/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-details_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | get-certification-details', () => {
   it('should return the certification details', async () => {
     // given
     const certificationCourseId = 1234;
-    const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue' });
+    const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: false });
     const answer = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
 
     const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -82,6 +82,7 @@ describe('Unit | UseCase | get-certification-details', () => {
         {
           challengeId: 'rec123',
           competence: '1.1',
+          isNeutralized: false,
           result: 'ok',
           skill: 'manger une mangue',
           value: 'prout',


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix PIX-2111: Neutralisation auto des épreuves certif EPIX EN COURS DE DEV, le pôle certif va pouvoir neutraliser une ou plusieurs épreuves de certification simplement depuis un onglet spécifique dans Pix Admin. Il n’est donc plus nécessaire pour les membres du pôle certif de pouvoir neutraliser une épreuve depuis l’onglet “Détails” d’une certification comme c’est le cas aujourd’hui, grâce à une liste déroulante avec les statuts possible d’une épreuve. Néanmoins, il faut toujours que le pôle certification puisse visualiser le statut des épreuves depuis cet onglet “Détails” (à renommer à un moment d’ailleurs...)

## :robot: Solution
Ajouter un booléen isNeutralized dans certifications details. 

## :100: Pour tester
- Se connecter à PixAdmin : pixmaster@example.net / pix123
- Se rendre sur la session de certification 5
- Se rendre sur la certification 104123
- Aller dans l'onglet Details
- Constater la présence de l'option Neutralisée sur le détail d'une épreuve.

