### PR TITLE
[TECH] Ajouter des détails dans les logs d'erreur du controller SAML.

### DIFF
--- a/api/lib/application/saml/saml-controller.js
+++ b/api/lib/application/saml/saml-controller.js
@@ -19,7 +19,7 @@ module.exports = {
     try {
       userAttributes = await saml.parsePostResponse(request.payload);
     } catch (e) {
-      logger.error(e);
+      logger.error({ e }, 'SAML: Error while parsing post response');
       return h.response(e.toString()).code(400);
     }
 
@@ -28,7 +28,7 @@ module.exports = {
 
       return h.redirect(redirectionUrl);
     } catch (e) {
-      logger.error(e);
+      logger.error({ e }, 'SAML: Error while get external authentication redirection url');
       return h.response(e.toString()).code(500);
     }
   },


### PR DESCRIPTION
## :unicorn: Problème
La recherche d'erreur dans Datadog concernant les erreurs remontées par l'échange GAR/PIX via la protocole SAML est difficile.

## :robot: Solution
Ajouter un message pour pouvoir filtrer dessus.

## :100: Pour tester
Tester en locale avec une simulation d'erreur GAR.
