### PR TITLE
[TECH] Pouvoir spécifier des KE dans les tests d'algo

### DIFF
--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -46,7 +46,7 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
       isFirstAnswer ? result = AnswerStatus.KO : result = AnswerStatus.OK;
       break;
     case 'KE': {
-      const ke = find(userKE, (ke) => challenge.skills.includes(ke.skillId));
+      const ke = find(userKE, (ke) => find(challenge.skills, (skill) => skill.id === ke.skillId));
       const status = ke ? ke.status : KnowledgeElement.StatusType.INVALIDATED;
       result = status === KnowledgeElement.StatusType.VALIDATED ? AnswerStatus.OK : AnswerStatus.KO;
       break;
@@ -54,7 +54,7 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
     default:
       result = AnswerStatus.OK;
   }
-
+  console.log(`Result : ${result.status}`);
   const newAnswer = new Answer({ challengeId: challenge.id, result });
 
   const _getSkillsFilteredByStatus = (knowledgeElements, targetSkills, status) => {

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -93,6 +93,11 @@ async function _getReferentiel({
         return targetProfile;
       },
     };
+    const campaignParticipationRepositoryStub = {
+      isRetrying: () => {
+        return false;
+      },
+    };
 
     const { targetSkills, challenges } = await dataFetcher.fetchForCampaigns({
       assessment,
@@ -101,6 +106,7 @@ async function _getReferentiel({
       challengeRepository,
       knowledgeElementRepository,
       improvementService,
+      campaignParticipationRepository: campaignParticipationRepositoryStub,
     });
 
     return { targetSkills, challenges };

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -1,6 +1,6 @@
 'use strict';
 require('dotenv').config();
-
+const fs = require('fs');
 const smartRandom = require('../../api/lib/domain/services/smart-random/smart-random');
 const dataFetcher = require('../../api/lib/domain/services/smart-random/data-fetcher');
 const challengeRepository = require('../../api/lib/infrastructure/repositories/challenge-repository');
@@ -13,6 +13,16 @@ const AnswerStatus = require('../../api/lib/domain/models/AnswerStatus');
 const KnowledgeElement = require('../../api/lib/domain/models/KnowledgeElement');
 
 const POSSIBLE_ANSWER_STATUSES = [AnswerStatus.OK, AnswerStatus.KO];
+
+function _read(path) {
+  if (path) {
+    const file = fs.readFileSync(path, 'utf-8');
+    if (file) {
+      return JSON.parse(file);
+    }
+  }
+  return [];
+}
 
 function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId, userResult }) {
 
@@ -133,7 +143,7 @@ async function _getChallenge({
 
 async function launchTest(argv) {
 
-  const { competenceId, targetProfileId, locale, userResult } = argv;
+  const { competenceId, targetProfileId, locale, userResult, userKEFile } = argv;
 
   let allAnswers = [];
   let knowledgeElements = [];
@@ -150,6 +160,8 @@ async function launchTest(argv) {
   const answerRepository = {
     findByAssessment: () => [],
   };
+
+  const userKE = _read(userKEFile);
 
   let isAssessmentOver = false;
 
@@ -183,6 +195,7 @@ async function launchTest(argv) {
         allKnowledgeElements: knowledgeElements,
         targetSkills,
         userResult,
+        userKE,
       });
       allAnswers = updatedAnswers;
       knowledgeElements = updatedKnowledgeElements;

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -1,6 +1,7 @@
 'use strict';
 require('dotenv').config();
 const fs = require('fs');
+const { find } = require('lodash');
 const smartRandom = require('../../api/lib/domain/services/smart-random/smart-random');
 const dataFetcher = require('../../api/lib/domain/services/smart-random/data-fetcher');
 const challengeRepository = require('../../api/lib/infrastructure/repositories/challenge-repository');
@@ -24,7 +25,7 @@ function _read(path) {
   return [];
 }
 
-function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId, userResult }) {
+function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId, userResult, userKE }) {
 
   let result;
   const isFirstAnswer = !allAnswers.length;
@@ -44,6 +45,12 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
     case 'firstKOthenOK':
       isFirstAnswer ? result = AnswerStatus.KO : result = AnswerStatus.OK;
       break;
+    case 'KE': {
+      const ke = find(userKE, (ke) => challenge.skills.includes(ke.skillId));
+      const status = ke ? ke.status : KnowledgeElement.StatusType.INVALIDATED;
+      result = status === KnowledgeElement.StatusType.VALIDATED ? AnswerStatus.OK : AnswerStatus.KO;
+      break;
+    }
     default:
       result = AnswerStatus.OK;
   }

--- a/high-level-tests/test-algo/index.js
+++ b/high-level-tests/test-algo/index.js
@@ -27,6 +27,10 @@ async function index() {
       choices: ['ok', 'ko', 'random', 'firstOKthenKO', 'firstKOthenOK'],
       default: 'ok',
     })
+    .option('userKEFile', {
+      type: 'string',
+      description: 'Localisation du fichier',
+    })
     .check((argv) => {
       return Boolean(argv.competenceId || argv.targetProfileId);
     })

--- a/high-level-tests/test-algo/tests/algo_test.js
+++ b/high-level-tests/test-algo/tests/algo_test.js
@@ -186,6 +186,36 @@ describe('#answerTheChallenge', () => {
 
   });
 
+  describe('when userKE is not empty', () => {
+    [
+      { userKE: { 'status': 'validated', 'skillId': 'recPgkHUdzk0HPGt1', 'competenceId': 'recsvLz0W2ShyfD63' }, answerStatus: 'ok' },
+      { userKE: { 'status': 'invalidated', 'skillId': 'recPgkHUdzk0HPGt1', 'competenceId': 'recsvLz0W2ShyfD63' }, answerStatus: 'ko' },
+      { userKE: null, answerStatus: 'ko' },
+    ].forEach((testCase) => {
+      it(`should return the list of answers with ${testCase.answerStatus} answers for ${testCase.userKE ? testCase.userKE.status : 'empty' } KE`, () => {
+        // given
+        challenge.skills = ['recPgkHUdzk0HPGt1'];
+
+        // when
+        const result = answerTheChallenge({
+          challenge,
+          allAnswers: previousAnswers,
+          allKnowledgeElements: [],
+          targetSkills: [],
+          userId: 1,
+          userResult: 'KE',
+          userKE: testCase.userKE ? [testCase.userKE] : [],
+        });
+
+        // then
+        expect(result.updatedAnswers).lengthOf(previousAnswers.length + 1);
+        expect(result.updatedAnswers[0]).to.be.deep.equal(previousAnswers[0]);
+        expect(result.updatedAnswers[1].challengeId).to.be.equal(challenge.id);
+        expect(result.updatedAnswers[1].result).to.be.deep.equal({ status: testCase.answerStatus });
+      });
+    });
+  });
+
 });
 
 describe('#_getReferentiel', () => {

--- a/high-level-tests/test-algo/tests/algo_test.js
+++ b/high-level-tests/test-algo/tests/algo_test.js
@@ -18,6 +18,7 @@ describe('#answerTheChallenge', () => {
     challenge = { id: 'recId' };
     newKe = { id: 'KE-id' };
     sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer').returns([newKe]);
+    sinon.stub(console, 'log');
   });
 
   afterEach(() => {
@@ -194,7 +195,7 @@ describe('#answerTheChallenge', () => {
     ].forEach((testCase) => {
       it(`should return the list of answers with ${testCase.answerStatus} answers for ${testCase.userKE ? testCase.userKE.status : 'empty' } KE`, () => {
         // given
-        challenge.skills = ['recPgkHUdzk0HPGt1'];
+        challenge.skills = [{ id: 'recPgkHUdzk0HPGt1' }];
 
         // when
         const result = answerTheChallenge({

--- a/high-level-tests/test-algo/tests/tests.sh
+++ b/high-level-tests/test-algo/tests/tests.sh
@@ -23,7 +23,7 @@ testExit() {
 }
 
 testExit 'should fetch challenge when competenceId is specified' 'npm start -- --competenceId example_competence_id' 0
-testExit 'should fetch challenge when targetProfileId is specified' 'npm start -- --targetProfileId 1' 0
+#testExit 'should fetch challenge when targetProfileId is specified' 'npm start -- --targetProfileId 1' 0
 testExit 'should return error when no argument is specified' "npm start" 1
 testExit 'should return error when specified locale does not exist' "npm start --competenceId example_competence_id --locale non-existing-locale" 1
 testExit 'should fetch challenge when competenceId and locale are specified' "npm start --competenceId example_competence_id --locale fr" 1

--- a/high-level-tests/test-algo/tests/tests.sh
+++ b/high-level-tests/test-algo/tests/tests.sh
@@ -23,7 +23,7 @@ testExit() {
 }
 
 testExit 'should fetch challenge when competenceId is specified' 'npm start -- --competenceId example_competence_id' 0
-#testExit 'should fetch challenge when targetProfileId is specified' 'npm start -- --targetProfileId 1' 0
+testExit 'should fetch challenge when targetProfileId is specified' 'npm start -- --targetProfileId 1' 0
 testExit 'should return error when no argument is specified' "npm start" 1
 testExit 'should return error when specified locale does not exist' "npm start --competenceId example_competence_id --locale non-existing-locale" 1
 testExit 'should fetch challenge when competenceId and locale are specified' "npm start --competenceId example_competence_id --locale fr" 1


### PR DESCRIPTION
## :unicorn: Problème
Dans les tests d'algo, on devait spécifier en entrée via le paramètre `userResult` le comportement de l'utilisateur souhaité (parmi ['ok', 'ko', 'random', 'firstOKthenKO', 'firstKOthenOK']).
Or il faudrait se rapprocher de la réalité et pouvoir fournir des KE (récupérés depuis un utilisateur réél) à notre algo.

## :robot: Solution
Dans l'algo, si un fichier de KE est donné en paramètre, alors ce fichier est lu et le statut de réussite de la question dépend des KE.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Tester en local avec : npm start -- --competenceId recsvLz0W2ShyfD63 --userKEFile ~/path/to/usertest.json
Le fichier usertest.json se trouve en pièce jointe du ticket Jira.
