### PR TITLE
[BUGFIX] Ne change pas le focus de la modal a chaque rendu (PIX-2521)

### DIFF
--- a/mon-pix/app/components/pix-modal.js
+++ b/mon-pix/app/components/pix-modal.js
@@ -16,7 +16,7 @@ export default ModalDialog.extend({
   containerClass: 'centered-scrolling-container',
   originId: defaultOrigin,
 
-  didRender() {
+  didInsertElement() {
     this._super(...arguments);
     document.querySelector('#modal-overlays').classList.add('active');
     document.body.classList.add('centered-modal-showing');


### PR DESCRIPTION
## :unicorn: Problème  (PIX-2521)
Lorsque le composant modal est rendu et a chaque mise à jour du contenu, on vole le focus pour le remettre sur le bouton fermer.

## :robot: Solution
Ne mettre le focus et autres opérations seulement au rendu initial

## :100: Pour tester
1. Faire un test de positionnement jusqu'a un checkpoint
2. Sur une réponse, cliquer sur "Réponses et tuto"
3. Essayer de signaler un problème tout en bas
4. Constater que lorsqu'on change un select ou qu'on remplit un textearea, le focus n'est pas changer
