### PR TITLE
[TECH] On s'assure que un slash final dans la configuration de l'url de LCMS ne fait rien casser

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -29,6 +29,10 @@ function _getDate(dateAsString) {
   return dateAsMoment.toDate();
 }
 
+function _removeTrailingSlashFromUrl(url) {
+  return url.replace(/\/$/, '');
+}
+
 module.exports = (function() {
 
   const config = {
@@ -51,7 +55,7 @@ module.exports = (function() {
     },
 
     lcms: {
-      url: process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL,
+      url: _removeTrailingSlashFromUrl(process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL),
       apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
     },
 


### PR DESCRIPTION
## :unicorn: Problème
Si dans la config de l'url de l'api de LCMS on rajoute un slash final, alors la requête pour recharger le cache ne fonctionne pas. C'est pô cool.

## :robot: Solution
Au chargement de la configuration, on supprime tout slash final inutile. Et ça c'est cool.

## :100: Pour tester
1. Modifier son `.env` et rajouter un slash final a `LCMS_API_URL`. Par exemple `LCMS_API_URL=https://lcms.pix.fr/api/`
2. Redémarrer l'API
3. Se connecter à pix-admin
4. Aller sur la page outils
5. Cliquer sur le bouton recharger le cache
6. Vérifier les logs de l'api pour ne pas voir 
```
Error while reloading cache TypeError: Cannot read property 'length' of undefined\n    at RedisCache.set (/pix/api/lib/infrastructure/caches/RedisCache.js:56:47)
```
7. Bien vérifier que la ligne en question n'apparait pas
8. :tada: 

