### PR TITLE
[FEATURE] Suppression de la notion de surnuméraire de l'API (PIX-2414)

### DIFF
--- a/api/db/database-builder/factory/build-schooling-registration.js
+++ b/api/db/database-builder/factory/build-schooling-registration.js
@@ -28,7 +28,6 @@ module.exports = function buildSchoolingRegistration({
   diploma = 'Licence',
   createdAt = new Date('2021-01-01'),
   updatedAt = new Date('2021-02-01'), // for BEGINNING_OF_THE_2020_SCHOOL_YEAR, can outdate very fast! ;)
-  isSupernumerary = false,
   organizationId,
   userId,
 } = {}) {
@@ -60,7 +59,6 @@ module.exports = function buildSchoolingRegistration({
     diploma,
     createdAt,
     updatedAt,
-    isSupernumerary,
     organizationId,
     userId,
   };

--- a/api/db/migrations/20210429113555_replace-organization-id-student-number-index-on-schooling-registration.js
+++ b/api/db/migrations/20210429113555_replace-organization-id-student-number-index-on-schooling-registration.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'schooling-registrations';
+
+exports.up = async function(knex) {
+  await knex.raw('DROP INDEX "organizationid_studentnumber_index"');
+  await knex.raw('DROP INDEX "organizationid_studentnumber_notsupernumerary_index"');
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.unique(['studentNumber', 'organizationId']);
+  });
+};
+
+exports.down = async function(knex) {
+  await knex.raw('CREATE INDEX "organizationid_studentnumber_index" ON "schooling-registrations" ("organizationId", "studentNumber");');
+  await knex.raw('CREATE UNIQUE INDEX "organizationid_studentnumber_notsupernumerary_index" ON "schooling-registrations" ("organizationId", "studentNumber") WHERE "isSupernumerary" IS FALSE;');
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropUnique(['studentNumber', 'organizationId']);
+  });
+};

--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -72,7 +72,7 @@ function organizationsSupBuilder({ databaseBuilder }) {
     studentNumber: 'JAIMELESLEGUMES123',
   });
 
-  // supernumerary with student number
+  // with student number
   const sansaStark = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Sansa',
     lastName: 'Stark',
@@ -87,11 +87,10 @@ function organizationsSupBuilder({ databaseBuilder }) {
     birthdate: '2000-05-28',
     organizationId: SUP_UNIVERSITY_ID,
     userId: sansaStark.id,
-    isSupernumerary: true,
-    studentNumber: null,
+    studentNumber: 'JAIMELECHOCOLAT',
   });
 
-  // supernumerary without student number
+  // with student number
   const branStark = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Bran',
     lastName: 'Stark',
@@ -106,7 +105,6 @@ function organizationsSupBuilder({ databaseBuilder }) {
     birthdate: '2000-05-28',
     organizationId: SUP_UNIVERSITY_ID,
     userId: branStark.id,
-    isSupernumerary: true,
     studentNumber: 'JAIMELESFECULENTS123',
   });
 }

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -149,7 +149,7 @@ module.exports = {
     const organizationId = parseInt(request.params.id);
     const buffer = request.payload;
     const higherSchoolingRegistrationParser = new HigherSchoolingRegistrationParser(buffer, organizationId, request.i18n);
-    await usecases.importHigherSchoolingRegistrations({ organizationId, higherSchoolingRegistrationParser });
+    await usecases.importHigherSchoolingRegistrations({ higherSchoolingRegistrationParser });
     return h.response(null).code(204);
   },
 

