### PR TITLE
[TECH] Signaler l'erreur si une route à tester est invalide. 

### DIFF
--- a/api/tests/integration/application/assessments/assessment-controller_test.js
+++ b/api/tests/integration/application/assessments/assessment-controller_test.js
@@ -9,10 +9,11 @@ describe('Integration | Application | Assessments | assessment-controller', () =
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(usecases, 'getAssessment');
     sinon.stub(assessmentAuthorization, 'verify');
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('#get', () => {

--- a/api/tests/integration/application/campaignParticipations/index_test.js
+++ b/api/tests/integration/application/campaignParticipations/index_test.js
@@ -12,14 +12,15 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(campaignParticipationController, 'shareCampaignResult').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignParticipationController, 'find').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignParticipationController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignParticipationController, 'getCampaignAssessmentParticipation').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignParticipationController, 'getCampaignAssessmentParticipationResult').callsFake((request, h) => h.response('ok').code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/campaign-participations?filter[assessmentId]={id}', () => {

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -12,7 +12,7 @@ describe('Integration | Application | Route | campaignRouter', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(campaignController, 'save').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignController, 'getCsvAssessmentResults').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignController, 'getCsvProfilesCollectionResults').callsFake((request, h) => h.response('ok').code(200));
@@ -20,7 +20,8 @@ describe('Integration | Application | Route | campaignRouter', () => {
     sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/campaigns', () => {

--- a/api/tests/integration/application/certifications/index_test.js
+++ b/api/tests/integration/application/certifications/index_test.js
@@ -14,12 +14,13 @@ describe('Integration | Application | Route | Certifications', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(certificationController, 'findUserCertifications').returns('ok');
     sinon.stub(certificationController, 'getCertification').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/certifications', () => {

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -19,7 +19,7 @@ describe('Integration | API | Controller Error', () => {
     return payload.errors[0].title;
   }
 
-  before(async()=>{
+  before(async () => {
     const moduleUnderTest = {
       name: 'test-route',
       register: async function(server) {
@@ -33,7 +33,8 @@ describe('Integration | API | Controller Error', () => {
         }]);
       },
     };
-    server = new HttpTestServer(moduleUnderTest);
+    server = new HttpTestServer();
+    await server.register(moduleUnderTest);
   });
 
   context('412 Precondition Failed', () => {

--- a/api/tests/integration/application/healthcheck/index_test.js
+++ b/api/tests/integration/application/healthcheck/index_test.js
@@ -6,12 +6,13 @@ describe('Integration | Application | Route | healthcheckRouter', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     sinon.stub(healthCheckController, 'get').callsFake((request, h) => h.response(true));
     sinon.stub(healthCheckController, 'checkDbStatus').callsFake((request, h) => h.response(true));
     sinon.stub(healthCheckController, 'checkRedisStatus').callsFake((request, h) => h.response(true));
     sinon.stub(healthCheckController, 'crashTest').callsFake((request, h) => h.response(true));
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api', () => {

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -9,13 +9,14 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(usecases, 'createMembership');
     sinon.stub(usecases, 'updateMembership');
     sinon.stub(usecases, 'disableMembership');
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster');
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('#create', () => {

--- a/api/tests/integration/application/organization-invitations/index_test.js
+++ b/api/tests/integration/application/organization-invitations/index_test.js
@@ -12,12 +12,13 @@ describe('Integration | Application | Organization-invitations | Routes', () => 
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(organisationInvitationController, 'acceptOrganizationInvitation').callsFake((request, h) => h.response().code(204));
     sinon.stub(organisationInvitationController, 'sendScoInvitation').callsFake((request, h) => h.response().code(201));
     sinon.stub(organisationInvitationController, 'getOrganizationInvitation').callsFake((request, h) => h.response().code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/organization-invitations/:id/response', () => {

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -13,13 +13,14 @@ describe('Integration | Application | Organization-invitations | organization-in
   let sandbox;
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(usecases, 'acceptOrganizationInvitation');
     sandbox.stub(usecases, 'sendScoInvitation');
     sandbox.stub(scoOrganizationInvitationSerializer, 'serialize');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   afterEach(() => {

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -8,7 +8,7 @@ describe('Integration | Application | Organizations | Routes', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response(true));
@@ -25,7 +25,8 @@ describe('Integration | Application | Organizations | Routes', () => {
     sinon.stub(organizationController, 'findPaginatedFilteredSchoolingRegistrations').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(organizationController, 'attachTargetProfiles').callsFake((request, h) => h.response('ok').code(204));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/organizations', () => {

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -14,7 +14,7 @@ describe('Integration | Application | Organizations | organization-controller', 
   let sandbox;
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(usecases, 'updateOrganizationInformation');
     sandbox.stub(usecases, 'findPaginatedFilteredOrganizationMemberships');
@@ -30,7 +30,8 @@ describe('Integration | Application | Organizations | organization-controller', 
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToOrganizationManagingStudents');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToOrganizationOrHasRolePixMaster');
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   afterEach(() => {

--- a/api/tests/integration/application/passwords/index_test.js
+++ b/api/tests/integration/application/passwords/index_test.js
@@ -8,12 +8,13 @@ describe('Integration | Application | Password | Routes', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(passwordController, 'checkResetDemand').resolves('ok');
     sinon.stub(passwordController, 'createResetDemand').callsFake((request, h) => h.response().created());
     sinon.stub(passwordController, 'updateExpiredPassword').callsFake((request, h) => h.response().created());
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/password-reset-demands', () => {

--- a/api/tests/integration/application/passwords/password-controller_test.js
+++ b/api/tests/integration/application/passwords/password-controller_test.js
@@ -15,12 +15,13 @@ describe('Integration | Application | Passwords | password-controller', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(usecases, 'createPasswordResetDemand');
     sinon.stub(usecases, 'getUserByResetPasswordDemand');
     sinon.stub(usecases, 'updateExpiredPassword');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('#createResetDemand', () => {

--- a/api/tests/integration/application/prescribers/index_test.js
+++ b/api/tests/integration/application/prescribers/index_test.js
@@ -9,13 +9,14 @@ describe('Integration | Application | Prescribers | Routes', () => {
   let httpTestServer;
   const method = 'GET';
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
     sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser');
 
     sinon.stub(prescriberController, 'get').returns('ok');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/prescription/prescribers/{id}', () => {

--- a/api/tests/integration/application/prescribers/prescriber-controller_test.js
+++ b/api/tests/integration/application/prescribers/prescriber-controller_test.js
@@ -10,12 +10,13 @@ describe('Integration | Application | Prescribers | prescriber-controller', () =
   let sandbox;
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser');
     sandbox.stub(usecases, 'getPrescriber');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   afterEach(() => {

--- a/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
@@ -8,13 +8,14 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
     sinon.stub(schoolingRegistrationDependentUserController, 'createAndReconcileUserToSchoolingRegistration').callsFake((request, h) => h.response().code(204));
     sinon.stub(schoolingRegistrationDependentUserController, 'createUserAndReconcileToSchoolingRegistrationFromExternalUser').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(schoolingRegistrationDependentUserController, 'generateUsernameWithTemporaryPassword').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(schoolingRegistrationDependentUserController, 'updatePassword').callsFake((request, h) => h.response('ok').code(200));
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/schooling-registration-dependent-users', () => {

--- a/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
@@ -11,13 +11,14 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
   let sandbox;
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(usecases, 'createAndReconcileUserToSchoolingRegistration').rejects(new Error('not expected error'));
     sandbox.stub(usecases, 'updateSchoolingRegistrationDependentUserPassword').rejects(new Error('not expected error'));
     sandbox.stub(usecases, 'generateUsernameWithTemporaryPassword').resolves();
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents');
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   afterEach(() => {

--- a/api/tests/integration/application/schooling-registration-user-associations/index_test.js
+++ b/api/tests/integration/application/schooling-registration-user-associations/index_test.js
@@ -7,14 +7,15 @@ describe('Integration | Application | Route | schooling-registration-user-associ
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(schoolingRegistrationUserAssociationController, 'reconcileSchoolingRegistrationManually').callsFake((request, h) => h.response('ok').code(204));
     sinon.stub(schoolingRegistrationUserAssociationController, 'reconcileHigherSchoolingRegistration').callsFake((request, h) => h.response('ok').code(204));
     sinon.stub(schoolingRegistrationUserAssociationController, 'reconcileSchoolingRegistrationAutomatically').callsFake((request, h) => h.response('ok').code(204));
     sinon.stub(schoolingRegistrationUserAssociationController, 'findAssociation').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(schoolingRegistrationUserAssociationController, 'generateUsername').callsFake((request, h) => h.response('ok').code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/schooling-registration-user-associations', () => {

--- a/api/tests/integration/application/schooling-registration-user-associations/schooling-registration-user-association-controller_test.js
+++ b/api/tests/integration/application/schooling-registration-user-associations/schooling-registration-user-association-controller_test.js
@@ -10,10 +10,11 @@ describe('Integration | Application | Schooling-registration-user-association | 
   let sandbox;
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(usecases, 'generateUsername').rejects(new Error('not expected error'));
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   afterEach(() => {

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -12,7 +12,7 @@ describe('Integration | Application | Users | Routes', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
     sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
 
@@ -21,7 +21,8 @@ describe('Integration | Application | Users | Routes', () => {
     sinon.stub(userController, 'dissociateSchoolingRegistrations').returns('ok');
     sinon.stub(userController, 'resetScorecard').returns('ok');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/admin/users/{id}', () => {

--- a/api/tests/integration/application/users/user-controller_test.js
+++ b/api/tests/integration/application/users/user-controller_test.js
@@ -11,7 +11,7 @@ describe('Integration | Application | Users | user-controller', () => {
   let sandbox;
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser');
     sandbox.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
@@ -22,7 +22,8 @@ describe('Integration | Application | Users | user-controller', () => {
     sandbox.stub(usecases, 'dissociateSchoolingRegistrations');
     sandbox.stub(usecases, 'removeAuthenticationMethod');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   afterEach(() => {

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -19,20 +19,19 @@ const routesConfig = {
  * beforeEach(() => {
  *   sinon.stub(usecases, 'updateOrganizationInformation');
  *   sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, reply) => reply(true));
- *   httpTestServer = new HttpTestServer(moduleUnderTest);
+ *   httpTestServer = new HttpTestServer();
+ *   await httpTestServer.register(moduleUnderTest);
  * });
  */
 class HttpTestServer {
 
-  constructor(moduleUnderTest) {
+  constructor() {
     this.hapiServer = Hapi.server(routesConfig);
-
     this._setupErrorHandling();
+  }
 
-    // register returns a promise, which is ignored
-    // TODO: extract register in a separate async method
-    // https://stackoverflow.com/questions/43431550/async-await-class-constructor
-    this.hapiServer.register(moduleUnderTest);
+  async register(moduleUnderTest) {
+    await this.hapiServer.register(moduleUnderTest);
   }
 
   _setupErrorHandling() {

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -12,13 +12,14 @@ describe('Unit | Router | answer-router', function() {
 
   let httpTestServer;
 
-  beforeEach(function() {
+  beforeEach(async function() {
     sinon.stub(AnswerController, 'save').callsFake((request, h) => h.response().code(201));
     sinon.stub(AnswerController, 'get').callsFake((request, h) => h.response().code(200));
     sinon.stub(AnswerController, 'find').callsFake((request, h) => h.response().code(200));
     sinon.stub(AnswerController, 'update').callsFake((request, h) => h.response().code(204));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/answers', function() {

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -15,7 +15,7 @@ describe('Integration | Route | AssessmentRoute', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(assessmentController, 'save').returns('ok');
     sinon.stub(assessmentController, 'getNextChallenge').returns('ok');
     sinon.stub(assessmentController, 'findByFilters').returns('ok');
@@ -24,7 +24,8 @@ describe('Integration | Route | AssessmentRoute', () => {
     sinon.stub(assessmentAuthorization, 'verify').returns('userId');
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/assessments', () => {

--- a/api/tests/unit/application/cache/index_test.js
+++ b/api/tests/unit/application/cache/index_test.js
@@ -14,12 +14,13 @@ describe('Unit | Router | cache-router', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(cacheController, 'refreshCacheEntries').callsFake((request, h) => h.response().code(204));
     sinon.stub(cacheController, 'refreshCacheEntry').callsFake((request, h) => h.response().code(204));
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('PATCH /api/cache/{model}/{id}', () => {

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -13,7 +13,7 @@ describe('Unit | Application | Router | campaign-router ', function() {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     sinon.stub(campaignController, 'save').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignController, 'getByCode').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
@@ -28,7 +28,8 @@ describe('Unit | Application | Router | campaign-router ', function() {
     sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignController, 'division').callsFake((request, h) => h.response('ok').code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/campaigns', () => {

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -13,13 +13,14 @@ describe('Unit | Router | certification-center-router', () => {
 
   let httpTestServer;
 
-  beforeEach(function() {
+  beforeEach(async function() {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').returns(true);
     sinon.stub(certificationCenterController, 'createCertificationCenterMembershipByEmail').returns('ok');
     sinon.stub(certificationCenterController, 'findCertificationCenterMembershipsByCertificationCenter').returns('ok');
     sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/certification-centers/{certificationCenterId}/divisions', () => {

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -13,7 +13,7 @@ describe('Unit | Application | Certifications Course | Route', function() {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(certificationCoursesController, 'getCertificationResultInformation').returns('ok');
     sinon.stub(certificationCoursesController, 'update').returns('ok');
@@ -22,7 +22,8 @@ describe('Unit | Application | Certifications Course | Route', function() {
     sinon.stub(certificationCoursesController, 'get').returns('ok');
     sinon.stub(certificationCoursesController, 'getCertifiedProfile').returns('ok');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/admin/certifications/{id}/details', () => {

--- a/api/tests/unit/application/certification-issue-reports/index_test.js
+++ b/api/tests/unit/application/certification-issue-reports/index_test.js
@@ -1,13 +1,16 @@
 const { expect, HttpTestServer, sinon } = require('../../../test-helper');
-const certificationIssueReportModule = require('../../../../lib/application/certification-issue-reports');
 const certificationIssueReportController = require('../../../../lib/application/certification-issue-reports/certification-issue-report-controller');
+
+const moduleUnderTest = require('../../../../lib/application/certification-issue-reports');
 
 describe('Unit | Application | Certifications Issue Report | Route', () => {
 
   it('DELETE /api/certification-issue-reports/{id} should exist', async () => {
     // given
     sinon.stub(certificationIssueReportController, 'deleteCertificationIssueReport').returns('ok');
-    const httpTestServer = new HttpTestServer(certificationIssueReportModule);
+
+    const httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
 
     // when
     const response = await httpTestServer.request('DELETE', '/api/certification-issue-reports/1');

--- a/api/tests/unit/application/certification-point-of-contacts/index_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/index_test.js
@@ -12,10 +12,11 @@ describe('Unit | Router | certification-point-of-contact-router', function() {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(certificationPointOfContactController, 'get').callsFake((request, h) => h.response().code(200));
     sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').returns('ok');
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   afterEach(() => {

--- a/api/tests/unit/application/certification-report/index_test.js
+++ b/api/tests/unit/application/certification-report/index_test.js
@@ -1,13 +1,15 @@
 const { expect, HttpTestServer, sinon } = require('../../../test-helper');
-const certificationReportModule = require('../../../../lib/application/certification-reports');
 const certificationReportController = require('../../../../lib/application/certification-reports/certification-report-controller');
+
+const moduleUnderTest = require('../../../../lib/application/certification-reports');
 
 describe('Unit | Application | Certifications Report | Route', () => {
 
   it('POST /api/certification-reports/{id}/certification-issue-reports should exist', async () => {
     // given
     sinon.stub(certificationReportController, 'saveCertificationIssueReport').returns('ok');
-    const httpTestServer = new HttpTestServer(certificationReportModule);
+    const httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
 
     // when
     const response = await httpTestServer.request('POST', '/api/certification-reports/1/certification-issue-reports');

--- a/api/tests/unit/application/certifications/index_test.js
+++ b/api/tests/unit/application/certifications/index_test.js
@@ -13,7 +13,8 @@ describe('Unit | Application | Certification | Routes', () => {
       sinon.stub(certificationController, 'neutralizeChallenge').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
       securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
-      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       const payload = {
         data: {
           attributes: {
@@ -35,7 +36,8 @@ describe('Unit | Application | Certification | Routes', () => {
       sinon.stub(certificationController, 'neutralizeChallenge').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
       securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
-      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       const payload = {
         data: {
           attributes: {
@@ -57,7 +59,8 @@ describe('Unit | Application | Certification | Routes', () => {
       sinon.stub(certificationController, 'neutralizeChallenge').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
       securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
-      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       const payload = {
         data: {
           attributes: {
@@ -82,7 +85,8 @@ describe('Unit | Application | Certification | Routes', () => {
       sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
       securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
-      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       const payload = {
         data: {
           attributes: {
@@ -104,7 +108,8 @@ describe('Unit | Application | Certification | Routes', () => {
       sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
       securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
-      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       const payload = {
         data: {
           attributes: {
@@ -126,7 +131,8 @@ describe('Unit | Application | Certification | Routes', () => {
       sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
       securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
-      const httpTestServer = new HttpTestServer(moduleUnderTest);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       const payload = {
         data: {
           attributes: {

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -16,11 +16,12 @@ describe('Unit | Controller | challenge-controller', function() {
   let ChallengeRepoStub;
   let ChallengeSerializerStub;
 
-  beforeEach(function() {
+  beforeEach(async function() {
     ChallengeRepoStub = sinon.stub(ChallengeRepository, 'get');
     ChallengeSerializerStub = sinon.stub(ChallengeSerializer, 'serialize');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('#get', function() {

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -14,11 +14,12 @@ describe('Unit | Router | course-router', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(courseController, 'get').returns('ok');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/courses/{id}', () => {

--- a/api/tests/unit/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/unit/application/feedbacks/feedback-controller_test.js
@@ -14,8 +14,9 @@ describe('Unit | Controller | feedback-controller', function() {
 
   let httpTestServer;
 
-  beforeEach(function() {
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+  beforeEach(async function() {
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('#save', function() {

--- a/api/tests/unit/application/feedbacks/index_test.js
+++ b/api/tests/unit/application/feedbacks/index_test.js
@@ -12,10 +12,11 @@ describe('Unit | Router | feedback-router', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(feedbackController, 'save').returns('ok');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/feedbacks', () => {

--- a/api/tests/unit/application/healthcheck/index_test.js
+++ b/api/tests/unit/application/healthcheck/index_test.js
@@ -12,10 +12,11 @@ describe('Unit | Router | HealthcheckRouter', function() {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(healthcheckController, 'get').returns('ok');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api', function() {

--- a/api/tests/unit/application/organization-invitations/index_test.js
+++ b/api/tests/unit/application/organization-invitations/index_test.js
@@ -12,11 +12,12 @@ describe('Unit | Router | organization-invitation-router', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(organizationInvitationController, 'acceptOrganizationInvitation').callsFake((request, h) => h.response().code(204));
     sinon.stub(organizationInvitationController, 'getOrganizationInvitation').callsFake((request, h) => h.response().code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/organization-invitations/{id}/response', () => {

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -11,7 +11,7 @@ describe('Unit | Router | organization-router', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(usecases, 'findPendingOrganizationInvitations').resolves([]);
 
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
@@ -22,7 +22,8 @@ describe('Unit | Router | organization-router', () => {
     sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
     sinon.stub(organizationController, 'getSchoolingRegistrationsCsvTemplate').callsFake((request, h) => h.response('ok').code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/organizations', () => {

--- a/api/tests/unit/application/passwords/index_test.js
+++ b/api/tests/unit/application/passwords/index_test.js
@@ -8,12 +8,13 @@ describe('Unit | Router | Password router', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(passwordController, 'checkResetDemand');
     sinon.stub(passwordController, 'createResetDemand');
     sinon.stub(passwordController, 'updateExpiredPassword').callsFake((request, h) => h.response().created());
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/password-reset-demands', () => {

--- a/api/tests/unit/application/prescribers/index_test.js
+++ b/api/tests/unit/application/prescribers/index_test.js
@@ -16,11 +16,12 @@ describe('Unit | Router | prescriber-router', () => {
 
   describe('GET /api/prescription/prescribers/{id}', () => {
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(prescriberController, 'get').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
 
-      httpTestServer = new HttpTestServer(moduleUnderTest);
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
     });
 
     it('should exist', async () => {

--- a/api/tests/unit/application/progressions/index_test.js
+++ b/api/tests/unit/application/progressions/index_test.js
@@ -12,10 +12,11 @@ describe('Unit | Router | progression-router', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(progressionController, 'get').callsFake((request, h) => h.response().code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/progressions/{id}', function() {

--- a/api/tests/unit/application/schooling-registration-user-associations/index_test.js
+++ b/api/tests/unit/application/schooling-registration-user-associations/index_test.js
@@ -18,13 +18,14 @@ describe('Unit | Application | Router | schooling-registration-user-associations
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(preHandler, 'checkUserIsAdminInSUPOrganizationManagingStudents');
 
     sinon.stub(schoolingRegistrationUserAssociationController, 'dissociate').returns('ok');
     sinon.stub(schoolingRegistrationUserAssociationController, 'updateStudentNumber').returns('ok');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('PATCH /api/organizations/id/schooling-registration-user-associations/studentId', () => {

--- a/api/tests/unit/application/scorecards/index_test.js
+++ b/api/tests/unit/application/scorecards/index_test.js
@@ -2,15 +2,16 @@ const { expect, sinon, HttpTestServer } = require('../../../test-helper');
 const scorecardController = require('../../../../lib/application/scorecards/scorecard-controller');
 const moduleUnderTest = require('../../../../lib/application/scorecards');
 
-let server;
+let httpTestServer;
 
 describe('Unit | Router | scorecard-router', () => {
 
   describe('GET /api/scorecards/{id}', () => {
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(scorecardController, 'getScorecard').returns('ok');
-      server = new HttpTestServer(moduleUnderTest);
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
     });
 
     it('should exist', async () => {
@@ -21,7 +22,7 @@ describe('Unit | Router | scorecard-router', () => {
       };
 
       // when
-      const response = await server.request(options.method, options.url);
+      const response = await httpTestServer.request(options.method, options.url);
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -30,9 +31,10 @@ describe('Unit | Router | scorecard-router', () => {
 
   describe('GET /api/scorecards/{id}/tutorials', () => {
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(scorecardController, 'findTutorials').returns('ok');
-      server = new HttpTestServer(moduleUnderTest);
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
     });
 
     it('should exist', async () => {
@@ -43,7 +45,7 @@ describe('Unit | Router | scorecard-router', () => {
       };
 
       // when
-      const response = await server.request(options.method, options.url);
+      const response = await httpTestServer.request(options.method, options.url);
 
       // then
       expect(response.statusCode).to.equal(200);

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -21,7 +21,7 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(sessionAuthorization, 'verify').returns(null);
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
 
@@ -47,7 +47,8 @@ describe('Unit | Application | Sessions | Routes', () => {
     sinon.stub(finalizedSessionController, 'findFinalizedSessionsToPublish').returns('ok');
     sinon.stub(finalizedSessionController, 'findFinalizedSessionsWithRequiredAction').returns('ok');
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('GET /api/sessions/{id}', () => {

--- a/api/tests/unit/application/stages/index_test.js
+++ b/api/tests/unit/application/stages/index_test.js
@@ -5,17 +5,19 @@ const moduleUnderTest = require('../../../../lib/application/stages');
 
 let httpTestServer;
 
-function startServer() {
-  return new HttpTestServer(moduleUnderTest);
+async function startServer() {
+  const server = new HttpTestServer();
+  await server.register(moduleUnderTest);
+  return server;
 }
 
 describe('Unit | Router | stages-router', () => {
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(stagesController, 'create').returns('ok');
     sinon.stub(stagesController, 'updateStage').callsFake((request, h) => h.response('ok').code(204));
     sinon.stub(stagesController, 'getStageDetails').callsFake((request, h) => h.response('ok').code(200));
-    httpTestServer = startServer();
+    httpTestServer = await startServer();
   });
 
   describe('POST /api/admin/stages', () => {

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -8,7 +8,7 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(targetProfileController, 'outdateTargetProfile').callsFake((request, h) => h.response('ok').code(204));
     sinon.stub(targetProfileController, 'createTargetProfile').callsFake((request, h) => h.response('ok').code(200));
@@ -17,7 +17,8 @@ describe('Integration | Application | Target Profiles | Routes', () => {
     sinon.stub(targetProfileController, 'getTargetProfileDetails').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(targetProfileController, 'updateTargetProfileName').callsFake((request, h) => h.response('ok').code(204));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('POST /api/target-profiles', () => {

--- a/api/tests/unit/application/user-orga-settings/index_test.js
+++ b/api/tests/unit/application/user-orga-settings/index_test.js
@@ -7,9 +7,10 @@ describe('Unit | Router | user-orga-settings-router', () => {
 
   let httpTestServer;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     sinon.stub(userOrgaSettingsController, 'createOrUpdate').returns('ok');
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
   });
 
   describe('PUT /api/user-orga-settings/{id}', () => {

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -8,8 +8,10 @@ const moduleUnderTest = require('../../../../lib/application/users');
 
 let httpTestServer;
 
-function startServer() {
-  return new HttpTestServer(moduleUnderTest);
+async function startServer() {
+  const server = new HttpTestServer();
+  await server.register(moduleUnderTest);
+  return server;
 }
 
 describe('Unit | Router | user-router', () => {
@@ -18,10 +20,10 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(() => {
+    beforeEach(async () => {
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(userController, 'findPaginatedFilteredUsers').returns('ok');
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should exist', async () => {
@@ -41,9 +43,9 @@ describe('Unit | Router | user-router', () => {
     const method = 'POST';
     const url = '/api/users';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'save').returns('ok');
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     context('Payload schema validation', () => {
@@ -76,9 +78,9 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'getCurrentUser').returns('ok');
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should exist', async () => {
@@ -97,10 +99,10 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'getMemberships').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should exist', async () => {
@@ -120,10 +122,10 @@ describe('Unit | Router | user-router', () => {
     const method = 'PATCH';
     const url = '/api/users/12344/password-update';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'updatePassword').returns('ok');
       sinon.stub(userVerification, 'verifyById').returns('ok');
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should exist and pass through user verification pre-handler', async () => {
@@ -184,10 +186,10 @@ describe('Unit | Router | user-router', () => {
     const method = 'GET';
     const url = '/api/users/42/is-certifiable';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'isCertifiable').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should exist', async () => {
@@ -204,10 +206,10 @@ describe('Unit | Router | user-router', () => {
     const method = 'GET';
     const url = '/api/users/42/profile';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'getProfile').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should exist', async () => {
@@ -223,10 +225,10 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'getUserProfileSharedForCampaign').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should return 200', async () => {
@@ -269,10 +271,10 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'getUserCampaignParticipationToCampaign').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should return 200', async () => {
@@ -315,10 +317,10 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'PATCH';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'updateUserDetailsForAdministration').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should verify user identity and return sucess update', async () => {
@@ -366,10 +368,10 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'POST';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'anonymizeUser').callsFake((request, h) => h.response({}).code(204));
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should exist', async () => {
@@ -400,10 +402,10 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'PATCH';
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'dissociateSchoolingRegistrations').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     it('should exist', async () => {
@@ -432,10 +434,10 @@ describe('Unit | Router | user-router', () => {
 
   describe('POST /api/admin/users/{id}/remove-authentication', () => {
 
-    beforeEach(() => {
+    beforeEach(async() => {
       sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      httpTestServer = startServer();
+      httpTestServer = await startServer();
     });
 
     ['GAR', 'EMAIL', 'USERNAME', 'POLE_EMPLOI']

--- a/api/tests/unit/tooling/http-test-server_test.js
+++ b/api/tests/unit/tooling/http-test-server_test.js
@@ -5,21 +5,49 @@ const HttpTestServer = require('../../tooling/server/http-test-server');
 describe('Unit | Tooling | Http-test-server', () => {
 
   describe('#constructor', () => {
-    let httpTestServer;
+    let server;
 
     before(() => {
-      httpTestServer = new HttpTestServer([]);
+      server = new HttpTestServer();
     });
 
     it('should create hapi server', () => {
       // then
-      expect(httpTestServer.hapiServer).to.exist;
+      expect(server.hapiServer).to.exist;
     });
 
     it('Should use pre-response-utils function', () => {
       // then
-      expect(httpTestServer.hapiServer._core.extensions.route.onPreResponse.nodes[0].func.name).to.equal('handleDomainAndHttpErrors');
+      expect(server.hapiServer._core.extensions.route.onPreResponse.nodes[0].func.name).to.equal('handleDomainAndHttpErrors');
     });
-
   });
+
+  describe('#register', () => {
+
+    it('should throw error if route is invalid', async () => {
+
+      const invalidRoute = {
+        name: 'foo-route',
+        register: async function(server) {
+          server.route([{
+            method: 'GET',
+          }]);
+        },
+      };
+
+      const server = new HttpTestServer();
+
+      let registerError;
+      try {
+        await server.register(invalidRoute);
+      } catch (error) {
+        registerError = error;
+      }
+
+      expect(registerError.message).to.contain('Invalid route options (GET )');
+
+    });
+  });
+
 });
+


### PR DESCRIPTION
## :unicorn: Problème
[server.register](https://hapi.dev/api/?v=20.1.2#-await-serverregisterplugins-options) renvoie une promesse,  ignorée dans le constructeur de `http-test-server`. 

```
constructor(moduleUnderTest) {
  this.hapiServer = Hapi.server(routesConfig);
  this.hapiServer.register(moduleUnderTest);
}
```

## :robot: Solution
Extraire cet appel dans une méthode séparée (aucun constructeur ne peut renvoyer de promesse.. sauf `new Promise()`)
L'ajouter après chaque instanciation. 

## :rainbow: Remarques
Le problème avait été identifié dans la PR #2868, ajouté en commentaire, mais non corrigé dans la PR qui faisait déjà 300 lignes.

## :100: Pour tester
Vérifier que la CI passe: un test unitaire sur une route incorrecte a été ajouté.
