### PR TITLE
[FEATURE] Afficher le graphique de répartition des participants par paliers (PIX-2549)

### DIFF
--- a/api/db/seeds/data/campaign-participations-builder.js
+++ b/api/db/seeds/data/campaign-participations-builder.js
@@ -72,14 +72,14 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
     });
 
     databaseBuilder.factory.buildKnowledgeElement({
-      skillId: 'recndXqXiv4pv2Ukp',
+      skillId: 'recGd7oJ2wVEyKmPS',
       assessmentId,
       userId,
       competenceId: 'recIhdrmCuEmCDAzj',
       answerId,
     });
     databaseBuilder.factory.buildKnowledgeElement({
-      skillId: 'rectL2ZZeWPc7yezp',
+      skillId: 'recVv1eoSLW7yFgXv',
       assessmentId,
       userId,
       competenceId: 'recIhdrmCuEmCDAzj',
@@ -87,7 +87,7 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
       source: KnowledgeElement.SourceType.INFERRED,
     });
     databaseBuilder.factory.buildKnowledgeElement({
-      skillId: 'recMOy4S8XnaWblYI',
+      skillId: 'recVywppdS4hGEekR',
       assessmentId,
       userId,
       competenceId: 'recIhdrmCuEmCDAzj',
@@ -97,7 +97,7 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
 
     if (addInferredKE) {
       databaseBuilder.factory.buildKnowledgeElement({
-        skillId: 'recgOc2OreHCosoRp',
+        skillId: 'recDZTKszXX02aXD1',
         assessmentId,
         userId,
         competenceId: 'recIhdrmCuEmCDAzj',

--- a/api/lib/application/campaigns/campaign-stats-controller.js
+++ b/api/lib/application/campaigns/campaign-stats-controller.js
@@ -1,0 +1,17 @@
+const usecases = require('../../domain/usecases');
+const participationsByStageSerializer = require('../../infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer');
+
+module.exports = {
+  async getParticipationsByStage(request) {
+    const { userId } = request.auth.credentials;
+    const campaignId = request.params.id;
+
+    const participationsByStage = await usecases.getCampaignParticipationsCountByStage({ userId, campaignId });
+
+    return participationsByStageSerializer.serialize({
+      campaignId,
+      data: participationsByStage,
+    });
+  },
+};
+

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -1,5 +1,6 @@
 const Joi = require('joi');
 const campaignController = require('./campaign-controller');
+const campaignStatsController = require('./campaign-stats-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
@@ -228,6 +229,21 @@ exports.register = async function(server) {
           '- Récupération des classes des participants à la campagne',
         ],
         tags: ['api', 'division'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/campaigns/{id}/stats/participations-by-stage',
+      config: {
+        validate: {
+          params: Joi.object({ id: identifiersType.campaignId }),
+        },
+        handler: campaignStatsController.getParticipationsByStage,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération des statistiques de participations par paliers',
+        ],
+        tags: ['api', 'campaign', 'stats'],
       },
     },
   ]);

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -292,6 +292,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.TargetProfileInvalidError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.NoStagesForCampaign) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
 
   if (error instanceof DomainErrors.TargetProfileCannotBeCreated) {
     return new HttpErrors.UnprocessableEntityError(error.message);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -120,6 +120,12 @@ class NoCampaignParticipationForUserAndCampaign extends DomainError {
   }
 }
 
+class NoStagesForCampaign extends DomainError {
+  constructor(message = 'The campaign does not have stages.') {
+    super(message);
+  }
+}
+
 class SchoolingRegistrationsCouldNotBeSavedError extends DomainError {
   constructor() {
     super('An error occurred during process');
@@ -858,6 +864,7 @@ module.exports = {
   MissingOrInvalidCredentialsError,
   NoCampaignParticipationForUserAndCampaign,
   NoCertificationResultForDivision,
+  NoStagesForCampaign,
   NotEligibleCandidateError,
   NotFoundError,
   NotImplementedError,

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -151,22 +151,37 @@ class TargetProfileWithLearningContent {
     return skillMaxDifficulty ? skillMaxDifficulty.difficulty : null;
   }
 
+  getStageSkillsBoundaries() {
+    const totalSkills = this.skills.length;
+    const boundaries = [];
+    let lastTo = null;
+
+    this.stages.forEach((currentStage, index) => {
+      let to, from;
+
+      if (lastTo === null) {
+        from = currentStage.getMinSkillsCountToReachStage(totalSkills);
+      } else {
+        from = lastTo + 1;
+      }
+
+      if (index + 1 >= this.stages.length) {
+        to = totalSkills;
+      } else {
+        const nextSkillCount = this.stages[index + 1].getMinSkillsCountToReachStage(totalSkills);
+        to = Math.max(from, nextSkillCount - 1);
+      }
+
+      lastTo = to;
+      boundaries.push({ id: currentStage.id, from, to });
+    });
+
+    return boundaries;
+  }
+
   getSkillsCountBoundariesFromStages(stageIds) {
     if (!stageIds || stageIds.length === 0) return null;
-
-    const totalSkills = this.skills.length;
-
-    return stageIds.map((stageId) => {
-      const boundary = {};
-      const stageIndex = this.stages.findIndex((stage) => stage.id == stageId);
-      boundary.from = this.stages[stageIndex].getMinSkillsCountToReachStage(totalSkills);
-      if (stageIndex !== this.stages.length - 1) {
-        boundary.to = this.stages[stageIndex + 1].getMinSkillsCountToReachStage(totalSkills) - 1;
-      } else {
-        boundary.to = totalSkills;
-      }
-      return boundary;
-    });
+    return this.getStageSkillsBoundaries().filter((boundary) => stageIds.includes(boundary.id));
   }
 }
 

--- a/api/lib/domain/usecases/get-campaign-participations-counts-by-stage.js
+++ b/api/lib/domain/usecases/get-campaign-participations-counts-by-stage.js
@@ -1,0 +1,28 @@
+const { UserNotAuthorizedToAccessEntityError, NoStagesForCampaign } = require('../errors');
+
+module.exports = async function getCampaignParticipationsCountByStage({
+  userId,
+  campaignId,
+  campaignRepository,
+  campaignParticipationRepository,
+  targetProfileWithLearningContentRepository,
+}) {
+  if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
+  }
+
+  const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
+  if (!targetProfile.hasReachableStages()) {
+    throw new NoStagesForCampaign();
+  }
+
+  const stagesBoundaries = targetProfile.getStageSkillsBoundaries();
+  const data = await campaignParticipationRepository.countParticipationsByStage(campaignId, stagesBoundaries);
+
+  return targetProfile.stages.map((stage) => ({
+    id: stage.id,
+    value: data[stage.id] || 0,
+    title: stage.prescriberTitle,
+    description: stage.prescriberDescription,
+  }));
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -204,6 +204,7 @@ module.exports = injectDependencies({
   getCampaignAssessmentParticipation: require('./get-campaign-assessment-participation'),
   getCampaignAssessmentParticipationResult: require('./get-campaign-assessment-participation-result'),
   getCampaignParticipation: require('./get-campaign-participation'),
+  getCampaignParticipationsCountByStage: require('./get-campaign-participations-counts-by-stage'),
   getCampaignProfile: require('./get-campaign-profile'),
   getCertificationAttestation: require('./certificate/get-certification-attestation'),
   getCertificationCandidate: require('./get-certification-candidate'),

--- a/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
@@ -157,7 +157,7 @@ async function _findTargetedAreas(competences, locale) {
 
 async function _findStages(targetProfileId) {
   const stageRows = await knex('stages')
-    .select('stages.id', 'stages.threshold', 'stages.message', 'stages.title')
+    .select('stages.id', 'stages.threshold', 'stages.message', 'stages.title', 'stages.prescriberTitle', 'stages.prescriberDescription')
     .where('stages.targetProfileId', targetProfileId);
 
   if (_.isEmpty(stageRows)) {

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer.js
@@ -1,0 +1,18 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(model) {
+    return new Serializer('campaign-participations-count-by-stage', {
+      id: 'campaignId',
+      attributes: ['data'],
+      data: {
+        attributes: [
+          'id',
+          'value',
+          'title',
+          'description',
+        ],
+      },
+    }).serialize(model);
+  },
+};

--- a/api/tests/acceptance/application/campaign-stats-controller_test.js
+++ b/api/tests/acceptance/application/campaign-stats-controller_test.js
@@ -1,0 +1,84 @@
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  learningContentBuilder,
+  mockLearningContent,
+} = require('../../test-helper');
+
+const createServer = require('../../../server');
+
+describe('Acceptance | API | Campaign Stats Controller', () => {
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('GET /api/campaigns/{id}/stats/participations-by-stage', () => {
+    it('should return the campaign by id', async () => {
+      // given
+      const learningContentObjects = learningContentBuilder.buildLearningContent([{
+        id: 'recArea1',
+        titleFrFr: 'area1_Title',
+        color: 'specialColor',
+        competences: [{
+          id: 'recCompetence1',
+          name: 'Fabriquer un meuble',
+          index: '1.1',
+          tubes: [{
+            id: 'recTube1',
+            skills: [
+              { id: 'recSkillId1', nom: '@web1', challenges: [] },
+              { id: 'recSkillId2', nom: '@web2', challenges: [] },
+            ],
+          }],
+        }],
+      }]);
+      mockLearningContent(learningContentObjects);
+
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId1' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId2' });
+      const stage1 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 0, prescriberTitle: 'title', prescriberDescription: 'desc' });
+      const stage2 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 30 });
+
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ organizationId: campaign.organizationId, userId });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/stats/participations-by-stage`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.id).to.equal(campaign.id.toString());
+      expect(response.result.data.attributes.data).to.deep.equal([
+        { id: stage1.id, value: 0, title: stage1.prescriberTitle, description: stage1.prescriberDescription },
+        { id: stage2.id, value: 0, title: null, description: null },
+      ]);
+    });
+
+    it('should return HTTP code 403 if the authenticated user is not authorize to access the campaign', async () => {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/stats/participations-by-stage`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+});

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -115,6 +115,13 @@ describe('Integration | API | Controller Error', () => {
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
     });
+
+    it('responds Precondition Failed when a NoStagesForCampaign error occurs', async () => {
+      routeHandler.throws(new DomainErrors.NoStagesForCampaign());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(PRECONDITION_FAILED);
+    });
   });
 
   context('404 Not Found', () => {

--- a/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-stage__test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-stage__test.js
@@ -1,0 +1,116 @@
+const { expect, catchErr, databaseBuilder, learningContentBuilder, mockLearningContent } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const { UserNotAuthorizedToAccessEntityError, NoStagesForCampaign } = require('../../../../lib/domain/errors');
+
+describe('Integration | UseCase | get-campaign-participations-counts-by-stage', () => {
+  let organizationId;
+  let campaignId;
+  let userId;
+  let stage1, stage2, stage3;
+
+  beforeEach(async () => {
+    const learningContentObjects = learningContentBuilder.buildLearningContent([{
+      id: 'recArea1',
+      titleFrFr: 'area1_Title',
+      color: 'specialColor',
+      competences: [{
+        id: 'recCompetence1',
+        name: 'Fabriquer un meuble',
+        index: '1.1',
+        tubes: [{
+          id: 'recTube1',
+          skills: [
+            { id: 'recSkillId1', nom: '@web1', challenges: [] },
+            { id: 'recSkillId2', nom: '@web2', challenges: [] },
+            { id: 'recSkillId3', nom: '@web3', challenges: [] },
+            { id: 'recSkillId4', nom: '@web4', challenges: [] },
+          ],
+        }],
+      }],
+    }]);
+    mockLearningContent(learningContentObjects);
+
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId1' });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId2' });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId3' });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId4' });
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildMembership({ organizationId, userId });
+    stage1 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 0, prescriberTitle: 'title', prescriberDescription: 'desc' });
+    stage2 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 30 });
+    stage3 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 70 });
+    campaignId = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId }).id;
+  });
+
+  context('when requesting user is not allowed to access campaign informations', () => {
+    it('should throw a UserNotAuthorizedToAccessEntityError error', async () => {
+      const user2 = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(usecases.getCampaignParticipationsCountByStage)({
+        userId: user2.id,
+        campaignId,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
+      expect(error.message).to.equal('User does not belong to the organization that owns the campaign');
+    });
+  });
+
+  context('when the campaign doesnt manage stages', () => {
+    it('should throw a NoStagesForCampaign error', async () => {
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId1' });
+      const campaign2 = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId });
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(usecases.getCampaignParticipationsCountByStage)({
+        userId,
+        campaignId: campaign2.id,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NoStagesForCampaign);
+      expect(error.message).to.equal('The campaign does not have stages.');
+    });
+  });
+
+  context('when the campaign manage stages', () => {
+    it('should return participations counts by stages', async () => {
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, validatedSkillsCount: 0 });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, validatedSkillsCount: 1 });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, validatedSkillsCount: 2 });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.getCampaignParticipationsCountByStage({ userId, campaignId });
+
+      // then
+      expect(result).to.deep.equal([
+        { id: stage1.id, value: 1, title: stage1.prescriberTitle, description: stage1.prescriberDescription },
+        { id: stage2.id, value: 1, title: null, description: null },
+        { id: stage3.id, value: 1, title: null, description: null },
+      ]);
+    });
+
+    it('should set to 0 all participation counts when no participations', async () => {
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.getCampaignParticipationsCountByStage({ userId, campaignId });
+
+      // then
+      expect(result).to.deep.equal([
+        { id: stage1.id, value: 0, title: stage1.prescriberTitle, description: stage1.prescriberDescription },
+        { id: stage2.id, value: 0, title: null, description: null },
+        { id: stage3.id, value: 0, title: null, description: null },
+      ]);
+    });
+  });
+});
+

