### PR TITLE
[TECH] Supprimer la colonne color des BadgePartnerCompetences (PIX-2523).

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -39,7 +39,7 @@
             {{#each criterion.partnerCompetences as |badgePartnerCompetence|}}
             <li>
               <details>
-                <summary>{{badgePartnerCompetence.name}}{{#if badgePartnerCompetence.color}} - {{badgePartnerCompetence.color}}{{/if}}</summary>
+                <summary>{{badgePartnerCompetence.name}}</summary>
                 <table class="table-admin badge-partner-competences-table">
                   <thead>
                     <tr>

--- a/admin/app/models/badge-partner-competence.js
+++ b/admin/app/models/badge-partner-competence.js
@@ -3,7 +3,6 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class BadgePartnerCompetence extends Model {
 
   @attr('string') name;
-  @attr('string') color;
 
   @belongsTo('badge') badge;
   @belongsTo('badge-criterion') criterion;

--- a/admin/tests/acceptance/authenticated/badges/badges_test.js
+++ b/admin/tests/acceptance/authenticated/badges/badges_test.js
@@ -56,7 +56,7 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
     const badgeElement = find('.page-section__details');
     assert.ok(badgeElement.textContent.match(badge.title));
     assert.contains('20');
-    assert.contains('Internet for dummies - red');
+    assert.contains('Internet for dummies');
     assert.contains('@skill2');
     assert.contains('Practical title of tube');
   });

--- a/admin/tests/integration/components/badges/badge_test.js
+++ b/admin/tests/integration/components/badges/badge_test.js
@@ -60,7 +60,7 @@ module('Integration | Component | Badges::Badge', function(hooks) {
     assert.ok(detailsContent.match('Certifiable'), 'Certifiable');
     assert.dom('.page-section__details img').exists();
     assert.contains('L‘évalué doit obtenir 85% sur l‘ensemble des acquis du target profile');
-    assert.contains('Competence - red');
+    assert.contains('Competence');
     assert.contains('@skill2');
     assert.contains('Mon tube');
   });

--- a/api/db/database-builder/factory/build-badge-partner-competence.js
+++ b/api/db/database-builder/factory/build-badge-partner-competence.js
@@ -4,7 +4,6 @@ const _ = require('lodash');
 module.exports = function buildBadgePartnerCompetence({
   id = databaseBuffer.getNextId(),
   name = 'name',
-  color = null,
   skillIds = [],
   badgeId,
 } = {}) {
@@ -19,7 +18,6 @@ module.exports = function buildBadgePartnerCompetence({
   const values = {
     id,
     name,
-    color,
     skillIds,
     badgeId,
   };

--- a/api/db/migrations/20210517162046_drop-column-color-in-badge-partner-competences.js
+++ b/api/db/migrations/20210517162046_drop-column-color-in-badge-partner-competences.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'badge-partner-competences';
+const COLUMN_NAME = 'color';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/badges-builder.js
+++ b/api/db/seeds/data/badges-builder.js
@@ -228,28 +228,24 @@ function _returnIds(...builders) {
 function _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIds, badge) {
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name: 'Rechercher des informations sur internet',
-    color: null,
     skillIds: targetProfileSkillIds[0].map((id) => id),
     badgeId: badge.id,
   });
 
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name: 'Utiliser des outils informatiques',
-    color: null,
     skillIds: targetProfileSkillIds[1].map((id) => id),
     badgeId: badge.id,
   });
 
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name: 'Naviguer sur internet',
-    color: null,
     skillIds: targetProfileSkillIds[2].map((id) => id),
     badgeId: badge.id,
   });
 
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name: 'Partager sur les réseaux sociaux',
-    color: null,
     skillIds: targetProfileSkillIds[3].map((id) => id),
     badgeId: badge.id,
   });
