### PR TITLE
[FEATURE] Passer les sessions assignées comme sessions "à traiter" (PIX-2571)

### DIFF
--- a/api/lib/domain/models/CertificationOfficer.js
+++ b/api/lib/domain/models/CertificationOfficer.js
@@ -8,6 +8,10 @@ class CertificationOfficer {
     this.firstName = firstName;
     this.lastName = lastName;
   }
+
+  getFullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
 }
 
 module.exports = CertificationOfficer;

--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -44,6 +44,11 @@ module.exports = class FinalizedSession {
       publishedAt: null,
     });
   }
+
+  assignCertificationOfficer({ certificationOfficerName }) {
+    this.isPublishable = false;
+    this.assignedCertificationOfficerName = certificationOfficerName;
+  }
 };
 
 function _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries) {

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -34,7 +34,6 @@ const typesPositiveInteger32bits = [
   'organizationInvitationId',
   'schoolingRegistrationId',
   'sessionId',
-  'sessionId',
   'stageId',
   'targetProfileId',
   'userId',

--- a/api/lib/domain/usecases/assign-certification-officer-to-jury-session.js
+++ b/api/lib/domain/usecases/assign-certification-officer-to-jury-session.js
@@ -23,11 +23,12 @@ module.exports = async function assignCertificationOfficerToJurySession({
   const certificationOfficer = await userRepository.get(certificationOfficerId);
   const { firstName, lastName } = certificationOfficer;
   const certificationOfficerName = `${firstName} ${lastName}`;
+  const finalizedSession = await finalizedSessionRepository.get({ sessionId: integerSessionId });
 
-  await finalizedSessionRepository.assignCertificationOfficer({
-    sessionId: integerSessionId,
-    assignedCertificationOfficerName: certificationOfficerName,
-  });
+  finalizedSession.assignCertificationOfficer({ certificationOfficerName });
+
+  await finalizedSessionRepository.save(finalizedSession);
+
   return jurySessionRepository.assignCertificationOfficer({
     id: integerSessionId,
     assignedCertificationOfficerId: integerCertificationOfficerId,

--- a/api/lib/domain/usecases/assign-certification-officer-to-jury-session.js
+++ b/api/lib/domain/usecases/assign-certification-officer-to-jury-session.js
@@ -5,7 +5,7 @@ module.exports = async function assignCertificationOfficerToJurySession({
   certificationOfficerId,
   jurySessionRepository,
   finalizedSessionRepository,
-  userRepository,
+  certificationOfficerRepository,
 } = {}) {
   const integerSessionId = parseInt(sessionId);
   if (!Number.isFinite(integerSessionId)) {
@@ -20,17 +20,15 @@ module.exports = async function assignCertificationOfficerToJurySession({
     );
   }
 
-  const certificationOfficer = await userRepository.get(certificationOfficerId);
-  const { firstName, lastName } = certificationOfficer;
-  const certificationOfficerName = `${firstName} ${lastName}`;
+  const certificationOfficer = await certificationOfficerRepository.get(certificationOfficerId);
   const finalizedSession = await finalizedSessionRepository.get({ sessionId: integerSessionId });
 
-  finalizedSession.assignCertificationOfficer({ certificationOfficerName });
+  finalizedSession.assignCertificationOfficer({ certificationOfficerName: certificationOfficer.getFullName() });
 
   await finalizedSessionRepository.save(finalizedSession);
 
   return jurySessionRepository.assignCertificationOfficer({
-    id: integerSessionId,
-    assignedCertificationOfficerId: integerCertificationOfficerId,
+    id: finalizedSession.sessionId,
+    assignedCertificationOfficerId: certificationOfficer.id,
   });
 };

--- a/api/lib/domain/usecases/assign-certification-officer-to-jury-session.js
+++ b/api/lib/domain/usecases/assign-certification-officer-to-jury-session.js
@@ -1,5 +1,3 @@
-const { ObjectValidationError } = require('../errors');
-
 module.exports = async function assignCertificationOfficerToJurySession({
   sessionId,
   certificationOfficerId,
@@ -7,21 +5,9 @@ module.exports = async function assignCertificationOfficerToJurySession({
   finalizedSessionRepository,
   certificationOfficerRepository,
 } = {}) {
-  const integerSessionId = parseInt(sessionId);
-  if (!Number.isFinite(integerSessionId)) {
-    throw new ObjectValidationError(
-      `L'id ${sessionId} n'est pas un id de session valide.`,
-    );
-  }
-  const integerCertificationOfficerId = parseInt(certificationOfficerId);
-  if (!Number.isFinite(integerCertificationOfficerId)) {
-    throw new ObjectValidationError(
-      `L'id ${certificationOfficerId} n'est pas un id de chargé de certification valide.`,
-    );
-  }
 
   const certificationOfficer = await certificationOfficerRepository.get(certificationOfficerId);
-  const finalizedSession = await finalizedSessionRepository.get({ sessionId: integerSessionId });
+  const finalizedSession = await finalizedSessionRepository.get({ sessionId });
 
   finalizedSession.assignCertificationOfficer({ certificationOfficerName: certificationOfficer.getFullName() });
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -36,6 +36,7 @@ const dependencies = {
   certificationCourseRepository: require('../../infrastructure/repositories/certification-course-repository'),
   certificationIssueReportRepository: require('../../infrastructure/repositories/certification-issue-report-repository'),
   certificationLsRepository: require('../../infrastructure/repositories/certification-livret-scolaire-repository'),
+  certificationOfficerRepository: require('../../infrastructure/repositories/certification-officer-repository'),
   certificationPointOfContactRepository: require('../../infrastructure/repositories/certification-point-of-contact-repository'),
   certificationReportRepository: require('../../infrastructure/repositories/certification-report-repository'),
   certificationRepository: require('../../infrastructure/repositories/certification-repository'),

--- a/api/lib/infrastructure/repositories/certification-officer-repository.js
+++ b/api/lib/infrastructure/repositories/certification-officer-repository.js
@@ -1,0 +1,29 @@
+const BookshelfUser = require('../data/user');
+
+const {
+  UserNotFoundError,
+} = require('../../domain/errors');
+const CertificationOfficer = require('../../domain/models/CertificationOfficer');
+
+module.exports = {
+
+  async get(certificationOfficerId) {
+
+    try {
+      const certificationOfficer = await BookshelfUser
+        .where({ id: certificationOfficerId })
+        .fetch({ columns: ['id', 'firstName', 'lastName'] });
+
+      return _toDomain(certificationOfficer.attributes);
+    } catch (error) {
+      if (error instanceof BookshelfUser.NotFoundError) {
+        throw new UserNotFoundError(`User not found for ID ${certificationOfficerId}`);
+      }
+      throw error;
+    }
+  },
+};
+
+function _toDomain(certificationOfficer) {
+  return new CertificationOfficer(certificationOfficer);
+}

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -26,7 +26,7 @@ module.exports = {
 
   async findFinalizedSessionsToPublish() {
     const publishableFinalizedSessions = await FinalizedSessionBookshelf
-      .where({ isPublishable: true, publishedAt: null })
+      .where({ isPublishable: true, publishedAt: null, assignedCertificationOfficerName: null })
       .orderBy('finalizedAt')
       .fetchAll();
 

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const { NotFoundError } = require('../../domain/errors');
 
 const FinalizedSessionBookshelf = require('../data/finalized-session');
 
@@ -7,15 +8,27 @@ const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-convert
 module.exports = {
 
   async save(finalizedSession) {
-    return await new FinalizedSessionBookshelf(_toDTO(finalizedSession)).save();
+    const foundSession = await FinalizedSessionBookshelf.where({ sessionId: finalizedSession.sessionId }).fetch({ require: false });
+
+    if (foundSession) {
+      return FinalizedSessionBookshelf
+        .where({ sessionId: finalizedSession.sessionId })
+        .save(_toDTO(finalizedSession), { method: 'update', require: false });
+    }
+
+    return new FinalizedSessionBookshelf(_toDTO(finalizedSession), { method: 'insert' }).save();
   },
 
   async get({ sessionId }) {
     const bookshelfFinalizedSession = await FinalizedSessionBookshelf
       .where({ sessionId })
-      .fetch();
+      .fetch({ require: false });
 
-    return bookshelfToDomainConverter.buildDomainObject(FinalizedSessionBookshelf, bookshelfFinalizedSession);
+    if (bookshelfFinalizedSession) {
+      return bookshelfToDomainConverter.buildDomainObject(FinalizedSessionBookshelf, bookshelfFinalizedSession);
+    }
+
+    throw new NotFoundError(`Session of id ${sessionId} does not exist.`);
   },
 
   async updatePublishedAt({ sessionId, publishedAt }) {
@@ -40,12 +53,6 @@ module.exports = {
       .fetchAll();
 
     return bookshelfToDomainConverter.buildDomainObjects(FinalizedSessionBookshelf, publishableFinalizedSessions);
-  },
-
-  async assignCertificationOfficer({ sessionId, assignedCertificationOfficerName }) {
-    await FinalizedSessionBookshelf
-      .where({ sessionId })
-      .save({ assignedCertificationOfficerName }, { method: 'update', require: false });
   },
 };
 

--- a/api/tests/integration/infrastructure/repositories/certification-officer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-officer-repository_test.js
@@ -1,0 +1,40 @@
+const { databaseBuilder, expect, catchErr } = require('../../../test-helper');
+const certificationOfficerRepository = require('../../../../lib/infrastructure/repositories/certification-officer-repository');
+
+const { UserNotFoundError } = require('../../../../lib/domain/errors');
+const CertificationOfficer = require('../../../../lib/domain/models/CertificationOfficer');
+
+describe('Integration | Repository | CertificationOfficer', function() {
+
+  describe('#get', () => {
+
+    let userInDb;
+
+    beforeEach(async () => {
+      userInDb = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+    });
+
+    it('should return the found certificationOfficer', async () => {
+      // when
+      const certificationOfficer = await certificationOfficerRepository.get(userInDb.id);
+
+      // then
+      expect(certificationOfficer).to.be.an.instanceOf(CertificationOfficer);
+      expect(certificationOfficer.id).to.equal(userInDb.id);
+      expect(certificationOfficer.firstName).to.equal(userInDb.firstName);
+      expect(certificationOfficer.lastName).to.equal(userInDb.lastName);
+    });
+
+    it('should return a UserNotFoundError if no certificationOfficer is found', async () => {
+      // given
+      const nonExistentUserId = 678;
+
+      // when
+      const result = await catchErr(certificationOfficerRepository.get)(nonExistentUserId);
+
+      // then
+      expect(result).to.be.instanceOf(UserNotFoundError);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -117,6 +117,7 @@ describe('Integration | Repository | Finalized-session', () => {
         const publishableFinalizedSession2 = databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: null, finalizedAt: new Date('2019-01-01') });
         const publishableFinalizedSession3 = databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: null, finalizedAt: new Date('2021-01-01') });
 
+        databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: null, finalizedAt: new Date('2020-01-01'), assignedCertificationOfficerName: 'Ruppert Giles' });
         databaseBuilder.factory.buildFinalizedSession({ isPublishable: false, publishedAt: null });
         databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: '2021-01-01' });
 

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -1,6 +1,7 @@
-const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { expect, databaseBuilder, knex, catchErr } = require('../../../test-helper');
 const finalizedSessionRepository = require('../../../../lib/infrastructure/repositories/finalized-session-repository');
 const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Repository | Finalized-session', () => {
 
@@ -10,32 +11,72 @@ describe('Integration | Repository | Finalized-session', () => {
       return knex('finalized-sessions').delete();
     });
 
-    it('saves a finalized session', async () => {
-      // given
-      const finalizedSession = new FinalizedSession({
-        sessionId: 1234,
-        finalizedAt: new Date('2021-02-01T11:48:00Z'),
-        certificationCenterName: 'A certification center name',
-        sessionDate: '2021-01-01',
-        sessionTime: '14:00:00',
-        isPublishable: true,
+    context('When the session does not exist', () => {
+
+      it('saves a finalized session', async () => {
+        // given
+        const finalizedSession = new FinalizedSession({
+          sessionId: 1234,
+          finalizedAt: new Date('2021-02-01T11:48:00Z'),
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-01',
+          sessionTime: '14:00:00',
+          isPublishable: true,
+        });
+
+        // when
+        await finalizedSessionRepository.save(finalizedSession);
+
+        // then
+        const result = await knex('finalized-sessions');
+        expect(result).to.have.lengthOf(1);
+        expect(result[0]).to.deep.equal({
+          sessionId: 1234,
+          finalizedAt: new Date('2021-02-01T11:48:00Z'),
+          certificationCenterName: 'A certification center name',
+          date: '2021-01-01',
+          time: '14:00:00',
+          isPublishable: true,
+          publishedAt: null,
+          assignedCertificationOfficerName: null,
+        });
       });
+    });
 
-      // when
-      await finalizedSessionRepository.save(finalizedSession);
+    context('When the session does exist', () => {
 
-      // then
-      const result = await knex('finalized-sessions');
-      expect(result).to.have.lengthOf(1);
-      expect(result[0]).to.deep.equal({
-        sessionId: 1234,
-        finalizedAt: new Date('2021-02-01T11:48:00Z'),
-        certificationCenterName: 'A certification center name',
-        date: '2021-01-01',
-        time: '14:00:00',
-        isPublishable: true,
-        publishedAt: null,
-        assignedCertificationOfficerName: null,
+      it('updates a finalized session', async () => {
+        // given
+        const finalizedSession = databaseBuilder.factory.buildFinalizedSession({
+          sessionId: 1234,
+          isPublishable: true,
+          finalizedAt: new Date('2021-02-01T11:48:00Z'),
+          certificationCenterName: 'A certification center name',
+          date: '2021-01-01',
+          time: '14:00:00',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await finalizedSessionRepository.save({
+          ...finalizedSession,
+          isPublishable: false,
+        });
+
+        // then
+        const result = await knex('finalized-sessions');
+        expect(result).to.have.lengthOf(1);
+        expect(result[0]).to.deep.equal({
+          sessionId: 1234,
+          finalizedAt: new Date('2021-02-01T11:48:00Z'),
+          certificationCenterName: 'A certification center name',
+          date: '2021-01-01',
+          time: '14:00:00',
+          isPublishable: false,
+          publishedAt: null,
+          assignedCertificationOfficerName: null,
+        });
       });
     });
   });
@@ -46,26 +87,38 @@ describe('Integration | Repository | Finalized-session', () => {
       return knex('finalized-sessions').delete();
     });
 
-    it('retrieves a finalized session', async () => {
-      // given
-      const finalizedSession = databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 });
-      await databaseBuilder.commit();
+    context('When the session does exist', () => {
 
-      // when
-      const result = await finalizedSessionRepository.get({ sessionId: finalizedSession.sessionId });
+      it('retrieves a finalized session', async () => {
+        // given
+        const finalizedSession = databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 });
+        await databaseBuilder.commit();
 
-      // then
-      expect(result).to.deep.equal({
-        sessionId: finalizedSession.sessionId,
-        finalizedAt: finalizedSession.finalizedAt,
-        certificationCenterName: finalizedSession.certificationCenterName,
-        sessionDate: finalizedSession.date,
-        sessionTime: finalizedSession.time,
-        isPublishable: finalizedSession.isPublishable,
-        publishedAt: null,
-        assignedCertificationOfficerName: null,
+        // when
+        const result = await finalizedSessionRepository.get({ sessionId: finalizedSession.sessionId });
+
+        // then
+        expect(result).to.deep.equal({
+          sessionId: finalizedSession.sessionId,
+          finalizedAt: finalizedSession.finalizedAt,
+          certificationCenterName: finalizedSession.certificationCenterName,
+          sessionDate: finalizedSession.date,
+          sessionTime: finalizedSession.time,
+          isPublishable: finalizedSession.isPublishable,
+          publishedAt: null,
+          assignedCertificationOfficerName: null,
+        });
       });
     });
+
+    context('When the session does not exist', () => {
+      it('throws a not found error', async() => {
+        // when
+        const error = await catchErr(finalizedSessionRepository.get)({ sessionId: 404 });
+        expect(error).to.be.an.instanceOf(NotFoundError);
+      });
+    });
+
   });
 
   describe('#updatePublishedAt', () => {
@@ -238,45 +291,6 @@ describe('Integration | Repository | Finalized-session', () => {
 
         // then
         expect(result).to.have.lengthOf(0);
-      });
-    });
-  });
-
-  describe('#assignCertificationOfficer', () => {
-    it('should add the name to the finalized session', async () => {
-      // given
-      const session = databaseBuilder.factory.buildFinalizedSession();
-      const sessionId = session.sessionId;
-      await databaseBuilder.commit();
-
-      // when
-      await finalizedSessionRepository.assignCertificationOfficer({
-        sessionId,
-        assignedCertificationOfficerName: 'Severus Snape',
-      });
-
-      // then
-      const updatedFinalizedSession = await knex('finalized-sessions').where({ sessionId }).first();
-      expect(updatedFinalizedSession.assignedCertificationOfficerName)
-        .to.deep.equal('Severus Snape');
-    });
-
-    context('when sessionId does not exist', () => {
-
-      it('should not throw when trying to assign certification officer on non-existent finalized session', async () => {
-        // given
-        const sessionId = databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 }).sessionId;
-        await databaseBuilder.commit();
-        const unknownSessionId = sessionId + 1;
-
-        // when
-        const promise = finalizedSessionRepository.assignCertificationOfficer({
-          sessionId: unknownSessionId,
-          assignedCertificationOfficerName: 'Severus Snape',
-        });
-
-        // then
-        return expect(promise).to.be.fulfilled;
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-certification-officer.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-officer.js
@@ -1,0 +1,13 @@
+const CertificationOfficer = require('../../../../lib/domain/models/CertificationOfficer');
+
+module.exports = function buildCertificationOfficer({
+  id = 123,
+  firstName = 'Dean',
+  lastName = 'Winchester',
+} = {}) {
+  return new CertificationOfficer({
+    id,
+    firstName,
+    lastName,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-finalized-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-finalized-session.js
@@ -1,4 +1,4 @@
-const Session = require('../../../../lib/domain/models/Session');
+const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession');
 
 module.exports = function buildFinalizedSession({
   sessionId = 123,
@@ -9,7 +9,7 @@ module.exports = function buildFinalizedSession({
   publishedAt = null,
   isPublishable = true,
 } = {}) {
-  return new Session({
+  return new FinalizedSession({
     sessionId,
     certificationCenterName,
     sessionDate,

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -21,6 +21,7 @@ module.exports = {
   buildCertificationAssessment: require('./build-certification-assessment'),
   buildCertificationCandidate: require('./build-certification-candidate'),
   buildCertificationIssueReport: require('./build-certification-issue-report'),
+  buildCertificationOfficer: require('./build-certification-officer'),
   buildSCOCertificationCandidate: require('./build-sco-certification-candidate'),
   buildCertificationCenter: require('./build-certification-center'),
   buildCertificationCenterMembership: require('./build-certification-center-membership'),

--- a/api/tests/unit/domain/models/CertificationOfficer_test.js
+++ b/api/tests/unit/domain/models/CertificationOfficer_test.js
@@ -1,0 +1,15 @@
+const { expect } = require('../../../test-helper');
+const CertificationOfficer = require('../../../../lib/domain/models/CertificationOfficer');
+
+describe('Unit | Domain | Models | CertificationOfficer', () => {
+
+  describe('#getFullName', () => {
+    it('should return certification officer full name', () => {
+      // when
+      const certificationOfficer = new CertificationOfficer({ id: 1234, firstName: 'Chuck', lastName: 'Norris' });
+
+      // then
+      expect(certificationOfficer.getFullName()).to.equal('Chuck Norris');
+    });
+  });
+});

--- a/api/tests/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/unit/domain/models/FinalizedSession_test.js
@@ -100,6 +100,32 @@ describe('Unit | Domain | Models | FinalizedSession', () => {
       expect(finalizedSession.isPublishable).to.be.true;
     });
   });
+
+  context('#assignCertificationOfficer', () => {
+
+    it('Assigns certification officer and make the session not publishable', () => {
+      // given / when
+      const certificationOfficerName = 'Ruppert Giles';
+      const finalizedSession = new FinalizedSession({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+        isPublishable: true,
+        publishedAt: null,
+        assignedCertificationOfficerName: null,
+      });
+
+      finalizedSession.assignCertificationOfficer({ certificationOfficerName });
+
+      // then
+      expect(finalizedSession.isPublishable).to.be.false;
+      expect(finalizedSession.assignedCertificationOfficerName).to.equal(certificationOfficerName);
+    });
+  });
 });
 
 function _noneWithRequiredActionNorErrorOrStartedStatus() {

--- a/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
+++ b/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
@@ -1,4 +1,4 @@
-const { expect, sinon, catchErr } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const assignCertificationOfficerToJurySession = require('../../../../lib/domain/usecases/assign-certification-officer-to-jury-session');
 const { ObjectValidationError } = require('../../../../lib/domain/errors');
 
@@ -60,8 +60,15 @@ describe('Unit | UseCase | assign-certification-officer-to-session', () => {
           .resolves(returnedSessionId);
 
         const finalizedSessionRepository = {
-          assignCertificationOfficer: sinon.stub(),
+          get: sinon.stub(),
+          save: sinon.stub(),
         };
+
+        const finalizedSession = domainBuilder.buildFinalizedSession();
+
+        finalizedSessionRepository.get
+          .withArgs({ sessionId })
+          .resolves(finalizedSession);
 
         const userRepository = { get: sinon.stub() };
         userRepository.get
@@ -85,11 +92,8 @@ describe('Unit | UseCase | assign-certification-officer-to-session', () => {
           assignedCertificationOfficerId: certificationOfficerId,
         });
         expect(
-          finalizedSessionRepository.assignCertificationOfficer,
-        ).to.have.been.calledWith({
-          sessionId: 1,
-          assignedCertificationOfficerName: 'Severus Snape',
-        });
+          finalizedSessionRepository.save,
+        ).to.have.been.calledWith(finalizedSession);
         expect(actualSessionId).to.equal(returnedSessionId);
       });
     });

--- a/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
+++ b/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
@@ -70,10 +70,11 @@ describe('Unit | UseCase | assign-certification-officer-to-session', () => {
           .withArgs({ sessionId })
           .resolves(finalizedSession);
 
-        const userRepository = { get: sinon.stub() };
-        userRepository.get
+        const certificationOfficerRepository = { get: sinon.stub() };
+        const certificationOfficer = domainBuilder.buildCertificationOfficer();
+        certificationOfficerRepository.get
           .withArgs(2)
-          .resolves({ firstName: 'Severus', lastName: 'Snape' });
+          .resolves(certificationOfficer);
 
         // when
         const actualSessionId = await assignCertificationOfficerToJurySession({
@@ -81,15 +82,15 @@ describe('Unit | UseCase | assign-certification-officer-to-session', () => {
           certificationOfficerId,
           jurySessionRepository,
           finalizedSessionRepository,
-          userRepository,
+          certificationOfficerRepository,
         });
 
         // then
         expect(
           jurySessionRepository.assignCertificationOfficer,
         ).to.have.been.calledWith({
-          id: sessionId,
-          assignedCertificationOfficerId: certificationOfficerId,
+          id: finalizedSession.sessionId,
+          assignedCertificationOfficerId: certificationOfficer.id,
         });
         expect(
           finalizedSessionRepository.save,

--- a/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
+++ b/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
@@ -1,102 +1,56 @@
-const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const assignCertificationOfficerToJurySession = require('../../../../lib/domain/usecases/assign-certification-officer-to-jury-session');
-const { ObjectValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | assign-certification-officer-to-session', () => {
-  context('when session id is not a number', () => {
-    it('should throw a NotFound error', async () => {
-      // given
-      const jurySessionRepository = {
-        assignCertificationOfficer: sinon.stub(),
-      };
-      const sessionId = 'notANumber';
-      const certificationOfficerId = 1;
 
-      // when
-      const error = await catchErr(assignCertificationOfficerToJurySession)({
-        sessionId,
-        certificationOfficerId,
-        jurySessionRepository,
-      });
+  it('should return the session id after assigningUser to it', async () => {
+    // given
+    const returnedSessionId = Symbol('returnedSessionId');
+    const sessionId = 1;
+    const certificationOfficerId = 2;
 
-      // then
-      expect(error).to.be.an.instanceOf(ObjectValidationError);
-    });
-  });
+    const jurySessionRepository = {
+      assignCertificationOfficer: sinon.stub(),
+    };
+    jurySessionRepository.assignCertificationOfficer
+      .resolves(returnedSessionId);
 
-  context('when session id is a number', () => {
-    context('when certificationOfficerId is not a number', () => {
-      it('should throw a NotFound error', async () => {
-        // given
-        const jurySessionRepository = {
-          assignCertificationOfficer: sinon.stub(),
-        };
-        const sessionId = 1;
-        const certificationOfficerId = 'notANumber';
+    const finalizedSessionRepository = {
+      get: sinon.stub(),
+      save: sinon.stub(),
+    };
 
-        // when
-        const error = await catchErr(assignCertificationOfficerToJurySession)({
-          sessionId,
-          certificationOfficerId,
-          jurySessionRepository,
-        });
+    const finalizedSession = domainBuilder.buildFinalizedSession();
 
-        // then
-        expect(error).to.be.an.instanceOf(ObjectValidationError);
-      });
+    finalizedSessionRepository.get
+      .withArgs({ sessionId })
+      .resolves(finalizedSession);
+
+    const certificationOfficerRepository = { get: sinon.stub() };
+    const certificationOfficer = domainBuilder.buildCertificationOfficer();
+    certificationOfficerRepository.get
+      .withArgs(2)
+      .resolves(certificationOfficer);
+
+    // when
+    const actualSessionId = await assignCertificationOfficerToJurySession({
+      sessionId,
+      certificationOfficerId,
+      jurySessionRepository,
+      finalizedSessionRepository,
+      certificationOfficerRepository,
     });
 
-    context('when certificationOfficerId is a number', () => {
-      it('should return the session id after assigningUser to it', async () => {
-        // given
-        const returnedSessionId = Symbol('returnedSessionId');
-        const sessionId = 1;
-        const certificationOfficerId = 2;
-
-        const jurySessionRepository = {
-          assignCertificationOfficer: sinon.stub(),
-        };
-        jurySessionRepository.assignCertificationOfficer
-          .resolves(returnedSessionId);
-
-        const finalizedSessionRepository = {
-          get: sinon.stub(),
-          save: sinon.stub(),
-        };
-
-        const finalizedSession = domainBuilder.buildFinalizedSession();
-
-        finalizedSessionRepository.get
-          .withArgs({ sessionId })
-          .resolves(finalizedSession);
-
-        const certificationOfficerRepository = { get: sinon.stub() };
-        const certificationOfficer = domainBuilder.buildCertificationOfficer();
-        certificationOfficerRepository.get
-          .withArgs(2)
-          .resolves(certificationOfficer);
-
-        // when
-        const actualSessionId = await assignCertificationOfficerToJurySession({
-          sessionId,
-          certificationOfficerId,
-          jurySessionRepository,
-          finalizedSessionRepository,
-          certificationOfficerRepository,
-        });
-
-        // then
-        expect(
-          jurySessionRepository.assignCertificationOfficer,
-        ).to.have.been.calledWith({
-          id: finalizedSession.sessionId,
-          assignedCertificationOfficerId: certificationOfficer.id,
-        });
-        expect(
-          finalizedSessionRepository.save,
-        ).to.have.been.calledWith(finalizedSession);
-        expect(actualSessionId).to.equal(returnedSessionId);
-      });
+    // then
+    expect(
+      jurySessionRepository.assignCertificationOfficer,
+    ).to.have.been.calledWith({
+      id: finalizedSession.sessionId,
+      assignedCertificationOfficerId: certificationOfficer.id,
     });
+    expect(
+      finalizedSessionRepository.save,
+    ).to.have.been.calledWith(finalizedSession);
+    expect(actualSessionId).to.equal(returnedSessionId);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui lorsqu'une session publiable est assignée à un membre du pôle certif, elle reste dans les sessions à publier et n'apparaît pas dans les sessions à traiter.

## :robot: Solution
Passer les sessions assignées dans les sessions "à traiter" et les sortir de la liste des sessions "à publier"

## :100: Pour tester
- Se connecter à Pix-Admin
- S'assigner une session à publier
- Constater qu'elle apparaît dans les session à traiter et qu'elle n'est plus dans les sessions à publier
