### PR TITLE
[FEATURE] Empêcher l'accès à une session de certification déjà finalisée (PIX-2584)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -298,6 +298,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.NoStagesForCampaign) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.SessionNotAccessible) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
 
   if (error instanceof DomainErrors.TargetProfileCannotBeCreated) {
     return new HttpErrors.UnprocessableEntityError(error.message);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -655,6 +655,12 @@ class SessionAlreadyPublishedError extends DomainError {
   }
 }
 
+class SessionNotAccessible extends DomainError {
+  constructor(message = 'La session de certification n\'est plus accessible.') {
+    super(message);
+  }
+}
+
 class TargetProfileInvalidError extends DomainError {
   constructor(message = 'Le profil cible ne possède aucun acquis ciblé.') {
     super(message);
@@ -896,6 +902,7 @@ module.exports = {
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
+  SessionNotAccessible,
   SiecleXmlImportError,
   TargetProfileInvalidError,
   TargetProfileCannotBeCreated,

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -71,6 +71,10 @@ class Session {
   isPublished() {
     return this.publishedAt !== null;
   }
+
+  isAccessible() {
+    return this.status === statuses.CREATED;
+  }
 }
 
 module.exports = Session;

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -6,6 +6,7 @@ const {
   MatchingReconciledStudentNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   UserAlreadyLinkedToCandidateInSessionError,
+  SessionNotAccessible,
 } = require('../errors');
 const UserLinkedToCertificationCandidate = require('../events/UserLinkedToCertificationCandidate');
 const UserAlreadyLinkedToCertificationCandidate = require('../events/UserAlreadyLinkedToCertificationCandidate');
@@ -20,7 +21,12 @@ async function linkUserToSessionCertificationCandidate({
   certificationCenterRepository,
   organizationRepository,
   schoolingRegistrationRepository,
+  sessionRepository,
 }) {
+  const session = await sessionRepository.get(sessionId);
+  if (!session.isAccessible()) {
+    throw new SessionNotAccessible();
+  }
   const participatingCertificationCandidate = new CertificationCandidate({
     firstName,
     lastName,

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -1,6 +1,6 @@
 const CertificationCourse = require('../models/CertificationCourse');
 const Assessment = require('../models/Assessment');
-const { UserNotAuthorizedToCertifyError, NotFoundError } = require('../errors');
+const { UserNotAuthorizedToCertifyError, NotFoundError, SessionNotAccessible } = require('../errors');
 const { features } = require('../../config');
 const _ = require('lodash');
 const bluebird = require('bluebird');
@@ -23,6 +23,9 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   const session = await sessionRepository.get(sessionId);
   if (session.accessCode !== accessCode) {
     throw new NotFoundError('Session not found');
+  }
+  if (!session.isAccessible()) {
+    throw new SessionNotAccessible();
   }
 
   const existingCertificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -122,6 +122,13 @@ describe('Integration | API | Controller Error', () => {
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
     });
+
+    it('responds Precondition Failed when a SessionNotAccessible error occurs', async () => {
+      routeHandler.throws(new DomainErrors.SessionNotAccessible());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(PRECONDITION_FAILED);
+    });
   });
 
   context('404 Not Found', () => {

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -1,6 +1,6 @@
 const Session = require('../../../../lib/domain/models/Session');
 
-module.exports = function buildSession({
+const buildSession = function({
   id = 123,
   accessCode = 'ABCD123',
   address = '4 avenue du général perlimpimpim',
@@ -37,3 +37,137 @@ module.exports = function buildSession({
     certificationCandidates,
   });
 };
+
+buildSession.created = function({
+  id,
+  accessCode,
+  address,
+  certificationCenter,
+  certificationCenterId,
+  date,
+  description,
+  examiner,
+  room,
+  time,
+  certificationCandidates,
+} = {}) {
+  return buildSession({
+    id,
+    accessCode,
+    address,
+    certificationCenter,
+    certificationCenterId,
+    date,
+    description,
+    examiner,
+    room,
+    time,
+    certificationCandidates,
+    examinerGlobalComment: null,
+    finalizedAt: null,
+    resultsSentToPrescriberAt: null,
+    publishedAt: null,
+    assignedCertificationOfficerId: null,
+  });
+};
+
+buildSession.finalized = function({
+  id,
+  accessCode,
+  address,
+  certificationCenter,
+  certificationCenterId,
+  date,
+  description,
+  examiner,
+  room,
+  time,
+  certificationCandidates,
+} = {}) {
+  return buildSession({
+    id,
+    accessCode,
+    address,
+    certificationCenter,
+    certificationCenterId,
+    date,
+    description,
+    examiner,
+    room,
+    time,
+    certificationCandidates,
+    examinerGlobalComment: null,
+    finalizedAt: new Date('2020-01-01'),
+    resultsSentToPrescriberAt: null,
+    publishedAt: null,
+    assignedCertificationOfficerId: null,
+  });
+};
+
+buildSession.inProcess = function({
+  id,
+  accessCode,
+  address,
+  certificationCenter,
+  certificationCenterId,
+  date,
+  description,
+  examiner,
+  room,
+  time,
+  certificationCandidates,
+} = {}) {
+  return buildSession({
+    id,
+    accessCode,
+    address,
+    certificationCenter,
+    certificationCenterId,
+    date,
+    description,
+    examiner,
+    room,
+    time,
+    certificationCandidates,
+    examinerGlobalComment: null,
+    finalizedAt: new Date('2020-01-01'),
+    resultsSentToPrescriberAt: null,
+    publishedAt: null,
+    assignedCertificationOfficerId: 123,
+  });
+};
+
+buildSession.processed = function({
+  id,
+  accessCode,
+  address,
+  certificationCenter,
+  certificationCenterId,
+  date,
+  description,
+  examiner,
+  room,
+  time,
+  certificationCandidates,
+} = {}) {
+  return buildSession({
+    id,
+    accessCode,
+    address,
+    certificationCenter,
+    certificationCenterId,
+    date,
+    description,
+    examiner,
+    room,
+    time,
+    certificationCandidates,
+    examinerGlobalComment: null,
+    finalizedAt: new Date('2020-01-01'),
+    resultsSentToPrescriberAt: new Date('2020-01-02'),
+    publishedAt: new Date('2020-01-02'),
+    assignedCertificationOfficerId: 123,
+  });
+};
+
+module.exports = buildSession;

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -75,6 +75,10 @@ describe('Unit | Domain | Errors', () => {
     expect(errors.AuthenticationMethodNotFoundError).to.exist;
   });
 
+  it('should export a SessionNotAccessible error', () => {
+    expect(errors.SessionNotAccessible).to.exist;
+  });
+
   describe('#SameNationalStudentIdInOrganizationError', () => {
 
     context('When errorDetail is provided', () => {

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -168,4 +168,51 @@ describe('Unit | Domain | Models | Session', () => {
       expect(isPublished).to.be.false;
     });
   });
+
+  context('#isAccessible', () => {
+
+    it('returns true when the session is created', () => {
+      // given
+      const session = domainBuilder.buildSession.created();
+
+      // when
+      const isAccessible = session.isAccessible();
+
+      // then
+      expect(isAccessible).to.be.true;
+    });
+
+    it('returns false when the session is finalized', () => {
+      // given
+      const session = domainBuilder.buildSession.finalized();
+
+      // when
+      const isAccessible = session.isAccessible();
+
+      // then
+      expect(isAccessible).to.be.false;
+    });
+
+    it('returns false when the session is in process', () => {
+      // given
+      const session = domainBuilder.buildSession.inProcess();
+
+      // when
+      const isAccessible = session.isAccessible();
+
+      // then
+      expect(isAccessible).to.be.false;
+    });
+
+    it('returns false when the session is processed', () => {
+      // given
+      const session = domainBuilder.buildSession.processed();
+
+      // when
+      const isAccessible = session.isAccessible();
+
+      // then
+      expect(isAccessible).to.be.false;
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -6,6 +6,7 @@ const {
   MatchingReconciledStudentNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   UserAlreadyLinkedToCandidateInSessionError,
+  SessionNotAccessible,
 } = require('../../../../lib/domain/errors');
 const UserLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserLinkedToCertificationCandidate');
 const UserAlreadyLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserAlreadyLinkedToCertificationCandidate');
@@ -17,78 +18,44 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
   const lastName = 'Bideau';
   const birthdate = '2010-10-10';
 
-  context('when there is a problem with the personal info', () => {
+  context('when the session is not accessible', () => {
 
-    context('when no certification candidates match with the provided personal info', () => {
+    it('should throw a SessionNotAccessible error', async () => {
+      // given
+      const sessionRepository = {
+        get: sinon.stub(),
+      };
+      sessionRepository.get.withArgs(42).resolves(domainBuilder.buildSession.finalized());
 
-      it('should throw a CertificationCandidateByPersonalInfoNotFoundError', async () => {
-        // given
-        const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-          .withFindBySessionIdAndPersonalInfo({
-            args: {
-              sessionId,
-              firstName,
-              lastName,
-              birthdate,
-            },
-            resolves: [],
-          });
-
-        // when
-        const err = await catchErr(linkUserToSessionCertificationCandidate)({
-          sessionId,
-          userId,
-          firstName,
-          lastName,
-          birthdate,
-          certificationCandidateRepository,
-        });
-
-        // then
-        expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoNotFoundError);
+      // when
+      const err = await catchErr(linkUserToSessionCertificationCandidate)({
+        sessionId,
+        userId,
+        firstName,
+        lastName,
+        birthdate,
+        sessionRepository,
       });
-    });
 
-    context('when there are more than one certification candidates that match with the provided personal info', () => {
-
-      it('should throw a CertificationCandidateByPersonalInfoTooManyMatchesError', async () => {
-        // given
-        const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-          .withFindBySessionIdAndPersonalInfo({
-            args: {
-              sessionId,
-              firstName,
-              lastName,
-              birthdate,
-            },
-            resolves: ['candidate1', 'candidate2'],
-          });
-
-        // when
-        const err = await catchErr(linkUserToSessionCertificationCandidate)({
-          sessionId,
-          userId,
-          firstName,
-          lastName,
-          birthdate,
-          certificationCandidateRepository,
-        });
-
-        // then
-        expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoTooManyMatchesError);
-      });
+      // then
+      expect(err).to.be.instanceOf(SessionNotAccessible);
     });
   });
 
-  context('when there is exactly one certification candidate that matches with the provided personal info', () => {
+  context('when the session is accessible', () => {
+    const sessionRepository = { get: () => undefined };
 
-    context('when the matching certification candidate is already linked to a user', () => {
+    beforeEach(() => {
+      sessionRepository.get = sinon.stub();
+      sessionRepository.get.withArgs(42).resolves(domainBuilder.buildSession.created());
+    });
 
-      context('when the linked user is the same as the user being linked', () => {
+    context('when there is a problem with the personal info', () => {
 
-        it('should not create a link and return the matching certification candidate', async () => {
+      context('when no certification candidates match with the provided personal info', () => {
+
+        it('should throw a CertificationCandidateByPersonalInfoNotFoundError', async () => {
           // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
           const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
               args: {
@@ -97,50 +64,8 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
                 lastName,
                 birthdate,
               },
-              resolves: [certificationCandidate],
+              resolves: [],
             });
-
-          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
-          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
-            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
-
-          // when
-          const result = await linkUserToSessionCertificationCandidate({
-            sessionId,
-            userId,
-            firstName,
-            lastName,
-            birthdate,
-            certificationCandidateRepository,
-            certificationCenterRepository,
-          });
-
-          // then
-          expect(result).to.deep.equal(
-            new UserAlreadyLinkedToCertificationCandidate(),
-          );
-        });
-      });
-
-      context('when the linked user is the not the same as the user being linked', () => {
-
-        it('should throw a CertificationCandidateAlreadyLinkedToUserError', async () => {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: 'otherUserId' });
-          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-            .withFindBySessionIdAndPersonalInfo({
-              args: {
-                sessionId,
-                firstName,
-                lastName,
-                birthdate,
-              },
-              resolves: [certificationCandidate],
-            });
-
-          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
-          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
-            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
 
           // when
           const err = await catchErr(linkUserToSessionCertificationCandidate)({
@@ -149,58 +74,393 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             firstName,
             lastName,
             birthdate,
+            sessionRepository,
             certificationCandidateRepository,
-            certificationCenterRepository,
           });
 
           // then
-          expect(err).to.be.instanceOf(CertificationCandidateAlreadyLinkedToUserError);
+          expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoNotFoundError);
+        });
+      });
+
+      context('when there are more than one certification candidates that match with the provided personal info', () => {
+
+        it('should throw a CertificationCandidateByPersonalInfoTooManyMatchesError', async () => {
+          // given
+          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+            .withFindBySessionIdAndPersonalInfo({
+              args: {
+                sessionId,
+                firstName,
+                lastName,
+                birthdate,
+              },
+              resolves: ['candidate1', 'candidate2'],
+            });
+
+          // when
+          const err = await catchErr(linkUserToSessionCertificationCandidate)({
+            sessionId,
+            userId,
+            firstName,
+            lastName,
+            birthdate,
+            sessionRepository,
+            certificationCandidateRepository,
+          });
+
+          // then
+          expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoTooManyMatchesError);
         });
       });
     });
 
-    context('when the matching certification candidate has no link to any user', () => {
+    context('when there is exactly one certification candidate that matches with the provided personal info', () => {
 
-      context('when the user is already linked to another candidate in the session', () => {
+      context('when the matching certification candidate is already linked to a user', () => {
 
-        it('should throw a UserAlreadyLinkedToCandidateInSessionError', async () => {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null });
-          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-            .withFindBySessionIdAndPersonalInfo({
-              args: {
-                sessionId,
-                firstName,
-                lastName,
-                birthdate,
-              },
-              resolves: [certificationCandidate],
-            })
-            .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: 'existingLinkedCandidateToUser' });
+        context('when the linked user is the same as the user being linked', () => {
 
-          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
-          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
-            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+          it('should not create a link and return the matching certification candidate', async () => {
+            // given
+            const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
+            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+              .withFindBySessionIdAndPersonalInfo({
+                args: {
+                  sessionId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                },
+                resolves: [certificationCandidate],
+              });
 
-          // when
-          const err = await catchErr(linkUserToSessionCertificationCandidate)({
-            sessionId,
-            userId,
-            firstName,
-            lastName,
-            birthdate,
-            certificationCandidateRepository,
-            certificationCenterRepository,
+            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+
+            // when
+            const result = await linkUserToSessionCertificationCandidate({
+              sessionId,
+              userId,
+              firstName,
+              lastName,
+              birthdate,
+              sessionRepository,
+              certificationCandidateRepository,
+              certificationCenterRepository,
+            });
+
+            // then
+            expect(result).to.deep.equal(
+              new UserAlreadyLinkedToCertificationCandidate(),
+            );
           });
+        });
 
-          // then
-          expect(err).to.be.instanceOf(UserAlreadyLinkedToCandidateInSessionError);
+        context('when the linked user is not the same as the user being linked', () => {
+
+          it('should throw a CertificationCandidateAlreadyLinkedToUserError', async () => {
+            // given
+            const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: 'otherUserId' });
+            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+              .withFindBySessionIdAndPersonalInfo({
+                args: {
+                  sessionId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                },
+                resolves: [certificationCandidate],
+              });
+
+            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+
+            // when
+            const err = await catchErr(linkUserToSessionCertificationCandidate)({
+              sessionId,
+              userId,
+              firstName,
+              lastName,
+              birthdate,
+              sessionRepository,
+              certificationCandidateRepository,
+              certificationCenterRepository,
+            });
+
+            // then
+            expect(err).to.be.instanceOf(CertificationCandidateAlreadyLinkedToUserError);
+          });
         });
       });
 
-      context('when the user is not linked to any candidate in this session', () => {
+      context('when the matching certification candidate has no link to any user', () => {
 
-        it('should create a link with between the candidate and the user and return the linked certification candidate', async () => {
+        context('when the user is already linked to another candidate in the session', () => {
+
+          it('should throw a UserAlreadyLinkedToCandidateInSessionError', async () => {
+            // given
+            const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null });
+            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+              .withFindBySessionIdAndPersonalInfo({
+                args: {
+                  sessionId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                },
+                resolves: [certificationCandidate],
+              })
+              .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: 'existingLinkedCandidateToUser' });
+
+            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+
+            // when
+            const err = await catchErr(linkUserToSessionCertificationCandidate)({
+              sessionId,
+              userId,
+              firstName,
+              lastName,
+              birthdate,
+              sessionRepository,
+              certificationCandidateRepository,
+              certificationCenterRepository,
+            });
+
+            // then
+            expect(err).to.be.instanceOf(UserAlreadyLinkedToCandidateInSessionError);
+          });
+        });
+
+        context('when the user is not linked to any candidate in this session', () => {
+
+          it('should create a link between the candidate and the user and return the linked certification candidate', async () => {
+            // given
+            const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null, id: 'candidateId' });
+            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+              .withFindBySessionIdAndPersonalInfo({
+                args: {
+                  sessionId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                },
+                resolves: [certificationCandidate],
+              })
+              .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
+              .withLinkToUser({});
+
+            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+
+            // when
+            const result = await linkUserToSessionCertificationCandidate({
+              sessionId,
+              userId,
+              firstName,
+              lastName,
+              birthdate,
+              sessionRepository,
+              certificationCandidateRepository,
+              certificationCenterRepository,
+            });
+
+            // then
+            expect(result).to.deep.equal(new UserAlreadyLinkedToCertificationCandidate());
+            sinon.assert.calledWith(certificationCandidateRepository.linkToUser, {
+              id: certificationCandidate.id,
+              userId,
+            });
+          });
+        });
+      });
+    });
+
+    context('when the organization behind this session is of type SCO', () => {
+
+      context('when the organization is also managing students', () => {
+
+        context('when the user does not match with a session candidate and its schooling registration', () => {
+
+          it('throws MatchingReconciledStudentNotFoundError', async () => {
+            // given
+            const certificationCandidate = domainBuilder.buildCertificationCandidate({
+              userId: null,
+              firstName, lastName, birthdate,
+            });
+            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+              .withFindBySessionIdAndPersonalInfo({
+                args: {
+                  sessionId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                },
+                resolves: [certificationCandidate] });
+
+            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
+            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+            const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
+            const organizationRepository = _buildFakeOrganizationRepository()
+              .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
+
+            const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
+              .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
+                args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId },
+                resolves: false,
+              });
+
+            // when
+            const err = await catchErr(linkUserToSessionCertificationCandidate)({
+              sessionId,
+              userId,
+              firstName,
+              lastName,
+              birthdate,
+              sessionRepository,
+              certificationCandidateRepository,
+              schoolingRegistrationRepository,
+              certificationCenterRepository,
+              organizationRepository,
+            });
+
+            // then
+            expect(err).to.be.instanceOf(MatchingReconciledStudentNotFoundError);
+          });
+        });
+
+        context('when the user matches with a session candidate and its schooling registration', () => {
+
+          context('when no other candidates is already linked to that user', () => {
+
+            it('should create a link between the candidate and the user and return an event to notify it, ', async () => {
+              // given
+              const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
+              const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                userId: null,
+                firstName, lastName, birthdate,
+                schoolingRegistrationId: schoolingRegistration.id,
+              });
+              const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+                .withFindBySessionIdAndPersonalInfo({
+                  args: {
+                    sessionId,
+                    firstName,
+                    lastName,
+                    birthdate,
+                  },
+                  resolves: [certificationCandidate],
+                })
+                .withFindOneBySessionIdAndUserId({
+                  args: {
+                    sessionId,
+                    userId,
+                  },
+                  resolves: null,
+                });
+
+              const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
+              const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+                .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+              const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
+              const organizationRepository = _buildFakeOrganizationRepository()
+                .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
+
+              const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
+                .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
+
+              // when
+              const event = await linkUserToSessionCertificationCandidate({
+                sessionId,
+                userId,
+                firstName,
+                lastName,
+                birthdate,
+                sessionRepository,
+                certificationCandidateRepository,
+                schoolingRegistrationRepository,
+                certificationCenterRepository,
+                organizationRepository,
+              });
+
+              // then
+              expect(certificationCandidateRepository.linkToUser).to.have.been.calledWith({
+                id: certificationCandidate.id,
+                userId,
+              });
+              expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization)
+                .to.have.been.calledWith({ userId, schoolingRegistrationId: schoolingRegistration.id });
+              expect(event).to.be.instanceOf(UserLinkedToCertificationCandidate);
+            });
+          });
+
+          context('when another candidates is already linked to that user', () => {
+
+            it('throws UserAlreadyLinkedToCandidateInSessionError', async () => {
+              // given
+              const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
+              const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                userId: null,
+                firstName, lastName, birthdate,
+                schoolingRegistrationId: schoolingRegistration.id,
+              });
+              const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+                .withFindBySessionIdAndPersonalInfo({
+                  args: {
+                    sessionId,
+                    firstName,
+                    lastName,
+                    birthdate,
+                  },
+                  resolves: [certificationCandidate],
+                })
+                .withFindOneBySessionIdAndUserId({ args: {
+                  sessionId,
+                  userId,
+                }, resolves: domainBuilder.buildCertificationCandidate({ id: 'another candidate' }) });
+
+              const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
+              const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+                .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+              const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
+              const organizationRepository = _buildFakeOrganizationRepository()
+                .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
+
+              const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
+                .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
+
+              // when
+              const error = await catchErr(linkUserToSessionCertificationCandidate)({
+                sessionId,
+                userId,
+                firstName,
+                lastName,
+                birthdate,
+                sessionRepository,
+                certificationCandidateRepository,
+                schoolingRegistrationRepository,
+                certificationCenterRepository,
+                organizationRepository,
+              });
+
+              // then
+              expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization)
+                .to.have.been.calledWith({ userId, schoolingRegistrationId: schoolingRegistration.id });
+              expect(error).to.be.an.instanceof(UserAlreadyLinkedToCandidateInSessionError);
+            });
+          });
+        });
+      });
+
+      context('when the organization is not managing students', () => {
+
+        it('should return the linked certification candidate', async () => {
           // given
           const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null, id: 'candidateId' });
           const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
@@ -216,9 +476,18 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
             .withLinkToUser({});
 
-          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
           const certificationCenterRepository = _buildFakeCertificationCenterRepository()
             .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+          const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: false, externalId: '123456' });
+          const organizationRepository = _buildFakeOrganizationRepository()
+            .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
+
+          const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
+            .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
+              args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId },
+              resolves: true,
+            });
 
           // when
           const result = await linkUserToSessionCertificationCandidate({
@@ -227,242 +496,17 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             firstName,
             lastName,
             birthdate,
+            sessionRepository,
             certificationCandidateRepository,
-            certificationCenterRepository,
-          });
-
-          // then
-          expect(result).to.deep.equal(new UserAlreadyLinkedToCertificationCandidate());
-          sinon.assert.calledWith(certificationCandidateRepository.linkToUser, {
-            id: certificationCandidate.id,
-            userId,
-          });
-        });
-      });
-    });
-  });
-
-  context('when the organization behind this session is of type SCO', () => {
-
-    context('when the organization is also managing students', () => {
-
-      context('when the user does not match with a session candidate and its schooling registration', () => {
-
-        it('throws MatchingReconciledStudentNotFoundError', async () => {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            userId: null,
-            firstName, lastName, birthdate,
-          });
-          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-            .withFindBySessionIdAndPersonalInfo({
-              args: {
-                sessionId,
-                firstName,
-                lastName,
-                birthdate,
-              },
-              resolves: [certificationCandidate] });
-
-          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
-          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
-            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
-          const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
-          const organizationRepository = _buildFakeOrganizationRepository()
-            .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
-
-          const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-            .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
-              args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId },
-              resolves: false,
-            });
-
-          // when
-          const err = await catchErr(linkUserToSessionCertificationCandidate)({
-            sessionId,
-            userId,
-            firstName,
-            lastName,
-            birthdate,
-            certificationCandidateRepository,
-            schoolingRegistrationRepository,
             certificationCenterRepository,
             organizationRepository,
+            schoolingRegistrationRepository,
           });
 
           // then
-          expect(err).to.be.instanceOf(MatchingReconciledStudentNotFoundError);
+          expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization).to.be.not.called;
+          expect(result).to.be.an.instanceof(UserLinkedToCertificationCandidate);
         });
-      });
-
-      context('when the user matches with a session candidate and its schooling registration', () => {
-
-        context('when no other candidates is already linked to that user', () => {
-
-          it('should create a link between the candidate and the user and return an event to notify it, ', async () => {
-            // given
-            const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
-            const certificationCandidate = domainBuilder.buildCertificationCandidate({
-              userId: null,
-              firstName, lastName, birthdate,
-              schoolingRegistrationId: schoolingRegistration.id,
-            });
-            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-              .withFindBySessionIdAndPersonalInfo({
-                args: {
-                  sessionId,
-                  firstName,
-                  lastName,
-                  birthdate,
-                },
-                resolves: [certificationCandidate],
-              })
-              .withFindOneBySessionIdAndUserId({
-                args: {
-                  sessionId,
-                  userId,
-                },
-                resolves: null,
-              });
-
-            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
-            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
-              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
-            const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
-            const organizationRepository = _buildFakeOrganizationRepository()
-              .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
-
-            const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-              .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
-
-            // when
-            const event = await linkUserToSessionCertificationCandidate({
-              sessionId,
-              userId,
-              firstName,
-              lastName,
-              birthdate,
-              certificationCandidateRepository,
-              schoolingRegistrationRepository,
-              certificationCenterRepository,
-              organizationRepository,
-            });
-
-            // then
-            expect(certificationCandidateRepository.linkToUser).to.have.been.calledWith({
-              id: certificationCandidate.id,
-              userId,
-            });
-            expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization)
-              .to.have.been.calledWith({ userId, schoolingRegistrationId: schoolingRegistration.id });
-            expect(event).to.be.instanceOf(UserLinkedToCertificationCandidate);
-          });
-        });
-
-        context('when another candidates is already linked to that user', () => {
-
-          it('throws UserAlreadyLinkedToCandidateInSessionError', async () => {
-            // given
-            const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
-            const certificationCandidate = domainBuilder.buildCertificationCandidate({
-              userId: null,
-              firstName, lastName, birthdate,
-              schoolingRegistrationId: schoolingRegistration.id,
-            });
-            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-              .withFindBySessionIdAndPersonalInfo({
-                args: {
-                  sessionId,
-                  firstName,
-                  lastName,
-                  birthdate,
-                },
-                resolves: [certificationCandidate],
-              })
-              .withFindOneBySessionIdAndUserId({ args: {
-                sessionId,
-                userId,
-              }, resolves: domainBuilder.buildCertificationCandidate({ id: 'another candidate' }) });
-
-            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
-            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
-              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
-            const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
-            const organizationRepository = _buildFakeOrganizationRepository()
-              .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
-
-            const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-              .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
-
-            // when
-            const error = await catchErr(linkUserToSessionCertificationCandidate)({
-              sessionId,
-              userId,
-              firstName,
-              lastName,
-              birthdate,
-              certificationCandidateRepository,
-              schoolingRegistrationRepository,
-              certificationCenterRepository,
-              organizationRepository,
-            });
-
-            // then
-            expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization)
-              .to.have.been.calledWith({ userId, schoolingRegistrationId: schoolingRegistration.id });
-            expect(error).to.be.an.instanceof(UserAlreadyLinkedToCandidateInSessionError);
-          });
-        });
-      });
-    });
-
-    context('when the organization is not managing students', () => {
-
-      it('should return the linked certification candidate', async () => {
-        // given
-        const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null, id: 'candidateId' });
-        const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-          .withFindBySessionIdAndPersonalInfo({
-            args: {
-              sessionId,
-              firstName,
-              lastName,
-              birthdate,
-            },
-            resolves: [certificationCandidate],
-          })
-          .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
-          .withLinkToUser({});
-
-        const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
-        const certificationCenterRepository = _buildFakeCertificationCenterRepository()
-          .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
-        const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: false, externalId: '123456' });
-        const organizationRepository = _buildFakeOrganizationRepository()
-          .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
-
-        const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-          .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
-            args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId },
-            resolves: true,
-          });
-
-        // when
-        const result = await linkUserToSessionCertificationCandidate({
-          sessionId,
-          userId,
-          firstName,
-          lastName,
-          birthdate,
-          certificationCandidateRepository,
-          certificationCenterRepository,
-          organizationRepository,
-          schoolingRegistrationRepository,
-        });
-
-        // then
-        expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization).to.be.not.called;
-        expect(result).to.be.an.instanceof(UserLinkedToCertificationCandidate);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -1,5 +1,5 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
-const { UserNotAuthorizedToCertifyError, NotFoundError } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToCertifyError, NotFoundError, SessionNotAccessible } = require('../../../../lib/domain/errors');
 const retrieveLastOrCreateCertificationCourse = require('../../../../lib/domain/usecases/retrieve-last-or-create-certification-course');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
