### PR TITLE
[TECH] Supprimer le package inutilisé dezalgo.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1248,11 +1248,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -2363,15 +2358,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-    },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "requires": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
     },
     "diff": {
       "version": "4.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -34,7 +34,6 @@
     "catbox": "^10.0.6",
     "catbox-memory": "^4.0.1",
     "csv-parse": "^4.15.3",
-    "dezalgo": "^1.0.3",
     "dotenv": "^8.2.0",
     "fast-levenshtein": "^3.0.0",
     "file-type": "^16.3.0",


### PR DESCRIPTION
## :unicorn: Problème
Le package [dezalgo](https://github.com/npm/dezalgo) est installé dans l'API, mais à priori non utilisé.
`dezalgo` mitige des risques liéées à l'implémentation native des callback JS
> It will ensure that it is always called in a future tick, and never in this tick.

Il a été introduit dans [cette PR](https://github.com/1024pix/pix/pull/64) Sentry en 2018
`git log --source -S 'dezalgo' -- ./package.json`

@jbuget [mettait déjà en doute](https://github.com/1024pix/pix/pull/64#discussion_r188695342) son utilité dans ce contexte

## :robot: Solution
Supprimer le package et vérifier que les tests passent.

## :rainbow: Remarques
[depcheck](https://www.npmjs.com/package/depcheck) le remonte comme inutilisé
` npx depcheck`

## :100: Pour tester
Vérifier que la CI passe
