### PR TITLE
[BUGFIX] Ne pas empêcher l'export des résultats même en cas de champs manquant (PIX-2512)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -1,3 +1,5 @@
+const logger = require('../../../infrastructure/logger');
+
 function _csvFormulaEscapingPrefix(data) {
   const mayBeInterpretedAsFormula = /^[-@=+]/.test(data);
   return mayBeInterpretedAsFormula ? '\'' : '';
@@ -13,15 +15,13 @@ function _csvSerializeValue(data) {
       return `"${_csvFormulaEscapingPrefix(data)}${data.replace(/"/g, '""')}"`;
     }
   } else {
-    throw new Error(`Unknown value type in _csvSerializeValue: ${typeof data}: ${data}`);
+    logger.error(`Unknown value type in _csvSerializeValue: ${typeof data}: ${data}`);
+    return '""';
   }
 }
 
 module.exports = {
-
   serializeLine(lineArray) {
     return lineArray.map(_csvSerializeValue).join(';') + '\n';
   },
-
 };
-

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1,6 +1,6 @@
-const { expect, catchErr } = require('../../../../test-helper');
-
+const { expect, catchErr, sinon } = require('../../../../test-helper');
 const csvSerializer = require('../../../../../lib/infrastructure/serializers/csv/csv-serializer');
+const logger = require('../../../../../lib/infrastructure/logger');
 
 describe('Unit | Serializer | CSV | csv-serializer', () => {
 
@@ -64,23 +64,26 @@ describe('Unit | Serializer | CSV | csv-serializer', () => {
     context('should throw exceptions invalid format', () => {
       it('given object', async () => {
         // when
-        const err = await catchErr(csvSerializer.serializeLine)([{}]);
+        sinon.stub(logger, 'error');
+        await catchErr(csvSerializer.serializeLine)([{}]);
         // then
-        expect(err).to.be.an.instanceOf(Error);
+        expect(logger.error).to.have.been.calledWith('Unknown value type in _csvSerializeValue: object: [object Object]');
       });
 
       it('given null', async () => {
         // when
-        const err = await catchErr(csvSerializer.serializeLine)([null]);
+        sinon.stub(logger, 'error');
+        await catchErr(csvSerializer.serializeLine)([null]);
         // then
-        expect(err).to.be.an.instanceOf(Error);
+        expect(logger.error).to.have.been.calledWith('Unknown value type in _csvSerializeValue: object: null');
       });
 
       it('given undefined', async () => {
         // when
-        const err = await catchErr(csvSerializer.serializeLine)([undefined]);
+        sinon.stub(logger, 'error');
+        await catchErr(csvSerializer.serializeLine)([undefined]);
         // then
-        expect(err).to.be.an.instanceOf(Error);
+        expect(logger.error).to.have.been.calledWith('Unknown value type in _csvSerializeValue: undefined: undefined');
       });
 
     });


### PR DESCRIPTION
## :unicorn: Problème
Certains participants n'ont pas de participantExternalId alors que la campagne en nécessite un. De ce fait quand un Prescripteur fait un export de résultat, la demande fail.

## :robot: Solution
Permettre le téléchargement de l'export, même s'il y a un champs manquant. Pour la donnée manquante, on met "null"
On envoie quand même l'erreur à Datadog pour être au courant.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
