### PR TITLE
[FEATURE] Vérifier la validité des badges certifiables avant leur certification (PIX-2513).

### DIFF
--- a/api/lib/domain/models/Badge.js
+++ b/api/lib/domain/models/Badge.js
@@ -26,6 +26,8 @@ class Badge {
 
 Badge.keys = {
   PIX_EMPLOI_CLEA: 'PIX_EMPLOI_CLEA',
+  PIX_DROIT_MAITRE_CERTIF: 'PIX_DROIT_MAITRE_CERTIF',
+  PIX_DROIT_EXPERT_CERTIF: 'PIX_DROIT_EXPERT_CERTIF',
 };
 
 module.exports = Badge;

--- a/api/lib/domain/services/certification-badges-service.js
+++ b/api/lib/domain/services/certification-badges-service.js
@@ -9,7 +9,7 @@ const badgeCriteriaService = require('../../domain/services/badge-criteria-servi
 const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../domain/models/Badge').keys;
 
 module.exports = {
-  async findStillAcquiredBadgeAcquisitions({ userId, domainTransaction }) {
+  async findStillValidBadgeAcquisitions({ userId, domainTransaction }) {
     const certifiableBadgeAcquisitions = await badgeAcquisitionRepository.findCertifiable({ userId, domainTransaction });
     const highestCertifiableBadgeAcquisitions = this._keepHighestBadgeWithinPlusCertifications(certifiableBadgeAcquisitions);
     const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId });

--- a/api/lib/domain/services/certification-badges-service.js
+++ b/api/lib/domain/services/certification-badges-service.js
@@ -1,0 +1,31 @@
+const badgeAcquisitionRepository = require('../../infrastructure/repositories/badge-acquisition-repository');
+const _ = require('lodash');
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../domain/models/Badge').keys;
+
+module.exports = {
+  async findStillAcquiredBadgeAcquisitions({ userId, domainTransaction }) {
+    const certifiableBadgeAcquisitions = await badgeAcquisitionRepository.findCertifiable({ userId, domainTransaction });
+    const highestCertifiableBadgeAcquisitions = this._keepHighestBadgeWithinPlusCertifications(certifiableBadgeAcquisitions);
+    return highestCertifiableBadgeAcquisitions;
+  },
+
+  _keepHighestBadgeWithinPlusCertifications(certifiableBadgeAcquisitions) {
+    return this._keepHighestBadgeWithinDroitCertification(certifiableBadgeAcquisitions);
+  },
+
+  _keepHighestBadgeWithinDroitCertification(certifiableBadgeAcquisitions) {
+    const [pixDroitBadgeAcquisitions, nonPixDroitBadgeAcquisitions] = _.partition(certifiableBadgeAcquisitions, this._isPixDroit);
+    if (pixDroitBadgeAcquisitions.length === 0) return nonPixDroitBadgeAcquisitions;
+    const expertBadgeAcquisition = _.find(certifiableBadgeAcquisitions, { badgeKey: PIX_DROIT_EXPERT_CERTIF });
+    const maitreBadgeAcquisition = _.find(certifiableBadgeAcquisitions, { badgeKey: PIX_DROIT_MAITRE_CERTIF });
+    return [
+      ...nonPixDroitBadgeAcquisitions,
+      expertBadgeAcquisition || maitreBadgeAcquisition,
+    ];
+  },
+
+  _isPixDroit(badgeAcquisition) {
+    return [PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF].includes(badgeAcquisition.badgeKey);
+  },
+};
+

--- a/api/lib/domain/services/certification-badges-service.js
+++ b/api/lib/domain/services/certification-badges-service.js
@@ -12,11 +12,11 @@ module.exports = {
   async findStillValidBadgeAcquisitions({ userId, domainTransaction }) {
     const certifiableBadgeAcquisitions = await badgeAcquisitionRepository.findCertifiable({ userId, domainTransaction });
     const highestCertifiableBadgeAcquisitions = this._keepHighestBadgeWithinPlusCertifications(certifiableBadgeAcquisitions);
-    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId });
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId, domainTransaction });
 
     const badgeAcquisitions = await bluebird.mapSeries(highestCertifiableBadgeAcquisitions, async (badgeAcquisition) => {
       const badge = badgeAcquisition.badge;
-      const targetProfile = await targetProfileRepository.get(badge.targetProfileId);
+      const targetProfile = await targetProfileRepository.get(badge.targetProfileId, domainTransaction);
       const isBadgeValid = badgeCriteriaService.areBadgeCriteriaFulfilled({
         knowledgeElements,
         targetProfile,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -26,6 +26,7 @@ const dependencies = {
   campaignCsvExportService: require('../../domain/services/campaign-csv-export-service'),
   certificationAssessmentRepository: require('../../infrastructure/repositories/certification-assessment-repository'),
   certificationAttestationPdf: require('../../infrastructure/utils/pdf/certification-attestation-pdf'),
+  certificationBadgesService: require('../../domain/services/certification-badges-service'),
   certificationCandidateRepository: require('../../infrastructure/repositories/certification-candidate-repository'),
   certificationCandidatesOdsService: require('../../domain/services/certification-candidates-ods-service'),
   certificationCenterMembershipRepository: require('../../infrastructure/repositories/certification-center-membership-repository'),

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -88,7 +88,7 @@ async function _startNewCertification({
 }
 
 async function _findChallengesFromPixPlus({ userId, domainTransaction, certificationBadgesService, certificationChallengesService }) {
-  const highestCertifiableBadgeAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+  const highestCertifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
   const challengesPixPlusByCertifiableBadges = await bluebird.mapSeries(highestCertifiableBadgeAcquisitions,
     ({ badge }) => certificationChallengesService.pickCertificationChallengesForPixPlus(badge, userId));
   return _.flatMap(challengesPixPlusByCertifiableBadges);

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -11,13 +11,13 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   sessionId,
   userId,
   assessmentRepository,
-  badgeAcquisitionRepository,
   competenceRepository,
   certificationCandidateRepository,
   certificationCourseRepository,
   sessionRepository,
   certificationChallengesService,
   placementProfileService,
+  certificationBadgesService,
 }) {
   const session = await sessionRepository.get(sessionId);
   if (session.accessCode !== accessCode) {
@@ -41,11 +41,11 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     sessionId,
     userId,
     assessmentRepository,
-    badgeAcquisitionRepository,
     competenceRepository,
     certificationCandidateRepository,
     certificationCourseRepository,
     certificationChallengesService,
+    certificationBadgesService,
     placementProfileService,
   });
 };
@@ -55,11 +55,11 @@ async function _startNewCertification({
   sessionId,
   userId,
   assessmentRepository,
-  badgeAcquisitionRepository,
   certificationCandidateRepository,
   certificationCourseRepository,
   certificationChallengesService,
   placementProfileService,
+  certificationBadgesService,
 }) {
   const challengesForPixCertification = await _createPixCertification(placementProfileService, certificationChallengesService, userId);
 
@@ -73,7 +73,7 @@ async function _startNewCertification({
     };
   }
 
-  const challengesForPixPlusCertification = await _findChallengesFromPixPlus({ userId, badgeAcquisitionRepository, certificationChallengesService, domainTransaction });
+  const challengesForPixPlusCertification = await _findChallengesFromPixPlus({ userId, certificationBadgesService, certificationChallengesService, domainTransaction });
   const challengesForCertification = challengesForPixCertification.concat(challengesForPixPlusCertification);
 
   return _createCertificationCourse({
@@ -87,9 +87,8 @@ async function _startNewCertification({
   });
 }
 
-async function _findChallengesFromPixPlus({ userId, badgeAcquisitionRepository, certificationChallengesService, domainTransaction }) {
-  const certifiableBadgeAcquisitions = await badgeAcquisitionRepository.findCertifiable({ userId, domainTransaction });
-  const highestCertifiableBadgeAcquisitions = _keepHighestBadgeWithinPlusCertifications(certifiableBadgeAcquisitions);
+async function _findChallengesFromPixPlus({ userId, domainTransaction, certificationBadgesService, certificationChallengesService }) {
+  const highestCertifiableBadgeAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
   const challengesPixPlusByCertifiableBadges = await bluebird.mapSeries(highestCertifiableBadgeAcquisitions,
     ({ badge }) => certificationChallengesService.pickCertificationChallengesForPixPlus(badge, userId));
   return _.flatMap(challengesPixPlusByCertifiableBadges);
@@ -132,26 +131,4 @@ async function _createCertificationCourse({ certificationCandidateRepository, ce
     created: true,
     certificationCourse: savedCertificationCourse,
   };
-}
-
-function _keepHighestBadgeWithinPlusCertifications(certifiableBadgeAcquisitions) {
-  return _keepHighestBadgeWithinDroitCertification(certifiableBadgeAcquisitions);
-}
-
-const pixDroitMaitre = 'PIX_DROIT_MAITRE_CERTIF';
-const pixDroitExpert = 'PIX_DROIT_EXPERT_CERTIF';
-
-function _keepHighestBadgeWithinDroitCertification(certifiableBadgeAcquisitions) {
-  const [pixDroitBadgeAcquisitions, nonPixDroitBadgeAcquisitions] = _.partition(certifiableBadgeAcquisitions, _isPixDroit);
-  if (pixDroitBadgeAcquisitions.length === 0) return nonPixDroitBadgeAcquisitions;
-  const expertBadgeAcquisition = _.find(certifiableBadgeAcquisitions, { badgeKey: pixDroitExpert });
-  const maitreBadgeAcquisition = _.find(certifiableBadgeAcquisitions, { badgeKey: pixDroitMaitre });
-  return [
-    ...nonPixDroitBadgeAcquisitions,
-    expertBadgeAcquisition || maitreBadgeAcquisition,
-  ];
-}
-
-function _isPixDroit(badgeAcquisition) {
-  return [pixDroitMaitre, pixDroitExpert].includes(badgeAcquisition.badgeKey);
 }

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -55,7 +55,7 @@ module.exports = {
         qb.where('badges.isCertifiable', '=', true);
       })
       .fetchAll({
-        withRelated: ['badge'],
+        withRelated: ['badge', 'badge.badgePartnerCompetences', 'badge.badgeCriteria'],
         require: false,
         transacting: domainTransaction.knexTransaction,
       });

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -24,8 +24,9 @@ function _applyFilters(knowledgeElements) {
   return _dropResetKnowledgeElements(uniqsMostRecentPerSkill);
 }
 
-function _findByUserIdAndLimitDateQuery({ userId, limitDate }) {
+function _findByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction = DomainTransaction.emptyTransaction() }) {
   return knex('knowledge-elements')
+    .transacting(domainTransaction)
     .where((qb) => {
       qb.where({ userId });
       if (limitDate) {
@@ -34,8 +35,8 @@ function _findByUserIdAndLimitDateQuery({ userId, limitDate }) {
     });
 }
 
-async function _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate }) {
-  const knowledgeElementRows = await _findByUserIdAndLimitDateQuery({ userId, limitDate });
+async function _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction }) {
+  const knowledgeElementRows = await _findByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction });
 
   const knowledgeElements = _.map(knowledgeElementRows, (knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow));
   return _applyFilters(knowledgeElements);
@@ -89,8 +90,8 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfKnowledgeElement, savedKnowledgeElement);
   },
 
-  async findUniqByUserId({ userId, limitDate }) {
-    return _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate });
+  async findUniqByUserId({ userId, limitDate, domainTransaction }) {
+    return _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction });
   },
 
   async findUniqByUserIdAndAssessmentId({ userId, assessmentId }) {

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -25,8 +25,8 @@ function _applyFilters(knowledgeElements) {
 }
 
 function _findByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  return knex('knowledge-elements')
-    .transacting(domainTransaction)
+  const knexConn = domainTransaction.knexTransaction || knex;
+  return knexConn('knowledge-elements')
     .where((qb) => {
       qb.where({ userId });
       if (limitDate) {

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -8,6 +8,7 @@ const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-convert
 const { knex } = require('../bookshelf');
 const { isUniqConstraintViolated, foreignKeyConstraintViolated } = require('../utils/knex-utils.js');
 const { TargetProfileCannotBeCreated, NotFoundError, AlreadyExistingEntityError, ObjectValidationError } = require('../../domain/errors');
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = {
 
@@ -37,10 +38,10 @@ module.exports = {
     }
   },
 
-  async get(id) {
+  async get(id, domainTransaction = DomainTransaction.emptyTransaction()) {
     const targetProfileBookshelf = await BookshelfTargetProfile
       .where({ id })
-      .fetch({ require: false, withRelated: ['skillIds'] });
+      .fetch({ require: false, withRelated: ['skillIds'], transacting: domainTransaction.knexTransaction });
 
     if (!targetProfileBookshelf) {
       throw new NotFoundError(`Le profil cible avec l'id ${id} n'existe pas`);

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -54,7 +54,7 @@ describe('Integration | Service | Certification-Badges Service', () => {
       listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
       const badge = databaseBuilder.factory.buildBadge({ isCertifiable: true, targetProfileId: targetProfileId });
       databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge.id });
-      databaseBuilder.factory.buildBadgeCriterion({
+      const badgeCriterion = databaseBuilder.factory.buildBadgeCriterion({
         scope: 'EveryPartnerCompetence',
         badgeId: badge.id,
         threshold: 40,
@@ -63,7 +63,7 @@ describe('Integration | Service | Certification-Badges Service', () => {
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' }).id;
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' }).id;
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' }).id;
-      databaseBuilder.factory.buildBadgePartnerCompetence({ badgeId: badge.id, skillIds: ['web1', 'web2', 'web3', 'web4'] });
+      const badgePartnerCompetence = databaseBuilder.factory.buildBadgePartnerCompetence({ badgeId: badge.id, skillIds: ['web1', 'web2', 'web3', 'web4'] });
 
       await databaseBuilder.commit();
 
@@ -76,9 +76,27 @@ describe('Integration | Service | Certification-Badges Service', () => {
       });
 
       // then
+      const expectedBadgeCriteria = [
+        {
+          id: badgeCriterion.id,
+          scope: badgeCriterion.scope,
+          threshold: badgeCriterion.threshold,
+          partnerCompetenceIds: badgeCriterion.partnerCompetenceIds,
+        },
+      ];
+
+      const expectedBadgePartnerCompetences = [
+        {
+          id: badgePartnerCompetence.id,
+          name: badgePartnerCompetence.name,
+          color: badgePartnerCompetence.color,
+          skillIds: badgePartnerCompetence.skillIds,
+        },
+      ];
+
       expect(badgeAcquisitions.length).to.equal(1);
-      expect(badgeAcquisitions[0].badge.badgeCriteria.length).to.equal(1);
-      expect(badgeAcquisitions[0].badge.badgePartnerCompetences.length).to.equal(1);
+      expect(badgeAcquisitions[0].badge.badgeCriteria).to.deep.equal(expectedBadgeCriteria);
+      expect(badgeAcquisitions[0].badge.badgePartnerCompetences).to.deep.equal(expectedBadgePartnerCompetences);
     });
   });
 });

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -1,0 +1,84 @@
+const { expect, databaseBuilder, mockLearningContent, learningContentBuilder } = require('../../../test-helper');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+
+const certificationBadgesService = require('../../../../lib/domain/services/certification-badges-service');
+
+const listSkill = ['web1', 'web2', 'web3', 'web4'];
+const learningContent = [{
+  id: 'recArea1',
+  titleFrFr: 'area1_Title',
+  color: 'someColor',
+  competences: [{
+    id: 'competenceId',
+    nameFrFr: 'Mener une recherche et une veille d’information',
+    index: '1.1',
+    tubes: [{
+      id: 'recTube0_0',
+      skills: [{
+        id: listSkill[0],
+        nom: '@web1',
+        status: 'actif',
+        challenges: [],
+      }, {
+        id: listSkill[1],
+        nom: '@web2',
+        status: 'actif',
+        challenges: [],
+      }, {
+        id: listSkill[2],
+        nom: 'web3',
+        status: 'actif',
+        challenges: [],
+      }, {
+        id: listSkill[3],
+        nom: 'web4',
+        status: 'actif',
+        challenges: [],
+      }],
+    }],
+  }],
+}];
+
+describe('Integration | Service | Certification-Badges Service', () => {
+
+  describe('#findStillValidBadgeAcquisitions', () => {
+
+    afterEach(async() => {
+      await databaseBuilder.clean();
+    });
+
+    it('should return one badgeAcquisition', async () => {
+      // given
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
+      const badge = databaseBuilder.factory.buildBadge({ isCertifiable: true, targetProfileId: targetProfileId });
+      databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge.id });
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: 'EveryPartnerCompetence',
+        badgeId: badge.id,
+        threshold: 40,
+      });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' }).id;
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' }).id;
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' }).id;
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' }).id;
+      databaseBuilder.factory.buildBadgePartnerCompetence({ badgeId: badge.id, skillIds: ['web1', 'web2', 'web3', 'web4'] });
+
+      await databaseBuilder.commit();
+
+      const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+      mockLearningContent(learningContentObjects);
+
+      // when
+      const badgeAcquisitions = await DomainTransaction.execute(async (domainTransaction) => {
+        return certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
+      });
+
+      // then
+      expect(badgeAcquisitions.length).to.equal(1);
+      expect(badgeAcquisitions[0].badge.badgeCriteria.length).to.equal(1);
+      expect(badgeAcquisitions[0].badge.badgePartnerCompetences.length).to.equal(1);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -105,16 +105,18 @@ describe('Integration | Repository | Badge Acquisition', () => {
   });
 
   describe('#findCertifiable', () => {
-    let badgeCertifiable1, badgeNonCertifiable, user, userWithoutBadge;
+    let badgeCertifiable, badgeNonCertifiable, user, userWithoutBadge;
     beforeEach(async () => {
       const targetProfile = databaseBuilder.factory.buildTargetProfile();
-      badgeCertifiable1 = databaseBuilder.factory.buildBadge({ key: 'key1', targetProfileId: targetProfile.id, isCertifiable: true });
+      badgeCertifiable = databaseBuilder.factory.buildBadge({ key: 'key1', targetProfileId: targetProfile.id, isCertifiable: true });
       databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id, isCertifiable: true });
       badgeNonCertifiable = databaseBuilder.factory.buildBadge({ key: 'key2', targetProfileId: targetProfile.id, isCertifiable: false });
       user = databaseBuilder.factory.buildUser();
       userWithoutBadge = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badgeCertifiable1.id, userId: user.id });
+      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badgeCertifiable.id, userId: user.id });
       databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badgeNonCertifiable.id, userId: user.id });
+      databaseBuilder.factory.buildBadgePartnerCompetence({ badgeId: badgeCertifiable.id });
+      databaseBuilder.factory.buildBadgeCriterion({ badgeId: badgeCertifiable.id });
       await databaseBuilder.commit();
     });
 
@@ -126,7 +128,9 @@ describe('Integration | Repository | Badge Acquisition', () => {
 
       // then
       expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
-      expect(certifiableBadgesAcquiredByUser[0].badge).to.includes(badgeCertifiable1);
+      expect(certifiableBadgesAcquiredByUser[0].badge).to.includes(badgeCertifiable);
+      expect(certifiableBadgesAcquiredByUser[0].badge.badgePartnerCompetences.length).to.equal(1);
+      expect(certifiableBadgesAcquiredByUser[0].badge.badgeCriteria.length).to.deep.equal(1);
     });
 
     it('should return an empty array when user has no certifiable acquired badge', async () => {

--- a/api/tests/unit/domain/services/certification-badges-service-test.js
+++ b/api/tests/unit/domain/services/certification-badges-service-test.js
@@ -7,7 +7,7 @@ const badgeCriteriaService = require('../../../../lib/domain/services/badge-crit
 
 describe('Unit | Service | Certification Badges Service', () => {
 
-  describe('#findStillAcquiredBadgeAcquisitions', () => {
+  describe('#findStillValidBadgeAcquisitions', () => {
 
     beforeEach(() => {
       sinon.stub(badgeAcquisitionRepository, 'findCertifiable');
@@ -24,7 +24,7 @@ describe('Unit | Service | Certification Badges Service', () => {
         badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([]);
 
         // when
-        const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+        const badgesAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
 
         // then
         expect(badgesAcquisitions).to.deep.equal([]);
@@ -53,7 +53,7 @@ describe('Unit | Service | Certification Badges Service', () => {
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ targetProfile, badge, knowledgeElements }).returns(true);
 
           // when
-          const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+          const badgesAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
 
           // then
           expect(badgesAcquisitions).to.deep.equal([badgeAcquisition]);
@@ -66,7 +66,7 @@ describe('Unit | Service | Certification Badges Service', () => {
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ targetProfile, badge, knowledgeElements }).returns(false);
 
           // when
-          const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+          const badgesAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
 
           // then
           expect(badgesAcquisitions).to.deep.equal([]);
@@ -102,7 +102,7 @@ describe('Unit | Service | Certification Badges Service', () => {
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ targetProfile, badge: otherBadge, knowledgeElements }).returns(true);
 
           // when
-          const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+          const badgesAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
 
           // then
           expect(badgesAcquisitions).to.deep.equal([otherBadgeAcquisition, maitreBadgeAcquisition]);
@@ -124,7 +124,7 @@ describe('Unit | Service | Certification Badges Service', () => {
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ targetProfile, badge: expertBadge, knowledgeElements }).returns(true);
 
           // when
-          const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+          const badgesAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
 
           // then
           expect(badgesAcquisitions).to.deep.equal([expertBadgeAcquisition]);

--- a/api/tests/unit/domain/services/certification-badges-service-test.js
+++ b/api/tests/unit/domain/services/certification-badges-service-test.js
@@ -43,8 +43,8 @@ describe('Unit | Service | Certification Badges Service', () => {
         badge = { targetProfileId: targetProfile.id };
         badgeAcquisition = { id: 'badgeId', userId, badge };
         badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([badgeAcquisition]);
-        knowledgeElementRepository.findUniqByUserId.withArgs({ userId }).resolves(knowledgeElements);
-        targetProfileRepository.get.withArgs(targetProfile.id).resolves(targetProfile);
+        knowledgeElementRepository.findUniqByUserId.withArgs({ userId, domainTransaction }).resolves(knowledgeElements);
+        targetProfileRepository.get.withArgs(targetProfile.id, domainTransaction).resolves(targetProfile);
       });
 
       context('and badges are still valid', () => {
@@ -96,8 +96,8 @@ describe('Unit | Service | Certification Badges Service', () => {
           const maitreBadgeAcquisition = { id: 'badgeId1', userId, badgeKey: pixDroitMaitre, badge: maitreBadge };
           const otherBadgeAcquisition = { id: 'badgeId2', userId, badge: otherBadge };
           badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([maitreBadgeAcquisition, otherBadgeAcquisition]);
-          knowledgeElementRepository.findUniqByUserId.withArgs({ userId }).resolves(knowledgeElements);
-          targetProfileRepository.get.withArgs(targetProfile.id).resolves(targetProfile);
+          knowledgeElementRepository.findUniqByUserId.withArgs({ userId, domainTransaction }).resolves(knowledgeElements);
+          targetProfileRepository.get.withArgs(targetProfile.id, domainTransaction).resolves(targetProfile);
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ targetProfile, badge: maitreBadge, knowledgeElements }).returns(true);
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ targetProfile, badge: otherBadge, knowledgeElements }).returns(true);
 
@@ -118,8 +118,8 @@ describe('Unit | Service | Certification Badges Service', () => {
           const maitreBadgeAcquisition = { id: 'badgeId1', userId, badgeKey: pixDroitMaitre, badge: maitreBadge };
           const expertBadgeAcquisition = { id: 'badgeId2', userId, badgeKey: pixDroitExpert, badge: expertBadge };
           badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([maitreBadgeAcquisition, expertBadgeAcquisition]);
-          knowledgeElementRepository.findUniqByUserId.withArgs({ userId }).resolves(knowledgeElements);
-          targetProfileRepository.get.withArgs(targetProfile.id).resolves(targetProfile);
+          knowledgeElementRepository.findUniqByUserId.withArgs({ userId, domainTransaction }).resolves(knowledgeElements);
+          targetProfileRepository.get.withArgs(targetProfile.id, domainTransaction).resolves(targetProfile);
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ targetProfile, badge: maitreBadge, knowledgeElements }).returns(true);
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ targetProfile, badge: expertBadge, knowledgeElements }).returns(true);
 

--- a/api/tests/unit/domain/services/certification-badges-service-test.js
+++ b/api/tests/unit/domain/services/certification-badges-service-test.js
@@ -1,0 +1,85 @@
+const { expect, sinon } = require('../../../test-helper');
+const certificationBadgesService = require('./../../../../lib/domain/services/certification-badges-service');
+const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
+
+describe('Unit | Service | Certification Badges Service', () => {
+
+  describe('#findStillAcquiredBadgeAcquisitions', () => {
+
+    beforeEach(() => {
+      sinon.stub(badgeAcquisitionRepository, 'findCertifiable');
+    });
+
+    context('has no certifiable badges', () => {
+      it('should return []', async () => {
+        // given
+        const userId = 12;
+        const domainTransaction = Symbol('someDomainTransaction');
+        badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([]);
+
+        // when
+        const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+
+        // then
+        expect(badgesAcquisitions).to.deep.equal([]);
+      });
+    });
+
+    context('has certifiable badges but not from pix+droit', () => {
+      it('should return their badge-acquisitions', async () => {
+        // given
+        const userId = 12;
+        const domainTransaction = Symbol('someDomainTransaction');
+        const badgeAcquisition = { id: 'badgeId', userId };
+        badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([badgeAcquisition]);
+
+        // when
+        const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+
+        // then
+        expect(badgesAcquisitions).to.deep.equal([badgeAcquisition]);
+      });
+    });
+
+    context('has certifiable badges including pix+droit', () => {
+      const pixDroitMaitre = 'PIX_DROIT_MAITRE_CERTIF';
+      const pixDroitExpert = 'PIX_DROIT_EXPERT_CERTIF';
+
+      context('has maitreBadgeAcquisition', () => {
+
+        it('should return badge-acquisitions with maitreBadgeAcquisition', async () => {
+          // given
+          const userId = 12;
+          const domainTransaction = Symbol('someDomainTransaction');
+          const maitreBadgeAcquisition = { id: 'badgeId1', userId, badgeKey: pixDroitMaitre };
+          const otherBadgeAcquisition = { id: 'badgeId2', userId };
+          badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([maitreBadgeAcquisition, otherBadgeAcquisition]);
+
+          // when
+          const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+
+          // then
+          expect(badgesAcquisitions).to.deep.equal([otherBadgeAcquisition, maitreBadgeAcquisition]);
+        });
+      });
+
+      context('has maitreBadgeAcquisition and expertBadgeAcquisition', () => {
+
+        it('should return badge-acquisitions with expertBadgeAcquisition', async () => {
+          // given
+          const userId = 12;
+          const domainTransaction = Symbol('someDomainTransaction');
+          const maitreBadgeAcquisition = { id: 'badgeId1', userId, badgeKey: pixDroitMaitre };
+          const expertBadgeAcquisition = { id: 'badgeId2', userId, badgeKey: pixDroitExpert };
+          badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([maitreBadgeAcquisition, expertBadgeAcquisition]);
+
+          // when
+          const badgesAcquisitions = await certificationBadgesService.findStillAcquiredBadgeAcquisitions({ userId, domainTransaction });
+
+          // then
+          expect(badgesAcquisitions).to.deep.equal([expertBadgeAcquisition]);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -16,10 +16,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
   let foundSession;
   const assessmentRepository = { save: sinon.stub() };
   const competenceRepository = { listPixCompetencesOnly: sinon.stub() };
+  const certificationBadgesService = { findStillAcquiredBadgeAcquisitions: sinon.stub() };
   const certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub() };
   const certificationChallengeRepository = { save: sinon.stub() };
   const certificationChallengesService = { pickCertificationChallengesForPixPlus: sinon.stub(), pickCertificationChallenges: sinon.stub() };
-  const badgeAcquisitionRepository = { findCertifiable: sinon.stub() };
   const certificationCourseRepository = {
     findOneCertificationCourseByUserIdAndSessionId: sinon.stub(),
     save: sinon.stub(),
@@ -37,7 +37,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
     certificationChallengeRepository,
     certificationCourseRepository,
     sessionRepository,
-    badgeAcquisitionRepository,
+    certificationBadgesService,
     certificationChallengesService,
     placementProfileService,
   };
@@ -258,7 +258,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             certificationCandidateRepository.getBySessionIdAndUserId.withArgs({ sessionId, userId }).resolves(foundCertificationCandidate);
             certificationCourseRepository.save.resolves(savedCertificationCourse);
             assessmentRepository.save.resolves(savedAssessment);
-            badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([]);
+            certificationBadgesService.findStillAcquiredBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
           });
 
           it('should return it with flag created marked as true with related ressources', async function() {
@@ -319,7 +319,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
               const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
               const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge1 });
               const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge2 });
-              badgeAcquisitionRepository.findCertifiable
+              certificationBadgesService.findStillAcquiredBadgeAcquisitions
                 .withArgs({ userId, domainTransaction })
                 .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
               certificationChallengesService.pickCertificationChallengesForPixPlus
@@ -359,11 +359,11 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
                 ];
                 const maitreBadge = domainBuilder.buildBadge({ key: 'PIX_DROIT_MAITRE_CERTIF', targetProfileId: 11 });
                 const expertBadge = domainBuilder.buildBadge({ key: 'PIX_DROIT_EXPERT_CERTIF', targetProfileId: 22 });
-                const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
+                domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
                 const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: expertBadge });
-                badgeAcquisitionRepository.findCertifiable
+                certificationBadgesService.findStillAcquiredBadgeAcquisitions
                   .withArgs({ userId, domainTransaction })
-                  .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
+                  .resolves([certifiableBadgeAcquisition2]);
                 certificationChallengesService.pickCertificationChallengesForPixPlus
                   .withArgs(maitreBadge, userId)
                   .resolves(challengesForMaitre)
@@ -393,7 +393,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
             beforeEach(() => {
               sinon.spy(CertificationCourse, 'from');
-              badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([]);
+              certificationBadgesService.findStillAcquiredBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
               certificationChallengesService.pickCertificationChallengesForPixPlus.throws();
             });
 

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
   let foundSession;
   const assessmentRepository = { save: sinon.stub() };
   const competenceRepository = { listPixCompetencesOnly: sinon.stub() };
-  const certificationBadgesService = { findStillAcquiredBadgeAcquisitions: sinon.stub() };
+  const certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
   const certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub() };
   const certificationChallengeRepository = { save: sinon.stub() };
   const certificationChallengesService = { pickCertificationChallengesForPixPlus: sinon.stub(), pickCertificationChallenges: sinon.stub() };
@@ -258,7 +258,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             certificationCandidateRepository.getBySessionIdAndUserId.withArgs({ sessionId, userId }).resolves(foundCertificationCandidate);
             certificationCourseRepository.save.resolves(savedCertificationCourse);
             assessmentRepository.save.resolves(savedAssessment);
-            certificationBadgesService.findStillAcquiredBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
+            certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
           });
 
           it('should return it with flag created marked as true with related ressources', async function() {
@@ -319,7 +319,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
               const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
               const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge1 });
               const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge2 });
-              certificationBadgesService.findStillAcquiredBadgeAcquisitions
+              certificationBadgesService.findStillValidBadgeAcquisitions
                 .withArgs({ userId, domainTransaction })
                 .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
               certificationChallengesService.pickCertificationChallengesForPixPlus
@@ -361,7 +361,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
                 const expertBadge = domainBuilder.buildBadge({ key: 'PIX_DROIT_EXPERT_CERTIF', targetProfileId: 22 });
                 domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
                 const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: expertBadge });
-                certificationBadgesService.findStillAcquiredBadgeAcquisitions
+                certificationBadgesService.findStillValidBadgeAcquisitions
                   .withArgs({ userId, domainTransaction })
                   .resolves([certifiableBadgeAcquisition2]);
                 certificationChallengesService.pickCertificationChallengesForPixPlus
@@ -393,7 +393,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
             beforeEach(() => {
               sinon.spy(CertificationCourse, 'from');
-              certificationBadgesService.findStillAcquiredBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
+              certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
               certificationChallengesService.pickCertificationChallengesForPixPlus.throws();
             });
 


### PR DESCRIPTION
## :unicorn: Problème

Jusqu'à maintenant, pour tous les badges certifiables, nous posions les questions des acquis associés sans se soucier de savoir si les badges étaient encore valides (ex: possibilité pour l'utilisateur de remettre à zéro une compétence et donc d'invalider l'acquisition de son badge)

## :robot: Solution

Re-création d'un service `certification-badge-service` qui retourne les badges acquisitions valides.

## :rainbow: Remarques

N/A

## :100: Pour tester
Alors que les badges Droit maitre et Droit expert sont acquis, vérifier que seul les épreuves de Pix+ droit expert soient posées lors de la certif:
- Finir la campagne DROIT1234 et obtenir les deux badges Droit maitre et Droit expert
- Démarrer la certif DROI01 avec le user 9/nicky/larson/01012000
- Vérifier que 23 questions sont posées et qu'il n'y a pas de questions venant du badge droit maitre 

Alors que les badges Droit maitre et Droit expert sont acquis, vérifier que seul les épreuves Pix soient posées lors de la certif:
- Finir la campagne DROIT1234 et obtenir les deux badges Droit maitre et Droit expert
- Reset toutes les compétences, puis obtenir au moins le niveau 1 sur les compétences "protection et sécurité" et "environnement numérique" pour être éligible à la certif
- Démarrer la certif DROI01 avec le user 9/nicky/larson/01012000
- Vérifier que 15 questions sont posées et qu'il n'y a pas de questions venant des deux badges Pix+ droit
