### PR TITLE
[BUGFIX] Afficher correctement le détail d'un test de certification qui n'a pas été complété (PIX-2501)

### DIFF
--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -78,6 +78,10 @@ class CertificationAssessment {
     const challengeIds = _.map(certificationChallengesForBadge, 'challengeId');
     return _.filter(this.certificationAnswersByDate, ({ challengeId }) => _.includes(challengeIds, challengeId));
   }
+
+  isCompleted() {
+    return this.state === states.COMPLETED;
+  }
 }
 
 CertificationAssessment.states = states;

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -1,9 +1,13 @@
 const Joi = require('joi')
   .extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
-const { states } = require('./Assessment');
 const _ = require('lodash');
 const { ChallengeToBeNeutralizedNotFoundError, ChallengeToBeDeneutralizedNotFoundError } = require('../errors');
+
+const states = {
+  COMPLETED: 'completed',
+  STARTED: 'started',
+};
 
 const certificationAssessmentSchema = Joi.object({
   id: Joi.number().integer().required(),
@@ -11,7 +15,7 @@ const certificationAssessmentSchema = Joi.object({
   certificationCourseId: Joi.number().integer().required(),
   createdAt: Joi.date().required(),
   completedAt: Joi.date().allow(null),
-  state: Joi.string().valid(states.COMPLETED, states.STARTED, states.ABORTED).required(),
+  state: Joi.string().valid(states.COMPLETED, states.STARTED).required(),
   isV2Certification: Joi.boolean().required(),
   certificationChallenges: Joi.array().min(1).required(),
   certificationAnswersByDate: Joi.array().min(0).required(),

--- a/api/lib/domain/usecases/get-certification-details.js
+++ b/api/lib/domain/usecases/get-certification-details.js
@@ -1,13 +1,39 @@
 const CertificationDetails = require('../read-models/CertificationDetails');
+const CertificationAssessmentStates = require('../models/CertificationAssessment').states;
 
 module.exports = async function getCertificationDetails({
   certificationCourseId,
   competenceMarkRepository,
   certificationAssessmentRepository,
   placementProfileService,
+  certificationService,
 }) {
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId });
+  if (certificationAssessment.state === CertificationAssessmentStates.STARTED) {
+    return _computeCertificationDetailsOnTheFly(
+      certificationCourseId,
+      certificationService,
+    );
+  } else {
+    return _retrievePersistedCertificationDetails(
+      certificationCourseId,
+      certificationAssessment,
+      competenceMarkRepository,
+      placementProfileService,
+    );
+  }
+};
 
+async function _computeCertificationDetailsOnTheFly(certificationCourseId, certificationService) {
+  const certificationResult = await certificationService.calculateCertificationResultByCertificationCourseId(certificationCourseId);
+  return new CertificationDetails(
+    {
+      id: certificationCourseId,
+      ...certificationResult,
+    });
+}
+
+async function _retrievePersistedCertificationDetails(certificationCourseId, certificationAssessment, competenceMarkRepository, placementProfileService) {
   const competenceMarks = await competenceMarkRepository.findByCertificationCourseId(certificationCourseId);
 
   const placementProfile = await placementProfileService.getPlacementProfile({
@@ -21,4 +47,4 @@ module.exports = async function getCertificationDetails({
     certificationAssessment,
     placementProfile,
   });
-};
+}

--- a/api/lib/domain/usecases/get-certification-details.js
+++ b/api/lib/domain/usecases/get-certification-details.js
@@ -1,5 +1,4 @@
 const CertificationDetails = require('../read-models/CertificationDetails');
-const CertificationAssessmentStates = require('../models/CertificationAssessment').states;
 
 module.exports = async function getCertificationDetails({
   certificationCourseId,
@@ -9,17 +8,17 @@ module.exports = async function getCertificationDetails({
   certificationService,
 }) {
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId });
-  if (certificationAssessment.state === CertificationAssessmentStates.STARTED) {
-    return _computeCertificationDetailsOnTheFly(
-      certificationCourseId,
-      certificationService,
-    );
-  } else {
+  if (certificationAssessment.isCompleted()) {
     return _retrievePersistedCertificationDetails(
       certificationCourseId,
       certificationAssessment,
       competenceMarkRepository,
       placementProfileService,
+    );
+  } else {
+    return _computeCertificationDetailsOnTheFly(
+      certificationCourseId,
+      certificationService,
     );
   }
 };

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -65,9 +65,9 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       });
     });
 
-    it('should throw an ObjectValidationError when status is of unknown value', () => {
+    it('should throw an ObjectValidationError when status is not one of [completed, started]', () => {
       // when
-      expect(() => new CertificationAssessment({ ...validArguments, state: 'aaa' }))
+      expect(() => new CertificationAssessment({ ...validArguments, state: 'aborted' }))
         .to.throw(ObjectValidationError);
     });
 

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -326,4 +326,24 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       expect(answersByCertifiableBadgeKey).to.be.empty;
     });
   });
