### PR TITLE
[BUGFIX] Homogéneiser des incohérences de clé json pour les ids de compétence lors de la modification jury (PIX-2594)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -159,7 +159,7 @@ export default class CertificationInformationsController extends Controller {
       const newCompetences = Object.entries(state.marks)
         .map(([code, mark]) => {
           return {
-            'competence-id': mark.competenceId,
+            competenceId: mark.competenceId,
             competence_code: code,
             area_code: code.substr(0, 1),
             level: mark.level,

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -21,13 +21,14 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     competence_code,
     score,
     level,
+    competenceId,
   }) => {
     return {
       competence_code,
       level,
       score,
       area_code: competence_code.substr(0, 1),
-      'competence-id': undefined,
+      competenceId: competenceId,
     };
   };
 
@@ -382,11 +383,13 @@ module('Unit | Controller | authenticated/certifications/certification/informati
             competence_code: anExistingCompetenceCode,
             level: anExistingCompetence.level + 1,
             score: anExistingCompetence.score + 1,
+            competenceId: 'recComp1',
           }),
           createMark({
             competence_code: aNewCompetenceCode,
             level: 5,
             score: 6,
+            competenceId: 'recComp2',
           }),
         ];
 
@@ -397,10 +400,12 @@ module('Unit | Controller | authenticated/certifications/certification/informati
             [anExistingCompetenceCode]: {
               level: anExistingCompetence.level + 1,
               score: anExistingCompetence.score + 1,
+              competenceId: 'recComp1',
             },
             [aNewCompetenceCode]: {
               level: 5,
               score: 6,
+              competenceId: 'recComp2',
             },
           },
         });


### PR DESCRIPTION
## :unicorn: Problème
Avec #2961 nous avons fixé une erreur de dé-sérialisation, les `competence-id` étaient mal désérialisés en tant que `competenceId` (ce qui avait pour effet de les considérer comme `null` coté back). Depuis ce fix, les `competence-id` sont correctement désérialisés en tant que `competence-id`, MAIS au travers d'un parcours utilisateur différent cette même route était appelée avec des `competenceId` qui eux, depuis le fix, sont mal dé-sérialisés.

## :robot: Solution
Homogénéiser les `competence-id` en `competenceId` et rajouter les tests manquants.

## :rainbow: Remarques
RAS

## :100: Pour tester
Pour reproduire le bug (avant checkout la branche) : 
- se connecter à Pix-Admin, aller sur la session 6, choisir la session en "démarrée"
- aller dans l'onglet détail, modifier quelques réponses (passer des succès en échec par exemple)
- cliquer sur "enregister" en bas de la page détail
- dans la page de modification pré-rempli de modification des score/niveaux, modifié le statut de "démarrée" à "rejetée"
- constater l'erreur et l'apparition d'une notification rouge

Après checkout de la branche, cette erreur ne se produit plus.

