### PR TITLE
[FEATURE] Empêcher la mise à jour de "LastQuestionDate" quand l'assessment est terminé (PIX-2524).

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -94,7 +94,9 @@ module.exports = {
 async function _getChallenge(assessment, request) {
   const locale = extractLocaleFromRequest(request);
 
-  await assessmentRepository.updateLastQuestionDate({ id: assessment.id, lastQuestionDate: new Date() });
+  if (assessment.isStarted()) {
+    await assessmentRepository.updateLastQuestionDate({ id: assessment.id, lastQuestionDate: new Date() });
+  }
 
   if (assessment.isPreview()) {
     return usecases.getNextChallengeForPreview({});

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -60,7 +60,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
 
       beforeEach(async () => {
         databaseBuilder.factory.buildUser({ id: userId });
-        databaseBuilder.factory.buildAssessment({ id: assessmentId, type: Assessment.types.COMPETENCE_EVALUATION, userId, competenceId, lastQuestionDate: new Date('2020-01-20') });
+        databaseBuilder.factory.buildAssessment({ id: assessmentId, type: Assessment.types.COMPETENCE_EVALUATION, userId, competenceId, lastQuestionDate: new Date('2020-01-20'), state: 'started' });
         const { id: answerId } = databaseBuilder.factory.buildAnswer({ challengeId: firstChallengeId, assessmentId, value: 'any good answer', result: 'ok' });
         databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
         databaseBuilder.factory.buildKnowledgeElement({


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur visite une épreuve, la colonne `lastQuestionDate` de la table assessment est mise à jour. Elle est utilisée pour connaitre le temps passée sur une épreuve.
Or lorsque l'utilisateur revient sur une question déjà répondu, ce champs est mis à jour.

## :robot: Solution
Empêcher la mise à jour du champs `lastQuestionDate` lorsque l'assessment est terminé.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Finir une campagne.
Noter la valeur de `lastQuestionDate`.
Faire "retour" jusqu'aux épreuves, puis cliquer sur "poursuivre".
Noter que la valeur de `lastQuestionDate` n'a pas changé.
