### PR TITLE
[FEATURE] Ajout d'un wording pour l'étudiant dans la page de réconciliation SUP (PIX-2547).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -1,4 +1,6 @@
 {{!-- template-lint-disable require-input-label no-triple-curlies no-unknown-arguments-for-builtin-components --}}
+<div class="join-restricted-campaign__title">{{t 'pages.join.sco.first-title' organizationName=@organizationName}}</div>
+<div class="join-restricted-campaign__subtitle">{{t 'pages.join.sco.subtitle'}}</div>
 <form>
   <div class="join-restricted-campaign__row">
     <label class="join-restricted-campaign__label">{{t 'pages.join.fields.firstname.label'}}</label>

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
@@ -1,3 +1,5 @@
+<div class="join-restricted-campaign__title">{{t 'pages.join.sup.title' organizationName=@organizationName}}</div>
+<div class="join-restricted-campaign__subtitle">{{t 'pages.join.sup.message' organizationName=@organizationName}}</div>
 <form>
   <div class="join-restricted-campaign__row">
     <label for="studentNumber" class="join-restricted-campaign__label">

--- a/mon-pix/app/templates/campaigns/restricted/join.hbs
+++ b/mon-pix/app/templates/campaigns/restricted/join.hbs
@@ -5,12 +5,10 @@
   <div
     class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner join-restricted-campaign__container">
     <div class="join-restricted-campaign">
-      <div class="join-restricted-campaign__title">{{t 'pages.join.first-title' organizationName=@model.organizationName}}</div>
-      <div class="join-restricted-campaign__subtitle">{{t 'pages.join.subtitle'}}</div>
       {{#if (eq @model.organizationType "SCO")}}
-        <Routes::Campaigns::Restricted::JoinSco @campaignCode={{@model.code}} @onSubmitToCreateAndReconcile={{this.createAndReconcile}} @onSubmitToReconcile={{this.reconcile}} />
+        <Routes::Campaigns::Restricted::JoinSco @organizationName={{@model.organizationName}} @campaignCode={{@model.code}} @onSubmitToCreateAndReconcile={{this.createAndReconcile}} @onSubmitToReconcile={{this.reconcile}} />
       {{else}}
-        <Routes::Campaigns::Restricted::JoinSup @campaignCode={{@model.code}} @onSubmitToReconcile={{this.reconcile}} />
+        <Routes::Campaigns::Restricted::JoinSup @organizationName={{@model.organizationName}} @campaignCode={{@model.code}} @onSubmitToReconcile={{this.reconcile}} />
       {{/if}}
     </div>
   </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -721,10 +721,10 @@
             "label": "Student number",
             "modify": "Change student number",
             "not-existing": "I don't have a student number"
-          },
-        "message": "This is the first time you have accepted the invitation from {organizationName}.\nPlease fill in these 4 fields as accurately as possible: Pix will then be able to find you in the student database and link your Pix account to it once and for all.",
-        "title": "{organizationName} has invited you to use Pix as part of your training."
-        }
+          }
+        },
+        "message": "Enter the information as it appears on your student card to access the test and submit the results. Pix will remember it next time.",
+        "title": "Register your Pix account with {organizationName}."
       }
     },
     "learning-more": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -704,15 +704,15 @@
           "label": "Last name"
         }
       },
-      "first-title": "{ organizationName }",
       "sco": {
         "associate": "Link",
         "continue-with-pix": "Continue with my Pix account",
         "error-not-found": "If you're a pupil '<br>' Check your information (first name, last name and date of birth) or contact a teacher.'<br><br>' If you're a teacher '<br>' Access to this customised test is not available at the moment.",
+        "first-title": "{ organizationName }",
         "login-information-message": "The Pix account  '<b>'{ connectionMethod }'</b>' will be linked with the pupil:  '<b>'{ firstName }  { lastName }'</b>'.'<b>'If this is you, click on \"Link\". Otherwise, log out.",
-        "login-information-title": "Pix account information"
+        "login-information-title": "Pix account information",
+        "subtitle": "Please fill in the missing information"
       },
-      "subtitle": "Please fill in the missing information",
       "sup": {
         "error": "Please check the information you have entered. If you already have a Pix account, log in with this account.",
         "fields": {
@@ -721,7 +721,9 @@
             "label": "Student number",
             "modify": "Change student number",
             "not-existing": "I don't have a student number"
-          }
+          },
+        "message": "This is the first time you have accepted the invitation from {organizationName}.\nPlease fill in these 4 fields as accurately as possible: Pix will then be able to find you in the student database and link your Pix account to it once and for all.",
+        "title": "{organizationName} has invited you to use Pix as part of your training."
         }
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -704,15 +704,15 @@
           "label": "Nom"
         }
       },
-      "first-title": "Rejoignez l'organisation { organizationName }",
       "sco": {
         "associate": "Associer",
         "continue-with-pix": "Continuer avec mon compte Pix",
         "error-not-found": "Vous êtes un élève ? '<br>' Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.'<br><br>' Vous êtes un enseignant ? '<br>' L‘accès à un parcours n‘est pas disponible pour le moment.",
+        "first-title": "Rejoignez l'organisation { organizationName }",
         "login-information-message": "Le compte Pix '<b>'{ connectionMethod }'</b>' va être associé à l'élève: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'S’il s’agit bien de vous, cliquez sur \"Associer\", sinon déconnectez-vous.",
-        "login-information-title": "Information de connexion"
+        "login-information-title": "Information de connexion",
+        "subtitle": "Remplissez les informations manquantes"
       },
-      "subtitle": "Remplissez les informations manquantes",
       "sup": {
         "error": "Veuillez vérifier les informations saisies, ou si vous avez déjà un compte Pix, connectez-vous avec celui-ci.",
         "fields": {
@@ -721,7 +721,9 @@
             "label": "Numéro étudiant",
             "modify": "Modifier le numéro étudiant",
             "not-existing": "Je n'ai pas de numéro étudiant"
-          }
+          },
+        "message": "C’est la première fois que vous répondez à l’invitation de {organizationName}. Saisissez ces 4 données avec précision : Pix pourra ainsi vous retrouver dans la base des étudiants et y associer une fois pour toutes votre compte Pix.",
+        "title": "{organizationName} vous invite à utiliser Pix dans le cadre de votre formation."
         }
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -721,10 +721,10 @@
             "label": "Numéro étudiant",
             "modify": "Modifier le numéro étudiant",
             "not-existing": "Je n'ai pas de numéro étudiant"
-          },
-        "message": "C’est la première fois que vous répondez à l’invitation de {organizationName}. Saisissez ces 4 données avec précision : Pix pourra ainsi vous retrouver dans la base des étudiants et y associer une fois pour toutes votre compte Pix.",
-        "title": "{organizationName} vous invite à utiliser Pix dans le cadre de votre formation."
-        }
+          }
+        },
+        "message": "Saisissez les informations telles qu’elles figurent sur votre carte d’étudiant pour accéder au test et envoyer les résultats. Pix s’en rappellera la prochaine fois.",
+        "title": "Déclarez votre compte Pix auprès de {organizationName}."
       }
     },
     "learning-more": {


### PR DESCRIPTION
## :unicorn: Problème
Le texte affiché pour la réconciliation SUP et SCO est le même.

## :robot: Solution
Ajouter un texte spécifique pour la réconciliation SUP.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Rejoindre une campagne restreinte d'un organisation SUP et vérifier que les nouvelles traductions sont là.
Rejoindre une campagne restreinte d'un organisation SCO et vérifier que les anciennes traductions sont là.