@@ -76,22 +76,15 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
   context('when session access code is the same as the provided access code', () => {
 
-    beforeEach(() => {
-      foundSession = { accessCode };
-      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
-    });
+    context('when session is not accessible', () => {
 
-    context('when a certification course with provided userId and sessionId already exists', () => {
+      it('should throw a SessionNotAccessible error', async () => {
+        // given
+        const foundSession = domainBuilder.buildSession.finalized({ accessCode });
+        sessionRepository.get.withArgs(sessionId).resolves(foundSession);
 
-      let existingCertificationCourse;
-      beforeEach(() => {
-        existingCertificationCourse = Symbol('existingCertificationCourse');
-        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.withArgs({ userId, sessionId, domainTransaction }).resolves(existingCertificationCourse);
-      });
-
-      it('should return it with flag created marked as false', async function() {
         // when
-        const result = await retrieveLastOrCreateCertificationCourse({
+        const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
           sessionId,
           accessCode,
           userId,
@@ -99,35 +92,28 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
         });
 
         // then
-        expect(result).to.deep.equal({
-          created: false,
-          certificationCourse: existingCertificationCourse,
-        });
+        expect(error).to.be.instanceOf(SessionNotAccessible);
       });
-
     });
 
-    context('when no certification course exists for this userId and sessionId', () => {
-      let placementProfile;
-      let competences;
+    context('when session is accessible', () => {
 
       beforeEach(() => {
-        competences = [{ id: 'rec123' }, { id: 'rec456' }];
-        competenceRepository.listPixCompetencesOnly.resolves(competences);
-        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-          .withArgs({ userId, sessionId, domainTransaction }).onCall(0).resolves(null);
+        const foundSession = domainBuilder.buildSession.created({ accessCode });
+        sessionRepository.get.withArgs(sessionId).resolves(foundSession);
       });
 
-      context('when the user is not certifiable', () => {
+      context('when a certification course with provided userId and sessionId already exists', () => {
 
+        let existingCertificationCourse;
         beforeEach(() => {
-          placementProfile = { isCertifiable: sinon.stub().returns(false) };
-          placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
+          existingCertificationCourse = Symbol('existingCertificationCourse');
+          certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.withArgs({ userId, sessionId, domainTransaction }).resolves(existingCertificationCourse);
         });
 
-        it('should throw a UserNotAuthorizedToCertifyError', async function() {
+        it('should return it with flag created marked as false', async function() {
           // when
-          const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
+          const result = await retrieveLastOrCreateCertificationCourse({
             sessionId,
             accessCode,
             userId,
@@ -135,137 +121,35 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           });
 
           // then
-          expect(error).to.be.an.instanceOf(UserNotAuthorizedToCertifyError);
-        });
-
-        it('should not create any new resource', async function() {
-          // when
-          await catchErr(retrieveLastOrCreateCertificationCourse)({
-            sessionId,
-            accessCode,
-            userId,
-            ...parameters,
+          expect(result).to.deep.equal({
+            created: false,
+            certificationCourse: existingCertificationCourse,
           });
-
-          // then
-          sinon.assert.notCalled(certificationCourseRepository.save);
-          sinon.assert.notCalled(assessmentRepository.save);
-          sinon.assert.notCalled(certificationChallengeRepository.save);
         });
+
       });
 
-      context('when user is certifiable', () => {
-
-        const skill1 = domainBuilder.buildSkill();
-        const skill2 = domainBuilder.buildSkill();
-        const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-        const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+      context('when no certification course exists for this userId and sessionId', () => {
+        let placementProfile;
+        let competences;
 
         beforeEach(() => {
-          // TODO : use the domainBuilder to instanciate userCompetences
-          placementProfile = { isCertifiable: sinon.stub().returns(true), userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }] };
-          placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
-          const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-          userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-          userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
-          certificationChallengesService.pickCertificationChallenges.withArgs(placementProfile).resolves(
-            _.flatMap(userCompetencesWithChallenges, 'challenges'),
-          );
+          competences = [{ id: 'rec123' }, { id: 'rec456' }];
+          competenceRepository.listPixCompetencesOnly.resolves(competences);
+          certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+            .withArgs({ userId, sessionId, domainTransaction }).onCall(0).resolves(null);
         });
 
-        context('when a certification course has been created meanwhile', () => {
-
-          let existingCertificationCourse;
-          beforeEach(() => {
-            existingCertificationCourse = Symbol('existingCertificationCourse');
-            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-              .withArgs({ userId, sessionId, domainTransaction }).onCall(1).resolves(existingCertificationCourse);
-          });
-
-          it('should return it with flag created marked as false', async function() {
-            // when
-            const result = await retrieveLastOrCreateCertificationCourse({
-              sessionId,
-              accessCode,
-              userId,
-              ...parameters,
-            });
-
-            // then
-            expect(result).to.deep.equal({
-              created: false,
-              certificationCourse: existingCertificationCourse,
-            });
-          });
-
-          it('should have filled the certification profile with challenges anyway', async () => {
-            // when
-            await retrieveLastOrCreateCertificationCourse({
-              sessionId,
-              accessCode,
-              userId,
-              ...parameters,
-            });
-
-            // then
-            expect(certificationChallengesService.pickCertificationChallenges).to.have.been.calledWith(placementProfile);
-          });
-
-        });
-
-        context('when a certification still has not been created meanwhile', () => {
-
-          const foundCertificationCandidate = {
-            firstName: Symbol('firstName'),
-            lastName: Symbol('lastName'),
-            birthdate: Symbol('birthdate'),
-            birthCity: Symbol('birthCity'),
-            externalId: Symbol('externalId'),
-            userId,
-            sessionId,
-          };
-          const mockCertificationCourse = {
-            userId,
-            sessionId,
-            firstName: foundCertificationCandidate.firstName,
-            lastName: foundCertificationCandidate.lastName,
-            birthdate: foundCertificationCandidate.birthdate,
-            birthplace: foundCertificationCandidate.birthCity,
-            externalId: foundCertificationCandidate.externalId,
-            isV2Certification: true,
-          };
-
-          const savedCertificationChallenge1 = { id: 'savedCertificationChallenge1' };
-          const savedCertificationChallenge2 = { id: 'savedCertificationChallenge2' };
-
-          const savedCertificationCourse = {
-            id: 'savedCertificationCourse',
-            challenges: [savedCertificationChallenge1, savedCertificationChallenge2],
-          };
-
-          const mockAssessment = {
-            userId,
-            certificationCourseId: savedCertificationCourse.id,
-            state: Assessment.states.STARTED,
-            type: Assessment.types.CERTIFICATION,
-          };
-          const savedAssessment = {
-            id: 'savedAssessment',
-          };
+        context('when the user is not certifiable', () => {
 
           beforeEach(() => {
-            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-              .withArgs({ userId, sessionId, domainTransaction }).onCall(1).resolves(null);
+            placementProfile = { isCertifiable: sinon.stub().returns(false) };
             placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
-            certificationCandidateRepository.getBySessionIdAndUserId.withArgs({ sessionId, userId }).resolves(foundCertificationCandidate);
-            certificationCourseRepository.save.resolves(savedCertificationCourse);
-            assessmentRepository.save.resolves(savedAssessment);
-            certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
           });
 
-          it('should return it with flag created marked as true with related ressources', async function() {
+          it('should throw a UserNotAuthorizedToCertifyError', async function() {
             // when
-            const result = await retrieveLastOrCreateCertificationCourse({
+            const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
               sessionId,
               accessCode,
               userId,
@@ -273,19 +157,12 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             });
 
             // then
-            expect(result).to.deep.equal({
-              created: true,
-              certificationCourse: {
-                ...savedCertificationCourse,
-                assessment: savedAssessment,
-                challenges: [savedCertificationChallenge1, savedCertificationChallenge2],
-              },
-            });
+            expect(error).to.be.an.instanceOf(UserNotAuthorizedToCertifyError);
           });
 
-          it('should have save the certification course based on an appropriate argument', async function() {
+          it('should not create any new resource', async function() {
             // when
-            await retrieveLastOrCreateCertificationCourse({
+            await catchErr(retrieveLastOrCreateCertificationCourse)({
               sessionId,
               accessCode,
               userId,
@@ -293,43 +170,57 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             });
 
             // then
-            expect(certificationCourseRepository.save).to.have.been.calledWith({ certificationCourse: sinon.match(mockCertificationCourse), domainTransaction });
+            sinon.assert.notCalled(certificationCourseRepository.save);
+            sinon.assert.notCalled(assessmentRepository.save);
+            sinon.assert.notCalled(certificationChallengeRepository.save);
+          });
+        });
+
+        context('when user is certifiable', () => {
+
+          const skill1 = domainBuilder.buildSkill();
+          const skill2 = domainBuilder.buildSkill();
+          const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
+          const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+
+          beforeEach(() => {
+            // TODO : use the domainBuilder to instanciate userCompetences
+            placementProfile = { isCertifiable: sinon.stub().returns(true), userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }] };
+            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
+            const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
+            userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
+            userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+            certificationChallengesService.pickCertificationChallenges.withArgs(placementProfile).resolves(
+              _.flatMap(userCompetencesWithChallenges, 'challenges'),
+            );
           });
 
-          it('should have save the assessment based on an appropriate argument', async function() {
-            // when
-            await retrieveLastOrCreateCertificationCourse({
-              sessionId,
-              accessCode,
-              userId,
-              ...parameters,
+          context('when a certification course has been created meanwhile', () => {
+
+            let existingCertificationCourse;
+            beforeEach(() => {
+              existingCertificationCourse = Symbol('existingCertificationCourse');
+              certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                .withArgs({ userId, sessionId, domainTransaction }).onCall(1).resolves(existingCertificationCourse);
             });
 
-            // then
-            expect(assessmentRepository.save).to.have.been.calledWith({ assessment: sinon.match(mockAssessment), domainTransaction });
-          });
+            it('should return it with flag created marked as false', async function() {
+              // when
+              const result = await retrieveLastOrCreateCertificationCourse({
+                sessionId,
+                accessCode,
+                userId,
+                ...parameters,
+              });
 
-          context('when user has certifiable badges with pix plus', async function() {
+              // then
+              expect(result).to.deep.equal({
+                created: false,
+                certificationCourse: existingCertificationCourse,
+              });
+            });
 
-            it('should save all the challenges from pix and pix plus', async function() {
-              // given
-              sinon.spy(CertificationCourse, 'from');
-              const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
-              const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-              const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-              const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
-              const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
-              const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge1 });
-              const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge2 });
-              certificationBadgesService.findStillValidBadgeAcquisitions
-                .withArgs({ userId, domainTransaction })
-                .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
-              certificationChallengesService.pickCertificationChallengesForPixPlus
-                .withArgs(certifiableBadge1, userId)
-                .resolves([challengePlus1, challengePlus2])
-                .withArgs(certifiableBadge2, userId)
-                .resolves([challengePlus3]);
-              const expectedChallenges = [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3];
+            it('should have filled the certification profile with challenges anyway', async () => {
               // when
               await retrieveLastOrCreateCertificationCourse({
                 sessionId,
@@ -339,40 +230,128 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
               });
 
               // then
-              expect(CertificationCourse.from).to.have.been.calledWith({
-                certificationCandidate: foundCertificationCandidate,
-                challenges: expectedChallenges,
-                maxReachableLevelOnCertificationDate: 5,
+              expect(certificationChallengesService.pickCertificationChallenges).to.have.been.calledWith(placementProfile);
+            });
+
+          });
+
+          context('when a certification still has not been created meanwhile', () => {
+
+            const foundCertificationCandidate = {
+              firstName: Symbol('firstName'),
+              lastName: Symbol('lastName'),
+              birthdate: Symbol('birthdate'),
+              birthCity: Symbol('birthCity'),
+              externalId: Symbol('externalId'),
+              userId,
+              sessionId,
+            };
+            const mockCertificationCourse = {
+              userId,
+              sessionId,
+              firstName: foundCertificationCandidate.firstName,
+              lastName: foundCertificationCandidate.lastName,
+              birthdate: foundCertificationCandidate.birthdate,
+              birthplace: foundCertificationCandidate.birthCity,
+              externalId: foundCertificationCandidate.externalId,
+              isV2Certification: true,
+            };
+
+            const savedCertificationChallenge1 = { id: 'savedCertificationChallenge1' };
+            const savedCertificationChallenge2 = { id: 'savedCertificationChallenge2' };
+
+            const savedCertificationCourse = {
+              id: 'savedCertificationCourse',
+              challenges: [savedCertificationChallenge1, savedCertificationChallenge2],
+            };
+
+            const mockAssessment = {
+              userId,
+              certificationCourseId: savedCertificationCourse.id,
+              state: Assessment.states.STARTED,
+              type: Assessment.types.CERTIFICATION,
+            };
+            const savedAssessment = {
+              id: 'savedAssessment',
+            };
+
+            beforeEach(() => {
+              certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                .withArgs({ userId, sessionId, domainTransaction }).onCall(1).resolves(null);
+              placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
+              certificationCandidateRepository.getBySessionIdAndUserId.withArgs({ sessionId, userId }).resolves(foundCertificationCandidate);
+              certificationCourseRepository.save.resolves(savedCertificationCourse);
+              assessmentRepository.save.resolves(savedAssessment);
+              certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
+            });
+
+            it('should return it with flag created marked as true with related ressources', async function() {
+              // when
+              const result = await retrieveLastOrCreateCertificationCourse({
+                sessionId,
+                accessCode,
+                userId,
+                ...parameters,
+              });
+
+              // then
+              expect(result).to.deep.equal({
+                created: true,
+                certificationCourse: {
+                  ...savedCertificationCourse,
+                  assessment: savedAssessment,
+                  challenges: [savedCertificationChallenge1, savedCertificationChallenge2],
+                },
               });
             });
 
-            context('pix+ droit', () => {
+            it('should have save the certification course based on an appropriate argument', async function() {
+              // when
+              await retrieveLastOrCreateCertificationCourse({
+                sessionId,
+                accessCode,
+                userId,
+                ...parameters,
+              });
 
-              it('should generate challenges for expert badge only if both maitre and expert badges are acquired', async function() {
+              // then
+              expect(certificationCourseRepository.save).to.have.been.calledWith({ certificationCourse: sinon.match(mockCertificationCourse), domainTransaction });
+            });
+
+            it('should have save the assessment based on an appropriate argument', async function() {
+              // when
+              await retrieveLastOrCreateCertificationCourse({
+                sessionId,
+                accessCode,
+                userId,
+                ...parameters,
+              });
+
+              // then
+              expect(assessmentRepository.save).to.have.been.calledWith({ assessment: sinon.match(mockAssessment), domainTransaction });
+            });
+
+            context('when user has certifiable badges with pix plus', async function() {
+
+              it('should save all the challenges from pix and pix plus', async function() {
                 // given
                 sinon.spy(CertificationCourse, 'from');
-                const challengesForMaitre = [
-                  domainBuilder.buildChallenge({ id: 'challenge-pixmaitre1' }),
-                  domainBuilder.buildChallenge({ id: 'challenge-pixmaitre2' }),
-                ];
-                const challengesForExpert = [
-                  domainBuilder.buildChallenge({ id: 'challenge-pixexpert1' }),
-                  domainBuilder.buildChallenge({ id: 'challenge-pixexpert2' }),
-                ];
-                const maitreBadge = domainBuilder.buildBadge({ key: 'PIX_DROIT_MAITRE_CERTIF', targetProfileId: 11 });
-                const expertBadge = domainBuilder.buildBadge({ key: 'PIX_DROIT_EXPERT_CERTIF', targetProfileId: 22 });
-                domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
-                const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: expertBadge });
+                const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
+                const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
+                const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
+                const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge1 });
+                const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge2 });
                 certificationBadgesService.findStillValidBadgeAcquisitions
                   .withArgs({ userId, domainTransaction })
-                  .resolves([certifiableBadgeAcquisition2]);
+                  .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
                 certificationChallengesService.pickCertificationChallengesForPixPlus
-                  .withArgs(maitreBadge, userId)
-                  .resolves(challengesForMaitre)
-                  .withArgs(expertBadge, userId)
-                  .resolves(challengesForExpert);
-                const expectedChallenges = [challenge1, challenge2, ...challengesForExpert];
-
+                  .withArgs(certifiableBadge1, userId)
+                  .resolves([challengePlus1, challengePlus2])
+                  .withArgs(certifiableBadge2, userId)
+                  .resolves([challengePlus3]);
+                const expectedChallenges = [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3];
                 // when
                 await retrieveLastOrCreateCertificationCourse({
                   sessionId,
@@ -388,33 +367,77 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
                   maxReachableLevelOnCertificationDate: 5,
                 });
               });
+
+              context('pix+ droit', () => {
+
+                it('should generate challenges for expert badge only if both maitre and expert badges are acquired', async function() {
+                  // given
+                  sinon.spy(CertificationCourse, 'from');
+                  const challengesForMaitre = [
+                    domainBuilder.buildChallenge({ id: 'challenge-pixmaitre1' }),
+                    domainBuilder.buildChallenge({ id: 'challenge-pixmaitre2' }),
+                  ];
+                  const challengesForExpert = [
+                    domainBuilder.buildChallenge({ id: 'challenge-pixexpert1' }),
+                    domainBuilder.buildChallenge({ id: 'challenge-pixexpert2' }),
+                  ];
+                  const maitreBadge = domainBuilder.buildBadge({ key: 'PIX_DROIT_MAITRE_CERTIF', targetProfileId: 11 });
+                  const expertBadge = domainBuilder.buildBadge({ key: 'PIX_DROIT_EXPERT_CERTIF', targetProfileId: 22 });
+                  domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
+                  const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: expertBadge });
+                  certificationBadgesService.findStillValidBadgeAcquisitions
+                    .withArgs({ userId, domainTransaction })
+                    .resolves([certifiableBadgeAcquisition2]);
+                  certificationChallengesService.pickCertificationChallengesForPixPlus
+                    .withArgs(maitreBadge, userId)
+                    .resolves(challengesForMaitre)
+                    .withArgs(expertBadge, userId)
+                    .resolves(challengesForExpert);
+                  const expectedChallenges = [challenge1, challenge2, ...challengesForExpert];
+
+                  // when
+                  await retrieveLastOrCreateCertificationCourse({
+                    sessionId,
+                    accessCode,
+                    userId,
+                    ...parameters,
+                  });
+
+                  // then
+                  expect(CertificationCourse.from).to.have.been.calledWith({
+                    certificationCandidate: foundCertificationCandidate,
+                    challenges: expectedChallenges,
+                    maxReachableLevelOnCertificationDate: 5,
+                  });
+                });
+              });
             });
-          });
 
-          context('when user has no certifiable badges with pix plus', async function() {
+            context('when user has no certifiable badges with pix plus', async function() {
 
-            beforeEach(() => {
-              sinon.spy(CertificationCourse, 'from');
-              certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
-              certificationChallengesService.pickCertificationChallengesForPixPlus.throws();
-            });
-
-            it('should save only the challenges from pix', async function() {
-              // given
-              const expectedChallenges = [challenge1, challenge2];
-              // when
-              await retrieveLastOrCreateCertificationCourse({
-                sessionId,
-                accessCode,
-                userId,
-                ...parameters,
+              beforeEach(() => {
+                sinon.spy(CertificationCourse, 'from');
+                certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId, domainTransaction }).resolves([]);
+                certificationChallengesService.pickCertificationChallengesForPixPlus.throws();
               });
 
-              // then
-              expect(CertificationCourse.from).to.have.been.calledWith({
-                certificationCandidate: foundCertificationCandidate,
-                challenges: expectedChallenges,
-                maxReachableLevelOnCertificationDate: 5,
+              it('should save only the challenges from pix', async function() {
+                // given
+                const expectedChallenges = [challenge1, challenge2];
+                // when
+                await retrieveLastOrCreateCertificationCourse({
+                  sessionId,
+                  accessCode,
+                  userId,
+                  ...parameters,
+                });
+
+                // then
+                expect(CertificationCourse.from).to.have.been.calledWith({
+                  certificationCandidate: foundCertificationCandidate,
+                  challenges: expectedChallenges,
+                  maxReachableLevelOnCertificationDate: 5,
+                });
               });
             });
           });

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -14,6 +14,10 @@ function _isMatchingReconciledStudentNotFoundError(err) {
   return _get(err, 'errors[0].code') === 'MATCHING_RECONCILED_STUDENT_NOT_FOUND';
 }
 
+function _isSessionNotAccessibleError(err) {
+  return _get(err, 'errors[0].status') === '412';
+}
+
 export default class CertificationJoiner extends Component {
   @service store;
   @service peeker;
@@ -97,6 +101,8 @@ export default class CertificationJoiner extends Component {
 
       if (_isMatchingReconciledStudentNotFoundError(err)) {
         this.errorMessage = 'Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification.\nPour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant.';
+      } else if (_isSessionNotAccessibleError(err)) {
+        this.errorMessage = 'Oups ! La session de certification que vous tentez de rejoindre n\'est plus accessible.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.';
       } else {
         this.errorMessage = 'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.';
       }

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -46,8 +46,10 @@ export default Component.extend({
         this.getCurrentCertificationCourse().deleteRecord();
         if (err.errors && err.errors[0] && err.errors[0].status === '404') {
           this.set('errorMessage', 'Ce code n’existe pas ou n’est plus valide.');
+        } else if (err.errors && err.errors[0] && err.errors[0].status === '412') {
+          this.set('errorMessage', 'La session de certification n\'est plus accessible.');
         } else {
-          this.set('errorMessage', 'Une erreur serveur inattendue vient de se produire');
+          this.set('errorMessage', 'Une erreur serveur inattendue vient de se produire.');
         }
         this.set('isLoading', false);
       }

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -145,5 +145,31 @@ describe('Integration | Component | certification-joiner', function() {
       // then
       expect(contains('Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.')).to.exist;
     });
+
+    it('should display an error message on session not accessible', async function() {
+      // given
+      this.set('stepsData', {});
+      await render(hbs`<CertificationJoiner @stepsData={{this.stepsData}}/>`);
+      await fillIn('#certificationJoinerSessionId', '123456');
+      await fillIn('#certificationJoinerFirstName', 'Robert');
+      await fillIn('#certificationJoinerLastName', 'de Pix');
+      await fillIn('#certificationJoinerDayOfBirth', '02');
+      await fillIn('#certificationJoinerMonthOfBirth', '01');
+      await fillIn('#certificationJoinerYearOfBirth', '2000');
+      const store = this.owner.lookup('service:store');
+      const saveStub = sinon.stub();
+      saveStub
+        .withArgs({ adapterOptions: { joinSession: true, sessionId: '123456' } })
+        .throws({ errors: [ { status: '412' }] });
+      const createRecordMock = sinon.mock();
+      createRecordMock.returns({ save: saveStub, deleteRecord: function() {} });
+      store.createRecord = createRecordMock;
+
+      // when
+      await click('[type="submit"]');
+
+      // then
+      expect(contains('Oups ! La session de certification que vous tentez de rejoindre n\'est plus accessible.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.')).to.exist;
+    });
   });
 });

--- a/mon-pix/tests/unit/components/certification-starter_test.js
+++ b/mon-pix/tests/unit/components/certification-starter_test.js
@@ -123,12 +123,9 @@ describe('Unit | Component | certification-starter', function() {
 
           context('when the error is known', function() {
 
-            beforeEach(() => {
-              err = { errors: [{ status: '404' }] };
-            });
-
-            it('should display a specific error', async function() {
+            it('should display a specific error when code not found', async function() {
               // given
+              err = { errors: [{ status: '404' }] };
               storeSaveStub.rejects(err);
 
               // when
@@ -138,6 +135,20 @@ describe('Unit | Component | certification-starter', function() {
               sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode, sessionId });
               await sinon.assert.called(courseDeleteRecordStub);
               expect(component.get('errorMessage')).to.equal('Ce code n’existe pas ou n’est plus valide.');
+            });
+
+            it('should display a specific error when session is not accessible', async function() {
+              // given
+              err = { errors: [{ status: '412' }] };
+              storeSaveStub.rejects(err);
+
+              // when
+              await component.send('submit');
+
+              // then
+              sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode, sessionId });
+              await sinon.assert.called(courseDeleteRecordStub);
+              expect(component.get('errorMessage')).to.equal('La session de certification n\'est plus accessible.');
             });
           });
 
@@ -157,7 +168,7 @@ describe('Unit | Component | certification-starter', function() {
               // then
               sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode, sessionId });
               await sinon.assert.called(courseDeleteRecordStub);
-              expect(component.get('errorMessage')).to.equal('Une erreur serveur inattendue vient de se produire');
+              expect(component.get('errorMessage')).to.equal('Une erreur serveur inattendue vient de se produire.');
             });
           });
         });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, aucune vérification est faite sur le statut de la session lorsqu'un candidat tente de la rejoindre. Or, afin de conserver une cohérence à la fois métier et dans les données, il est important d'empêcher des candidats de rejoindre une session dès lors que celle-ci a été finalisée, c'est-à-dire lorsque le centre de certification en charge de l'organisation de cette session estime que celle-ci est close.

## :robot: Solution
Vérification faite à deux endroits :
- Dans la page formulaire N° session / nom / prénom / ddn
- Dans la page de code d'accès

## :rainbow: Remarques
Remarque : il semble qu'on puisse continer d'inscrire des candidats à une session finalisée. Demander au produit si c'est ok (ne fais pas partie du ticket de toute façon).

## :100: Pour tester
Préparer une session "finalisable", donc créer une session, y inscrire un candidat et faire en sorte que ce candidat commence son test de certification (page de la première question)
- Puis avec un candidat tester le cas **2** en premier, à savoir : inscrire un autre candidat en session de certif, passer la première page d'entrée en certification avec ce candidat, puis finaliser la session. Tenter d'entrer le code d'accès et constater le message d'erreur spécifique.
- Avec un autre candidat, tester le cas 1 : inscrire encore un autre candidat, tenter de passer la première page d'entrée en certification et constater le message d'erreur spécifique.
