### PR TITLE
[BUGFIX] Supprimer le compteur de participations sur la page d'accueil de Pix Orga

### DIFF
--- a/api/lib/domain/read-models/CampaignReport.js
+++ b/api/lib/domain/read-models/CampaignReport.js
@@ -17,8 +17,8 @@ class CampaignReport {
     targetProfileId,
     targetProfileName,
     targetProfileImageUrl,
-    participationsCount,
-    sharedParticipationsCount,
+    participationsCount = 0,
+    sharedParticipationsCount = 0,
     badges = [],
     stages = [],
   } = {}) {

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -56,8 +56,6 @@ module.exports = {
         'users.id AS "creatorId"',
         'users.firstName AS creatorFirstName',
         'users.lastName AS creatorLastName',
-        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER (partition by "campaigns"."id") AS "participationsCount"'),
-        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isShared" IS TRUE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'),
       )
       .join('users', 'users.id', 'campaigns.creatorId')
       .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -454,8 +454,8 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(200);
         const campaigns = response.result.data;
         expect(campaigns).to.have.lengthOf(1);
-        expect(response.result.data[0].attributes['participations-count']).to.equal(1);
-        expect(response.result.data[0].attributes['shared-participations-count']).to.equal(1);
+        expect(response.result.data[0].attributes['participations-count']).to.equal(0);
+        expect(response.result.data[0].attributes['shared-participations-count']).to.equal(0);
       });
 
       it('should return default pagination meta data', async () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -150,7 +150,7 @@ describe('Integration | Repository | Campaign-Report', () => {
 
           // then
           expect(campaignReports[0]).to.be.instanceOf(CampaignReport);
-          expect(campaignReports[0]).to.include({ id: campaign.id, participationsCount: 3, sharedParticipationsCount: 1 });
+          expect(campaignReports[0]).to.include({ id: campaign.id, participationsCount: 0, sharedParticipationsCount: 0 });
         });
       });
 

--- a/orga/app/components/routes/authenticated/campaign/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/list.hbs
@@ -13,12 +13,6 @@
             <th class="table__column table__column--small">
               {{t 'pages.campaigns-list.table.column.created-on'}}
             </th>
-            <th class="table__column table__column--small">
-              {{t 'pages.campaigns-list.table.column.participants'}}
-            </th>
-            <th class="table__column table__column--small">
-              {{t 'pages.campaigns-list.table.column.results'}}
-            </th>
           </tr>
           <tr>
             <Table::HeaderFilterInput
@@ -36,8 +30,6 @@
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::Header/>
-            <Table::Header/>
-            <Table::Header/>
           </tr>
         </thead>
 
@@ -47,8 +39,6 @@
             <td>{{campaign.name}}</td>
             <td class="table__column--truncated">{{campaign.creatorFullName}}</td>
             <td>{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
-            <td>{{campaign.participationsCount}}</td>
-            <td>{{campaign.sharedParticipationsCount}}</td>
           </tr>
         {{/each}}
         </tbody>

--- a/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
@@ -140,52 +140,6 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       assert.contains('02/02/2020');
     });
 
-    test('it should display the participations count', async function(assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const campaign1 = store.createRecord('campaign', {
-        participationsCount: 10,
-      });
-
-      const campaigns = [campaign1];
-      campaigns.meta = {
-        rowCount: 1,
-      };
-      this.set('campaigns', campaigns);
-
-      // when
-      await render(hbs`<Routes::Authenticated::Campaign::List
-                  @campaigns={{campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
-                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
-      // then
-      assert.dom('[aria-label="Campagne"]').containsText('10');
-    });
-
-    test('it should display the shared participations count', async function(assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const campaign1 = store.createRecord('campaign', {
-        sharedParticipationsCount: 4,
-      });
-
-      const campaigns = [campaign1];
-      campaigns.meta = {
-        rowCount: 1,
-      };
-      this.set('campaigns', campaigns);
-
-      // when
-      await render(hbs`<Routes::Authenticated::Campaign::List
-                  @campaigns={{campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
-                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
-      // then
-      assert.dom('[aria-label="Campagne"]').containsText('4');
-    });
-
     test('it should display the placeholder of the filter by campaign field', async function(assert) {
       // given
       const campaigns = [];


### PR DESCRIPTION
## :unicorn: Problème
Nous avons un problème en production du a la volumétrie du nombre de campagne participation. Le fait de compter le nombre de participations crée des ralentissements.

## :robot: Solution
Supprimer les 2 compteurs sur la page d'accueil de Pix Orga d'une manière temporaire

## :rainbow: Remarques


## :100: Pour tester
1. Se connecter sur Pix Orga
2. Constater que sur la page d'accueil le nombre de participations ne s'affiche plus.