### PR TITLE
[FEATURE] Annuler une certification (PIX-2572)

### DIFF
--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -36,4 +36,24 @@ export default class Certification extends ApplicationAdapter {
     }
     return hash;
   }
+
+  buildURL(
+    modelName,
+    id,
+    snapshot,
+    requestType,
+    query,
+  ) {
+    if (requestType === 'cancel') {
+      return `${this.host}/${this.namespace}/admin/certification-courses/${id}/cancel`;
+    } else {
+      return super.buildURL(
+        modelName,
+        id,
+        snapshot,
+        requestType,
+        query,
+      );
+    }
+  }
 }

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -62,6 +62,11 @@ export default class CertificationInformationsController extends Controller {
     return Boolean(this.certification.certificationIssueReports.filter((issueReport) => !issueReport.isActionRequired).length);
   }
 
+  @computed('certification.status')
+  get isCertificationCancelled() {
+    return this.certification.status === 'cancelled';
+  }
+
   @action
   onEdit() {
     this.edition = true;
@@ -176,6 +181,27 @@ export default class CertificationInformationsController extends Controller {
   @action
   onUpdateCertificationBirthdate(selectedDates, lastSelectedDateFormatted) {
     this.certification.birthdate = lastSelectedDateFormatted;
+  }
+
+  @action
+  onCancelCourseButtonClick() {
+    const confirmMessage = 'Êtes vous sur de vouloir annuler cette certification ? Cliquer sur confirmer pour poursuivre';
+
+    this.confirmAction = 'onCancelCourseConfirmation';
+    this.confirmMessage = confirmMessage;
+    this.displayConfirm = true;
+  }
+
+  @action
+  async onCancelCourseConfirmation() {
+
+    try {
+      await this.certification.cancel();
+    } catch (error) {
+      this.notifications.error('Une erreur est survenue.');
+    }
+
+    this.displayConfirm = false;
   }
 
   // Private methods

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -1,7 +1,9 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes */
 
+import { set } from '@ember/object';
 import { computed } from '@ember/object';
 import Model, { attr, hasMany } from '@ember-data/model';
+import { memberAction } from 'ember-api-actions';
 
 export const ACQUIRED = 'acquired';
 export const REJECTED = 'rejected';
@@ -101,4 +103,13 @@ export default class Certification extends Model {
   get pixPlusDroitExpertCertificationStatusLabel() {
     return partnerCertificationStatusToDisplayName[this.pixPlusDroitExpertCertificationStatus];
   }
+
+  cancel = memberAction({
+    type: 'post',
+    urlType: 'cancel',
+
+    after() {
+      set(this, 'status', 'cancelled');
+    },
+  });
 }

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -1,6 +1,14 @@
 .certification-informations {
   padding: 20px;
 
+  .buttons-row {
+  display: flex;
+  justify-content: flex-end;
+      .cancel-btn {
+        margin-bottom: 20px;
+      }
+  }
+
   .card {
     margin-bottom: 20px;
   }

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -1,5 +1,15 @@
 {{!-- template-lint-disable no-action --}}
 <div class="certification-informations">
+  <div class="buttons-row">
+    <PixButton
+      class="form-action cancel-btn"
+      @backgroundColor="red"
+      @isDisabled={{this.isCertificationCancelled}}
+      @border="squircle-small"
+      @triggerAction={{this.onCancelCourseButtonClick}}>
+      Annuler la certification
+      </PixButton>
+  </div>
   <div class="row">
     <div class="col">
       <div class="card">

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -14507,9 +14507,9 @@
           }
         },
         "ember-cli-htmlbars": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.4.1.tgz",
-          "integrity": "sha512-ESXk6lJDK4ua71b8/d8FFK9qKd4Bfdi0hNyNSJ/Z6g8ZgO2SwZ7NMHfzgMRgqD+E2n2TGXA6xk0qLTDxbqq51w==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
+          "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
           "dev": true,
           "requires": {
             "@ember/edition-utils": "^1.2.0",
@@ -25917,12 +25917,12 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#2a24ca3a656809066a20ea7003d8ecd9a95548a3",
-      "from": "git://github.com/1024pix/pix-ui.git#v2.1.0",
+      "version": "git://github.com/1024pix/pix-ui.git#991430600802cab6b6731a43e187d4944a287d7c",
+      "from": "git://github.com/1024pix/pix-ui.git#v3.5.0",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.23.0",
-        "ember-cli-htmlbars": "^5.3.1",
+        "ember-cli-babel": "^7.23.1",
+        "ember-cli-htmlbars": "^5.6.2",
         "ember-cli-sass": "^10.0.1",
         "ember-cli-string-utils": "^1.1.0",
         "ember-click-outside": "^2.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -95,7 +95,7 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.1",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.1.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v3.5.0",
     "popper.js": "^1.16.1",
     "query-string": "^7.0.0",
     "qunit": "^2.14.0",

--- a/admin/tests/integration/components/routes/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/certification/informations_test.js
@@ -14,6 +14,44 @@ module('Integration | Component | routes/authenticated/certifications/certificat
     await createAuthenticateSession({ userId: user.id });
   });
 
+  module('When certification is not cancelled', () => {
+
+    test('the certification cancellation button is not disabled ', async function(assert) {
+      // given
+      const certification = this.server.create('certification', {
+        status: 'started',
+        competencesWithMark: [],
+      });
+
+      const cancellationButtonSelector = '.buttons-row .pix-button';
+
+      // when
+      await visit(`/certifications/${certification.id}`);
+
+      // then
+      assert.dom(cancellationButtonSelector).doesNotHaveAttribute('disabled');
+    });
+  });
+
+  module('When certification is cancelled', () => {
+
+    test('the certification cancellation button is disabled ', async function(assert) {
+      // given
+      const certification = this.server.create('certification', {
+        status: 'cancelled',
+        competencesWithMark: [],
+      });
+
+      const cancellationButtonSelector = '.buttons-row .pix-button';
+
+      // when
+      await visit(`/certifications/${certification.id}`);
+
+      // then
+      assert.dom(cancellationButtonSelector).hasAttribute('disabled');
+    });
+  });
+
   module('certification issue report container', function() {
 
     module('when there is no certification issue report', function() {

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -151,6 +151,19 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
+  module('#isCertificationCancelled', function() {
+
+    test('should return true when certification status is cancelled', (assert) => {
+      // given
+      controller.certification = EmberObject.create({
+        status: 'cancelled',
+      });
+
+      // when/then
+      assert.equal(controller.isCertificationCancelled, true);
+    });
+  });
+
   module('#certificationIssueReportsWithRequiredAction', () => {
     test('it should return certification issue reports with action required', async function(assert) {
       // given
@@ -422,6 +435,37 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         await settled();
         assert.ok(controller.edition);
       });
+    });
+  });
+
+  module('#onCancelCourseButtonClick', () => {
+    test('should enable cancel course confirm dialog', async (assert) => {
+      // when
+      await controller.onCancelCourseButtonClick();
+
+      // then
+      assert.equal(controller.confirmAction, 'onCancelCourseConfirmation');
+      assert.equal(controller.displayConfirm, true);
+      assert.equal(controller.confirmMessage, 'Êtes vous sur de vouloir annuler cette certification ? Cliquer sur confirmer pour poursuivre');
+    });
+  });
+
+  module('#onCancelCourseConfirmation', () => {
+    test('should cancel course', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification');
+      const cancel = sinon.stub().resolves();
+      certification.cancel = cancel;
+      controller.certification = certification;
+      controller.send = sinon.stub().resolves();
+
+      // when
+      await controller.onCancelCourseConfirmation();
+
+      // then
+      sinon.assert.called(certification.cancel);
+      assert.notOk(controller.displayConfirm);
     });
   });
 

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -63,4 +63,10 @@ module.exports = {
     const certifiedProfile = await certifiedProfileRepository.get(certificationCourseId);
     return certifiedProfileSerializer.serialize(certifiedProfile);
   },
+
+  async cancel(request) {
+    const certificationCourseId = request.params.id;
+    const cancelledCertificationCourse = await usecases.cancelCertificationCourse({ certificationCourseId });
+    return certificationCourseSerializer.serialize(cancelledCertificationCourse);
+  },
 };

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -112,6 +112,23 @@ exports.register = async function(server) {
         tags: ['api'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/certification-courses/{id}/cancel',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: certificationCourseController.cancel,
+        tags: ['api'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -39,7 +39,7 @@ class CertificationCourse {
     this.userId = userId;
     this.sessionId = sessionId;
     this.maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;
-    this.isCancelled = isCancelled;
+    this._isCancelled = isCancelled;
   }
 
   reportIssue(issueReport) {
@@ -63,7 +63,11 @@ class CertificationCourse {
   }
 
   cancel() {
-    this.isCancelled = true;
+    this._isCancelled = true;
+  }
+
+  isCancelled() {
+    return this._isCancelled === true;
   }
 }
 

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -61,6 +61,10 @@ class CertificationCourse {
       maxReachableLevelOnCertificationDate,
     });
   }
+
+  cancel() {
+    this.isCancelled = true;
+  }
 }
 
 module.exports = CertificationCourse;

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -39,7 +39,7 @@ async function getCertificationResultByCertifCourse({ certificationCourse }) {
     certificationIssueReports: certificationCourse.certificationIssueReports,
     hasSeenEndTestScreen: certificationCourse.hasSeenEndTestScreen,
     sessionId: certificationCourse.sessionId,
-    isCourseCancelled: certificationCourse.isCancelled,
+    isCourseCancelled: certificationCourse.isCancelled(),
   });
 }
 

