### PR TITLE
[INFRA] Loguer les traces d'erreurs dont le code est 500 ou plus en dev

### DIFF
--- a/api/lib/application/pre-response-utils.js
+++ b/api/lib/application/pre-response-utils.js
@@ -1,3 +1,5 @@
+const config = require('../config');
+const logger = require('../infrastructure/logger');
 const errorManager = require('./error-manager');
 const { BaseHttpError, UnauthorizedError } = require('./http-errors');
 const { DomainError } = require('../domain/errors');
@@ -14,7 +16,15 @@ function handleDomainAndHttpErrors(request, h) {
     return errorManager.handle(request, h, new UnauthorizedError(undefined, 401));
   }
 
+  if (_is5XXError(response) && config.logging.shouldLog5XXErrors) {
+    logger.error(response);
+  }
+
   return h.continue;
+}
+
+function _is5XXError(response) {
+  return response.isBoom && response.output && response.output.statusCode >= 500;
 }
 
 module.exports = {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -62,6 +62,7 @@ module.exports = (function() {
     logging: {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: (process.env.NODE_ENV === 'development'),
+      shouldLog5XXErrors: isFeatureEnabled(process.env.SHOULD_LOG_5XX_ERRORS),
       logLevel: (process.env.LOG_LEVEL || 'info'),
     },
 
@@ -179,6 +180,9 @@ module.exports = (function() {
     ],
   };
 
+  if (config.environment === 'development') {
+    config.logging.shouldLog5XXErrors = true;
+  }
   if (process.env.NODE_ENV === 'test') {
     config.port = 0;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -61,7 +61,7 @@ module.exports = (function() {
 
     logging: {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
-      colorEnabled: (process.env.NODE_ENV === 'development'),
+      colorEnabled: false,
       shouldLog5XXErrors: isFeatureEnabled(process.env.SHOULD_LOG_5XX_ERRORS),
       logLevel: (process.env.LOG_LEVEL || 'info'),
     },
@@ -181,9 +181,10 @@ module.exports = (function() {
   };
 
   if (config.environment === 'development') {
+    config.enabled = true;
+    config.logging.colorEnabled = true;
     config.logging.shouldLog5XXErrors = true;
-  }
-  if (process.env.NODE_ENV === 'test') {
+  } else if (process.env.NODE_ENV === 'test') {
     config.port = 0;
 
     config.lcms.apiKey = 'test-api-key';

--- a/api/sample.env
+++ b/api/sample.env
@@ -199,7 +199,7 @@ LCMS_API_URL=https://lcms.minimal.pix.fr/api
 # LOGGING
 # =======
 
-# Enable or disable the logging of the API.
+# Enable or disable the logging of the API. Always true in development.
 #
 # presence: optionnal
 # type: Boolean

--- a/api/sample.env
+++ b/api/sample.env
@@ -213,6 +213,14 @@ LOG_ENABLED=true
 # default: "info"
 # LOG_LEVEL=debug
 
+# Enable or disable the logging of the 5XX error traces. Always true in
+# development. Doesn't log if logging is disabled.
+#
+# presence: optionnal
+# type: Boolean
+# default: `false`
+# SHOULD_LOG_5XX_ERRORS=true
+
 # ========
 # SECURITY
 # ========

--- a/api/tests/unit/application/pre-response-utils_test.js
+++ b/api/tests/unit/application/pre-response-utils_test.js
@@ -1,5 +1,7 @@
 const { expect, sinon, hFake } = require('../../test-helper');
 
+const logger = require('../../../lib/infrastructure/logger');
+const config = require('../../../lib/config');
 const errorManager = require('../../../lib/application/error-manager');
 const { BaseHttpError } = require('../../../lib/application/http-errors');
 const { handleDomainAndHttpErrors } = require('../../../lib/application/pre-response-utils');
@@ -54,6 +56,49 @@ describe('Unit | Application | PreResponse-utils', () => {
       // then
       expect(errorManager.handle).to.have.been.calledWithExactly(request, hFake, request.response);
     });
+
+    context('when dealing with 5XX errors', () => {
+      context('when 5XX error logging is enabled', () => {
+        it('logs 5XX errors', () => {
+          // given
+          const response = _create500ErrorResponse();
+          const request = { response };
+
+          sinon.stub(logger, 'error');
+          sinon.stub(config.logging, 'shouldLog5XXErrors').value(true);
+
+          // when
+          handleDomainAndHttpErrors(request, hFake);
+
+          // then
+          expect(logger.error).to.have.been.calledWith(response);
+        });
+      });
+
+      context('when 5XX error logging is disabled', () => {
+        it('skips 5XX errors logging', () => {
+          // given
+          const response = _create500ErrorResponse();
+          const request = { response };
+
+          sinon.stub(logger, 'error');
+          sinon.stub(config.logging, 'shouldLog5XXErrors').value(false);
+
+          // when
+          handleDomainAndHttpErrors(request, hFake);
+
+          // then
+          expect(logger.error).not.to.have.been.calledWith(response);
+        });
+      });
+    });
   });
 
 });
+
+function _create500ErrorResponse() {
+  return {
+    isBoom: true,
+    output: { statusCode: 500 },
+  };
+}


### PR DESCRIPTION
## :unicorn: Problème

Quand une erreur se produit, pendant le développement on souhaite en voir la trace pour comprendre rapidement ce qui se passe. Or, les traces des erreurs non catchées ne sont pas loguées.

## :robot: Solution

Ajouter une config `logging.shouldLog5XXErrors`, dont la valeur est vraie quand `config.environment` est `development`

## :rainbow: Remarques 

- Est-ce qu'on a besoin de le désactiver sur les envs de prod ? C'est ce qu'on a fait, mais est-ce utile ?
- Le deuxième commit qui rassemble trois confs de développement est optionnel, vous en pensez quoi ?

## :100: Pour tester

Par exemple, lancer une erreur dans `/api`, démarrer l'api et appeler cette route. Voir ce qui est logué et ce qui ne l'est pas en fonction des variables d'env.

```diff
--- a/api/lib/application/healthcheck/healthcheck-controller.js
+++ b/api/lib/application/healthcheck/healthcheck-controller.js
@@ -7,6 +7,7 @@ const { knex } = require('../../../db/knex-database-connection');
 module.exports = {

   get(request) {
+    throw Error("salut");
     return {
       'name': packageJSON.name,
       'version': packageJSON.version,
```