### PR TITLE
[FEATURE] Inverser les listes de session à publier et à traiter dans ADMIN (PIX-2433)

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -24,7 +24,7 @@
     </li>
     <li class="menu-bar__entry">
       <PixTooltip @text='Sessions de certifications' @position='right' @inline={{true}}>
-        <LinkTo @route="authenticated.sessions.list.to-be-published" class="menu-bar__link menu-bar__link--sessions">
+        <LinkTo @route="authenticated.sessions.list.with-required-action" class="menu-bar__link menu-bar__link--sessions">
           <FaIcon @icon="chalkboard-teacher"></FaIcon>
         </LinkTo>
       </PixTooltip>

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -1,11 +1,11 @@
 <header class="session-list">
   <h1 class="page-header page-title session-list__title">Sessions de certifications</h1>
   <nav class="navbar session-list__navbar">
-    <LinkTo @route="authenticated.sessions.list.to-be-published" class="navbar-item">
-      Sessions à publier
-    </LinkTo>
     <LinkTo @route="authenticated.sessions.list.with-required-action" class="navbar-item">
       Sessions à traiter ({{ this.sessionsWithRequiredActionCount }})
+    </LinkTo>
+    <LinkTo @route="authenticated.sessions.list.to-be-published" class="navbar-item">
+      Sessions à publier
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.all" class="navbar-item">
       Toutes les sessions


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création du nouvel onglet “Sessions à traiter” dans Pix Admin > Sessions de certification, nous avions décidé avec le pôle certification de réorganiser les différents onglets présents sur cette page dans l’ordre suivant : 

- Sessions à publier

- Sessions à traiter

- Toutes les sessions

Néanmoins, dans l’utilisation régulière de ces nouveaux onglets, le pôle certification a remarqué qu’il serait plus optimal pour eux dans leur process de traitement des sessions de certification d’avoir l’onglet “Sessions à traiter” en 1er, ayant besoin d’y accéder plus régulièrement, donc de l’avoir affiché par défaut au clic sur le menu “Sessions de certification”, que l’onglet des “Sessions à publier” visité une fois par jour.

## :robot: Solution
Sur la page “Sessions de certification” dans Pix Admin : switcher les onglets “Sessions à publier” et “Sessions à traiter” pour avoir le nouvel ordre suivant : 

- Sessions à traiter

- Sessions à publier

- Toutes les sessions



## :100: Pour tester
- Se connecter à pix Admin
- Constater que les listes de sessions sont bien affichées dans l'ordre suivant: 

![image](https://user-images.githubusercontent.com/37305474/117782705-2c8dac80-b242-11eb-9f26-cb5f025d1712.png)

