### PR TITLE
[TECH] Ajout d'une redirection www vers une url sans www 

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -17,6 +17,12 @@ log_format keyvalue
 access_log off;
 
 server {
+  listen <%= ENV['PORT'] %>;
+  server_name ~^www\.(.*)$;
+  return 301 $scheme://$1$request_uri;
+}
+
+server {
   access_log logs/access.log keyvalue;
   server_name localhost;
   listen <%= ENV['PORT'] %>;

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -17,6 +17,12 @@ log_format keyvalue
 access_log off;
 
 server {
+  listen <%= ENV['PORT'] %>;
+  server_name ~^www\.(.*)$;
+  return 301 $scheme://$1$request_uri;
+}
+
+server {
   access_log logs/access.log keyvalue;
   server_name localhost;
   listen <%= ENV['PORT'] %>;

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -17,6 +17,12 @@ log_format keyvalue
 access_log off;
 
 server {
+  listen <%= ENV['PORT'] %>;
+  server_name ~^www\.(.*)$;
+  return 301 $scheme://$1$request_uri;
+}
+
+server {
   access_log logs/access.log keyvalue;
   server_name localhost;
   listen <%= ENV['PORT'] %>;

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -17,6 +17,12 @@ log_format keyvalue
 access_log off;
 
 server {
+  listen <%= ENV['PORT'] %>;
+  server_name ~^www\.(.*)$;
+  return 301 $scheme://$1$request_uri;
+}
+  
+server {
   access_log logs/access.log keyvalue;
   server_name localhost;
   listen <%= ENV['PORT'] %>;


### PR DESCRIPTION
## :unicorn: Problème
il n'y a pas de certificat pour `www.orga.pix.fr`. FireFox et Internet Explorer. Celà à pour effet d'afficher une page connexion non sécurisé. 

Les navigateurs basé sur Chromium.
`Redirecting navigation www.orga.pix.fr -> orga.pix.fr because the server presented a certificate valid for orga.pix.fr but not for www.orga.pix.fr. To disable such redirects launch Chrome with the following flag: --disable-features=SSLCommonNameMismatchHandling`


## :robot: Solution
Nous ne voulons pas forcément avoir x certificat pour x domaine si nous décidons  de rediriger le `www.orga.pix.fr` 
 automatiquement vers le `https://orga.pix.fr`

## :rainbow: Remarques
Je ne sais pas comment tester cette modif (les RA utilise pix-review-router). 
On est censé redirigé automatiquement le www. vers le site classique. 

Est ce que ça nous évite d'avoir à gérer un certificat Let's encrypt pour le www ? Ou dans tout les cas il faut faire un certificat pour le www même en faisant le redirection ?

A répéter sur les 4 applis si tout est ok.

## :100: Pour tester
> __
