### PR TITLE
[SCRIPT] Ecriture d'un script pour annuler massivement des certifications (PIX-2583)

### DIFF
--- a/api/scripts/prod/cancel-certifications-and-publish-sessions.js
+++ b/api/scripts/prod/cancel-certifications-and-publish-sessions.js
@@ -1,0 +1,198 @@
+const _ = require('lodash');
+const yargs = require('yargs');
+const unpublishSession = require('../../lib/domain/usecases/unpublish-session');
+const publishSession = require('../../lib/domain/usecases/publish-session');
+const finalizedSessionRepository = require('../../lib/infrastructure/repositories/finalized-session-repository');
+const sessionRepository = require('../../lib/infrastructure/repositories/session-repository');
+const certificationRepository = require('../../lib/infrastructure/repositories/certification-repository');
+const sessionPublicationService = require('../../lib/domain/services/session-publication-service');
+const { parseCsvWithHeader } = require('../helpers/csvHelpers');
+const { knex } = require('../../db/knex-database-connection');
+
+let progression = 0;
+function _logProgression(totalCount) {
+  ++progression;
+  process.stdout.cursorTo(0);
+  process.stdout.write(`${Math.round(progression * 100 / totalCount, 2)} %`);
+}
+
+function _resetProgression() {
+  progression = 0;
+}
+
+async function main() {
+  try {
+    const commandLineArgs = yargs
+      .option('file', {
+        description: 'fichier csv contenant les données de certification à annuler.',
+        type: 'string',
+      })
+      .help()
+      .argv;
+    const { file } = _validateArgs(commandLineArgs);
+    await _do({ file });
+  } catch (error) {
+    console.error('\x1b[31mErreur : %s\x1b[0m', error.message);
+    yargs.showHelp();
+    process.exit(1);
+  }
+}
+
+function _validateArgs({
+  file,
+}) {
+  if (!_.isString(file)) {
+    throw new Error(`Argument "file" ${file} doit être une chaîne vers un fichier existant.`);
+  }
+
+  return { file };
+}
+
+async function _do({ file }) {
+  const trx = await knex.transaction();
+  let certificationsToCancelBySession;
+  try {
+    certificationsToCancelBySession = await _parseFile(file, trx);
+
+    const certificationIdsToCancel = [];
+    for (const certificationIdsOfSession of Object.values(certificationsToCancelBySession)) {
+      certificationIdsToCancel.push(...certificationIdsOfSession);
+    }
+    await _cancelCertifications(certificationIdsToCancel, trx);
+    await trx.commit();
+  } catch (err) {
+    await trx.rollback();
+    throw err;
+  }
+
+  const sessionIdsToPublish = _.map(Object.keys(certificationsToCancelBySession), (sessionIdStr) => parseInt(sessionIdStr));
+  await _publishSessions(sessionIdsToPublish);
+}
+
+async function _parseFile(file, trx) {
+  console.log(`\tParsing file ${file}...`);
+  const parsedCsv = await parseCsvWithHeader(file);
+  const certificationsToCancelBySession = {};
+  for (const line of parsedCsv) {
+    const { sessionId, certificationIds } = await _parseLine(line, trx);
+    if (!certificationsToCancelBySession[sessionId]) {
+      certificationsToCancelBySession[sessionId] = [];
+    }
+    certificationsToCancelBySession[sessionId].push(...certificationIds);
+  }
+
+  console.log('\tDone !');
+  return certificationsToCancelBySession;
+}
+
+async function _parseLine(line, trx) {
+  const sessionId = _parseSessionId(line);
+  const certificationIds = await _parseCertifications(line, sessionId, trx);
+  if (certificationIds.length === 0) {
+    throw new Error(`No certifications indicated for session ${sessionId}`);
+  }
+  return { sessionId, certificationIds };
+}
+
+function _parseSessionId(line) {
+  const COL_NAME_SESSION_ID = 'session_id';
+  const sessionIdValue = line[COL_NAME_SESSION_ID];
+  if (!sessionIdValue || _.isNaN(sessionIdValue)) {
+    throw new Error(`Invalid session id ${sessionIdValue}`);
+  }
+  return _.toNumber(sessionIdValue);
+}
+
+async function _parseCertifications(line, sessionId, trx) {
+  const COL_NAME_CERTIFICATIONS = 'certifications';
+  const certificationsValue = line[COL_NAME_CERTIFICATIONS];
+  if (certificationsValue === 'tout annuler') {
+    return _findAllCertificationIdsOfSession(sessionId, trx);
+  }
+  const certificationIdValues = certificationsValue.split(', ');
+  const certificationIds = [];
+  for (const certificationIdValue of certificationIdValues) {
+    if (!_.isInteger(parseInt(certificationIdValue))) {
+      throw new Error(`Invalid certification ID ${certificationIdValue} for session ${sessionId}`);
+    }
+    certificationIds.push(parseInt(certificationIdValue));
+  }
+  return certificationIds;
+}
+
+async function _findAllCertificationIdsOfSession(sessionId, trx) {
+  const results = await trx
+    .select('certification-courses.id')
+    .from('certification-courses')
+    .where({ sessionId });
+
+  return _.map(results, 'id');
+}
+
+async function _cancelCertifications(certificationIdsToCancel, trx) {
+  console.log(`\tCancelling ${certificationIdsToCancel.length} certifications...`);
+  const cancelledCertificationIds = await trx('certification-courses')
+    .whereIn('id', certificationIdsToCancel)
+    .update({ isCancelled: true, updatedAt: new Date() })
+    .returning('id');
+
+  const notUpdatedCertificationIds = _.difference(certificationIdsToCancel, cancelledCertificationIds);
+  if (notUpdatedCertificationIds.length > 0) {
+    throw new Error(`Some certifications do not exist or were already cancelled : ${notUpdatedCertificationIds.join(', ')}`);
+  }
+  console.log('\tDone !');
+}
+
+async function _publishSessions(sessionIdsToPublish) {
+  const alreadyPublishedSessionIds = await _findAlreadyPublishedSessions(sessionIdsToPublish);
+  console.log(`\tUnpublishing ${alreadyPublishedSessionIds.length} sessions...`);
+  for (const alreadyPublishedSessionId of alreadyPublishedSessionIds) {
+    await unpublishSession({
+      sessionId: alreadyPublishedSessionId,
+      certificationRepository,
+      finalizedSessionRepository,
+      sessionRepository,
+    });
+    _logProgression(alreadyPublishedSessionIds.length);
+  }
+  console.log('\tDone !');
+  _resetProgression();
+  console.log(`\tPublishing ${sessionIdsToPublish.length} sessions...`);
+  for (const sessionId of sessionIdsToPublish) {
+    try {
+      await publishSession({
+        sessionId,
+        certificationRepository,
+        finalizedSessionRepository,
+        sessionRepository,
+        sessionPublicationService,
+      });
+    } catch (err) {
+      console.log(`\nError when trying to publish session ${sessionId}`);
+      throw err;
+    }
+    _logProgression(sessionIdsToPublish.length);
+  }
+  console.log('\tDone !');
+  throw new Error('coucou');
+}
+
+async function _findAlreadyPublishedSessions(sessionIdsToPublish) {
+  const results = await knex
+    .select('id')
+    .from('sessions')
+    .whereNotNull('publishedAt')
+    .whereIn('id', sessionIdsToPublish);
+
+  return _.map(results, 'id');
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}


