### PR TITLE
[BUGFIX] Valider le payload sur POST /api/users (PIX-2514).

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -16,6 +16,15 @@ exports.register = async function(server) {
       path: '/api/users',
       config: {
         auth: false,
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              type: Joi.string(),
+              attributes: Joi.object().required(),
+              relationships: Joi.object(),
+            }).required(),
+          }).required(),
+        },
         handler: userController.save,
         tags: ['api'],
       },

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -46,24 +46,29 @@ describe('Unit | Router | user-router', () => {
       httpTestServer = startServer();
     });
 
-    it('should exist', async () => {
-      // given
-      const payload = {
-        data: {
-          attributes: {
-            'first-name': 'Edouard',
-            'last-name': 'Doux',
-            email: 'doux.doudou@example.net',
-            password: 'password_1234',
-          },
-        },
-      };
+    context('Payload schema validation', () => {
 
-      // when
-      const response = await httpTestServer.request(method, url, payload);
+      it('should return HTTP 400 if payload does not exist', async () => {
+        // given
+        const payload = null;
 
-      // then
-      expect(response.statusCode).to.equal(200);
+        // when
+        const result = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it('should return HTTP 200 if payload is not empty and valid', async () => {
+        // given
+        const payload = { data: { attributes: {} } };
+
+        // when
+        const result = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(result.statusCode).to.equal(200);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
cf. Erreur [Sentry](https://sentry.io/organizations/pix/issues/2353774273/?project=1398749&referrer=slack)
Dans l'API la route POST /api/users ne contient pas de validation (Joi).

## :robot: Solution
Mettre en place une validation minimale du payload.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Dans Pix App, la création d'un utilisateur doit toujours être possible sans erreur.