### PR TITLE
[FEATURE] Ajout des titres à toutes les pages de Pix Orga (Pix-2504).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/analysis/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/analysis/tab.hbs
@@ -1,4 +1,4 @@
-<h4 class="campaign-details-analysis campaign-details-analysis__header">{{t 'pages.campaign-review.title'}}</h4>
+<h4 class="campaign-details-analysis campaign-details-analysis__header">{{t 'pages.campaign-review.sub-title'}}</h4>
 
 <p class="campaign-details-analysis campaign-details-analysis__text">
   {{this.description}}

--- a/orga/app/components/routes/authenticated/campaign/profile/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/details.hbs
@@ -1,3 +1,4 @@
+{{page-title this.pageTitle}}
 <article class="profile">
   <header class="navigation">
    <PreviousPageButton

--- a/orga/app/components/routes/login-or-register.hbs
+++ b/orga/app/components/routes/login-or-register.hbs
@@ -3,7 +3,7 @@
     <div>
       <img src="/pix-orga.svg" alt="" role="none" class="login-or-register-panel__logo">
     </div>
-    <span class="login-or-register-panel__invitation">{{t 'pages.login-or-register.invitation'}} {{@organizationName}}</span>
+    <span class="login-or-register-panel__invitation">{{t 'pages.login-or-register.title' organizationName=@organizationName}}</span>
     <div class="login-or-register-panel__forms-container">
       <div class="login-or-register-panel__form">
         <h1 class="form-title">{{t 'pages.login-or-register.register-form.title'}}</h1>

--- a/orga/app/controllers/authenticated/campaigns/assessment/analysis.js
+++ b/orga/app/controllers/authenticated/campaigns/assessment/analysis.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class AnalysisController extends Controller {
+
+  @service intl;
+
+  get pageTitle() {
+    return this.intl.t('pages.campaign-individual-review.title', { firstName: this.model.firstName, lastName: this.model.lastName });
+  }
+}

