### PR TITLE
[FEATURE] Filtrer les épreuves de certif selon la langue de l'utilisateur (PIX-2557).

### DIFF
--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -9,6 +9,8 @@ const certifiedProfileSerializer = require('../../infrastructure/serializers/jso
 const usecases = require('../../domain/usecases');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+
 module.exports = {
 
   computeResult(request) {
@@ -39,9 +41,10 @@ module.exports = {
     const userId = request.auth.credentials.userId;
     const accessCode = request.payload.data.attributes['access-code'];
     const sessionId = request.payload.data.attributes['session-id'];
+    const locale = extractLocaleFromRequest(request);
 
     const { created, certificationCourse } = await DomainTransaction.execute((domainTransaction) => {
-      return usecases.retrieveLastOrCreateCertificationCourse({ domainTransaction, sessionId, accessCode, userId });
+      return usecases.retrieveLastOrCreateCertificationCourse({ domainTransaction, sessionId, accessCode, userId, locale });
     });
 
     const serialized = await certificationCourseSerializer.serialize(certificationCourse);

--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -17,7 +17,7 @@ const certifiableProfileForLearningContentRepository = require('../../infrastruc
 
 module.exports = {
 
-  async pickCertificationChallenges(placementProfile) {
+  async pickCertificationChallenges(placementProfile, locale) {
     const knowledgeElementsByCompetence = await knowledgeElementRepository
       .findUniqByUserIdGroupedByCompetenceId({ userId: placementProfile.userId, limitDate: placementProfile.profileDate });
     const knowledgeElements = KnowledgeElement.findDirectlyValidatedFromGroups(knowledgeElementsByCompetence);
@@ -26,19 +26,19 @@ module.exports = {
       UserCompetence.orderSkillsOfCompetenceByDifficulty(placementProfile.userCompetences)
         .filter((uc) => uc.isCertifiable());
 
-    const allFrFrOperativeChallenges = await challengeRepository.findFrenchFranceOperative();
+    const allOperativeChallenges = await challengeRepository.findOperativeHavingLocale(locale);
     const alreadyAnsweredChallengeIds = await answerRepository.findChallengeIdsFromAnswerIds(answerIds);
-    return _pickCertificationChallengesForAllCompetences(certifiableUserCompetencesWithOrderedSkills, alreadyAnsweredChallengeIds, allFrFrOperativeChallenges);
+    return _pickCertificationChallengesForAllCompetences(certifiableUserCompetencesWithOrderedSkills, alreadyAnsweredChallengeIds, allOperativeChallenges);
   },
 
-  async pickCertificationChallengesForPixPlus(certifiableBadge, userId) {
+  async pickCertificationChallengesForPixPlus(certifiableBadge, userId, locale) {
     const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.get({ id: certifiableBadge.targetProfileId });
     const certifiableProfile = await certifiableProfileForLearningContentRepository.get({ id: userId, profileDate: new Date(), targetProfileWithLearningContent });
     const excludedOrigins = [PIX_ORIGIN];
     const skillIdsByArea = certifiableProfile.getOrderedCertifiableSkillsByAreaId(excludedOrigins);
 
     const alreadyAnsweredChallengeIds = certifiableProfile.getAlreadyAnsweredChallengeIds();
-    const allFrFrOperativeChallenges = await challengeRepository.findFrenchFranceOperative();
+    const allFrFrOperativeChallenges = await challengeRepository.findOperativeHavingLocale(locale);
     return _pickCertificationChallengesForAllAreas(skillIdsByArea, alreadyAnsweredChallengeIds, allFrFrOperativeChallenges, targetProfileWithLearningContent, certifiableBadge.key);
   },
 };

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
-const { FRENCH_FRANCE } = require('../../../domain/constants').LOCALE;
 
 const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
 const OPERATIVE_CHALLENGES = [...VALIDATED_CHALLENGES, 'archivé'];
@@ -31,13 +30,9 @@ module.exports = datasource.extend({
       _.includes(OPERATIVE_CHALLENGES, challengeData.status));
   },
 
-  async _findOperativeHavingLocale(locale) {
+  async findOperativeHavingLocale(locale) {
     const operativeChallenges = await this.findOperative();
     return operativeChallenges.filter((challenge) => _.includes(challenge.locales, locale));
-  },
-
-  async findFrenchFranceOperative() {
-    return this._findOperativeHavingLocale(FRENCH_FRANCE);
   },
 
   async findValidated() {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -38,8 +38,8 @@ module.exports = {
     return _toDomainCollection({ challengeDataObjects, skills: operativeSkills });
   },
 
-  async findFrenchFranceOperative() {
-    const challengeDataObjects = await challengeDatasource.findFrenchFranceOperative();
+  async findOperativeHavingLocale(locale) {
+    const challengeDataObjects = await challengeDatasource.findOperativeHavingLocale(locale);
     const operativeSkills = await skillDatasource.findOperative();
     return _toDomainCollection({ challengeDataObjects, skills: operativeSkills });
   },

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -621,6 +621,29 @@ describe('Acceptance | API | Certification Course', () => {
                 },
               ],
             },
+            {
+              id: 'recCompetence5',
+              tubes: [{
+                id: 'recTube0_0',
+                skills: [
+                  {
+                    id: 'recSkill5_0',
+                    nom: '@recSkill5_0',
+                    challenges: [
+                      { id: 'recChallenge5_0_0', langues: ['Franco Français'] },
+                      { id: 'recChallenge5_0_1' },
+                    ],
+                  },
+                  {
+                    id: 'recSkill5_1',
+                    nom: '@recSkill5_1',
+                    challenges: [
+                      { id: 'recChallenge5_1_1', langues: ['Franco Français'] },
+                    ],
+                  },
+                ],
+              }],
+            },
           ],
         },
       ];
@@ -669,6 +692,14 @@ describe('Acceptance | API | Certification Course', () => {
         expect(certificationCourses[0].birthdate).to.equal(certificationCandidate.birthdate);
         expect(certificationCourses[0].birthplace).to.equal(certificationCandidate.birthCity);
         expect(certificationCourses[0].externalId).to.equal(certificationCandidate.externalId);
+      });
+
+      it('should have only fr-fr challenges associated with certification-course', async () => {
+        // then
+        const certificationChallenges = await knex('certification-challenges');
+        expect(certificationChallenges.length).to.equal(2);
+        expect(certificationChallenges[0].challengeId).to.equal('recChallenge5_1_1');
+        expect(certificationChallenges[1].challengeId).to.equal('recChallenge5_0_0');
       });
 
     });

--- a/api/tests/integration/domain/services/pick-certification-challenge_test.js
+++ b/api/tests/integration/domain/services/pick-certification-challenge_test.js
@@ -9,6 +9,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
   const certificationDate = _addOneDayToDate(placementDate);
   const sufficientPixValueToBeCertifiableOnCompetence = PIX_COUNT_BY_LEVEL;
   const unsufficientPixValueToBeCertifiableOnCompetence = 1;
+  const locale = 'fr-fr';
   let certifiableUserId;
 
   beforeEach(() => {
@@ -82,7 +83,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
     });
 
     // when
-    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
     //then
     expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(['recArea1_Competence1_Tube1_Skill2_Challenge1']);
@@ -156,7 +157,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
     });
 
     // when
-    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
     //then
     expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(['recArea1_Competence1_Tube1_Skill2_Challenge1']);
@@ -237,7 +238,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
     });
 
     // when
-    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
     //then
     expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(['recArea1_Competence2_Tube1_Skill1_Challenge1']);
@@ -318,7 +319,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
     });
 
     // when
