### PR TITLE
[FEATURE] Ajout de la traduction anglaise du bouton repasser une campagne (PIX-2598)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -874,8 +874,8 @@
       "explanation": "You already submitted the profile below to the organisation {organization}'<br>'on {date} at {hour,time,hhmm}",
       "first-title": "There was a problem",
       "retry": {
-        "message": "{organization} encourages you to resend your profile in order to measure your progress.",
-        "button": "Resend my profile"
+        "message": "{organization} encourages you to resubmit your profile to measure your progress.",
+        "button": "Resubmit my profile"
       }
     },
     "proposals": {


### PR DESCRIPTION
## :unicorn: Problème

Le bouton repasser une campagne et le message associés sont mal traduit en anglais

## :robot: Solution

Ajouter la traduction du bouton repasser une campagne.

## :rainbow: Remarques
n/a

## :100: Pour tester
repasser une campagne
