### PR TITLE
[BUGFIX] Correction de l'erreur Ember "Cannot read property 'targetName' of undefined"

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -68,7 +68,7 @@ export default class ChallengeRoute extends Route {
     catch (error) {
       answer.rollbackAttributes();
 
-      return this.send('error');
+      return this.intermediateTransitionTo('error', undefined);
     }
   }
 

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -241,7 +241,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
       it('should remove temporary answer and send error', async function() {
         // given
         answerToChallengeOne.save = sinon.stub().rejects();
-        route.actions.error = sinon.stub().rejects();
+        route.intermediateTransitionTo = sinon.stub().rejects();
         const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
 
         // when / then
@@ -250,8 +250,8 @@ describe('Unit | Route | Assessments | Challenge', function() {
             throw new Error('was supposed to fail');
           })
           .catch(function() {
-            sinon.assert.called(route.actions.error);
             sinon.assert.called(answerToChallengeOne.rollbackAttributes);
+            sinon.assert.calledWith(route.intermediateTransitionTo, 'error', undefined);
           });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
L'erreur front "Cannot read property 'targetName' of undefined" revient assez souvent dans [Sentry](https://sentry.io/organizations/pix/issues/2056881235/?environment=recette&project=5476250&query=is%3Aunresolved&statsPeriod=90d) (environnement de recette). Cette erreur se produit lorsqu'un problème survient lors de l'envoi (ou abandon) d'une réponse à une question. En effet, quand cela se produit, nous appelons l'action `error` sur les routes parentes. Etant donné que celles-ci ne possèdent pas d'action portant ce nom, cela revient à appeler l'action `error` d'Ember ce qui, in fine, affiche la page Oups.

https://github.com/1024pix/pix/blob/1df7d9cf5e80c6f87ca7382ffbe42e2996c25e3f/mon-pix/app/routes/assessments/challenge.js#L68-L72

Cependant, cette action `error` correspond à la fonctionnalité [d'error substate](https://guides.emberjs.com/release/routing/loading-and-error-substates/) et est réservée aux erreurs renvoyées durant la phase de transition d'une route (voir https://github.com/emberjs/ember.js/issues/15960).
L'erreur que l'on reçoit en est d'ailleurs une preuve car Ember souhaite logger le nom de la route cible de la transition.

https://github.com/emberjs/ember.js/blob/a6b944e63f7250b39cb20233c42ecedb07ca4f79/packages/%40ember/-internals/routing/lib/system/router.ts#L1326

Or, dans notre cas, nous n'avons pas de transition car l'action `error` est appelé depuis une action de route custom.

## :robot: Solution
- Rediriger l'utilisateur vers la page Oups sans passer par l'action `error` d'Ember.

## :rainbow: Remarques
Pour y parvenir, il suffit de regarder ce que fait l'action `error`.

https://github.com/emberjs/ember.js/blob/a6b944e63f7250b39cb20233c42ecedb07ca4f79/packages/%40ember/-internals/routing/lib/system/router.ts#L1297-L1327

Cette fonction va, dans le cas de la route /assessments/{assessmentId}/challenges/{challengeId}
- Regarder s'il existe, pour la route /assessments/{assessmentId}/challenges/{challengeId} une route error.js
- Regarder s'il existe, pour la route /assessments/{assessmentId}/ une route error.js
- Regarder s'il existe, pour la route application une route error.js
Il ne va trouver cette route error.js que pour la route application et va donc appeler la fonction `intermediateTransitionTo('error', undefined);` (l'objet error est undefined ici).   

## :100: Pour tester
- Commencer ou reprendre une compétence
- Avant de cliquer sur `Passer` ou `Je valide`, passer en mode hors-ligne.
- Cliquer sur l'un des deux boutons.
- Vérifier que la page `Oups` s'affiche.
- Vérifier dans la console que le message d'erreur "Cannot read property 'targetName' of undefined" n'est pas affiché.  