--- a/api/tests/tooling/domain-builder/factory/build-stage.js
+++ b/api/tests/tooling/domain-builder/factory/build-stage.js
@@ -5,8 +5,8 @@ module.exports = function buildStage({
   title = 'Courage',
   message = 'Insister',
   threshold = 1,
-  prescriberTitle,
-  prescriberDescription,
+  prescriberTitle = null,
+  prescriberDescription = null,
 } = {}) {
 
   return new Stage({

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -8,6 +8,7 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 const moduleUnderTest = require('../../../../lib/application/campaigns');
 
 const campaignController = require('../../../../lib/application/campaigns/campaign-controller');
+const campaignStatsController = require('../../../../lib/application/campaigns/campaign-stats-controller');
 
 describe('Unit | Application | Router | campaign-router ', function() {
 
@@ -27,6 +28,7 @@ describe('Unit | Application | Router | campaign-router ', function() {
     sinon.stub(campaignController, 'findProfilesCollectionParticipations').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignController, 'division').callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(campaignStatsController, 'getParticipationsByStage').callsFake((request, h) => h.response('ok').code(200));
 
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
@@ -447,6 +449,25 @@ describe('Unit | Application | Router | campaign-router ', function() {
     it('should return 400 with an invalid campaign id', async () => {
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/invalid/divisions');
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+  });
+
+  describe('GET /api/campaigns/{id}/stats/participations-by-stage', () => {
+
+    it('should return 200', async () => {
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/stats/participations-by-stage');
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it('should return 400 with an invalid campaign id', async () => {
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/invalid/stats/participations-by-stage');
 
       // then
       expect(result.statusCode).to.equal(400);

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -736,6 +736,60 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
     });
   });
 
+  describe('getStageSkillsBoundaries()', () => {
+    it('should return skill count boundaries for all stages', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill();
+      const skill2 = domainBuilder.buildTargetedSkill();
+      const skill3 = domainBuilder.buildTargetedSkill();
+
+      const stage1 = domainBuilder.buildStage({ id: 'stage1', threshold: 40 });
+      const stage2 = domainBuilder.buildStage({ id: 'stage2', threshold: 70 });
+      const stage3 = domainBuilder.buildStage({ id: 'stage3', threshold: 90 });
+
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2, skill3],
+        stages: [stage1, stage2, stage3],
+      });
+
+      // when
+      const skillCountBoundaries = targetProfile.getStageSkillsBoundaries();
+
+      // then
+      expect(skillCountBoundaries).to.deep.equal([
+        { id: 'stage1', from: 1, to: 1 },
+        { id: 'stage2', from: 2, to: 2 },
+        { id: 'stage3', from: 3, to: 3 },
+      ]);
+    });
+
+    it('should return skill count boundaries with a stage threshold 0', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill();
+      const skill2 = domainBuilder.buildTargetedSkill();
+      const skill3 = domainBuilder.buildTargetedSkill();
+
+      const stage1 = domainBuilder.buildStage({ id: 'stage1', threshold: 0 });
+      const stage2 = domainBuilder.buildStage({ id: 'stage2', threshold: 20 });
+      const stage3 = domainBuilder.buildStage({ id: 'stage3', threshold: 90 });
+
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2, skill3],
+        stages: [stage1, stage2, stage3],
+      });
+
+      // when
+      const skillCountBoundaries = targetProfile.getStageSkillsBoundaries();
+
+      // then
+      expect(skillCountBoundaries).to.deep.equal([
+        { id: 'stage1', from: 0, to: 0 },
+        { id: 'stage2', from: 1, to: 1 },
+        { id: 'stage3', from: 2, to: 3 },
+      ]);
+    });
+  });
+
   describe('getSkillsCountBoundariesFromStages()', () => {
 
     it('should return skill count boundary for the given stage id', () => {
@@ -761,7 +815,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
       // then
       expect(skillCountBoundaries).to.deep.equal([
-        { from: 2, to: 3 },
+        { id: 'stage2', from: 2, to: 3 },
       ]);
     });
 
@@ -788,8 +842,8 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
       // then
       expect(skillCountBoundaries).to.deep.equal([
-        { from: 0, to: 1 },
-        { from: 2, to: 3 },
+        { id: 'stage1', from: 0, to: 1 },
+        { id: 'stage2', from: 2, to: 3 },
       ]);
     });
 
@@ -816,7 +870,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
       // then
       expect(skillCountBoundaries).to.deep.equal([
-        { from: 4, to: 6 },
+        { id: 'stage3', from: 4, to: 6 },
       ]);
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer_test.js
@@ -1,0 +1,30 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer');
+
+describe('Unit | Serializer | JSONAPI | campaign-participations-count-by-stage-serializer', function() {
+
+  describe('#serialize', function() {
+    it('should convert a participations count by stage model object into JSON API data', function() {
+      const json = serializer.serialize({
+        campaignId: 1,
+        data: [
+          { id: 'stage1', value: 0, title: 'title1', description: 'description1' },
+          { id: 'stage2', value: 1, title: 'title2', description: 'description2' },
+        ],
+      });
+
+      expect(json).to.deep.equal({
+        data: {
+          type: 'campaign-participations-count-by-stages',
+          id: '1',
+          attributes: {
+            data: [
+              { id: 'stage1', value: 0, title: 'title1', description: 'description1' },
+              { id: 'stage2', value: 1, title: 'title2', description: 'description2' },
+            ],
+          },
+        },
+      });
+    });
+  });
+});

--- a/orga/app/adapters/campaign-stats.js
+++ b/orga/app/adapters/campaign-stats.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class CampaignStatsAdapter extends ApplicationAdapter {
+  getParticipationsByStage(campaignId) {
+    const url = `${this.host}/${this.namespace}/campaigns/${campaignId}/stats/participations-by-stage`;
+    return this.ajax(url, 'GET');
+  }
+}

--- a/orga/app/components/charts/participants-by-stage-loader.hbs
+++ b/orga/app/components/charts/participants-by-stage-loader.hbs
@@ -1,0 +1,16 @@
+<p class="sr-only">{{t 'charts.participants-by-stage.loader'}}</p>
+<div class="participants-by-stage" aria-hidden="true">
+  <div class="participants-by-stage__stars--loader placeholder-box" />
+  <div class="participants-by-stage__values--loader placeholder-box" />
+  <div class="participants-by-stage__graph--loader placeholder-box" />
+</div>
+<div class="participants-by-stage" aria-hidden="true">
+  <div class="participants-by-stage__stars--loader placeholder-box" />
+  <div class="participants-by-stage__values--loader placeholder-box" />
+  <div class="participants-by-stage__graph--loader placeholder-box" />
+</div>
+<div class="participants-by-stage" aria-hidden="true">
+  <div class="participants-by-stage__stars--loader placeholder-box" />
+  <div class="participants-by-stage__values--loader placeholder-box" />
+  <div class="participants-by-stage__graph--loader placeholder-box" />
+</div>

--- a/orga/app/components/charts/participants-by-stage.hbs
+++ b/orga/app/components/charts/participants-by-stage.hbs
@@ -1,11 +1,23 @@
 <Charts::Card @title={{t 'charts.participants-by-stage.title'}} ...attributes>
   {{#each this.data as |stage|}}
     <div class="participants-by-stage">
-      <PixStars @count={{stage.stage}} @total={{@maxStage}} @color="blue" class="stage-stars" />
+      <PixStars
+        @count={{stage.index}}
+        @total={{this.totalStage}}
+        @color="blue"
+        class="participants-by-stage__stars"
+      />
       <div class="participants-by-stage__values">
         {{t 'charts.participants-by-stage.participants' count=stage.value}}
       </div>
-      <PixTooltip role="tooltip" @text={{stage.tooltip}} @position="bottom-right" @isWide={{true}} @isLight={{true}} class="participants-by-stage__tooltip">
+      <PixTooltip
+        role="tooltip"
+        @text={{stage.tooltip}}
+        @position="bottom-right"
+        @isWide={{true}}
+        @isLight={{true}}
+        class="participants-by-stage__tooltip"
+        >
         <div class="participants-by-stage__graph" role="button" {{on "click" (fn this.onClickBar stage.id)}}>
           <div class="participants-by-stage__bar" style={{stage.barWidth}} />
           <div class="participants-by-stage__percentage">

--- a/orga/app/components/charts/participants-by-stage.hbs
+++ b/orga/app/components/charts/participants-by-stage.hbs
@@ -1,30 +1,34 @@
 <Charts::Card @title={{t 'charts.participants-by-stage.title'}} ...attributes>
-  {{#each this.data as |stage|}}
-    <div class="participants-by-stage">
-      <PixStars
-        @count={{stage.index}}
-        @total={{this.totalStage}}
-        @color="blue"
-        class="participants-by-stage__stars"
-      />
-      <div class="participants-by-stage__values">
-        {{t 'charts.participants-by-stage.participants' count=stage.value}}
-      </div>
-      <PixTooltip
-        role="tooltip"
-        @text={{stage.tooltip}}
-        @position="bottom-right"
-        @isWide={{true}}
-        @isLight={{true}}
-        class="participants-by-stage__tooltip"
-        >
-        <div class="participants-by-stage__graph" role="button" {{on "click" (fn this.onClickBar stage.id)}}>
-          <div class="participants-by-stage__bar" style={{stage.barWidth}} />
-          <div class="participants-by-stage__percentage">
-            {{t 'charts.participants-by-stage.percentage' percentage=stage.percentage}}
-          </div>
+  {{#if this.loading}}
+    <Charts::ParticipantsByStageLoader />
+  {{else}}
+    {{#each this.data as |stage|}}
+      <div class="participants-by-stage">
+        <PixStars
+          @count={{stage.index}}
+          @total={{this.totalStage}}
+          @color="blue"
+          class="participants-by-stage__stars"
+        />
+        <div class="participants-by-stage__values">
+          {{t 'charts.participants-by-stage.participants' count=stage.value}}
         </div>
-      </PixTooltip>
-    </div>
-  {{/each}}
+        <PixTooltip
+          role="tooltip"
+          @text={{stage.tooltip}}
+          @position="bottom-right"
+          @isWide={{true}}
+          @isLight={{true}}
+          class="participants-by-stage__tooltip"
+          >
+          <div class="participants-by-stage__graph" role="button" {{on "click" (fn this.onClickBar stage.id)}}>
+            <div class="participants-by-stage__bar" style={{stage.barWidth}} />
+            <div class="participants-by-stage__percentage">
+              {{t 'charts.participants-by-stage.percentage' percentage=stage.percentage}}
+            </div>
+          </div>
+        </PixTooltip>
+      </div>
+    {{/each}}
+  {{/if}}
 </Charts::Card>

--- a/orga/app/components/charts/participants-by-stage.js
+++ b/orga/app/components/charts/participants-by-stage.js
@@ -11,6 +11,7 @@ export default class ParticipantsByStage extends Component {
 
   @tracked data = [];
   @tracked totalStage = [];
+  @tracked loading = true;
 
   constructor(...args) {
     super(...args);
@@ -39,6 +40,7 @@ export default class ParticipantsByStage extends Component {
             tooltip: buildTooltipText(stage.title, stage.description),
           };
         });
+        this.loading = false;
       });
   }
 

--- a/orga/app/components/charts/participants-by-stage.js
+++ b/orga/app/components/charts/participants-by-stage.js
@@ -1,23 +1,45 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import maxBy from 'lodash/maxBy';
 import sumBy from 'lodash/sumBy';
 import { htmlSafe } from '@ember/string';
 
 export default class ParticipantsByStage extends Component {
+  @service store;
+
+  @tracked data = [];
+  @tracked totalStage = [];
+
   constructor(...args) {
     super(...args);
-    const { data } = this.args;
+    const { campaignId } = this.args;
 
-    const maxValue = maxBy(data, 'value').value;
-    const totalValues = sumBy(data, 'value');
+    const adapter = this.store.adapterFor('campaign-stats');
+    adapter.getParticipationsByStage(campaignId)
+      .then((response) => {
+        const { data } = response.data.attributes;
+        const maxValue = maxBy(data, 'value').value;
+        const totalValues = sumBy(data, 'value');
 
-    this.data = data.map((stage) => ({
-      ...stage,
-      percentage: Math.round((stage.value / totalValues) * 100),
-      barWidth: `width: ${Math.round((stage.value / maxValue) * 100)}%`,
-      tooltip: buildTooltipText(stage.title, stage.description),
-    }));
+        this.totalStage = data.length - 1;
+
+        this.data = data.map((stage, index) => {
+          const percentage = totalValues !== 0 ? Math.round((stage.value / totalValues) * 100) : 0;
+          const width = maxValue !== 0 ? Math.round((stage.value / maxValue) * 100) : 0;
+          return {
+            index,
+            id: stage.id,
+            value: stage.value,
+            title: stage.title,
+            description: stage.description,
+            percentage,
+            barWidth: `width: ${width}%`,
+            tooltip: buildTooltipText(stage.title, stage.description),
+          };
+        });
+      });
   }
 
   @action

--- a/orga/app/components/routes/authenticated/campaign/collective-results/results-stats.hbs
+++ b/orga/app/components/routes/authenticated/campaign/collective-results/results-stats.hbs
@@ -1,0 +1,28 @@
+<div class="panel participant-row participant-row__result">
+  <div class="participant-results-content__summary">
+    <div class="participant-content participant-content--large participant-content--wide">
+      <div class="label-text participant-content__label-text">{{t 'pages.campaign-collective-results.table.column.validated-items'}}</div>
+      <div class="content-text content-text--big">
+        {{ @validatedSkills }}
+      </div>
+    </div>
+    <div class="participant-content participant-content--large participant-content--wide">
+      <div class="label-text participant-content__label-text">{{t 'pages.campaign-collective-results.table.column.tested-items'}}</div>
+      <div class="content-text content-text--big">
+        {{ @totalSkills }}
+      </div>
+    </div>
+  </div>
+  <div class="participant-content participant-results-content">
+    <div aria-label={{t 'pages.campaign-collective-results.average'}} class="participant-results-content__score">
+      <div class="content-text content-text--big content-text--bold">{{t 'pages.campaign-collective-results.result'}}</div>
+      <div class="participant-results-content__circle-chart">
+        <CircleChart @value={{ @averageResult }}>
+          <span class="participant-results-content__circle-chart-value">
+            {{ @averageResult }}%
+          </span>
+        </CircleChart>
+      </div>
+    </div>
+  </div>
+</div>

--- a/orga/app/components/routes/authenticated/campaign/collective-results/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/collective-results/tab.hbs
@@ -1,36 +1,18 @@
-<div class="panel participant-row participant-row__result">
+{{#if @hasStages}}
+  <Charts::ParticipantsByStage
+    @campaignId={{@campaignId}}
+    @onSelectStage={{@goToParticipantsForStage}}
+    class="participant-row__result"
+  />
+{{else}}
+  <Routes::Authenticated::Campaign::CollectiveResults::ResultsStats
+    @validatedSkills={{@campaignCollectiveResult.averageValidatedSkillsSum}}
+    @totalSkills={{@campaignCollectiveResult.totalSkills}}
+    @averageResult={{@campaignCollectiveResult.averageResult}}
+  />
+{{/if}}
 
-  <div class="participant-results-content__summary">
-    <div class="participant-content participant-content--large participant-content--wide">
-      <div class="label-text participant-content__label-text">{{t 'pages.campaign-collective-results.table.column.validated-items'}}</div>
-      <div class="content-text content-text--big">
-        {{ @campaignCollectiveResult.averageValidatedSkillsSum }}
-      </div>
-    </div>
-    <div class="participant-content participant-content--large participant-content--wide">
-      <div class="label-text participant-content__label-text">{{t 'pages.campaign-collective-results.table.column.tested-items'}}</div>
-      <div class="content-text content-text--big">
-        {{ @campaignCollectiveResult.totalSkills }}
-      </div>
-    </div>
-  </div>
-
-  <div class="participant-content participant-results-content">
-    <div aria-label={{t 'pages.campaign-collective-results.average'}} class="participant-results-content__score">
-      <div class="content-text content-text--big content-text--bold">{{t 'pages.campaign-collective-results.result'}}</div>
-      <div class="participant-results-content__circle-chart">
-        <CircleChart @value={{@campaignCollectiveResult.averageResult}}>
-          <span class="participant-results-content__circle-chart-value">
-            {{@campaignCollectiveResult.averageResult}}%
-          </span>
-        </CircleChart>
-      </div>
-    </div>
-  </div>
-
-</div>
 <div class="panel panel--light-shadow participant-results__details content-text content-text--small">
-
 
   <table aria-label={{t 'pages.campaign-collective-results.table.title'}}>
     <thead>

--- a/orga/app/controllers/authenticated/campaigns/campaign/collective-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/collective-results.js
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class CollectiveResultsController extends Controller {
+  @action
+  async goToParticipantsForStage(stageId) {
+    this.transitionToRoute(
+      'authenticated.campaigns.campaign.assessments',
+      { queryParams: { stages: [String(stageId)] } },
+    );
+  }
+}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -19,6 +19,7 @@
 @import "components/login-form";
 @import "components/campaign-list";
 @import "components/charts/cards";
+@import "components/charts/placeholders";
 @import "components/charts/participants-by-stage";
 @import "components/circle-chart";
 @import "components/current-organization";

--- a/orga/app/styles/components/charts/cards.scss
+++ b/orga/app/styles/components/charts/cards.scss
@@ -3,12 +3,13 @@
   border: none;
   box-shadow: 0 1px 1px 0 rgba($black, 0.1), 0 2px 5px 0 rgba($black, 0.1);
   background-color: $white;
-  padding: 16px 32px 32px 32px;
+  padding: 32px;
 
   &__title {
     font-size: 1rem;
     font-weight: 500;
     color: $grey-30;
+    margin-top: 0;
     margin-bottom: 32px;
   }
 }

--- a/orga/app/styles/components/charts/participants-by-stage.scss
+++ b/orga/app/styles/components/charts/participants-by-stage.scss
@@ -5,6 +5,13 @@
   justify-content: space-between;
   margin-bottom: 8px;
 
+  &__stars {
+    svg {
+      width: 18px;
+      height: 18px;
+    }
+  }
+
   &__values {
     color: $grey-50;
     font-size: 0.75rem;

--- a/orga/app/styles/components/charts/participants-by-stage.scss
+++ b/orga/app/styles/components/charts/participants-by-stage.scss
@@ -10,6 +10,11 @@
       width: 18px;
       height: 18px;
     }
+
+    &--loader {
+      height: 20px;
+      min-width: 100px;
+    }
   }
 
   &__values {
@@ -17,6 +22,12 @@
     font-size: 0.75rem;
     min-width: 140px;
     margin-left: 32px;
+
+    &--loader {
+      height: 20px;
+      min-width: 100px;
+      margin: 0 16px;
+    }
   }
 
   &__tooltip {
@@ -33,6 +44,11 @@
     width: 100%;
     display: flex;
     align-items: center;
+
+    &--loader {
+      flex-grow: 1;
+      height: 20px;
+    }
   }
 
   &__bar {

--- a/orga/app/styles/components/charts/placeholders.scss
+++ b/orga/app/styles/components/charts/placeholders.scss
@@ -1,0 +1,10 @@
+.placeholder-box {
+  background-color: $grey-10;
+  border-radius: 5px;
+  animation: placeholder-color 2s infinite alternate;
+}
+
+@keyframes placeholder-color {
+  from { background-color: $grey-10; }
+  to { background-color: $grey-20; }
+}

--- a/orga/app/templates/authenticated/campaigns/campaign/collective-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/collective-results.hbs
@@ -1,1 +1,6 @@
-<Routes::Authenticated::Campaign::CollectiveResults::Tab @campaignCollectiveResult={{@model.campaignCollectiveResult}} @sharedParticipationsCount={{@model.sharedParticipationsCount}} />
+<Routes::Authenticated::Campaign::CollectiveResults::Tab
+  @campaignId={{@model.id}}
+  @hasStages={{@model.hasStages}}
+  @campaignCollectiveResult={{@model.campaignCollectiveResult}}
+  @sharedParticipationsCount={{@model.sharedParticipationsCount}}
+/>

--- a/orga/app/templates/authenticated/campaigns/campaign/collective-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/collective-results.hbs
@@ -1,6 +1,7 @@
 <Routes::Authenticated::Campaign::CollectiveResults::Tab
   @campaignId={{@model.id}}
   @hasStages={{@model.hasStages}}
+  @goToParticipantsForStage={{this.goToParticipantsForStage}}
   @campaignCollectiveResult={{@model.campaignCollectiveResult}}
   @sharedParticipationsCount={{@model.sharedParticipationsCount}}
 />

--- a/orga/tests/integration/components/dashboards/participants-by-stage_test.js
+++ b/orga/tests/integration/components/dashboards/participants-by-stage_test.js
@@ -6,70 +6,64 @@ import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | Charts::ParticipantsByStage', function(hooks) {
   setupIntlRenderingTest(hooks);
+  const campaignId = 1;
   let onSelectStage;
 
-  module('For one stage', (hooks) => {
-    hooks.beforeEach(async function() {
-      // given
-      onSelectStage = sinon.stub();
-      this.set('onSelectStage', onSelectStage);
-      this.set('maxStage', 3);
-      this.set('data', [{ id: 100498, stage: 1, value: 5, title: 'title', description: 'description' }]);
+  hooks.beforeEach(async function() {
+    // given
+    onSelectStage = sinon.stub();
+    this.set('onSelectStage', onSelectStage);
+    this.set('campaignId', campaignId);
 
-      // when
-      await render(hbs`<Charts::ParticipantsByStage @data={{data}} @maxStage={{maxStage}} @onSelectStage={{onSelectStage}} />`);
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('campaign-stats');
+    const dataFetcher = sinon.stub(adapter, 'getParticipationsByStage');
+
+    dataFetcher.withArgs(campaignId).resolves({
+      data: {
+        attributes: {
+          data: [
+            { id: 100498, value: 0, title: 'title1', description: 'description1' },
+            { id: 100499, value: 5, title: 'title2', description: 'description2' },
+          ],
+        },
+      },
     });
 
-    test('it should display stage stars', async function(assert) {
-      // then
-      assert.dom('[data-test-status=unacquired]').isVisible({ count: 2 });
-      assert.dom('[data-test-status=acquired]').isVisible({ count: 1 });
-    });
-
-    test('it should display participants number', async function(assert) {
-      // then
-      assert.contains('5 participants');
-    });
-
-    test('it should display participants percentage by stages', async function(assert) {
-      // then
-      assert.contains('100 %');
-    });
-
-    test('it should contains tooltip info in dom', async function(assert) {
-      // then
-      assert.contains('title');
-      assert.contains('description');
-    });
-
-    test('it should call onSelectStage when user click on a bar', async function(assert) {
-      // when
-      await click('[role=button]');
-      // then
-      assert.dom('[role=button]').exists();
-      sinon.assert.calledWith(onSelectStage, 100498);
-    });
+    // when
+    await render(hbs`<Charts::ParticipantsByStage @campaignId={{campaignId}} @onSelectStage={{onSelectStage}} />`);
   });
 
-  module('For several stages', (hooks) => {
-    hooks.beforeEach(async function() {
-      // given
-      this.set('maxStage', 2);
-      this.set('data', [
-        { id: 100498, stage: 0, value: 5, title: 'title', description: 'description' },
-        { id: 100499, stage: 1, value: 10, title: 'title', description: 'description' },
-      ]);
+  test('it should display stage stars', async function(assert) {
+    assert.dom('[data-test-status=acquired]').isVisible({ count: 1 });
+    assert.dom('[data-test-status=unacquired]').isVisible({ count: 1 });
+  });
 
-      // when
-      await render(hbs`<Charts::ParticipantsByStage @data={{data}} @maxStage={{maxStage}} />`);
-    });
+  test('it should display participants number', async function(assert) {
+    // then
+    assert.contains('0 participant');
+    assert.contains('5 participants');
+  });
 
-    test('it should display data for each stage', async function(assert) {
-      // then
-      assert.contains('5 participants');
-      assert.contains('10 participants');
-      assert.contains('33 %');
-      assert.contains('67 %');
-    });
+  test('it should display participants percentage by stages', async function(assert) {
+    // then
+    assert.contains('0 %');
+    assert.contains('100 %');
+  });
+
+  test('it should contains tooltip info', async function(assert) {
+    // then
+    assert.contains('title1');
+    assert.contains('description1');
+    assert.contains('title2');
+    assert.contains('description2');
+  });
+
+  test('it should call onSelectStage when user click on a bar', async function(assert) {
+    // when
+    await click('[role=button]');
+    // then
+    assert.dom('[role=button]').exists();
+    sinon.assert.calledWith(onSelectStage, 100498);
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -73,9 +73,10 @@
   },
   "charts": {
     "participants-by-stage": {
+      "loader": "Loading and sorting the participants grouped by success rates",
       "participants": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}}",
       "percentage": "{percentage} %",
-      "title": "Distribution of participants by rating"
+      "title": "Distribution of participants grouped by success rate"
     }
   },
   "navigation": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -73,6 +73,7 @@
   },
   "charts": {
     "participants-by-stage": {
+      "loader": "Chargement de la répartition des participants par paliers",
       "participants": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}}",
       "percentage": "{percentage} %",
       "title": "Répartition des participants par paliers"


### PR DESCRIPTION
## :unicorn: Problème

On ne peut pas visualiser facilement la répartition des résultats des participations à une campagne en fonction des paliers de celles-ci. Dans le cadre du PIC 2020, le besoin de ce premier graphe avait été levé.

## :robot: Solution

Le composant du graphe a déjà été réalisé dans la PR #2974 , il est maintenant nécessaire de : 
1. Réaliser un endpoint permettant de récupérer les données nécessaires.
- [x] Faire des tests de volumétrie pour valider la/les requêtes SQL
- [x] nommage du endpoint: `/api/campaign/{id}/stats/participations-by-stage`
2. Appeler cet endpoint au sein du composant `<Charts::ParticipantsByStage />`.
- [x] Le composant réalise l'appel à l'API via le store et un adapter dédié
- [x] Le composant gère son état de loading affiché sous forme de placeholder
- [x] Au clique sur une barre pouvoir filtrer les recherches de participants en fonction du palier sélectionné
3. Intégrer ce composant dans la page des résultats collectifs.
- [x] Si la campagne n'a pas de palier afficher le bloc résultat actuel
- [x] Si la campagne a des paliers, remplacer le bloc résultat actuel par le composant.

## :rainbow: Remarques

### Tests de performances SQL

Afin de s'assurer que la ou les requêtes SQL utilisées pour récupérer ces données soient performantes, nous avons exécuté ces requêtes sur une volumérie similaire à la production (sur la base de réplication).

2 pistes ont été étudiées, faire **1 requête par palier** ou **1 requête pour tous les paliers**.

**Requête 1:** 1 requête par palier.
```
EXPLAIN ANALYZE 
SELECT count("id") as "Palier 1"
FROM "campaign-participations"
WHERE
"campaignId" = 161608
AND "isImproved" is false
AND "validatedSkillsCount" between 0 and 12;

QUERY PLAN
-------------------------------------
 Aggregate  (cost=62.79..62.80 rows=1 width=8) (actual time=0.121..0.121 rows=1 loops=1)
   ->  Index Scan using campaign_participations_campaignid_index on "campaign-participations"  (cost=0.43..62.78 rows=3 width=4) (actual time=0.046..0.116 rows=5 loops=1)
         Index Cond: ("campaignId" = 161608)
         Filter: (("isImproved" IS FALSE) AND ("validatedSkillsCount" >= 0) AND ("validatedSkillsCount" <= 12))
         Rows Removed by Filter: 18
 Planning Time: 0.149 ms
 Execution Time: 0.161 ms
(7 rows)
```

**Requête 2:** 1 requête pour tous les paliers.
```
EXPLAIN ANALYZE
SELECT
COUNT("id") FILTER (WHERE "validatedSkillsCount" between 0 and 1) OVER (PARTITION BY "campaignId") AS "Palier 1",
COUNT("id") FILTER (WHERE "validatedSkillsCount" between 2 and 12) OVER (PARTITION BY "campaignId") AS "Palier 2",
COUNT("id") FILTER (WHERE "validatedSkillsCount" between 13 and 40) OVER (PARTITION BY "campaignId") AS "Palier 3"
FROM "campaign-participations"
WHERE "campaignId" = 161608 AND "isImproved" is false limit 1;

QUERY PLAN
-------------------------------------
 Limit  (cost=0.43..1.24 rows=1 width=28) (actual time=0.112..0.113 rows=1 loops=1)
   ->  WindowAgg  (cost=0.43..65.18 rows=80 width=28) (actual time=0.111..0.112 rows=1 loops=1)
         ->  Index Scan using campaign_participations_campaignid_index on "campaign-participations"  (cost=0.43..62.38 rows=80 width=12) (actual time=0.038..0.090 rows=23 loops=1)
               Index Cond: ("campaignId" = 161608)
               Filter: ("isImproved" IS FALSE)
 Planning Time: 0.216 ms
 Execution Time: 0.176 ms
(7 rows)
```

Les 2 requêtes ont un explain plan similaire et de temps d'exécution très bon. 

Bien que la **Requête 1** soit plus rapide a être exécuté, elle devra l'être 3 fois (une pour chaque palier) soit 0.161*3=0.483ms (sans compter le temps de récupération des connexions par knex).

Par conséquent, nous avons choisi d'utiliser la **Requête 2** afin de récupérer l'ensemble des données en une unique requête.

### Rendus

**Rendu du graphique et redirection sur la liste des participants filtrés au clique:**
![Kapture 2021-05-11 at 17 39 38](https://user-images.githubusercontent.com/516360/117844417-f3742d00-b27f-11eb-95b7-f0e8727bc642.gif)

**Affichage du placeholder au chargement des données:**
![Kapture 2021-05-11 at 17 09 42](https://user-images.githubusercontent.com/516360/117839897-f0773d80-b27b-11eb-8ebf-e1da4ada868c.gif)


## :100: Pour tester

1. Se connecter avec le compte `pro.admin@example.net`
2. Sélectionner la campagne "Pro - Campagne d’évaluation 5.1"
3. Cliquer sur l'onglet "Résultats collectifs"
> Voir le graphique s'afficher

> Vérifier les données et l'affichage des tooltips

> Vérifier la redirection et le filtrage de la liste des participants au clique sur un palier du graphe

4. Aller sur la campagne "Sup - Campagne d’évaluation Pix+ Droit"
> Vérifier que l'ancien bandeau de stats est affiché (car pas de palier)