+
+  describe('#isCompleted', () => {
+    it('returns true when completed', () => {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        state: CertificationAssessment.states.COMPLETED,
+      });
+      // when / then
+      expect(certificationAssessment.isCompleted()).to.be.true;
+    });
+
+    it('returns false when only started', () => {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        state: CertificationAssessment.states.STARTED,
+      });
+      // when / then
+      expect(certificationAssessment.isCompleted()).to.be.false;
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-details_test.js
@@ -1,6 +1,7 @@
 const { sinon, expect, domainBuilder } = require('../../../test-helper');
 const getCertificationDetails = require('../../../../lib/domain/usecases/get-certification-details');
 const CertificationDetails = require('../../../../lib/domain/read-models/CertificationDetails');
+const CertificationAssessmentStates = require('../../../../lib/domain/models/CertificationAssessment').states;
 
 describe('Unit | UseCase | get-certification-details', () => {
 
@@ -16,82 +17,162 @@ describe('Unit | UseCase | get-certification-details', () => {
     findByCertificationCourseId: sinon.stub(),
   };
 
-  it('should return the certification details', async () => {
-    // given
-    const certificationCourseId = 1234;
-    const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: false });
-    const answer = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
+  const certificationService = {
+    calculateCertificationResultByCertificationCourseId: sinon.stub(),
+  };
 
-    const certificationAssessment = domainBuilder.buildCertificationAssessment({
-      certificationCourseId,
-      certificationChallenges: [certificationChallenge],
-      certificationAnswersByDate: [answer],
+  context('the certification assessment has not been completed', () => {
+    it('should compute the certification details on the fly', async () => {
+      // given
+      const certificationCourseId = 1234;
+      const certificationChallenge = domainBuilder.buildCertificationChallenge({
+        challengeId: 'rec123',
+        competenceId: 'recComp1',
+        associatedSkillName: 'manger une mangue',
+        isNeutralized: false,
+      });
+      const answer = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId,
+        certificationChallenges: [certificationChallenge],
+        certificationAnswersByDate: [answer],
+        state: CertificationAssessmentStates.STARTED,
+      });
+
+      certificationAssessmentRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId })
+        .resolves(certificationAssessment);
+
+      const certificationResult = {
+        competencesWithMark: [
+          {
+            areaCode: '1',
+            id: 'recComp1',
+            index: '1.1',
+            name: 'Manger des fruits',
+            obtainedLevel: 1,
+            obtainedScore: 5,
+            positionedLevel: 3,
+            positionedScore: 45,
+          },
+        ],
+        createdAt: certificationAssessment.createdAt,
+        completedAt: certificationAssessment.completedAt,
+        listChallengesAndAnswers: [
+          {
+            challengeId: 'rec123',
+            competence: '1.1',
+            isNeutralized: false,
+            result: 'ok',
+            skill: 'manger une mangue',
+            value: 'prout',
+          },
+        ],
+        percentageCorrectAnswers: 100,
+        status: 'started',
+        totalScore: 5,
+        userId: 123,
+      };
+
+      certificationService.calculateCertificationResultByCertificationCourseId.withArgs(certificationCourseId).resolves(
+        certificationResult,
+      );
+
+      // when
+      const result = await getCertificationDetails({
+        certificationCourseId,
+        placementProfileService,
+        competenceMarkRepository,
+        certificationAssessmentRepository,
+        certificationService,
+      });
+
+      //then
+      expect(result).to.be.an.instanceof(CertificationDetails);
+      expect(result).to.deep.equal({ ...certificationResult, id: certificationCourseId });
     });
+  });
 
-    const competenceMark = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
-    const competenceMarks = [competenceMark];
-    const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
-      competencesData: [
-        { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
-      ],
-    });
+  context('the certification assessment has been completed', () => {
+    it('should return the certification details', async () => {
+      // given
+      const certificationCourseId = 1234;
+      const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: false });
+      const answer = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
 
-    certificationAssessmentRepository.getByCertificationCourseId
-      .withArgs({ certificationCourseId })
-      .resolves(certificationAssessment);
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId,
+        certificationChallenges: [certificationChallenge],
+        certificationAnswersByDate: [answer],
+        state: CertificationAssessmentStates.COMPLETED,
+      });
 
-    placementProfileService.getPlacementProfile
-      .withArgs({
-        userId: certificationAssessment.userId,
-        limitDate: certificationAssessment.createdAt,
-        isV2Certification: certificationAssessment.isV2Certification,
-      })
-      .resolves(placementProfile);
+      const competenceMark = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
+      const competenceMarks = [competenceMark];
+      const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
+        competencesData: [
+          { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
+        ],
+      });
 