-    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
     //then
     expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(['recArea1_Competence2_Tube1_Skill1_Challenge1']);
@@ -383,7 +384,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
     });
 
     // when
-    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
     expect(challenges.length).to.equal(1);
     expect(challenges[0].challengeId).to.be.oneOf(['recArea1_Competence1_Tube1_Skill1_Challenge2', 'recArea1_Competence1_Tube1_Skill1_Challenge3']);
   });
@@ -464,7 +465,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
     });
 
     // when
-    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
     expect(challenges.length).to.equal(1);
     expect(['recArea1_Competence1_Tube1_Skill1_Challenge1', 'recArea1_Competence1_Tube1_Skill1_Challenge2', 'recArea1_Competence1_Tube1_Skill1_Challenge3']).to.include(challenges[0].challengeId);
   });
@@ -577,7 +578,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
     });
 
     // when
-    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
     expect(challenges.length).to.equal(3);
     expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(
       [
@@ -655,7 +656,7 @@ describe('Integration | CertificationChallengeService | pickCertificationChallen
     });
 
     // when
-    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
     expect(challenges.length).to.equal(1);
     expect(challenges[0].challengeId).to.equal('recArea1_Competence1_Tube1_Skill1_And_Skill2_Challenge');
   });

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -175,31 +175,6 @@ describe('Integration | Repository | challenge-repository', () => {
       expect(actualChallenges[0]).to.be.instanceOf(Challenge);
       expect(_.omit(actualChallenges[0], 'validator')).to.deep.equal(_.omit(actualChallenges[0], 'validator'));
     });
