### PR TITLE
[BUGFIX] Corriger l'erreur "TransitionAborted" lors du clic sur "Retenter" une compétence.

### DIFF
--- a/mon-pix/app/services/competence-evaluation.js
+++ b/mon-pix/app/services/competence-evaluation.js
@@ -7,7 +7,7 @@ export default class CompetenceEvaluationService extends Service {
   async improve({ userId, competenceId, scorecardId }) {
     try {
       await this.store.queryRecord('competence-evaluation', { improve: true, userId, competenceId });
-      return this.router.transitionTo('competences.resume', competenceId);
+      this.router.transitionTo('competences.resume', competenceId);
     } catch (error) {
       const title = ('errors' in error) ? error.errors.get('firstObject').title : null;
       if (title === 'ImproveCompetenceEvaluationForbidden') {


### PR DESCRIPTION
## :unicorn: Problème
L'erreur [Sentry](https://sentry.io/organizations/pix/issues/2106136291/?environment=recette&project=5476250&query=is%3Aunresolved&statsPeriod=90d) `TransitionAborted` revient souvent sur l'environnement de recette. Elle se produit lorsqu'un utilisateur retente une compétence et est loguée par `PixButton`. J'aurais aimé pouvoir expliquer clairement les raisons de ce problème mais l'explication m'échappe encore. Pour résumer, on pourrait dire que la combinaison de fonctions `async` et la gestion des transitions dans les routes ne font pas bon ménage.

## :robot: Solution
- Ne pas renvoyer le retour de `transitionTo` du  service `CompetenceEvaluationServiceservice`.

## :rainbow: Remarques
Cette PR ne corrige pas l'erreur `TransitionAborted` mais permet que `PixButton` ne la logue pas. De toute façon, je ne suis pas sûr que ce soit réellement une erreur qui nous importe mais plutôt le fonctionnement d'Ember qui `abort` automatiquement la transition lorsque un transitionTo/replaceWith et effectué dans un hook `beforeModel/model/afterModel` d'une route (et que donc une nouvelle transition est créée). Voir le `afterModel` de la route `resume.js`. 

## :100: Pour tester
- Se connecter à Pix App avec l'utilisateur userpix1@example.net.
- Cliquer sur une compétence à retenter (bas de la page).
- Vérifier que l'erreur `TransitionAborted` n'apparaît plus dans la console. 
