### PR TITLE
[BUGFIX] Le taux de repro est incorrect après une neutralisation sur la page de détails d'une certification dans PixAdmin (PIX-2599)

### DIFF
--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -77,12 +77,6 @@ class CertificationAssessment {
       .value();
   }
 
-  findAnswersForCertifiableBadgeKey(certifiableBadgeKey) {
-    const certificationChallengesForBadge = _.filter(this.certificationChallenges, { certifiableBadgeKey });
-    const challengeIds = _.map(certificationChallengesForBadge, 'challengeId');
-    return _.filter(this.certificationAnswersByDate, ({ challengeId }) => _.includes(challengeIds, challengeId));
-  }
-
   findAnswersAndChallengesForCertifiableBadgeKey(certifiableBadgeKey) {
     const certificationChallengesForBadge = _.filter(this.certificationChallenges, { certifiableBadgeKey });
     const challengeIds = _.map(certificationChallengesForBadge, 'challengeId');

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -83,6 +83,16 @@ class CertificationAssessment {
     return _.filter(this.certificationAnswersByDate, ({ challengeId }) => _.includes(challengeIds, challengeId));
   }
 
+  findAnswersAndChallengesForCertifiableBadgeKey(certifiableBadgeKey) {
+    const certificationChallengesForBadge = _.filter(this.certificationChallenges, { certifiableBadgeKey });
+    const challengeIds = _.map(certificationChallengesForBadge, 'challengeId');
+    const answersForBadge = _.filter(this.certificationAnswersByDate, ({ challengeId }) => _.includes(challengeIds, challengeId));
+    return {
+      certificationChallenges: certificationChallengesForBadge,
+      certificationAnswers: answersForBadge,
+    };
+  }
+
   isCompleted() {
     return this.state === states.COMPLETED;
   }

--- a/api/lib/domain/models/ReproducibilityRate.js
+++ b/api/lib/domain/models/ReproducibilityRate.js
@@ -15,18 +15,6 @@ class ReproducibilityRate {
     return new ReproducibilityRate(Math.round((numberOfCorrectAnswers / numberOfNonNeutralizedChallenges) * 100));
   }
 
-  static fromAnswers({ answers }) {
-    const numberOfAnswers = answers.length;
-
-    if (!numberOfAnswers) {
-      return new ReproducibilityRate(0);
-    }
-
-    const numberOfCorrectAnswers = answers.filter((answer) => answer.isOk()).length;
-
-    return new ReproducibilityRate(Math.round((numberOfCorrectAnswers / numberOfAnswers) * 100));
-  }
-
   isEnoughToBeCertified() {
     return this.value >= MINIMUM_REPRODUCIBILITY_RATE_TO_BE_CERTIFIED;
   }

--- a/api/lib/domain/read-models/CertificationDetails.js
+++ b/api/lib/domain/read-models/CertificationDetails.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const AnswerCollectionForScoring = require('../models/AnswerCollectionForScoring');
 const { ReproducibilityRate } = require('../models/ReproducibilityRate');
 
 class CertificationDetails {
@@ -29,7 +30,14 @@ class CertificationDetails {
     competenceMarks,
     placementProfile,
   }) {
-    const reproducibilityRate = ReproducibilityRate.fromAnswers({ answers: certificationAssessment.certificationAnswersByDate });
+    const answerCollection = AnswerCollectionForScoring.from({
+      answers: certificationAssessment.certificationAnswersByDate,
+      challenges: certificationAssessment.certificationChallenges,
+    });
+    const reproducibilityRate = ReproducibilityRate.from({
+      numberOfNonNeutralizedChallenges: answerCollection.numberOfNonNeutralizedChallenges(),
+      numberOfCorrectAnswers: answerCollection.numberOfCorrectAnswers(),
+    });
     const competencesWithMark = _buildCompetencesWithMark({ competenceMarks, placementProfile });
     const listChallengesAndAnswers = _buildListChallengesAndAnswers({ certificationAssessment, competencesWithMark });
 

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -327,6 +327,51 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
     });
   });
 