--- a/orga/app/controllers/authenticated/campaigns/assessment/results.js
+++ b/orga/app/controllers/authenticated/campaigns/assessment/results.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class ResultsController extends Controller {
+
+  @service intl;
+
+  get pageTitle() {
+    return this.intl.t('pages.assessment-individual-results.title', { firstName: this.model.firstName, lastName: this.model.lastName });
+  }
+}

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -15,6 +15,7 @@ export default class ListController extends Controller {
   @tracked status = null;
 
   @service currentUser;
+  @service intl;
 
   get isArchived() {
     return this.status === 'archived';
@@ -22,6 +23,14 @@ export default class ListController extends Controller {
 
   get displayNoCampaignPanel() {
     return !this.model.meta.hasCampaigns;
+  }
+
+  get pageTitle() {
+    let title = this.intl.t('pages.campaigns-list.title.active');
+    if (this.model.query.filter.status === 'archived') {
+      title = this.intl.t('pages.campaigns-list.title.archived');
+    }
+    return title;
   }
 
   updateFilters(filters) {

--- a/orga/app/controllers/authenticated/campaigns/profile.js
+++ b/orga/app/controllers/authenticated/campaigns/profile.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class ProfileController extends Controller {
+
+  @service intl;
+
+  get pageTitle() {
+    return this.intl.t('pages.profiles-individual-results.title', { firstName: this.model.campaignProfile.firstName, lastName: this.model.campaignProfile.lastName });
+  }
+}

--- a/orga/app/routes/authenticated/campaigns/assessment/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/assessment/analysis.js
@@ -4,6 +4,10 @@ export default class AnalysisRoute extends Route {
 
   model() {
     const { campaignAssessmentParticipation } = this.modelFor('authenticated.campaigns.assessment');
-    return campaignAssessmentParticipation.campaignAnalysis;
+    return campaignAssessmentParticipation;
+  }
+
+  afterModel(model) {
+    return model.belongsTo('campaignAnalysis').reload();
   }
 }

--- a/orga/app/routes/authenticated/campaigns/assessment/results.js
+++ b/orga/app/routes/authenticated/campaigns/assessment/results.js
@@ -4,6 +4,6 @@ export default class ResultsRoute extends Route {
 
   model() {
     const { campaignAssessmentParticipation } = this.modelFor('authenticated.campaigns.assessment');
-    return campaignAssessmentParticipation.campaignAssessmentParticipationResult;
+    return campaignAssessmentParticipation;
   }
 }

--- a/orga/app/templates/application.hbs
+++ b/orga/app/templates/application.hbs
@@ -1,0 +1,2 @@
+{{page-title (t 'navigation.pix-orga')}}
+{{outlet}}

--- a/orga/app/templates/authenticated/campaigns/assessment.hbs
+++ b/orga/app/templates/authenticated/campaigns/assessment.hbs
@@ -1,3 +1,4 @@
+{{page-title @model.campaign.name}}
 <Routes::Authenticated::Campaign::Assessment::Details
   @campaign={{@model.campaign}}
   @campaignAssessmentParticipation={{@model.campaignAssessmentParticipation}}

--- a/orga/app/templates/authenticated/campaigns/assessment/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/assessment/analysis.hbs
@@ -1,4 +1,7 @@
+{{page-title this.pageTitle}}
 <Routes::Authenticated::Campaign::Analysis::Tab
-  @campaignTubeRecommendations={{@model.campaignTubeRecommendations}}
-  @displayAnalysis={{gt @model.campaignTubeRecommendations.length 0}}
+  @campaignTubeRecommendations={{@model.campaignAnalysis.campaignTubeRecommendations}}
+  @displayAnalysis={{gt @model.campaignAnalysis.campaignTubeRecommendations.length 0}}
+  @participantFirstName= {{@model.firstName}}
+  @participantLastName= {{@model.lastName}}
 />

--- a/orga/app/templates/authenticated/campaigns/assessment/loading.hbs
+++ b/orga/app/templates/authenticated/campaigns/assessment/loading.hbs
@@ -1,1 +1,2 @@
+{{page-title (t "common.loading")}}
 <PixLoader />

--- a/orga/app/templates/authenticated/campaigns/assessment/results.hbs
+++ b/orga/app/templates/authenticated/campaigns/assessment/results.hbs
@@ -1,5 +1,8 @@
+{{page-title this.pageTitle}}
 <Routes::Authenticated::Campaign::Assessment::Results
-  @campaignAssessmentParticipationResult={{@model}}
-  @displayResults={{gt @model.sortedCompetenceResults.length 0}}
+  @campaignAssessmentParticipationFirstName={{@model.firstName}}
+  @campaignAssessmentParticipationLastName={{@model.lastName}}
+  @campaignAssessmentParticipationResult={{@model.campaignAssessmentParticipationResult}}
+  @displayResults={{gt @model.campaignAssessmentParticipationResult.sortedCompetenceResults.length 0}}
   @class="participant-results"
 />

--- a/orga/app/templates/authenticated/campaigns/campaign.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign.hbs
@@ -1,1 +1,2 @@
+{{page-title @model.name}}
 <Routes::Authenticated::Campaign::Report @campaign={{@model}} />

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.campaign-review.title')}}
 <Routes::Authenticated::Campaign::Analysis::Tab
   @campaignTubeRecommendations={{@model.campaignAnalysis.campaignTubeRecommendations}}
   @displayAnalysis={{gt @model.sharedParticipationsCount 0}}

--- a/orga/app/templates/authenticated/campaigns/campaign/assessments.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessments.hbs
@@ -1,4 +1,4 @@
-{{page-title (t 'pages.campaign.participants-page-title')}}
+{{page-title (t 'pages.assessment-participants-list.title')}}
 <Routes::Authenticated::Campaign::Assessment::List
   @campaign={{@model.campaign}}
   @participations={{@model.campaignAssessmentParticipationSummaries}}

--- a/orga/app/templates/authenticated/campaigns/campaign/assessments.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessments.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.campaign.participants-page-title')}}
 <Routes::Authenticated::Campaign::Assessment::List
   @campaign={{@model.campaign}}
   @participations={{@model.campaignAssessmentParticipationSummaries}}

--- a/orga/app/templates/authenticated/campaigns/campaign/collective-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/collective-results.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.campaign-collective-results.title')}}
 <Routes::Authenticated::Campaign::CollectiveResults::Tab
   @campaignId={{@model.id}}
   @hasStages={{@model.hasStages}}

--- a/orga/app/templates/authenticated/campaigns/campaign/details.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/details.hbs
@@ -1,1 +1,2 @@
+{{page-title (t 'pages.campaign-details.title')}}
 <Routes::Authenticated::Campaign::Details::Tab @campaign={{@model}} />

--- a/orga/app/templates/authenticated/campaigns/campaign/loading.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/loading.hbs
@@ -1,1 +1,2 @@
+{{page-title (t "common.loading")}}
 <PixLoader />

--- a/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.campaign.participants-page-title')}}
 <Routes::Authenticated::Campaign::Profile::List
   @campaign={{@model.campaign}}
   @profiles={{@model.profiles}}

--- a/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
@@ -1,4 +1,4 @@
-{{page-title (t 'pages.campaign.participants-page-title')}}
+{{page-title (t 'pages.profiles-list.title')}}
 <Routes::Authenticated::Campaign::Profile::List
   @campaign={{@model.campaign}}
   @profiles={{@model.profiles}}

--- a/orga/app/templates/authenticated/campaigns/list.hbs
+++ b/orga/app/templates/authenticated/campaigns/list.hbs
@@ -1,3 +1,4 @@
+{{page-title this.pageTitle}}
 <div class="list-campaigns-page">
   {{#if this.displayNoCampaignPanel}}
     <Routes::Authenticated::Campaign::NoCampaignPanel />

--- a/orga/app/templates/authenticated/campaigns/new.hbs
+++ b/orga/app/templates/authenticated/campaigns/new.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.campaign-creation.title')}}
 <div class="new-campaign-page">
 
   <h1 class="page__title page-title">{{t 'pages.campaign-creation.title' }}</h1>

--- a/orga/app/templates/authenticated/campaigns/profile.hbs
+++ b/orga/app/templates/authenticated/campaigns/profile.hbs
@@ -1,4 +1,6 @@
+{{page-title @model.campaign.name}}
+{{page-title this.pageTitle}}
 <Routes::Authenticated::Campaign::Profile::Details
-  @campaign= {{@model.campaign}}
-  @campaignProfile= {{@model.campaignProfile}}
+  @campaign={{@model.campaign}}
+  @campaignProfile={{@model.campaignProfile}}
 />

--- a/orga/app/templates/authenticated/campaigns/update.hbs
+++ b/orga/app/templates/authenticated/campaigns/update.hbs
@@ -1,1 +1,3 @@
+{{page-title this.campaignName}}
+{{page-title (t 'pages.campaign-modification.title')}}
 <Routes::Authenticated::Campaign::Update @campaign={{@model}} @subTitle={{this.campaignName}} @update={{this.update}} @cancel={{this.cancel}} />

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.certifications.title')}}
 <div class="certifications-page">
   <h1 class="page__title page-title">{{t 'pages.certifications.title'}}</h1>
   <p class="certifications-page__text">
@@ -6,7 +7,7 @@
 
   <form class="certifications-page__action" {{on 'submit' this.downloadSessionResultFile}}>
     <label for="certifications-page-action__select">{{t 'pages.certifications.select-label'}}</label>
-    <PixSelect id="certifications-page-action__select" 
+    <PixSelect id="certifications-page-action__select"
       @options={{@model.options}}
       @selectedOption={{this.selectedDivision}}
       @onChange={{this.onSelectDivision}}

--- a/orga/app/templates/authenticated/sco-students/list.hbs
+++ b/orga/app/templates/authenticated/sco-students/list.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.students-sco.title')}}
 <div class="list-students-page">
   <Routes::Authenticated::ScoStudents::ListItems
     @students={{@model}}

--- a/orga/app/templates/authenticated/sup-students/list.hbs
+++ b/orga/app/templates/authenticated/sup-students/list.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.students-sup.title')}}
 <div class="list-students-page">
   <Routes::Authenticated::SupStudents::ListItems
     @students={{@model}}

--- a/orga/app/templates/authenticated/team/list.hbs
+++ b/orga/app/templates/authenticated/team/list.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.team-list.title')}}
 <div class="list-team-page">
   <div class="list-team-page__header">
     <div class="page__title page-title">{{t 'pages.team-list.title'}}</div>

--- a/orga/app/templates/authenticated/team/list/invitations.hbs
+++ b/orga/app/templates/authenticated/team/list/invitations.hbs
@@ -1,1 +1,2 @@
+{{page-title (t 'pages.team-invitations.title')}}
 <Routes::Authenticated::Team::Invitations @organizationInvitations={{@model}}/>

--- a/orga/app/templates/authenticated/team/list/members.hbs
+++ b/orga/app/templates/authenticated/team/list/members.hbs
@@ -1,1 +1,2 @@
+{{page-title (t 'pages.team-members.title')}}
 <Routes::Authenticated::Team::Members @memberships={{@model}} @removeMembership={{this.removeMembership}} />

--- a/orga/app/templates/authenticated/team/new.hbs
+++ b/orga/app/templates/authenticated/team/new.hbs
@@ -1,3 +1,5 @@
+{{page-title (t 'pages.team-list.title')}}
+{{page-title (t 'pages.team-new.title')}}
 <div class="new-team-page">
 
   <h1 class="page__title page-title">{{t 'pages.team-new.title'}}</h1>

--- a/orga/app/templates/join-request.hbs
+++ b/orga/app/templates/join-request.hbs
@@ -1,3 +1,4 @@
+{{page-title "Activez ou récupérez votre espace"}}
 <div class="join-request">
   <div class="panel join-request__panel">
     <div class="panel__image">

--- a/orga/app/templates/join.hbs
+++ b/orga/app/templates/join.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.login-or-register.title' organizationName=@model.organizationName)}}
 <div class="join-page">
   <Routes::LoginOrRegister @organizationInvitationId={{this.invitationId}} @organizationInvitationCode={{this.code}} @organizationName={{@model.organizationName}} />
 </div>

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.login.title')}}
 <div class="login-page">
   <div class="panel login-page__panel">
     <div class="panel__image">

--- a/orga/app/templates/terms-of-service.hbs
+++ b/orga/app/templates/terms-of-service.hbs
@@ -1,3 +1,4 @@
+{{page-title (t 'pages.terms-of-service.title')}}
 <div class="terms-of-service-page">
   <div class="terms-of-service-form">
 

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -5360,9 +5360,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "mkdirp": {
@@ -12107,24 +12107,24 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }
@@ -18852,6 +18852,15 @@
         }
       }
     },
+    "ember-page-title": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ember-page-title/-/ember-page-title-6.2.1.tgz",
+      "integrity": "sha512-cfBDuP14KBJCdz/AeBQJFGnJbUHd2gmenG+i0ilR2kYX0G0zHAsseFZFuTNVZDNiQ8BnMdrdjRnfjx9Vdi/dag==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.22.1"
+      }
+    },
     "ember-qunit": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",
@@ -20313,9 +20322,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
-      "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
@@ -20327,7 +20336,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -22113,6 +22122,7 @@
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -22388,9 +22398,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -22942,6 +22952,12 @@
           "dev": true
         }
       }
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -24268,7 +24284,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
@@ -24505,7 +24522,8 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -24562,9 +24580,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-int64": {
@@ -24662,26 +24680,42 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-9.0.1.tgz",
+      "integrity": "sha512-fPNFIp2hF/Dq7qLDzSg4vZ0J4e9v60gJR+Qx7RbjbWqzPDdEqeVpEx5CFeDAELIl+A/woaaNn1fQ5nEVerMxJg==",
       "dev": true,
       "requires": {
         "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.2",
         "shellwords": "^0.1.1",
-        "which": "^1.3.0"
+        "uuid": "^8.3.0",
+        "which": "^2.0.2"
       },
       "dependencies": {
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "is-docker": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },
@@ -26112,9 +26146,9 @@
       }
     },
     "printf": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/printf/-/printf-0.5.3.tgz",
