### PR TITLE
[BUGFIX] Rendre la finalisation de session idempotente (PIX-2580)

### DIFF
--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -45,6 +45,14 @@ module.exports = class FinalizedSession {
     });
   }
 
+  publish(now) {
+    this.publishedAt = now;
+  }
+
+  unpublish() {
+    this.publishedAt = null;
+  }
+
   assignCertificationOfficer({ certificationOfficerName }) {
     this.isPublishable = false;
     this.assignedCertificationOfficerName = certificationOfficerName;

--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -19,7 +19,7 @@ async function publishSession({
 
   await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
 
-  await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt });
+  await _updateFinalizedSession(finalizedSessionRepository, sessionId, publishedAt);
 
   const emailingAttempts = await _sendPrescriberEmails(session);
   if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {
@@ -73,6 +73,12 @@ function _someHaveFailed(emailingAttempts) {
 function _failedAttemptsRecipients(emailingAttempts) {
   return emailingAttempts.filter((emailAttempt) => emailAttempt.hasFailed())
     .map((emailAttempt) => emailAttempt.recipientEmail);
+}
+
+async function _updateFinalizedSession(finalizedSessionRepository, sessionId, publishedAt) {
+  const finalizedSession = await finalizedSessionRepository.get({ sessionId });
+  finalizedSession.publish(publishedAt);
+  await finalizedSessionRepository.save(finalizedSession);
 }
 
 module.exports = {

--- a/api/lib/domain/usecases/unpublish-session.js
+++ b/api/lib/domain/usecases/unpublish-session.js
@@ -12,7 +12,13 @@ module.exports = async function unpublishSession({
 
   await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt: session.publishedAt });
 
-  await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt: session.publishedAt });
+  await _updateFinalizedSession(finalizedSessionRepository, sessionId);
 
   return sessionRepository.getWithCertificationCandidates(sessionId);
 };
+
+async function _updateFinalizedSession(finalizedSessionRepository, sessionId) {
+  const finalizedSession = await finalizedSessionRepository.get({ sessionId });
+  finalizedSession.unpublish();
+  await finalizedSessionRepository.save(finalizedSession);
+}

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -28,12 +28,6 @@ module.exports = {
     throw new NotFoundError(`Session of id ${sessionId} does not exist.`);
   },
 
-  async updatePublishedAt({ sessionId, publishedAt }) {
-    await FinalizedSessionBookshelf
-      .where({ sessionId })
-      .save({ publishedAt }, { method: 'update', require: false });
-  },
-
   async findFinalizedSessionsToPublish() {
     const publishableFinalizedSessions = await FinalizedSessionBookshelf
       .where({ isPublishable: true, publishedAt: null, assignedCertificationOfficerName: null })

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const { NotFoundError } = require('../../domain/errors');
+const { knex } = require('../bookshelf');
 
 const FinalizedSessionBookshelf = require('../data/finalized-session');
 
@@ -8,15 +9,11 @@ const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-convert
 module.exports = {
 
   async save(finalizedSession) {
-    const foundSession = await FinalizedSessionBookshelf.where({ sessionId: finalizedSession.sessionId }).fetch({ require: false });
-
-    if (foundSession) {
-      return FinalizedSessionBookshelf
-        .where({ sessionId: finalizedSession.sessionId })
-        .save(_toDTO(finalizedSession), { method: 'update', require: false });
-    }
-
-    return new FinalizedSessionBookshelf(_toDTO(finalizedSession), { method: 'insert' }).save();
+    await knex('finalized-sessions')
+      .insert(_toDTO(finalizedSession))
+      .onConflict('sessionId')
+      .merge();
+    return finalizedSession;
   },
 
   async get({ sessionId }) {

--- a/api/tests/acceptance/application/session/session-controller-patch-unpublish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-unpublish-session_test.js
@@ -79,6 +79,7 @@ describe('PATCH /api/admin/sessions/:id/unpublish', () => {
 
         beforeEach(() => {
           sessionId = databaseBuilder.factory.buildSession({ publishedAt: date }).id;
+          databaseBuilder.factory.buildFinalizedSession({ sessionId, publishedAt: date });
           options.url = `/api/admin/sessions/${sessionId}/unpublish`;
           certificationId = databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: true }).id;
 

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -137,45 +137,6 @@ describe('Integration | Repository | Finalized-session', () => {
 
   });
 
-  describe('#updatePublishedAt', () => {
-
-    afterEach(() => {
-      return knex('finalized-sessions').delete();
-    });
-
-    it('should update the publication date of a finalized session', async () => {
-      // given
-      const publishedAt = new Date('2021-01-01');
-      const finalizedSession = databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 });
-      await databaseBuilder.commit();
-
-      // when
-      await finalizedSessionRepository.updatePublishedAt({
-        sessionId: finalizedSession.sessionId,
-        publishedAt,
-      });
-
-      // then
-      const { publishedAt: actualPublishedAt } = await knex.select('publishedAt').from('finalized-sessions').where({ sessionId: 1234 }).first();
-      expect(actualPublishedAt).to.deep.equal(publishedAt);
-    });
-
-    it('should not throw when trying to setup publishedAt date on non-existent finalized session', async () => {
-      // given
-      databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 });
-      await databaseBuilder.commit();
-
-      // when
-      const promise = finalizedSessionRepository.updatePublishedAt({
-        sessionId: 7894,
-        publishedAt: new Date(),
-      });
-
-      // then
-      return expect(promise).to.be.fulfilled;
-    });
-  });
-
   describe('#findFinalizedSessionsToPublish', () => {
 
     context('when there are publishable sessions', () => {

--- a/api/tests/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/unit/domain/models/FinalizedSession_test.js
@@ -126,6 +126,54 @@ describe('Unit | Domain | Models | FinalizedSession', () => {
       expect(finalizedSession.assignedCertificationOfficerName).to.equal(certificationOfficerName);
     });
   });
+
+  context('#publish', () => {
+    it('publishes the session', () => {
+      // given
+      const now = new Date();
+      const session = new FinalizedSession({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+        isPublishable: true,
+        publishedAt: null,
+        assignedCertificationOfficerName: null,
+      });
+
+      // when
+      session.publish(now);
+
+      // then
+      expect(session.publishedAt).to.equal(now);
+    });
+  });
+
+  context('#unpublish', () => {
+    it('unpublishes the session', () => {
+      const session = new FinalizedSession({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+        isPublishable: true,
+        publishedAt: new Date(),
+        assignedCertificationOfficerName: null,
+      });
+
+      // when
+      session.unpublish();
+
+      // then
+      expect(session.publishedAt).to.be.null;
+    });
+  });
 });
 
 function _noneWithRequiredActionNorErrorOrStartedStatus() {


### PR DESCRIPTION
## :unicorn: Problème
Pour une raison qui nous reste obscure malgré différentes investigations, nous recevons parfois 2 requêtes quasi simultanées sur la finalisation de session. Cette quasi-simultanéité provoque une tentative d'insertion en doublon dans la table `finalized-sessions` ce qui remonte une erreur 500 en raison de la violation d'unicité sur la clé primaire sessionId. 

## :robot: Solution
Rendre cette action idempotente afin d'éviter que le client ait une notification d'erreur alors que son action est permise et valide. Techniquement nous optons pour un `ON CONFLICT UPDATE` (ie. `onConflict(...).merge()` dans knex)

## :rainbow: Remarques
RAS

## :100: Pour tester
Difficile à tester fonctionnellement, cependant un test unitaire caractérise le problème et sa solution.
