### PR TITLE
[FEATURE] Vérifier les diplômes et régimes dans l'import SUP (PIX-2416)

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -10,6 +10,7 @@ const organizationSerializer = require('../../infrastructure/serializers/jsonapi
 const organizationInvitationSerializer = require('../../infrastructure/serializers/jsonapi/organization-invitation-serializer');
 const targetProfileSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-serializer');
 const userWithSchoolingRegistrationSerializer = require('../../infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer');
+const higherSchoolingRegistrationWarningSerializer = require('../../infrastructure/serializers/jsonapi/higher-schooling-registration-warnings-serializer');
 const HigherSchoolingRegistrationParser = require('../../infrastructure/serializers/csv/higher-schooling-registration-parser');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
@@ -149,8 +150,9 @@ module.exports = {
     const organizationId = parseInt(request.params.id);
     const buffer = request.payload;
     const higherSchoolingRegistrationParser = new HigherSchoolingRegistrationParser(buffer, organizationId, request.i18n);
-    await usecases.importHigherSchoolingRegistrations({ higherSchoolingRegistrationParser });
-    return h.response(null).code(204);
+    const warnings = await usecases.importHigherSchoolingRegistrations({ higherSchoolingRegistrationParser });
+    const response = higherSchoolingRegistrationWarningSerializer.serialize({ id: organizationId, warnings });
+    return h.response(response).code(200);
   },
 
   async sendInvitations(request, h) {

--- a/api/lib/domain/models/HigherSchoolingRegistrationSet.js
+++ b/api/lib/domain/models/HigherSchoolingRegistrationSet.js
@@ -1,15 +1,80 @@
 const HigherSchoolingRegistration = require('./HigherSchoolingRegistration');
 const { checkValidation } = require('../validators/higher-schooling-registration-set-validator');
+const { areTwoStringsCloseEnough } = require('../services/string-comparison-service');
+
+const RATIO = 0.25;
+
+const STUDY_SCHEMES = [
+  'csv-import-values.higher-schooling-registrations.study-schemes.initial-training',
+  'csv-import-values.higher-schooling-registrations.study-schemes.training',
+  'csv-import-values.higher-schooling-registrations.study-schemes.continuous-training',
+  'csv-import-values.higher-schooling-registrations.study-schemes.other',
+];
+
+const DIPLOMAS = [
+  'csv-import-values.higher-schooling-registrations.diplomas.license',
+  'csv-import-values.higher-schooling-registrations.diplomas.master',
+  'csv-import-values.higher-schooling-registrations.diplomas.doctorat',
+  'csv-import-values.higher-schooling-registrations.diplomas.dnmade',
+  'csv-import-values.higher-schooling-registrations.diplomas.dma ',
+  'csv-import-values.higher-schooling-registrations.diplomas.bts',
+  'csv-import-values.higher-schooling-registrations.diplomas.dut',
+  'csv-import-values.higher-schooling-registrations.diplomas.dts',
+  'csv-import-values.higher-schooling-registrations.diplomas.dcg ',
+  'csv-import-values.higher-schooling-registrations.diplomas.deust',
+  'csv-import-values.higher-schooling-registrations.diplomas.etat-controle',
+  'csv-import-values.higher-schooling-registrations.diplomas.ingenieur',
+  'csv-import-values.higher-schooling-registrations.diplomas.license-grade',
+  'csv-import-values.higher-schooling-registrations.diplomas.master-grade',
+  'csv-import-values.higher-schooling-registrations.diplomas.vise',
+  'csv-import-values.higher-schooling-registrations.diplomas.classe-preparatoire',
+  'csv-import-values.higher-schooling-registrations.diplomas.other',
+];
+
+const UNKNOWN = 'csv-import-values.higher-schooling-registrations.unknown';
+
 class HigherSchoolingRegistrationSet {
 
-  constructor() {
+  constructor(i18n) {
+    this.i18n = i18n;
     this.registrations = [];
+    this.warnings = [];
   }
 
   addRegistration(registrationAttributes) {
     const registration = new HigherSchoolingRegistration(registrationAttributes);
+    this._checkStudyScheme(registration);
+    this._checkDiploma(registration);
     this.registrations.push(registration);
+
     checkValidation(this);
+  }
+
+  addWarning(studentNumber, field, value, code) {
+    this.warnings.push({ studentNumber, field, value, code });
+  }
+
+  _checkStudyScheme(registration) {
+    const { studentNumber, studyScheme } = registration;
+    if (this._isValidI18nValue(STUDY_SCHEMES, studyScheme)) return;
+    this.addWarning(studentNumber, 'study-scheme', registration.studyScheme, 'unknown');
+    registration.studyScheme = this.i18n.__(UNKNOWN);
+  }
+
+  _checkDiploma(registration) {
+    const { studentNumber, diploma } = registration;
+    if (this._isValidI18nValue(DIPLOMAS, diploma)) return;
+    this.addWarning(studentNumber, 'diploma', registration.diploma, 'unknown');
+    registration.diploma = this.i18n.__(UNKNOWN);
+  }
+
+  _isValidI18nValue(keys, valueToCheck) {
+    if (!valueToCheck) return false;
+    return keys.some((key) => {
+      const reference = this.i18n.__(key).toLowerCase();
+      const input = valueToCheck.toLowerCase();
+      return areTwoStringsCloseEnough(input, reference, RATIO);
+    });
   }
 }
 

--- a/api/lib/domain/usecases/import-higher-schooling-registrations.js
+++ b/api/lib/domain/usecases/import-higher-schooling-registrations.js
@@ -2,7 +2,9 @@ module.exports = async function importHigherSchoolingRegistration({
   higherSchoolingRegistrationRepository,
   higherSchoolingRegistrationParser,
 }) {
-  const { registrations } = higherSchoolingRegistrationParser.parse();
+  const { registrations, warnings } = higherSchoolingRegistrationParser.parse();
 
   await higherSchoolingRegistrationRepository.upsertStudents(registrations);
+
+  return warnings;
 };

--- a/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
@@ -12,7 +12,7 @@ const ERRORS = {
 class HigherSchoolingRegistrationParser extends CsvRegistrationParser {
 
   constructor(input, organizationId, i18n) {
-    const registrationSet = new HigherSchoolingRegistrationSet();
+    const registrationSet = new HigherSchoolingRegistrationSet(i18n);
 
     const columns = new HigherSchoolingRegistrationColumns(i18n).columns;
 

--- a/api/lib/infrastructure/serializers/jsonapi/higher-schooling-registration-warnings-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/higher-schooling-registration-warnings-serializer.js
@@ -1,0 +1,12 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(organizations, meta) {
+    return new Serializer('higher-schooling-registration-warnings', {
+      attributes: ['warnings'],
+      meta,
+    }).serialize(organizations);
+  },
+
+};

--- a/api/tests/acceptance/application/organizations/organization-controller-import-higher-schooling-registration_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-higher-schooling-registration_test.js
@@ -35,7 +35,7 @@ describe('Acceptance | Application | organization-controller-import-higher-schoo
         const buffer =
           `${higherSchoolingRegistrationColumns}\n` +
           'Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1990;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend\n' +
-          'O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;';
+          'O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;Autre;';
 
         const options = {
           method: 'POST',
@@ -48,10 +48,21 @@ describe('Acceptance | Application | organization-controller-import-higher-schoo
 
         const response = await server.inject(options);
         const registrations = await knex('schooling-registrations').where({ organizationId: organization.id });
-
-        expect(response.statusCode).to.equal(204);
+        expect(response.statusCode).to.equal(200);
+        expect(response.result).to.deep.equal({
+          data: {
+            id: String(organization.id),
+            type: 'higher-schooling-registration-warnings',
+            attributes: {
+              warnings: [
+                { code: 'unknown', field: 'study-scheme', studentNumber: '12346', value: 'hello darkness my old friend' },
+                { code: 'unknown', field: 'diploma', studentNumber: '12346', value: 'Master' },
+                { code: 'unknown', field: 'diploma', studentNumber: '789', value: 'DUT' },
+              ],
+            },
+          },
+        });
         expect(registrations).to.have.lengthOf(2);
-
       });
 
       it('fails when the file payload is too large', async () => {

--- a/api/tests/integration/domain/usecases/import-higher-schooling-registrations_test.js
+++ b/api/tests/integration/domain/usecases/import-higher-schooling-registrations_test.js
@@ -71,4 +71,25 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
       });
     });
   });
+
+  it('should return warnings about the import', async () => {
+    const input = `${higherSchoolingRegistrationColumns}
+            Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+        `.trim();
+
+    const encodedInput = iconv.encode(input, 'utf8');
+    const organization = databaseBuilder.factory.buildOrganization();
+    await databaseBuilder.commit();
+
+    const warnings = await importHigherSchoolingRegistration({
+      organizationId: organization.id,
+      higherSchoolingRegistrationRepository,
+      higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
+    });
+
+    expect(warnings).to.deep.equal([
+      { studentNumber: '123456', field: 'study-scheme', value: 'BAD', code: 'unknown' },
+      { studentNumber: '123456', field: 'diploma', value: 'BAD', code: 'unknown' },
+    ]);
+  });
 });