-      "integrity": "sha512-t3lYN6vPU5PZXDiEZZqoyXvN8wCsBfi8gPoxTKo2e5hhV673t/KUh+mfO8P8lCOCDC/BWcOGIxKyebxc5FuqLA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/printf/-/printf-0.6.1.tgz",
+      "integrity": "sha512-is0ctgGdPJ5951KulgfzvHGwJtZ5ck8l042vRkV6jrkpBzTmb/lueTqguWHy2JfVA+RY6gFVlaZgUS0j7S/dsw==",
       "dev": true
     },
     "private": {
@@ -27800,7 +27834,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -27956,9 +27991,9 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -28618,9 +28653,9 @@
       }
     },
     "testem": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/testem/-/testem-3.2.0.tgz",
-      "integrity": "sha512-FkFzNRCIzCxjbNSTxIQSC2tWn1Q2MTR/GTxusSw6uZA4byEQ7wc86TKutNnoCyZ5XIaD9wo4q+dmlK0GUEqFVA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/testem/-/testem-3.4.1.tgz",
+      "integrity": "sha512-UhKbTAb8JF6xRoDXd0AL0wl+Rpmio6KN7q+Xv7O9fcuioAqOQQVCNyxkYrJaihUPRKGr/r8ZKtSGe/Gdkm3uGQ==",
       "dev": true,
       "requires": {
         "backbone": "^1.1.2",
@@ -28642,16 +28677,16 @@
         "lodash.uniqby": "^4.7.0",
         "mkdirp": "^0.5.1",
         "mustache": "^3.0.0",
-        "node-notifier": "^5.0.1",
+        "node-notifier": "^9.0.1",
         "npmlog": "^4.0.0",
-        "printf": "^0.5.1",
+        "printf": "^0.6.1",
         "rimraf": "^2.4.4",
         "socket.io": "^2.1.0",
         "spawn-args": "^0.2.0",
         "styled_string": "0.0.1",
         "tap-parser": "^7.0.0",
         "tmp": "0.0.33",
-        "xmldom": "^0.1.19"
+        "xmldom": "^0.6.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -29059,6 +29094,7 @@
       "version": "3.13.5",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.5.tgz",
       "integrity": "sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==",
+      "dev": true,
       "optional": true
     },
     "unbox-primitive": {
@@ -29082,9 +29118,9 @@
       }
     },
     "underscore": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