+  describe('#findAnswersAndChallengesForCertifiableBadgeKey', () => {
+
+    it('returns the answers and challenges for a certifiableBadgeKey', () => {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_1' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_2' });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal3', certifiableBadgeKey: 'BADGE_1' });
+      const certificationChallenge4 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal4', certifiableBadgeKey: null });
+      const certificationAnswer1 = domainBuilder.buildAnswer({ challengeId: 'chal1' });
+      const certificationAnswer2 = domainBuilder.buildAnswer({ challengeId: 'chal2' });
+      const certificationAnswer3 = domainBuilder.buildAnswer({ challengeId: 'chal3' });
+      const certificationAnswer4 = domainBuilder.buildAnswer({ challengeId: 'chal4' });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1, certificationChallenge2, certificationChallenge3, certificationChallenge4],
+        certificationAnswersByDate: [certificationAnswer1, certificationAnswer2, certificationAnswer3, certificationAnswer4],
+      });
+
+      // when
+      const { certificationChallenges, certificationAnswers } = certificationAssessment.findAnswersAndChallengesForCertifiableBadgeKey('BADGE_1');
+
+      // then
+      expect(certificationAnswers).to.deep.equals([certificationAnswer1, certificationAnswer3]);
+      expect(certificationChallenges).to.deep.equals([certificationChallenge1, certificationChallenge3]);
+    });
+
+    it('returns empty arrays if there are no answers nor challenges for given key', () => {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_1' });
+      const certificationAnswer1 = domainBuilder.buildAnswer({ challengeId: 'chal1' });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1],
+        certificationAnswersByDate: [certificationAnswer1],
+      });
+
+      // when
+      const { certificationChallenges, certificationAnswers } = certificationAssessment.findAnswersAndChallengesForCertifiableBadgeKey('BADGE_TOTO');
+
+      // then
+      expect(certificationAnswers).to.be.empty;
+      expect(certificationChallenges).to.be.empty;
+    });
+  });
+
   describe('#isCompleted', () => {
     it('returns true when completed', () => {
       // given

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -284,49 +284,6 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
     });
   });
 
