### PR TITLE
[FEATURE] Empêcher l'utilisateur de se connecter avec un mot de passe à usage unique s'il a ensuite demandé une réinitilisation par email (PIX-2035).

### DIFF
--- a/api/lib/domain/usecases/create-password-reset-demand.js
+++ b/api/lib/domain/usecases/create-password-reset-demand.js
@@ -6,7 +6,7 @@ module.exports = async function createPasswordResetDemand({
   resetPasswordDemandRepository,
   userRepository,
 }) {
-  const { id: userId } = await userRepository.getByEmail(email);
+  await userRepository.isUserExistingByEmail(email);
 
   const temporaryKey = resetPasswordService.generateTemporaryKey();
   const passwordResetDemand = await resetPasswordDemandRepository.create({ email, temporaryKey });

--- a/api/lib/domain/usecases/create-password-reset-demand.js
+++ b/api/lib/domain/usecases/create-password-reset-demand.js
@@ -3,7 +3,6 @@ module.exports = async function createPasswordResetDemand({
   locale,
   mailService,
   resetPasswordService,
-  authenticationMethodRepository,
   resetPasswordDemandRepository,
   userRepository,
 }) {
@@ -11,10 +10,6 @@ module.exports = async function createPasswordResetDemand({
 
   const temporaryKey = resetPasswordService.generateTemporaryKey();
   const passwordResetDemand = await resetPasswordDemandRepository.create({ email, temporaryKey });
-  await authenticationMethodRepository.updateOnlyShouldChangePassword({
-    shouldChangePassword: false,
-    userId,
-  });
 
   await mailService.sendResetPasswordDemandEmail({ email, locale, temporaryKey });
 

--- a/api/lib/domain/usecases/update-user-password.js
+++ b/api/lib/domain/usecases/update-user-password.js
@@ -18,7 +18,7 @@ module.exports = async function updateUserPassword({
 
   await resetPasswordService.hasUserAPasswordResetDemandInProgress(user.email, temporaryKey);
 
-  const updatedUser = await authenticationMethodRepository.updateOnlyPassword({
+  const updatedUser = await authenticationMethodRepository.updateChangedPassword({
     userId: user.id,
     hashedPassword,
   });

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -53,18 +53,23 @@ module.exports = {
     }
   },
 
-  updateOnlyPassword({ userId, hashedPassword }) {
+  updateChangedPassword({ userId, hashedPassword }) {
+    const authenticationComplement = new AuthenticationMethod.PixAuthenticationComplement({
+      password: hashedPassword,
+      shouldChangePassword: false,
+    });
+
     return BookshelfAuthenticationMethod
       .where({
         userId,
         identityProvider: AuthenticationMethod.identityProviders.PIX,
       })
       .save(
+        { authenticationComplement },
         {
-          // eslint-disable-next-line quotes
-          authenticationComplement: Bookshelf.knex.raw(`jsonb_set("authenticationComplement", '{password}', ?)`, `"${hashedPassword}"`),
+          patch: true,
+          method: 'update',
         },
-        { patch: true, method: 'update' },
       )
       .then(_toDomainEntity)
       .catch((err) => {

--- a/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
@@ -2,7 +2,6 @@ const { catchErr, databaseBuilder, expect } = require('../../../test-helper');
 
 const mailService = require('../../../../lib/domain/services/mail-service');
 const resetPasswordService = require('../../../../lib/domain/services/reset-password-service');
-const authenticationMethodRepository = require('../../../../lib/infrastructure/repositories/authentication-method-repository');
 const resetPasswordDemandRepository = require('../../../../lib/infrastructure/repositories/reset-password-demands-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
@@ -32,7 +31,6 @@ describe('Integration | UseCases | create-password-reset-demand', () => {
       locale,
       mailService,
       resetPasswordService,
-      authenticationMethodRepository,
       resetPasswordDemandRepository,
       userRepository,
     });
@@ -52,7 +50,6 @@ describe('Integration | UseCases | create-password-reset-demand', () => {
       locale,
       mailService,
       resetPasswordService,
-      authenticationMethodRepository,
       resetPasswordDemandRepository,
       userRepository,
     });

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -94,7 +94,7 @@ describe('Integration | Repository | AuthenticationMethod', () => {
     });
   });
 
-  describe('#updateOnlyPassword', () => {
+  describe('#updateChangedPassword', () => {
 
     let userId;
 
@@ -112,7 +112,7 @@ describe('Integration | Repository | AuthenticationMethod', () => {
       await databaseBuilder.commit();
 
       // when
-      const updatedAuthenticationMethod = await authenticationMethodRepository.updateOnlyPassword({
+      const updatedAuthenticationMethod = await authenticationMethodRepository.updateChangedPassword({
         userId,
         hashedPassword: newHashedPassword,
       });
@@ -123,7 +123,7 @@ describe('Integration | Repository | AuthenticationMethod', () => {
       expect(updatedAuthenticationMethod.authenticationComplement.password).to.equal(newHashedPassword);
     });
 
-    it('should update only the password', async () => {
+    it('should update the password and disable changing password', async () => {
       // given
       databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
         userId,
@@ -133,14 +133,14 @@ describe('Integration | Repository | AuthenticationMethod', () => {
       await databaseBuilder.commit();
 
       // when
-      const updatedAuthenticationMethod = await authenticationMethodRepository.updateOnlyPassword({
+      const updatedAuthenticationMethod = await authenticationMethodRepository.updateChangedPassword({
         userId,
         hashedPassword: newHashedPassword,
       });
 
       // then
       expect(updatedAuthenticationMethod.authenticationComplement.password).to.equal(newHashedPassword);
-      expect(updatedAuthenticationMethod.authenticationComplement.shouldChangePassword).to.be.true;
+      expect(updatedAuthenticationMethod.authenticationComplement.shouldChangePassword).to.be.false;
     });
 
     it('should throw AuthenticationMethodNotFoundError when user id not found', async () => {
@@ -148,7 +148,7 @@ describe('Integration | Repository | AuthenticationMethod', () => {
       const wrongUserId = 0;
 
       // when
-      const error = await catchErr(authenticationMethodRepository.updateOnlyPassword)({
+      const error = await catchErr(authenticationMethodRepository.updateChangedPassword)({
         userId: wrongUserId,
         hashedPassword,
       });

--- a/api/tests/unit/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/unit/domain/usecases/create-password-reset-demand_test.js
@@ -32,10 +32,10 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
       create: sinon.stub(),
     };
     userRepository = {
-      getByEmail: sinon.stub(),
+      isUserExistingByEmail: sinon.stub(),
     };
 
-    userRepository.getByEmail.resolves({ id: 1 });
+    userRepository.isUserExistingByEmail.resolves({ id: 1 });
     resetPasswordService.generateTemporaryKey.returns(temporaryKey);
     resetPasswordDemandRepository.create.resolves(resetPasswordDemand);
   });
@@ -54,7 +54,7 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
     // then
     expect(result).to.deep.equal(resetPasswordDemand);
 
-    expect(userRepository.getByEmail).to.have.been.calledWithExactly(email);
+    expect(userRepository.isUserExistingByEmail).to.have.been.calledWithExactly(email);
     expect(resetPasswordService.generateTemporaryKey).to.have.been.calledOnce;
     expect(resetPasswordDemandRepository.create).to.have.been.calledWithExactly({ email, temporaryKey });
     expect(mailService.sendResetPasswordDemandEmail)
@@ -63,7 +63,7 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
 
   it('should throw UserNotFoundError if user email does not exist', async () => {
     // given
-    userRepository.getByEmail.throws(new UserNotFoundError());
+    userRepository.isUserExistingByEmail.throws(new UserNotFoundError());
 
     // when
     const error = await catchErr(createPasswordResetDemand)({

--- a/api/tests/unit/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/unit/domain/usecases/create-password-reset-demand_test.js
@@ -18,7 +18,6 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
 
   let mailService;
   let resetPasswordService;
-  let authenticationMethodRepository;
   let resetPasswordDemandRepository;
   let userRepository;
 
@@ -28,9 +27,6 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
     };
     resetPasswordService = {
       generateTemporaryKey: sinon.stub(),
-    };
-    authenticationMethodRepository = {
-      updateOnlyShouldChangePassword: sinon.stub(),
     };
     resetPasswordDemandRepository = {
       create: sinon.stub(),
@@ -51,7 +47,6 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
       locale,
       mailService,
       resetPasswordService,
-      authenticationMethodRepository,
       resetPasswordDemandRepository,
       userRepository,
     });
@@ -62,10 +57,6 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
     expect(userRepository.getByEmail).to.have.been.calledWithExactly(email);
     expect(resetPasswordService.generateTemporaryKey).to.have.been.calledOnce;
     expect(resetPasswordDemandRepository.create).to.have.been.calledWithExactly({ email, temporaryKey });
-    expect(authenticationMethodRepository.updateOnlyShouldChangePassword).to.have.been.calledWith({
-      userId: 1,
-      shouldChangePassword: false,
-    });
     expect(mailService.sendResetPasswordDemandEmail)
       .to.have.been.calledWithExactly({ email, locale, temporaryKey });
   });
@@ -80,7 +71,6 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
       locale,
       mailService,
       resetPasswordService,
-      authenticationMethodRepository,
       resetPasswordDemandRepository,
       userRepository,
     });

--- a/api/tests/unit/domain/usecases/update-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-user-password_test.js
@@ -31,7 +31,7 @@ describe('Unit | UseCase | update-user-password', () => {
       invalidateOldResetPasswordDemand: sinon.stub(),
     };
     authenticationMethodRepository = {
-      updateOnlyPassword: sinon.stub(),
+      updateChangedPassword: sinon.stub(),
     };
     userRepository = {
       get: sinon.stub(),
@@ -45,7 +45,7 @@ describe('Unit | UseCase | update-user-password', () => {
       .resolves();
     resetPasswordService.invalidateOldResetPasswordDemand.resolves();
 
-    authenticationMethodRepository.updateOnlyPassword.resolves();
+    authenticationMethodRepository.updateChangedPassword.resolves();
     userRepository.get.resolves(user);
   });
 
@@ -118,7 +118,7 @@ describe('Unit | UseCase | update-user-password', () => {
 
     // then
     expect(encryptionService.hashPassword).to.have.been.calledWith(password);
-    expect(authenticationMethodRepository.updateOnlyPassword).to.have.been.calledWith({
+    expect(authenticationMethodRepository.updateChangedPassword).to.have.been.calledWith({
       userId,
       hashedPassword,
     });


### PR DESCRIPTION
## :unicorn: Problème

Le flag 'shouldChangePassword' passe de true à false quand on clique sur le bouton [réinitialiser mon mot de passe](https://app.recette.pix.fr/mot-de-passe-oublie)

Par conséquent:

1. Si un prof reset le password d’un élève dans Pix Orga et que l'élève fait une demande de reset via [app.pix.fr](url). Et qu'il ne change pas son mot de passe depuis l’email qu’il a reçu. Mais qu'il retrouve le mot de passe à usage unique fourni par son prof. Il peut donc se connecter avec ce mot de passe à usage unique et ne sera pas invité à le changer. Le mot de passe à usage unique n’est plus à usage unique. De plus, le format de ce dernier n'est pas acceptable.
2. Si un utilisateur X fait le reset d'un user Y, cela change l'état du `shouldchangepassword` de l'utilisateur Y alors que ce dernier n'as rien demandé !

## :robot: Solution
Après que le mot de passe soit remplacé par l'utilisateur (via sa demande de reset de mot de passe), désactiver le changement (passer `shouldChangePassword` à `false`).

Si ce dernier ne le met pas à jour, il pourra toujours utiliser le mot de passe à usage unique fourni pas son professeur.

## :100: Pour tester
Au préalable, réinitialiser la base de données : 
```sh
scalingo --region osc-fr1 --app "pix-api-review-pr2902" run sh
npm run db:seed
```

**Scénario 1**
1. Se rendre sur Pix Orga, réinitialiser le mot de passe d'un élève qui dispose d'une connexion par email.
2. Se rendre sur Pix App, et faire une demande d'oublie de mot de passe.
3. Vérifier qu'on peut plus accéder via le mot de passe à usage unique et qu'on est redirigé vers l'écran de mise à jour de mot de passe expiré.

**Scénario 2**
1. Se rendre sur Pix Orga, réinitialiser le mot de passe d'un élève qui dispose d'une connexion par email.
2. Se rendre sur Pix App, et faire une demande d'oublie de mot de passe.
3. Réinitialiser son mot de passe depuis la demande recue par email.
4. Vérifier qu'on se connecte bien avec le mot de passe mise à jour.
5. Se connecter avec le mot de passe à usage unique du prof et vérifier qu'il est bien invalide.

