### PR TITLE
[FEATURE] Afficher les groupes d'acquis nécessaires pour obtenir un résultat thématique dans l'admin (PIX-2364)

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -31,30 +31,49 @@
 
 
     <div class="page-section__details table-admin">
-      <table>
-        <thead>
-          <tr>
-            <th>Périmètre</th>
-            <th>Seuil</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each @badge.badgeCriteria as |criterion|}}
-            <tr>
-              <td>{{criterion.scope}}
-                {{#if criterion.partnerCompetences}}
-                  <ul>
-                    {{#each criterion.partnerCompetences as |badgePartnerCompetence|}}
-                      <li>{{badgePartnerCompetence.name}}</li>
+      {{#each this.badgeCriteria as |criterion|}}
+        <p>L‘évalué doit obtenir <strong>{{criterion.threshold}}%</strong> sur {{call (fn this.scopeExplanation criterion.scope)}}</p>
+
+        {{#if criterion.partnerCompetences}}
+          <ul class="badge-criteria-competences">
+            {{#each criterion.partnerCompetences as |badgePartnerCompetence|}}
+            <li>
+              <details>
+                <summary>{{badgePartnerCompetence.name}}{{#if badgePartnerCompetence.color}} - {{badgePartnerCompetence.color}}{{/if}}</summary>
+                <table class="table-admin badge-partner-competences-table">
+                  <thead>
+                    <tr>
+                      <th class="table__column table__column--wide">Sujet</th>
+                      {{#each this.allLevels as |level|}}
+                      <th class="table__column table__column--small table__column--center">Niveau {{level}}</th>
+                      {{/each}}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {{#each badgePartnerCompetence.tubes as |tube|}}
+                    <tr>
+                      <td>{{tube.practicalTitle}}</td>
+                      {{#each tube.skillsWithAllLevels as |skill|}}
+                      <td class="table__column--center skill-column">
+                        {{#if skill}}
+                        <PixTooltip @text={{concat skill.id ' ' skill.name}} @position='bottom'  >
+                        <FaIcon @icon="check" class="skill-column--check" aria-label={{skill.name}} />
+                        </PixTooltip>
+                        {{else}}
+                        <FaIcon @icon="times" class="skill-column--uncheck" />
+                        {{/if}}
+                      </td>
+                      {{/each}}
+                    </tr>
                     {{/each}}
-                  </ul>
-                {{/if}}
-              </td>
-              <td>{{criterion.threshold}}</td>
-            </tr>
-          {{/each}}
-        </tbody>
-      </table>
+                  </tbody>
+                </table>
+              </details>
+            </li>
+            {{/each}}
+          </ul>
+        {{/if}}
+      {{/each}}
     </div>
   </section>
 </main>

--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -1,4 +1,8 @@
 import Component from '@glimmer/component';
+import uniqBy from 'lodash/uniqBy';
+import times from 'lodash/times';
+
+import ENV from 'pix-admin/config/environment';
 
 export default class Badge extends Component {
 
@@ -10,4 +14,28 @@ export default class Badge extends Component {
     return this.args.badge.isCertifiable ? 'Certifiable' : 'Non certifiable';
   }
 
+  get badgeCriteria() {
+    this.args.badge.badgeCriteria.forEach((badgeCriterion) => {
+      badgeCriterion.partnerCompetences.forEach((badgePartnerCompetence) => {
+        const tubes = uniqBy(badgePartnerCompetence.skills.map((skill) => skill.tube), (tube) => tube.get('id'));
+        tubes.forEach((tube) => {
+          tube.skillsWithAllLevels = new Array(ENV.APP.MAX_LEVEL).fill(undefined).map((_, index) => tube.get('skills').find((skill) => skill.difficulty === (index + 1)));
+        });
+        badgePartnerCompetence.tubes = tubes;
+      });
+    });
+    return this.args.badge.badgeCriteria;
+  }
+
+  get allLevels() {
+    return times(ENV.APP.MAX_LEVEL, (index) => index + 1);
+  }
+
+  scopeExplanation(criterionScope) {
+    switch (criterionScope) {
+      case 'SomePartnerCompetences': return 'tous les groupes d‘acquis suivants :';
+      case 'EveryPartnerCompetences': return 'l‘ensemble des groupes d‘acquis liés au badge :';
+      case 'CampaignParticipation': return 'l‘ensemble des acquis du target profile.';
+    }
+  }
 }

--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -20,7 +20,7 @@
               <td>{{badge.key}}</td>
               <td>{{badge.title}}</td>
               <td>{{badge.message}}</td>
-              <td><LinkTo @route="authenticated.badges.badge" @model={{badge}} class="btn btn-outline-default btn-thin">Voir détail</LinkTo></td>
+              <td><LinkTo @route="authenticated.badges.badge" @model={{badge.id}} class="btn btn-outline-default btn-thin">Voir détail</LinkTo></td>
             </tr>
           {{/each}}
         </tbody>

--- a/admin/app/models/badge-partner-competence.js
+++ b/admin/app/models/badge-partner-competence.js
@@ -1,9 +1,11 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class BadgePartnerCompetence extends Model {
 
   @attr('string') name;
+  @attr('string') color;
 
   @belongsTo('badge') badge;
   @belongsTo('badge-criterion') criterion;
+  @hasMany('skill') skills;
 }

--- a/admin/app/models/skill.js
+++ b/admin/app/models/skill.js
@@ -1,7 +1,9 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Skill extends Model {
   @attr('string') name;
   @attr('string') tubeId;
   @attr('number') difficulty;
+
+  @belongsTo('tube') tube;
 }

--- a/admin/app/models/tube.js
+++ b/admin/app/models/tube.js
@@ -1,6 +1,8 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Tube extends Model {
   @attr('string') practicalTitle;
   @attr('string') competenceId;
+
+  @hasMany('skill') skills;
 }

--- a/admin/app/styles/components/badges/badge.scss
+++ b/admin/app/styles/components/badges/badge.scss
@@ -9,3 +9,11 @@
     margin: 8px 0;
   }
 }
+
+.badge-criteria-competences {
+  list-style-type: none;
+}
+
+.badge-partner-competences-table {
+  margin: 20px 0;
+}

--- a/admin/mirage/handlers/badges.js
+++ b/admin/mirage/handlers/badges.js
@@ -1,6 +1,10 @@
 function getBadge(schema, request) {
   const id = request.params.id;
-  request.queryParams.include = 'badgeCriteria.partnerCompetences';
+  request.queryParams.include = [
+    'badgeCriteria.partnerCompetences',
+    'badgeCriteria.partnerCompetences.skills',
+    'badgeCriteria.partnerCompetences.skills.tube',
+  ].join(',');
   return schema.badges.find(id);
 }
 

--- a/admin/mirage/serializers/application.js
+++ b/admin/mirage/serializers/application.js
@@ -3,6 +3,6 @@ import Inflector from 'ember-inflector';
 
 export default JSONAPISerializer.extend({
   typeKeyForModel(model) {
-    return Inflector.inflector.singularize(model.modelName);
+    return Inflector.inflector.pluralize(model.modelName);
   },
 });

--- a/admin/tests/acceptance/authenticated/badges/badges_test.js
+++ b/admin/tests/acceptance/authenticated/badges/badges_test.js
@@ -16,9 +16,13 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
     currentUser = server.create('user');
     await createAuthenticateSession({ userId: currentUser.id });
 
+    const tube = this.server.create('tube', { practicalTitle: 'Practical title of tube' });
+    const skill = this.server.create('skill', { name: '@skill2', difficulty: 2, tube });
     const badgePartnerCompetence = this.server.create('badge-partner-competence', {
       id: 1,
       name: 'Internet for dummies',
+      color: 'red',
+      skills: [skill],
     });
 
     const criterionCampaignParticipation = this.server.create('badge-criterion', {
@@ -52,9 +56,9 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
     const badgeElement = find('.page-section__details');
     assert.ok(badgeElement.textContent.match(badge.title));
     assert.contains('20');
-    assert.dom('.table-admin tbody tr:nth-child(1) ul').doesNotExist();
-    assert.dom('.table-admin tbody tr:nth-child(2) ul').exists();
-    assert.contains('Internet for dummies');
+    assert.contains('Internet for dummies - red');
+    assert.contains('@skill2');
+    assert.contains('Practical title of tube');
   });
 
 });

--- a/admin/tests/helpers/contains.js
+++ b/admin/tests/helpers/contains.js
@@ -1,7 +1,7 @@
 import { getRootElement } from '@ember/test-helpers';
 
 function getChildrenThatContainsText(element, text, isChild) {
-  if (element.textContent.trim() === text) {
+  if (element.textContent.trim().includes(text)) {
     return isChild ? element : [element];
   }
 

--- a/admin/tests/integration/components/badges/badge_test.js
+++ b/admin/tests/integration/components/badges/badge_test.js
@@ -2,14 +2,28 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
 
 module('Integration | Component | Badges::Badge', function(hooks) {
   let badge;
+  let skill;
 
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    badge = {
+    const tube = EmberObject.create({
+      id: 1,
+      practicalTitle: 'Mon tube',
+    });
+    skill = EmberObject.create({
+      id: 1,
+      name: '@skill2',
+      difficulty: 2,
+      tube,
+    });
+    tube.skills = [skill];
+
+    badge = EmberObject.create({
       id: 42,
       title: 'mon titre',
       message: 'mon message',
@@ -18,10 +32,15 @@ module('Integration | Component | Badges::Badge', function(hooks) {
       altMessage: 'mon message alternatif',
       isCertifiable: true,
       badgeCriteria: [
-        { id: 1, scope: 'CampaignParticipation', threshold: 85 },
+        EmberObject.create({
+          id: 1, scope: 'CampaignParticipation', threshold: 85, partnerCompetences: [
+            EmberObject.create({ id: 1, name: 'Competence', color: 'red', skills: [
+              skill,
+            ] }),
+          ],
+        }),
       ],
-      badgePartnerCompetences: [],
-    };
+    });
 
     this.set('badge', badge);
   });
@@ -40,7 +59,9 @@ module('Integration | Component | Badges::Badge', function(hooks) {
     assert.ok(detailsContent.match(badge.altMessage), 'altMessage');
     assert.ok(detailsContent.match('Certifiable'), 'Certifiable');
     assert.dom('.page-section__details img').exists();
-    assert.contains('85');
-    assert.contains('CampaignParticipation');
+    assert.contains('L‘évalué doit obtenir 85% sur l‘ensemble des acquis du target profile');
+    assert.contains('Competence - red');
+    assert.contains('@skill2');
+    assert.contains('Mon tube');
   });
 });

--- a/api/db/seeds/data/target-profiles-builder.js
+++ b/api/db/seeds/data/target-profiles-builder.js
@@ -24,7 +24,7 @@ const skillIdsForBadgePartnerCompetence2 = [
 const skillIdsForBadgePartnerCompetence3 = [
   'recZnnTU4WUP6KwwX', 'rececWx6MmPhufxXk', 'recAFoEonOOChXe9t', 'recaMBgjv3EZnAlWO', 'recXDYAkqqIDCDePc',
   'recwOLZ8bzMQK9NF9', 'recR1SlS7sWoquhoC', 'recPGDVdX0LSOWQQC', 'rec0tk8dZWOzSQbaQ', 'recmoanUlDOyXexPF',
-  'recKbNbM8G7mKaloD', 'recEdU3ZJrHxWOLcb', 'recfktfO0ROu1OifX', 'rec7WOXWi5ClE8BxH', 'recHo6D1spbDR9C2N',
+  'recKbNbM8G7mKaloD', 'recfktfO0ROu1OifX', 'rec7WOXWi5ClE8BxH', 'recHo6D1spbDR9C2N',
   'recpdpemRXuzV9r10', 'recWXtN5cNP1JQUVx', 'rec7EvARki1b9t574', 'rec6IWrDOSaoX4aLn', 'recI4zS51by3N7Ryi',
   'recrV8JAEsieJOAch', 'recHBMRraNImyqmDF', 'recaTPKUCD6uAS0li', 'recicaqEeoJUtXT6j', 'recDotNI5r7ApHfwa',
 ];

--- a/api/lib/application/badges/badges-controller.js
+++ b/api/lib/application/badges/badges-controller.js
@@ -1,10 +1,10 @@
 const usecases = require('../../domain/usecases');
-const badgeSerializer = require('../../infrastructure/serializers/jsonapi/badge-serializer');
+const badgeWithLearningContentSerializer = require('../../infrastructure/serializers/jsonapi/badge-with-learning-content-serializer');
 
 module.exports = {
   async getBadge(request) {
     const badgeId = parseInt(request.params.id);
-    const badge = await usecases.getBadge({ badgeId });
-    return badgeSerializer.serialize(badge);
+    const badgeWithLearningContent = await usecases.getBadgeDetails({ badgeId });
+    return badgeWithLearningContentSerializer.serialize(badgeWithLearningContent);
   },
 };

--- a/api/lib/domain/models/BadgeWithLearningContent.js
+++ b/api/lib/domain/models/BadgeWithLearningContent.js
@@ -1,0 +1,9 @@
+class BadgeWithLearningContent {
+  constructor({ badge, skills, tubes } = {}) {
+    this.badge = badge;
+    this.skills = skills;
+    this.tubes = tubes;
+  }
+}
+
+module.exports = BadgeWithLearningContent;

--- a/api/lib/domain/usecases/get-badge-details.js
+++ b/api/lib/domain/usecases/get-badge-details.js
@@ -1,0 +1,19 @@
+const BadgeWithLearningContent = require('../../domain/models/BadgeWithLearningContent');
+const { FRENCH_FRANCE } = require('../../domain/constants').LOCALE;
+
+module.exports = async function getBadgeDetails({
+  badgeId,
+  badgeRepository,
+  skillRepository,
+  tubeRepository,
+}) {
+  const badge = await badgeRepository.get(badgeId);
+  const skillIds = badge.badgePartnerCompetences.flatMap(({ skillIds }) => skillIds);
+
+  const skills = await skillRepository.findOperativeByIds(skillIds);
+
+  const tubeNames = skills.map((skill) => skill.tubeName);
+  const tubes = await tubeRepository.findByNames({ tubeNames, locale: FRENCH_FRANCE });
+
+  return new BadgeWithLearningContent({ badge, skills, tubes });
+};

--- a/api/lib/domain/usecases/get-badge.js
+++ b/api/lib/domain/usecases/get-badge.js
@@ -1,6 +1,0 @@
-module.exports = function getBadge({
-  badgeId,
-  badgeRepository,
-}) {
-  return badgeRepository.get(badgeId);
-};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -189,7 +189,7 @@ module.exports = injectDependencies({
   getAnswer: require('./get-answer'),
   getAssessment: require('./get-assessment'),
   getAttendanceSheet: require('./get-attendance-sheet'),
-  getBadge: require('./get-badge'),
+  getBadgeDetails: require('./get-badge-details'),
   getCampaign: require('./get-campaign'),
   getCampaignByCode: require('./get-campaign-by-code'),
   getCampaignAssessmentParticipation: require('./get-campaign-assessment-participation'),

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -1,49 +1,10 @@
 const { Serializer } = require('jsonapi-serializer');
-const BadgeCriterion = require('../../../domain/models/BadgeCriterion');
-
-const mapType = {
-  badgeCriteria: 'badge-criterion',
-  badgePartnerCompetences: 'badge-partner-competence',
-  partnerCompetences: 'badge-partner-competence',
-};
 
 module.exports = {
   serialize(badge = {}) {
     return new Serializer('badge', {
       ref: 'id',
-      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable', 'badgeCriteria', 'badgePartnerCompetences'],
-      badgeCriteria: {
-        include: true,
-        ref: 'id',
-        attributes: ['threshold', 'scope', 'partnerCompetences'],
-        partnerCompetences: {
-          include: false,
-          ref: 'id',
-        },
-      },
-      badgePartnerCompetences: {
-        include: true,
-        ref: 'id',
-        attributes: ['name'],
-      },
-      typeForAttribute(attribute) {
-        return mapType[attribute];
-      },
-      transform(record) {
-        record.badgeCriteria.forEach((badgeCriterion) => {
-          if (badgeCriterion.scope === BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE) {
-            badgeCriterion.partnerCompetences = record.badgePartnerCompetences.map(({ id }) => {
-              return { id };
-            });
-          } else {
-            badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds?.map((partnerCompetenceId) => {
-              return { id: partnerCompetenceId };
-            });
-          }
-        });
-        return record;
-      },
-
+      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable'],
     }).serialize(badge);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer.js
@@ -1,0 +1,68 @@
+const { Serializer } = require('jsonapi-serializer');
+const BadgeCriterion = require('../../../domain/models/BadgeCriterion');
+
+const mapType = {
+  badgeCriteria: 'badge-criteria',
+  badgePartnerCompetences: 'badge-partner-competences',
+  partnerCompetences: 'badge-partner-competences',
+};
+
+module.exports = {
+  serialize(badgeWithLearningContent = {}) {
+    return new Serializer('badge', {
+      ref: 'id',
+      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable', 'badgeCriteria', 'badgePartnerCompetences'],
+      badgeCriteria: {
+        include: true,
+        ref: 'id',
+        attributes: ['threshold', 'scope', 'partnerCompetences'],
+        partnerCompetences: {
+          include: false,
+          ref: 'id',
+        },
+      },
+      badgePartnerCompetences: {
+        include: true,
+        ref: 'id',
+        attributes: ['name', 'skills'],
+        skills: {
+          include: true,
+          ref: 'id',
+          attributes: ['name', 'difficulty', 'tube'],
+          tube: {
+            include: true,
+            ref: 'id',
+            attributes: ['practicalTitle'],
+          },
+        },
+      },
+      typeForAttribute(attribute) {
+        return mapType[attribute];
+      },
+      transform(record) {
+        const badge = record.badge;
+        badge.badgeCriteria.forEach((badgeCriterion) => {
+          if (badgeCriterion.scope === BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE) {
+            badgeCriterion.partnerCompetences = badge.badgePartnerCompetences.map(({ id }) => {
+              return { id };
+            });
+          } else {
+            badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds?.map((partnerCompetenceId) => {
+              return { id: partnerCompetenceId };
+            });
+          }
+        });
+        badge.badgePartnerCompetences.forEach((badgePartnerCompetence) => {
+          badgePartnerCompetence.skills = badgePartnerCompetence.skillIds.map((skillId) => {
+            return record.skills.find(({ id }) => skillId === id);
+          });
+          badgePartnerCompetence.skills.forEach((skill) => {
+            skill.tube = { ...record.tubes.find(({ id }) => id === skill.tubeId) };
+          });
+        });
+        return { ...badge };
+      },
+
+    }).serialize(badgeWithLearningContent);
+  },
+};

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -1,5 +1,5 @@
 const createServer = require('../../../../server');
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, learningContentBuilder, mockLearningContent } = require('../../../test-helper');
 
 describe('Acceptance | API | Badges', () => {
 
@@ -13,6 +13,28 @@ describe('Acceptance | API | Badges', () => {
 
     beforeEach(async () => {
       userId = (await insertUserWithRolePixMaster()).id;
+
+      const learningContent = [{
+        id: 'recArea',
+        competences: [{
+          id: 'recCompetence',
+          tubes: [{
+            id: 'recTube',
+            name: '@recSkill',
+            practicalTitle: 'Titre pratique',
+            skills: [{
+              id: 'recABC123',
+              nom: '@recSkill3',
+            }, {
+              id: 'recDEF456',
+              nom: '@recSkill2',
+            }],
+          }],
+        }],
+      }];
+
+      const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+      mockLearningContent(learningContentObjects);
 
       badge = databaseBuilder.factory.buildBadge({
         id: 1,
@@ -52,19 +74,19 @@ describe('Acceptance | API | Badges', () => {
             'badge-criteria': {
               data: [{
                 id: badgeCriterion.id.toString(),
-                type: 'badge-criterion',
+                type: 'badge-criteria',
               }],
             },
             'badge-partner-competences': {
               data: [{
                 id: badgePartnerCompetence.id.toString(),
-                type: 'badge-partner-competence',
+                type: 'badge-partner-competences',
               }],
             },
           },
         },
         included: [{
-          type: 'badge-criterion',
+          type: 'badge-criteria',
           id: badgeCriterion.id.toString(),
           attributes: {
             scope: 'CampaignParticipation',
@@ -76,10 +98,61 @@ describe('Acceptance | API | Badges', () => {
             },
           },
         }, {
-          type: 'badge-partner-competence',
+          attributes: {
+            'practical-title': 'Titre pratique',
+          },
+          id: 'recTube',
+          type: 'tubes',
+          relationships: {},
+        }, {
+          attributes: {
+            name: '@recSkill3',
+            difficulty: 3,
+          },
+          id: 'recABC123',
+          type: 'skills',
+          relationships: {
+            tube: {
+              data: {
+                id: 'recTube',
+                type: 'tubes',
+              },
+            },
+          },
+        }, {
+          attributes: {
+            name: '@recSkill2',
+            difficulty: 2,
+          },
+          id: 'recDEF456',
+          type: 'skills',
+          relationships: {
+            tube: {
+              data: {
+                id: 'recTube',
+                type: 'tubes',
+              },
+            },
+          },
+        }, {
+          type: 'badge-partner-competences',
           id: badgePartnerCompetence.id.toString(),
           attributes: {
             name: 'name',
+          },
+          relationships: {
+            skills: {
+              data: [
+                {
+                  id: 'recABC123',
+                  type: 'skills',
+                },
+                {
+                  id: 'recDEF456',
+                  type: 'skills',
+                },
+              ],
+            },
           },
         }],
       };

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -302,14 +302,6 @@ describe('Acceptance | Controller | target-profile-controller', () => {
           'message': badge.message,
           'title': badge.title,
         },
-        relationships: {
-          'badge-criteria': {
-            data: [],
-          },
-          'badge-partner-competences': {
-            data: [],
-          },
-        },
       }];
       expect(response.result.data).to.deep.equal(expectedData);
     });

--- a/api/tests/tooling/domain-builder/factory/build-badge-with-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge-with-learning-content.js
@@ -1,0 +1,12 @@
+const BadgeWithLearningContent = require('../../../../lib/domain/models/BadgeWithLearningContent');
+const buildBadge = require('./build-badge');
+const buildSkill = require('./build-skill');
+const buildTube = require('./build-tube');
+
+module.exports = function buildBadgeWithLearningContent({
+  badge = buildBadge(),
+  skills = [buildSkill()],
+  tubes = [buildTube()],
+} = {}) {
+  return new BadgeWithLearningContent({ badge, skills, tubes });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -5,6 +5,7 @@ module.exports = {
   buildAssessmentResult: require('./build-assessment-result'),
   buildAuthenticationMethod: require('./build-authentication-method'),
   buildBadge: require('./build-badge'),
+  buildBadgeWithLearningContent: require('./build-badge-with-learning-content'),
   buildBadgeAcquisition: require('./build-badge-acquisition'),
   buildBadgeCriterion: require('./build-badge-criterion'),
   buildBadgePartnerCompetence: require('./build-badge-partner-competence'),

--- a/api/tests/unit/domain/usecases/get-badge-details_test.js
+++ b/api/tests/unit/domain/usecases/get-badge-details_test.js
@@ -1,0 +1,58 @@
+const { expect, sinon } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const BadgeWithLearningContent = require('../../../../lib/domain/models/BadgeWithLearningContent');
+
+describe('Unit | UseCase | get-badge-details', () => {
+
+  it('should get badge details', async () => {
+    // given
+    const badge = {
+      badgePartnerCompetences: [
+        {
+          skillIds: [1, 2],
+        },
+      ],
+    };
+    const badgeId = Symbol('badge id');
+
+    const skills = [
+      { tubeName: '@toto' },
+    ];
+    const tubes = [];
+    const locale = 'fr-fr';
+    const expectedResult = new BadgeWithLearningContent({
+      skills,
+      badge,
+      tubes,
+    });
+
+    const badgeRepository = {
+      get: sinon.stub(),
+    };
+    badgeRepository.get.resolves(badge);
+
+    const skillRepository = {
+      findOperativeByIds: sinon.stub(),
+    };
+    skillRepository.findOperativeByIds.resolves(skills);
+
+    const tubeRepository = {
+      findByNames: sinon.stub(),
+    };
+    tubeRepository.findByNames.resolves(tubes);
+
+    // when
+    const response = await usecases.getBadgeDetails({
+      badgeId,
+      badgeRepository,
+      skillRepository,
+      tubeRepository,
+    });
+
+    // then
+    expect(response).to.deep.equal(expectedResult);
+    expect(badgeRepository.get).to.has.been.calledWith(badgeId);
+    expect(skillRepository.findOperativeByIds).to.has.been.calledWith([1, 2]);
+    expect(tubeRepository.findByNames).to.has.been.calledWith({ tubeNames: ['@toto'], locale });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -35,28 +35,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
           },
           id: '1',
           type: 'badges',
-          relationships: {
-            'badge-criteria': {
-              'data': [{
-                id: '1',
-                type: 'badge-criterion',
-              }],
-            },
-            'badge-partner-competences': {
-              'data': [],
-            },
-          },
         },
-        included: [
-          {
-            attributes: {
-              scope: 'CampaignParticipation',
-              threshold: 40,
-            },
-            id: '1',
-            type: 'badge-criterion',
-          },
-        ],
       };
 
       // when
@@ -91,75 +70,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
           },
           id: '1',
           type: 'badges',
-          relationships: {
-            'badge-criteria': {
-              'data': [{
-                id: '1',
-                type: 'badge-criterion',
-              }, {
-                id: '2',
-                type: 'badge-criterion',
-              }],
-            },
-            'badge-partner-competences': {
-              'data': [{
-                id: '1',
-                type: 'badge-partner-competence',
-              }, {
-                id: '2',
-                type: 'badge-partner-competence',
-              }],
-            },
-          },
         },
-        included: [
-          {
-            attributes: {
-              scope: 'CampaignParticipation',
-              threshold: 40,
-            },
-            relationships: {
-              'partner-competences': {
-                data: [],
-              },
-            },
-            id: '1',
-            type: 'badge-criterion',
-          },
-          {
-            attributes: {
-              scope: 'CampaignParticipation',
-              threshold: 40,
-            },
-            relationships: {
-              'partner-competences': {
-                data: [{
-                  id: '1',
-                  type: 'badge-partner-competence',
-                }, {
-                  id: '2',
-                  type: 'badge-partner-competence',
-                }],
-              },
-            },
-            id: '2',
-            type: 'badge-criterion',
-          },
-          {
-            attributes: {
-              name: 'name',
-            },
-            id: '1',
-            type: 'badge-partner-competence',
-          },
-          {
-            attributes: {
-              name: 'name',
-            },
-            id: '2',
-            type: 'badge-partner-competence',
-          },
-        ],
       };
 
       // when
@@ -200,59 +111,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
           },
           id: '1',
           type: 'badges',
-          relationships: {
-            'badge-criteria': {
-              'data': [{
-                id: '1',
-                type: 'badge-criterion',
-              }],
-            },
-            'badge-partner-competences': {
-              'data': [{
-                id: '1',
-                type: 'badge-partner-competence',
-              }, {
-                id: '2',
-                type: 'badge-partner-competence',
-              }],
-            },
-          },
         },
-        included: [
-          {
-            attributes: {
-              scope: 'EveryPartnerCompetence',
-              threshold: 40,
-            },
-            relationships: {
-              'partner-competences': {
-                data: [{
-                  id: '1',
-                  type: 'badge-partner-competence',
-                }, {
-                  id: '2',
-                  type: 'badge-partner-competence',
-                }],
-              },
-            },
-            id: '1',
-            type: 'badge-criterion',
-          },
-          {
-            attributes: {
-              name: 'name',
-            },
-            id: '1',
-            type: 'badge-partner-competence',
-          },
-          {
-            attributes: {
-              name: 'name',
-            },
-            id: '2',
-            type: 'badge-partner-competence',
-          },
-        ],
       };
 
       // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer_test.js
@@ -1,0 +1,252 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer');
+
+describe('Unit | Serializer | JSONAPI | badge-with-learning-content-serializer', function() {
+
+  describe('#serialize', function() {
+
+    it('should convert a Badge model object into JSON API data', function() {
+      // given
+      const badge = domainBuilder.buildBadge({
+        id: '1',
+        altMessage: 'You won a banana badge',
+        imageUrl: '/img/banana.svg',
+        message: 'Congrats, you won a banana badge',
+        key: 'BANANA',
+        title: 'Banana',
+        targetProfileId: '1',
+        isCertifiable: false,
+        badgeCriteria: [
+          domainBuilder.buildBadgeCriterion({ partnerCompetenceIds: null }),
+        ],
+        badgePartnerCompetences: [],
+      });
+      const badgeWithLearningContent = domainBuilder.buildBadgeWithLearningContent({ badge });
+
+      const expectedSerializedBadge = {
+        data: {
+          attributes: {
+            'alt-message': 'You won a banana badge',
+            'image-url': '/img/banana.svg',
+            'is-certifiable': false,
+            message: 'Congrats, you won a banana badge',
+            title: 'Banana',
+            key: 'BANANA',
+          },
+          id: '1',
+          type: 'badges',
+          relationships: {
+            'badge-criteria': {
+              'data': [{
+                id: '1',
+                type: 'badge-criteria',
+              }],
+            },
+            'badge-partner-competences': {
+              'data': [],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              scope: 'CampaignParticipation',
+              threshold: 40,
+            },
+            id: '1',
+            type: 'badge-criteria',
+          },
+        ],
+      };
+
+      // when
+      const json = serializer.serialize(badgeWithLearningContent);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedBadge);
+    });
+
+    it('should convert a Badge model with badge partner competence object into JSON API data', function() {
+      // given
+      const badge = domainBuilder.buildBadge({
+        id: '1',
+        altMessage: 'You won a banana badge',
+        imageUrl: '/img/banana.svg',
+        message: 'Congrats, you won a banana badge',
+        key: 'BANANA',
+        title: 'Banana',
+        targetProfileId: '1',
+        isCertifiable: false,
+      });
+
+      const skills = [
+        domainBuilder.buildSkill({ id: 'recABC', name: '@sau6', tubeId: 'recTUB123' }),
+        domainBuilder.buildSkill({ id: 'recDEF', name: '@sau7', tubeId: 'recTUB123' }),
+      ];
+
+      const tubes = [
+        domainBuilder.buildTube({ id: 'recTUB123', name: '@sau', skills }),
+      ];
+
+      const badgeWithLearningContent = domainBuilder.buildBadgeWithLearningContent({ badge, skills, tubes });
+
+      const expectedSerializedBadge = {
+        data: {
+          attributes: {
+            'alt-message': 'You won a banana badge',
+            'image-url': '/img/banana.svg',
+            'is-certifiable': false,
+            message: 'Congrats, you won a banana badge',
+            title: 'Banana',
+            key: 'BANANA',
+          },
+          id: '1',
+          type: 'badges',
+          relationships: {
+            'badge-criteria': {
+              'data': [{
+                id: '1',
+                type: 'badge-criteria',
+              }, {
+                id: '2',
+                type: 'badge-criteria',
+              }],
+            },
+            'badge-partner-competences': {
+              'data': [{
+                id: '1',
+                type: 'badge-partner-competences',
+              }, {
+                id: '2',
+                type: 'badge-partner-competences',
+              }],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              scope: 'CampaignParticipation',
+              threshold: 40,
+            },
+            relationships: {
+              'partner-competences': {
+                data: [],
+              },
+            },
+            id: '1',
+            type: 'badge-criteria',
+          },
+          {
+            attributes: {
+              scope: 'CampaignParticipation',
+              threshold: 40,
+            },
+            relationships: {
+              'partner-competences': {
+                data: [{
+                  id: '1',
+                  type: 'badge-partner-competences',
+                }, {
+                  id: '2',
+                  type: 'badge-partner-competences',
+                }],
+              },
+            },
+            id: '2',
+            type: 'badge-criteria',
+          },
+          {
+            type: 'tubes',
+            id: 'recTUB123',
+            attributes: {
+              'practical-title': 'titre pratique',
+            },
+            relationships: {},
+          },
+          {
+            attributes: {
+              name: '@sau6',
+              difficulty: 6,
+            },
+            id: 'recABC',
+            relationships: {
+              tube: {
+                data: {
+                  id: 'recTUB123',
+                  type: 'tubes',
+                },
+              },
+            },
+            type: 'skills',
+          },
+          {
+            attributes: {
+              name: '@sau7',
+              difficulty: 7,
+            },
+            id: 'recDEF',
+            relationships: {
+              tube: {
+                data: {
+                  id: 'recTUB123',
+                  type: 'tubes',
+                },
+              },
+            },
+            type: 'skills',
+          },
+          {
+            attributes: {
+              name: 'name',
+            },
+            id: '1',
+            type: 'badge-partner-competences',
+            relationships: {
+              'skills': {
+                data: [
+                  {
+                    id: 'recABC',
+                    type: 'skills',
+                  },
+                  {
+                    id: 'recDEF',
+                    type: 'skills',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            attributes: {
+              name: 'name',
+            },
+            id: '2',
+            type: 'badge-partner-competences',
+            relationships: {
+              'skills': {
+                data: [
+                  {
+                    id: 'recABC',
+                    type: 'skills',
+                  },
+                  {
+                    id: 'recDEF',
+                    type: 'skills',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      };
+
+      // when
+      const json = serializer.serialize(badgeWithLearningContent);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedBadge);
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème (PIX-2364)
Il est compliqué pour le métier de savoir les critères d'un résultat thématique et particulièrement les acquis "testé".

## :robot: Solution
Afficher dans l'admin les groupes d'acquis testé

https://user-images.githubusercontent.com/86659/116377351-622da100-a811-11eb-9ebc-7bfe21518f3f.mp4

## :100: Pour tester
1. Se connecter a Pix admin
2. Aller sur un profil cible avec des résultats thématique
3. Cliquer sur détail
4. Déplier un ensemble d'acquis
5. Admirer :heart_eyes: 




