### PR TITLE
[TECH Documenter la configuration SAML.

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -226,5 +226,27 @@ LOG_ENABLED=true
 # default: none
 AUTH_SECRET=Change me!
 
+# SAML authentication - Identity provider (encrypted)
+#
+# If not provided, the SAML authentication will fail.
+#
+# presence: required
+# type: String
+# default: none
+# sample:{"metadata":"<EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata (...)
+SAML_IDP_CONFIG=
+
+
+# SAML authentication - Service provider (encrypted)
+#
+# If not provided, the SAML authentication will fail.
+#
+# presence: required
+# type: String
+# default: none
+# sample: {"metadata":"<EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metada (...)
+SAML_SP_CONFIG=
+
+
 # Allow email change in API
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -235,7 +235,7 @@ AUTH_SECRET=Change me!
 # type: String
 # default: none
 # sample:{"metadata":"<EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata (...)
-SAML_IDP_CONFIG=
+# SAML_IDP_CONFIG=
 
 
 # SAML authentication - Service provider (encrypted)
@@ -247,7 +247,7 @@ SAML_IDP_CONFIG=
 # type: String
 # default: none
 # sample: {"metadata":"<EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metada (...)
-SAML_SP_CONFIG=
+# SAML_SP_CONFIG=
 
 
 # Allow email change in API

--- a/api/sample.env
+++ b/api/sample.env
@@ -227,6 +227,7 @@ LOG_ENABLED=true
 AUTH_SECRET=Change me!
 
 # SAML authentication - Identity provider (encrypted)
+# If you need a local IDP, refer to https://github.com/1024pix/pix-saml-idp/blob/master/README.md
 #
 # If not provided, the SAML authentication will fail.
 #
@@ -238,6 +239,7 @@ SAML_IDP_CONFIG=
 
 
 # SAML authentication - Service provider (encrypted)
+# If you need a local IDP, refer to https://github.com/1024pix/pix-saml-idp/blob/master/README.md
 #
 # If not provided, the SAML authentication will fail.
 #


### PR DESCRIPTION
## :unicorn: Problème
L'authentification SAML est lue depuis 2 variables d'environnements, décrites uniquement dans le code
* `SAML_IDP_CONFIG`
* `SAML_SP_CONFIG`

## :robot: Solution
Les ajouter à la documentation, ici `sample.env`

## :100: Pour tester
Configurer un environnement local à partir du sample.env
