### PR TITLE
[TECH] Retourner un code HTTP 422 lorsque le YAML n'est pas valide

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -312,6 +312,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
 
+  if (error instanceof DomainErrors.YamlParsingError) {
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -801,6 +801,12 @@ class UnexpectedPoleEmploiStateError extends DomainError {
   }
 }
 
+class YamlParsingError extends DomainError {
+  constructor(message = 'Une erreur s\'est produite lors de l\'interprétation des réponses.') {
+    super(message);
+  }
+}
+
 module.exports = {
   AlreadyExistingEntityError,
   AlreadyExistingCampaignParticipationError,
@@ -910,4 +916,5 @@ module.exports = {
   UserOrgaSettingsCreationError,
   UserShouldChangePasswordError,
   WrongDateFormatError,
+  YamlParsingError,
 };

--- a/api/lib/domain/services/solution-service-qrocm-dep.js
+++ b/api/lib/domain/services/solution-service-qrocm-dep.js
@@ -3,6 +3,7 @@ const _ = require('../../infrastructure/utils/lodash-utils');
 const utils = require('./solution-service-utils');
 const deactivationsService = require('./deactivations-service');
 const { normalizeAndRemoveAccents: t1, removeSpecialCharacters: t2, applyPreTreatments } = require('./validation-treatments');
+const { YamlParsingError } = require('../../domain/errors');
 
 const AnswerStatus = require('../models/AnswerStatus');
 
@@ -143,9 +144,14 @@ module.exports = {
     const preTreatedAnswers = applyPreTreatments(yamlAnswer);
 
     // Convert Yaml to JS objects
-    const answers = jsYaml.safeLoad(preTreatedAnswers, { schema: jsYaml.FAILSAFE_SCHEMA });
-    const solutions = jsYaml.safeLoad(yamlSolution, { schema: jsYaml.FAILSAFE_SCHEMA });
-    const scoring = jsYaml.safeLoad(yamlScoring || '', { schema: jsYaml.FAILSAFE_SCHEMA });
+    let answers, solutions, scoring;
+    try {
+      answers = jsYaml.safeLoad(preTreatedAnswers, { schema: jsYaml.FAILSAFE_SCHEMA });
+      solutions = jsYaml.safeLoad(yamlSolution, { schema: jsYaml.FAILSAFE_SCHEMA });
+      scoring = jsYaml.safeLoad(yamlScoring || '', { schema: jsYaml.FAILSAFE_SCHEMA });
+    } catch (error) {
+      throw new YamlParsingError();
+    }
 
     // Treatments
     const treatedSolutions = _applyTreatmentsToSolutions(solutions, deactivations);

--- a/api/lib/domain/services/solution-service-qrocm-ind.js
+++ b/api/lib/domain/services/solution-service-qrocm-ind.js
@@ -3,6 +3,7 @@ const levenshtein = require('fast-levenshtein');
 const _ = require('../../infrastructure/utils/lodash-utils');
 const logger = require('../../infrastructure/logger');
 const { applyPreTreatments, applyTreatments } = require('./validation-treatments');
+const { YamlParsingError } = require('../../domain/errors');
 
 const AnswerStatus = require('../models/AnswerStatus');
 
@@ -77,8 +78,14 @@ module.exports = {
     const preTreatedSolutions = applyPreTreatments(yamlSolution);
 
     // Convert YAML to JSObject
-    const answers = jsYaml.safeLoad(preTreatedAnswers, { schema: jsYaml.FAILSAFE_SCHEMA });
-    const solutions = jsYaml.safeLoad(preTreatedSolutions, { schema: jsYaml.FAILSAFE_SCHEMA });
+    let answers, solutions;
+
+    try {
+      answers = jsYaml.safeLoad(preTreatedAnswers, { schema: jsYaml.FAILSAFE_SCHEMA });
+      solutions = jsYaml.safeLoad(preTreatedSolutions, { schema: jsYaml.FAILSAFE_SCHEMA });
+    } catch (error) {
+      throw new YamlParsingError();
+    }
 
     // Treatments
     const treatedSolutions = _applyTreatmentsToSolutions(solutions, enabledTreatments);

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -1,7 +1,9 @@
-const { expect } = require('../../../test-helper');
+const { expect, catchErr } = require('../../../test-helper');
 
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const service = require('../../../../lib/domain/services/solution-service-qrocm-dep');
+
+const { YamlParsingError } = require('../../../../lib/domain/errors');
 
 const ANSWER_PARTIALLY = AnswerStatus.PARTIALLY;
 const ANSWER_OK = AnswerStatus.OK;
@@ -216,6 +218,17 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
   });
 
   describe('match, strong focus on treatments', function() {
+
+    it('when yaml is not valid, should throw an error', async function() {
+      const answer = 'lecteur: [ a\nnum2: efgh';
+      const solution = 'lecteur:\n- G\n- Perso G\n\nnum2:\n- Eureka\n';
+      const enabledTreatments = ['t1', 't2', 't3'];
+
+      const error = await catchErr(service.match)(answer, solution, enabledTreatments);
+
+      expect(error).to.be.an.instanceOf(YamlParsingError);
+      expect(error.message).to.equal('Une erreur s\'est produite lors de l\'interprétation des réponses.');
+    });
 
     const allCases = [
       {

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -1,7 +1,8 @@
-const { expect } = require('../../../test-helper');
+const { expect, catchErr } = require('../../../test-helper');
 
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const service = require('../../../../lib/domain/services/solution-service-qrocm-ind');
+const { YamlParsingError } = require('../../../../lib/domain/errors');
 
 const ANSWER_OK = AnswerStatus.OK;
 const ANSWER_KO = AnswerStatus.KO;
@@ -290,6 +291,17 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
   });
 
   describe('match, strong focus on treatments', function() {
+
+    it('when yaml is not valid, should throw an error', async function() {
+      const answer = 'lecteur: [ a';
+      const solution = 'lecteur:\n- G\n- Perso G\n\ndossier1:\n- Eureka\n\ndossier2:\n- Concept\n\nnom:\n- Logo\n\next:\n- gif';
+      const enabledTreatments = ['t1', 't2', 't3'];
+
+      const error = await catchErr(service.match)(answer, solution, enabledTreatments);
+
+      expect(error).to.be.an.instanceOf(YamlParsingError);
+      expect(error.message).to.equal('Une erreur s\'est produite lors de l\'interprétation des réponses.');
+    });
 
     const allCases = [
       {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le YAML n'est pas valide sur /api/answers, une erreur avec le code http 500 "Internal Server Error" et le message "An internal server error occurred" est retourné.
Or, il s'agit de la donnée fournie à /api/answers qui est mal formée. On s'attendrait plutôt à une erreur 4XX.

## :robot: Solution
Lorsqu'une erreur de parsing Yaml survient, retourner une erreur 422 "Unprocessable entity" avec le message "Une erreur s'est produite lors de l'interprétation des réponses.".

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que le code retour est 422 :

curl 'https://app-pr3018.review.pix.fr/api/answers' \
-X 'POST' \
-H 'Content-Type: application/vnd.api+json' -H 'Authorization: **[insérer-token]**' \
--data-binary '{"data":{"attributes":{"value":"lecteur: [ a","result":null,"result-details":null,"timeout":null},"relationships":{"assessment":{"data":{"type":"assessments","id":**[insérer-id]**}},"challenge":{"data":{"type":"challenges","id":"recEJPSRl1o7tlifw"}}},"type":"answers"}}'
