### PR TITLE
[BUGFIX] Suppression du join sur les campagnes participation

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -58,7 +58,6 @@ module.exports = {
         'users.lastName AS creatorLastName',
       )
       .join('users', 'users.id', 'campaigns.creatorId')
-      .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
       .where('campaigns.organizationId', organizationId)
       .modify(_setSearchFiltersForQueryBuilder, filter)
       .orderBy('campaigns.createdAt', 'DESC');


### PR DESCRIPTION
## :unicorn: Problème
Suite a #2903, nous avons oublié de supprimer une jointure devenu inutile

## :robot: Solution
La supprimer

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
