### PR TITLE
[FEATURE] Vérifier que l'utilisateur a toujours un profil validant un badge avant de le certifier (PIX-2489).

### DIFF
--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -6,6 +6,10 @@ const eventTypes = [ CertificationScoringCompleted ];
 async function handleCleaCertificationScoring({
   event,
   partnerCertificationScoringRepository,
+  badgeRepository,
+  knowledgeElementRepository,
+  targetProfileRepository,
+  badgeCriteriaService,
 }) {
   checkEventTypes(event, eventTypes);
   const cleaCertificationScoring = await partnerCertificationScoringRepository.buildCleaCertificationScoring({
@@ -14,6 +18,12 @@ async function handleCleaCertificationScoring({
     reproducibilityRate: event.reproducibilityRate,
   });
 
+  if (cleaCertificationScoring.hasAcquiredBadge) {
+    const badge = await badgeRepository.getByKey(cleaCertificationScoring.partnerKey);
+    const targetProfile = await targetProfileRepository.get(badge.targetProfileId);
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: event.userId });
+    cleaCertificationScoring.setBadgeStillAcquired(badgeCriteriaService.areBadgeCriteriaFulfilled({ knowledgeElements, targetProfile, badge }));
+  }
   if (cleaCertificationScoring.isEligible()) {
     await partnerCertificationScoringRepository.save({ partnerCertificationScoring: cleaCertificationScoring });
   }

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -7,6 +7,7 @@ async function handleCleaCertificationScoring({
   event,
   partnerCertificationScoringRepository,
   badgeRepository,
+  certificationCourseRepository,
   knowledgeElementRepository,
   targetProfileRepository,
   badgeCriteriaService,
@@ -19,11 +20,13 @@ async function handleCleaCertificationScoring({
   });
 
   if (cleaCertificationScoring.hasAcquiredBadge) {
+    const beginningCertificationDate = await certificationCourseRepository.getCreationDate(event.certificationCourseId);
     const badge = await badgeRepository.getByKey(cleaCertificationScoring.partnerKey);
     const targetProfile = await targetProfileRepository.get(badge.targetProfileId);
-    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: event.userId });
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: event.userId, limitDate: beginningCertificationDate });
     cleaCertificationScoring.setBadgeStillAcquired(badgeCriteriaService.areBadgeCriteriaFulfilled({ knowledgeElements, targetProfile, badge }));
   }
+
   if (cleaCertificationScoring.isEligible()) {
     await partnerCertificationScoringRepository.save({ partnerCertificationScoring: cleaCertificationScoring });
   }

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -24,7 +24,7 @@ async function handleCleaCertificationScoring({
     const badge = await badgeRepository.getByKey(cleaCertificationScoring.partnerKey);
     const targetProfile = await targetProfileRepository.get(badge.targetProfileId);
     const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: event.userId, limitDate: beginningCertificationDate });
-    cleaCertificationScoring.setBadgeStillAcquired(badgeCriteriaService.areBadgeCriteriaFulfilled({ knowledgeElements, targetProfile, badge }));
+    cleaCertificationScoring.setBadgeStillValid(badgeCriteriaService.areBadgeCriteriaFulfilled({ knowledgeElements, targetProfile, badge }));
   }
 
   if (cleaCertificationScoring.isEligible()) {

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -39,7 +39,7 @@ async function _verifyBadgeValidity(certificationCourseRepository, event, badgeR
     limitDate: beginningCertificationDate,
   });
 
