### PR TITLE
[BUGFIX] Ne pas valider de badge quand ce dernier n'a pas de critère (PIX-2538).

### DIFF
--- a/api/lib/domain/services/badge-criteria-service.js
+++ b/api/lib/domain/services/badge-criteria-service.js
@@ -28,7 +28,7 @@ function getMasteryPercentageForAllPartnerCompetences({ targetedKnowledgeElement
 }
 
 function verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge }) {
-  if (badge.badgeCriteria.length === 0) {
+  if (!badge.badgeCriteria.length) {
     logger.warn(`No criteria for badge ${badge.id}`);
     return false;
   }

--- a/api/lib/domain/services/badge-criteria-service.js
+++ b/api/lib/domain/services/badge-criteria-service.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const BadgeCriterion = require('../../../lib/domain/models/BadgeCriterion');
+const logger = require('../../infrastructure/logger');
 
 function areBadgeCriteriaFulfilled({ knowledgeElements, targetProfile, badge }) {
   const targetProfileSkillsIds = targetProfile.getSkillIds();
@@ -27,6 +28,10 @@ function getMasteryPercentageForAllPartnerCompetences({ targetedKnowledgeElement
 }
 
 function verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge }) {
+  if (badge.badgeCriteria.length === 0) {
+    logger.warn(`No criteria for badge ${badge.id}`);
+    return false;
+  }
   return _.every(badge.badgeCriteria, (criterion) => {
     switch (criterion.scope) {
       case BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION:

--- a/api/tests/integration/domain/event/handle-badge-acquisition_test.js
+++ b/api/tests/integration/domain/event/handle-badge-acquisition_test.js
@@ -1,0 +1,119 @@
+const { expect, databaseBuilder, knex, mockLearningContent, learningContentBuilder } = require('../../../test-helper');
+const handleBadgeAcquisitionEvent = require('../../../../lib/domain/events/handle-badge-acquisition');
+const badgeCriteriaService = require('../../../../lib/domain/services/badge-criteria-service');
+const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
+const badgeRepository = require('../../../../lib/infrastructure/repositories/badge-repository');
+const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
+const targetProfileRepository = require('../../../../lib/infrastructure/repositories/target-profile-repository');
+const AsessmentCompletedEvent = require('../../../../lib/domain/events/AssessmentCompleted');
+
+describe('Integration | Event | Handle Badge Acquisition Service', function() {
+
+  let userId, event, badgeCompleted;
+
+  describe('#handleBadgeAcquisition', () => {
+
+    beforeEach(async() => {
+      const listSkill = ['web1', 'web2', 'web3', 'web4'];
+
+      const learningContent = [{
+        id: 'recArea1',
+        titleFrFr: 'area1_Title',
+        color: 'someColor',
+        competences: [{
+          id: 'competenceId',
+          nameFrFr: 'Mener une recherche et une veille d’information',
+          index: '1.1',
+          tubes: [{
+            id: 'recTube0_0',
+            skills: [{
+              id: listSkill[0],
+              nom: '@web1',
+              status: 'actif',
+              challenges: [],
+            }, {
+              id: listSkill[1],
+              nom: '@web2',
+              status: 'actif',
+              challenges: [],
+            }, {
+              id: listSkill[2],
+              nom: 'web3',
+              status: 'actif',
+              challenges: [],
+            }, {
+              id: listSkill[3],
+              nom: 'web4',
+              status: 'actif',
+              challenges: [],
+            }],
+          }],
+        }],
+      }];
+
+      userId = databaseBuilder.factory.buildUser().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' });
+
+      const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId }).id;
+
+      badgeCompleted = databaseBuilder.factory.buildBadge({
+        targetProfileId,
+        badgePartnerCompetences: [], key: 'Badge1' });
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: 'CampaignParticipation',
+        badgeId: badgeCompleted.id,
+        threshold: 40,
+      });
+
+      const badgeNotCompletedId = databaseBuilder.factory.buildBadge({
+        targetProfileId,
+        badgePartnerCompetences: [], key: 'Badge2' }).id;
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: 'CampaignParticipation',
+        badgeId: badgeNotCompletedId,
+        threshold: 90,
+      });
+
+      databaseBuilder.factory.buildBadge({ targetProfileId, badgeCriteria: [], badgePartnerCompetences: [], key: 'Badge3' }).id;
+
+      event = new AsessmentCompletedEvent();
+      event.userId = userId;
+      event.campaignParticipationId = campaignParticipationId;
+
+      const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+      mockLearningContent(learningContentObjects);
+
+      return databaseBuilder.commit();
+    });
+
+    afterEach(async() => {
+      await knex('badge-acquisitions').delete();
+      await databaseBuilder.clean();
+    });
+
+    it('should save only the validated badges', async () => {
+      // when
+      await handleBadgeAcquisitionEvent({
+        event,
+        badgeCriteriaService,
+        badgeAcquisitionRepository,
+        badgeRepository,
+        knowledgeElementRepository,
+        targetProfileRepository,
+      });
+
+      // then
+      const badgeAcquisitions = await knex('badge-acquisitions').where({ userId: userId });
+      expect(badgeAcquisitions.length).to.equal(1);
+      expect(badgeAcquisitions[0].userId).to.equal(userId);
+      expect(badgeAcquisitions[0].badgeId).to.equal(badgeCompleted.id);
+    });
+
+  });
+});

--- a/api/tests/unit/domain/services/badge-criteria-service_test.js
+++ b/api/tests/unit/domain/services/badge-criteria-service_test.js
@@ -205,6 +205,23 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         expect(result).to.be.equal(false);
       });
     });
+
+    context('when the badge does not have criterion', function() {
+      const badgeCriteria = [];
+      const badge = domainBuilder.buildBadge({ badgeCriteria });
+
+      it('should return false', async () => {
+        // given
+        const masteryPercentage = 90;
+        const partnerCompetenceResults = [];
+
+        // when
+        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
+
+        // then
+        expect(result).to.be.equal(false);
+      });
+    });
   });
 
   describe('#areBadgeCriteriaFulfilled', () => {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le badge n'a pas de critère, il est automatiquement validé, alors qu'il n'y a pas de raisons de valider un badge sans vérification.

## :robot: Solution
Ajouter une vérification avant la validation des critères

## :rainbow: Remarques
Cela vient du `_.every` qui renvoie `true` quand le tableau est vide.

## :100: Pour tester
