### PR TITLE
[TECH] Corrige le lancement des tests depuis #2953

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -55,7 +55,7 @@ module.exports = (function() {
     },
 
     lcms: {
-      url: _removeTrailingSlashFromUrl(process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL),
+      url: _removeTrailingSlashFromUrl(process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL || ''),
       apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
     },
 


### PR DESCRIPTION
## :unicorn: Problème
Depuis #2953, le lancement des tests sans les variables d'environnement CYPRESS_LCMS_API_URL ou LCMS_API_URL.

## :robot: Solution
On s'assure que on passe au minimum une chaine vide


## :100: Pour tester

1. Dans un terminal lancer les tests: npm run test
2. Les tests doivent se lancer correctement