### PR TITLE
[TECH] Ajoute des logs de debug sur http agent

### DIFF
--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
+const logger = require('../logger');
 
 class HttpResponse {
   constructor({
@@ -15,10 +16,15 @@ class HttpResponse {
 
 module.exports = {
   async post({ url, payload, headers }) {
+    logger.debug(`Starting POST request to ${url}`);
+
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
       });
+
+      logger.debug(`End POST request to ${url} success: ${httpResponse.status}`);
+
       return new HttpResponse({
         code: httpResponse.status,
         data: httpResponse.data,
@@ -35,6 +41,8 @@ module.exports = {
         data = httpErr.message;
       }
 
+      logger.debug(`End POST request to ${url} error: ${code} ${data.toString()}`);
+
       return new HttpResponse({
         code,
         data,
@@ -43,9 +51,14 @@ module.exports = {
     }
   },
   async get({ url, payload, headers }) {
+    logger.debug(`Starting GET request to ${url}`);
+
     try {
       const config = { data: payload, headers };
       const httpResponse = await axios.get(url, config);
+
+      logger.debug(`End GET request to ${url} success: ${httpResponse.status}`);
+
       return new HttpResponse({
         code: httpResponse.status,
         data: httpResponse.data,
@@ -64,6 +77,8 @@ module.exports = {
         code = '500';
         data = null;
       }
+
+      logger.debug(`End GET request to ${url} error: ${code}`);
 
       return new HttpResponse({
         code,


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas de détails dans les logs sur les requêtes externes qui sont faites.

## :robot: Solution
Ajouter des logs de debug en début et fin de requête.

## :100: Pour tester
1. S'assurer que `LOG_LEVEL=debug`
2. Se connecter sur Pix admin
3. Dans l'onglet Outils, cliquer sur recharger le cache
4. Dans les logs doivent apparaitre des lignes similaire à:
```
{"name":"pix-api","hostname":"e780697f77a9","pid":32,"level":20,"msg":"Starting GET request to https://lcms.pix.fr/api/releases/latest","time":"2021-05-04T10:40:33.338Z","v":0}
{"name":"pix-api","hostname":"e780697f77a9","pid":32,"level":20,"msg":"End GET request to https://lcms.pix.fr/api/releases/latest success: 200","time":"2021-05-04T10:40:35.265Z","v":0}
```