-
-    // TODO: remove duplicate test
-    it('should setup the expected validator and solution on found challenges', async () => {
-      // given
-      const skill = domainBuilder.buildSkill({ id: 'recSkill1' });
-      const frfrOperativeChallenge = domainBuilder.buildChallenge({ type: Challenge.Type.QCM, skills: [skill], locales: ['fr-fr'] });
-      const learningContent = {
-        skills: [{ ...skill, status: 'actif' }],
-        challenges: [{ ...frfrOperativeChallenge, skillIds: ['recSkill1'], t1Status: 'Activé', t2Status: 'Activé', t3Status: 'Désactivé' }],
-      };
-      mockLearningContent(learningContent);
-
-      // when
-      const [actualChallenge] = await challengeRepository.findOperative();
-
-      // then
-      expect(actualChallenge.validator).to.be.instanceOf(Validator);
-      expect(actualChallenge.validator.solution.id).to.equal(frfrOperativeChallenge.id);
-      expect(actualChallenge.validator.solution.isT1Enabled).to.equal(true);
-      expect(actualChallenge.validator.solution.isT2Enabled).to.equal(true);
-      expect(actualChallenge.validator.solution.isT3Enabled).to.equal(false);
-      expect(actualChallenge.validator.solution.scoring).to.equal('');
-      expect(actualChallenge.validator.solution.type).to.equal(frfrOperativeChallenge.type);
-      expect(actualChallenge.validator.solution.value).to.equal(frfrOperativeChallenge.solution);
-    });
   });
 
   describe('#findValidatedByCompetenceId', () => {

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -151,12 +151,13 @@ describe('Integration | Repository | challenge-repository', () => {
     });
   });
 
