### PR TITLE
[TECH] Corrige un test flacky en supprimant du code (ce n'est pas ce que vous croyez)

### DIFF
--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -26,10 +26,6 @@ describe('Acceptance | Controller | users-controller', () => {
 
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       context('user is valid', () => {
 
         let response;

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -32,7 +32,6 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
 
   beforeEach(async () => {
     server = await createServer();
-    databaseBuilder.clean();
   });
 
   describe('GET /users/{userId}/campaigns/{campaignId}/profile', () => {

--- a/api/tests/integration/domain/event/handle-badge-acquisition_test.js
+++ b/api/tests/integration/domain/event/handle-badge-acquisition_test.js
@@ -94,7 +94,6 @@ describe('Integration | Event | Handle Badge Acquisition Service', function() {
 
     afterEach(async() => {
       await knex('badge-acquisitions').delete();
-      await databaseBuilder.clean();
     });
 
     it('should save only the validated badges', async () => {

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -43,10 +43,6 @@ describe('Integration | Service | Certification-Badges Service', () => {
 
   describe('#findStillValidBadgeAcquisitions', () => {
 
-    afterEach(async() => {
-      await databaseBuilder.clean();
-    });
-
     it('should return one badgeAcquisition', async () => {
       // given
       const { id: userId } = databaseBuilder.factory.buildUser();

--- a/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
@@ -20,10 +20,6 @@ describe('Integration | UseCases | create-password-reset-demand', () => {
     await databaseBuilder.commit();
   });
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   it('should return a password reset demand', async () => {
     // when
     const result = await createPasswordResetDemand({

--- a/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
@@ -13,10 +13,6 @@ describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions
     sinon.stub(console, 'log');
   });
 
-  afterEach(() => {
-    databaseBuilder.clean();
-  });
-
   describe('#main', () => {
     it('should update the campaignParticipationId of BadgeAcquisition', async ()=> {
       // given

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -8,7 +8,7 @@ chai.use(require('sinon-chai'));
 const cache = require('../lib/infrastructure/caches/learning-content-cache');
 const { livretScolaireAuthentication } = require('../lib/config');
 
-const { knex } = require('../db/knex-database-connection');
+const { knex, disconnect } = require('../db/knex-database-connection');
 
 const DatabaseBuilder = require('../db/database-builder/database-builder');
 const databaseBuilder = new DatabaseBuilder({ knex });
@@ -26,6 +26,10 @@ afterEach(function() {
   cache.flushAll();
   nock.cleanAll();
   return databaseBuilder.clean();
+});
+
+after(function() {
+  return disconnect();
 });
 
 function generateValidRequestAuthorizationHeader(userId = 1234, source = 'pix') {


### PR DESCRIPTION
## :unicorn: Problème
En investiguant un test flacky sur le script de remplissage de `campaignParticipationId`, nous avons découvert qu'il y avait un `afterEach` avec un `databaseBuilder.clean()` sans `await`. Il se trouve que cet `afterEach` est inutile car nous avons un `afterEach` global qui fait précisément cela.

## :robot: Solution
Supprimer les `databaseBuilder.clean()` des tests.

## :rainbow: Remarques
En tentant de reproduire le flacky, j'ai lancé 90 fois le fichier de test en mode watch. J'ai ainsi rempli le pool de connexion ce qui m'a forcé a couper le mode watch pour relancer. En détruisant le pool de connexion après tout les tests, j'ai corrigé cela (en relancant 90 fois le même fichier <3).

## :100: Pour tester
1. Mettre un only sur le fichier de test `api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js`
2. Lancer les tests autant de fois que nécessaire pour reproduire le flacky (l'éternité vous attend)
