### PR TITLE
[BUGFIX] Afficher correctement le message d'erreur lors de la modification d'un identifiant déjà existant dans Pix Admin (PIX-2470).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -253,7 +253,13 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.InvalidTemporaryKeyError) {
     return new HttpErrors.UnauthorizedError(error.message);
   }
+  if (error instanceof DomainErrors.AlreadyRegisteredEmailAndUsernameError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
   if (error instanceof DomainErrors.AlreadyRegisteredEmailError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
+  if (error instanceof DomainErrors.AlreadyRegisteredUsernameError) {
     return new HttpErrors.BadRequestError(error.message);
   }
   if (error instanceof DomainErrors.WrongDateFormatError) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -90,6 +90,12 @@ class AssessmentResultNotCreatedError extends DomainError {
   }
 }
 
+class AlreadyRegisteredEmailAndUsernameError extends DomainError {
+  constructor(message = 'Cette adresse e-mail et cet identifiant sont déjà utilisés.') {
+    super(message);
+  }
+}
+
 class AlreadyRegisteredEmailError extends DomainError {
   constructor(message = 'Cette adresse e-mail est déjà utilisée.') {
     super(message);
@@ -825,6 +831,7 @@ module.exports = {
   AlreadyExistingMembershipError,
   AlreadyExistingOrganizationInvitationError,
   AlreadyRatedAssessmentError,
+  AlreadyRegisteredEmailAndUsernameError,
   AlreadyRegisteredEmailError,
   AlreadyRegisteredUsernameError,
   AlreadySharedCampaignParticipationError,

--- a/api/lib/domain/usecases/update-user-details-for-administration.js
+++ b/api/lib/domain/usecases/update-user-details-for-administration.js
@@ -1,13 +1,39 @@
+const has = require('lodash/has');
+const {
+  AlreadyRegisteredEmailAndUsernameError,
+  AlreadyRegisteredEmailError,
+  AlreadyRegisteredUsernameError,
+} = require('../errors');
+
 module.exports = async function updateUserDetailsForAdministration({
   userId,
   userDetailsForAdministration,
   userRepository,
 }) {
-  if (userDetailsForAdministration.email) {
-    await userRepository.isEmailAllowedToUseForCurrentUser(userId, userDetailsForAdministration.email);
-  }
+  const { email, username } = userDetailsForAdministration;
+
+  const foundUsersWithEmailAlreadyUsed = email && await userRepository.findAnotherUserByEmail(userId, email);
+  const foundUsersWithUsernameAlreadyUsed = username && await userRepository.findAnotherUserByUsername(userId, username);
+
+  await _checkEmailAndUsernameAreAvailable({
+    usersWithEmail: foundUsersWithEmailAlreadyUsed,
+    usersWithUsername: foundUsersWithUsernameAlreadyUsed,
+  });
 
   await userRepository.updateUserDetailsForAdministration(userId, userDetailsForAdministration);
 
-  return await userRepository.getUserDetailsForAdmin(userId);
+  return userRepository.getUserDetailsForAdmin(userId);
 };
+
+async function _checkEmailAndUsernameAreAvailable({ usersWithEmail, usersWithUsername }) {
+  const isEmailAlreadyUsed = has(usersWithEmail, '[0].email');
+  const isUsernameAlreadyUsed = has(usersWithUsername, '[0].username');
+
+  if (isEmailAlreadyUsed && isUsernameAlreadyUsed) {
+    throw new AlreadyRegisteredEmailAndUsernameError();
+  } else if (isEmailAlreadyUsed) {
+    throw new AlreadyRegisteredEmailError();
+  } else if (isUsernameAlreadyUsed) {
+    throw new AlreadyRegisteredUsernameError();
+  }
+}

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -5,11 +5,13 @@ const {
 } = require('../../test-helper');
 
 const {
+  AlreadyRegisteredEmailAndUsernameError,
+  AlreadyRegisteredEmailError,
+  AlreadyRegisteredUsernameError,
   EntityValidationError,
   MissingOrInvalidCredentialsError,
-  UserShouldChangePasswordError,
   UnexpectedUserAccountError,
-  AlreadyRegisteredEmailError,
+  UserShouldChangePasswordError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -175,6 +177,31 @@ describe('Unit | Application | ErrorManager', () => {
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
     });
 
+    it('should instantiate BadRequestError when AlreadyRegisteredUsernameError', async () => {
+      // given
+      const error = new AlreadyRegisteredUsernameError();
+      sinon.stub(HttpErrors, 'BadRequestError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate BadRequestError when AlreadyRegisteredEmailAndUsernameError', async () => {
+      // given
+      const error = new AlreadyRegisteredEmailAndUsernameError();
+      sinon.stub(HttpErrors, 'BadRequestError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
+    });
   });
 
 });

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -9,6 +9,7 @@ const {
   MissingOrInvalidCredentialsError,
   UserShouldChangePasswordError,
   UnexpectedUserAccountError,
+  AlreadyRegisteredEmailError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -160,6 +161,20 @@ describe('Unit | Application | ErrorManager', () => {
       // then
       expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message, error.code, error.meta);
     });
+
+    it('should instantiate BadRequestError when AlreadyRegisteredEmailError', async () => {
+      // given
+      const error = new AlreadyRegisteredEmailError();
+      sinon.stub(HttpErrors, 'BadRequestError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
+    });
+
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Pix Admin permet de modifier l'identifiant d'un utilisateur sur la page de détail d'un utilisateur.
Si l'on essaye de changer l'identifiant par un identifiant existant, un message d'erreur apparaît, ce qui est correct.
Or, le message d'erreur affiché est inexploitable : `OBJECT, OBJECT`

## :robot: Solution
Afficher le message d'erreur : **Cet identifiant est déjà utilisé.**

## :rainbow: Remarques
Rajouter la prise en compte du cas où l'email et l'identifiant sont tous les deux utilisés.

## :100: Pour tester

### Identifiant déjà utilisé
Sur la page de détail d'un utilisateur (ex. `George De Cambridge`)
Modifier l'identifiant en choisissant un identifiant déjà existant (ex. `blueivy.carter0701`)
Vérifier qu'une notification apparait avec le message d'erreur : **Cet identifiant est déjà utilisé.**

### Identifiant et username déjà utilisé
Sur la page de détail d'un utilisateur (ex. ` lance.low10@example.net`)
Modifier l'identifiant en choisissant 
- un identifiant déjà existant (ex. `blueivy.carter0701`)
- un email déjà existant (ex. `pixmaster@example.net`)
Vérifier qu'une notification apparait avec le message d'erreur : **Cette adresse e-mail et cet identifiant sont déjà utilisés.**