-  cleaCertificationScoring.setBadgeStillValid(badgeCriteriaService.areBadgeCriteriaFulfilled({
+  cleaCertificationScoring.setBadgeAcquisitionStillValid(badgeCriteriaService.areBadgeCriteriaFulfilled({
     knowledgeElements,
     targetProfile,
     badge,

--- a/api/lib/domain/models/CleaCertificationScoring.js
+++ b/api/lib/domain/models/CleaCertificationScoring.js
@@ -38,7 +38,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     hasAcquiredBadge,
     reproducibilityRate,
     cleaCompetenceMarks,
-    badgeStillAcquired = true,
+    isBadgeStillValid = true,
     maxReachablePixByCompetenceForClea,
   } = {}) {
     super({
@@ -47,7 +47,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     });
 
     this.hasAcquiredBadge = hasAcquiredBadge;
-    this.badgeStillAcquired = badgeStillAcquired;
+    this.isBadgeStillValid = isBadgeStillValid;
     this.reproducibilityRate = reproducibilityRate;
     this.cleaCompetenceMarks = cleaCompetenceMarks;
     this.maxReachablePixByCompetenceForClea = maxReachablePixByCompetenceForClea;
@@ -63,11 +63,11 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
   }
 
   isEligible() {
-    return this.hasAcquiredBadge && this.badgeStillAcquired;
+    return this.hasAcquiredBadge && this.isBadgeStillValid;
   }
 
-  setBadgeStillAcquired(badgeStillAcquired) {
-    this.badgeStillAcquired = badgeStillAcquired;
+  setBadgeStillValid(isValid) {
+    this.isBadgeStillValid = isValid;
   }
 
   isAcquired() {

--- a/api/lib/domain/models/CleaCertificationScoring.js
+++ b/api/lib/domain/models/CleaCertificationScoring.js
@@ -66,6 +66,10 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     return this.hasAcquiredBadge && this.badgeStillAcquired;
   }
 
+  setBadgeStillAcquired(badgeStillAcquired) {
+    this.badgeStillAcquired = badgeStillAcquired;
+  }
+
   isAcquired() {
     if (!this.hasAcquiredBadge) throw new NotEligibleCandidateError();
 

--- a/api/lib/domain/models/CleaCertificationScoring.js
+++ b/api/lib/domain/models/CleaCertificationScoring.js
@@ -38,6 +38,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     hasAcquiredBadge,
     reproducibilityRate,
     cleaCompetenceMarks,
+    badgeStillAcquired = true,
     maxReachablePixByCompetenceForClea,
   } = {}) {
     super({
@@ -46,6 +47,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     });
 
     this.hasAcquiredBadge = hasAcquiredBadge;
+    this.badgeStillAcquired = badgeStillAcquired;
     this.reproducibilityRate = reproducibilityRate;
     this.cleaCompetenceMarks = cleaCompetenceMarks;
     this.maxReachablePixByCompetenceForClea = maxReachablePixByCompetenceForClea;
@@ -61,7 +63,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
   }
 
   isEligible() {
-    return this.hasAcquiredBadge;
+    return this.hasAcquiredBadge && this.badgeStillAcquired;
   }
 
   isAcquired() {

--- a/api/lib/domain/models/CleaCertificationScoring.js
+++ b/api/lib/domain/models/CleaCertificationScoring.js
@@ -38,7 +38,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     hasAcquiredBadge,
     reproducibilityRate,
     cleaCompetenceMarks,
-    isBadgeStillValid = true,
+    isBadgeAcquisitionStillValid = true,
     maxReachablePixByCompetenceForClea,
   } = {}) {
     super({
@@ -47,7 +47,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     });
 
     this.hasAcquiredBadge = hasAcquiredBadge;
-    this.isBadgeStillValid = isBadgeStillValid;
+    this.isBadgeAcquisitionStillValid = isBadgeAcquisitionStillValid;
     this.reproducibilityRate = reproducibilityRate;
     this.cleaCompetenceMarks = cleaCompetenceMarks;
     this.maxReachablePixByCompetenceForClea = maxReachablePixByCompetenceForClea;
@@ -63,11 +63,11 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
   }
 
   isEligible() {
-    return this.hasAcquiredBadge && this.isBadgeStillValid;
+    return this.hasAcquiredBadge && this.isBadgeAcquisitionStillValid;
   }
 
-  setBadgeStillValid(isValid) {
-    this.isBadgeStillValid = isValid;
+  setBadgeAcquisitionStillValid(isValid) {
+    this.isBadgeAcquisitionStillValid = isValid;
   }
 
   isAcquired() {

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -50,4 +50,14 @@ module.exports = {
       });
     return bookshelfToDomainConverter.buildDomainObject(BookshelfBadge, bookshelfBadge);
   },
+
+  async getByKey(key) {
+    const bookshelfBadge = await BookshelfBadge
+      .where('key', key)
+      .fetch({
+        withRelated: ['badgeCriteria', 'badgePartnerCompetences'],
+      });
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfBadge, bookshelfBadge);
+  },
+
 };

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -53,7 +53,7 @@ module.exports = {
 
   async getByKey(key) {
     const bookshelfBadge = await BookshelfBadge
-      .where('key', key)
+      .where({ key })
       .fetch({
         withRelated: ['badgeCriteria', 'badgePartnerCompetences'],
       });

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -181,7 +181,7 @@ describe('Acceptance | API | Campaign Participations', () => {
         };
       });
 
-      it('it should reply an unauthorized error', () => {
+      it('should reply an unauthorized error', () => {
         // when
         const promise = server.inject(options);
 

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -347,4 +347,35 @@ describe('Integration | Repository | Badge', () => {
       expect(myBadge.badgePartnerCompetences.length).to.equal(1);
     });
   });
+
+  describe('#getByKey', () => {
+    let badge;
+
+    beforeEach(async () => {
+      badge = databaseBuilder.factory.buildBadge({
+        id: 1,
+        altMessage: 'You won the Toto badge!',
+        imageUrl: 'data:,',
+        message: 'Congrats, you won the Toto badge!',
+        key: 'TOTO2',
+      });
+      databaseBuilder.factory.buildBadgeCriterion({ badgeId: badge.id });
+      databaseBuilder.factory.buildBadgePartnerCompetence({ badgeId: badge.id });
+      await databaseBuilder.commit();
+    });
+
+    it('should return a badge', async () => {
+      const myBadge = await badgeRepository.getByKey(badge.key);
+
+      expect(myBadge.id).to.equal(1);
+    });
+
+    it('should return a badge with badgeCriteria and badgePartnerCompetences', async () => {
+      const myBadge = await badgeRepository.getByKey(badge.key);
+
+      expect(myBadge.badgeCriteria.length).to.equal(1);
+      expect(myBadge.badgePartnerCompetences.length).to.equal(1);
+    });
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -238,7 +238,7 @@ describe('Integration | Repository | JurySession', function() {
           return databaseBuilder.commit();
         });
 
-        it('it should find sessions by part of their certification center name, in a case-insensitive way', async () => {
+        it('should find sessions by part of their certification center name, in a case-insensitive way', async () => {
           // given
           const filters = { certificationCenterName: ' Des laURa' };
           const page = { number: 1, size: 10 };
@@ -281,7 +281,7 @@ describe('Integration | Repository | JurySession', function() {
           return databaseBuilder.commit();
         });
 
-        it('it should find sessions by part of their certification type', async () => {
+        it('should find sessions by part of their certification type', async () => {
           // given
           const filters = { certificationCenterType: 'SCO' };
           const page = { number: 1, size: 10 };
@@ -296,7 +296,7 @@ describe('Integration | Repository | JurySession', function() {
           expect(jurySessions).to.have.length(1);
         });
 
-        it('it should return all sessions if certification type filter is null', async () => {
+        it('should return all sessions if certification type filter is null', async () => {
           // given
           const filters = { certificationCenterType: null };
           const page = { number: 1, size: 10 };

--- a/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
@@ -4,7 +4,7 @@ const buildCompetenceMark = require('./build-competence-mark');
 module.exports = function buildCleaCertificationScoring({
   certificationCourseId = 42,
   hasAcquiredBadge = true,
-  badgeStillAcquired = true,
+  isBadgeStillValid = true,
   reproducibilityRate = 50,
   cleaCompetenceMarks = [buildCompetenceMark()],
   maxReachablePixByCompetenceForClea = { competence1: 51 },
@@ -13,7 +13,7 @@ module.exports = function buildCleaCertificationScoring({
   return new CleaCertificationScoring({
     certificationCourseId,
     hasAcquiredBadge,
-    badgeStillAcquired,
+    isBadgeStillValid,
     reproducibilityRate,
     cleaCompetenceMarks,
     maxReachablePixByCompetenceForClea,

--- a/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
@@ -4,6 +4,7 @@ const buildCompetenceMark = require('./build-competence-mark');
 module.exports = function buildCleaCertificationScoring({
   certificationCourseId = 42,
   hasAcquiredBadge = true,
+  badgeStillAcquired = true,
   reproducibilityRate = 50,
   cleaCompetenceMarks = [buildCompetenceMark()],
   maxReachablePixByCompetenceForClea = { competence1: 51 },
@@ -12,6 +13,7 @@ module.exports = function buildCleaCertificationScoring({
   return new CleaCertificationScoring({
     certificationCourseId,
     hasAcquiredBadge,
+    badgeStillAcquired,
     reproducibilityRate,
     cleaCompetenceMarks,
     maxReachablePixByCompetenceForClea,

--- a/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
@@ -4,7 +4,7 @@ const buildCompetenceMark = require('./build-competence-mark');
 module.exports = function buildCleaCertificationScoring({
   certificationCourseId = 42,
   hasAcquiredBadge = true,
-  isBadgeStillValid = true,
+  isBadgeAcquisitionStillValid = true,
   reproducibilityRate = 50,
   cleaCompetenceMarks = [buildCompetenceMark()],
   maxReachablePixByCompetenceForClea = { competence1: 51 },
@@ -13,7 +13,7 @@ module.exports = function buildCleaCertificationScoring({
   return new CleaCertificationScoring({
     certificationCourseId,
     hasAcquiredBadge,
-    isBadgeStillValid,
+    isBadgeAcquisitionStillValid,
     reproducibilityRate,
     cleaCompetenceMarks,
     maxReachablePixByCompetenceForClea,

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -12,8 +12,25 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
     save: _.noop(),
   };
 
+  const badgeRepository = {
+    getByKey: _.noop(),
+  };
+  const knowledgeElementRepository = {
+    findUniqByUserId: _.noop(),
+  };
+  const targetProfileRepository = {
+    get: _.noop(),
+  };
+  const badgeCriteriaService = {
+    areBadgeCriteriaFulfilled: _.noop(),
+  };
+
   const dependencies = {
     partnerCertificationScoringRepository,
+    badgeRepository,
+    knowledgeElementRepository,
+    targetProfileRepository,
+    badgeCriteriaService,
   };
 
   it('fails when event is not of correct type', async () => {
@@ -32,7 +49,10 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
   context('#handleCleaCertificationScoring', () => {
     const certificationCourseId = Symbol('certificationCourseId');
     const userId = Symbol('userId');
-    const cleaCertificationScoring = {};
+    const cleaCertificationScoring = { hasAcquiredBadge: true };
+    const targetProfile = { id: 'targetProfileId' };
+    const badge = { targetProfileId: targetProfile.id };
+    const knowledgeElements = Symbol('KnowledgeElements@& ');
 
     beforeEach(() => {
       event = new CertificationScoringCompleted({
@@ -42,6 +62,12 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
         reproducibilityRate,
         limitDate: new Date('2018-02-03'),
       });
+
+      badgeRepository.getByKey = sinon.stub().withArgs({ }).resolves(badge);
+      targetProfileRepository.get = sinon.stub().withArgs(targetProfile.id).resolves(targetProfile);
+      knowledgeElementRepository.findUniqByUserId = sinon.stub().withArgs({ userId: event.userId }).resolves(knowledgeElements);
+      badgeCriteriaService.areBadgeCriteriaFulfilled = sinon.stub().withArgs({ knowledgeElements, targetProfile, badge }).returns(true);
+      cleaCertificationScoring.setBadgeStillAcquired = sinon.stub().returns(true);
 
       partnerCertificationScoringRepository.save = sinon.stub();
       partnerCertificationScoringRepository.buildCleaCertificationScoring = sinon.stub();
@@ -55,6 +81,20 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
     });
 
     context('when certification is eligible', () => {
+
+      it('it should verify if the badge is still acquired', async () => {
+        // given
+        cleaCertificationScoring.isEligible = () => true;
+
+        // when
+        await handleCleaCertificationScoring({
+          event, ...dependencies,
+        });
+
+        // then
+        expect(badgeCriteriaService.areBadgeCriteriaFulfilled).to.have.been.calledWith({ knowledgeElements, targetProfile, badge });
+        expect(cleaCertificationScoring.setBadgeStillAcquired).to.have.been.calledWith(true);
+      });
 
       it('it should save a certif partner', async () => {
         // given
@@ -73,6 +113,21 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
     });
 
     context('when certification is not eligible', () => {
+
+      it('it not should verify if the badge is still acquired if the badge is not acquired', async () => {
+        // given
+        cleaCertificationScoring.hasAcquiredBadge = false;
+        cleaCertificationScoring.isEligible = () => true;
+
+        // when
+        await handleCleaCertificationScoring({
+          event, ...dependencies,
+        });
+
+        // then
+        expect(badgeCriteriaService.areBadgeCriteriaFulfilled).to.not.to.have.been.called;
+        expect(cleaCertificationScoring.setBadgeStillAcquired).to.not.to.have.been.called;
+      });
 
       it('it should not save a certif partner', async () => {
         // given

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -87,7 +87,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
 
     context('when certification is eligible', () => {
 
-      it('it should verify if the badge is still acquired', async () => {
+      it('should verify if the badge is still acquired', async () => {
         // given
         cleaCertificationScoring.isEligible = () => true;
 
@@ -101,7 +101,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
         expect(cleaCertificationScoring.setBadgeStillAcquired).to.have.been.calledWith(true);
       });
 
-      it('it should save a certif partner', async () => {
+      it('should save a certif partner', async () => {
         // given
         cleaCertificationScoring.isEligible = () => true;
 
@@ -119,7 +119,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
 
     context('when certification is not eligible', () => {
 
-      it('it not should verify if the badge is still acquired if the badge is not acquired', async () => {
+      it('should not verify if the badge is still acquired if the badge is not acquired', async () => {
         // given
         cleaCertificationScoring.hasAcquiredBadge = false;
         cleaCertificationScoring.isEligible = () => true;
@@ -134,7 +134,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
         expect(cleaCertificationScoring.setBadgeStillAcquired).to.not.to.have.been.called;
       });
 
-      it('it should not save a certif partner', async () => {
+      it('should not save a certif partner', async () => {
         // given
         cleaCertificationScoring.isEligible = () => false;
 

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -72,7 +72,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
       targetProfileRepository.get = sinon.stub().withArgs(targetProfile.id).resolves(targetProfile);
       knowledgeElementRepository.findUniqByUserId = sinon.stub().withArgs({ userId: event.userId, limitDate: date }).resolves(knowledgeElements);
       badgeCriteriaService.areBadgeCriteriaFulfilled = sinon.stub().withArgs({ knowledgeElements, targetProfile, badge }).returns(true);
-      cleaCertificationScoring.setBadgeStillValid = sinon.stub().returns(true);
+      cleaCertificationScoring.setBadgeAcquisitionStillValid = sinon.stub().returns(true);
 
       partnerCertificationScoringRepository.save = sinon.stub();
       partnerCertificationScoringRepository.buildCleaCertificationScoring = sinon.stub();
@@ -98,7 +98,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
 
         // then
         expect(badgeCriteriaService.areBadgeCriteriaFulfilled).to.have.been.calledWith({ knowledgeElements, targetProfile, badge });
-        expect(cleaCertificationScoring.setBadgeStillValid).to.have.been.calledWith(true);
+        expect(cleaCertificationScoring.setBadgeAcquisitionStillValid).to.have.been.calledWith(true);
       });
 
       it('should save a certif partner', async () => {
@@ -131,7 +131,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
 
         // then
         expect(badgeCriteriaService.areBadgeCriteriaFulfilled).to.not.to.have.been.called;
-        expect(cleaCertificationScoring.setBadgeStillValid).to.not.to.have.been.called;
+        expect(cleaCertificationScoring.setBadgeAcquisitionStillValid).to.not.to.have.been.called;
       });
 
       it('should not save a certif partner', async () => {

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -72,7 +72,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
       targetProfileRepository.get = sinon.stub().withArgs(targetProfile.id).resolves(targetProfile);
       knowledgeElementRepository.findUniqByUserId = sinon.stub().withArgs({ userId: event.userId, limitDate: date }).resolves(knowledgeElements);
       badgeCriteriaService.areBadgeCriteriaFulfilled = sinon.stub().withArgs({ knowledgeElements, targetProfile, badge }).returns(true);
-      cleaCertificationScoring.setBadgeStillAcquired = sinon.stub().returns(true);
+      cleaCertificationScoring.setBadgeStillValid = sinon.stub().returns(true);
 
       partnerCertificationScoringRepository.save = sinon.stub();
       partnerCertificationScoringRepository.buildCleaCertificationScoring = sinon.stub();
@@ -98,7 +98,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
 
         // then
         expect(badgeCriteriaService.areBadgeCriteriaFulfilled).to.have.been.calledWith({ knowledgeElements, targetProfile, badge });
-        expect(cleaCertificationScoring.setBadgeStillAcquired).to.have.been.calledWith(true);
+        expect(cleaCertificationScoring.setBadgeStillValid).to.have.been.calledWith(true);
       });
 
       it('should save a certif partner', async () => {
@@ -131,7 +131,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
 
         // then
         expect(badgeCriteriaService.areBadgeCriteriaFulfilled).to.not.to.have.been.called;
-        expect(cleaCertificationScoring.setBadgeStillAcquired).to.not.to.have.been.called;
+        expect(cleaCertificationScoring.setBadgeStillValid).to.not.to.have.been.called;
       });
 
       it('should not save a certif partner', async () => {

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -25,10 +25,15 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
     areBadgeCriteriaFulfilled: _.noop(),
   };
 
+  const certificationCourseRepository = {
+    getCreationDate: _.noop(),
+  };
+
   const dependencies = {
     partnerCertificationScoringRepository,
     badgeRepository,
     knowledgeElementRepository,
+    certificationCourseRepository,
     targetProfileRepository,
     badgeCriteriaService,
   };
@@ -60,12 +65,12 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', () => {
         userId,
         isCertification: true,
         reproducibilityRate,
-        limitDate: new Date('2018-02-03'),
       });
-
-      badgeRepository.getByKey = sinon.stub().withArgs({ }).resolves(badge);
+      const date = '2021-01-01';
+      certificationCourseRepository.getCreationDate = sinon.stub().withArgs(certificationCourseId).resolves(date);
+      badgeRepository.getByKey = sinon.stub().resolves(badge);
       targetProfileRepository.get = sinon.stub().withArgs(targetProfile.id).resolves(targetProfile);
-      knowledgeElementRepository.findUniqByUserId = sinon.stub().withArgs({ userId: event.userId }).resolves(knowledgeElements);
+      knowledgeElementRepository.findUniqByUserId = sinon.stub().withArgs({ userId: event.userId, limitDate: date }).resolves(knowledgeElements);
       badgeCriteriaService.areBadgeCriteriaFulfilled = sinon.stub().withArgs({ knowledgeElements, targetProfile, badge }).returns(true);
       cleaCertificationScoring.setBadgeStillAcquired = sinon.stub().returns(true);
 

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
@@ -159,7 +159,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
         organizationRepository.get.withArgs(organizationId).resolves({ isPoleEmploi: false });
       });
 
-      it('it should not notify to Pole Emploi', async () => {
+      it('should not notify to Pole Emploi', async () => {
         // when
         await handlePoleEmploiParticipationFinished({
           event,
@@ -186,7 +186,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
         organizationRepository.get.withArgs(organizationId).resolves({ isPoleEmploi: true });
       });
 
-      it('it should not notify to Pole Emploi', async () => {
+      it('should not notify to Pole Emploi', async () => {
         // when
         await handlePoleEmploiParticipationFinished({
           event,

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
@@ -203,7 +203,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
         organizationRepository.get.withArgs(organizationId).resolves({ isPoleEmploi: false });
       });
 
-      it('it should not notify to Pole Emploi', async () => {
+      it('should not notify to Pole Emploi', async () => {
         // when
         await handlePoleEmploiParticipationShared({
           event,
@@ -234,7 +234,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
         organizationRepository.get.withArgs(organizationId).resolves({ isPoleEmploi: true, organization: { id: organizationId } });
       });
 
-      it('it should not notify to Pole Emploi', async () => {
+      it('should not notify to Pole Emploi', async () => {
         // when
         await handlePoleEmploiParticipationShared({
           event,

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
@@ -148,7 +148,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
         event = new CampaignParticipationStarted({ campaignParticipationId });
       });
 
-      it('it should not notify to Pole Emploi', async () => {
+      it('should not notify to Pole Emploi', async () => {
         // when
         await handlePoleEmploiParticipationStarted({
           event,
@@ -176,7 +176,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
         event = new CampaignParticipationStarted({ campaignParticipationId });
       });
 
-      it('it should not notify to Pole Emploi', async () => {
+      it('should not notify to Pole Emploi', async () => {
         // when
         await handlePoleEmploiParticipationStarted({
           event,

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -243,7 +243,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         category: CertificationIssueReportCategories.FRAUD,
       };
 
-      it('it should be valid', () => {
+      it('should be valid', () => {
         expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).not.to.throw();
       });
     });

--- a/api/tests/unit/domain/models/CleaCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationScoring_test.js
@@ -80,6 +80,34 @@ describe('Unit | Domain | Models | CleaCertificationScoring', () => {
     });
   });
 
+  context('#setBadgeStillAcquired', () => {
+
+    it('when user has badge and set stillAcquired at true, should be eligible', async () => {
+      // given
+      const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge();
+
+      // when
+      cleaCertificationScoring.setBadgeStillAcquired(true);
+
+      // then
+      expect(cleaCertificationScoring.badgeStillAcquired).to.be.true;
+      expect(cleaCertificationScoring.isEligible()).to.be.true;
+    });
+
+    it('when user has badge and set stillAcquired at false, should not be eligible', async () => {
+      // given
+      const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge();
+
+      // when
+      cleaCertificationScoring.setBadgeStillAcquired(false);
+
+      // then
+      expect(cleaCertificationScoring.badgeStillAcquired).to.be.false;
+      expect(cleaCertificationScoring.hasAcquiredBadge).to.be.true;
+      expect(cleaCertificationScoring.isEligible()).to.be.false;
+    });
+  });
+
   context('#isAcquired', () => {
 
     it('throws when not eligible', async () => {

--- a/api/tests/unit/domain/models/CleaCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationScoring_test.js
@@ -80,17 +80,17 @@ describe('Unit | Domain | Models | CleaCertificationScoring', () => {
     });
   });
 
-  context('#setBadgeStillAcquired', () => {
+  context('#setBadgeStillValid', () => {
 
     it('when user has badge and set stillAcquired at true, should be eligible', async () => {
       // given
       const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge();
 
       // when
-      cleaCertificationScoring.setBadgeStillAcquired(true);
+      cleaCertificationScoring.setBadgeStillValid(true);
 
       // then
-      expect(cleaCertificationScoring.badgeStillAcquired).to.be.true;
+      expect(cleaCertificationScoring.isBadgeStillValid).to.be.true;
       expect(cleaCertificationScoring.isEligible()).to.be.true;
     });
 
@@ -99,10 +99,10 @@ describe('Unit | Domain | Models | CleaCertificationScoring', () => {
       const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge();
 
       // when
-      cleaCertificationScoring.setBadgeStillAcquired(false);
+      cleaCertificationScoring.setBadgeStillValid(false);
 
       // then
-      expect(cleaCertificationScoring.badgeStillAcquired).to.be.false;
+      expect(cleaCertificationScoring.isBadgeStillValid).to.be.false;
       expect(cleaCertificationScoring.hasAcquiredBadge).to.be.true;
       expect(cleaCertificationScoring.isEligible()).to.be.false;
     });

--- a/api/tests/unit/domain/models/CleaCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationScoring_test.js
@@ -80,17 +80,17 @@ describe('Unit | Domain | Models | CleaCertificationScoring', () => {
     });
   });
 
-  context('#setBadgeStillValid', () => {
+  context('#setBadgeAcquisitionStillValid', () => {
 
     it('when user has badge and set stillAcquired at true, should be eligible', async () => {
       // given
       const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge();
 
       // when
-      cleaCertificationScoring.setBadgeStillValid(true);
+      cleaCertificationScoring.setBadgeAcquisitionStillValid(true);
 
       // then
-      expect(cleaCertificationScoring.isBadgeStillValid).to.be.true;
+      expect(cleaCertificationScoring.isBadgeAcquisitionStillValid).to.be.true;
       expect(cleaCertificationScoring.isEligible()).to.be.true;
     });
 
@@ -99,10 +99,10 @@ describe('Unit | Domain | Models | CleaCertificationScoring', () => {
       const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge();
 
       // when
-      cleaCertificationScoring.setBadgeStillValid(false);
+      cleaCertificationScoring.setBadgeAcquisitionStillValid(false);
 
       // then
-      expect(cleaCertificationScoring.isBadgeStillValid).to.be.false;
+      expect(cleaCertificationScoring.isBadgeAcquisitionStillValid).to.be.false;
       expect(cleaCertificationScoring.hasAcquiredBadge).to.be.true;
       expect(cleaCertificationScoring.isEligible()).to.be.false;
     });

--- a/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
@@ -53,7 +53,7 @@ describe('Unit | UseCase | compute-campaign-analysis', () => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('it should throw an UserNotAuthorizedToAccessEntityError error', async () => {
+    it('should throw an UserNotAuthorizedToAccessEntityError error', async () => {
       // when
       const result = await catchErr(computeCampaignAnalysis)({
         userId,

--- a/api/tests/unit/domain/usecases/compute-campaign-collective-result_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-collective-result_test.js
@@ -50,7 +50,7 @@ describe('Unit | UseCase | compute-campaign-collective-result', () => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('it should throw an UserNotAuthorizedToAccessEntityError error', async () => {
+    it('should throw an UserNotAuthorizedToAccessEntityError error', async () => {
       // when
       const result = await catchErr(computeCampaignCollectiveResult)({
         userId,

--- a/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -91,7 +91,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('it should throw an UserNotAuthorizedToAccessEntityError error', async () => {
+    it('should throw an UserNotAuthorizedToAccessEntityError error', async () => {
       // when
       const result = await catchErr(computeCampaignParticipationAnalysis)({
         userId,


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la vérification du badge lors de la certification n'est pas faite de manière automatique.

## :robot: Solution
Au moment du calcul de la certification du badge en fin de campagne, appeler le service de vérification des badges pour savoir si l'utilisateur l'a toujours.

## :rainbow: Remarques
Certif prévoit un refacto du scoring.

## :100: Pour tester
- Passer la campagne pour avoir le badge
- Remettre à zéro et faire le minimum pour être certifier
- Se certifier
- Vérifier qu'automatiquement le badge n'est pas présent.