-      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
     },
     "underscore.string": {
@@ -29826,7 +29862,8 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -30018,15 +30055,15 @@
       "dev": true
     },
     "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
+      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
       "dev": true
     },
     "xtend": {
@@ -30036,9 +30073,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yallist": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -74,6 +74,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-modal-dialog": "^3.0.2",
     "ember-moment": "^8.0.1",
+    "ember-page-title": "^6.2.1",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-simple-auth": "^1.9.2",

--- a/orga/tests/integration/components/routes/login-or-register_test.js
+++ b/orga/tests/integration/components/routes/login-or-register_test.js
@@ -24,12 +24,12 @@ module('Integration | Component | routes/login-or-register', function(hooks) {
 
   test('it display the organization name the user is invited to', async function(assert) {
     // when
-    const invitationMessage = this.intl.t('pages.login-or-register.invitation');
+    const invitationMessage = this.intl.t('pages.login-or-register.title', { organizationName: 'Organization Aztec' });
 
     await render(hbs`<Routes::LoginOrRegister @organizationName='Organization Aztec'/>`);
 
     // then
-    assert.dom('.login-or-register-panel__invitation').hasText(`${invitationMessage} Organization Aztec`);
+    assert.dom('.login-or-register-panel__invitation').hasText(`${invitationMessage}`);
   });
 
   test('it toggle the register form by default', async function(assert) {

--- a/orga/tests/unit/controllers/authenticated/campaigns/assessment/analysis_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/assessment/analysis_test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/campaigns/assessment/analysis', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display correct page title', function(assert) {
+    const controller = this.owner.lookup('controller:authenticated/campaigns/assessment/analysis');
+    controller.model = {
+      firstName: 'Jaune',
+      lastName: 'attends',
+    };
+
+    assert.equal(controller.pageTitle, 'Analyse pour Jaune attends');
+  });
+});

--- a/orga/tests/unit/controllers/authenticated/campaigns/assessment/results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/assessment/results_test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/campaigns/assessment/results', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display correct page title', function(assert) {
+    const controller = this.owner.lookup('controller:authenticated/campaigns/assessment/results');
+    controller.model = {
+      firstName: 'Jaune',
+      lastName: 'attends',
+    };
+
+    assert.equal(controller.pageTitle, 'Résultats de Jaune attends');
+  });
+});

