### PR TITLE
[TECH] Déplacer la vérification du paramètre state dans l'API lors des requêtes Pole Emploi (PIX-2597).

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -59,9 +59,15 @@ module.exports = {
       throw new BadRequestError('This feature is not enable!');
     }
     const authenticatedUserId = get(request.auth, 'credentials.userId');
-    const { code, 'client_id': clientId, 'redirect_uri': redirectUri } = request.payload;
+    const {
+      code,
+      'client_id': clientId,
+      'redirect_uri': redirectUri,
+      'state_sent': stateSent,
+      'state_received': stateReceived,
+    } = request.payload;
 
-    const response = await usecases.authenticatePoleEmploiUser({ code, clientId, redirectUri, authenticatedUserId });
+    const response = await usecases.authenticatePoleEmploiUser({ code, clientId, redirectUri, authenticatedUserId, stateSent, stateReceived });
 
     return h.response(response).code(200);
   },

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -148,6 +148,8 @@ exports.register = async (server) => {
             code: Joi.string().required(),
             client_id: Joi.string().required(),
             redirect_uri: Joi.string().required(),
+            state_sent: Joi.string().required(),
+            state_received: Joi.string().required(),
           }),
         },
         handler: AuthenticationController.authenticatePoleEmploiUser,

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -305,6 +305,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
 
+  if (error instanceof DomainErrors.UnexpectedPoleEmploiStateError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -738,6 +738,7 @@ class UserAccountNotFoundForPoleEmploiError extends DomainError {
     this.authenticationKey = authenticationKey;
   }
 }
