### PR TITLE
[FIX] Afficher un message lorsque l'external id dépasse la limité autorisé (PIX-2505)

### DIFF
--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -63,6 +63,19 @@ exports.register = async function(server) {
       method: 'POST',
       path: '/api/campaign-participations',
       config: {
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              type: Joi.string(),
+              attributes: Joi.object({
+                'participant-external-id': Joi.string().allow(null).max(255),
+              }).required(),
+            }).required(),
+          }).required(),
+          options: {
+            allowUnknown: true,
+          },
+        },
         handler: campaignParticipationController.save,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -1,6 +1,7 @@
 const Assessment = require('../models/Assessment');
 const CampaignParticipationStarted = require('../events/CampaignParticipationStarted');
 const CampaignParticipation = require('../models/CampaignParticipation');
+const { EntityValidationError } = require('../../domain/errors');
 
 module.exports = async function startCampaignParticipation({
   campaignParticipation,
@@ -11,6 +12,9 @@ module.exports = async function startCampaignParticipation({
   domainTransaction,
 }) {
   const campaignToJoin = await campaignToJoinRepository.get(campaignParticipation.campaignId, domainTransaction);
+
+  if (campaignToJoin.idPixLabel && !campaignParticipation.participantExternalId)
+    throw new EntityValidationError('Un identifiant externe est requis pour accèder à la campagne.');
 
   await campaignToJoinRepository.checkCampaignIsJoinableByUser(campaignToJoin, userId, domainTransaction);
   let createdCampaignParticipation;

--- a/api/tests/unit/application/campaignParticipations/index_test.js
+++ b/api/tests/unit/application/campaignParticipations/index_test.js
@@ -1,0 +1,56 @@
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/campaign-participations');
+
+const campaignParticipationController = require('../../../../lib/application/campaign-participations/campaign-participation-controller');
+
+describe('Unit | Application | Router | campaign-participation-router ', function() {
+
+  let httpTestServer;
+
+  beforeEach(async () => {
+    sinon.stub(campaignParticipationController, 'save').callsFake((request, h) => h.response('ok').code(200));
+
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('POST /api/campaign-participations', () => {
+
+    it('should return 200 when participant have external id', async () => {
+      // when
+      const participantExternalId = 'toto';
+      const response = await httpTestServer.request('POST', '/api/campaign-participations', {
+        data: {
+          type: 'campaign-participations',
+          attributes: {
+            'participant-external-id': participantExternalId,
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 400 when participant external id exceeds 255 characters', async () => {
+      // when
+      const participantExternalId256Characters = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+      const response = await httpTestServer.request('POST', '/api/campaign-participations', {
+        data: {
+          type: 'campaign-participations',
+          attributes: {
+            'participant-external-id': participantExternalId256Characters,
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+});

--- a/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.js
+++ b/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.js
@@ -13,13 +13,19 @@ export default class FillInParticipantExternalId extends Component {
   @action
   submit(event) {
     event.preventDefault();
-    this.errorMessage = null;
 
-    if (this.participantExternalId) {
-      return this.args.onSubmit(this.participantExternalId);
-    } else {
+    if (!this.participantExternalId) {
       this.errorMessage = this.intl.t('pages.fill-in-participant-external-id.errors.missing-id-pix-label', { idPixLabel: this.args.campaign.idPixLabel });
+      return;
     }
+
+    if (this.participantExternalId.length > 255) {
+      this.errorMessage = this.intl.t('pages.fill-in-participant-external-id.errors.max-length-id-pix-label', { idPixLabel: this.args.campaign.idPixLabel });
+      return;
+    }
+
+    this.errorMessage = null;
+    return this.args.onSubmit(this.participantExternalId);
   }
 
   @action

--- a/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
+++ b/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
@@ -1,7 +1,19 @@
+import { Response } from 'ember-cli-mirage';
+
 export default function(schema, request) {
   const params = JSON.parse(request.requestBody);
 
   const participantExternalId = params.data.attributes['participant-external-id'];
+
+  if (participantExternalId && participantExternalId.length > 255) {
+    return new Response(400, {}, {
+      errors: [{
+        status: 400,
+        detail: 'participant-external-id',
+      }],
+    });
+  }
+
   const campaignId = params.data.relationships.campaign.data.id;
 
   const campaign = schema.campaigns.find(campaignId);

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -258,6 +258,19 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           });
         });
 
+        context('When participant external id exceeds 255 characters', function() {
+          beforeEach(async function() {
+            const externalId256Characters = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+            campaign = server.create('campaign', { isRestricted: false, idPixLabel: 'toto', type: ASSESSMENT });
+            await startCampaignByCodeAndExternalId(campaign.code, externalId256Characters);
+          });
+
+          it('should redirect to fill in external participant id page', async function() {
+            // then
+            expect(currentURL()).to.contains('/identifiant');
+          });
+        });
+
         context('When participant external id is set in the url', function() {
           beforeEach(async function() {
             campaign = server.create('campaign', { idPixLabel: 'nom de naissance de maman', type: ASSESSMENT });

--- a/mon-pix/tests/helpers/campaign.js
+++ b/mon-pix/tests/helpers/campaign.js
@@ -7,8 +7,8 @@ export async function startCampaignByCode(campaignCode) {
   await click('.campaign-landing-page__start-button');
 }
 
-export async function startCampaignByCodeAndExternalId(campaignCode) {
-  await visit(`/campagnes/${campaignCode}?participantExternalId=a73at01r3`);
+export async function startCampaignByCodeAndExternalId(campaignCode, externalId = 'a73at01r3') {
+  await visit(`/campagnes/${campaignCode}?participantExternalId=${externalId}`);
   await click('.campaign-landing-page__start-button');
 }
 

--- a/mon-pix/tests/unit/components/routes/campaigns/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/fill-in-participant-external-id_test.js
@@ -53,6 +53,17 @@ describe('Unit | Component | routes/campaigns/fill-in-participant-external-id', 
       // then
       expect(component.errorMessage).to.equal(`Merci de renseigner votre ${component.args.campaign.idPixLabel}.`);
     });
+
+    it('should display error when participant external id exceed 255 characters', async () => {
+      // given
+      component.participantExternalId = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+      // when
+      await component.actions.submit.call(component, eventStub);
+
+      // then
+      expect(component.errorMessage).to.equal(`Votre ${component.args.campaign.idPixLabel} ne doit pas dépasser les 255 caractères.`);
+    });
   });
 
   describe('#cancel', () => {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -675,6 +675,7 @@
         "continue": "Continue"
       },
       "errors": {
+        "max-length-id-pix-label": "Your { idPixLabel } must not exceed 255 characters.",
         "missing-id-pix-label": "Please enter your { idPixLabel }."
       },
       "first-title": "Before starting"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -675,6 +675,7 @@
         "continue": "Continuer"
       },
       "errors": {
+        "max-length-id-pix-label": "Votre { idPixLabel } ne doit pas dépasser les 255 caractères.",
         "missing-id-pix-label": "Merci de renseigner votre { idPixLabel }."
       },
       "first-title": "Avant de commencer"


### PR DESCRIPTION
## :unicorn: Problème
Une erreur Sentry remonté suite à une tentative d'insertion en base d'un externalId > 255 caractères

## :robot: Solution
Ajouter un validateur Joi sur la route API afin de ne plus accepter un externalId dépassant la limite autorisé.
Afficher une erreur côté Front à l'utilisateur si il tente de saisir un externalId supérieur à la limite autorisé

## :rainbow: Remarques

## :100: Pour tester
Utilisateur : `userpix1@example.net` . 
Code campagne : `FINISHED3`
Identififant entrprise : `GhBzfRiTXY5WijgZ3QeMlIce6nmDTHTFtwsc857XQ3ypzz0snyXZl0rqx7gM8HuUYGs6kEu0g9aDbEOQPmzVWT0KY7UDF7G33XDW3eyU9ZYTQ6m2rQtfvvyjqPWJpIcNfFqFlZMtEog8oHm1wNLNRBeksxRCQp9Ax5rXra7M8KifXD16877avES8JqX7bNiujPUm8NuQYD1mlYY3ruprK6jaVms3WcLgvw4N4ygxOR2Oq4YuSKfj3rv1yH3ZZBhw` 256 caractères .

Voir le message s'afficher `Votre identifiant entreprise .... 255 caractères`