--- a/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
 import ArrayProxy from '@ember/array/proxy';
 import sinon from 'sinon';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
-  setupTest(hooks);
+  setupIntlRenderingTest(hooks);
   let controller;
 
   hooks.beforeEach(function() {
@@ -79,6 +79,20 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
         // then
         assert.equal(isArchived, true);
       });
+
+      test('it should display page title as archived', async function(assert) {
+        // given
+        const pageTitle = 'Campagnes archivées';
+
+        controller.model = { query: {
+          filter: {
+            status: 'archived',
+          },
+        } };
+
+        // then
+        assert.equal(controller.pageTitle, pageTitle);
+      });
     });
 
     module('when status is not archived', function() {
@@ -92,6 +106,20 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
 
         // then
         assert.equal(isArchived, false);
+      });
+
+      test('it should display page title as active', async function(assert) {
+        // given
+        const pageTitle = 'Campagnes actives';
+
+        controller.model = { query: {
+          filter: {
+            status: null,
+          },
+        } };
+
+        // then
+        assert.equal(controller.pageTitle, pageTitle);
       });
     });
   });

--- a/orga/tests/unit/controllers/authenticated/campaigns/profile_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/profile_test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/campaigns/profile', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display correct page title', function(assert) {
+    const controller = this.owner.lookup('controller:authenticated/campaigns/profile');
+    controller.model = {
+      campaignProfile: {
+        firstName: 'Jaune',
+        lastName: 'attends',
+      },
+    };
+
+    assert.equal(controller.pageTitle, 'Profil de Jaune attends');
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -127,7 +127,8 @@
           "validatedSkills": "Items successfully completed"
         },
         "empty": "Results pending"
