### PR TITLE
[TECH] Supprimer le rôle jamais utilisé PIX-READER.

### DIFF
--- a/api/db/migrations/20210506121007_delete_pix_reader_row_in_pix_roles.js
+++ b/api/db/migrations/20210506121007_delete_pix_reader_row_in_pix_roles.js
@@ -1,0 +1,10 @@
+const TABLE_NAME = 'pix_roles';
+const ROW = { name: 'PIX_READER' };
+
+exports.up = function(knex) {
+  return knex.table(TABLE_NAME).where('name', ROW.name).delete();
+};
+
+exports.down = function(knex) {
+  return knex.table(TABLE_NAME).insert(ROW);
+};


### PR DESCRIPTION
## :unicorn: Problème
Le rôle PIX-READER n'est pas utilisé en production alors qu'il a été introduit en [2018](http://github.com/1024pix/pix/blob/dev/api/db/migrations/20180219191550_create_pix_roles.js#L18-L18)

```sql
SELECT
    u.email,
    r.name
FROM "users_pix_roles" ur
    INNER JOIN users u on ur.user_id = u.id
    INNER JOIN pix_roles r on ur.pix_role_id = r.id
WHERE 1=1
    AND r.name = 'PIX_READER'
```
Il n'est pas référencé dans le code et aucune IHM n'y donne accès

## :robot: Solution
Le supprimer

## :100: Pour tester
Exécuter la requête de détection sur la pré-production
Vérifier que la CI passe
