### PR TITLE
[BUGFIX] Lors d'un rescoring manuel sur PixAdmin, les competence-marks n'étaient pas enregistrées correctement (PIX-2566)

### DIFF
--- a/api/db/migrations/20210506112005_fill-missing-competence-id-values-in-table-competence-marks.js
+++ b/api/db/migrations/20210506112005_fill-missing-competence-id-values-in-table-competence-marks.js
@@ -1,0 +1,108 @@
+
+exports.up = async function(knex) {
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '1.1')
+    .update({
+      competenceId: 'recsvLz0W2ShyfD63',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '1.2')
+    .update({
+      competenceId: 'recIkYm646lrGvLNT',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '1.3')
+    .update({
+      competenceId: 'recNv8qhaY887jQb2',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '2.1')
+    .update({
+      competenceId: 'recDH19F7kKrfL3Ii',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '2.2')
+    .update({
+      competenceId: 'recgxqQfz3BqEbtzh',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '2.3')
+    .update({
+      competenceId: 'recMiZPNl7V1hyE1d',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '2.4')
+    .update({
+      competenceId: 'recFpYXCKcyhLI3Nu',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '3.1')
+    .update({
+      competenceId: 'recOdC9UDVJbAXHAm',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '3.2')
+    .update({
+      competenceId: 'recbDTF8KwupqkeZ6',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '3.3')
+    .update({
+      competenceId: 'recHmIWG6D0huq6Kx',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '3.4')
+    .update({
+      competenceId: 'rece6jYwH4WEw549z',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '4.1')
+    .update({
+      competenceId: 'rec6rHqas39zvLZep',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '4.2')
+    .update({
+      competenceId: 'recofJCxg0NqTqTdP',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '4.3')
+    .update({
+      competenceId: 'recfr0ax8XrfvJ3ER',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '5.1')
+    .update({
+      competenceId: 'recIhdrmCuEmCDAzj',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '5.2')
+    .update({
+      competenceId: 'recudHE5Omrr10qrx',
+    });
+  await knex('competence-marks')
+    .whereNull('competenceId')
+    .where('competence_code', '6.1')
+    .update({
+      competenceId: 'recAZLOoUMpe7kF5o',
+    });
+};
+
+exports.down = function(_) {
+};

--- a/api/db/migrations/20210506114245_remove-nullable-mentions-in-columns-table-competence-marks.js
+++ b/api/db/migrations/20210506114245_remove-nullable-mentions-in-columns-table-competence-marks.js
@@ -1,0 +1,13 @@
+exports.up = async function(knex) {
+  await knex.raw('ALTER TABLE "competence-marks" ALTER COLUMN "competenceId" SET NOT NULL');
+  await knex.raw('ALTER TABLE "competence-marks" ALTER COLUMN "assessmentResultId" SET NOT NULL');
+  await knex.raw('ALTER TABLE "competence-marks" ALTER COLUMN "level" SET NOT NULL');
+  await knex.raw('ALTER TABLE "competence-marks" ALTER COLUMN "score" SET NOT NULL');
+};
+
+exports.down = async function(knex) {
+  await knex.raw('ALTER TABLE "competence-marks" ALTER COLUMN "competenceId" DROP NOT NULL');
+  await knex.raw('ALTER TABLE "competence-marks" ALTER COLUMN "assessmentResultId" DROP NOT NULL');
+  await knex.raw('ALTER TABLE "competence-marks" ALTER COLUMN "level" DROP NOT NULL');
+  await knex.raw('ALTER TABLE "competence-marks" ALTER COLUMN "score" DROP NOT NULL');
+};

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -20,7 +20,7 @@ function _deserializeResultsAdd(json) {
       score: competenceMark.score,
       area_code: competenceMark.area_code,
       competence_code: competenceMark.competence_code,
-      competenceId: competenceMark['competence-id'],
+      competenceId: competenceMark['competenceId'],
     });
   });
   return { assessmentResult, competenceMarks };

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -42,19 +42,19 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
                   score: 18,
                   'area_code': 2,
                   'competence_code': 2.1,
-                  'competence-id': '2.1',
+                  'competenceId': '2.1',
                 }, {
                   level: 3,
                   score: 27,
                   'area_code': 3,
                   'competence_code': 3.2,
-                  'competence-id': '3.2',
+                  'competenceId': '3.2',
                 }, {
                   level: 1,
                   score: 9,
                   'area_code': 1,
                   'competence_code': 1.3,
-                  'competence-id': '1.3',
+                  'competenceId': '1.3',
                 },
               ],
             },
@@ -127,6 +127,7 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
             score: 0,
             area_code: 2,
             competence_code: 2.1,
+            competenceId: 'rec123',
           });
       });
 

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -29,16 +29,19 @@ describe('Unit | Controller | assessment-results', () => {
                 score: 18,
                 'area_code': 2,
                 'competence_code': 2.1,
+                'competenceId': 'rec123456',
               }, {
                 level: 3,
                 score: 27,
                 'area_code': 3,
                 'competence_code': 3.2,
+                'competenceId': 'rec159753',
               }, {
                 level: 1,
                 score: 9,
                 'area_code': 1,
                 'competence_code': 1.3,
+                'competenceId': 'rec456789',
               },
             ],
           },
@@ -76,18 +79,21 @@ describe('Unit | Controller | assessment-results', () => {
         score: 18,
         area_code: 2,
         competence_code: 2.1,
+        competenceId: 'rec123456',
       });
       const competenceMark2 = new CompetenceMark({
         level: 3,
         score: 27,
         area_code: 3,
         competence_code: 3.2,
+        competenceId: 'rec159753',
       });
       const competenceMark3 = new CompetenceMark({
         level: 1,
         score: 9,
         area_code: 1,
         competence_code: 1.3,
+        competenceId: 'rec456789',
       });
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, le pôle certif peut encore corriger "manuellement" des certifications. Lors de cette correction, le champ `competenceId` des `competence-marks` n'était pas sauvegardé en base de données.
Plus spécifiquement, le problème se trouve au niveau de la désérialisation des competence-marks à l'arrivée dans l'API.

## :robot: Solution
- Corriger la désérialisation de l'attribut `competenceId`
- Ajout d'une migration pour remplir la colonne competenceId de la table competence-marks avec la bonne valeur. Pour ce faire, nous nous sommes basés sur le competence_code, en prenant soin de vérifier qu'1 competence_code === 1 competenceId (vérif faite sur les données de prod)
- Ajout d'une migration pour ajouter une contrainte de non nullité sur les colonnes suivantes (qui n'ont pas lieu d'être null) : `competenceId`, `assessmentResultId,` `level` et `score`. encore une fois, nous avons vérifié au préalable qu'aucun enregistrement existe avec une de ces colonnes à null.

## :rainbow: Remarques
Suite à cette PR, les fonctionnalités derrière le toggle FT_IS_NEUTRALIZATION_AUTO_ENABLED seront complètement fonctionnelles !

## :100: Pour tester
Pour tester que l'information de competenceId est maintenant bien enregistrée :
-> Se connecter à pixAdmin avec pixmaster@example.net / pix123
-> Se rendre sur n'importe quelle certification
-> Sur la page de la certification, appuyer sur le bouton tout en bas pour la modifier
-> (conseil, ouvrez la console du dév) Changer quelques valeurs dans les competence-marks puis sauvegarder
-> Vérifier en BDD que la colonne "competenceId" a bien été remplie sur les competence-marks ainsi créées (pour les retrouver, regarder le payload envoyé lors de la sauvegarde des nouveaux competence-marks (route POST vers admin/assessment-results) et regarder l'assessmentId. Puis en BDD, trouver l'id de l'assessment-result le plus récent pour l'assessmentId relevé, et puis afficher les competence-marks de cet assessment-result)

Pour tester que le toggle fonctionne :
-> Activer le toggle sur l'API via Scalingo, redémarrer l'API puis recharger la page PixAdmin
-> Faire de la non-régression sur toutes les activités : neutralisation / déneutralisation / affichage des détails / scoring manuel
