### PR TITLE
[TECH] Nettoyer les tests unitaires des routes

### DIFF
--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -2,7 +2,8 @@ const Joi = require('joi');
 const answerController = require('./answer-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 const { NotFoundError } = require('../../domain/errors');
-exports.register = async function(server) {
+
+exports.register = async (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/assessment-results/index.js
+++ b/api/lib/application/assessment-results/index.js
@@ -1,7 +1,7 @@
 const AssessmentResultController = require('./assessment-result-controller');
 const securityPreHandlers = require('../security-pre-handlers');
 
-exports.register = async function(server) {
+exports.register = async (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -3,9 +3,8 @@ const assessmentController = require('./assessment-controller');
 const assessmentAuthorization = require('../preHandlers/assessment-authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = async (server) => {
   server.route([
-
     {
       method: 'POST',
       path: '/api/assessments',

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -3,29 +3,19 @@ const {
   HttpTestServer,
   sinon,
 } = require('../../../test-helper');
-
 const moduleUnderTest = require('../../../../lib/application/answers');
+const answerController = require('../../../../lib/application/answers/answer-controller');
 
-const AnswerController = require('../../../../lib/application/answers/answer-controller');
+describe('Unit | Application | Router | answer-router', () => {
 
-describe('Unit | Router | answer-router', function() {
+  describe('POST /api/answers', () => {
 
-  let httpTestServer;
-
-  beforeEach(async function() {
-    sinon.stub(AnswerController, 'save').callsFake((request, h) => h.response().code(201));
-    sinon.stub(AnswerController, 'get').callsFake((request, h) => h.response().code(200));
-    sinon.stub(AnswerController, 'find').callsFake((request, h) => h.response().code(200));
-    sinon.stub(AnswerController, 'update').callsFake((request, h) => h.response().code(204));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
-  describe('POST /api/answers', function() {
-
-    it('should exist', async () => {
+    it('should return 201', async () => {
       // given
+      sinon.stub(answerController, 'save').callsFake((request, h) => h.response().created());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           attributes: {
@@ -40,44 +30,60 @@ describe('Unit | Router | answer-router', function() {
           type: 'answers',
         },
       };
+
       // when
-      const result = await httpTestServer.request('POST', '/api/answers', payload);
+      const response = await httpTestServer.request('POST', '/api/answers', payload);
 
       // then
-      expect(result.statusCode).to.equal(201);
+      expect(response.statusCode).to.equal(201);
     });
   });
 
-  describe('GET /api/answers/{id}', function() {
+  describe('GET /api/answers/{id}', () => {
 
-    it('should exist', async () => {
+    it('should return 200', async () => {
+      //given
+      sinon.stub(answerController, 'get').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
-      const result = await httpTestServer.request('GET', '/api/answers/1');
+      const response = await httpTestServer.request('GET', '/api/answers/1');
 
       // then
-      expect(result.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(200);
     });
   });
 
-  describe('GET /api/answers?assessment=<assessment_id>&challenge=<challenge_id>', function() {
+  describe('PATCH /api/answers/{id}', () => {
 
-    it('should exist', async () => {
+    it('should return 204', async () => {
+      // given
+      sinon.stub(answerController, 'update').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
-      const result = await httpTestServer.request('GET', '/api/answers');
+      const response = await httpTestServer.request('PATCH', '/api/answers/1');
 
       // then
-      expect(result.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(204);
     });
   });
 
-  describe('PATCH /api/answers/{id}', function() {
+  describe('GET /api/answers', () => {
 
-    it('should exist', async () => {
+    it('should return 200', async () => {
+      // given
+      sinon.stub(answerController, 'find').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
-      const result = await httpTestServer.request('PATCH', '/api/answers/1');
+      const response = await httpTestServer.request('GET', '/api/answers');
 
       // then
-      expect(result.statusCode).to.equal(204);
+      expect(response.statusCode).to.equal(200);
     });
   });
 

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -3,34 +3,20 @@ const {
   HttpTestServer,
   sinon,
 } = require('../../../test-helper');
-
 const assessmentAuthorization = require('../../../../lib/application/preHandlers/assessment-authorization');
-const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
-
 const moduleUnderTest = require('../../../../lib/application/assessments');
-
 const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
 
-describe('Integration | Route | AssessmentRoute', () => {
-
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(assessmentController, 'save').returns('ok');
-    sinon.stub(assessmentController, 'getNextChallenge').returns('ok');
-    sinon.stub(assessmentController, 'findByFilters').returns('ok');
-    sinon.stub(assessmentController, 'get').returns('ok');
-    sinon.stub(assessmentController, 'findCompetenceEvaluations').returns('ok');
-    sinon.stub(assessmentAuthorization, 'verify').returns('userId');
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
+describe('Unit | Application | Router | assessment-router', () => {
 
   describe('POST /api/assessments', () => {
 
-    it('should exist', async () => {
+    it('should return 200', async () => {
+      // given
+      sinon.stub(assessmentController, 'save').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('POST', '/api/assessments');
 
@@ -39,22 +25,32 @@ describe('Integration | Route | AssessmentRoute', () => {
     });
   });
 
-  describe('GET /api/assessments/assessment_id/next', () => {
+  describe('GET /api/assessments', () => {
 
-    it('should exist', async () => {
+    it('should return 200', async () => {
+      // given
+      sinon.stub(assessmentController, 'findByFilters').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
-      const response = await httpTestServer.request('GET', '/api/assessments/1/next');
+      const response = await httpTestServer.request('GET', '/api/assessments');
 
       // then
       expect(response.statusCode).to.equal(200);
     });
   });
 
-  describe('GET /api/assessments', () => {
+  describe('GET /api/assessments/{id}/next', () => {
 
-    it('should exist', async () => {
+    it('should return 200', async () => {
+      // given
+      sinon.stub(assessmentController, 'getNextChallenge').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
-      const response = await httpTestServer.request('GET', '/api/assessments');
+      const response = await httpTestServer.request('GET', '/api/assessments/1/next');
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -66,7 +62,13 @@ describe('Integration | Route | AssessmentRoute', () => {
     const method = 'GET';
     const url = '/api/assessments/1';
 
-    it('should exist', async () => {
+    it('should return 200', async () => {
+      // given
+      sinon.stub(assessmentAuthorization, 'verify').callsFake((request, h) => h.response(null));
+      sinon.stub(assessmentController, 'get').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request(method, url);
 
@@ -75,6 +77,11 @@ describe('Integration | Route | AssessmentRoute', () => {
     });
 
     it('should call pre-handler', async () => {
+      // given
+      sinon.stub(assessmentAuthorization, 'verify').callsFake((request, h) => h.response(null));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       await httpTestServer.request(method, url);
 
@@ -85,7 +92,12 @@ describe('Integration | Route | AssessmentRoute', () => {
 
   describe('GET /api/assessments/{id}/competence-evaluations', () => {
 
-    it('should exist', async () => {
+    it('should return 200', async () => {
+      // given
+      sinon.stub(assessmentController, 'findCompetenceEvaluations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/assessments/123/competence-evaluations');
 
@@ -94,6 +106,10 @@ describe('Integration | Route | AssessmentRoute', () => {
     });
 
     it('should do throw a 400 status code when assessmentId provided is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/assessments/not_a_number/competence-evaluations');
 


### PR DESCRIPTION
## :unicorn: Problème
Pour une meilleure lisibilité des tests, je propose de nettoyer les tests existants sur Pix.
Je commence donc par deux tests unitaires. 

Si celle PR est mergée, je nettoie tous les autres tests unitaires de routes.

## :robot: Solution
Propositions (j'attends vos propositions/retours 😄 ) : 

- Supprimer les `beforeEach()` en début de test car il rendent difficile la lecture des tests. Tous les controllers sont stub au même endroit et on ne sait pas à quel test ils correspondent.
Cela implique d'ajouter plus de ligne, mais c'est un vrai gain de lisibilité.
- Nommer les tests de la même façon : `"Unit | Application | Router | xxx-router"`
- Renommer les tests appelés par défaut "should exist". Être plus explicite => `“should return OK/No Content/Created (2xx) when request is valid”` ? 
- J'ai ici fait le choix de stub avec `returns()` pour les méthodes sans toolkit (`h`) passé en argument, sinon j'utilise `callsFake()` sur les stubs. Votre avis est le bienvenu.
- Ranger les tests dans le même ordre que les routes sur le fichier `index.js`

## :rainbow: Remarques
Ajout des arrow functions dans les fichiers `index.js` 

## :100: Pour tester
Lancer les tests :) 