--- a/api/lib/domain/models/HigherSchoolingRegistration.js
+++ b/api/lib/domain/models/HigherSchoolingRegistration.js
@@ -16,7 +16,6 @@ class HigherSchoolingRegistration {
     group,
     studyScheme,
     organizationId,
-    isSupernumerary = false,
   } = {}) {
     this.firstName = firstName;
     this.middleName = middleName;
@@ -32,7 +31,6 @@ class HigherSchoolingRegistration {
     this.group = group;
     this.studyScheme = studyScheme;
     this.organizationId = organizationId;
-    this.isSupernumerary = isSupernumerary;
     checkValidation(this);
   }
 }

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -25,9 +25,8 @@ async function findMatchingHigherSchoolingRegistrationIdForGivenOrganizationIdAn
   reconciliationInfo: { studentNumber, firstName, lastName, birthdate },
   higherSchoolingRegistrationRepository,
 }) {
-  const schoolingRegistration = await higherSchoolingRegistrationRepository.findOneRegisteredByOrganizationIdAndUserData({
-    organizationId,
-    reconciliationInfo: { studentNumber, birthdate },
+  const schoolingRegistration = await higherSchoolingRegistrationRepository.findOneByStudentNumberAndBirthdate({
+    organizationId, studentNumber, birthdate,
   });
 
   if (!schoolingRegistration) {

--- a/api/lib/domain/usecases/import-higher-schooling-registrations.js
+++ b/api/lib/domain/usecases/import-higher-schooling-registrations.js
@@ -1,28 +1,8 @@
-const _ = require('lodash');
-const DomainTransaction = require('../../infrastructure/DomainTransaction');
-
 module.exports = async function importHigherSchoolingRegistration({
-  organizationId,
   higherSchoolingRegistrationRepository,
   higherSchoolingRegistrationParser,
 }) {
-  const higherSchoolingRegistrationSet = higherSchoolingRegistrationParser.parse();
+  const { registrations } = higherSchoolingRegistrationParser.parse();
 
-  await DomainTransaction.execute(async (domainTransaction) => {
-    const studentNumbersInOrga = await higherSchoolingRegistrationRepository.findStudentNumbersByOrganization(organizationId, domainTransaction);
-
-    const [registrationsToUpdate, registrationsToCreate] = _.partition(higherSchoolingRegistrationSet.registrations, (registration) => {
-      return studentNumbersInOrga.includes(registration.studentNumber);
-    });
-
-    if (!_.isEmpty(registrationsToUpdate)) {
-      for (const registration of registrationsToUpdate) {
-        await higherSchoolingRegistrationRepository.saveByStudentNumber(registration, domainTransaction);
-      }
-    }
-
-    if (!_.isEmpty(registrationsToCreate)) {
-      await higherSchoolingRegistrationRepository.batchCreate(registrationsToCreate, domainTransaction);
-    }
-  });
+  await higherSchoolingRegistrationRepository.upsertStudents(registrations);
 };

--- a/api/lib/domain/usecases/import-higher-schooling-registrations.js
+++ b/api/lib/domain/usecases/import-higher-schooling-registrations.js
@@ -1,15 +1,5 @@
 const _ = require('lodash');
-const { findMatchingCandidateIdForGivenUser } = require('../../domain/services/user-reconciliation-service');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
-
-function getMatchingSchoolingRegistration(registration, existingRegistrations) {
-  const matchingCandidateId = findMatchingCandidateIdForGivenUser(existingRegistrations, registration);
-  const matchingCandidate = existingRegistrations.find((existing) => existing.id === matchingCandidateId);
-  if (!matchingCandidate || matchingCandidate.birthdate !== registration.birthdate) {
-    return null;
-  }
-  return matchingCandidate;
-}
 
 module.exports = async function importHigherSchoolingRegistration({
   organizationId,
@@ -19,25 +9,15 @@ module.exports = async function importHigherSchoolingRegistration({
   const higherSchoolingRegistrationSet = higherSchoolingRegistrationParser.parse();
 
   await DomainTransaction.execute(async (domainTransaction) => {
-    const studentNumbersInOrga = await higherSchoolingRegistrationRepository.findStudentNumbersNonSupernumerary(organizationId, domainTransaction);
-    const [registrationsToUpdate, registrationsToCheck] = _.partition(higherSchoolingRegistrationSet.registrations, (registration) => {
+    const studentNumbersInOrga = await higherSchoolingRegistrationRepository.findStudentNumbersByOrganization(organizationId, domainTransaction);
+
+    const [registrationsToUpdate, registrationsToCreate] = _.partition(higherSchoolingRegistrationSet.registrations, (registration) => {
       return studentNumbersInOrga.includes(registration.studentNumber);
     });
 
-    for (const registration of registrationsToUpdate) {
-      await higherSchoolingRegistrationRepository.saveNonSupernumerary(registration, domainTransaction);
-    }
-
-    const supernumeraryRegistrations = await higherSchoolingRegistrationRepository.findSupernumerary(organizationId, domainTransaction);
-
-    const registrationsToCreate = [];
-    for (const registration of registrationsToCheck) {
-      const existingRegistrations = _.filter(supernumeraryRegistrations, ({ studentNumber }) => registration.studentNumber === studentNumber);
-      const matchingRegistration = getMatchingSchoolingRegistration(registration, existingRegistrations);
-      if (matchingRegistration) {
-        await higherSchoolingRegistrationRepository.save({ id: matchingRegistration.id, ...registration }, domainTransaction);
-      } else {
-        registrationsToCreate.push(registration);
+    if (!_.isEmpty(registrationsToUpdate)) {
+      for (const registration of registrationsToUpdate) {
+        await higherSchoolingRegistrationRepository.saveByStudentNumber(registration, domainTransaction);
       }
     }
 

--- a/api/lib/domain/usecases/update-student-number.js
+++ b/api/lib/domain/usecases/update-student-number.js
@@ -1,5 +1,3 @@
-const isEmpty = require('lodash/isEmpty');
-
 const { AlreadyExistingEntityError } = require('../../domain/errors');
 
 module.exports = async function updateStudentNumber({
@@ -8,15 +6,14 @@ module.exports = async function updateStudentNumber({
   organizationId,
   higherSchoolingRegistrationRepository,
 }) {
-  const foundHigherSchoolingRegistrations = await higherSchoolingRegistrationRepository.findByOrganizationIdAndStudentNumber({
+  const registration = await higherSchoolingRegistrationRepository.findOneByStudentNumber({
     organizationId,
     studentNumber,
   });
 
-  if (isEmpty(foundHigherSchoolingRegistrations)) {
-    await higherSchoolingRegistrationRepository.updateStudentNumber(schoolingRegistrationId, studentNumber);
-  } else {
-    const errorMessage = 'STUDENT_NUMBER_EXISTS';
-    throw new AlreadyExistingEntityError(errorMessage);
+  if (registration) {
+    throw new AlreadyExistingEntityError('STUDENT_NUMBER_EXISTS');
   }
+
+  await higherSchoolingRegistrationRepository.updateStudentNumber(schoolingRegistrationId, studentNumber);
 };

--- a/api/lib/domain/validators/higher-schooling-registration-validator.js
+++ b/api/lib/domain/validators/higher-schooling-registration-validator.js
@@ -5,16 +5,7 @@ const validationConfiguration = { allowUnknown: true };
 const MAX_LENGTH = 255;
 
 const validationSchema = Joi.object({
-  studentNumber: Joi.string().regex(/^[a-zA-Z0-9_\\-]*$/).max(MAX_LENGTH)
-    .when('$isSupernumerary', {
-      switch: [{
-        is: true,
-        then: Joi.optional().allow(null),
-      }, {
-        is: false,
-        then: Joi.required(),
-      }],
-    }),
+  studentNumber: Joi.string().regex(/^[a-zA-Z0-9_\\-]*$/).max(MAX_LENGTH).required(),
   firstName: Joi.string().max(MAX_LENGTH).required(),
   middleName: Joi.string().max(MAX_LENGTH).optional(),
   thirdName: Joi.string().max(MAX_LENGTH).optional(),
@@ -28,14 +19,13 @@ const validationSchema = Joi.object({
   group: Joi.string().max(MAX_LENGTH).optional(),
   studyScheme: Joi.string().max(MAX_LENGTH).optional(),
   organizationId: Joi.number().integer().required(),
-  isSupernumerary: Joi.boolean().required(),
 });
 
 module.exports = {
   checkValidation(higherSchoolingRegistration) {
     const { error } = validationSchema.validate(
       higherSchoolingRegistration,
-      { ...validationConfiguration, context: { isSupernumerary: higherSchoolingRegistration.isSupernumerary } },
+      validationConfiguration,
     );
     if (error) {
       const err = EntityValidationError.fromJoiErrors(error.details);

--- a/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
@@ -63,7 +63,7 @@ module.exports = {
       });
   },
 
-  async findOneRegisteredByOrganizationIdAndUserData({ organizationId, reconciliationInfo: { birthdate, studentNumber } = {} }) {
+  async findOneByStudentNumberAndBirthdate({ organizationId, studentNumber, birthdate }) {
     const schoolingRegistration = await BookshelfSchoolingRegistration
       .query((qb) => {
         qb.where('organizationId', organizationId);

--- a/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
@@ -75,14 +75,14 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration);
   },
 
-  async findByOrganizationIdAndStudentNumber({ organizationId, studentNumber }) {
+  async findOneByStudentNumber({ organizationId, studentNumber }) {
     const schoolingRegistration = await BookshelfSchoolingRegistration
       .query((qb) => {
         qb.where('organizationId', organizationId);
         qb.whereRaw('LOWER(?)=LOWER(??)', [studentNumber, 'studentNumber']);
       })
-      .fetchAll();
+      .fetch({ require: false });
 
-    return bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistration);
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration);
   },
 };

--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -278,7 +278,6 @@ function _buildSUPSchoolingRegistration({ userId, organizationId, identifier }) 
   return {
     ..._buildBaseSchoolingRegistration({ userId, organizationId, identifier }),
     studentNumber: `NUMETU_${organizationId}_${identifier}`,
-    isSupernumerary: _.random(0, 1) === 1,
     diploma: diplomas[_.random(0, 3)],
     group: groups[_.random(0, 3)],
   };

--- a/api/tests/integration/domain/usecases/import-higher-schooling-registrations_test.js
+++ b/api/tests/integration/domain/usecases/import-higher-schooling-registrations_test.js
@@ -9,10 +9,11 @@ const { getI18n } = require('../../../../tests/tooling/i18n/i18n');
 
 const i18n = getI18n();
 
-const higherSchoolingRegistrationColumns = new HigherSchoolingRegistrationColumns(i18n).columns.map((column) => column.label).join(';');
+const higherSchoolingRegistrationColumns = new HigherSchoolingRegistrationColumns(i18n).columns
+  .map((column) => column.label)
+  .join(';');
 
 describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
-
   afterEach(() => {
     return knex('schooling-registrations').delete();
   });
@@ -40,313 +41,10 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
   });
 
   context('when there are schooling registration for the organization', () => {
-    context('when there is a supernumerary schooling registrations matching by student number', () => {
-      context('which matches by student number but not by first name', () => {
-        it('creates a new schooling registration with csv data', async () => {
-          const input = `${higherSchoolingRegistrationColumns}
-            Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `.trim();
-
-          const encodedInput = iconv.encode(input, 'utf8');
-
-          const organization = databaseBuilder.factory.buildOrganization();
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Bill',
-            lastName: 'Kiddo',
-            birthdate: '1970-01-01',
-            isSupernumerary: true,
-          });
-
-          await databaseBuilder.commit();
-          await importHigherSchoolingRegistration({
-            organizationId: organization.id,
-            higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
-          });
-
-          const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
-          expect(registrations.length).to.equal(2);
-          expect(registrations[0].firstName).to.equal('Bill');
-          expect(registrations[0].studentNumber).to.equal('123456');
-          expect(registrations[0].isSupernumerary).to.equal(true);
-          expect(registrations[1].firstName).to.equal('Beatrix');
-          expect(registrations[1].studentNumber).to.equal('123456');
-          expect(registrations[1].isSupernumerary).to.equal(false);
-        });
-      });
-
-      context('which matches by student number, first name, lastName and birthdate', () => {
-        it('updates the existing schooling registration which have matched with csv data', async () => {
-          const input = `${higherSchoolingRegistrationColumns}
-            Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `.trim();
-
-          const encodedInput = iconv.encode(input, 'utf8');
-
-          const organization = databaseBuilder.factory.buildOrganization();
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Beatrix',
-            lastName: 'Kiddo',
-            birthdate: '1970-01-01',
-            isSupernumerary: true,
-            email: 'old.email@dva.com',
-          });
-
-          await databaseBuilder.commit();
-          await importHigherSchoolingRegistration({
-            organizationId: organization.id,
-            higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
-          });
-
-          const [registration] = await knex('schooling-registrations').where({ organizationId: organization.id });
-          expect(registration.email).to.equal('thebride@example.net');
-          expect(registration.isSupernumerary).to.equal(false);
-        });
-      });
-
-      context('which matches by student number but not by birthdate', () => {
-        it('creates a new schooling registration with csv data', async () => {
-          const input = `${higherSchoolingRegistrationColumns}
-            Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `.trim();
-
-          const encodedInput = iconv.encode(input, 'utf8');
-
-          const organization = databaseBuilder.factory.buildOrganization();
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Beatrix',
-            lastName: 'Kiddo',
-            birthdate: '2000-01-01',
-            isSupernumerary: true,
-          });
-
-          await databaseBuilder.commit();
-          await importHigherSchoolingRegistration({
-            organizationId: organization.id,
-            higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
-          });
-
-          const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
-          expect(registrations.length).to.equal(2);
-          expect(registrations[0].birthdate).to.equal('2000-01-01');
-          expect(registrations[0].studentNumber).to.equal('123456');
-          expect(registrations[0].isSupernumerary).to.equal(true);
-          expect(registrations[1].birthdate).to.equal('1970-01-01');
-          expect(registrations[1].studentNumber).to.equal('123456');
-          expect(registrations[1].isSupernumerary).to.equal(false);
-
-        });
-      });
-
-      context('which matches by student number but not by lastName', () => {
-        it('creates a new schooling registration with csv data', async () => {
-          const input = `${higherSchoolingRegistrationColumns}
-            Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `.trim();
-
-          const encodedInput = iconv.encode(input, 'utf8');
-
-          const organization = databaseBuilder.factory.buildOrganization();
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Beatrix',
-            lastName: 'Unknown',
-            birthdate: '1970-01-01',
-            isSupernumerary: true,
-          });
-
-          await databaseBuilder.commit();
-          await importHigherSchoolingRegistration({
-            organizationId: organization.id,
-            higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
-          });
-
-          const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
-          expect(registrations.length).to.equal(2);
-          expect(registrations[0].lastName).to.equal('Unknown');
-          expect(registrations[0].studentNumber).to.equal('123456');
-          expect(registrations[0].isSupernumerary).to.equal(true);
-          expect(registrations[1].lastName).to.equal('Kiddo');
-          expect(registrations[1].studentNumber).to.equal('123456');
-          expect(registrations[1].isSupernumerary).to.equal(false);
-        });
-      });
-
-      context('which matches by student number but when there is an acceptable error in the first name', () => {
-        it('updates the existing schooling registration which have matched with csv data', async () => {
-          const input = `${higherSchoolingRegistrationColumns}
-            Estelle;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `.trim();
-
-          const encodedInput = iconv.encode(input, 'utf8');
-
-          const organization = databaseBuilder.factory.buildOrganization();
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Estele',
-            lastName: 'Kiddo',
-            birthdate: '1970-01-01',
-            isSupernumerary: true,
-            email: 'old.email@dva.com',
-          });
-
-          await databaseBuilder.commit();
-          await importHigherSchoolingRegistration({
-            organizationId: organization.id,
-            higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
-          });
-
-          const [registration] = await knex('schooling-registrations').where({ organizationId: organization.id });
-          expect(registration.email).to.equal('thebride@example.net');
-          expect(registration.isSupernumerary).to.equal(false);
-        });
-      });
-
-      context('which matches by student number but when there is an acceptable error in the last name', () => {
-        it('updates the existing schooling registration which have matched with csv data', async () => {
-          const input = `${higherSchoolingRegistrationColumns}
-            Estelle;The;Bride;Landry;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `.trim();
-
-          const encodedInput = iconv.encode(input, 'utf8');
-
-          const organization = databaseBuilder.factory.buildOrganization();
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Estelle',
-            lastName: 'Lendry',
-            birthdate: '1970-01-01',
-            isSupernumerary: true,
-            email: 'old.email@dva.com',
-          });
-
-          await databaseBuilder.commit();
-          await importHigherSchoolingRegistration({
-            organizationId: organization.id,
-            higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
-          });
-
-          const [registration] = await knex('schooling-registrations').where({ organizationId: organization.id });
-          expect(registration.email).to.equal('thebride@example.net');
-          expect(registration.isSupernumerary).to.equal(false);
-        });
-      });
-    });
-
-    context('when there are several supernumerary schooling registrations which match by student number', () => {
-      context('when there are several supernumerary schooling registrations matching', () => {
-        it('creates a new schooling registration with csv data', async () => {
-          const input = `${higherSchoolingRegistrationColumns}
-            Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;email3@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `.trim();
-
-          const encodedInput = iconv.encode(input, 'utf8');
-
-          const organization = databaseBuilder.factory.buildOrganization();
-
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Beatrix',
-            lastName: 'Kiddo',
-            birthdate: '1970-01-01',
-            isSupernumerary: true,
-            createdAt: '2000-01-01',
-            nationalStudentId: null,
-          });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Beatrix',
-            lastName: 'Kiddo',
-            birthdate: '1970-01-01',
-            isSupernumerary: true,
-            createdAt: '2000-01-02',
-            nationalStudentId: null,
-          });
-
-          await databaseBuilder.commit();
-          await importHigherSchoolingRegistration({
-            organizationId: organization.id,
-            higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
-          });
-
-          const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
-          expect(registrations.length).to.equal(3);
-          expect(registrations[0].isSupernumerary).to.equal(true);
-          expect(registrations[1].isSupernumerary).to.equal(true);
-          expect(registrations[2].isSupernumerary).to.equal(false);
-        });
-      });
-
-      context('when there one supernumerary schooling registration matching', () => {
-        it('updates a the schooling registration with csv data', async () => {
-          const input = `${higherSchoolingRegistrationColumns}
-            Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;email@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `.trim();
-
-          const encodedInput = iconv.encode(input, 'utf8');
-
-          const organization = databaseBuilder.factory.buildOrganization();
-
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'Beatrix',
-            lastName: 'Kiddo',
-            birthdate: '1970-01-01',
-            isSupernumerary: true,
-            createdAt: '2000-01-01',
-            nationalStudentId: null,
-          });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            organizationId: organization.id,
-            studentNumber: '123456',
-            firstName: 'O-Ren',
-            lastName: 'Ishii',
-            birthdate: '1990-01-01',
-            email: 'old@example.net',
-            isSupernumerary: true,
-            createdAt: '2000-01-02',
-            nationalStudentId: null,
-          });
-
-          await databaseBuilder.commit();
-          await importHigherSchoolingRegistration({
-            organizationId: organization.id,
-            higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
-          });
-
-          const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
-          expect(registrations.length).to.equal(2);
-          expect(registrations[0].isSupernumerary).to.equal(false);
-          expect(registrations[0].email).to.equal('email@example.net');
-          expect(registrations[1].isSupernumerary).to.equal(true);
-          expect(registrations[1].email).to.equal('old@example.net');
-        });
-      });
-    });
-
-    context('when there is a schooling registration not supernumerary matching by student number', () => {
+    context('which matches by student number', () => {
       it('updates the existing schooling registration which have matched with csv data', async () => {
         const input = `${higherSchoolingRegistrationColumns}
-            Estelle;;;Landry;;01/01/2000;landry@elpresidente.com;123456;Négociation de ticket;;Merci pour le wording de VINCI!;Doctorat
+            Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
         `.trim();
 
         const encodedInput = iconv.encode(input, 'utf8');
@@ -358,21 +56,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           firstName: 'Beatrix',
           lastName: 'Kiddo',
           birthdate: '1970-01-01',
-          isSupernumerary: false,
           email: 'old.email@dva.com',
-          createdAt: '2000-01-01',
-          nationalStudentId: null,
-        });
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: organization.id,
-          studentNumber: '123456',
-          firstName: 'Beatrix',
-          lastName: 'Kiddo',
-          birthdate: '1970-01-01',
-          isSupernumerary: true,
-          email: 'other.email@dva.com',
-          createdAt: '2000-01-02',
-          nationalStudentId: null,
         });
 
         await databaseBuilder.commit();
@@ -382,19 +66,8 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
         });
 
-        const [registration1, registration2] = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
-
-        expect(registration1.firstName).to.equal('Estelle');
-        expect(registration1.lastName).to.equal('Landry');
-        expect(registration1.email).to.equal('landry@elpresidente.com');
-        expect(registration1.department).to.equal('Négociation de ticket');
-        expect(registration1.group).to.equal('Merci pour le wording de VINCI!');
-        expect(registration1.diploma).to.equal('Doctorat');
-        expect(registration1.isSupernumerary).to.equal(false);
-
-        expect(registration2.email).to.equal('other.email@dva.com');
-        expect(registration2.isSupernumerary).to.equal(true);
-
+        const [registration] = await knex('schooling-registrations').where({ organizationId: organization.id });
+        expect(registration.email).to.equal('thebride@example.net');
       });
     });
   });