-      }
+      },
+      "title": "Results of {firstName} {lastName}"
     },
     "assessment-participants-list": {
       "table": {
@@ -143,7 +144,8 @@
         },
         "empty": "No participants",
         "row-title": "Participant"
-      }
+      },
+      "title": "Participants"
     },
     "campaign": {
       "actions": {
@@ -249,6 +251,9 @@
       "shared-date": "Sent on",
       "start-date": "Started on"
     },
+    "campaign-individual-review": {
+      "title": "Review for {firstName} {lastName}"
+    },
     "campaign-modification": {
       "actions": {
         "edit": "Edit"
@@ -260,7 +265,6 @@
     },
     "campaign-review": {
       "description": "According to the target profile selected and the results of your campaign, Pix recommends focusing on the following topics, sorted by relevance ({bubble}).",
-      "page-title": "Review for {firstName} {lastName}",
       "sub-table": {
         "column": {
           "source": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -194,7 +194,8 @@
         },
         "empty": "Results pending",
         "row-title": "Competence"
-      }
+      },
+      "title": "Collective results"
     },
     "campaign-creation": {
       "title": "Create a campaign",
@@ -241,51 +242,54 @@
       "external-user-id-label": "External user ID label",
       "landing-page-text": "Text to display on the starting page",
       "personalised-test-title": "Title of the customised test",
-      "target-profile": "Target profile"
+      "target-profile": "Target profile",
+      "title": "Details"
     },
     "campaign-individual-results": {
       "shared-date": "Sent on",
       "start-date": "Started on"
     },
     "campaign-modification": {
-      "title": "Edit a campaign",
       "actions": {
         "edit": "Edit"
       },
       "campaign-name": "Name of the campaign",
       "landing-page-text": "Text to display on the starting page",
-      "personalised-test-title": "Title of the customised test"
+      "personalised-test-title": "Title of the personalised test",
+      "title": "Edit a campaign"
     },
     "campaign-review": {
-      "title": "Recommendations of topics to focus on",
       "description": "According to the target profile selected and the results of your campaign, Pix recommends focusing on the following topics, sorted by relevance ({bubble}).",
+      "page-title": "Review for {firstName} {lastName}",
       "sub-table": {
-        "title": "{count, plural, =1 {1 tutorial} other{{count} tutorials}} recommended by the Pix community",
         "column": {
           "source": {
             "value": "By {source}"
           }
         },
-        "row-title": "Tutorial"
+        "row-title": "Tutorial",
+        "title": "{count, plural, =1 {1 tutorial} other{{count} tutorials}} recommended by the Pix community"
       },
+      "sub-title": "Recommendations of topics to focus on",
       "table": {
-        "title": "Review by topic",
         "column": {
-          "relevance": "Relevance",
           "subjects": "Topics ({count, plural, =0 {-} other {{count}}})",
-          "tutorial": {
-            "aria-label": "Show all tutorials"
-          },
+          "relevance": "Relevance",
           "tutorial-count": {
             "value": "{count, plural, =1 {1 tutorial} other {{count} tutorials}}"
+          },
+          "tutorial": {
+            "aria-label": "Show all tutorials"
           }
         },
         "empty": "Results pending",
         "row-title": "Topic",
         "sort": {
           "relevance": "Sort by relevance"
-        }
-      }
+        },
+        "title": "Review by topic"
+      },
+      "title": "Review"
     },
     "campaigns-list": {
       "action": {
@@ -317,6 +321,10 @@
           "by-name": "Search for a campaign"
         },
         "row-title": "Campaign"
+      },
+      "title": {
+        "archived": "Archived campaigns",
+        "active": "Active campaigns"
       }
     },
     "certifications": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -355,7 +355,6 @@
       "show-password": "Show password"
     },
     "login-or-register": {
-      "invitation": "You have been invited to join the organisation",
       "login-form": {
         "title": "Already have an account?",
         "button": "Log in"
@@ -392,7 +391,8 @@
           }
         },
         "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr."
