### PR TITLE
[FEATURE] Permettre l'affichage d'une bannière d'informations sur Pix Orga en cas de problème sur la production (Pix-2430)

### DIFF
--- a/orga/app/components/communication-banner.hbs
+++ b/orga/app/components/communication-banner.hbs
@@ -1,0 +1,5 @@
+{{#if this.isEnabled}}
+  <PixBanner @type={{this.bannerType}}>
+    {{this.bannerContent}}
+  </PixBanner>
+{{/if}}

--- a/orga/app/components/communication-banner.js
+++ b/orga/app/components/communication-banner.js
@@ -1,0 +1,18 @@
+import { htmlSafe } from '@ember/string';
+import Component from '@glimmer/component';
+import isEmpty from 'lodash/isEmpty';
+import ENV from 'pix-orga/config/environment';
+
+export default class CommunicationBanner extends Component {
+  bannerType = ENV.APP.BANNER_TYPE;
+
+  _rawBannerContent = ENV.APP.BANNER_CONTENT;
+
+  get isEnabled() {
+    return !isEmpty(this._rawBannerContent) && !isEmpty(this.bannerType);
+  }
+
+  get bannerContent() {
+    return htmlSafe(this._rawBannerContent);
+  }
+}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -16,6 +16,7 @@
 @import "globals/tables";
 @import "globals/texts";
 @import "globals/titles";
+@import "components/communication-banner";
 @import "components/login-form";
 @import "components/campaign-list";
 @import "components/charts/cards";

--- a/orga/app/styles/components/communication-banner.scss
+++ b/orga/app/styles/components/communication-banner.scss
@@ -1,0 +1,3 @@
+.pix-banner {
+  justify-content: center;
+}

--- a/orga/app/templates/application.hbs
+++ b/orga/app/templates/application.hbs
@@ -1,2 +1,3 @@
 {{page-title (t 'navigation.pix-orga')}}
+<CommunicationBanner />
 {{outlet}}

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -33,10 +33,12 @@ module.exports = function(environment) {
 
     APP: {
       API_HOST: process.env.API_HOST || '',
+      BANNER_CONTENT: process.env.BANNER_CONTENT || '',
+      BANNER_TYPE: process.env.BANNER_TYPE || '',
       CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL,
+      IS_DISSOCIATE_BUTTON_ENABLED: _isFeatureEnabled(process.env.IS_DISSOCIATE_BUTTON_ENABLED),
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
-      IS_DISSOCIATE_BUTTON_ENABLED: _isFeatureEnabled(process.env.IS_DISSOCIATE_BUTTON_ENABLED),
     },
 
     googleFonts: [

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -14,6 +14,7 @@ module.exports = function() {
       'eye',
       'eye-slash',
       'exclamation-triangle',
+      'exclamation-circle',
       'external-link-alt',
       'hourglass-half',
       'info-circle',

--- a/orga/tests/integration/components/communication-banner_test.js
+++ b/orga/tests/integration/components/communication-banner_test.js
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import ENV from 'pix-orga/config/environment';
+
+module('Integration | Component | communication-banner', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const originalBannerContent = ENV.APP.BANNER_CONTENT;
+  const originalBannerType = ENV.APP.BANNER_TYPE;
+
+  hooks.afterEach(function() {
+    ENV.APP.BANNER_CONTENT = originalBannerContent;
+    ENV.APP.BANNER_TYPE = originalBannerType;
+  });
+
+  test('should not display the banner when no banner content', async function(assert) {
+    // given
+    ENV.APP.BANNER_CONTENT = '';
+    ENV.APP.BANNER_TYPE = '';
+
+    // when
+    await render(hbs`<CommunicationBanner />`);
+
+    // then
+    assert.dom('.pix-banner').doesNotExist();
+  });
+
+  test('should display the information banner', async function(assert) {
+    // given
+    ENV.APP.BANNER_CONTENT = 'information banner text ...';
+    ENV.APP.BANNER_TYPE = 'information';
+
+    // when
+    await render(hbs`<CommunicationBanner />`);
+
+    // then
+    assert.dom('.pix-banner--information').exists();
+    assert.dom('.pix-banner--information').containsText('information banner text ...');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Suite aux instabilité de fin Avril. Nous n'étions pas en mesure d'informer les utilisateurs de Pix Orga sur les instabilités de la production

## :robot: Solution
Ajouter la même banner que celle de Pix App

## :rainbow: Remarques
Il sera peut être judicieux dans un second temps de mutualiser ce composant, d'y ajouter la gestion des différentes langues (i18n) dans un composant `pix-ui` ?

## :100: Pour tester
Aller sur la RA et faites les même modification que dans les tests unitaires du composants. la banner devrait s'afficher