### PR TITLE
[TECH] POC d'intégration de chart.js dans Pix-ORGA (PIX-2544)

### DIFF
--- a/orga/app/components/charts/chart.hbs
+++ b/orga/app/components/charts/chart.hbs
@@ -1,0 +1,8 @@
+<canvas
+  width={{@width}}
+  height={{@height}}
+  {{did-insert this.drawChart}}
+  {{did-update this.updateChart @data @options}}
+  ...attributes
+>
+</canvas>

--- a/orga/app/components/charts/chart.js
+++ b/orga/app/components/charts/chart.js
@@ -1,0 +1,45 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+export default class EmberChart extends Component {
+
+  constructor() {
+    super(...arguments);
+
+    this.plugins = this.plugins || [];
+  }
+
+  @action
+  drawChart(element) {
+    const { data, type, options, plugins } = this.args;
+    const chart = new Chart(element, { type, data, options, plugins });
+    this.chart = chart;
+  }
+
+  @action
+  updateChart() {
+    const { chart, animate } = this.chart;
+    const { data, options } = this.args;
+
+    if (chart) {
+      chart.data = data;
+      chart.options = options;
+      if (animate) {
+        chart.update();
+      } else {
+        chart.update(0);
+      }
+
+      if (this.customLegendElement) {
+        this.customLegendElement.innerHTML = chart.generateLegend();
+      }
+    }
+  }
+
+  willDestroy() {
+    this.chart.destroy();
+    super.willDestroy();
+  }
+}

--- a/orga/app/components/charts/test.hbs
+++ b/orga/app/components/charts/test.hbs
@@ -1,0 +1,9 @@
+<Charts::Card @title="Mon beau graphique">
+  <Charts::Chart
+    @type="scatter"
+    @options={{this.options}}
+    @data={{this.data}}
+    aria-label="Hello ARIA World"
+    role="img"
+  />
+</Charts::Card>

--- a/orga/app/components/charts/test.js
+++ b/orga/app/components/charts/test.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+
+export default class TestChart extends Component {
+  get data() {
+    return {
+      labels: ['January', 'February', 'March', 'April'],
+      datasets: [
+        {
+          type: 'line',
+          label: 'line 1 Dataset',
+          data: [10, 20, 30, 40],
+          borderColor: 'rgb(99, 255, 132)',
+          backgroundColor: 'rgba(99, 255, 132, 0.5)',
+          fill: 'origin',
+        },
+        {
+          type: 'line',
+          label: 'Line 2 Dataset',
+          data: [20, 30, 50, 40],
+          borderColor: 'rgb(255, 99, 132)',
+          backgroundColor: 'rgba(255, 99, 132, 0.5)',
+          fill: '0',
+        },
+      ],
+    };
+  }
+
+  get options() {
+    return {
+      plugins: {
+        legend: {
+          position: 'bottom',
+        },
+      },
+    };
+  }
+}

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -36,6 +36,7 @@ Router.map(function() {
       });
       this.route('new', { path: '/creation' });
     });
+    this.route('charts');
     this.route('campaigns', { path: '/campagnes' }, function() {
       this.route('list', { path: '/' });
       this.route('new', { path: '/creation' });

--- a/orga/app/templates/authenticated/charts.hbs
+++ b/orga/app/templates/authenticated/charts.hbs
@@ -1,0 +1,1 @@
+<Charts::Test />

--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -29,6 +29,11 @@ module.exports = function(defaults) {
   // modules that you would like to import into your application
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
+  app.import('node_modules/chart.js/dist/chart.js', {
+    using: [
+      { transformation: 'amd', as: 'chart.js' },
+    ],
+  });
 
   return app.toTree();
 };

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -10960,6 +10960,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "chart.js": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.2.1.tgz",
+      "integrity": "sha512-XsNDf3854RGZkLCt+5vWAXGAtUdKP2nhfikLGZqud6G4CvRE2ts64TIxTTfspOin2kEZvPgomE29E6oU02dYjQ=="
+    },
     "chokidar": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
@@ -22113,6 +22118,7 @@
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -24268,7 +24274,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
@@ -24505,7 +24512,8 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -27800,7 +27808,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -29059,6 +29068,7 @@
       "version": "3.13.5",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.5.tgz",
       "integrity": "sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==",
+      "dev": true,
       "optional": true
     },
     "unbox-primitive": {
@@ -29826,7 +29836,8 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -95,5 +95,7 @@
     "qunit-dom": "^1.6.0",
     "sass": "^1.32.8"
   },
-  "dependencies": {}
+  "dependencies": {
+    "chart.js": "^3.2.1"
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème

Nous n'avons pas de librairie pour la création de composants graphiques (bar, line, pie...)

## :robot: Solution

1. Intégration de `chart.js` dans pix-orga : https://www.chartjs.org
2. Création d'une page de test pour afficher un composant graphique

## :rainbow: Remarques

Afin d'avoir la dernière version de `chart.js`, nous avons décider d'intégrer manuellement la librairie plutôt que d'utiliser la librairie https://github.com/aomran/ember-cli-chart qui est restée à la version 2.9. (depuis plus d'un an)

## :100: Pour tester

1. Aller sur https://orga-pr3022.review.pix.fr/charts
2. Se connecter avec sco.admin@example.net
3. Apprécier

![image](https://user-images.githubusercontent.com/516360/118938876-6734ca80-b94f-11eb-9d7d-a3bf603f36eb.png)