--- a/api/lib/domain/usecases/cancel-certification-course.js
+++ b/api/lib/domain/usecases/cancel-certification-course.js
@@ -1,0 +1,5 @@
+module.exports = async function cancelCertificationCourse({ certificationCourseId, certificationCourseRepository }) {
+  const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
+  certificationCourse.cancel();
+  return certificationCourseRepository.update(certificationCourse);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -131,6 +131,7 @@ module.exports = injectDependencies({
   authenticateExternalUser: require('./authenticate-external-user'),
   authenticateApplicationLivretScolaire: require('./authenticate-application-livret-scolaire'),
   beginCampaignParticipationImprovement: require('./begin-campaign-participation-improvement'),
+  cancelCertificationCourse: require('./cancel-certification-course'),
   completeAssessment: require('./complete-assessment'),
   computeCampaignAnalysis: require('./compute-campaign-analysis'),
   computeCampaignCollectiveResult: require('./compute-campaign-collective-result'),

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -108,7 +108,7 @@ module.exports = {
         qb.whereIn('certification-candidates.id', candidateIds);
       })
       .fetchAll();
-    return bookshelfToDomainConverter.buildDomainObjects(CertificationCourseBookshelf, bookshelfCertificationCourses);
+    return bookshelfCertificationCourses.map(_toDomain);
   },
 
   async findBySessionIdAndUserIds({ sessionId, userIds }) {
@@ -116,7 +116,8 @@ module.exports = {
       .where({ sessionId })
       .where('userId', 'in', userIds)
       .fetchAll();
-    return bookshelfToDomainConverter.buildDomainObjects(CertificationCourseBookshelf, bookshelfCertificationCourses);
+
+    return bookshelfCertificationCourses.map(_toDomain);
   },
 };
 
@@ -145,15 +146,24 @@ function _toDomain(bookshelfCertificationCourse) {
       'isPublished',
       'isV2Certification',
       'hasSeenEndTestScreen',
+      'isCancelled',
+      'maxReachableLevelOnCertificationDate',
+      'verificationCode',
     ]),
   });
 }
 
 function _adaptModelToDb(certificationCourse) {
-  return _.omit(certificationCourse, [
+
+  const dto = _.omit(certificationCourse, [
     'certificationIssueReports',
     'assessment',
     'challenges',
     'createdAt',
+    '_isCancelled',
   ]);
+
+  dto.isCancelled = certificationCourse.isCancelled();
+
+  return dto;
 }

--- a/api/lib/infrastructure/serializers/jsonapi/certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-serializer.js
@@ -5,6 +5,7 @@ const { Serializer, Deserializer } = require('jsonapi-serializer');
 const { WrongDateFormatError } = require('../../../domain/errors');
 const { NO_EXAMINER_COMMENT } = require('../../../domain/models/CertificationReport');
 const { isValidDate } = require('../../utils/date-utils');
+const CertificationCourse = require('../../../domain/models/CertificationCourse');
 
 module.exports = {
 
@@ -26,17 +27,19 @@ module.exports = {
 
     return new Deserializer({ keyForAttribute: 'camelCase' })
       .deserialize(json)
-      .then(((certifications) => {
+      .then(((certification) => {
         if (birthdate) {
           if (!isValidDate(birthdate, 'YYYY-MM-DD')) {
             return Promise.reject(new WrongDateFormatError());
           }
         }
 
-        if (!_isOmitted(certifications.examinerComment) && _hasNoExaminerComment(certifications.examinerComment)) {
-          certifications.examinerComment = NO_EXAMINER_COMMENT;
+        const certificationDomainModel = new CertificationCourse(certification);
+
+        if (!_isOmitted(certification.examinerComment) && _hasNoExaminerComment(certification.examinerComment)) {
+          certificationDomainModel.examinerComment = NO_EXAMINER_COMMENT;
         }
-        return certifications;
+        return certificationDomainModel;
       }));
   },
 };

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -701,4 +701,26 @@ describe('Acceptance | API | Certification Course', () => {
     });
 
   });
+
+  describe('POST /api/admin/certification-courses/{id}/cancel', () => {
+
+    it('should respond with a 200', async () => {
+      // given
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
+      const options = {
+        method: 'POST',
+        url: `/api/admin/certification-courses/${certificationCourse.id}/cancel`,
+        headers: {},
+      };
+      await databaseBuilder.commit();
+      const userPixMaster = await insertUserWithRolePixMaster();
+      options.headers.authorization = generateValidRequestAuthorizationHeader(userPixMaster.id);
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -392,8 +392,8 @@ describe('Integration | Repository | Certification Course', function() {
 
       // then
       expect(certificationCourses).to.have.lengthOf(2);
-      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(firstCertifCourse));
-      expect(_cleanCertificationCourse(certificationCourses[1])).to.deep.equal(_cleanCertificationCourse(secondCertifCourse));
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(new CertificationCourse(firstCertifCourse)));
+      expect(_cleanCertificationCourse(certificationCourses[1])).to.deep.equal(_cleanCertificationCourse(new CertificationCourse(secondCertifCourse)));
     });
 
     it('should return empty array when no certification course found', async () => {
@@ -425,7 +425,7 @@ describe('Integration | Repository | Certification Course', function() {
 
       // then
       expect(certificationCourses).to.have.lengthOf(1);
-      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(firstCertifCourse));
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(new CertificationCourse(firstCertifCourse)));
     });
   });
 
@@ -455,7 +455,7 @@ describe('Integration | Repository | Certification Course', function() {
       // then
       expect(certificationCourses).to.have.lengthOf(1);
       expect(certificationCourses[0]).to.be.an.instanceof(CertificationCourse);
-      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(certifCourse));
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(new CertificationCourse(certifCourse)));
     });
 
     it('returns only the certification course that is linked to the candidate\'s session', async () => {
@@ -474,7 +474,7 @@ describe('Integration | Repository | Certification Course', function() {
       const certificationCourses = await certificationCourseRepository.findCertificationCoursesByCandidateIds({ candidateIds: [certificationCandidateId] });
       // then
       expect(certificationCourses).to.have.lengthOf(1);
-      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(certifCourse));
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(new CertificationCourse(certifCourse)));
     });
 
     it('returns only the certification course that is linked to the candidate\'s user', async () => {
@@ -493,7 +493,7 @@ describe('Integration | Repository | Certification Course', function() {
       const certificationCourses = await certificationCourseRepository.findCertificationCoursesByCandidateIds({ candidateIds: [certificationCandidateId] });
       // then
       expect(certificationCourses).to.have.lengthOf(1);
-      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(certifCourse));
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(new CertificationCourse(certifCourse)));
     });
   });
 });

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -485,4 +485,50 @@ describe('Unit | Controller | certification-course-controller', () => {
       });
     });
   });
