### PR TITLE
[FEATURE] Ré-afficher les colonnes supprimées suite à l'ajout de l'index en base de donnée (PIX-2552)

### DIFF
--- a/api/lib/domain/read-models/CampaignReport.js
+++ b/api/lib/domain/read-models/CampaignReport.js
@@ -17,8 +17,8 @@ class CampaignReport {
     targetProfileId,
     targetProfileName,
     targetProfileImageUrl,
-    participationsCount = 0,
-    sharedParticipationsCount = 0,
+    participationsCount,
+    sharedParticipationsCount,
     badges = [],
     stages = [],
   } = {}) {

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -56,8 +56,11 @@ module.exports = {
         'users.id AS "creatorId"',
         'users.firstName AS creatorFirstName',
         'users.lastName AS creatorLastName',
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER (partition by "campaigns"."id") AS "participationsCount"'),
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isShared" IS TRUE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'),
       )
       .join('users', 'users.id', 'campaigns.creatorId')
+      .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
       .where('campaigns.organizationId', organizationId)
       .modify(_setSearchFiltersForQueryBuilder, filter)
       .orderBy('campaigns.createdAt', 'DESC');

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -454,8 +454,8 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(200);
         const campaigns = response.result.data;
         expect(campaigns).to.have.lengthOf(1);
-        expect(response.result.data[0].attributes['participations-count']).to.equal(0);
-        expect(response.result.data[0].attributes['shared-participations-count']).to.equal(0);
+        expect(response.result.data[0].attributes['participations-count']).to.equal(1);
+        expect(response.result.data[0].attributes['shared-participations-count']).to.equal(1);
       });
 
       it('should return default pagination meta data', async () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -49,7 +49,7 @@ describe('Integration | Repository | Campaign-Report', () => {
       await databaseBuilder.commit();
 
       filter = {};
-      page = { number: 1, size: 3 };
+      page = { number: 1, size: 4 };
     });
 
     context('when the given organization has no campaign', () => {
@@ -120,7 +120,8 @@ describe('Integration | Repository | Campaign-Report', () => {
 
         const campaignBInThePastId = databaseBuilder.factory.buildCampaign({ organizationId, name: 'B', createdAt: createdAtInThePast }).id;
         const campaignAInThePresentId = databaseBuilder.factory.buildCampaign({ organizationId, name: 'A', createdAt: createdAtInThePresent }).id;
-        const campaignBInTheFutureId = databaseBuilder.factory.buildCampaign({ organizationId, name: 'B', createdAt: createdAtInTheFuture }).id;
+        const campaignCInTheFutureId = databaseBuilder.factory.buildCampaign({ organizationId, name: 'C', createdAt: createdAtInTheFuture }).id;
+        databaseBuilder.factory.buildCampaign({ organizationId, name: 'D', createdAt: createdAtInThePast, archivedAt: createdAtInThePresent });
         await databaseBuilder.commit();
 
         // when
@@ -128,7 +129,7 @@ describe('Integration | Repository | Campaign-Report', () => {
 
         // then
         expect(campaignsWithReports).to.have.lengthOf(3);
-        expect(_.map(campaignsWithReports, 'id')).to.deep.equal([campaignBInTheFutureId, campaignAInThePresentId, campaignBInThePastId]);
+        expect(_.map(campaignsWithReports, 'id')).to.deep.equal([campaignCInTheFutureId, campaignAInThePresentId, campaignBInThePastId]);
       });
 
       context('when campaigns have participants', async () => {
@@ -150,7 +151,7 @@ describe('Integration | Repository | Campaign-Report', () => {
 
           // then
           expect(campaignReports[0]).to.be.instanceOf(CampaignReport);
-          expect(campaignReports[0]).to.include({ id: campaign.id, participationsCount: 0, sharedParticipationsCount: 0 });
+          expect(campaignReports[0]).to.include({ id: campaign.id, participationsCount: 3, sharedParticipationsCount: 1 });
         });
       });
 
@@ -294,8 +295,8 @@ describe('Integration | Repository | Campaign-Report', () => {
         let expectedPagination;
 
         beforeEach(() => {
-          _.times(4, () => databaseBuilder.factory.buildCampaign({ organizationId }));
-          expectedPagination = { page: page.number, pageSize: page.size, pageCount: 2, rowCount: 4 };
+          _.times(5, () => databaseBuilder.factory.buildCampaign({ organizationId }));
+          expectedPagination = { page: page.number, pageSize: page.size, pageCount: 2, rowCount: 5 };
           return databaseBuilder.commit();
         });
 
@@ -304,7 +305,7 @@ describe('Integration | Repository | Campaign-Report', () => {
           const { models: campaignsWithReports, meta: pagination } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
 
           // then
-          expect(campaignsWithReports).to.have.lengthOf(3);
+          expect(campaignsWithReports).to.have.lengthOf(4);
           expect(pagination).to.include(expectedPagination);
         });
       });

--- a/orga/app/components/routes/authenticated/campaign/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/list.hbs
@@ -13,6 +13,12 @@
             <th class="table__column table__column--small">
               {{t 'pages.campaigns-list.table.column.created-on'}}
             </th>
+            <th class="table__column table__column--small">
+              {{t 'pages.campaigns-list.table.column.participants'}}
+            </th>
+            <th class="table__column table__column--small">
+              {{t 'pages.campaigns-list.table.column.results'}}
+            </th>
           </tr>
           <tr>
             <Table::HeaderFilterInput
@@ -30,6 +36,8 @@
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::Header/>
+            <Table::Header/>
+            <Table::Header/>
           </tr>
         </thead>
 
@@ -39,6 +47,8 @@
             <td>{{campaign.name}}</td>
             <td class="table__column--truncated">{{campaign.creatorFullName}}</td>
             <td>{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
+            <td>{{campaign.participationsCount}}</td>
+            <td>{{campaign.sharedParticipationsCount}}</td>
           </tr>
         {{/each}}
         </tbody>

--- a/orga/tests/integration/components/routes/authenticated/campaign/list_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/list_test.js
@@ -140,6 +140,52 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       assert.contains('02/02/2020');
     });
 
+    test('it should display the participations count', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const campaign1 = store.createRecord('campaign', {
+        participationsCount: 10,
+      });
+
+      const campaigns = [campaign1];
+      campaigns.meta = {
+        rowCount: 1,
+      };
+      this.set('campaigns', campaigns);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::List
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+
+      // then
+      assert.dom('[aria-label="Campagne"]').containsText('10');
+    });
+
+    test('it should display the shared participations count', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const campaign1 = store.createRecord('campaign', {
+        sharedParticipationsCount: 4,
+      });
+
+      const campaigns = [campaign1];
+      campaigns.meta = {
+        rowCount: 1,
+      };
+      this.set('campaigns', campaigns);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::List
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+
+      // then
+      assert.dom('[aria-label="Campagne"]').containsText('4');
+    });
+
     test('it should display the placeholder of the filter by campaign field', async function(assert) {
       // given
       const campaigns = [];


### PR DESCRIPTION
## :unicorn: Problème
On avait supprimé ces deux colonnes suite à des soucis de performances en production.

## :robot: Solution
Suite à l'ajout de l'index qui avait disparu. Nous pouvons à nouveau afficher ces deux colonnes

## :rainbow: Remarques
Test sur la réplication :

Organisations avec campagnes + 5000 participants  sans limit

3 campagnes dont une avec 5000 et l'autre 1000 participants
```
Limit (cost=1516.33..1516.91 rows=10 width=547) (actual time=54.931..61.228 rows=3 loops=1)
-> Unique (cost=1516.33..1539.56 rows=404 width=547) (actual time=54.929..61.224 rows=3 loops=1)
-> Sort (cost=1516.33..1517.34 rows=404 width=547) (actual time=54.925..55.687 rows=6184 loops=1)
Sort Key: campaigns."createdAt" DESC, campaigns.id, campaigns.name, campaigns.code, campaigns."creatorId", campaigns."targetProfileId", campaigns."idPixLabel", campaigns.title, campaigns."customLandingPageText", campaigns."archivedAt", campaigns.type, campaigns."externalIdHelpImageUrl", campaigns."alternativeTextToExternalIdHelpImage", campaigns."isForAbsoluteNovice", campaigns."customResultPageText", campaigns."customResultPageButtonText", campaigns."customResultPageButtonUrl", campaigns."multipleSendings", users."firstName", users."lastName", (count(*) FILTER (WHERE ("campaign-participations".id IS NOT NULL)) OVER (?)), (count(*) FILTER (WHERE (("campaign-participations".id IS NOT NULL) AND ("campaign-participations"."isShared" IS TRUE))) OVER (?))
Sort Method: quicksort Memory: 5579kB
-> WindowAgg (cost=1490.76..1498.84 rows=404 width=547) (actual time=21.682..25.185 rows=6184 loops=1)
-> Sort (cost=1490.76..1491.77 rows=404 width=532) (actual time=15.402..16.134 rows=6184 loops=1)
Sort Key: campaigns.id
Sort Method: quicksort Memory: 5579kB
-> Nested Loop Left Join (cost=1.29..1473.27 rows=404 width=532) (actual time=0.048..10.476 rows=6184 loops=1)
-> Nested Loop (cost=0.85..78.54 rows=21 width=527) (actual time=0.029..0.104 rows=3 loops=1)
-> Index Scan using campaigns_organizationid_index on campaigns (cost=0.42..27.09 rows=21 width=508) (actual time=0.019..0.059 rows=3 loops=1)
Index Cond: ("organizationId" = 301)
Filter: ("archivedAt" IS NULL)
Rows Removed by Filter: 13
-> Index Scan using users_pkey on users (cost=0.43..2.45 rows=1 width=19) (actual time=0.010..0.010 rows=1 loops=3)
Index Cond: (id = campaigns."creatorId")
-> Index Scan using campaign_participations_campaignid_index on "campaign-participations" (cost=0.43..65.57 rows=85 width=9) (actual time=0.012..3.017 rows=2061 loops=3)
Index Cond: ("campaignId" = campaigns.id)
Planning Time: 0.640 ms
Execution Time: 61.363 ms
```

Organisation avec campagnes + 500 participants sans limit

27 campagnes dont 6 de 630 à 670 participants
```
Limit (cost=1516.33..1517.77 rows=25 width=547) (actual time=32.656..34.339 rows=25 loops=1)
-> Unique (cost=1516.33..1539.56 rows=404 width=547) (actual time=32.654..34.333 rows=25 loops=1)
-> Sort (cost=1516.33..1517.34 rows=404 width=547) (actual time=32.649..32.906 rows=2187 loops=1)
Sort Key: campaigns."createdAt" DESC, campaigns.id, campaigns.name, campaigns.code, campaigns."creatorId", campaigns."targetProfileId", campaigns."idPixLabel", campaigns.title, campaigns."customLandingPageText", campaigns."archivedAt", campaigns.type, campaigns."externalIdHelpImageUrl", campaigns."alternativeTextToExternalIdHelpImage", campaigns."isForAbsoluteNovice", campaigns."customResultPageText", campaigns."customResultPageButtonText", campaigns."customResultPageButtonUrl", campaigns."multipleSendings", users."firstName", users."lastName", (count(*) FILTER (WHERE ("campaign-participations".id IS NOT NULL)) OVER (?)), (count(*) FILTER (WHERE (("campaign-participations".id IS NOT NULL) AND ("campaign-participations"."isShared" IS TRUE))) OVER (?))
Sort Method: quicksort Memory: 4252kB
-> WindowAgg (cost=1490.76..1498.84 rows=404 width=547) (actual time=13.489..17.289 rows=4145 loops=1)
-> Sort (cost=1490.76..1491.77 rows=404 width=532) (actual time=12.896..13.479 rows=4145 loops=1)
Sort Key: campaigns.id
Sort Method: quicksort Memory: 4252kB
-> Nested Loop Left Join (cost=1.29..1473.27 rows=404 width=532) (actual time=0.081..10.149 rows=4145 loops=1)
-> Nested Loop (cost=0.85..78.54 rows=21 width=527) (actual time=0.061..0.279 rows=27 loops=1)
-> Index Scan using campaigns_organizationid_index on campaigns (cost=0.42..27.09 rows=21 width=508) (actual time=0.047..0.123 rows=27 loops=1)
Index Cond: ("organizationId" = 990)
Filter: ("archivedAt" IS NULL)
Rows Removed by Filter: 10
-> Index Scan using users_pkey on users (cost=0.43..2.45 rows=1 width=19) (actual time=0.004..0.004 rows=1 loops=27)
Index Cond: (id = campaigns."creatorId")
-> Index Scan using campaign_participations_campaignid_index on "campaign-participations" (cost=0.43..65.57 rows=85 width=9) (actual time=0.010..0.330 rows=153 loops=27)
Index Cond: ("campaignId" = campaigns.id)
Planning Time: 0.668 ms
Execution Time: 34.952 ms
```
Organisations avec des campagnes a + 50 participants sans limit

23 campagnes dont 16 de 60 à 150 participants
```
Unique (cost=1516.33..1539.56 rows=404 width=547) (actual time=10.603..11.712 rows=23 loops=1)
-> Sort (cost=1516.33..1517.34 rows=404 width=547) (actual time=10.600..10.734 rows=1759 loops=1)
Sort Key: campaigns."createdAt" DESC, campaigns.id, campaigns.name, campaigns.code, campaigns."creatorId", campaigns."targetProfileId", campaigns."idPixLabel", campaigns.title, campaigns."customLandingPageText", campaigns."archivedAt", campaigns.type, campaigns."externalIdHelpImageUrl", campaigns."alternativeTextToExternalIdHelpImage", campaigns."isForAbsoluteNovice", campaigns."customResultPageText", campaigns."customResultPageButtonText", campaigns."customResultPageButtonUrl", campaigns."multipleSendings", users."firstName", users."lastName", (count(*) FILTER (WHERE ("campaign-participations".id IS NOT NULL)) OVER (?)), (count(*) FILTER (WHERE (("campaign-participations".id IS NOT NULL) AND ("campaign-participations"."isShared" IS TRUE))) OVER (?))
Sort Method: quicksort Memory: 782kB
-> WindowAgg (cost=1490.76..1498.84 rows=404 width=547) (actual time=4.718..6.026 rows=1759 loops=1)
-> Sort (cost=1490.76..1491.77 rows=404 width=532) (actual time=4.630..4.774 rows=1759 loops=1)
Sort Key: campaigns.id
Sort Method: quicksort Memory: 782kB
-> Nested Loop Left Join (cost=1.29..1473.27 rows=404 width=532) (actual time=0.046..3.766 rows=1759 loops=1)
-> Nested Loop (cost=0.85..78.54 rows=21 width=527) (actual time=0.031..0.158 rows=23 loops=1)
-> Index Scan using campaigns_organizationid_index on campaigns (cost=0.42..27.09 rows=21 width=508) (actual time=0.019..0.062 rows=23 loops=1)
Index Cond: ("organizationId" = 4029)
Filter: ("archivedAt" IS NULL)
Rows Removed by Filter: 2
-> Index Scan using users_pkey on users (cost=0.43..2.45 rows=1 width=19) (actual time=0.003..0.003 rows=1 loops=23)
Index Cond: (id = campaigns."creatorId")
-> Index Scan using campaign_participations_campaignid_index on "campaign-participations" (cost=0.43..65.57 rows=85 width=9) (actual time=0.008..0.139 rows=76 loops=23)
Index Cond: ("campaignId" = campaigns.id)
Planning Time: 0.561 ms
Execution Time: 11.827 ms
```

Les résultats semble satisfaisant

## :100: Pour tester