### PR DESCRIPTION
## :unicorn: Problème
L'Epix permettant d'offrir au pôle certif la possibilité de pouvoir annuler une certification en cours. En attendant, ces dernières semaines, nous avons malheureusement rencontré pas mal de soucis en prod. Pendant ces soucis, des sessions de certification sont parfois en cours. Et souvent, il est recommandé de dire aux centres de certification d'annuler carrément la session de certification si le problème dure "longtemps".

Donc, le pôle certif a recueilli la liste des certifications à passer en "Annulée" dans un fichier CSV.

## :robot: Solution
Ecrire un script qui prend en entrée un fichier CSV (fichier transmis dans le ticket Jira correspondant).
Description du fichier :
- Fichier CSV
- Seules deux colonnes nous intéressent : celle contenant l'id de la session et celle contenant l'indication de quelles certifications il faut annuler.
- La colonne contenant l'id de la session ne doit contenir qu'un ID
- La colonne contenant les certifications peut contenir plusieurs valeurs : "tout annuler" pour signifier d'annuler toutes les certifications de la session, un ID seul lorsqu'il s'agit d'un seul ID (duh), ou bien une liste d'IDs séparés par des virgules + espace
- Une session peut être mentionnée plusieurs fois dans le fichier (plusieurs lignes pour une seule session) auquel cas il faut "merger" les données.

Aussi, lorsque l'annulation est effectuée, il faut déclencher le flux de publication de ces sessions. Si une session était déjà publiée, il faut procéder à sa dé-publication / re-publication.

## :rainbow: Remarques
Une transaction entoure les opérations de parsing CSV + annulation des certifications.
En revanche, les opérations de publication / dé-publication ne sont pas dans la transaction (car ça faisait bcp de modifs + impact pas gênant à mon sens).

## :100: Pour tester
- Se procurer un fichier CSV qui ressemble à celui du ticket (idéalement avec des valeurs avalables par la BDD locale ou de la RA)
- Lancer le script en passant le fichier en argument
- Voir que tout se passe bien
