### PR TITLE
[BUGFIX] Problème de scroll au niveau du tableau dans Pix Orga (PIX-2536)

### DIFF
--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -56,6 +56,7 @@ tbody {
     font-size: 0.875rem;
     font-weight: 400;
     color: $grey-80;
+    position: relative;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Quand on allait dans le tableau des participants à une campagne, il y avait un grand espace en dessous.
L'attribut sr-only des étoiles (paliers) est placé en absolu, donc tout en bas. Plus on a de participations, plus il y a de sr-only, et donc ils se stackent en bas.

## :robot: Solution
Rajouter un attribut `position: relative` sur tous les td de l'application.

## :rainbow: Remarques


## :100: Pour tester
Aller voir la liste des participants d'une campagne dans Pix Orga. 
