### PR TITLE
[TECH] Ne pas remonter d'erreur lorsqu'aucun ticket Jira ne correspond à la PR.

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Find Issue Key
       id: find
       uses: atlassian/gajira-find-issue-key@master
+      continue-on-error: true
       with:
         from: commits
 


### PR DESCRIPTION
## :unicorn: Problème
Le workflow [on-dev-merge](https://github.com/1024pix/pix/blob/dev/.github/workflows/on-dev-merge.yml) sort en erreur si le ticket indiqué dans la PR n'existe pas dans JIRA. Cela cause une remontée sur la branche `dev`, alors que le code du ticket lui-même est correct. Cela engendre de la confusion.

## :robot: Solution
Utiliser la syntaxe [continue-on-error]( https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) sur le step de recherche de l'issue.

Le step suivant ne se déclenche pas si aucun résultat n'a été trouvé
```
- name: Transition issue
  uses: atlassian/gajira-transition@master
  if: ${{ steps.find.outputs.issue }}
```
## :rainbow: Remarques
La cause du problème est que :
- certaines PR techniques n'existent pas dans JIRA;
- il peut y avoir erreur de saisie lors de la PR.

## :100: Pour tester
Vérifier le comportement [sur cette PR simplifiée](https://github.com/GradedJestRisk/github-training/pull/11)
Puis merger la PR qui ne doit pas remonter d'erreur, alors qu'elle ne correspond pas à un ticket JIRA.