-      }
+      },
+      "title": "You have been invited to join the organisation {organizationName}"
     },
     "profiles-individual-results": {
       "certifiable": "Eligible for certification",
@@ -581,7 +581,8 @@
           "aria-label": "Pending invitation",
           "message": "Sent on"
         }
-      }
+      },
+      "title": "Team invitations"
     },
     "team-list": {
       "title": "My team",
@@ -624,7 +625,8 @@
         },
         "empty": "No members yet",
         "row-title": "Member"
-      }
+      },
+      "title": "Team members"
     },
     "team-new": {
       "title": "Invite a member",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -648,7 +648,8 @@
       "invite-button": "Invite"
     },
     "terms-of-service": {
-      "accept" : "I accept the terms and conditions"
+      "accept" : "I accept the terms and conditions",
+      "title": "Terms and conditions of use"
     }
   }
 }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -92,6 +92,7 @@
       "students-sup": "Students",
       "team": "Team"
     },
+    "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Log out",
       "summary": "User summary"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -415,7 +415,8 @@
         },
         "empty": "Results pending",
         "row-title": "Competence"
-      }
+      },
+      "title": "Profile of {firstName} {lastName}"
     },
     "profiles-list": {
       "table": {
@@ -435,7 +436,8 @@
         },
         "empty": "Waiting for profiles",
         "row-title": "Profile"
-      }
+      },
+      "title": "Participants"
     },
     "students-sco": {
       "title": "Students",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -648,7 +648,8 @@
       "invite-button": "Inviter"
     },
     "terms-of-service": {
-      "accept" : "J’accepte les conditions d’utilisation"
+      "accept" : "J’accepte les conditions d’utilisation",
+      "title": "Conditions d'utilisation"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -127,7 +127,8 @@
           "validatedSkills": "Acquis validés"
         },
         "empty": "En attente de résultats"