--- a/api/tests/integration/domain/usecases/reconcile-higher-schooling-registration_test.js
+++ b/api/tests/integration/domain/usecases/reconcile-higher-schooling-registration_test.js
@@ -79,7 +79,6 @@ describe('Integration | UseCases | reconcile-higher-schooling-registration', () 
           databaseBuilder.factory.buildSchoolingRegistration({
             ...reconciliationInfo,
             firstName: 'first name',
-            isSupernumerary: false,
             userId: null,
             organizationId,
           });
@@ -99,7 +98,6 @@ describe('Integration | UseCases | reconcile-higher-schooling-registration', () 
           const [schoolingRegistration] = await knex('schooling-registrations');
           expect(schoolingRegistration.userId).to.equal(userId);
           expect(schoolingRegistration.firstName).to.equal('first name');
-          expect(schoolingRegistration.isSupernumerary).to.be.false;
         });
       });
 
@@ -114,7 +112,7 @@ describe('Integration | UseCases | reconcile-higher-schooling-registration', () 
             birthdate: '2008-01-01',
           };
           const otherUserId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildSchoolingRegistration({ ...reconciliationInfo, userId: otherUserId, isSupernumerary: false, organizationId });
+          databaseBuilder.factory.buildSchoolingRegistration({ ...reconciliationInfo, userId: otherUserId, organizationId });
           await databaseBuilder.commit();
 
           // when

