### PR TITLE
[FEATURE] Autoneutraliser les questions avec signalements sans vérification préalable nécessaire (PIX-2575)

### DIFF
--- a/api/lib/domain/events/AutoJuryDone.js
+++ b/api/lib/domain/events/AutoJuryDone.js
@@ -1,0 +1,17 @@
+module.exports = class AutoJuryDone {
+  constructor({
+    sessionId,
+    finalizedAt,
+    certificationCenterName,
+    sessionDate,
+    sessionTime,
+    hasExaminerGlobalComment,
+  }) {
+    this.sessionId = sessionId;
+    this.finalizedAt = finalizedAt;
+    this.certificationCenterName = certificationCenterName;
+    this.sessionDate = sessionDate;
+    this.sessionTime = sessionTime;
+    this.hasExaminerlobalComment = hasExaminerGlobalComment;
+  }
+};

--- a/api/lib/domain/events/CertificationJuryDone.js
+++ b/api/lib/domain/events/CertificationJuryDone.js
@@ -1,0 +1,5 @@
+module.exports = class CertificationJuryDone {
+  constructor({ certificationCourseId }) {
+    this.certificationCourseId = certificationCourseId;
+  }
+};

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -52,7 +52,11 @@ async function _autoNeutralizeChallenges({
   for (const neutralizableIssueReport of neutralizableIssueReports) {
     const questionNumber = neutralizableIssueReport.questionNumber;
     const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(questionNumber);
-    if (neutralizationAttempt.hasSucceeded()) certificationImpacted++;
+    if (neutralizationAttempt.hasSucceeded()) {
+      neutralizableIssueReport.resolve('Cette question a été neutralisée automatiquement');
+      await certificationIssueReportRepository.save(neutralizableIssueReport);
+      certificationImpacted++;
+    }
   }
 
   if (certificationImpacted > 0) {

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -7,9 +7,10 @@ const {
 } = require('../errors');
 const ChallengeNeutralized = require('./ChallengeNeutralized');
 const ChallengeDeneutralized = require('./ChallengeDeneutralized');
+const CertificationJuryDone = require('./CertificationJuryDone');
 const { checkEventTypes } = require('./check-event-types');
 
-const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized];
+const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized, CertificationJuryDone];
 const EMITTER = 'PIX-ALGO-NEUTRALIZATION';
 
 async function handleCertificationRescoring({

--- a/api/lib/domain/events/handle-session-finalized.js
+++ b/api/lib/domain/events/handle-session-finalized.js
@@ -1,8 +1,8 @@
 const FinalizedSession = require('../models/FinalizedSession');
 const { checkEventTypes } = require('./check-event-types');
-const SessionFinalized = require('./SessionFinalized');
+const AutoJuryDone = require('./AutoJuryDone');
 
-const eventTypes = [ SessionFinalized ];
+const eventTypes = [ AutoJuryDone ];
 
 async function handleSessionFinalized({
   event,

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -14,6 +14,7 @@ const dependencies = {
   certificationAssessmentRepository: require('../../infrastructure/repositories/certification-assessment-repository'),
   certificationCourseRepository: require('../../infrastructure/repositories/certification-course-repository'),
   cleaCertificationResultRepository: require('../../infrastructure/repositories/clea-certification-result-repository'),
+  certificationIssueReportRepository: require('../../infrastructure/repositories/certification-issue-report-repository'),
   competenceMarkRepository: require('../../infrastructure/repositories/competence-mark-repository'),
   competenceRepository: require('../../infrastructure/repositories/competence-repository'),
   knowledgeElementRepository: require('../../infrastructure/repositories/knowledge-element-repository'),
@@ -36,6 +37,7 @@ const partnerCertificationScoringRepository = injectDependencies(
 dependencies.partnerCertificationScoringRepository = partnerCertificationScoringRepository;
 
 const handlersToBeInjected = {
+  handleAutoJury: require('./handle-auto-jury'),
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
   handleCertificationScoring: require('./handle-certification-scoring'),
   handleCertificationRescoring: require('./handle-certification-rescoring'),

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -97,6 +97,12 @@ const deprecatedSubcategories = {
   [CertificationIssueReportSubcategories.OTHER]: 'E7',
 };
 
+const autoNeutralizableSubcategories = {
+  [CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E4',
+  [CertificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E5',
+  [CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]: 'E9',
+};
+
 class CertificationIssueReport {
   constructor(
     {
@@ -118,6 +124,7 @@ class CertificationIssueReport {
     this.resolvedAt = resolvedAt;
     this.resolution = resolution;
     this.isImpactful = _isImpactful({ category, subcategory });
+    this.isAutoNeutralizable = _isSubcategoryAutoNeutralizable(subcategory);
 
     if ([CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN, CertificationIssueReportCategories.OTHER].includes(this.category)) {
       this.subcategory = null;
@@ -183,4 +190,8 @@ function _isImpactful({ category, subcategory }) {
 
 function _isSubcategoryDeprecated(subcategory) {
   return Boolean(deprecatedSubcategories[subcategory]);
+}
+
+function _isSubcategoryAutoNeutralizable(subcategory) {
+  return Boolean(autoNeutralizableSubcategories[subcategory]);
 }

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -180,6 +180,11 @@ class CertificationIssueReport {
   isResolved() {
     return Boolean(this.resolvedAt);
   }
+
+  resolve(resolution) {
+    this.resolvedAt = new Date();
+    this.resolution = resolution;
+  }
 }
 
 module.exports = CertificationIssueReport;

--- a/api/lib/domain/models/NeutralizationAttempt.js
+++ b/api/lib/domain/models/NeutralizationAttempt.js
@@ -1,0 +1,32 @@
+module.exports = class NeutralizationAttempt {
+  constructor(questionNumber, status) {
+    this.questionNumber = questionNumber;
+    this.status = status;
+  }
+
+  static neutralized(questionNumber) {
+    return new NeutralizationAttempt(questionNumber, NeutralizationStatus.NEUTRALIZED);
+  }
+
+  static failure(questionNumber) {
+    return new NeutralizationAttempt(questionNumber, NeutralizationStatus.FAILURE);
+  }
+
+  static skipped(questionNumber) {
+    return new NeutralizationAttempt(questionNumber, NeutralizationStatus.SKIPPED);
+  }
+
+  hasFailed() {
+    return this.status === NeutralizationStatus.FAILURE;
+  }
+
+  hasSucceeded() {
+    return this.status === NeutralizationStatus.NEUTRALIZED;
+  }
+};
+
+const NeutralizationStatus = {
+  NEUTRALIZED: 'NEUTRALIZED',
+  FAILURE: 'FAILURE',
+  SKIPPED: 'SKIPPED',
+};

--- a/api/lib/infrastructure/events/EventDispatcher.js
+++ b/api/lib/infrastructure/events/EventDispatcher.js
@@ -21,8 +21,18 @@ class EventDispatcher {
     const subscriptions = this._subscriptions.filter(({ event }) => dispatchedEvent instanceof event);
 
     for (const { eventHandler } of subscriptions) {
-      const returnedEvent = await eventHandler({ domainTransaction, event: dispatchedEvent });
-      await this.dispatch(returnedEvent, domainTransaction);
+      const returnedEventOrEvents = await eventHandler({ domainTransaction, event: dispatchedEvent });
+      await this._dispatchEventOrEvents(returnedEventOrEvents, domainTransaction);
+    }
+  }
+
+  async _dispatchEventOrEvents(eventOrEvents, domainTransaction) {
+    if (!Array.isArray(eventOrEvents)) {
+      await this.dispatch(eventOrEvents, domainTransaction);
+    } else {
+      for (const event of eventOrEvents) {
+        await this.dispatch(event, domainTransaction);
+      }
     }
   }
 }

--- a/api/lib/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-issue-report-repository.js
@@ -25,6 +25,13 @@ module.exports = {
     }
   },
 
+  async findByCertificationCourseId(certificationCourseId) {
+    const certificationIssueReports = await CertificationIssueReportBookshelf
+      .where({ certificationCourseId })
+      .fetchAll();
+    return bookshelfToDomainConverter.buildDomainObjects(CertificationIssueReportBookshelf, certificationIssueReports);
+  },
+
   async delete(id) {
     try {
       await CertificationIssueReportBookshelf

--- a/api/lib/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-issue-report-repository.js
@@ -6,7 +6,7 @@ const omit = require('lodash/omit');
 module.exports = {
   async save(certificationIssueReport) {
     const newCertificationIssueReport = await new CertificationIssueReportBookshelf(
-      omit(certificationIssueReport, ['isImpactful']),
+      omit(certificationIssueReport, ['isImpactful', 'isAutoNeutralizable']),
     ).save();
     return bookshelfToDomainConverter.buildDomainObject(CertificationIssueReportBookshelf, newCertificationIssueReport);
   },

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -1,5 +1,7 @@
-const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, knex, learningContentBuilder, mockLearningContent } = require('../../../test-helper');
 const createServer = require('../../../../server');
+const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
+const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 
 describe('Acceptance | Controller | sessions-controller', () => {
 
@@ -81,8 +83,11 @@ describe('Acceptance | Controller | sessions-controller', () => {
 
     describe('Success case', () => {
 
-      afterEach(() => {
-        return knex('certification-issue-reports').delete();
+      afterEach(async () => {
+        await knex('certification-issue-reports').delete();
+        await knex('finalized-sessions').delete();
+        await knex('competence-marks').delete();
+        await knex('assessment-results').delete();
       });
 
       it('should return the serialized updated session', async () => {
@@ -109,6 +114,225 @@ describe('Acceptance | Controller | sessions-controller', () => {
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.deep.equal(expectedSessionJSONAPI.data);
+      });
+
+      it('should neutralize auto-neutralizable challenges', async () => {
+        // given
+        const learningContent = [
+          {
+            id: 'recArea0',
+            code: '66',
+            competences: [
+              {
+                id: 'recCompetence0',
+                index: '1',
+                tubes: [
+                  {
+                    id: 'recTube0_0',
+                    skills: [
+                      {
+                        id: 'recSkill0_0',
+                        nom: '@recSkill0_0',
+                        challenges: [
+                          { id: 'recChallenge0_0_0' },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+        mockLearningContent(learningContentObjects);
+
+        const userId = databaseBuilder.factory.buildUser().id;
+        const session = databaseBuilder.factory.buildSession();
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id }).id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId: session.certificationCenterId });
+        const report = databaseBuilder.factory.buildCertificationReport({
+          certificationCourseId,
+          sessionId: session.id,
+        });
+
+        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+        databaseBuilder.factory.buildCertificationIssueReport({
+          certificationCourseId,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          description: '',
+          subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+          questionNumber: 1,
+        });
+
+        const certificationChallengeKo = databaseBuilder.factory.buildCertificationChallenge({ courseId: certificationCourseId, isNeutralized: false });
+        const certificationChallengeOk = databaseBuilder.factory.buildCertificationChallenge({ courseId: certificationCourseId, isNeutralized: false });
+
+        databaseBuilder.factory.buildAnswer({ assessmentId, challengeId: certificationChallengeKo.challengeId, result: AnswerStatus.KO.status });
+        databaseBuilder.factory.buildAnswer({ assessmentId, challengeId: certificationChallengeOk.challengeId, result: AnswerStatus.OK.status });
+
+        await databaseBuilder.commit();
+
+        options = {
+          method: 'PUT',
+          payload: {
+            data: {
+              attributes: {
+                'examiner-global-comment': examinerGlobalComment,
+              },
+              included: [
+                {
+                  id: report.id,
+                  type: 'certification-reports',
+                  attributes: {
+                    'certification-course-id': report.certificationCourseId,
+                    'examiner-comment': 'What a fine lad this one',
+                    'has-seen-end-test-screen': false,
+                  },
+                },
+              ],
+            },
+          },
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          url: `/api/sessions/${session.id}/finalization`,
+        };
+
+        const expectedSessionJSONAPI = {
+          data: {
+            type: 'sessions',
+            id: session.id.toString(),
+            attributes: {
+              'status': 'finalized',
+              'examiner-global-comment': examinerGlobalComment,
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.deep.equal(expectedSessionJSONAPI.data);
+        const actualKoCertificationChallenge = await knex('certification-challenges').where({ id: certificationChallengeKo.id }).first();
+        const actualOkCertificationChallenge = await knex('certification-challenges').where({ id: certificationChallengeOk.id }).first();
+        expect(actualKoCertificationChallenge.isNeutralized).to.be.true;
+        expect(actualOkCertificationChallenge.isNeutralized).to.be.false;
+      });
+
+      it('should re score assessment when there is auto-neutralizable challenge', async () => {
+        // given
+
+        const learningContent = [
+          {
+            id: 'recArea0',
+            code: '66',
+            competences: [
+              {
+                id: 'recCompetence0',
+                index: '1',
+                tubes: [
+                  {
+                    id: 'recTube0_0',
+                    skills: [
+                      {
+                        id: 'recSkill0_0',
+                        nom: '@recSkill0_0',
+                        challenges: [
+                          { id: 'recChallenge0_0_0' },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+        mockLearningContent(learningContentObjects);
+
+        const userId = databaseBuilder.factory.buildUser().id;
+        const session = databaseBuilder.factory.buildSession();
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id, userId, createdAt: new Date() }).id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId: session.certificationCenterId });
+
+        const report = databaseBuilder.factory.buildCertificationReport({
+          certificationCourseId,
+          sessionId: session.id,
+        });
+
+        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId, userId }).id;
+        databaseBuilder.factory.buildCertificationIssueReport({
+          certificationCourseId,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          description: '',
+          subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+          questionNumber: 1,
+        });
+
+        const assessmentResultKo = databaseBuilder.factory.buildAssessmentResult({
+          assessmentId,
+          pixScore: 42,
+        });
+
+        databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResultKo.id, competenceId: 'recCompetence0' });
+
+        const certificationChallengeKo = databaseBuilder.factory.buildCertificationChallenge({ courseId: certificationCourseId, isNeutralized: false, challengeId: 'recChallenge0_0_0', competenceId: 'recCompetence0' });
+
+        const answerId = databaseBuilder.factory.buildAnswer({ assessmentId, challengeId: certificationChallengeKo.challengeId, result: AnswerStatus.KO.status }).id;
+
+        databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId, skillId: 'recSkill0_0', competenceId: 'recCompetence0', userId, earnedPix: 16 });
+
+        await databaseBuilder.commit();
+
+        options = {
+          method: 'PUT',
+          payload: {
+            data: {
+              attributes: {
+                'examiner-global-comment': examinerGlobalComment,
+              },
+              included: [
+                {
+                  id: report.id,
+                  type: 'certification-reports',
+                  attributes: {
+                    'certification-course-id': report.certificationCourseId,
+                    'examiner-comment': 'What a fine lad this one',
+                    'has-seen-end-test-screen': false,
+                  },
+                },
+              ],
+            },
+          },
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          url: `/api/sessions/${session.id}/finalization`,
+        };
+
+        const expectedSessionJSONAPI = {
+          data: {
+            type: 'sessions',
+            id: session.id.toString(),
+            attributes: {
+              'status': 'finalized',
+              'examiner-global-comment': examinerGlobalComment,
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.deep.equal(expectedSessionJSONAPI.data);
+        const actualKoAssessmentResult = await knex('assessment-results').where({ assessmentId, emitter: 'PIX-ALGO-NEUTRALIZATION' }).first();
+        expect(actualKoAssessmentResult.pixScore).not.to.equal(assessmentResultKo.pixScore);
       });
     });
   });

--- a/api/tests/integration/infrastructure/event-dispatcher_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher_test.js
@@ -74,7 +74,7 @@ describe('Integration | Infrastructure | EventHandler', () => {
     expect(eventHandler).not.to.have.been.calledWith({ domainTransaction, otherEvent });
   });
 
-  it('dispatches events returned by eventHandlers', async () => {
+  it('dispatches event returned by eventHandlers', async () => {
     // given
     const returnedEvent = new AnotherTestEvent();
     const originEventEmitter = () => returnedEvent;
@@ -87,5 +87,22 @@ describe('Integration | Infrastructure | EventHandler', () => {
 
     // then
     expect(eventHandler).to.have.been.calledWith({ domainTransaction, event: returnedEvent });
+  });
+
+  it('dispatches events returned by eventHandlers', async () => {
+    // given
+    const returnedEvent1 = new AnotherTestEvent();
+    const returnedEvent2 = new AnotherTestEvent();
+    const originEventEmitter = () => [returnedEvent1, returnedEvent2];
+    const eventHandler = getEventHandlerMock();
+    eventDispatcher.subscribe(TestEvent, originEventEmitter);
+    eventDispatcher.subscribe(AnotherTestEvent, eventHandler);
+
+    // when
+    await eventDispatcher.dispatch(event, domainTransaction);
+
+    // then
+    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event: returnedEvent1 });
+    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event: returnedEvent2 });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -37,6 +37,7 @@ describe('Integration | Repository | Certification Issue Report', function() {
         category: CertificationIssueReportCategories.IN_CHALLENGE,
         description: 'Un gros problème',
         isActionRequired: true,
+        isAutoNeutralizable: false,
         subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
         questionNumber: 5,
         resolvedAt: new Date('2020-01-01'),
@@ -98,7 +99,10 @@ describe('Integration | Repository | Certification Issue Report', function() {
       const result = await certificationIssueReportRepository.get(issueReport.id);
 
       // then
-      const expectedIssueReport = domainBuilder.buildCertificationIssueReport(issueReport);
+      const expectedIssueReport = domainBuilder.buildCertificationIssueReport({
+        ...issueReport,
+        isAutoNeutralizable: false,
+      });
       expect(result).to.deep.equal(expectedIssueReport);
       expect(result).to.be.instanceOf(CertificationIssueReport);
     });

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -116,4 +116,35 @@ describe('Integration | Repository | Certification Issue Report', function() {
     });
   });
 
+  describe('#findByCertificationCourseId', () => {
+    it('should return certification issue reports for a certification course id', async () => {
+      // given
+      const targetCertificationCourse = databaseBuilder.factory.buildCertificationCourse();
+      const otherCertificationCourse = databaseBuilder.factory.buildCertificationCourse();
+      const issueReportForTargetCourse1 = databaseBuilder.factory.buildCertificationIssueReport({ certificationCourseId: targetCertificationCourse.id });
+      const issueReportForTargetCourse2 = databaseBuilder.factory.buildCertificationIssueReport({ certificationCourseId: targetCertificationCourse.id });
+      databaseBuilder.factory.buildCertificationIssueReport({ certificationCourseId: otherCertificationCourse.id });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await certificationIssueReportRepository.findByCertificationCourseId(targetCertificationCourse.id);
+
+      // then
+      const expectedIssueReports = [
+        new CertificationIssueReport(issueReportForTargetCourse1),
+        new CertificationIssueReport(issueReportForTargetCourse2),
+      ];
+      expect(results).to.deep.equal(expectedIssueReports);
+      expect(results[0]).to.be.instanceOf(CertificationIssueReport);
+    });
+
+    it('should throw a notFound error', async () => {
+      // when
+      const error = await catchErr(certificationIssueReportRepository.get)(1234);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -36,7 +36,7 @@ describe('Integration | Repository | CertificationReport', function() {
           certificationCourseId: certificationCourse1.id,
           firstName: certificationCourse1.firstName,
           lastName: certificationCourse1.lastName,
-          certificationIssueReports: [ { ...certificationIssueReport1, isImpactful: true } ],
+          certificationIssueReports: [ { ...certificationIssueReport1, isImpactful: true, isAutoNeutralizable: false } ],
           hasSeenEndTestScreen: certificationCourse1.hasSeenEndTestScreen,
         });
         const expectedCertificationReport2 = domainBuilder.buildCertificationReport({

--- a/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
@@ -57,8 +57,8 @@ describe('Integration | Repository | General certification information', functio
           birthdate: certificationCourseDTO.birthdate,
           birthplace: certificationCourseDTO.birthplace,
           certificationIssueReports: [
-            { ...firstCertificationReport, isImpactful: true, resolution: 'challenge neutralized', resolvedAt: new Date('2021-01-01T00:00:00Z') },
-            { ...secondCertificationReport, isImpactful: true, resolution: null, resolvedAt: null },
+            { ...firstCertificationReport, isAutoNeutralizable: false, isImpactful: true, resolution: 'challenge neutralized', resolvedAt: new Date('2021-01-01T00:00:00Z') },
+            { ...secondCertificationReport, isAutoNeutralizable: false, isImpactful: true, resolution: null, resolvedAt: null },
           ],
         };
         expect(result).to.be.instanceOf(GeneralCertificationInformation);

--- a/api/tests/unit/domain/events/event-choreography-certification-rescoring-after-jury_test.js
+++ b/api/tests/unit/domain/events/event-choreography-certification-rescoring-after-jury_test.js
@@ -1,0 +1,17 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const CertificationJuryDone = require('../../../../lib/domain/events/CertificationJuryDone');
+
+describe('Event Choreography | CertificationJuryDone', function() {
+  it('Should trigger the certification rescoring', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new CertificationJuryDone({});
+
+    // when
+    await eventDispatcher.dispatch(event);
+
+    // then
+    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWith({ event, domainTransaction: undefined });
+  });
+});

--- a/api/tests/unit/domain/events/event-choreography-finalized-session_test.js
+++ b/api/tests/unit/domain/events/event-choreography-finalized-session_test.js
@@ -1,12 +1,25 @@
 const { expect } = require('../../../test-helper');
 const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
 const SessionFinalized = require('../../../../lib/domain/events/SessionFinalized');
+const AutoJuryDone = require('../../../../lib/domain/events/AutoJuryDone');
 
 describe('Event Choreography | Finalized session', function() {
-  it('Should trigger persiting a finalized session on Finalized Session event', async () => {
+  it('Should trigger the automated jury', async () => {
     // given
     const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
     const event = new SessionFinalized({});
+
+    // when
+    await eventDispatcher.dispatch(event);
+
+    // then
+    expect(handlerStubs.handleAutoJury).to.have.been.calledWith({ event, domainTransaction: undefined });
+  });
+
+  it('Should trigger persisting a finalized session on Auto Jury Done event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new AutoJuryDone({});
 
     // when
     await eventDispatcher.dispatch(event);

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -1,0 +1,240 @@
+const { sinon, expect, catchErr, domainBuilder } = require('../../../test-helper');
+const handleAutoJury = require('../../../../lib/domain/events/handle-auto-jury');
+const SessionFinalized = require('../../../../lib/domain/events/SessionFinalized');
+const AutoJuryDone = require('../../../../lib/domain/events/AutoJuryDone');
+const CertificationJuryDone = require('../../../../lib/domain/events/CertificationJuryDone');
+const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
+const { CertificationIssueReportSubcategories, CertificationIssueReportCategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
+const NeutralizationAttempt = require('../../../../lib/domain/models/NeutralizationAttempt');
+
+describe('Unit | Domain | Events | handle-auto-jury', () => {
+
+  it('fails when event is not of correct type', async () => {
+    // given
+    const event = 'not an event of the correct type';
+
+    // when
+    const error = await catchErr(handleAutoJury)(event);
+
+    // / then
+    expect(error).not.to.be.null;
+  });
+
+  it('auto neutralizes challenges', async () => {
+    // given
+    const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+    const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
+    const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal456', isNeutralized: false });
+    const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal789', isNeutralized: false });
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
+      certificationAnswersByDate: [
+        domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+        domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
+        domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
+      ],
+      certificationChallenges: [
+        challengeToBeNeutralized1,
+        challengeToBeNeutralized2,
+        challengeNotToBeNeutralized,
+      ],
+    });
+    const certificationCourse = domainBuilder.buildCertificationCourse();
+    const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, questionNumber: 1 });
+    const certificationIssueReport2 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING, questionNumber: 2 });
+    const certificationIssueReport3 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING, questionNumber: 3 });
+    certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+    certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([ certificationIssueReport1, certificationIssueReport2, certificationIssueReport3 ]);
+    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.id }).resolves(certificationAssessment);
+    sinon.stub(certificationAssessment, 'neutralizeChallengeByNumberIfKoOrSkipped').returns(NeutralizationAttempt.neutralized(1));
+    certificationAssessmentRepository.save.resolves();
+    const event = new SessionFinalized({
+      sessionId: 1234,
+      finalizedAt: new Date(),
+      hasExaminerGlobalComment: false,
+      certificationCenterName: 'A certification center name',
+      sessionDate: '2021-01-29',
+      sessionTime: '14:00',
+    });
+
+    // when
+    await handleAutoJury({
+      event,
+      certificationIssueReportRepository,
+      certificationAssessmentRepository,
+      certificationCourseRepository,
+    });
+
+    // then
+    expect(certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped).to.have.been.calledWith(1);
+    expect(certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped).to.have.been.calledWith(2);
+    expect(certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped).not.to.have.been.calledWith(3);
+    expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
+  });
+
+  it('returns an AutoJuryDone event', async () => {
+    // given
+    const now = Date.now();
+    const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+
+    const certificationCourse = domainBuilder.buildCertificationCourse();
+    certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+    certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([]);
+
+    const event = new SessionFinalized({
+      sessionId: 1234,
+      finalizedAt: now,
+      hasExaminerGlobalComment: false,
+      certificationCenterName: 'A certification center name',
+      sessionDate: '2021-01-29',
+      sessionTime: '14:00',
+    });
+
+    // when
+    const resultEvents = await handleAutoJury({
+      event,
+      certificationIssueReportRepository,
+      certificationAssessmentRepository,
+      certificationCourseRepository,
+    });
+
+    // then
+    expect(resultEvents[0]).to.be.an.instanceof(AutoJuryDone);
+    expect(resultEvents[0]).to.deep.equal(new AutoJuryDone({
+      sessionId: 1234,
+      finalizedAt: now,
+      hasExaminerGlobalComment: false,
+      certificationCenterName: 'A certification center name',
+      sessionDate: '2021-01-29',
+      sessionTime: '14:00',
+    }));
+  });
+
+  it('returns a CertificationJuryDone event', async () => {
+    // given
+    const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+    const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
+      certificationAnswersByDate: [
+        domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+      ],
+      certificationChallenges: [
+        challengeToBeNeutralized1,
+      ],
+    });
+    const certificationCourse = domainBuilder.buildCertificationCourse();
+    const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, questionNumber: 1 });
+    certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+    certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([ certificationIssueReport1 ]);
+    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.id }).resolves(certificationAssessment);
+    sinon.stub(certificationAssessment, 'neutralizeChallengeByNumberIfKoOrSkipped').returns(NeutralizationAttempt.neutralized(1));
+    certificationAssessmentRepository.save.resolves();
+    const event = new SessionFinalized({
+      sessionId: 1234,
+      finalizedAt: new Date(),
+      hasExaminerGlobalComment: false,
+      certificationCenterName: 'A certification center name',
+      sessionDate: '2021-01-29',
+      sessionTime: '14:00',
+    });
+
+    // when
+    const events = await handleAutoJury({
+      event,
+      certificationIssueReportRepository,
+      certificationAssessmentRepository,
+      certificationCourseRepository,
+    });
+
+    // then
+    expect(events[1]).to.be.an.instanceof(CertificationJuryDone);
+    expect(events[1]).to.deep.equal(new CertificationJuryDone({
+      certificationCourseId: certificationCourse.id,
+    }));
+  });
+
+  context('when there is no certification issue report', () => {
+    it('does not return a CertificationJuryDone event', async () => {
+      // given
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+
+      const certificationCourse = domainBuilder.buildCertificationCourse();
+      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([]);
+      const event = new SessionFinalized({
+        sessionId: 1234,
+        finalizedAt: new Date(),
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-29',
+        sessionTime: '14:00',
+      });
+
+      // when
+      const events = await handleAutoJury({
+        event,
+        certificationIssueReportRepository,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(events.length).to.equal(1);
+      expect(events[0]).not.to.be.an.instanceOf(CertificationJuryDone);
+    });
+  });
+
+  context('when there is no impacted certification', () => {
+
+    it('does not return a CertificationJuryDone event', async () => {
+      // given
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const challenge = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.OK }),
+        ],
+        certificationChallenges: [
+          challenge,
+        ],
+      });
+      const certificationCourse = domainBuilder.buildCertificationCourse();
+      const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, questionNumber: 1 });
+      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([ certificationIssueReport1 ]);
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.id }).resolves(certificationAssessment);
+      sinon.stub(certificationAssessment, 'neutralizeChallengeByNumberIfKoOrSkipped').returns(NeutralizationAttempt.skipped(1));
+      certificationAssessmentRepository.save.resolves();
+      const event = new SessionFinalized({
+        sessionId: 1234,
+        finalizedAt: new Date(),
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-29',
+        sessionTime: '14:00',
+      });
+
+      // when
+      const events = await handleAutoJury({
+        event,
+        certificationIssueReportRepository,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(events.length).to.equal(1);
+      expect(events[0]).not.to.be.an.instanceOf(CertificationJuryDone);
+    });
+  });
+});
+

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -23,7 +23,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
   it('auto neutralizes challenges', async () => {
     // given
     const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
     const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
     const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal456', isNeutralized: false });
@@ -46,6 +46,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     const certificationIssueReport3 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING, questionNumber: 3 });
     certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
     certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([ certificationIssueReport1, certificationIssueReport2, certificationIssueReport3 ]);
+    certificationIssueReportRepository.save.resolves();
     certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.id }).resolves(certificationAssessment);
     sinon.stub(certificationAssessment, 'neutralizeChallengeByNumberIfKoOrSkipped').returns(NeutralizationAttempt.neutralized(1));
     certificationAssessmentRepository.save.resolves();
@@ -116,7 +117,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
   it('returns a CertificationJuryDone event', async () => {
     // given
     const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
     const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
     const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -131,6 +132,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, questionNumber: 1 });
     certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
     certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([ certificationIssueReport1 ]);
+    certificationIssueReportRepository.save.resolves();
     certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.id }).resolves(certificationAssessment);
     sinon.stub(certificationAssessment, 'neutralizeChallengeByNumberIfKoOrSkipped').returns(NeutralizationAttempt.neutralized(1));
     certificationAssessmentRepository.save.resolves();

--- a/api/tests/unit/domain/events/handle-session-finalized_test.js
+++ b/api/tests/unit/domain/events/handle-session-finalized_test.js
@@ -3,7 +3,7 @@ const handleFinalizedSession = require('../../../../lib/domain/events/handle-ses
 const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
 const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
-const SessionFinalized = require('../../../../lib/domain/events/SessionFinalized');
+const AutoJuryDone = require('../../../../lib/domain/events/AutoJuryDone');
 const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession');
 
 describe('Unit | Domain | Events | handle-session-finalized', () => {
@@ -31,7 +31,7 @@ describe('Unit | Domain | Events | handle-session-finalized', () => {
 
   it('saves a finalized session', async () => {
     // given
-    const event = new SessionFinalized({
+    const event = new AutoJuryDone({
       sessionId: 1234,
       finalizedAt: new Date(),
       hasExaminerGlobalComment: false,

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -417,4 +417,21 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       expect(isResolved).to.be.true;
     });
   });
+  describe('#resolve', () => {
+
+    it('Sets the issue report as resolved', () => {
+      // given
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+        resolvedAt: null,
+      });
+
+      // when
+      certificationIssueReport.resolve('RESOLVED');
+
+      // then
+      expect(certificationIssueReport.resolvedAt).not.to.be.null;
+      expect(certificationIssueReport.resolution).to.equal('RESOLVED');
+    });
+
+  });
 });

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -306,17 +306,32 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
     context('Adds isImpactful boolean to certif issue report when the category or subcategory is impactful', function() {
       [
         { certificationCourseId: 42, category: 'OTHER', subcategory: undefined, description: 'toto' },
-        { certificationCourseId: 42, category: 'CANDIDATE_INFORMATIONS_CHANGES', subcategory: 'NAME_OR_BIRTHDATE', description: 'toto' },
+        {
+          certificationCourseId: 42,
+          category: 'CANDIDATE_INFORMATIONS_CHANGES',
+          subcategory: 'NAME_OR_BIRTHDATE',
+          description: 'toto',
+        },
         { certificationCourseId: 42, category: 'LATE_OR_LEAVING', subcategory: 'LEFT_EXAM_ROOM', description: 'toto' },
         { certificationCourseId: 42, category: 'FRAUD' },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_BLOCKED', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_UNAVAILABLE', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'FILE_NOT_OPENING', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'LINK_NOT_WORKING', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'IMAGE_NOT_DISPLAYING', questionNumber: 42 },
+        {
+          certificationCourseId: 42,
+          category: 'IN_CHALLENGE',
+          subcategory: 'IMAGE_NOT_DISPLAYING',
+          questionNumber: 42,
+        },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EMBED_NOT_WORKING', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EXTRA_TIME_EXCEEDED', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'SOFTWARE_NOT_WORKING', questionNumber: 42 },
+        {
+          certificationCourseId: 42,
+          category: 'IN_CHALLENGE',
+          subcategory: 'SOFTWARE_NOT_WORKING',
+          questionNumber: 42,
+        },
         { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
       ].forEach((certificationIssueReportDTO) => {
         it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isImpactful to true`, () => {
@@ -325,7 +340,12 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       });
 
       [
-        { certificationCourseId: 42, category: 'CANDIDATE_INFORMATIONS_CHANGES', subcategory: 'EXTRA_TIME_PERCENTAGE', description: 'toto' },
+        {
+          certificationCourseId: 42,
+          category: 'CANDIDATE_INFORMATIONS_CHANGES',
+          subcategory: 'EXTRA_TIME_PERCENTAGE',
+          description: 'toto',
+        },
         { certificationCourseId: 42, category: 'LATE_OR_LEAVING', subcategory: 'SIGNATURE_ISSUE' },
         { certificationCourseId: 42, category: 'CONNECTION_OR_END_SCREEN' },
       ].forEach((certificationIssueReportDTO) => {
@@ -334,6 +354,39 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         });
       });
     });
+
+    context('Adds isAutoneutralizable boolean to certif issue report when an subcategory is neutralizable', function() {
+      [
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_BLOCKED', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_UNAVAILABLE', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'SOFTWARE_NOT_WORKING', questionNumber: 42 },
+      ].forEach((certificationIssueReportDTO) => {
+        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isAutoneutralizable to true`, () => {
+          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isAutoNeutralizable).to.be.true;
+        });
+      });
+
+      [
+        { certificationCourseId: 42, category: 'CANDIDATE_INFORMATIONS_CHANGES', subcategory: 'EXTRA_TIME_PERCENTAGE', description: 'toto' },
+        { certificationCourseId: 42, category: 'LATE_OR_LEAVING', subcategory: 'SIGNATURE_ISSUE' },
+        { certificationCourseId: 42, category: 'CONNECTION_OR_END_SCREEN' },
+        { certificationCourseId: 42, category: 'OTHER', subcategory: undefined, description: 'toto' },
+        { certificationCourseId: 42, category: 'CANDIDATE_INFORMATIONS_CHANGES', subcategory: 'NAME_OR_BIRTHDATE', description: 'toto' },
+        { certificationCourseId: 42, category: 'LATE_OR_LEAVING', subcategory: 'LEFT_EXAM_ROOM', description: 'toto' },
+        { certificationCourseId: 42, category: 'FRAUD' },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'FILE_NOT_OPENING', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'LINK_NOT_WORKING', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'IMAGE_NOT_DISPLAYING', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EMBED_NOT_WORKING', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EXTRA_TIME_EXCEEDED', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
+      ].forEach((certificationIssueReportDTO) => {
+        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isAutoneutralizable to false`, () => {
+          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isAutoNeutralizable).to.be.false;
+        });
+      });
+    });
+
   });
 
   describe('#isResolved', () => {


### PR DESCRIPTION
## :unicorn: Problème

Avec la massification des certifications, il devient de plus en plus compliqué pour le pôle certif de traiter manuellement tous les types de signalements, notamment ceux de la catégorie “Problème technique sur une question” qui représentent la plus grand majorité. 
L’idée est donc d’automatiser la prise en compte des signalements de ce type.

## :robot: Solution

A la finalisation d’une session, si il y a un signalement de type “Problème technique sur une question”, avec l’une des sous-catégories suivantes : 
- E4 - Le site à visiter est indisponible/en maintenance/inaccessible
- E5 - Le site est bloqué par les restrictions réseau de l’établissement
- E9 - Le logiciel installé sur l’ordinateur n’a pas fonctionné

=> Neutraliser la question concernée si celle-ci est au statut “Echec” ou “Abandon”

## 🛠️  To do

- [x] Méthode `challengeRepository.getFromQuestionNumbers` pour récupérer les challenges à partir des numéros des questions
- [x] Ajouter la notion "auto-neutralisable sans vérification" aux `certificationIssueReports`
- [x] Filter les issues reports pour ne conserver que ceux avec des catégories auto-neutralisables
- [x] Filter les challenges pour ne conserver que ceux qui ont un statut “Echec” ou “Abandon”
- [x] Neutraliser les challenges correspondant lors de la finalisation

![Capture d’écran 2021-05-18 à 09 52 47](https://user-images.githubusercontent.com/5627688/118613235-d9c27080-b7be-11eb-93c9-5dd09c2d5cdf.png)

## :rainbow: Remarques

*RAS*

## :100: Pour tester

**Dans Pix Certif**

1. Créer une session de certification et ajouter un candidat

**Dans Pix App**

Rejoindre la session de certification, puis :

1. Répondre correctement à une question
2. Répondre incorrectement à une question
3. Passer une question
3. Passer une autre question
5. Répondre aux autres questions

**Dans Pix Certif**

Finaliser la session en ajoutant  :

- un signalement auto-neutralisable (sous-catégories E4, E5 et E9) à la question répondue correctement
- un signalement auto-neutralisable (sous-catégories E4, E5 et E9) à la question répondue incorrectement
- un signalement auto-neutralisable (sous-catégories E4, E5 et E9) à la question passée
- un signalement non auto-neutralisable à l'autre question passée (n'importe quel autre sous-catégorie Ex)

**Dans Pix Admin**

Constater que : 
- la session est bien finalisée
- la question répondue correctement n'est pas neutralisée
- la question répondue incorrectement est neutralisée
- la question passée est neutralisée
- la question avec un signalement non auto-neutralisable n'est pas neutralisée
