### PR TITLE
[FEATURE] Ajout de sous-catégories de support pour les embed (PIX-2436).

### DIFF
--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -149,6 +149,9 @@ export default class FeedbackPanel extends Component {
       this.quickHelpInstructions = category.content;
     } else if (category.type === 'textbox') {
       this.displayTextBox = true;
+    } else if (category.type === 'tutorialAndTextbox') {
+      this.quickHelpInstructions = category.content;
+      this.displayTextBox = true;
     }
   }
 

--- a/mon-pix/app/static-data/feedback-panel-issue-labels.js
+++ b/mon-pix/app/static-data/feedback-panel-issue-labels.js
@@ -83,6 +83,16 @@ const questions = {
       name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-other',
       type: 'textbox',
     },
+    {
+      name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-displayed-on-desktop-with-problems.label',
+      type: 'tutorialAndTextbox',
+      content: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-displayed-on-desktop-with-problems.solution',
+    },
+    {
+      name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-displayed-on-mobile-devices-with-problems.label',
+      type: 'tutorialAndTextbox',
+      content: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-displayed-on-mobile-devices-with-problems.solution',
+    },
   ],
   'download': [
     {

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -26,14 +26,14 @@
             <form class="feedback-panel__form" {{on "submit" this.sendFeedback}}>
               <div class="feedback-panel__group">
                 <div class="feedback-panel__category-selection">
-                  <select class="feedback-panel__dropdown" {{on "change" this.displayCategoryOptions}} aria-label={{t 'pages.challenge.feedback-panel.form.fields.detail-selection.aria-first'}}>
+                  <select class="feedback-panel__dropdown" {{on "change" this.displayCategoryOptions}} aria-label={{t 'pages.challenge.feedback-panel.form.fields.detail-selection.aria-first'}} data-test-feedback-category-dropdown>
                     <option value="" disabled selected>{{t 'pages.challenge.feedback-panel.form.fields.category-selection.label'}}</option>
                     {{#each this.categories as |category|}}
                       <option value={{category.value}}>{{t category.name}}</option>
                     {{/each}}
                   </select>
                   {{#if this.displayQuestionDropdown}}
-                    <select class="feedback-panel__dropdown" {{on "change" this.showFeedback}} aria-label={{t 'pages.challenge.feedback-panel.form.fields.detail-selection.aria-secondary'}}>
+                    <select class="feedback-panel__dropdown" {{on "change" this.showFeedback}} aria-label={{t 'pages.challenge.feedback-panel.form.fields.detail-selection.aria-secondary'}} data-test-feedback-subcategory-dropdown>
                       <option value="default" selected>{{t 'pages.challenge.feedback-panel.form.fields.detail-selection.label'}}</option>
                         {{#each this.nextCategory as |question index|}}
                           <option value={{index}}>{{t question.name}}</option>

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -18,14 +18,16 @@ const BUTTON_SEND = '.feedback-panel__button--send';
 
 const TEXTAREA = 'textarea.feedback-panel__field--content';
 const DROPDOWN = '.feedback-panel__dropdown';
-const TUTORIAL_AREA = '.feedback-panel__tutorial-content';
+const TUTORIAL_AREA = '.feedback-panel__quick-help';
 
-const PICK_CATEGORY_WITH_NESTED_LEVEL = 'question';
-const PICK_CATEGORY_WITH_TEXTAREA = 'accessibility';
-const PICK_CATEGORY_WITH_TUTORIAL = 'picture';
+const PICK_SELECT_OPTION_WITH_NESTED_LEVEL = 'question';
+const PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL = 'embed';
+const PICK_SELECT_OPTION_WITH_TEXTAREA = 'accessibility';
+const PICK_SELECT_OPTION_WITH_TUTORIAL = 'picture';
+const PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL = '3';
 
 async function setContent(content) {
-  await fillIn(DROPDOWN, PICK_CATEGORY_WITH_TEXTAREA);
+  await fillIn(DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
   await fillIn(TEXTAREA, content);
   await blur(TEXTAREA);
 }
@@ -77,7 +79,7 @@ describe('Integration | Component | feedback-panel', function() {
     context('when selecting a category', function() {
       it('should display a second dropdown with the list of questions when category have a nested level', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_NESTED_LEVEL);
+        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(2);
@@ -87,7 +89,7 @@ describe('Integration | Component | feedback-panel', function() {
 
       it('should directly display the message box and the submit button when category has a textarea', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_TEXTAREA);
+        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
@@ -96,7 +98,7 @@ describe('Integration | Component | feedback-panel', function() {
 
       it('should directly display the tuto without the textbox nor the send button when category has a tutorial', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_TUTORIAL);
+        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TUTORIAL);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(2);
@@ -106,8 +108,8 @@ describe('Integration | Component | feedback-panel', function() {
 
       it('should show the correct feedback action when selecting two different categories', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_TUTORIAL);
-        await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_TEXTAREA);
+        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TUTORIAL);
+        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
@@ -118,14 +120,29 @@ describe('Integration | Component | feedback-panel', function() {
 
       it('should hide the second dropdown when category has fewer levels after a deeper category', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_NESTED_LEVEL);
-        await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_TEXTAREA);
+        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
+        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
         expect(find(TUTORIAL_AREA)).to.not.exist;
         expect(find(BUTTON_SEND)).to.exist;
         expect(find(TEXTAREA)).to.exist;
+      });
+
+      it('should display tutorial with textarea with selecting related category and subcategory', async function() {
+        // when
+        const categoryDropdown = find('select[data-test-feedback-category-dropdown]');
+        await fillIn(categoryDropdown, PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL);
+
+        const subcategoryDropdown = find('select[data-test-feedback-subcategory-dropdown]');
+        await fillIn(subcategoryDropdown, PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL);
+
+        // then
+        expect(findAll(DROPDOWN).length).to.equal(2);
+        expect(find(TUTORIAL_AREA)).to.exist;
+        expect(find(TEXTAREA)).to.exist;
+        expect(find(BUTTON_SEND)).to.exist;
       });
     });
   });
@@ -237,7 +254,7 @@ describe('Integration | Component | feedback-panel', function() {
 
     it('should display error if "content" is empty', async function() {
       // given
-      await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_TEXTAREA);
+      await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TEXTAREA);
 
       // when
       await click(BUTTON_SEND);

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -18,6 +18,8 @@ const BUTTON_SEND = '.feedback-panel__button--send';
 
 const TEXTAREA = 'textarea.feedback-panel__field--content';
 const DROPDOWN = '.feedback-panel__dropdown';
+const CATEGORY_DROPDOWN = 'select[data-test-feedback-category-dropdown]';
+const SUBCATEGORY_DROPDOWN = 'select[data-test-feedback-subcategory-dropdown]';
 const TUTORIAL_AREA = '.feedback-panel__quick-help';
 
 const PICK_SELECT_OPTION_WITH_NESTED_LEVEL = 'question';
@@ -79,7 +81,7 @@ describe('Integration | Component | feedback-panel', function() {
     context('when selecting a category', function() {
       it('should display a second dropdown with the list of questions when category have a nested level', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
+        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(2);
@@ -89,16 +91,17 @@ describe('Integration | Component | feedback-panel', function() {
 
       it('should directly display the message box and the submit button when category has a textarea', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TEXTAREA);
+        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
+        expect(find(TEXTAREA)).to.exist;
         expect(findAll(BUTTON_SEND).length).to.equal(1);
       });
 
-      it('should directly display the tuto without the textbox nor the send button when category has a tutorial', async function() {
+      it('should directly display the tuto without the textbox or the send button when category has a tutorial', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TUTORIAL);
+        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TUTORIAL);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(2);
@@ -108,8 +111,8 @@ describe('Integration | Component | feedback-panel', function() {
 
       it('should show the correct feedback action when selecting two different categories', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TUTORIAL);
-        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TEXTAREA);
+        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TUTORIAL);
+        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
@@ -120,8 +123,8 @@ describe('Integration | Component | feedback-panel', function() {
 
       it('should hide the second dropdown when category has fewer levels after a deeper category', async function() {
         // when
-        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
-        await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TEXTAREA);
+        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
+        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
@@ -132,11 +135,9 @@ describe('Integration | Component | feedback-panel', function() {
 
       it('should display tutorial with textarea with selecting related category and subcategory', async function() {
         // when
-        const categoryDropdown = find('select[data-test-feedback-category-dropdown]');
-        await fillIn(categoryDropdown, PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL);
+        await fillIn(CATEGORY_DROPDOWN, PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL);
 
-        const subcategoryDropdown = find('select[data-test-feedback-subcategory-dropdown]');
-        await fillIn(subcategoryDropdown, PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL);
+        await fillIn(SUBCATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL);
 
         // then
         expect(findAll(DROPDOWN).length).to.equal(2);
@@ -254,7 +255,7 @@ describe('Integration | Component | feedback-panel', function() {
 
     it('should display error if "content" is empty', async function() {
       // given
-      await fillIn('.feedback-panel__dropdown', PICK_SELECT_OPTION_WITH_TEXTAREA);
+      await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
       // when
       await click(BUTTON_SEND);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -374,6 +374,14 @@
                   },
                   "other": "I have another problem with the file"
                 },
+                "embed-displayed-on-desktop-with-problems": {
+                    "label": "On a computer, the simulator is displayed but has a problem",
+                    "solution": "We are doing our best to make the simulators work on all devices, all operating systems, and all browsers but you may be using a specific system.'<br>'You can stop your test and resume on a computer. Please specify your problem, as well as your browser and your operating system."
+                },
+                "embed-displayed-on-mobile-devices-with-problems": {
+                    "label": "On a smartphone or a tablet, the simulator is displayed but has a problem",
+                    "solution": "We are doing our best to make the simulators work on all devices, all operating systems, and all browsers but you may be using a specific system.'<br>'Please specify your problem, as well as your type of device (smartphone, tablet etc.), your browser and your operating system."
+                },
                 "embed-not-displayed": {
                   "label": "I cannot see the simulator/app",
                   "solution": "Your internet connection may not be strong enough.'<br>'Refresh the page by clicking on the refresh button'<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' next to the address bar. Wait a little while, the simulator might display. '<br><br>'If it doesn’t, you can try again later or from another location with a better connection."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -374,6 +374,14 @@
                   },
                   "other": "J’ai un autre problème avec le fichier"
                 },
+                "embed-displayed-on-desktop-with-problems": {
+                  "label": "Sur ordinateur, le simulateur s'affiche mais a un problème",
+                  "solution": "Nous faisons notre possible pour que les simulateurs fonctionnent sur tous les appareils, tous les OS et tous les navigateurs mais il se peut que vous utilisiez un système particulier. Vous pouvez arrêter là et reprendre sur un ordinateur.'<br>'Précisez votre problème en indiquant votre navigateur et votre système d'exploitation."
+                },
+                "embed-displayed-on-mobile-devices-with-problems": {
+                    "label": "Sur téléphone ou tablette, le simulateur s'affiche mais a un problème",
+                    "solution": "Nous faisons notre possible pour que les simulateurs fonctionnent sur tous les appareils, tous les OS et tous les navigateurs mais il se peut que vous utilisiez un système particulier.'<br>'Précisez votre problème en indiquant votre type d'appareil (smartphone, tablette...), votre système d'exploitation et votre navigateur."
+                },
                 "embed-not-displayed": {
                   "label": "Le simulateur / l’application ne s’affiche pas",
                   "solution": "Votre connexion internet est peut-être trop faible.'<br>'Rechargez la page en appuyant sur le bouton actualiser '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' à côté de la barre d’adresse. Attendez un peu, le simulateur va peut-être s’afficher. '<br><br>'Si ce n’est pas le cas, pouvez-vous retenter à un autre moment ou depuis un autre endroit avec une meilleure connexion ?"


### PR DESCRIPTION
## :unicorn: Problème

Il manque aux utilisateurs la possibilité de contacter le support  pour des problèmes liés aux simulateurs dans les cas suivants :

- Difficulté d'affichage sur desktop
- Difficulté d'affichage sur écrans mobiles (téléphone/tablette)

## :robot: Solution

Ajout de nouvelles sous-catégories répondant à cette problématique.
Ces nouvelles sous-catégories sont constituées d'une partie `tutoriel` et d'un `textarea`.

## :rainbow: Remarques
N/A

## :100: Pour tester

Lors d'une épreuve, aller sur : 
- Signaler un problème
- Le simulateur / l'application
- Choisir les deux dernières options.

Pour chacune des options, vérifier la présence de la partie tutoriel et du textarea et du bon fonctionnement de ce dernier lors de l'envoi en DB.