-      }
+      },
+      "title": "Résultats de {firstName} {lastName}"
     },
     "assessment-participants-list": {
       "table": {
@@ -143,7 +144,8 @@
         },
         "empty": "Aucun participant",
         "row-title": "Participant"
-      }
+      },
+      "title": "Participants"
     },
     "campaign": {
       "actions": {
@@ -249,6 +251,9 @@
       "shared-date": "Envoyé le",
       "start-date": "Commencé le"
     },
+    "campaign-individual-review": {
+      "title": "Analyse pour {firstName} {lastName}"
+    },
     "campaign-modification": {
       "actions": {
         "edit": "Modifier"
@@ -260,7 +265,6 @@
     },
     "campaign-review": {
       "description": "En fonction du référentiel testé et des résultats de la campagne, Pix vous recommande ces sujets à travailler, classés par degré de pertinence ({bubble}).",
-      "page-title": "Analyse pour {firstName} {lastName}",
       "sub-table": {
         "column": {
           "source": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -194,7 +194,8 @@
         },
         "empty": "En attente de résultats",
         "row-title": "Compétence"
-      }
+      },
+      "title": "Résultats collectifs"
     },
     "campaign-creation": {
       "title": "Création d'une campagne",
@@ -241,51 +242,54 @@
       "external-user-id-label": "Libellé de l'identifiant",
       "landing-page-text": "Texte de la page d'accueil",
       "personalised-test-title": "Titre du parcours",
-      "target-profile": "Profil cible"
+      "target-profile": "Profil cible",
+      "title": "Détails"
     },
     "campaign-individual-results": {
       "shared-date": "Envoyé le",
       "start-date": "Commencé le"
     },
     "campaign-modification": {
-      "title": "Modification d'une campagne",
       "actions": {
         "edit": "Modifier"
       },
       "campaign-name": "Nom de la campagne",
       "landing-page-text": "Texte de la page d'accueil",
-      "personalised-test-title": "Titre du parcours"
+      "personalised-test-title": "Titre du parcours",
+      "title": "Modification d'une campagne"
     },
     "campaign-review": {
-      "title": "Recommandation de sujets à travailler",
       "description": "En fonction du référentiel testé et des résultats de la campagne, Pix vous recommande ces sujets à travailler, classés par degré de pertinence ({bubble}).",
+      "page-title": "Analyse pour {firstName} {lastName}",
       "sub-table": {
-        "title": "{count, plural, =1 {1 tuto recommandé} other{{count} tutos recommandés}} par la communauté Pix",
         "column": {
           "source": {
             "value": "Par {source}"
           }
         },
-        "row-title": "Tutoriel"
+        "row-title": "Tutoriel",
+        "title": "{count, plural, =1 {1 tuto recommandé} other{{count} tutos recommandés}} par la communauté Pix"
       },
+      "sub-title": "Recommandation de sujets à travailler",
       "table": {
-        "title": "Analyse par sujet",
         "column": {
-          "relevance": "Pertinence",
           "subjects": "Sujets ({count, plural, =0 {-} other {{count}}})",
-          "tutorial": {
-            "aria-label": "Afficher la liste des tutos"
-          },
+          "relevance": "Pertinence",
           "tutorial-count": {
             "value": "{count, plural, =1 {1 tuto} other {{count} tutos}}"
+          },
+          "tutorial": {
+            "aria-label": "Afficher la liste des tutos"
           }
         },
         "empty": "En attente de résultats",
         "row-title": "Sujet",
         "sort": {
           "relevance": "Trier par pertinence"
-        }
-      }
+        },
+        "title": "Analyse par sujet"
+      },
+      "title": "Analyse"
     },
     "campaigns-list": {
       "action": {
@@ -317,6 +321,10 @@
           "by-name": "Rechercher une campagne"
         },
         "row-title": "Campagne"
+      },
+      "title": {
+        "archived": "Campagnes archivées",
+        "active": "Campagnes actives"
       }
     },
     "certifications": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -415,7 +415,8 @@
         },
         "empty": "En attente de résultats",
         "row-title": "Compétence"
-      }
+      },
+      "title": "Profil de {firstName} {lastName}"
     },
     "profiles-list": {
       "table": {
@@ -435,7 +436,8 @@
         },
         "empty": "En attente de profils",
         "row-title": "Profil"
-      }
+      },
+      "title": "Participants"
     },
     "students-sco": {
       "title": "Élèves",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -355,7 +355,6 @@
       "show-password": "rendre le mot de passe lisible"
     },
     "login-or-register": {
-      "invitation": "Vous êtes invité(e) à rejoindre l'organisation",
       "login-form": {
         "title": "J'ai déjà un compte",
         "button": "Se connecter"
@@ -392,7 +391,8 @@
           }
         },
         "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr."
-      }
+      },
+      "title": "Vous êtes invité(e) à rejoindre l'organisation {organizationName}"
     },
     "profiles-individual-results": {
       "certifiable": "Certifiable",
@@ -581,7 +581,8 @@
           "aria-label": "Invitation en attente",
           "message": "Dernière invitation envoyée le"
         }
-      }
+      },
+      "title": "Invitations"
     },
     "team-list": {
       "title": "Mon équipe",
@@ -624,7 +625,8 @@
         },
         "empty": "En attente de membres",
         "row-title": "Membre"
-      }
+      },
+      "title": "Membres"
     },
     "team-new": {
       "title": "Inviter un membre",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -92,6 +92,7 @@
       "students-sup": "Étudiants",
       "team": "Équipe"
     },
+    "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Se déconnecter",
       "summary": "Résumé utilisateur"


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, les pages de Pix Orga n'ont pas de titre, il faut en rajouter comme dans Pix App

## :robot: Solution
Ajout des titres à toutes la pages de Pix Orga

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur PixOrga puis survolez sur l'onglet overt dans le navigateur, vous pouvez voir le title de la page actuel marqué sur l'onglet.