@@ -275,28 +271,24 @@ function _associatePixDroitMasterBadgePartnerCompetences(databaseBuilder, target
 
     databaseBuilder.factory.buildBadgePartnerCompetence({
       name: 'Acquis du référentiel Pix',
-      color: null,
       skillIds: targetProfileSkillIds[0].map((id) => id),
       badgeId: badge.id,
     }),
 
     databaseBuilder.factory.buildBadgePartnerCompetence({
       name: 'Acquis Pix+ Droit',
-      color: null,
       skillIds: targetProfileSkillIds[1].map((id) => id),
       badgeId: badge.id,
     }),
 
     databaseBuilder.factory.buildBadgePartnerCompetence({
       name: 'Domaine Pix+ Droit Domaine 7',
-      color: null,
       skillIds: targetProfileSkillIds[2].map((id) => id),
       badgeId: badge.id,
     }),
 
     databaseBuilder.factory.buildBadgePartnerCompetence({
       name: 'Domaine Pix+ Droit Domaine 10',
-      color: null,
       skillIds: targetProfileSkillIds[3].map((id) => id),
       badgeId: badge.id,
     }),
@@ -307,28 +299,24 @@ function _associatePixDroitExpertBadgePartnerCompetences(databaseBuilder, target
   return _returnIds(
     databaseBuilder.factory.buildBadgePartnerCompetence({
       name: 'Acquis du référentiel Pix',
-      color: null,
       skillIds: targetProfileSkillIds[0].map((id) => id),
       badgeId: badge.id,
     }),
 
     databaseBuilder.factory.buildBadgePartnerCompetence({
       name: 'Acquis Pix+ Droit',
-      color: null,
       skillIds: targetProfileSkillIds[1].map((id) => id),
       badgeId: badge.id,
     }),
 
     databaseBuilder.factory.buildBadgePartnerCompetence({
       name: 'Domaine Pix+ Droit Domaine 7',
-      color: null,
       skillIds: targetProfileSkillIds[2].map((id) => id),
       badgeId: badge.id,
     }),
 
     databaseBuilder.factory.buildBadgePartnerCompetence({
       name: 'Domaine Pix+ Droit Domaine 10',
-      color: null,
       skillIds: targetProfileSkillIds[3].map((id) => id),
       badgeId: badge.id,
     }),

--- a/api/lib/domain/models/BadgePartnerCompetence.js
+++ b/api/lib/domain/models/BadgePartnerCompetence.js
@@ -3,12 +3,10 @@ class BadgePartnerCompetence {
   constructor({
     id,
     name,
-    color,
     skillIds,
   } = {}) {
     this.id = id;
     this.name = name;
-    this.color = color;
     this.skillIds = skillIds;
   }
 }

--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -132,7 +132,7 @@ function _getTestedCompetenceResults(competence, targetedKnowledgeElements) {
   const testedSkillsCount = targetedKnowledgeElementsForCompetence.length;
   const validatedSkillsCount = validatedKnowledgeElementsForCompetence.length;
   const totalSkillsCount = competence.skillIds.length;
-  const areaColor = _getCompetenceColor(competence);
+  const areaColor = competence.area ? competence.area.color : null;
   const areaName = _getAreaName(competence);
 
   return new CompetenceResult({
@@ -151,18 +151,6 @@ function _getTestedCompetenceResults(competence, targetedKnowledgeElements) {
 function _getAreaName(competence) {
   if (!competence.area) return;
   return competence.area.name;
-}
-
-function _getCompetenceColor(competence) {
-  let areaColor;
-  const isBadgePartnerCompetenceColorAvailable = competence.color !== undefined;
-
-  if (isBadgePartnerCompetenceColorAvailable) {
-    areaColor = competence.color;
-  } else {
-    areaColor = competence.area.color;
-  }
-  return areaColor;
 }
 
 module.exports = CampaignParticipationResult;

--- a/api/lib/domain/read-models/participant-results/PartnerCompetenceResult.js
+++ b/api/lib/domain/read-models/participant-results/PartnerCompetenceResult.js
@@ -4,7 +4,6 @@ class PartnerCompetenceResult {
     const validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
 
     this.id = competence.id;
-    this.color = competence.color;
     this.name = competence.name;
     this.totalSkillsCount = totalSkillsCount;
     this.testedSkillsCount = knowledgeElements.length;

--- a/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
@@ -200,7 +200,7 @@ async function _fillBadgesWithCriteria(badges) {
 async function _fillBadgesWithPartnerCompetences(badges) {
   const badgeIds = badges.map((badge) => badge.id);
   const partnerCompetencesRows = await knex('badge-partner-competences')
-    .select('badge-partner-competences.id', 'badge-partner-competences.name', 'badge-partner-competences.color', 'badge-partner-competences.skillIds', 'badge-partner-competences.badgeId')
+    .select('badge-partner-competences.id', 'badge-partner-competences.name', 'badge-partner-competences.skillIds', 'badge-partner-competences.badgeId')
     .whereIn('badge-partner-competences.badgeId', badgeIds);
 
   const partnerCompetencesRowsByBadgeId = _.groupBy(partnerCompetencesRows, 'badgeId');

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -74,7 +74,6 @@ describe('Acceptance | API | Campaign Participation Result', () => {
       id: 1,
       badgeId: 1,
       name: 'Pix Emploi',
-      color: 'emerald',
       skillIds,
     });
 
@@ -219,7 +218,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
         },
         included: [{
           attributes: {
-            'area-color': 'emerald',
+            'area-color': undefined,
             'mastery-percentage': 38,
             name: 'Pix Emploi',
             'tested-skills-count': 5,

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -85,7 +85,6 @@ describe('Integration | Service | Certification-Badges Service', () => {
         {
           id: badgePartnerCompetence.id,
           name: badgePartnerCompetence.name,
-          color: badgePartnerCompetence.color,
           skillIds: badgePartnerCompetence.skillIds,
         },
       ];

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -131,7 +131,6 @@ describe('Integration | Repository | Badge Acquisition', () => {
         {
           id: badgePartnerCompetence.id,
           name: badgePartnerCompetence.name,
-          color: badgePartnerCompetence.color,
           skillIds: badgePartnerCompetence.skillIds,
         },
       ];

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -41,14 +41,12 @@ describe('Integration | Repository | Badge', () => {
 
     badgePartnerCompetence_1 = {
       id: 1,
-      color: 'jaffa',
       name: 'Idenfier des éléments',
       skillIds: ['recA1B2', 'recC3D4'],
     };
 
     badgePartnerCompetence_2 = {
       id: 2,
-      color: null,
       name: 'Rechercher des éléments',
       skillIds: ['recABC1', 'recDEF2'],
     };

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
@@ -426,7 +426,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
             .sort((a, b) => a.id <= b.id);
           expect(partnerCompetenceResults[0]).to.deep.equal({
             id: 1,
-            areaColor: 'BadgeCompt1Color',
+            areaColor: null,
             areaName: undefined,
             index: undefined,
             name: 'BadgeCompt1',
@@ -437,7 +437,7 @@ describe('Integration | Repository | Campaign Participation Result', () => {
 
           expect(partnerCompetenceResults[1]).to.deep.equal({
             id: 2,
-            areaColor: 'BadgeCompt2Color',
+            areaColor: null,
             areaName: undefined,
             index: undefined,
             name: 'BadgeCompt2',

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -523,7 +523,6 @@ describe('Integration | Repository | ParticipantResultRepository', () => {
           expect(participantResult.competenceResults).to.have.lengthOf(2);
           expect(partnerCompetenceResult1).to.deep.equal({
             id: 1,
-            color: 'BadgeCompt1Color',
             name: 'BadgeCompt1',
             testedSkillsCount: 2,
             totalSkillsCount: 2,
@@ -533,7 +532,6 @@ describe('Integration | Repository | ParticipantResultRepository', () => {
 
           expect(partnerCompetenceResult2).to.deep.equal({
             id: 2,
-            color: 'BadgeCompt2Color',
             name: 'BadgeCompt2',
             testedSkillsCount: 2,
             totalSkillsCount: 2,

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -9,7 +9,7 @@ async function _buildDomainAndDatabaseBadge(key, targetProfileId) {
   badgeCriterion1.id = undefined;
   const badgeCriterion2 = domainBuilder.buildBadgeCriterion();
   badgeCriterion2.id = undefined;
-  const badgePartnerCompetence1 = domainBuilder.buildBadgePartnerCompetence({ color: 'someColor' });
+  const badgePartnerCompetence1 = domainBuilder.buildBadgePartnerCompetence();
   badgePartnerCompetence1.id = undefined;
   const badgePartnerCompetence2 = domainBuilder.buildBadgePartnerCompetence();
   badgePartnerCompetence2.id = undefined;

--- a/api/tests/tooling/domain-builder/factory/build-badge-partner-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge-partner-competence.js
@@ -3,7 +3,6 @@ const BadgePartnerCompetence = require('../../../../lib/domain/models/BadgePartn
 module.exports = function buildBadgePartnerCompetence({
   id = 1,
   name = 'name',
-  color = null,
   skillIds = [
     'recABC',
     'recDEF',
@@ -12,7 +11,6 @@ module.exports = function buildBadgePartnerCompetence({
   return new BadgePartnerCompetence({
     id,
     name,
-    color,
     skillIds,
   });
 };

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -289,13 +289,12 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             badgePartnerCompetences: [{
               id: 18,
               name: 'Yellow',
-              color: 'emerald',
               skillIds: [1, 2, 4],
             }],
             targetProfileId: targetProfile.id,
             partnerCompetenceResults: [{
               id: 18,
-              areaColor: 'emerald',
+              areaColor: null,
               areaName: undefined,
               index: undefined,
               name: 'Yellow',
@@ -421,13 +420,12 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             badgePartnerCompetences: [{
               id: 42,
               name: 'Green',
-              color: 'jaffa',
               skillIds: [1, 2, 4],
             }],
             partnerCompetenceResults: [{
               id: 42,
               name: 'Green',
-              areaColor: 'jaffa',
+              areaColor: null,
               areaName: undefined,
               testedSkillsCount: 2,
               totalSkillsCount: 3,
@@ -576,14 +574,13 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             badgePartnerCompetences: [{
               id: 42,
               name: 'Green',
-              color: 'jaffa',
               skillIds: [1, 2, 4],
             }],
             partnerCompetenceResults: [{
               id: 42,
               index: undefined,
               name: 'Green',
-              areaColor: 'jaffa',
+              areaColor: null,
               areaName: undefined,
               totalSkillsCount: 3,
               testedSkillsCount: 2,
@@ -611,7 +608,6 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
               domainBuilder.buildBadgePartnerCompetence({
                 id: 48,
                 name: 'Yellow',
-                color: 'emerald',
                 skillIds: [2],
               }),
             ],
@@ -620,7 +616,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
               index: undefined,
               name: 'Yellow',
               areaName: undefined,
-              areaColor: 'emerald',
+              areaColor: null,
               totalSkillsCount: 1,
               testedSkillsCount: 1,
               validatedSkillsCount: 0,

--- a/api/tests/unit/domain/read-models/participant-results/PartnerCompetenceResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/PartnerCompetenceResult_test.js
@@ -23,7 +23,6 @@ describe('Unit | Domain | Read-Models | ParticipantResults | PartnerCompetenceRe
     expect(partnerCompetenceResult).to.deep.equal({
       id: 'rec1',
       name: 'C1',
-      color: 'Couleur1',
       testedSkillsCount: 2,
       totalSkillsCount: 3,
       validatedSkillsCount: 1,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -103,7 +103,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         included: [
           {
             attributes: {
-              'area-color': 'BadgeColor',
+              'area-color': undefined,
               'mastery-percentage': 100,
               name: 'BadgeC1',
               'tested-skills-count': 1,

--- a/mon-pix/app/models/partner-competence-result.js
+++ b/mon-pix/app/models/partner-competence-result.js
@@ -3,7 +3,6 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 export default class PartnerCompetenceResult extends Model {
 
   // attributes
-  @attr('string') areaColor;
   @attr('string') name;
   @attr('number') masteryPercentage;
   @attr('number') totalSkillsCount;

--- a/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
@@ -11,7 +11,7 @@
     {{#each @partnerCompetenceResults as |partnerCompetence|}}
       <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
         <th scope="row">
-          <span class="skill-review-competence__border skill-review-competence__border--{{partnerCompetence.areaColor}}" aria-hidden="true"></span>
+          <span class="skill-review-competence__border" aria-hidden="true"></span>
           <span>{{partnerCompetence.name}}</span>
         </th>
         <td>
@@ -21,7 +21,7 @@
         </td>
       </tr>
     {{/each}}
-    {{else}}
+  {{else}}
     {{#each @competenceResults as |competence|}}
       <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
         <th scope="row">


### PR DESCRIPTION
## :unicorn: Problème
La colonne `color` de la table BadgePartnerCompetences n'est utilisé que dans le cas du badge CléA Numérique.

## :robot: Solution
- supprimer cette colonne de la DB
- supprimer l'utilisation de cette donnée côté api, admin et app
- lors de l'affichage des compétences associées au CléA Numérique en fin de campagne:  utiliser la couleur de base (Noir) pour les puces de résultats

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Passer la campagne qui permet de gagner un badge CléA (QWERTY789)
- Vérifier que les compétences affichées en fin de campagne ont bien une puce noire
