### PR TITLE
[FEATURE] Correctif graphique de la progress bar dans l'onglet Résultats par compétence (PIX-2553).

### DIFF
--- a/orga/app/styles/globals/competences.scss
+++ b/orga/app/styles/globals/competences.scss
@@ -15,6 +15,7 @@
 
   &__gauge {
     padding-top: 16px;
+    padding-right: 32px;
   }
 
   &__border {


### PR DESCRIPTION
## :unicorn: Problème
La bulle de la barre de progression est trop proche de la colonne suivante quand la barre est à 100%

## :robot: Solution
Modifier le css du composant progress bar pour qu'il prenne 100% de la largeur de son conteneur

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter sur PixOrga puis cliquez sur Campagnes , sélectionnez une campagne d’évaluation , cliquez sur l'onglet 
participants puis sélectionnez un participant pour vois ses détails.
- vous pouvez voir ses résultats par compétences dans l’onglet Résultats qui contient un bar de progression. 
- vous pouvez constater que visuellement il y a assez d'espace entre la barre de progression et la colonne suivante à son à droite 