--- a/api/tests/unit/domain/models/HigherSchoolingRegistrationSet_test.js
+++ b/api/tests/unit/domain/models/HigherSchoolingRegistrationSet_test.js
@@ -1,14 +1,15 @@
 const HigherSchoolingRegistrationSet = require('../../../../lib/domain/models/HigherSchoolingRegistrationSet');
 const { expect, catchErr } = require('../../../test-helper');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
+  const i18n = getI18n();
 
   context('#addRegistration', () => {
     context('when set has no registration', () => {
       it('creates the first registration of the set', () => {
-
-        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet();
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
         const registrationAttributes = {
           firstName: 'Beatrix',
           middleName: 'The',
@@ -18,11 +19,11 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
           studentNumber: '1',
           email: 'thebride@example.net',
           birthdate: new Date('1980-07-01'),
-          diploma: 'Master',
+          diploma: 'Autre',
           department: 'Assassination Squad',
           educationalTeam: 'Pai Mei',
           group: 'Deadly Viper Assassination Squad',
-          studyScheme: 'I have no idea what it\'s like.',
+          studyScheme: 'Autre',
           organizationId: 1,
         };
 
@@ -36,8 +37,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
 
     context('when set has registrations', () => {
       it('creates the a new registration for the set', () => {
-
-        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet();
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
         const registration1 = {
           firstName: 'Beatrix',
           middleName: 'The',
@@ -47,11 +47,11 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
           studentNumber: '1',
           email: 'thebride@example.net',
           birthdate: new Date('1980-07-01'),
-          diploma: 'Master',
+          diploma: 'Autre',
           department: 'Assassination Squad',
           educationalTeam: 'Pai Mei',
           group: 'Deadly Viper Assassination Squad',
-          studyScheme: 'I have no idea what it\'s like.',
+          studyScheme: 'Autre',
           userId: 12345,
           organizationId: 1,
         };
@@ -64,11 +64,11 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
           studentNumber: '2',
           email: 'bill@example.net',
           birthdate: new Date('1960-07-01'),
-          diploma: 'Doctorat',
+          diploma: 'Autre',
           department: 'Assassination Squad Management',
           educationalTeam: 'Pai Mei',
           group: 'Deadly Viper Assassination Squad',
-          studyScheme: 'I have always no idea what it\'s like.',
+          studyScheme: 'Autre',
           organizationId: 2,
         };
 
@@ -83,8 +83,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
 
     context('when a registration is not valid', () => {
       it('throws an error', async () => {
-
-        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet();
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
         const registration = {
           firstName: null,
           lastName: 'Kiddo',
@@ -100,8 +99,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
 
     context('when there is a registration with the same student number', () => {
       it('throws an error', async () => {
-
-        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet();
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
         const registration1 = {
           firstName: 'Beatrix',
           lastName: 'Kiddo',
@@ -118,11 +116,96 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', () => {
         };
         await higherSchoolingRegistrationSet.addRegistration(registration1);
 
-        const error = await catchErr(higherSchoolingRegistrationSet.addRegistration, higherSchoolingRegistrationSet)(registration2);
+        const error = await catchErr(
+          higherSchoolingRegistrationSet.addRegistration,
+          higherSchoolingRegistrationSet,
+        )(registration2);
 
         expect(error).to.be.instanceOf(EntityValidationError);
         expect(error.key).to.equal('studentNumber');
         expect(error.why).to.equal('uniqueness');
+      });
+    });
+
+    context('When there are warnings', () => {
+      it('should add a diploma warning', async () => {
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
+        const registration = {
+          firstName: 'Beatrix',
+          lastName: 'Kiddo',
+          birthdate: '1990-04-01',
+          studentNumber: '123ABC',
+          organizationId: 123,
+          diploma: 'BAD',
+          studyScheme: 'Autre',
+        };
+
+        higherSchoolingRegistrationSet.addRegistration(registration);
+        const { registrations, warnings } = higherSchoolingRegistrationSet;
+
+        expect(registrations).to.have.lengthOf(1);
+        expect(registrations[0].diploma).to.equal('Non reconnu');
+        expect(warnings).to.have.lengthOf(1);
+        expect(warnings[0]).to.deep.equal({ studentNumber: '123ABC', field: 'diploma', value: 'BAD', code: 'unknown' });
+      });
+
+      it('should add a study scheme warning', async () => {
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
+        const registration = {
+          firstName: 'Beatrix',
+          lastName: 'Kiddo',
+          birthdate: '1990-04-01',
+          studentNumber: '123ABC',
+          organizationId: 123,
+          diploma: 'Autre',
+          studyScheme: 'BAD',
+        };
+
+        higherSchoolingRegistrationSet.addRegistration(registration);
+        const { registrations, warnings } = higherSchoolingRegistrationSet;
+
+        expect(registrations).to.have.lengthOf(1);
+        expect(registrations[0].studyScheme).to.equal('Non reconnu');
+        expect(warnings).to.have.lengthOf(1);
+        expect(warnings[0]).to.deep.equal({ studentNumber: '123ABC', field: 'study-scheme', value: 'BAD', code: 'unknown' });
+      });
+
+      it('should check diplomas and study schemes with lower case', async () => {
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
+        const registration = {
+          firstName: 'Beatrix',
+          lastName: 'Kiddo',
+          birthdate: '1990-04-01',
+          studentNumber: '123ABC',
+          organizationId: 123,
+          diploma: 'aUTRe',
+          studyScheme: 'aUTRe',
+        };
+
+        higherSchoolingRegistrationSet.addRegistration(registration);
+        const { registrations, warnings } = higherSchoolingRegistrationSet;
+
+        expect(registrations).to.have.lengthOf(1);
+        expect(warnings).to.have.lengthOf(0);
+      });
+
+      it('should check diplomas and study schemes with Levenshtein distance', async () => {
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
+        const registration = {
+          firstName: 'Beatrix',
+          lastName: 'Kiddo',
+          birthdate: '1990-04-01',
+          studentNumber: '123ABC',
+          organizationId: 123,
+          diploma: 'Autra',
+          studyScheme: 'Autra',
+        };
+
+        higherSchoolingRegistrationSet.addRegistration(registration);
+        const { registrations, warnings } = higherSchoolingRegistrationSet;
+
+        expect(registrations).to.have.lengthOf(1);
+        expect(warnings).to.have.lengthOf(0);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
@@ -37,8 +37,8 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
 
       it('returns a HigherSchoolingRegistrationSet with a schooling registration for each line using the CSV column', () => {
         const input = `${higherSchoolingRegistrationColumns}
-        Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
+        Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Autre;Autre;
+        O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT contrôlé par l'Etat;Autre;
         `;
         const organizationId = 789;
         const encodedInput = iconv.encode(input, 'utf8');
@@ -55,11 +55,11 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
           studentNumber: '123456',
           email: 'thebride@example.net',
           birthdate: '1970-01-01',
-          diploma: 'Master',
+          diploma: 'Autre',
           department: 'Assassination Squad',
           educationalTeam: 'Hattori Hanzo',
           group: 'Deadly Viper Assassination Squad',
-          studyScheme: 'hello darkness my old friend',
+          studyScheme: 'Autre',
           organizationId,
         });
         expect(registrations[1]).to.deep.equal({
@@ -71,11 +71,11 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
           studentNumber: '789',
           email: 'ishii@example.net',
           birthdate: '1980-01-01',
-          diploma: 'DUT',
+          diploma: 'DUT contrôlé par l\'Etat',
           department: 'Assassination Squad',
           educationalTeam: 'Bill',
           group: 'Deadly Viper Assassination Squad',
-          studyScheme: undefined,
+          studyScheme: 'Autre',
           organizationId,
         });
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/higher-schooling-registration-warnings-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/higher-schooling-registration-warnings-serializer_test.js
@@ -1,0 +1,35 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/higher-schooling-registration-warnings-serializer');
+
+describe('Unit | Serializer | higher-schooling-registration-warnings-serializer', () => {
+
+  describe('#serialize', () => {
+
+    it('should return a JSON API serialized warning', () => {
+      // given
+      const importWarnings = {
+        id: 123,
+        warnings: [
+          { studentNumber: '123', field: 'toto', code: 'titi', value: 'yo' },
+          { studentNumber: '123', field: 'tata', code: 'tutu', value: 'ya' },
+        ],
+      };
+      const meta = { some: 'meta' };
+
+      // when
+      const serialized = serializer.serialize(importWarnings, meta);
+
+      // then
+      expect(serialized).to.deep.equal({
+        data: {
+          type: 'higher-schooling-registration-warnings',
+          id: importWarnings.id.toString(),
+          attributes: {
+            'warnings': importWarnings.warnings,
+          },
+        },
+        meta: { some: 'meta' },
+      });
+    });
+  });
+});

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -82,6 +82,36 @@
     },
     "template-name": "import-template"
   },
+  "csv-import-values": {
+    "higher-schooling-registrations": {
+      "diplomas": {
+        "license": "Diplôme National de Licence contrôlé par l'Etat",
+        "master": "Diplôme National de Master contrôlé par l'Etat",
+        "doctorat": "Diplôme National de Doctorat contrôlé par l'Etat",
+        "dnmade": "DNMADE contrôlé par l'Etat",
+        "dma ": "DMA contrôlé par l'Etat",
+        "bts": "BTS contrôlé par l'Etat",
+        "dut": "DUT contrôlé par l'Etat",
+        "dts": "DTS contrôlé par l'Etat",
+        "dcg ": "DCG contrôlé par l'Etat",
+        "deust": "DEUST contrôlé par l'Etat",
+        "etat-controle": "Diplôme d'Etat contrôlé",
+        "ingenieur": "Diplôme d'ingénieur contrôlé par l'Etat",
+        "license-grade": "Diplôme conférant le grade de licence contrôlé par l'Etat",
+        "master-grade": "Diplôme conférant le grade de master contrôlé par l'Etat",
+        "vise": "Diplôme visé contrôlé par l'Etat",
+        "classe-preparatoire": "Classe préparatoire contrôlée par l'Etat",
+        "other": "Autre"
+      },
+      "study-schemes": {
+        "initial-training": "Formation initiale hors apprentissage",
+        "training": "Apprentissage",
+        "continuous-training": "Formation continue",
+        "other": "Autre"
+      },
+      "unknown": "Not recognised"
+    }
+  },
   "current-lang": "en",
   "email-change-email": {
     "body": {

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -82,6 +82,36 @@
     },
     "template-name": "modele-import"
   },
+  "csv-import-values": {
+    "higher-schooling-registrations": {
+      "diplomas": {
+        "license": "Diplôme National de Licence contrôlé par l'Etat",
+        "master": "Diplôme National de Master contrôlé par l'Etat",
+        "doctorat": "Diplôme National de Doctorat contrôlé par l'Etat",
+        "dnmade": "DNMADE contrôlé par l'Etat",
+        "dma ": "DMA contrôlé par l'Etat",
+        "bts": "BTS contrôlé par l'Etat",
+        "dut": "DUT contrôlé par l'Etat",
+        "dts": "DTS contrôlé par l'Etat",
+        "dcg ": "DCG contrôlé par l'Etat",
+        "deust": "DEUST contrôlé par l'Etat",
+        "etat-controle": "Diplôme d'Etat contrôlé",
+        "ingenieur": "Diplôme d'ingénieur contrôlé par l'Etat",
+        "license-grade": "Diplôme conférant le grade de licence contrôlé par l'Etat",
+        "master-grade": "Diplôme conférant le grade de master contrôlé par l'Etat",
+        "vise": "Diplôme visé contrôlé par l'Etat",
+        "classe-preparatoire": "Classe préparatoire contrôlée par l'Etat",
+        "other": "Autre"
+      },
+      "study-schemes": {
+        "initial-training": "Formation initiale hors apprentissage",
+        "training": "Apprentissage",
+        "continuous-training": "Formation continue",
+        "other": "Autre"
+      },
+      "unknown": "Non reconnu"
+    }
+  },
   "current-lang": "fr",
   "email-change-email": {
     "body": {

--- a/orga/app/services/notifications.js
+++ b/orga/app/services/notifications.js
@@ -10,10 +10,10 @@ export default class Notifications extends NotificationsService {
   }
 
   sendWarning(message) {
-    return this.warning(message, { autoClear: false, cssClasses: 'notification notification--warning' });
+    return this.warning(message, { autoClear: false, htmlContent: true, cssClasses: 'notification notification--warning' });
   }
 
   sendSuccess(message) {
-    return this.success(message, { autoClear: defaultAutoClear, cssClasses: 'notification notification--success' });
+    return this.success(message, { autoClear: defaultAutoClear, htmlContent: true, cssClasses: 'notification notification--success' });
   }
 }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -177,12 +177,16 @@ export default function() {
     }
   });
 
-  this.post('/organizations/:id/schooling-registrations/import-csv', (schema, request) => {
+  this.post('/organizations/:id/schooling-registrations/import-csv', async (schema, request) => {
     const type = request.requestBody.type;
 
     if (type === 'valid-file') {
       const organizationId = request.params.id;
       return schema.students.create({ organizationId: organizationId, firstName: 'Harry', lastName: 'Cover' });
+    } else if (type === 'valid-file-with-warnings') {
+      const organizationId = request.params.id;
+      await schema.students.create({ organizationId: organizationId, firstName: 'Harry', lastName: 'Cover' });
+      return Promise.resolve(new Response(200, {}, { data: { attributes: { warnings: [{ field: 'diploma', value: 'BAD', code: 'unknown' }] } } }));
     } else if (type === 'invalid-file') {
       return new Promise((resolve) => {
         resolve(new Response(412, {}, { errors: [ { status: '412', detail: 'Erreur d’import' } ] }));

--- a/orga/tests/acceptance/sup-student-list_test.js
+++ b/orga/tests/acceptance/sup-student-list_test.js
@@ -54,6 +54,23 @@ module('Acceptance | Sup Student List', function(hooks) {
         assert.contains('Harry');
       });
 
+      test('it should display warnings message and reload students', async function(assert) {
+        // given
+        await visit('/etudiants');
+
+        const file = new Blob(['foo'], { type: 'valid-file-with-warnings' });
+
+        // when
+        const input = find('#students-file-upload');
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.dom('[data-test-notification-message="warning"]').hasText('La liste a été importée avec succès.Cependant les valeurs suivantes n’ont pas été reconnues.Diplômes non reconnus : BAD; Elles ont été remplacées par “Non reconnu”. Si vous considérez qu’il manque des valeurs dans la liste limitative, veuillez nous contacter à sup@pix.fr');
+        assert.dom('[aria-label="Étudiant"]').exists({ count: 1 });
+        assert.contains('Cover');
+        assert.contains('Harry');
+      });
+
       test('it should display an error message when import failed', async function(assert) {
         // given
         await visit('/etudiants');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -530,7 +530,12 @@
       "import": {
         "error-wrapper": "<div>Import has failed.<br/><strong>{message}</strong><br/> Please edit your file and try to import it again.</div>",
         "global-error": "<div>Import has failed.<br/>Please try again or contact us through <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">the help form</a></div>",
-        "global-success": "The list has been successfully imported."
+        "global-success": "The list has been successfully imported.",
+        "global-success-with-warnings": "<div>The list has been successfully imported.<br/><br/>However some values were not recognised:<br/>{warnings}<br/><br/>They have been replaced by \"Not recognised\". If you need other values, please contact us at <a href=\"mailto:sup@pix.fr\">sup@pix.fr</a></div>",
+        "warnings": {
+          "diploma": "Diplomas unknown: {diplomas}; ",
+          "study-scheme": "Study schemes unknown: {studySchemes}; "
+        }
       },
       "table": {
         "column": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -530,7 +530,12 @@
       "import": {
         "error-wrapper": "<div>Aucun étudiant n’a été importé.<br/><strong>{message}</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>",
         "global-error": "<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">le formulaire du centre d’aide</a></div>",
-        "global-success": "La liste a été importée avec succès."
+        "global-success": "La liste a été importée avec succès.",
+        "global-success-with-warnings": "<div>La liste a été importée avec succès.<br/><br/>Cependant les valeurs suivantes n’ont pas été reconnues.<br />{warnings}<br/><br/>Elles ont été remplacées par “Non reconnu”. Si vous considérez qu’il manque des valeurs dans la liste limitative, veuillez nous contacter à <a href=\"mailto:sup@pix.fr\">sup@pix.fr</a></div>",
+        "warnings": {
+          "diploma": "Diplômes non reconnus : {diplomas}; ",
+          "study-scheme": "Régimes non reconnus : {studySchemes}; "
+        }
       },
       "table": {
         "column": {


### PR DESCRIPTION
## :unicorn: Problème

Côté SUP, la facturation peut varier en fonction du diplôme et du régime d'un étudiant. Actuellement, lors de l'import, il n'y a aucun contrôle sur ces valeurs et on se retrouve avec de données incorrectes ou vides.

## :robot: Solution

Vérifier les valeurs de diplômes et régimes importées par rapport à des listes de valeurs pré-définie.
Si ces valeurs ne sont pas reconnues ou vides, mettre une valeur “non reconnu” en base de données.
A la fin de l’import, afficher un message indiquant les données non reconnues.

## :rainbow: Remarques

N/A

## :100: Pour tester

Se connecter avec `sup.admin@example.net`, aller sur l'onglet étudiant
Télécharger le template:
- Importer avec un étudiant diplome="Autre" et regime="Autre"
> Message: Importé avec succès
- Importer avec un étudiant diplome="toto" et regime="Autre"
> Message: Importé avec succès et warning sur le diplome
- Importer avec un étudiant diplome="Autre" et regime="toto"
> Message: Importé avec succès et warning sur le regime
- Importer avec un étudiant diplome="toto" et regime="toto"
> Message: Importé avec succès et warning sur le regime et le diplome