+
 class WrongDateFormatError extends DomainError {
   constructor(message = 'Format de date invalide.') {
     super(message);
@@ -784,6 +785,12 @@ class GeneratePoleEmploiTokensError extends DomainError {
 
 class InvalidMembershipOrganizationRoleError extends DomainError {
   constructor(message = 'Le rôle du membre est invalide.') {
+    super(message);
+  }
+}
+
+class UnexpectedPoleEmploiStateError extends DomainError {
+  constructor(message = 'La valeur du paramètre state reçu ne correspond pas à celui envoyé.') {
     super(message);
   }
 }
@@ -872,6 +879,7 @@ module.exports = {
   SiecleXmlImportError,
   TargetProfileInvalidError,
   TargetProfileCannotBeCreated,
+  UnexpectedPoleEmploiStateError,
   UnexpectedUserAccountError,
   UserAccountNotFoundForPoleEmploiError,
   UserAlreadyExistsWithAuthenticationMethodError,

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -1,19 +1,26 @@
 const AuthenticationMethod = require('../models/AuthenticationMethod');
-const { UnexpectedUserAccountError, UserAccountNotFoundForPoleEmploiError } = require('../errors');
+const { UnexpectedUserAccountError, UnexpectedPoleEmploiStateError, UserAccountNotFoundForPoleEmploiError } = require('../errors');
 const moment = require('moment');
 const uuidv4 = require('uuid/v4');
+const logger = require('../../infrastructure/logger');
 
 module.exports = async function authenticatePoleEmploiUser({
   code,
   clientId,
   redirectUri,
   authenticatedUserId,
+  stateSent,
+  stateReceived,
   authenticationService,
   tokenService,
   userRepository,
   authenticationMethodRepository,
   authenticationCache,
 }) {
+  if (stateSent !== stateReceived) {
+    logger.error(`State sent ${stateSent} did not match the state received ${stateReceived}`);
+    throw new UnexpectedPoleEmploiStateError();
+  }
 
   const poleEmploiTokens = await authenticationService.generatePoleEmploiTokens({ code, clientId, redirectUri });
 

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -227,6 +227,8 @@ describe('Acceptance | Controller | authentication-controller', () => {
       const code = 'code';
       const client_id = 'client_id';
       const redirect_uri = 'redirect_uri';
+      const state_sent = 'state';
+      const state_received = 'state';
 
       options = {
         method: 'POST',
@@ -238,6 +240,8 @@ describe('Acceptance | Controller | authentication-controller', () => {
           code,
           client_id,
           redirect_uri,
+          state_sent,
+          state_received,
         }),
       };
 
@@ -262,6 +266,26 @@ describe('Acceptance | Controller | authentication-controller', () => {
 
     afterEach(() => {
       clock.restore();
+    });
+
+    context('When the state sent does not match the state received', () => {
+
+      it('should return http code 400', async () => {
+        // given
+        options.payload = querystring.stringify({
+          code: 'code',
+          client_id: 'client_id',
+          redirect_uri: 'redirect_uri',
+          state_sent: 'a_state',
+          state_received: 'another_state',
+        });
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
     });
 
     context('When user is not connected to Pix', () => {

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -281,6 +281,8 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
     const code = 'ABCD';
     const client_id = 'CLIENT_ID';
     const redirect_uri = 'http://redirectUri.fr';
+    const state_sent = 'state_sent';
+    const state_received = 'state_received';
 
     let payload;
 
@@ -291,6 +293,8 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
         code,
         client_id,
         redirect_uri,
+        state_sent,
+        state_received,
       });
     });
 

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -108,6 +108,8 @@ describe('Unit | Application | Controller | Authentication', () => {
     const code = 'ABCD';
     const client_id = 'CLIENT_ID';
     const redirect_uri = 'http://redirectUri.fr';
+    const state_sent = 'state';
+    const state_received = 'state';
 
     let request;
 
@@ -118,6 +120,8 @@ describe('Unit | Application | Controller | Authentication', () => {
           code,
           client_id,
           redirect_uri,
+          state_sent,
+          state_received,
         },
       };
 
@@ -145,6 +149,8 @@ describe('Unit | Application | Controller | Authentication', () => {
         clientId: client_id,
         redirectUri: redirect_uri,
         authenticatedUserId: undefined,
+        stateSent: state_sent,
+        stateReceived: state_received,
       };
 
       // when

--- a/docs/security/poleEmploi/authenticate_with_pole_emploi.puml
+++ b/docs/security/poleEmploi/authenticate_with_pole_emploi.puml
@@ -12,13 +12,13 @@ Demandeur_d_emploi -> Pole_Emploi_Connect: Saisie des crédentials de l'utilisat
 Pole_Emploi_Connect --> MonPix: Envoi de l'authorization code
 
 MonPix -> API_Pix: POST /api/token/pole-emploi
-note left: Transfert de l'authorization code, client_id et redirect_uri
+note left: Transfert de l'authorization code, client_id,\nredirect_uri, state_sent et state_received
 API_Pix -> Pole_Emploi_Connect: POST <PoleEmploi>/connexion/oauth2/access_token
 note right: Génération d'un access_token Pôle Emploi
 Pole_Emploi_Connect --> API_Pix: Envoi de l'access_token et de l'id_token
 
 API_Pix -> API_Pix: Décodage de l'id_token
-note left: Récupération de family_name, given_name, nonce et idIdentiteExterne
+note left: Récupération de family_name, given_name,\nnonce et idIdentiteExterne
 
 API_Pix -> API_Pix: Création du user en BDD
 API_Pix -> API_Pix: Génération d'un access_token Pix

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -20,7 +20,7 @@ export default OIDCAuthenticator.extend({
 
   session: service(),
 
-  async authenticate({ code, redirectUri, authenticationKey }) {
+  async authenticate({ code, redirectUri, state, authenticationKey }) {
     let request;
     let serverTokenEndpoint;
 
@@ -38,6 +38,8 @@ export default OIDCAuthenticator.extend({
         code,
         client_id: clientId,
         redirect_uri: redirectUri,
+        state_sent: this.session.data.state,
+        state_received: state,
       };
 
       const body = Object.keys(bodyObject)

--- a/mon-pix/app/routes/login-pe.js
+++ b/mon-pix/app/routes/login-pe.js
@@ -43,16 +43,11 @@ export default class LoginPeRoute extends Route {
   }
 
   async _handleCallbackRequest(code, state) {
-    if (state !== this.session.data.state) {
-      throw new Error('State did not match');
-    }
-
-    this.session.set('data.state', undefined);
-
     try {
       await this.session.authenticate('authenticator:oidc', {
         code,
         redirectUri: this.redirectUri,
+        state,
       });
     } catch (response) {
       const shouldValidateCgu = get(response, 'errors[0].code') === 'SHOULD_VALIDATE_CGU';
@@ -61,6 +56,8 @@ export default class LoginPeRoute extends Route {
         return this.replaceWith('terms-of-service-pe', { queryParams: { authenticationKey } });
       }
       throw new Error(JSON.stringify(response.errors));
+    } finally {
+      this.session.set('data.state', undefined);
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Le paramètre `state` est un uuid généré par Pix App lors de la redirection vers le formulaire de connexion de Pole Emploi. Ce paramètre est renvoyé par Pole Emploi suite à l'authentification des utilisateurs. On doit vérifier son égalité avec celui qui a été envoyé. 

Cette vérification se fait côté front; en cas de différence, une erreur est renvoyée. Cependant, certains utilisateurs se plaignent de ne pas réussir à se connecter à Pix via Pole Emploi et cette erreur est affichée. Il nous est difficile en l'état de comprendre d'où vient le problème. 

## :robot: Solution
- Déplacer la vérification de la cohérence du paramètre `state` côté API.
- Logger la valeur du paramètre envoyé dans la requête et celui reçu lors d'une différence de valeur.  

## :100: Pour tester
Testable en local uniquement en donnant une valeur quelconque à `request_state` ou `response_state` dans `oidc.js`et vérifier que l'erreur est bien loggée.
