### PR TITLE
[BUGFIX] Les macarons de certifications complémentaires ne s'affichaient que si le candidat avait obtenu son CléA dans le certificat partagé par code (PIX-2582)

### DIFF
--- a/mon-pix/app/controllers/shared-certification.js
+++ b/mon-pix/app/controllers/shared-certification.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+
+export default class SharedCertificationController extends Controller {
+  get shouldDisplayDetailsSection() {
+    const model = this.model;
+    return Boolean(model.commentForCandidate || model.hasAcquiredComplementaryCertifications);
+  }
+}

--- a/mon-pix/app/templates/shared-certification.hbs
+++ b/mon-pix/app/templates/shared-certification.hbs
@@ -14,8 +14,8 @@
             @resultCompetenceTree={{this.model.resultCompetenceTree}}
             @maxReachableLevelOnCertificationDate={{this.model.maxReachableLevelOnCertificationDate}}
     />
-    {{#if this.model.hasCleaCertif}}
-      <UserCertificationsDetailResult @certification={{this.model}} />
+    {{#if this.shouldDisplayDetailsSection}}
+      <UserCertificationsDetailResult @certification={{@model}} />
     {{/if}}
   </div>
 

--- a/mon-pix/tests/unit/controllers/shared-certification_test.js
+++ b/mon-pix/tests/unit/controllers/shared-certification_test.js
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { context, describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Controller | shared-certification', function() {
+  setupTest();
+
+  context('#get shouldDisplayDetailsSection', function() {
+
+    it('should return true when certification has a commentForCandidate', function() {
+      const controller = this.owner.lookup('controller:shared-certification');
+      const store = this.owner.lookup('service:store');
+      controller.model = store.createRecord('certification', {
+        firstName: 'Laura',
+        lastName: 'Summers',
+        commentForCandidate: 'some comment',
+        cleaCertificationStatus: 'not_taken',
+        certifiedBadgeImages: [],
+      });
+
+      // when
+      const shouldDisplayDetailsSection = controller.shouldDisplayDetailsSection;
+
+      // then
+      expect(shouldDisplayDetailsSection).to.be.true;
+    });
+
+    it('should return true when certification has an acquired clea certification', function() {
+      const controller = this.owner.lookup('controller:shared-certification');
+      const store = this.owner.lookup('service:store');
+      controller.model = store.createRecord('certification', {
+        firstName: 'Laura',
+        lastName: 'Summers',
+        commentForCandidate: null,
+        cleaCertificationStatus: 'acquired',
+        certifiedBadgeImages: [],
+      });
+
+      // when
+      const shouldDisplayDetailsSection = controller.shouldDisplayDetailsSection;
+
+      // then
+      expect(shouldDisplayDetailsSection).to.be.true;
+    });
+
+    it('should return true when certification has at least one certified badge image', function() {
+      const controller = this.owner.lookup('controller:shared-certification');
+      const store = this.owner.lookup('service:store');
+      controller.model = store.createRecord('certification', {
+        firstName: 'Laura',
+        lastName: 'Summers',
+        commentForCandidate: null,
+        cleaCertificationStatus: 'not_taken',
+        certifiedBadgeImages: ['/some/img'],
+      });
+
+      // when
+      const shouldDisplayDetailsSection = controller.shouldDisplayDetailsSection;
+
+      // then
+      expect(shouldDisplayDetailsSection).to.be.true;
+    });
+
+    it('should return false when none of the above is checked', function() {
+      const controller = this.owner.lookup('controller:shared-certification');
+      const store = this.owner.lookup('service:store');
+      controller.model = store.createRecord('certification', {
+        firstName: 'Laura',
+        lastName: 'Summers',
+        commentForCandidate: null,
+        cleaCertificationStatus: 'not_taken',
+        certifiedBadgeImages: [],
+      });
+
+      // when
+      const shouldDisplayDetailsSection = controller.shouldDisplayDetailsSection;
+
+      // then
+      expect(shouldDisplayDetailsSection).to.be.false;
+    });
+  });
+});

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -184,7 +184,7 @@
         "subtitle": "(niveaux sur {maxReachableLevel})"
       },
       "complementary": {
-        "title": "Autre certification obtenue",
+        "title": "Autre(s) certification(s) obtenue(s)",
         "alternative": "Certification complémentaire"
       },
       "exam-date": "Date de passage :",


### PR DESCRIPTION
## :unicorn: Problème
Pour reproduire, aller sur une autre RA puis :
- Se connecter à PixApp avec certif-success@example.net / pix123
- Se rendre sur son seul certificat validé
- Constater la présence de deux macarons (CléA et un autre). Jusque là tout va bien
- Récupérer le code de vérification
- Se rendre sur ....fr/verification-certificat
- Saisir le code de vérification
- Constater la présence de deux macarons (CléA et un autre). Jusque là aussi tout va bien
- Ouvrir la console du développeur sur un navigateur avec l'addon Ember
- Aller dans Data > Certifications > cliquer sur la ligne de certification pour l'éditer
- Passer l'attribut cleaCertificationStatus à une autre valeur que "acquired" (n'importe quoi fait l'affaire).
- Constater la disparition de tous les macarons (pas seulement CléA)

## :robot: Solution
Oubli de mise à jour des conditions d'affichage du bloc de certifications complémentaires.
Bug non présent sur le certificat de l'utilisateur.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Ne pas réussir à reproduire les étapes décrites dans la section **_Problème_**
