### PR TITLE
[TECH] Ajouter un index sur campaignID dans la table campaign-participations.

### DIFF
--- a/api/db/migrations/20210427100545_add_indexes_on_table_campaign-participations.js
+++ b/api/db/migrations/20210427100545_add_indexes_on_table_campaign-participations.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'campaign-participations';
+const CAMPAIGNID_COLUMN = 'campaignId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(CAMPAIGNID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(CAMPAIGNID_COLUMN);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
L'index sur campaignID dans la table `campaign-participations` n'existe pas.

## :robot: Solution
Le remettre

## :rainbow: Remarques
Est-ce qu'on est OK pour le remettre ? 

## :100: Pour tester
