### PR TITLE
[TECH] Supprimer la colonne IsSupernumerary dans la table SchoolingRegistration (PIX-2519).

### DIFF
--- a/api/db/migrations/20210503164450_remove-isSupernumeray-column.js
+++ b/api/db/migrations/20210503164450_remove-isSupernumeray-column.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'schooling-registrations';
+const COLUMN = 'isSupernumerary';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.boolean(COLUMN);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
La colonne `isSupernumerary` en BDD n'est plus utilisée parce que le gestion de l'accès des étudiants SUP aux campagnes à 
changer.

## :robot: Solution
Supprimer le colonne en BDD

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