-  describe('#findFrenchFranceOperative', () => {
+  describe('#findOperativeHavingLocale', () => {
     it('should return only french france operative challenges with skills', async () => {
       // given
       const skill = domainBuilder.buildSkill({ id: 'recSkill1' });
       const frfrOperativeChallenge = domainBuilder.buildChallenge({ skills: [skill], locales: ['fr-fr'] });
       const nonFrfrOperativeChallenge = domainBuilder.buildChallenge({ skills: [skill], locales: ['en'] });
+      const locale = 'fr-fr';
       const learningContent = {
         skills: [{ ...skill, status: 'actif' }],
         challenges: [
@@ -167,7 +168,7 @@ describe('Integration | Repository | challenge-repository', () => {
       mockLearningContent(learningContent);
 
       // when
-      const actualChallenges = await challengeRepository.findFrenchFranceOperative();
+      const actualChallenges = await challengeRepository.findOperativeHavingLocale(locale);
 
       // then
       expect(actualChallenges).to.have.lengthOf(1);
@@ -175,6 +176,7 @@ describe('Integration | Repository | challenge-repository', () => {
       expect(_.omit(actualChallenges[0], 'validator')).to.deep.equal(_.omit(actualChallenges[0], 'validator'));
     });
 
+    // TODO: remove duplicate test
     it('should setup the expected validator and solution on found challenges', async () => {
       // given
       const skill = domainBuilder.buildSkill({ id: 'recSkill1' });

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -24,6 +24,7 @@ const certifiableProfileForLearningContentRepository = require('../../../../lib/
 describe('Unit | Service | Certification Challenge Service', () => {
 
   const userId = 63731;
+  const locale = 'fr-fr';
 
   function _createCompetence(id, index, name, areaCode) {
     const competence = new Competence();
@@ -116,7 +117,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
     let userCompetence2;
 
     beforeEach(() => {
-      sinon.stub(challengeRepository, 'findFrenchFranceOperative').resolves([
+      sinon.stub(challengeRepository, 'findOperativeHavingLocale').withArgs(locale).resolves([
         challengeForSkillCitation4,
         anotherChallengeForSkillCitation4,
         challengeForSkillCitation4AndMoteur3,
@@ -180,7 +181,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
       const expectedCertificationChallenge = _createCertificationChallenge(challengeForSkillRemplir2.id, skillRemplir2);
 
       // when
-      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
       // then
       expect(certificationChallenges).to.deep.equal([expectedCertificationChallenge]);
@@ -208,7 +209,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         answerRepository.findChallengeIdsFromAnswerIds.withArgs([123]).resolves(['whatever']);
 
         // when
-        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
         // then
         expect(certificationChallenges).to.deep.equal([]);
@@ -226,7 +227,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
           .resolves(['challengeRecordIdEleven']);
 
         // when
-        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
         // then
         expect(certificationChallenges).to.deep.equal([]);
@@ -251,7 +252,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
           .resolves(['challengeRecordIdOne']);
 
         // when
-        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
         // then
         expect(certificationChallenges[0].challengeId).to.be.oneOf(['challengeRecordIdTen', 'challengeRecordIdTwo']);
@@ -279,7 +280,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         const expectedSkills = [skillCitation4.name, skillRecherche4.name, skillMoteur3.name];
 
         // when
-        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
         // then
         const skillsForChallenges = _.uniq(_.map(certificationChallenges, 'associatedSkillName'));
@@ -308,7 +309,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         const expectedSkills = [skillCitation4, skillRecherche4, skillMoteur3];
 
         // when
-        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+        const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
         // then
         const skillsForChallenges = _.uniq(_.map(certificationChallenges, 'associatedSkillName'));
@@ -351,7 +352,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
       ];
 
       // when
-      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
       // then
       expect(certificationChallenges).to.deep.equal(expectedCertificationChallenges);
@@ -388,7 +389,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
       ];
 
       // when
-      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
       // then
       expect(certificationChallenges).to.deep.equal(expectedCertificationChallenges);
@@ -430,7 +431,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
       ];
 
       // when
-      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
       // then
       expect(certificationChallenges).to.deep.equal(expectedCertificationChallenges);
@@ -457,7 +458,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         'anotherChallengeForSkillRemplir2',
       ]);
       // when
-      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
       // then
       expect(certificationChallenges).to.deep.equal([_createCertificationChallenge(challengeForSkillRemplir2.id, skillRemplir2)]);
@@ -477,7 +478,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         challengeForSkillRequin5,
         challengeForSkillRequin8,
       ];
-      challengeRepository.findFrenchFranceOperative.resolves(onlyOneChallengeForCitation4AndMoteur3);
+      challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(onlyOneChallengeForCitation4AndMoteur3);
       placementProfile.userCompetences = [
         new UserCompetence({
           ...userCompetence1,
@@ -496,7 +497,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         'challengeRecordIdTwo',
       ]);
       // when
-      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
       // then
       expect(_.map(certificationChallenges, 'challengeId')).to.deep.equal(['challengeRecordIdTwo']);
@@ -513,7 +514,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         'nonExistentchallengeRecordId',
       ]);
       // when
-      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
       // then
       expect(certificationChallenges).to.deep.equal([]);
@@ -530,7 +531,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         'challengeRecordIdThree',
       ]);
       // when
-      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+      const certificationChallenges = await certificationChallengesService.pickCertificationChallenges(placementProfile, locale);
 
       // then
       expect(certificationChallenges).to.deep.equal([]);
@@ -686,11 +687,11 @@ describe('Unit | Service | Certification Challenge Service', () => {
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents3', [{ id: 'laverLesDents3_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', [{ id: 'faireSonLit4_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', [{ id: 'faireSonLit6_id' }], 1));
-      sinon.stub(challengeRepository, 'findFrenchFranceOperative').resolves(challenges);
+      sinon.stub(challengeRepository, 'findOperativeHavingLocale').withArgs(locale).resolves(challenges);
       const certifiableBadge = domainBuilder.buildBadge({ key: 'BADGE_KEY', targetProfileId: 123 });
 
       // when
-      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456);
+      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456, locale);
 
       // then
       let expectedCertificationChallenges = [];
@@ -803,11 +804,11 @@ describe('Unit | Service | Certification Challenge Service', () => {
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents3', [{ id: 'laverLesDents3_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', [{ id: 'faireSonLit4_id' }], 2));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', [{ id: 'faireSonLit6_id' }], 1));
-      sinon.stub(challengeRepository, 'findFrenchFranceOperative').resolves(challenges);
+      sinon.stub(challengeRepository, 'findOperativeHavingLocale').withArgs(locale).resolves(challenges);
       const certifiableBadge = domainBuilder.buildBadge({ key: 'BADGE_KEY', targetProfileId: 123 });
 
       // when
-      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456);
+      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456, locale);
 
       // then
       let expectedCertificationChallenges = [];
@@ -926,11 +927,11 @@ describe('Unit | Service | Certification Challenge Service', () => {
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', [{ id: 'faireSonLit4_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit5', [{ id: 'faireSonLit5_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', [{ id: 'faireSonLit6_id' }], 1));
-      sinon.stub(challengeRepository, 'findFrenchFranceOperative').resolves(challenges);
+      sinon.stub(challengeRepository, 'findOperativeHavingLocale').withArgs(locale).resolves(challenges);
       const certifiableBadge = domainBuilder.buildBadge({ key: 'BADGE_KEY', targetProfileId: 123 });
 
       // when
-      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456);
+      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456, locale);
 
       // then
       let expectedCertificationChallenges = [];
@@ -1050,11 +1051,11 @@ describe('Unit | Service | Certification Challenge Service', () => {
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', [{ id: 'faireSonLit4_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit5', [{ id: 'faireSonLit5_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', [{ id: 'faireSonLit6_id' }], 1));
-      sinon.stub(challengeRepository, 'findFrenchFranceOperative').resolves(challenges);
+      sinon.stub(challengeRepository, 'findOperativeHavingLocale').withArgs(locale).resolves(challenges);
       const certifiableBadge = domainBuilder.buildBadge({ key: 'BADGE_KEY', targetProfileId: 123 });
 
       // when
-      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456);
+      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456, locale);
 
       // then
       let expectedCertificationChallenges = [];
@@ -1146,11 +1147,11 @@ describe('Unit | Service | Certification Challenge Service', () => {
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents2', [{ id: 'laverLesDents2_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents3', [{ id: 'laverLesDents3_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit', [{ id: 'faireSonLit6_id' }, { id: 'faireSonLit4_id' }], 1));
-      sinon.stub(challengeRepository, 'findFrenchFranceOperative').resolves(challenges);
+      sinon.stub(challengeRepository, 'findOperativeHavingLocale').withArgs(locale).resolves(challenges);
       const certifiableBadge = domainBuilder.buildBadge({ key: 'BADGE_KEY', targetProfileId: 123 });
 
       // when
-      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456);
+      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456, locale);
 
       // then
       let expectedCertificationChallenges = [];
@@ -1258,11 +1259,11 @@ describe('Unit | Service | Certification Challenge Service', () => {
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents3', [{ id: 'laverLesDents3_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', [{ id: 'faireSonLit4_id' }], 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', [{ id: 'faireSonLit6_id' }], 1));
-      sinon.stub(challengeRepository, 'findFrenchFranceOperative').resolves(challenges);
+      sinon.stub(challengeRepository, 'findOperativeHavingLocale').withArgs(locale).resolves(challenges);
       const certifiableBadge = domainBuilder.buildBadge({ key: 'BADGE_KEY', targetProfileId: 123 });
 
       // when
-      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456);
+      const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(certifiableBadge, 456, locale);
 
       // then
       let expectedCertificationChallenges = [];

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -28,8 +28,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
   const placementProfileService = {
     getPlacementProfile: sinon.stub(),
   };
+  const locale = 'fr';
 
   const parameters = {
+    locale,
     domainTransaction,
     assessmentRepository,
     competenceRepository,

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -147,10 +147,11 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     });
   });
 
-  describe('#findFrenchFranceOperative', () => {
+  describe('#findOperativeHavingLocale', () => {
 
     it('should retrieve the operative Challenges of given locale only', async () => {
       // given
+      const locale = 'fr-fr';
       sinon.stub(lcms, 'getLatestRelease').resolves({ 'challenges': [
         challenge_web1,
         challenge_web1_notValidated,
@@ -159,7 +160,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       ] });
 
       // when
-      const result = await challengeDatasource.findFrenchFranceOperative();
+      const result = await challengeDatasource.findOperativeHavingLocale(locale);
 
       // then
       expect(_.map(result, 'id')).to.deep.equal([


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la certification filtre ses épreuves possibles pour n’avoir que des épreuves Franco-française. Il faudrait pouvoir proposer les épreuves dans la langue choisie par l'utilisateur.

## :robot: Solution
- récupérer la langue de l'utilisateur dans le header de la requête HTTP
- fournir la langue sélectionnée à `retrieveLastOrCreateCertificationCourse`
- filtrer les challenges par langues dans les fonctions de choix de challenges (`certificationChallengesService.pickCertificationChallenges` et `certificationChallengesService.pickCertificationChallengesForPixPlus`)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
En DB:
- vérifier que les épreuves dans la table certification-challenges soit de la langue choisie par l'utilisateur

Sur l'app:
- Passer une certification
- Vérifier que les épreuves sont dans la langue choisie par l'utilisateur