### PR TITLE
[FEATURE] Améliorer l'accessibilité de l'infobulle sur le nombre de pix total

### DIFF
--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -20,6 +20,10 @@ export default class HexagonScore extends Component {
     return ENV.APP.MAX_REACHABLE_LEVEL;
   }
 
+  get isTooltipDisplayed() {
+    return this.displayHelp === 'hexagon-score__information--visible';
+  }
+
   @action
   hideHelp() {
     this.displayHelp = 'hexagon-score__information--hidden';
@@ -28,5 +32,14 @@ export default class HexagonScore extends Component {
   @action
   showHelp() {
     this.displayHelp = 'hexagon-score__information--visible';
+  }
+
+  @action
+  toggleTooltip() {
+    if (this.isTooltipDisplayed) {
+      this.hideHelp();
+      return;
+    }
+    this.showHelp();
   }
 }

--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import ENV from 'mon-pix/config/environment';
 
 export default class HexagonScore extends Component {
-  @tracked displayHelp = 'hexagon-score__information--hidden';
+  @tracked displayHelp = false;
 
   get score() {
     const score = this.args.pixScore;
@@ -20,26 +20,18 @@ export default class HexagonScore extends Component {
     return ENV.APP.MAX_REACHABLE_LEVEL;
   }
 
-  get isTooltipDisplayed() {
-    return this.displayHelp === 'hexagon-score__information--visible';
-  }
-
   @action
   hideHelp() {
-    this.displayHelp = 'hexagon-score__information--hidden';
+    this.displayHelp = false;
   }
 
   @action
   showHelp() {
-    this.displayHelp = 'hexagon-score__information--visible';
+    this.displayHelp = true;
   }
 
   @action
   toggleTooltip() {
-    if (this.isTooltipDisplayed) {
-      this.hideHelp();
-      return;
-    }
-    this.showHelp();
+    this.displayHelp = !this.displayHelp;
   }
 }

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -94,20 +94,13 @@
       border-right: none;
     }
   }
-
-  &--visible {
-    display: block;
-  }
-
-  &--hidden {
-    display: none;
-  }
 }
 
 .hexagon-score-information__text {
   font-family: $font-open-sans;
   font-size: 1rem;
   line-height: 1.375rem;
+  display: block;
 
   &--strong {
     font-weight: $font-bold;

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -58,6 +58,9 @@
     left: 31px;
     top: 100px;
     padding-top: 3px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 }
 
@@ -116,4 +119,9 @@
   @include device-is('desktop') {
     display: none;
   }
+}
+
+.hexagon-score-content-pix-total__button {
+  padding: 0 0 0 4px;
+  border: none;
 }

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -73,9 +73,11 @@
   width: 300px;
   padding: 20px 36px;
   margin: 150px 0 0 -80px;
+  letter-spacing: 0.12rem;
+  word-spacing: 0.16rem;
 
   @include device-is('large-screen') {
-    height: 161px;
+    height: 270px;
     width: 587px;
     padding: 20px 36px;
     margin: 135px 0 0 -520px;
@@ -97,12 +99,21 @@
       border-right: none;
     }
   }
