### PR TITLE
[BUGFIX] Un candidat inscrit à une session de certification ne pouvait la rejoindre si, à l'inscription, un espace au début ou à la fin est présent dans son nom ou son prénom (PIX-2382)

### DIFF
--- a/api/db/migrations/20210430154711_trim-certification-candidates-first-name-and-last-name.js
+++ b/api/db/migrations/20210430154711_trim-certification-candidates-first-name-and-last-name.js
@@ -1,0 +1,10 @@
+exports.up = function(knex) {
+  return knex.raw('UPDATE "certification-candidates"' +
+    'SET "firstName" = TRIM("firstName"), "lastName" = TRIM("lastName")' +
+    'WHERE "firstName" LIKE \'% \' OR "firstName" LIKE \' %\'' +
+    ' OR "lastName" LIKE \'% \' OR "lastName" LIKE \' %\'');
+};
+
+exports.down = function(_) {
+
+};

--- a/api/lib/domain/usecases/enroll-students-to-session.js
+++ b/api/lib/domain/usecases/enroll-students-to-session.js
@@ -28,8 +28,8 @@ module.exports = async function enrollStudentsToSession({
 
   const scoCertificationCandidates = students.map((student) => {
     return new SCOCertificationCandidate({
-      firstName: student.firstName,
-      lastName: student.lastName,
+      firstName: student.firstName.trim(),
+      lastName: student.lastName.trim(),
       birthdate: student.birthdate,
       sessionId,
       schoolingRegistrationId: student.id,


### PR DESCRIPTION
## :unicorn: Problème
Bug découvert, étape de reproduction :
- Importer un élève dans une organisation SCO isManagingStudents dont le nom ou le prénom comporte un espace au début ou à la fin
- Inscrire ce même élève à une session de certification
- Tenter de rejoindre la session de certification avec les informations de l'élève -> impossible

En effet, les informations indiquées dans le formulaire pour rejoindre la session sont trimmées. Or, le candidat, dans la base de données, a été inscrit avec des espaces inutiles dans son nom ou son prénom. Comme le matching est exact, il lui est impossible de rejoindre la session.

## :robot: Solution
Ce problème ne concerne a priori que les inscriptions via le mécanisme de prescription de certif SCO. Côté Orga, il n'y a jamais eu le besoin de trimmer les informations venant d'import externes (SIECLE, etc...) car, dans le cadre de la prescription, le matching d'informations saisies et d'informations d'inscription se fait à l'aide d'algo de Levenshtein (donc la présence d'un espace de trop n'est pas gênant).

Solution en deux temps :
- Effectuer une migration dans la table de "certification-candidates" pour corriger les inscriptions cassées
- Forcer le trim lors de l'inscription d'un candidat à une certification lors de la prescription de certif SCO

## :rainbow: Remarques


## :100: Pour tester
- Se rendre du pixCertif avec certifsco@example.net / pix123
- Créer une session de certification et inscrire First Last (en bdd, dans les schooling-registrations, son nom et son prénom ont des espaces au début ou bien à la fin)
- Se rendre du PixApp en se connectant avec son compte réconcilié certif1@example.net / pix123
- Rejoindre la session de certification fraichement créée avec First Last
- Si vous atteignez la page de code d'accès, alors vous avez gagné! 