-  describe('#findAnswersForCertifiableBadgeKey', () => {
-
-    it('returns the answers for a certifiableBadgeKey', () => {
-      // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_1' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_2' });
-      const certificationChallenge3 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal3', certifiableBadgeKey: 'BADGE_1' });
-      const certificationChallenge4 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal4', certifiableBadgeKey: null });
-      const certificationAnswer1 = domainBuilder.buildAnswer({ challengeId: 'chal1' });
-      const certificationAnswer2 = domainBuilder.buildAnswer({ challengeId: 'chal2' });
-      const certificationAnswer3 = domainBuilder.buildAnswer({ challengeId: 'chal3' });
-      const certificationAnswer4 = domainBuilder.buildAnswer({ challengeId: 'chal4' });
-
-      const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationChallenges: [certificationChallenge1, certificationChallenge2, certificationChallenge3, certificationChallenge4],
-        certificationAnswersByDate: [certificationAnswer1, certificationAnswer2, certificationAnswer3, certificationAnswer4],
-      });
-
-      // when
-      const answersByCertifiableBadgeKey = certificationAssessment.findAnswersForCertifiableBadgeKey('BADGE_1');
-
-      // then
-      expect(answersByCertifiableBadgeKey).to.deep.equals([certificationAnswer1, certificationAnswer3]);
-    });
-
-    it('returns an empty array if there are no answers for given key', () => {
-      // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_1' });
-      const certificationAnswer1 = domainBuilder.buildAnswer({ challengeId: 'chal1' });
-
-      const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationChallenges: [certificationChallenge1],
-        certificationAnswersByDate: [certificationAnswer1],
-      });
-
-      // when
-      const answersByCertifiableBadgeKey = certificationAssessment.findAnswersForCertifiableBadgeKey('BADGE_TOTO');
-
-      // then
-      expect(answersByCertifiableBadgeKey).to.be.empty;
-    });
-  });
-
   describe('#findAnswersAndChallengesForCertifiableBadgeKey', () => {
 
     it('returns the answers and challenges for a certifiableBadgeKey', () => {

--- a/api/tests/unit/domain/models/ReproducibilityRate_test.js
+++ b/api/tests/unit/domain/models/ReproducibilityRate_test.js
@@ -1,51 +1,11 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 const { ReproducibilityRate } = require('../../../../lib/domain/models/ReproducibilityRate');
-const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const {
   MINIMUM_REPRODUCIBILITY_RATE_TO_BE_CERTIFIED,
 } = require('../../../../lib/domain/constants');
 
 describe('Unit | Domain | Models | ReproducibilityRate', function() {
 
-  context('#static fromAnswers', () => {
-
-    it('is equal to 0% if no answers', () => {
-      // when
-      const reproducibilityRate = ReproducibilityRate.fromAnswers({ answers: [] });
-
-      // then
-      expect(reproducibilityRate.value).to.equal(0);
-    });
-
-    it('is equal to 50% if 1 answer is correct and 1 is non-correct', () => {
-      // given
-      const answers = [
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.KO }),
-      ];
-
-      // when
-      const reproducibilityRate = ReproducibilityRate.fromAnswers({ answers });
-
-      // then
-      expect(reproducibilityRate.value).to.equal(50);
-    });
-
-    it('is equal to 33% if 1 answer is correct and 2 are non-correct', () => {
-      // given
-      const answers = [
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.TIMEDOUT }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.SKIPPED }),
-      ];
-
-      // when
-      const reproducibilityRate = ReproducibilityRate.fromAnswers({ answers });
-
-      // then
-      expect(reproducibilityRate.value).to.equal(33);
-    });
-  });
   context('#static from', () => {
 
     it('is equal to 0% non non-neutralizedAnswers', () => {

--- a/api/tests/unit/domain/read-models/CertificationDetails_test.js
+++ b/api/tests/unit/domain/read-models/CertificationDetails_test.js
@@ -77,6 +77,26 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
       expect(certificationDetails.percentageCorrectAnswers).to.equal(50);
     });
 
+    it('should take into account neutralized challenges when compution the reproducibility rate', () => {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', isNeutralized: true });
+      const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+      const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456' });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1, certificationChallenge2],
+        certificationAnswersByDate: [answer1, answer2],
+      });
+      const competenceMarks = [];
+      const placementProfile = null;
+
+      // when
+      const certificationDetails = CertificationDetails.from({ certificationAssessment, placementProfile, competenceMarks });
+
+      // then
+      expect(certificationDetails.percentageCorrectAnswers).to.equal(0);
+    });
+
     it('should create competencesWithMark', () => {
       // given
       const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });


### PR DESCRIPTION
## :unicorn: Problème
Grâce aux divers correctifs, nous avons enfin pu activer en prod le toggle FT_IS_NEUTRALIZATION_AUTO_ENABLED. Ce toggle activé permet d'afficher une page de détails de certification sans avoir à rescorer complètement la certification si celle-ci a déja été scorée. Ca va aller chercher les competence-marks existants pour cette certification.

Etapes de reproduction :
- Sur une autre branche que celle-ci, se rendre sur la page de détails d'une certification complétée sur PixAdmin
- Retenir le taux de repro
- Neutraliser une épreuve
- Retourner sur la page de détails et constater que le taux de repro reste visuellement inchangé

## :robot: Solution
Dans la nouvelle route de récupération des détails de la certification, le taux de repro est calculé de façon incorrecte. En effet, le taux de repro est calculée en passant par un constructeur statique qui ne tient pas compte des épreuves neutralisées.

La solution est donc, dans un premier temps, d'utiliser le bon constructeur statique à l'endroit de la récupération des détails de la certification.
De manière générale, on cherchera aussi dans cette PR a carrément supprimer l'usage de ce constructeur statique incomplet.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Reproduire les étapes du dessus sans parvenir à reproduire le bug
