### PR TITLE
[BUGFIX] Corriger la suppression d'un membre sur Pix Orga (Pix-2541).

### DIFF
--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -30,7 +30,7 @@ module.exports = async function acceptOrganizationInvitation({
     }
 
     if (existingMembership) {
-      await membershipRepository.updateById({ id: existingMembership.id, membershipAttributes: { organizationRole: invitationRole } });
+      await membershipRepository.updateById({ id: existingMembership.id, membership: { organizationRole: invitationRole } });
     } else {
       const organizationRole = invitationRole || _pickDefaultRole(memberships);
       await membershipRepository.create(userFound.id, organizationId, organizationRole);

--- a/api/lib/domain/usecases/disable-membership.js
+++ b/api/lib/domain/usecases/disable-membership.js
@@ -3,6 +3,6 @@ module.exports = async function disableMembership({
   userId,
   membershipRepository,
 }) {
-  const membershipAttributes = { disabledAt: new Date(), updatedByUserId: userId };
-  return membershipRepository.updateById({ id: membershipId, membershipAttributes });
+  const membership = { disabledAt: new Date(), updatedByUserId: userId };
+  return membershipRepository.updateById({ id: membershipId, membership });
 };

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -112,6 +112,11 @@ module.exports = {
 
   async updateById({ id, membership }, domainTransaction = DomainTransaction.emptyTransaction()) {
     let updatedMembership;
+
+    if (!membership) {
+      throw new MembershipUpdateError('Le membership n\'est pas renseigné');
+    }
+
     try {
       updatedMembership = await new BookshelfMembership({ id })
         .save(membership, { patch: true, method: 'update', require: true, transacting: domainTransaction.knexTransaction });

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -585,6 +585,22 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
         expect(error.message).to.be.equal(messageNotRowUpdated);
       });
     });
+
+    context('When membership attributes are empty', () => {
+
+      it('should throw MembershipUpdateError', async () => {
+        // given
+        const errorMessage = 'Le membership n\'est pas renseigné';
+        const membership = undefined;
+
+        // when
+        const error = await catchErr(membershipRepository.updateById)({ id: existingMembershipId, membership });
+
+        // then
+        expect(error).to.be.an.instanceOf(MembershipUpdateError);
+        expect(error.message).to.be.equal(errorMessage);
+      });
+    });
   });
 
 });

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -177,7 +177,7 @@ describe('Unit | UseCase | accept-organization-invitation', () => {
           });
 
           // then
-          expect(membershipRepository.updateById).to.have.been.calledWith({ id: membership.id, membershipAttributes: { organizationRole: pendingOrganizationInvitation.role } });
+          expect(membershipRepository.updateById).to.have.been.calledWith({ id: membership.id, membership: { organizationRole: pendingOrganizationInvitation.role } });
           expect(organizationInvitationRepository.markAsAccepted).to.have.been.calledWith(organizationInvitationId);
         });
       });

--- a/api/tests/unit/domain/usecases/disable-membership_test.js
+++ b/api/tests/unit/domain/usecases/disable-membership_test.js
@@ -23,7 +23,7 @@ describe('Unit | UseCase | disable-membership', () => {
       disabledAt: sinon.match.instanceOf(Date),
       updatedByUserId: userId,
     };
-    expect(membershipRepository.updateById).to.has.been.calledWithExactly({ id: membershipId, membershipAttributes: expectedMembershipAttributes });
+    expect(membershipRepository.updateById).to.has.been.calledWithExactly({ id: membershipId, membership: expectedMembershipAttributes });
   });
 
   it('should throw a MembershipUpdateError if membership does not exist', async () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -189,11 +189,11 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
 
     it('should convert JSON API data into a map object that contain attribute to patch', () => {
       // when
-      const membershipAttributes = serializer.deserialize(jsonMembership);
+      const membership = serializer.deserialize(jsonMembership);
 
       // then
-      expect(membershipAttributes.organizationRole).to.equal('ADMIN');
-      expect(membershipAttributes.id).to.equal('12345');
+      expect(membership.organizationRole).to.equal('ADMIN');
+      expect(membership.id).to.equal('12345');
 
     });
   });

--- a/orga/app/components/routes/authenticated/team/items.js
+++ b/orga/app/components/routes/authenticated/team/items.js
@@ -94,9 +94,9 @@ export default class Items extends Component {
       const memberLastName = membership.user.get('lastName');
 
       await this.args.removeMembership(membership);
-      this.notifications.success(this.intl.t('pages.team-items.notifications.success', { memberFirstName, memberLastName }));
+      this.notifications.success(this.intl.t('pages.team-members.notifications.success', { memberFirstName, memberLastName }));
     } catch (e) {
-      this.notifications.error(this.intl.t('pages.team-items.notifications.error'));
+      this.notifications.error(this.intl.t('pages.team-members.notifications.error'));
     } finally {
       this.closeRemoveMembershipModal();
     }


### PR DESCRIPTION
## :unicorn: Problème
La suppression d'un membre sur Pix Orga ne supprimait plus le membre en question. 

Ce bug a été introduit par la PR [suivante](https://github.com/1024pix/pix/pull/2872) lors du changement de la signature d'une fonction du membership repository (renommage du paramètre `membershipAttributes`).
Cela impacte également l'invitation à rejoindre une organisation, lorsque l'on est déjà membre de cette dernière.

## :robot: Solution
Renommer dans l'ensemble du code le `membershipAttributes` en `membership` et ajouter un test pour renvoyer une erreur si le membership est vide (`undefined`).

## :rainbow: Remarques
Correction d'une coquille sur une clé de traduction sur les notifs de suppression d'un membre

## :100: Pour tester
Se connecter sur Pix Orga : sco.admin@example.net
Aller sur Équipe > Supprimer un membre > vérifier que le message s'affiche correctement et que le membre est supprimé.
