### PR TITLE
[TECH] Empêcher les rôles dupliqués.

### DIFF
--- a/api/db/migrations/20210506134706_alter_users_pix_roles_add_unique_constraint.js
+++ b/api/db/migrations/20210506134706_alter_users_pix_roles_add_unique_constraint.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'users_pix_roles';
+const COLUMNS_NAME = ['user_id', 'pix_role_id'];
+
+exports.up = async function(knex) {
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.unique(COLUMNS_NAME);
+  });
+};
+
+exports.down = function(knex) {
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropUnique(COLUMNS_NAME);
+  });
+};
+


### PR DESCRIPTION
## :unicorn: Problème
Les rôles internes à Pix (table `users_pix_roles`) ne sont pas créées par IHM + API mais par commande SQL.
Il n'y a pas de contrainte d'unicité sur cette table (type de rôle/utilisateur), aussi des doublons ont été créés par erreur en production.

## :robot: Solution
Supprimer les doublons en production
Ajouter une contrainte d'unicité

## :rainbow: Remarques
Les doublons en production ont été supprimés ce jour.
Le jour de la mise en production, vérifier qu'il n'a pas eu de doublons introduits.

```sql
SELECT
    u.email,
    r.name,
    COUNT(1)
FROM "users_pix_roles" ur
    INNER JOIN users u on ur.user_id = u.id
    INNER JOIN pix_roles r on ur.pix_role_id = r.id
WHERE 1=1
    AND u.email IS NOT NULL
GROUP BY  u.email, r.name
HAVING COUNT(1) > 1
```

## :100: Pour tester
Exécuter cette requête en local ou en RA 
```
INSERT INTO "users_pix_roles" (user_id, pix_role_id)
VALUES (100008, 1)
```

Vérifier qu'elle est rejetée avec ce message
` ERROR: duplicate key value violates unique constraint "users_pix_roles_user_id_pix_role_id_unique"`