--- a/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
@@ -4,13 +4,14 @@ const SchoolingRegistration = require('../../../../lib/domain/models/SchoolingRe
 const { SchoolingRegistrationsCouldNotBeSavedError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Infrastructure | Repository | higher-schooling-registration-repository', () => {
-  describe('#findByOrganizationIdAndStudentNumber', () => {
+  describe('#findOneByStudentNumber', () => {
 
     let organization;
+    let schoolingRegistration;
 
     beforeEach(async () => {
       organization = databaseBuilder.factory.buildOrganization();
-      databaseBuilder.factory.buildSchoolingRegistration({
+      schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({
         organizationId: organization.id,
         studentNumber: '123A',
       });
@@ -19,26 +20,26 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
 
     it('should return found schoolingRegistrations with student number', async () => {
       // when
-      const result = await higherSchoolingRegistrationRepository.findByOrganizationIdAndStudentNumber({ organizationId: organization.id, studentNumber: '123A' });
+      const result = await higherSchoolingRegistrationRepository.findOneByStudentNumber({ organizationId: organization.id, studentNumber: '123A' });
 
       // then
-      expect(result.length).to.be.equal(1);
+      expect(result.id).to.deep.equal(schoolingRegistration.id);
     });
 
     it('should return empty array when there is no schooling-registrations with the given student number', async () => {
       // when
-      const result = await higherSchoolingRegistrationRepository.findByOrganizationIdAndStudentNumber({ organizationId: organization.id, studentNumber: '123B' });
+      const result = await higherSchoolingRegistrationRepository.findOneByStudentNumber({ organizationId: organization.id, studentNumber: '123B' });
 
       // then
-      expect(result.length).to.be.equal(0);
+      expect(result).to.equal(null);
     });
 
     it('should return empty array when there is no schooling-registrations with the given organizationId', async () => {
       // when
-      const result = await higherSchoolingRegistrationRepository.findByOrganizationIdAndStudentNumber({ organizationId: '999', studentNumber: '123A' });
+      const result = await higherSchoolingRegistrationRepository.findOneByStudentNumber({ organizationId: '999', studentNumber: '123A' });
 
       // then
-      expect(result.length).to.be.equal(0);
+      expect(result).to.equal(null);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
@@ -42,7 +42,7 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
     });
   });
 
-  describe('#findOneRegisteredByOrganizationIdAndUserData', () => {
+  describe('#findOneByStudentNumberAndBirthdate', () => {
 
     let organizationId;
     const studentNumber = '1234567';
@@ -61,7 +61,7 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
 
       it('should return null', async () => {
         // when
-        const result = await higherSchoolingRegistrationRepository.findOneRegisteredByOrganizationIdAndUserData({ organizationId, reconciliationInfo: { birthdate, studentNumber: 'XXX' } });
+        const result = await higherSchoolingRegistrationRepository.findOneByStudentNumberAndBirthdate({ organizationId, birthdate, studentNumber: 'XXX' });
 
         // then
         expect(result).to.equal(null);
@@ -77,7 +77,7 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
 
       it('should return null', async () => {
         // when
-        const result = await higherSchoolingRegistrationRepository.findOneRegisteredByOrganizationIdAndUserData({ organizationId, reconciliationInfo: { birthdate, studentNumber } });
+        const result = await higherSchoolingRegistrationRepository.findOneByStudentNumberAndBirthdate({ organizationId, birthdate, studentNumber });
 
         // then
         expect(result).to.equal(null);
@@ -92,7 +92,7 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
 
       it('should return null', async () => {
         // when
-        const result = await higherSchoolingRegistrationRepository.findOneRegisteredByOrganizationIdAndUserData({ organizationId, reconciliationInfo: { birthdate, studentNumber } });
+        const result = await higherSchoolingRegistrationRepository.findOneByStudentNumberAndBirthdate({ organizationId, birthdate, studentNumber });
 
         // then
         expect(result).to.equal(null);
@@ -107,7 +107,7 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
 
       it('should return null', async () => {
         // when
-        const result = await higherSchoolingRegistrationRepository.findOneRegisteredByOrganizationIdAndUserData({ organizationId, reconciliationInfo: { birthdate, studentNumber } });
+        const result = await higherSchoolingRegistrationRepository.findOneByStudentNumberAndBirthdate({ organizationId, birthdate, studentNumber });
 
         // then
         expect(result).to.equal(null);
@@ -123,7 +123,7 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
 
       it('should return the schooling registration', async () => {
         // when
-        const schoolingRegistration = await higherSchoolingRegistrationRepository.findOneRegisteredByOrganizationIdAndUserData({ organizationId, reconciliationInfo: { studentNumber, birthdate } });
+        const schoolingRegistration = await higherSchoolingRegistrationRepository.findOneByStudentNumberAndBirthdate({ organizationId, studentNumber, birthdate });
 
         // then
         expect(schoolingRegistration).to.be.an.instanceOf(SchoolingRegistration);

--- a/api/tests/tooling/domain-builder/factory/build-higher-schooling-registration.js
+++ b/api/tests/tooling/domain-builder/factory/build-higher-schooling-registration.js
@@ -16,7 +16,6 @@ function buildSchoolingRegistration({
   group = 'grp12',
   diploma = 'licence',
   studyScheme = 'sch23',
-  isSupernumerary = false,
 } = {}) {
 
   return new HigherSchoolingRegistration({
@@ -34,7 +33,6 @@ function buildSchoolingRegistration({
     group,
     studyScheme,
     organizationId: organization.id,
-    isSupernumerary,
   });
 }
 

--- a/api/tests/unit/domain/models/HigherSchoolingRegistrationSet_test.js
+++ b/api/tests/unit/domain/models/HigherSchoolingRegistrationSet_test.js
@@ -24,7 +24,6 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'I have no idea what it\'s like.',
           organizationId: 1,
-          isSupernumerary: false,
         };
 
         higherSchoolingRegistrationSet.addRegistration(registrationAttributes);
@@ -55,7 +54,6 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
           studyScheme: 'I have no idea what it\'s like.',
           userId: 12345,
           organizationId: 1,
-          isSupernumerary: false,
         };
         const registration2 = {
           firstName: 'Bill',
@@ -72,7 +70,6 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'I have always no idea what it\'s like.',
           organizationId: 2,
-          isSupernumerary: false,
         };
 
         higherSchoolingRegistrationSet.addRegistration(registration1);

--- a/api/tests/unit/domain/models/HigherSchoolingRegistration_test.js
+++ b/api/tests/unit/domain/models/HigherSchoolingRegistration_test.js
@@ -1,6 +1,5 @@
 const HigherSchoolingRegistration = require('../../../../lib/domain/models/HigherSchoolingRegistration');
 const { expect, catchErr } = require('../../../test-helper');
-const { EntityValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | Models | HigherSchoolingRegistration', () => {
 
@@ -28,7 +27,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistration', () => {
 
     ['firstName', 'lastName', 'birthdate', 'studentNumber'].forEach((field) => {
       it(`throw an error when ${field} is required`, async () => {
-        const error = await catchErr(buildRegistration)({ ...validAttributes, [field]: undefined, isSupernumerary: false });
+        const error = await catchErr(buildRegistration)({ ...validAttributes, [field]: undefined });
 
         expect(error.key).to.equal(field);
         expect(error.why).to.equal('required');
@@ -85,55 +84,6 @@ describe('Unit | Domain | Models | HigherSchoolingRegistration', () => {
 
       expect(error.key).to.equal('organizationId');
       expect(error.why).to.equal('not_an_integer');
-    });
-
-    it('throw an error when isSupernumerary is not a boolean', async () => {
-      const error = await catchErr(buildRegistration)({ ...validAttributes, isSupernumerary: 'saaaaluuuut' });
-
-      expect(error.key).to.equal('isSupernumerary');
-      expect(error.why).to.equal('not_a_boolean');
-    });
-
-    context('when isSupernumerary is true', () => {
-      context('when student number is not present', () => {
-        it('is valid', async () => {
-          try {
-            await buildRegistration({ ...validAttributes, studentNumber: null, isSupernumerary: true });
-          } catch (e) {
-            expect.fail('higherSchoolingRegistration is valid when all required fields are present');
-          }
-        });
-      });
-
-      context('when student number is present', () => {
-        it('is valid', async () => {
-          try {
-            await buildRegistration({ ...validAttributes, studentNumber: '1234', isSupernumerary: true });
-          } catch (e) {
-            expect.fail('higherSchoolingRegistration is valid when all required fields are present');
-          }
-        });
-      });
-    });
-
-    context('when isSupernumerary is false', () => {
-      context('when student number is not present', () => {
-        it('throws an error', async () => {
-          const error = await catchErr(buildRegistration)({ ...validAttributes, studentNumber: null, isSupernumerary: false });
-
-          expect(error).to.be.instanceOf(EntityValidationError);
-        });
-      });
-
-      context('when student number is present', () => {
-        it('is valid', async () => {
-          try {
-            await buildRegistration({ ...validAttributes, studentNumber: '1234', isSupernumerary: false });
-          } catch (e) {
-            expect.fail('higherSchoolingRegistration is valid when all required fields are present');
-          }
-        });
-      });
     });
 
     context('when birthdate is not a date', () => {

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -399,14 +399,14 @@ describe('Unit | Service | user-reconciliation-service', () => {
     beforeEach(() => {
       organizationId = domainBuilder.buildOrganization().id;
       higherSchoolingRegistrationRepositoryStub = {
-        findOneRegisteredByOrganizationIdAndUserData: sinon.stub(),
+        findOneByStudentNumberAndBirthdate: sinon.stub(),
       };
     });
 
     context('When schooling registrations are found for organization and birthdate', () => {
 
       beforeEach(() => {
-        higherSchoolingRegistrationRepositoryStub.findOneRegisteredByOrganizationIdAndUserData.resolves(schoolingRegistrations[0]);
+        higherSchoolingRegistrationRepositoryStub.findOneByStudentNumberAndBirthdate.resolves(schoolingRegistrations[0]);
       });
 
       context('When no schooling registrations matched on names', () => {
@@ -442,7 +442,7 @@ describe('Unit | Service | user-reconciliation-service', () => {
 
           it('should throw an error', async () => {
             // given
-            higherSchoolingRegistrationRepositoryStub.findOneRegisteredByOrganizationIdAndUserData.resolves(schoolingRegistrations[0]);
+            higherSchoolingRegistrationRepositoryStub.findOneByStudentNumberAndBirthdate.resolves(schoolingRegistrations[0]);
 
             // when
             const result = await catchErr(userReconciliationService.findMatchingHigherSchoolingRegistrationIdForGivenOrganizationIdAndUser)({ organizationId, reconciliationInfo: user, higherSchoolingRegistrationRepository: higherSchoolingRegistrationRepositoryStub });
@@ -468,7 +468,7 @@ describe('Unit | Service | user-reconciliation-service', () => {
     context('When no schooling registrations found', () => {
 
       beforeEach(() => {
-        higherSchoolingRegistrationRepositoryStub.findOneRegisteredByOrganizationIdAndUserData.resolves(null);
+        higherSchoolingRegistrationRepositoryStub.findOneByStudentNumberAndBirthdate.resolves(null);
       });
 
       it('should throw an error', async () => {

--- a/api/tests/unit/domain/usecases/update-student-number_test.js
+++ b/api/tests/unit/domain/usecases/update-student-number_test.js
@@ -13,7 +13,7 @@ describe('Unit | UseCase | update-student-number', () => {
   let schoolingRegistration;
 
   const higherSchoolingRegistrationRepository = {
-    findByOrganizationIdAndStudentNumber: sinon.stub(),
+    findOneByStudentNumber: sinon.stub(),
     updateStudentNumber: sinon.stub(),
   };
 
@@ -22,9 +22,9 @@ describe('Unit | UseCase | update-student-number', () => {
     beforeEach(() => {
       schoolingRegistration = domainBuilder.buildHigherSchoolingRegistration();
 
-      higherSchoolingRegistrationRepository.findByOrganizationIdAndStudentNumber
+      higherSchoolingRegistrationRepository.findOneByStudentNumber
         .withArgs({ organizationId, studentNumber })
-        .resolves([schoolingRegistration]);
+        .resolves(schoolingRegistration);
     });
 
     it('should throw an AlreadyExistingEntityError', async () => {
@@ -48,7 +48,7 @@ describe('Unit | UseCase | update-student-number', () => {
   context('When there are not schooling registration with the same student number', () => {
 
     beforeEach(() => {
-      higherSchoolingRegistrationRepository.findByOrganizationIdAndStudentNumber.withArgs({ organizationId, studentNumber }).resolves([]);
+      higherSchoolingRegistrationRepository.findOneByStudentNumber.withArgs({ organizationId, studentNumber }).resolves(null);
     });
 
     it('should update a student number', async () => {

--- a/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
@@ -61,7 +61,6 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'hello darkness my old friend',
           organizationId,
-          isSupernumerary: false,
         });
         expect(registrations[1]).to.deep.equal({
           firstName: 'O-Ren',
@@ -78,7 +77,6 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
           group: 'Deadly Viper Assassination Squad',
           studyScheme: undefined,
           organizationId,
-          isSupernumerary: false,
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Lors de la mise en place de l’import pour le SUP, nous avons remarqué que l'import actuel permettant de créer des étudiants sans numéro étudiant créé de nombreux doublons / triplons au moment de la réconciliation (notamment à cause du système surnuméraire mis en place).

## :robot: Solution

Le numéro étudiant est désormais obligatoire pour l'import d'étudiant dans les organisations SUP.

Tâches réalisées:
- Suppression de la notion de surnuméraire dans le code et la base de données (index).
- Mettre le numéro étudiant obligatoire dans le fichier d'import SUP.

Désormais l'algo d'import est beaucoup plus simple, dans la table `schooling-regsitrations`:
1. Si l'étudiant existe dans l'organisation et pour un numéro étudiant donné, on le mets à jour.
2. Sinon on créé l'étudiant en base.

Si un numéro étudiant est manquant dans le fichier d'import, alors une erreur est remontée.

## :rainbow: Remarques

Les index portant sur 'studentNumber/organizationId' ont été remplacés dans cette PR
- Drop `organizationid_studentnumber_index`
- Drop `organizationid_studentnumber_notsupernumerary_index`
- Ajout de l'index unique `student number + organization id`

## :100: Pour tester

Se connecter à pix-orga avec `sup.admin@example.net`
Aller sur l'onglet étudiant
Télécharger le modèle

1. Importer un fichier SUP avec numéro étudiant manquant sur une ligne.
> Un erreur est remontée.

2. Importer un fichier SUP avec de nouveaux étudiants.
> Les étudiants sont ajoutés.

3. Modifier les infos des étudiant précédemment importés et charger le fichier.
> Les étudiants sont mis à jour.
