### PR TITLE
[BUGFIX] Corrige l'entrée des dates de naissance pour l'ajout des candidats de certif (PIX-2526)

### DIFF
--- a/certif/app/components/certification-candidate-in-staging-item.hbs
+++ b/certif/app/components/certification-candidate-in-staging-item.hbs
@@ -26,7 +26,7 @@
       <OneWayDateMask
           required
           @placeholder='dd/mm/yyyy'
-          @options={{hash inputFormat='dd/mm/yyyy' outputFormat='yyyy-mm-dd'}}
+          @options={{hash inputFormat='dd/mm/yyyy' outputFormat='dd/mm/yyyy'}}
           @class="certification-candidates-input {{if this.birthdateFocused 'focused'}}"
           id="certification-candidates-input-birthdate"
           {{on 'focus' this.focusBirthdate}}

--- a/certif/app/components/certification-candidate-in-staging-item.js
+++ b/certif/app/components/certification-candidate-in-staging-item.js
@@ -81,9 +81,14 @@ export default class CertificationCandidateInStagingItem extends Component {
   }
 
   @action
-  updateCandidateDataBirthdate(unmasked, masked) {
+  updateCandidateDataBirthdate(_, masked) {
     this.maskedBirthdate = masked;
-    this.args.updateCandidateBirthdate(this.args.candidateData, unmasked);
+    this.args.updateCandidateBirthdate(this.args.candidateData, this._formatDate(masked));
+  }
+
+  _formatDate(date) {
+    const [day, month, year] = date.split('/');
+    return `${year}-${month}-${day}` ;
   }
 
   @action


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Certif, dans l'onglet d'ajout de candidat d'une session, quand on essaie d'enregistrer un candidat dont la date de naissance est le 20 mars 2000, le bouton "enregistrer" devrait s'activer une fois qu'on a rempli tous les champs obligatoires et il ne le fait pas.

Quand on essaie d’enregistrer un candidat dont la date de naissance est le 20 mars 2001, tout se passe correctement.

## :robot: Solution

On a appris que la source du pb vient du fait que la lib ember-inputmask qu’on utilise ne fonctionne pas correctement pour mettre à jour la valeur de la date quand on inverse les caractères entre input (dd/mm/yyyy) et output (yyyy-mm-dd), voir la remarque ci-dessous pour plus de détails.

=> Ne pas utiliser le OneWayDateMask pour formater la date en `yyyy-mm-dd`, rester en `dd/mm/yyyy` puis formater la date nous-même au bon moment.

## :100: Pour tester

Dans Pix Certif :

- Créer une session dans Pix Certif
- Ajouter un candidat à cette session (onglet "candidat") en choisissant le 20 mars 2000 comme date de naissance
- Remplir les champs obligatoires

Une fois que tous les champs obligatoires ont été remplis, le bouton "Enregistrer" doit s'activer, et après l'enregistrement le candidat doit apparaître avec la bonne date de naissance.

## :rainbow: Remarques


La ligne de code qui semble coincer dans la lib :

https://github.com/brandynbennett/ember-inputmask/blob/84cee4e/addon/components/one-way-input-mask.js#L229

Composant : OneWayDateMask, dérivant de OneWayInputMask.

Pour reproduire le pb dans la console du navigateur :

```
> let IM = require('inputmask')
> const options = {
    inputFormat:'dd/mm/yyyy',
    outputFormat: 'yyyy-mm-dd',
    alias:'datetime'
}

> /////////////////////////////////////////////////
> // vvvvvv Ce qui se passe quand on tape
> //        20/03/20 puis 20/03/200 puis 20/03/2000

> IM.format('20yy-03-20', options)
"20/03/20yy"
> // ^^^^^^ semble ok ?

> IM.format('200y-03-20', options)
"20/03/20yy"
> // ^^^^^^ c'est n'importe quoi (il manque un zéro)

> IM.format('2000-03-20', options)
"20/03/20yy"
> // ^^^^^^ c'est n'importe quoi et c'est identique à la valeur
> //        précédente donc le callback d'update n'est pas appelé

> /////////////////////////////////////////////////
> // vvvvvv Ce qui se passe quand on tape
> //        20/03/200 puis 20/03/2001

> IM.format('200y-03-20', options)
"20/03/20yy"
> // ^^^^^^ c'est n'importe quoi (il manque un zéro)

> IM.format('2001-03-20', options)
"20/01/0320"
> // ^^^^^^ c'est n'importe quoi mais c'est différent de la valeur
> //        précédente donc le callback d'update est appelé
```

On peut remarquer que comparer le résultat de Inputmask.format() sur deux valeurs qui ont des format différents (dans notre cas `dd/mm/yyyy` et `yyyy-mm-dd`) avec les mêmes options n'a pas de sens. Probablement qu'Inputmask.format() de la lib inputmask se comporte correctement mais que l'auteur d'ember-inputmask l'utilise pour comparer deux valeurs qui ne sont pas homogènes, ce qui fonctionne par coïncidence quand les chiffres sont dans le même ordre dans le format d'input et le format d'output, mais qui cause le pb quand les chiffres ne sont pas dans le même ordre, ce qui était notre cas.
