### PR TITLE
Mise à jour du changelog des hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 - [#2898](https://github.com/1024pix/pix/pull/2898) [BUGFIX] L'affichage du score dans la page de détails d'une certification sur PixAdmin pouvait être erroné (PIX-2507)
 - [#2888](https://github.com/1024pix/pix/pull/2888) [ADMIN] Supprimer les boutons “Récupérer le fichier avant jury” et “Exporter les résultats” de la page session dans Pix Admin (PIX-2495)
 
+## v3.47.2 (26/04/2021)
+
+- [#2905](https://github.com/1024pix/pix/pull/2905) [BUGFIX] Suppression du join sur les campagnes participation.
+
+## v3.47.1 (26/04/2021)
+
+- [#2904](https://github.com/1024pix/pix/pull/2904) [FEATURE] Changer la page de maintenance (PIX-2515).
+- [#2903](https://github.com/1024pix/pix/pull/2903) [BUGFIX] Supprimer le compteur de participations sur la page d'accueil de Pix Orga.
+
 ## v3.47.0 (22/04/2021)
 
 - [#2887](https://github.com/1024pix/pix/pull/2887) [FEATURE] Toujours renvoyer un niveau de competence positif pour le livret scolaire


### PR DESCRIPTION
## :unicorn: Problème
Nous avons mis en prod 2 hotfix hier. Du coup le changelog n'est pas a jour sur dev.

## :robot: Solution
Mettre a jour le changelog.

## :rainbow: Remarques
Les commits qui ont été déployé ont déjà été fusionné sur dev. C'est seulement ensuite que nous avons cueilli les cerises dans la branche de hotfix.