+
+  describe('#cancelCertificationCourse', () => {
+
+    it('should cancel certification course', async () => {
+      // given
+      sinon.stub(usecases, 'cancelCertificationCourse');
+      const certificationCourseId = 1234;
+      const request = {
+        params: {
+          id: certificationCourseId,
+        },
+      };
+      const cancelledCertificationCourse = domainBuilder.buildCertificationCourse({
+        id: certificationCourseId,
+        isCancelled: true,
+      });
+      usecases.cancelCertificationCourse
+        .withArgs({ certificationCourseId })
+        .resolves(cancelledCertificationCourse);
+
+      // when
+      const response = await certificationCourseController.cancel(request, hFake);
+
+      // then
+      expect(response).to.deep.equal({
+        data: {
+          attributes: {
+            'examiner-comment': 'A cassé le clavier',
+            'first-name': 'Gandhi',
+            'has-seen-end-test-screen': false,
+            'last-name': 'Matmatah',
+            'nb-challenges': 0,
+          },
+          id: '1234',
+          relationships: {
+            assessment: {
+              links: {
+                related: '/api/assessments/123',
+              },
+            },
+          },
+          type: 'certification-courses',
+        },
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -115,4 +115,15 @@ describe('Unit | Application | Certifications Course | Route', function() {
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('POST /api/admin/certification-courses/{id}/cancel', () => {
+
+    it('should check pixMaster role', async () => {
+      // when
+      await httpTestServer.request('POST', '/api/admin/certification-courses/1/cancel');
+
+      // then
+      expect(securityPreHandlers.checkUserHasRolePixMaster).to.have.been.called;
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/unit/domain/models/CertificationCourse_test.js
@@ -1,0 +1,36 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | CertificationCourse', () => {
+
+  describe('#cancel', () => {
+
+    it('should cancel a certification course', () => {
+      // given
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        isCancelled: false,
+      });
+
+      // when
+      certificationCourse.cancel();
+
+      // then
+      expect(certificationCourse.isCancelled).to.be.true;
+    });
+
+    describe('when certification course is already cancelled', () => {
+      it('should not change isCancelled value', () => {
+        // given
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          isCancelled: false,
+        });
+
+        // when
+        certificationCourse.cancel();
+        certificationCourse.cancel();
+
+        // then
+        expect(certificationCourse.isCancelled).to.be.true;
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/unit/domain/models/CertificationCourse_test.js
@@ -2,7 +2,7 @@ const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | CertificationCourse', () => {
 
-  describe('#cancel', () => {
+  describe('#cancel #isCancelled', () => {
 
     it('should cancel a certification course', () => {
       // given
@@ -14,7 +14,7 @@ describe('Unit | Domain | Models | CertificationCourse', () => {
       certificationCourse.cancel();
 
       // then
-      expect(certificationCourse.isCancelled).to.be.true;
+      expect(certificationCourse.isCancelled()).to.be.true;
     });
 
     describe('when certification course is already cancelled', () => {
@@ -29,7 +29,7 @@ describe('Unit | Domain | Models | CertificationCourse', () => {
         certificationCourse.cancel();
 
         // then
-        expect(certificationCourse.isCancelled).to.be.true;
+        expect(certificationCourse.isCancelled()).to.be.true;
       });
     });
   });

--- a/api/tests/unit/domain/usecases/cancel-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/cancel-certification-course_test.js
@@ -23,7 +23,7 @@ describe('Unit | UseCase | cancel-certification-course', () => {
     });
 
     // then
-    expect(actualCertificationCourse.isCancelled).to.be.true;
+    expect(actualCertificationCourse.isCancelled()).to.be.true;
     expect(certificationCourseRepository.update).to.have.been.calledWith(certificationCourse);
   });
 
@@ -52,6 +52,6 @@ describe('Unit | UseCase | cancel-certification-course', () => {
     });
 
     // then
-    expect(actualCertificationCourse.isCancelled).to.be.true;
+    expect(actualCertificationCourse.isCancelled()).to.be.true;
   });
 });

--- a/api/tests/unit/domain/usecases/cancel-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/cancel-certification-course_test.js
@@ -1,0 +1,57 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const cancelCertificationCourse = require('../../../../lib/domain/usecases/cancel-certification-course');
+
+describe('Unit | UseCase | cancel-certification-course', () => {
+
+  it('should update certification course cancelled status', async () => {
+    // given
+    const certificationCourse = domainBuilder.buildCertificationCourse({ id: 123, isCancelled: false });
+    const cancelledCertificationCourse = domainBuilder.buildCertificationCourse({ id: 123, isCancelled: true });
+
+    const certificationCourseRepository = {
+      update: sinon.stub(),
+      get: sinon.stub(),
+    };
+
+    certificationCourseRepository.get.withArgs(123).resolves(certificationCourse);
+    certificationCourseRepository.update.resolves(cancelledCertificationCourse);
+
+    // when
+    const actualCertificationCourse = await cancelCertificationCourse({
+      certificationCourseId: 123,
+      certificationCourseRepository,
+    });
+
+    // then
+    expect(actualCertificationCourse.isCancelled).to.be.true;
+    expect(certificationCourseRepository.update).to.have.been.calledWith(certificationCourse);
+  });
+
+  it('should not cancel an already cancelled certification course', async () => {
+    // given
+    const certificationCourse = domainBuilder.buildCertificationCourse({ id: 123, isCancelled: false });
+    const cancelledCertificationCourse = domainBuilder.buildCertificationCourse({ id: 123, isCancelled: true });
+
+    const certificationCourseRepository = {
+      update: sinon.stub(),
+      get: sinon.stub(),
+    };
+
+    certificationCourseRepository.get.withArgs(123).resolves(certificationCourse);
+    certificationCourseRepository.update.resolves(cancelledCertificationCourse);
+
+    // when
+    await cancelCertificationCourse({
+      certificationCourseId: 123,
+      certificationCourseRepository,
+    });
+
+    const actualCertificationCourse = await cancelCertificationCourse({
+      certificationCourseId: 123,
+      certificationCourseRepository,
+    });
+
+    // then
+    expect(actualCertificationCourse.isCancelled).to.be.true;
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -2,6 +2,7 @@ const { expect, EMPTY_BLANK_AND_NULL } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-serializer');
 const { WrongDateFormatError } = require('../../../../../lib/domain/errors');
 const { NO_EXAMINER_COMMENT } = require('../../../../../lib/domain/models/CertificationReport');
+const CertificationCourse = require('../../../../../lib/domain/models/CertificationCourse');
 
 describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
 
@@ -26,7 +27,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
         },
       };
 
-      certificationCourseObject = {
+      certificationCourseObject = new CertificationCourse({
         id: 1,
         firstName: 'Freezer',
         lastName: 'The all mighty',
@@ -35,7 +36,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
         deliveredAt: '2020-10-24',
         externalId: 'xenoverse2',
         examinerComment: 'Un signalement surveillant',
-      };
+      });
     });
 
     it('should convert a JSON API data into a Certification Course object', async function() {


### PR DESCRIPTION
## :unicorn: Problème
En tant que membre du pôle certification, on souhaite pouvoir annuler une certification depuis l'interface de Pix Admin. 

## :robot: Solution
Ajouter un bouton "Annuler la certification" sur l'onglet Informations de la page Certifications. 

## :100: Pour tester
- Se connecter avec un compte Pix Master sur Pix Admin. 
- Se rendre sur le détail d'une Certification puis sur l'onglet Informations.
- Constater la présence d'un bouton "Annuler la certification" et le statut de certification différent d'Annulé.
- Cliquer sur le bouton Annuler puis confirmer l'annulation. 
- Constater le statut Annulé et la désactivation du bouton Annuler.