+
+  p {
+    margin-top: 0;
+    margin-bottom: 2rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .hexagon-score-information__text {
   font-family: $font-open-sans;
   font-size: 1rem;
-  line-height: 1.375rem;
+  line-height: 1.5rem;
   display: block;
 
   &--strong {

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -74,7 +74,7 @@
   padding: 20px 36px;
   margin: 150px 0 0 -80px;
 
-  @include device-is('desktop') {
+  @include device-is('large-screen') {
     height: 161px;
     width: 587px;
     padding: 20px 36px;
@@ -92,7 +92,7 @@
     border-left: 20px solid transparent;
     border-right: 20px solid transparent;
 
-    @include device-is('desktop') {
+    @include device-is('large-screen') {
       right: 0;
       border-right: none;
     }

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -1,5 +1,4 @@
-<div class="hexagon-score" {{on 'mouseover' this.showHelp}} {{on 'mouseout' this.hideHelp}}
-     role="tooltip">
+<div class="hexagon-score" {{on 'mouseenter' this.showHelp}} {{on 'mouseleave' this.hideHelp}}>
   <div class="hexagon-score__content">
     <div class="hexagon-score-content__title">{{t 'common.pix'}}</div>
     <div class="hexagon-score-content__pix-score">{{this.score}}</div>
@@ -16,9 +15,11 @@
     </div>
   </div>
 
-  <div role="tooltip" id="hexagon-score-tooltip" class="hexagon-score__information hexagon-score-information__text {{this.displayHelp}}">
-    <span class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</span>
-    <br><br>
-    {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}
-  </div>
+  {{#if this.displayHelp}}
+    <div role="tooltip" id="hexagon-score-tooltip" class="hexagon-score__information hexagon-score-information__text">
+      <span class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</span>
+      <br><br>
+      {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}
+    </div>
+  {{/if}}
 </div>

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -24,8 +24,7 @@
          id="hexagon-score-tooltip"
          class="hexagon-score__information hexagon-score-information__text"
          {{on-key 'Escape' this.hideHelp event='keyup'}}>
-      <span class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</span>
-      <br><br>
+      <p class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</p>
       {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}
     </div>
   {{/if}}

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -6,16 +6,17 @@
     <div class="hexagon-score-content__pix-total">
       1024
       <PixButton role="button"
+                 aria-label={{t 'pages.profile.total-score-helper.title'}}
                  @backgroundColor="transparent"
                  @isBorderVisible={{false}}
                  @triggerAction={{this.toggleTooltip}}
-                 aria-describedby="hexagon-score-information__text">
+                 aria-describedby="hexagon-score-tooltip">
         <FaIcon @icon="info-circle"/>
       </PixButton>
     </div>
   </div>
 
-  <div role="tooltip" class="hexagon-score__information hexagon-score-information__text {{this.displayHelp}}">
+  <div role="tooltip" id="hexagon-score-tooltip" class="hexagon-score__information hexagon-score-information__text {{this.displayHelp}}">
     <span class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</span>
     <br><br>
     {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -1,13 +1,21 @@
 <div class="hexagon-score" {{on 'mouseover' this.showHelp}} {{on 'mouseout' this.hideHelp}}
-     role="tooltip"
-     aria-describedby="hexagon-score-information__text">
+     role="tooltip">
   <div class="hexagon-score__content">
     <div class="hexagon-score-content__title">{{t 'common.pix'}}</div>
     <div class="hexagon-score-content__pix-score">{{this.score}}</div>
-    <div class="hexagon-score-content__pix-total">1024 <FaIcon @icon="info-circle"/></div>
+    <div class="hexagon-score-content__pix-total">
+      1024
+      <PixButton role="button"
+                 @backgroundColor="transparent"
+                 @isBorderVisible={{false}}
+                 @triggerAction={{this.toggleTooltip}}
+                 aria-describedby="hexagon-score-information__text">
+        <FaIcon @icon="info-circle"/>
+      </PixButton>
+    </div>
   </div>
 
-  <div class="hexagon-score__information hexagon-score-information__text {{this.displayHelp}}">
+  <div role="tooltip" class="hexagon-score__information hexagon-score-information__text {{this.displayHelp}}">
     <span class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</span>
     <br><br>
     {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -12,7 +12,8 @@
                  @isBorderVisible={{false}}
                  @triggerAction={{this.toggleTooltip}}
                  {{on 'focusout' this.hideHelp}}
-                 aria-describedby="hexagon-score-tooltip">
+                 aria-describedby="hexagon-score-tooltip"
+                 class="hexagon-score-content-pix-total__button">
         <FaIcon @icon="info-circle"/>
       </PixButton>
     </div>

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -1,4 +1,6 @@
-<div class="hexagon-score" {{on 'mouseenter' this.showHelp}} {{on 'mouseleave' this.hideHelp}}>
+<div class="hexagon-score"
+  {{on 'mouseenter' this.showHelp}}
+  {{on 'mouseleave' this.hideHelp}}>
   <div class="hexagon-score__content">
     <div class="hexagon-score-content__title">{{t 'common.pix'}}</div>
     <div class="hexagon-score-content__pix-score">{{this.score}}</div>
@@ -16,7 +18,7 @@
   </div>
 
   {{#if this.displayHelp}}
-    <div role="tooltip" id="hexagon-score-tooltip" class="hexagon-score__information hexagon-score-information__text">
+    <div role="tooltip" id="hexagon-score-tooltip" class="hexagon-score__information hexagon-score-information__text" {{on-key 'Escape' this.hideHelp}}>
       <span class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</span>
       <br><br>
       {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -11,6 +11,7 @@
                  @backgroundColor="transparent"
                  @isBorderVisible={{false}}
                  @triggerAction={{this.toggleTooltip}}
+                 {{on 'focusout' this.hideHelp}}
                  aria-describedby="hexagon-score-tooltip">
         <FaIcon @icon="info-circle"/>
       </PixButton>
@@ -18,7 +19,10 @@
   </div>
 
   {{#if this.displayHelp}}
-    <div role="tooltip" id="hexagon-score-tooltip" class="hexagon-score__information hexagon-score-information__text" {{on-key 'Escape' this.hideHelp}}>
+    <div role="tooltip"
+         id="hexagon-score-tooltip"
+         class="hexagon-score__information hexagon-score-information__text"
+         {{on-key 'Escape' this.hideHelp event='keyup'}}>
       <span class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</span>
       <br><br>
       {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -85,13 +85,28 @@ describe('Integration | Component | hexagon-score', function() {
 
     describe('on ‘Escape‘ key pressed', () => {
       it('should hide tooltip', async () => {
-        // when
+        // given
         await triggerEvent('.hexagon-score', 'mouseenter');
         expect(find(tooltip)).to.exist;
 
-        // then
+        // when
         const escapeKeyCode = 27;
-        await triggerKeyEvent('.hexagon-score__information', 'keydown', escapeKeyCode);
+        await triggerKeyEvent('.hexagon-score__information', 'keyup', escapeKeyCode);
+
+        // then
+        expect(find(tooltip)).not.to.exist;
+      });
+    });
+
+    describe('on button focusout', () => {
+      it('should hide tooltip', async () => {
+        // given
+        const button = find('.hexagon-score-content__pix-total button');
+        await click(button);
+        expect(find(tooltip)).to.exist;
+
+        // when
+        await triggerEvent(button, 'focusout');
 
         // then
         expect(find(tooltip)).not.to.exist;

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { click, find, render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | hexagon-score', function() {
@@ -34,5 +34,34 @@ describe('Integration | Component | hexagon-score', function() {
       // then
       expect(this.element.querySelector('.hexagon-score-content__pix-score').innerHTML).to.equal(pixScore);
     });
+  });
+
+  describe('Tooltip behaviour', () => {
+    const tooltip = '.hexagon-score__information--visible';
+
+    beforeEach(async () => {
+      await render(hbs`<HexagonScore />`);
+      expect(find(tooltip)).not.to.exist;
+    });
+
+    describe('on click', () => {
+      it('when tooltip is hidden, should display tooltip on click', async function() {
+        // when
+        await click('.hexagon-score-content__pix-total button');
+
+        // then
+        expect(find(tooltip)).to.exist;
+      });
+
+      it('when tooltip is displayed, should hide tooltip on click', async function() {
+        // when
+        await click('.hexagon-score-content__pix-total button');
+        await click('.hexagon-score-content__pix-total button');
+
+        // then
+        expect(find(tooltip)).not.to.exist;
+      });
+    });
+
   });
 });

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -25,7 +25,7 @@ describe('Integration | Component | hexagon-score', function() {
       expect(this.element.querySelector('.hexagon-score-content__pix-score').innerHTML).to.equal('–');
     });
 
-    it('should display provided score in pastille', async function() {
+    it('should display provided score in hexagon', async function() {
       // given
       const pixScore = '777';
       this.set('pixScore', pixScore);
@@ -37,7 +37,7 @@ describe('Integration | Component | hexagon-score', function() {
   });
 
   describe('Tooltip behaviour', () => {
-    const tooltip = '.hexagon-score__information--visible';
+    const tooltip = '.hexagon-score__information';
 
     beforeEach(async () => {
       await render(hbs`<HexagonScore />`);
@@ -45,7 +45,7 @@ describe('Integration | Component | hexagon-score', function() {
     });
 
     describe('on click', () => {
-      it('when tooltip is hidden, should display tooltip on click', async function() {
+      it('should display tooltip on click when tooltip is hidden', async function() {
         // when
         await click('.hexagon-score-content__pix-total button');
 
@@ -53,7 +53,7 @@ describe('Integration | Component | hexagon-score', function() {
         expect(find(tooltip)).to.exist;
       });
 
-      it('when tooltip is displayed, should hide tooltip on click', async function() {
+      it('should hide tooltip on click when tooltip is displayed', async function() {
         // when
         await click('.hexagon-score-content__pix-total button');
         await click('.hexagon-score-content__pix-total button');
@@ -65,18 +65,18 @@ describe('Integration | Component | hexagon-score', function() {
 
     describe('on hover', () => {
 
-      it('should display tooltip on mouseover', async function() {
+      it('should display tooltip when mouse enters the score hexagon', async function() {
         // when
-        await triggerEvent('.hexagon-score', 'mouseover');
+        await triggerEvent('.hexagon-score', 'mouseenter');
 
         // then
         expect(find(tooltip)).to.exist;
       });
 
-      it('should hide tooltip on mouseout', async function() {
+      it('should hide tooltip when mouse leaves the score hexagon', async function() {
         // when
-        await triggerEvent('.hexagon-score', 'mouseover');
-        await triggerEvent('.hexagon-score', 'mouseout');
+        await triggerEvent('.hexagon-score', 'mouseenter');
+        await triggerEvent('.hexagon-score', 'mouseleave');
 
         // then
         expect(find(tooltip)).to.not.exist;

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -7,6 +7,8 @@ import hbs from 'htmlbars-inline-precompile';
 describe('Integration | Component | hexagon-score', function() {
   setupIntlRenderingTest();
 
+  const buttonClass = '.hexagon-score-content-pix-total__button';
+
   describe('Component rendering', function() {
 
     it('should render component', async function() {
@@ -47,7 +49,7 @@ describe('Integration | Component | hexagon-score', function() {
     describe('on click', () => {
       it('should display tooltip on click when tooltip is hidden', async function() {
         // when
-        await click('.hexagon-score-content__pix-total button');
+        await click(buttonClass);
 
         // then
         expect(find(tooltip)).to.exist;
@@ -55,8 +57,8 @@ describe('Integration | Component | hexagon-score', function() {
 
       it('should hide tooltip on click when tooltip is displayed', async function() {
         // when
-        await click('.hexagon-score-content__pix-total button');
-        await click('.hexagon-score-content__pix-total button');
+        await click(buttonClass);
+        await click(buttonClass);
 
         // then
         expect(find(tooltip)).not.to.exist;
@@ -101,7 +103,7 @@ describe('Integration | Component | hexagon-score', function() {
     describe('on button focusout', () => {
       it('should hide tooltip', async () => {
         // given
-        const button = find('.hexagon-score-content__pix-total button');
+        const button = find(buttonClass);
         await click(button);
         expect(find(tooltip)).to.exist;
 
@@ -112,6 +114,5 @@ describe('Integration | Component | hexagon-score', function() {
         expect(find(tooltip)).not.to.exist;
       });
     });
-
   });
 });

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -63,5 +63,25 @@ describe('Integration | Component | hexagon-score', function() {
       });
     });
 
+    describe('on hover', () => {
+
+      it('should display tooltip on mouseover', async function() {
+        // when
+        await triggerEvent('.hexagon-score', 'mouseover');
+
+        // then
+        expect(find(tooltip)).to.exist;
+      });
+
+      it('should hide tooltip on mouseout', async function() {
+        // when
+        await triggerEvent('.hexagon-score', 'mouseover');
+        await triggerEvent('.hexagon-score', 'mouseout');
+
+        // then
+        expect(find(tooltip)).to.not.exist;
+      });
+    });
+
   });
 });

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, find, render, triggerEvent } from '@ember/test-helpers';
+import { click, find, render, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | hexagon-score', function() {
@@ -80,6 +80,21 @@ describe('Integration | Component | hexagon-score', function() {
 
         // then
         expect(find(tooltip)).to.not.exist;
+      });
+    });
+
+    describe('on ‘Escape‘ key pressed', () => {
+      it('should hide tooltip', async () => {
+        // when
+        await triggerEvent('.hexagon-score', 'mouseenter');
+        expect(find(tooltip)).to.exist;
+
+        // then
+        const escapeKeyCode = 27;
+        await triggerKeyEvent('.hexagon-score__information', 'keydown', escapeKeyCode);
+
+        // then
+        expect(find(tooltip)).not.to.exist;
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -860,7 +860,7 @@
       },
       "total-score-helper": {
         "title": "Why 1,024 pix?",
-        "explanation": "That’s the maximum number of pix you can get when the 8 levels of the Pix framework will be available.'<br>'Today, '<span class=\"hexagon-score-information__text--strong\">'the maximum number available is {maxReachablePixCount} pix'</span>', corresponding to level {maxReachableLevel}."
+        "explanation": "<p>That’s the maximum number of pix you can get when the 8 levels of the Pix framework will be available.'</p><p>'Today, '<span class=\"hexagon-score-information__text--strong\">'the maximum number available is {maxReachablePixCount} pix'</span>', corresponding to level {maxReachableLevel}.'</p>'"
       }
     },
     "profile-already-shared": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -860,7 +860,7 @@
       },
       "total-score-helper": {
         "title": "Pourquoi 1024 pix ?",
-        "explanation": "C’est le nombre maximum de pix qu’on pourra atteindre lorsque les 8 niveaux du référentiel Pix seront disponibles.'<br>'Aujourd’hui, '<span class=\"hexagon-score-information__text--strong\">'le maximum est de {maxReachablePixCount} pix'</span>', correspondant au niveau {maxReachableLevel}."
+        "explanation": "<p>C’est le nombre maximum de pix qu’on pourra atteindre lorsque les 8 niveaux du référentiel Pix seront disponibles.'</p><p>'Aujourd’hui, '<span class=\"hexagon-score-information__text--strong\">'le maximum est de {maxReachablePixCount} pix'</span>', correspondant au niveau {maxReachableLevel}.'</p>'"
       }
     },
     "profile-already-shared": {


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur au clavier n'a pas accès à l'icône "i" servant à afficher l'infobulle.

## :robot: Solution
- [X]  Rendre atteignable l'infobulle en l'encapsulant dans un button
- [X] Ajouter un attribut id à l’infobulle contenant la valeur de l'attribut aria-describedby du button servant à afficher l'infobulle
- [x]  Ajouter aria-label sur le button
- [x] Améliorer la lisiblité du texte dans l'infobulle (line-height, letter-spacing, word-spacing)
- [x] Sortir de l'infobulle si l'utilisateur appuie sur la touche Escape
- [x] Sortir de l'infobulle si le bouton perd le focus clavier

## :rainbow: Remarques
Documentation pour une infobulle accessible:
- https://www.w3.org/TR/wai-aria-practices/#tooltip
- https://www.accede-web.com/notices/interface-riche/infobulles-personnalisees/

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
