### PR TITLE
[BUGFIX] Ne pas lancer d'erreur lors d'un payload avec plus de meta que prévu par notre validation (PIX-2555).

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -23,7 +23,11 @@ exports.register = async function(server) {
               attributes: Joi.object().required(),
               relationships: Joi.object(),
             }).required(),
+            meta: Joi.object(),
           }).required(),
+          options: {
+            allowUnknown: true,
+          },
         },
         handler: userController.save,
         tags: ['api'],

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -1,4 +1,4 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const { expect, sinon, HttpTestServer, knex } = require('../../../test-helper');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const userController = require('../../../../lib/application/users/user-controller');
 const moduleUnderTest = require('../../../../lib/application/users');
@@ -23,6 +23,64 @@ describe('Integration | Application | Users | Routes', () => {
 
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('POST /api/users', () => {
+
+    afterEach(async () => {
+      await knex('authentication-methods').delete();
+      await knex('users').delete();
+    });
+
+    context('when user create account before joining campaign', () => {
+
+      it('should return HTTP 201', async () => {
+        // given
+        const payload = {
+          data: {
+            attributes: {
+              'first-name': 'marine',
+              'last-name': 'test',
+              email: 'test1@example.net',
+              username: null,
+              password: 'Password123',
+              cgu: true,
+              'must-validate-terms-of-service': false,
+              'has-seen-assessment-instructions': false,
+              'has-seen-new-dashboard-info': false,
+              lang: 'fr',
+              'is-anonymous': false,
+            },
+            type: 'users',
+          },
+          meta: {
+            'campaign-code': 'TRWYWV411',
+          },
+        };
+
+        const url = '/api/users';
+
+        // when
+        const response = await httpTestServer.request('POST', url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(201);
+      });
+
+      it('should return HTTP 400', async () => {
+        // given
+        const payload = {};
+
+        const url = '/api/users';
+
+        // when
+        const response = await httpTestServer.request('POST', url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
   });
 
   describe('GET /api/admin/users/{id}', () => {
@@ -235,4 +293,5 @@ describe('Integration | Application | Users | Routes', () => {
     });
 
   });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
Mercredi après midi il y avait beaucoup d'erreur 400 sur la route POST /api/users.
Beaucoup de demande de support ont été relevée à ce moment là :
https://support.pix.org/a/tickets/30462
https://support.pix.org/a/tickets/30463
https://support.pix.org/a/tickets/30454

Une PR de validation JOI sur la route qui pose problème avait été faite récemment : https://github.com/1024pix/pix/pull/2925

En fait la validation joi était trop restrictive et lancait des 400 quand le payload avait des éléments non prévu dans la validation.

## :robot: Solution
Autoriser plus de champs que ceux prévu par la validation Joi de la route '/api/users'.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer les tests