-    competenceMarkRepository.findByCertificationCourseId
-      .withArgs(certificationCourseId)
-      .resolves(competenceMarks);
+      certificationAssessmentRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId })
+        .resolves(certificationAssessment);
 
-    // when
-    const result = await getCertificationDetails({
-      certificationCourseId,
-      placementProfileService,
-      competenceMarkRepository,
-      certificationAssessmentRepository,
-    });
+      placementProfileService.getPlacementProfile
+        .withArgs({
+          userId: certificationAssessment.userId,
+          limitDate: certificationAssessment.createdAt,
+          isV2Certification: certificationAssessment.isV2Certification,
+        })
+        .resolves(placementProfile);
 
-    //then
-    expect(result).to.be.an.instanceof(CertificationDetails);
-    expect(result).to.deep.equal({
-      competencesWithMark: [
-        {
-          areaCode: '1',
-          id: 'recComp1',
-          index: '1.1',
-          name: 'Manger des fruits',
-          obtainedLevel: 1,
-          obtainedScore: 5,
-          positionedLevel: 3,
-          positionedScore: 45,
-        },
-      ],
-      createdAt: certificationAssessment.createdAt,
-      completedAt: certificationAssessment.completedAt,
-      id: certificationAssessment.certificationCourseId,
-      listChallengesAndAnswers: [
-        {
-          challengeId: 'rec123',
-          competence: '1.1',
-          isNeutralized: false,
-          result: 'ok',
-          skill: 'manger une mangue',
-          value: 'prout',
-        },
-      ],
-      percentageCorrectAnswers: 100,
-      status: 'started',
-      totalScore: 5,
-      userId: 123,
+      competenceMarkRepository.findByCertificationCourseId
+        .withArgs(certificationCourseId)
+        .resolves(competenceMarks);
+
+      // when
+      const result = await getCertificationDetails({
+        certificationCourseId,
+        placementProfileService,
+        competenceMarkRepository,
+        certificationAssessmentRepository,
+      });
+
+      //then
+      expect(result).to.be.an.instanceof(CertificationDetails);
+      expect(result).to.deep.equal({
+        competencesWithMark: [
+          {
+            areaCode: '1',
+            id: 'recComp1',
+            index: '1.1',
+            name: 'Manger des fruits',
+            obtainedLevel: 1,
+            obtainedScore: 5,
+            positionedLevel: 3,
+            positionedScore: 45,
+          },
+        ],
+        createdAt: certificationAssessment.createdAt,
+        completedAt: certificationAssessment.completedAt,
+        id: certificationAssessment.certificationCourseId,
+        listChallengesAndAnswers: [
+          {
+            challengeId: 'rec123',
+            competence: '1.1',
+            isNeutralized: false,
+            result: 'ok',
+            skill: 'manger une mangue',
+            value: 'prout',
+          },
+        ],
+        percentageCorrectAnswers: 100,
+        status: 'completed',
+        totalScore: 5,
+        userId: 123,
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Suite à #2781 l'affichage du détail d'une certification dans Pix-Admin utilise les résultats déjà calculés et persistés en base de données (plutôt que de les recalculer à la volée à chaque fois). Or dans le cas d'un test de certification qui n'aurait pas été jusqu'au bout (ex. le candidat a quitté la session, un problème technique est survenu), le calcul des résultats n'a pas eu lieu, il n'y a donc aucune données persistée en base à afficher.  

## :robot: Solution
Si et seulement si le test de certification n'a pas été jusqu'au bout, calculer les résultats de certification à la volée.

## :rainbow: Remarques
Avant cette PR il était possible de créer dans le code un `CertificationAssessment` au statut `ABORTED` alors que ce statut n'est possible dans la réalité que pour les `Assessments` appartenant à une campagne. Cette possibilité a été supprimée.

## :100: Pour tester
- Mettre le feature toggle `FT_IS_NEUTRALIZATION_AUTO_ENABLED` à `false`
- Aller dans Pix Certification
- Créer une session de certification
- Ajouter un candidat
- Aller dans Mon-Pix
- Rejoindre la session (ne répondre à aucune question)
- Aller dans Pix-Admin
- Afficher le détail de la certification (celle-ci est au statut démarrée) 
- Prendre une capture d'écran (ou se souvenir de ce qui est affiché)
- Mettre le feature toggle `FT_IS_NEUTRALIZATION_AUTO_ENABLED` à `true`
- Se déconnecter / reconnecter à Pix-Admin
- Afficher le détail de la certification
- Constater que l'affichage est identique à l'affichage avec le toggle à `false`
