### PR TITLE
[FEATURE] Afficher le block "repasser" pour une campagne de collecte de profils à envois multiples (PIX-2537).

### DIFF
--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -25,6 +25,7 @@ class Campaign {
     customResultPageText,
     customResultPageButtonText,
     customResultPageButtonUrl,
+    multipleSendings,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -44,7 +45,7 @@ class Campaign {
     this.customResultPageText = customResultPageText;
     this.customResultPageButtonText = customResultPageButtonText;
     this.customResultPageButtonUrl = customResultPageButtonUrl;
-
+    this.multipleSendings = multipleSendings;
   }
 
   get organizationId() {

--- a/api/lib/domain/models/SharedProfileForCampaign.js
+++ b/api/lib/domain/models/SharedProfileForCampaign.js
@@ -1,15 +1,19 @@
 const _ = require('lodash');
+const moment = require('moment');
+const constants = require('../constants');
 
 class SharedProfileForCampaign {
   constructor({
     id,
     sharedAt,
+    campaignAllowsRetry,
     scorecards = [],
   }) {
     this.id = id;
     this.sharedAt = sharedAt;
     this.scorecards = scorecards;
     this.pixScore = _.sumBy(this.scorecards, 'earnedPix') || 0;
+    this.canRetry = campaignAllowsRetry && moment().diff(this.sharedAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
   }
 }
 

--- a/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
+++ b/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
@@ -8,6 +8,7 @@ module.exports = async function getUserProfileSharedForCampaign({
   userId,
   campaignId,
   campaignParticipationRepository,
+  campaignRepository,
   knowledgeElementRepository,
   competenceRepository,
 }) {
@@ -17,6 +18,7 @@ module.exports = async function getUserProfileSharedForCampaign({
     throw new NoCampaignParticipationForUserAndCampaign();
   }
 
+  const { multipleSendings: campaignAllowsRetry } = await campaignRepository.get(campaignId);
   const [knowledgeElementsGroupedByCompetenceId, competencesWithArea] = await Promise.all([
     knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId, limitDate: campaignParticipation.sharedAt }),
     competenceRepository.listPixCompetencesOnly(),
@@ -36,6 +38,7 @@ module.exports = async function getUserProfileSharedForCampaign({
   return new SharedProfileForCampaign({
     id: campaignParticipation.id,
     sharedAt: campaignParticipation.sharedAt,
+    campaignAllowsRetry,
     scorecards,
   });
 };

--- a/api/lib/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js
@@ -17,6 +17,7 @@ module.exports = {
         'pixScore',
         'sharedAt',
         'scorecards',
+        'canRetry',
       ],
       scorecards: {
         ref: 'id',

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -74,6 +74,7 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
             'attributes': {
               'pix-score': 2,
               'shared-at': sharedAt,
+              'can-retry': false,
             },
             'relationships': {
               'scorecards': {

--- a/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
@@ -1,0 +1,70 @@
+const { expect, sinon } = require('../../../test-helper');
+const constants = require('../../../../lib/domain/constants');
+const SharedProfileForCampaign = require('../../../../lib/domain/models/SharedProfileForCampaign');
+
+describe('Unit | Domain | Models | SharedProfileForCampaign', () => {
+  let clock;
+  afterEach(() => {
+    clock.restore();
+  });
+
+  describe('#canRetry', () => {
+    context('when the campaign allows retry', () => {
+      context('when the profile has been shared MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', () => {
+        beforeEach(() => {
+          constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 5;
+          const now = new Date('2020-01-06');
+          clock = sinon.useFakeTimers(now);
+        });
+
+        it('return true', () => {
+          const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, scorecards: [], sharedAt: new Date('2020-01-01') });
+
+          expect(sharedProfileForCampaign.canRetry).to.equal(true);
+        });
+      });
+
+      context('when the profile has been shared less than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', () => {
+        beforeEach(() => {
+          constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 5;
+          const now = new Date('2020-01-06');
+          clock = sinon.useFakeTimers(now);
+        });
+
+        it('return false', () => {
+          const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, scorecards: [], sharedAt: new Date('2020-01-04') });
+
+          expect(sharedProfileForCampaign.canRetry).to.equal(false);
+        });
+      });
+
+      context('when the profile has been shared more than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', () => {
+        beforeEach(() => {
+          constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 5;
+          const now = new Date('2020-01-09');
+          clock = sinon.useFakeTimers(now);
+        });
+
+        it('return true', () => {
+          const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, scorecards: [], sharedAt: new Date('2020-01-02') });
+
+          expect(sharedProfileForCampaign.canRetry).to.equal(true);
+        });
+      });
+    });
+
+    context('when the campaign does not allow retry', () => {
+      beforeEach(() => {
+        constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 5;
+        const now = new Date('2020-01-06');
+        clock = sinon.useFakeTimers(now);
+      });
+
+      it('return false', () => {
+        const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: false, scorecards: [], sharedAt: new Date('2020-01-01') });
+
+        expect(sharedProfileForCampaign.canRetry).to.equal(false);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -148,9 +148,9 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', (
   describe('#canRetry', () => {
     const now = new Date('2020-01-05T05:06:07Z');
     let clock;
-    constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 3;
 
     beforeEach(() => {
+      constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 3;
       clock = sinon.useFakeTimers(now);
     });
 

--- a/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
@@ -12,6 +12,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
   let campaignParticipationRepository;
   let knowledgeElementRepository;
   let competenceRepository;
+  let campaignRepository;
 
   context('When user has shared its profile for the campaign', () => {
 
@@ -19,6 +20,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
       campaignParticipationRepository = { findOneByCampaignIdAndUserId: sinon.stub() };
       knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
       competenceRepository = { listPixCompetencesOnly: sinon.stub() };
+      campaignRepository = { get: sinon.stub() };
       sinon.stub(Scorecard, 'buildFrom');
     });
 
@@ -29,10 +31,12 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
     it('should return the shared profile for campaign', async () => {
       const knowledgeElements = { 'competence1': [], 'competence2': [] };
       const competences = [{ id: 'competence1' }, { id: 'competence2' }];
+      const campaign = { multipleSendings: false };
       // given
       campaignParticipationRepository.findOneByCampaignIdAndUserId.withArgs({ userId, campaignId }).resolves(expectedCampaignParticipation);
       knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.withArgs({ userId, limitDate: sharedAt }).resolves(knowledgeElements);
       competenceRepository.listPixCompetencesOnly.resolves(competences);
+      campaignRepository.get.withArgs(campaignId).resolves(campaign);
       Scorecard
         .buildFrom
         .withArgs({ userId, knowledgeElements: knowledgeElements['competence1'], competence: competences[0] })
@@ -49,6 +53,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
         campaignParticipationRepository,
         knowledgeElementRepository,
         competenceRepository,
+        campaignRepository,
       });
 
       // then
@@ -56,6 +61,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
         id: '1',
         sharedAt,
         pixScore: 15,
+        canRetry: false,
         scorecards: [
           { id: 'Score1', earnedPix: 10 },
           { id: 'Score2', earnedPix: 5 },
@@ -76,6 +82,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
         campaignParticipationRepository,
         knowledgeElementRepository,
         competenceRepository,
+        campaignRepository,
       });
 
       // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -1,8 +1,20 @@
-const { expect, domainBuilder } = require('../../../../test-helper');
+const { expect, domainBuilder, sinon } = require('../../../../test-helper');
 const SharedProfileForCampaign = require('../../../../../lib/domain/models/SharedProfileForCampaign');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer');
+const constants = require('../../../../../lib/domain/constants');
 
 describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer', () => {
+  let clock;
+  afterEach(() => {
+    clock.restore();
+  });
+
+  beforeEach(() => {
+    constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 1;
+    const now = new Date('2020-01-02');
+    clock = sinon.useFakeTimers(now);
+  });
+
   describe('#serialize()', () => {
     const area1 = {
       id: '1',
@@ -24,6 +36,7 @@ describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer',
     const profileSharedForCampaign = new SharedProfileForCampaign({
       id: '1',
       sharedAt: new Date('2020-01-01'),
+      campaignAllowsRetry: true,
       scorecards: expectedScorecards,
     });
 
@@ -34,6 +47,7 @@ describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer',
         attributes: {
           'pix-score': profileSharedForCampaign.pixScore,
           'shared-at': profileSharedForCampaign.sharedAt,
+          'can-retry': true,
         },
         relationships: {
           scorecards: {

--- a/mon-pix/app/models/shared-profile-for-campaign.js
+++ b/mon-pix/app/models/shared-profile-for-campaign.js
@@ -6,6 +6,7 @@ import { computed } from '@ember/object';
 export default class SharedProfileForCampaign extends Model {
   @attr('number') pixScore;
   @attr('date') sharedAt;
+  @attr('boolean') canRetry;
   @hasMany('scorecard') scorecards;
 
   @computed('scorecards.@each.area')

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -119,6 +119,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'pages/login-or-register-to-access-restricted-campaign';
 @import 'pages/not-connected';
 @import 'pages/profile';
+@import 'pages/profile-already-shared';
 @import 'pages/send-profile';
 @import 'pages/sign-form';
 @import 'pages/skill-review';

--- a/mon-pix/app/styles/pages/_profile-already-shared.scss
+++ b/mon-pix/app/styles/pages/_profile-already-shared.scss
@@ -1,0 +1,21 @@
+.profile-already-shared-retry {
+  border-top: 1px dashed $grey-22;
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  margin-top: 40px;
+  padding-bottom: 20px;
+  padding-top: 20px;
+
+  &__message {
+    font-size: 1.5rem;
+    font-weight: $font-light;
+    font-family: $font-open-sans;
+    text-align: center;
+  }
+
+  &__button {
+    font-size: 0.875rem;
+    padding: 10px;
+  }
+}

--- a/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
@@ -5,7 +5,9 @@
   <div class="background-banner"></div>
   <PixBlock @shadow="heavy" class="send-profile-header">
     <div class="send-profile-header__announcement">
-      <img class="send-profile-header__image" src="{{rootURL}}/images/illustrations/fat-bee.svg" alt={{t "pages.profile-already-shared.first-title"}}>
+      {{#unless this.model.sharedProfile.canRetry}}
+        <img class="send-profile-header__image" src="{{rootURL}}/images/illustrations/fat-bee.svg" alt={{t "pages.profile-already-shared.first-title"}}>
+      {{/unless}}
       <p class="send-profile-header__instruction">
         {{t "pages.profile-already-shared.explanation" organization=this.model.campaign.organizationName date=(moment-format this.model.sharedProfile.sharedAt 'D MMMM YYYY') hour=this.model.sharedProfile.sharedAt htmlSafe=true}}
       </p>
@@ -13,6 +15,15 @@
         {{t "pages.profile-already-shared.actions.continue"}}
       </LinkTo>
     </div>
+    {{#if this.model.sharedProfile.canRetry}}
+      <div class="profile-already-shared-retry">
+        <p class="profile-already-shared-retry__message">{{t 'pages.profile-already-shared.retry.message' organization=this.model.campaign.organizationName}}</p>
+        <LinkTo @route="campaigns.start-or-resume"
+                @model={{@model.campaign.code}}
+                @query={{hash retry=true}}
+                class="button button--link profile-already-shared-retry__button">{{t 'pages.profile-already-shared.retry.button'}}</LinkTo>
+      </div>
+    {{/if}}
     <div class="send-profile-header__profile">
       <HexagonScore @pixScore={{this.model.sharedProfile.pixScore}} />
       <div class="send-profile-header__profile__cards">

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -869,7 +869,11 @@
         "continue": "Continue my Pix experience"
       },
       "explanation": "You already submitted the profile below to the organisation {organization}'<br>'on {date} at {hour,time,hhmm}",
-      "first-title": "There was a problem"
+      "first-title": "There was a problem",
+      "retry": {
+        "message": "{organization} encourages you to resend your profile in order to measure your progress.",
+        "button": "Resend my profile"
+      }
     },
     "proposals": {
       "answer": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -869,7 +869,11 @@
         "continue": "Continuez votre expérience Pix"
       },
       "explanation": "Vous avez déjà envoyé le profil ci-dessous à l'organisation {organization}'<br>'le {date} à {hour,time,hhmm}",
-      "first-title": "Tout ne se passe pas comme prévu"
+      "first-title": "Tout ne se passe pas comme prévu",
+      "retry": {
+          "message": "{organization} vous invite à renvoyer votre profil pour mesurer votre progression.",
+          "button": "Renvoyer mon profil"
+      }
     },
     "proposals": {
       "answer": {


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible de renvoyer son profil lors d'un campagne de collecte de profils.

## :robot: Solution
Afficher un bouton pour permettre de renvoyer son profil quand il a déjà été partagé.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Participer à une campagne de collecte de profils qui permet de participer plusieurs fois, partager son profil.
Le bouton pour partager une nouvelle fois son profil doit être affiché.  
