### PR TITLE
[FEATURE] Dans Pix Admin, permettre d'ouvrir les pages de détail d'une organisation et d'un centre de certification, dans un nouvel onglet (PIX-2570).

### DIFF
--- a/admin/app/components/certification-centers/list-items.hbs
+++ b/admin/app/components/certification-centers/list-items.hbs
@@ -42,13 +42,16 @@
     {{#if @certificationCenters}}
       <tbody>
       {{#each @certificationCenters as |certificationCenter|}}
-        <tr
-          aria-label="Centre de certification"
-          role="button"
-          class="tr--clickable"
-          {{on "click" (fn @goToCertificationCenterPage certificationCenter.id)}}
-        >
-          <td>{{certificationCenter.id}}</td>
+        <tr aria-label="Centre de certification">
+          <td>
+            <LinkTo
+              @route="authenticated.certification-centers.get"
+              @model={{certificationCenter.id}}
+              data-test-certification={{certificationCenter.id}}
+            >
+              {{certificationCenter.id}}
+            </LinkTo>
+          </td>
           <td>{{certificationCenter.name}}</td>
           <td>{{certificationCenter.type}}</td>
           <td>{{certificationCenter.externalId}}</td>

--- a/admin/app/components/certification-centers/list-items.hbs
+++ b/admin/app/components/certification-centers/list-items.hbs
@@ -1,42 +1,42 @@
 <div class="certification-center-list content-text content-text--small">
   <table class="table-admin">
     <thead>
-    <tr>
-      <th>ID</th>
-      <th>Nom</th>
-      <th>Type</th>
-      <th>ID externe</th>
-    </tr>
-    <tr>
-      <th>
-        <input id="id"
-               type="text"
-               value={{@id}}
-               oninput={{perform @triggerFiltering 'id'}}
-               class="table-admin-input" />
-      </th>
-      <th>
-        <input id="name"
-               type="text"
-               value={{@name}}
-               oninput={{perform @triggerFiltering 'name'}}
-               class="table-admin-input" />
-      </th>
-      <th>
-        <input id="type"
-               type="text"
-               value={{@type}}
-               oninput={{perform @triggerFiltering 'type'}}
-               class="table-admin-input" />
-      </th>
-      <th>
-        <input id="externalId"
-               type="text"
-               value={{@externalId}}
-               oninput={{perform @triggerFiltering 'externalId'}}
-               class="table-admin-input" />
-      </th>
-    </tr>
+      <tr>
+        <th><label for="id">ID</label></th>
+        <th><label for="name">Nom</label></th>
+        <th><label for="type">Type</label></th>
+        <th><label for="externalId">ID externe</label></th>
+      </tr>
+      <tr>
+        <td>
+          <input id="id"
+                 type="text"
+                 value={{@id}}
+                 oninput={{perform @triggerFiltering 'id'}}
+                 class="table-admin-input" />
+        </td>
+        <td>
+          <input id="name"
+                 type="text"
+                 value={{@name}}
+                 oninput={{perform @triggerFiltering 'name'}}
+                 class="table-admin-input" />
+        </td>
+        <td>
+          <input id="type"
+                 type="text"
+                 value={{@type}}
+                 oninput={{perform @triggerFiltering 'type'}}
+                 class="table-admin-input" />
+        </td>
+        <td>
+          <input id="externalId"
+                 type="text"
+                 value={{@externalId}}
+                 oninput={{perform @triggerFiltering 'externalId'}}
+                 class="table-admin-input" />
+        </td>
+      </tr>
     </thead>
 
     {{#if @certificationCenters}}

--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -2,58 +2,58 @@
 
   <ul class="menu-bar__entries">
     <li class="menu-bar__entry">
-      <PixTooltip @text='Organisation' @position='right'>
+      <PixTooltip @text="Organisations" @position="right">
         <LinkTo @route="authenticated.organizations" class="menu-bar__link menu-bar__link--organizations">
-          <FaIcon @icon="building"></FaIcon>
+          <FaIcon @icon="building" @title="Organisations" />
         </LinkTo>
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">
-      <PixTooltip @text='Utilisateurs' @position='right'>
+      <PixTooltip @text="Utilisateurs" @position="right">
         <LinkTo @route="authenticated.users.list" class="menu-bar__link menu-bar__link--users">
-          <FaIcon @icon="users"></FaIcon>
+          <FaIcon @icon="users" @title="Utilisateurs" />
         </LinkTo>
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">
-      <PixTooltip @text='Centres de certification' @position='right' @inline={{true}}>
+      <PixTooltip @text="Centres de certification" @position="right" @inline={{true}}>
         <LinkTo @route="authenticated.certification-centers.list" class="menu-bar__link menu-bar__link--certification-centers">
-          <FaIcon @icon="map-pin"></FaIcon>
+          <FaIcon @icon="map-pin" @title="Centres de certification" />
         </LinkTo>
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">
-      <PixTooltip @text='Sessions de certifications' @position='right' @inline={{true}}>
+      <PixTooltip @text="Sessions de certifications" @position="right" @inline={{true}}>
         <LinkTo @route="authenticated.sessions.list.with-required-action" class="menu-bar__link menu-bar__link--sessions">
-          <FaIcon @icon="chalkboard-teacher"></FaIcon>
+          <FaIcon @icon="chalkboard-teacher" @title="Sessions de certifications" />
         </LinkTo>
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">
-      <PixTooltip @text='Certifications' @position='right' @inline={{true}}>
+      <PixTooltip @text="Certifications" @position="right" @inline={{true}}>
         <LinkTo @route="authenticated.certifications" class="menu-bar__link menu-bar__link--certifications">
-          <FaIcon @icon="graduation-cap"></FaIcon>
+          <FaIcon @icon="graduation-cap" @title="Certifications" />
         </LinkTo>
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">
-      <PixTooltip @text='Profils cibles' @position='right' @inline={{true}}>
+      <PixTooltip @text="Profils cibles" @position="right" @inline={{true}}>
         <LinkTo @route="authenticated.target-profiles.list" class="menu-bar__link menu-bar__link--target-profiles">
-          <FaIcon @icon="clipboard-list"></FaIcon>
+          <FaIcon @icon="clipboard-list" @title="Profils cibles" />
         </LinkTo>
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">
-      <PixTooltip @text='Outils' @position='right'>
+      <PixTooltip @text="Outils" @position="right">
         <LinkTo @route="authenticated.tools" class="menu-bar__link menu-bar__link--tools">
-          <FaIcon @icon="tools"></FaIcon>
+          <FaIcon @icon="tools" @title="Outils" />
         </LinkTo>
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">
-      <PixTooltip @text='Se déconnecter' @position='right' @inline={{true}}>
+      <PixTooltip @text="Se déconnecter" @position="right" @inline={{true}}>
         <LinkTo @route="logout" class="menu-bar__link menu-bar__link--logout">
-          <FaIcon @icon="power-off"></FaIcon>
+          <FaIcon @icon="power-off" @title="Se déconnecter" />
         </LinkTo>
       </PixTooltip>
     </li>

--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -43,8 +43,16 @@
       {{#if @organizations}}
         <tbody>
         {{#each @organizations as |organization|}}
-          <tr aria-label="Organisation" role="button" {{on "click" (fn @goToOrganizationPage organization.id)}} class="tr--clickable">
-            <td>{{organization.id}}</td>
+          <tr aria-label="Organisation">
+            <td>
+              <LinkTo
+                @route="authenticated.organizations.get"
+                @model={{organization.id}}
+                data-test-orga={{organization.id}}
+              >
+                {{organization.id}}
+              </LinkTo>
+            </td>
             <td>{{organization.name}}</td>
             <td>{{organization.type}}</td>
             <td>{{organization.externalId}}</td>

--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -3,40 +3,40 @@
     <table>
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Nom</th>
-          <th>Type</th>
-          <th>Identifiant externe</th>
+          <th><label for="id">ID</label></th>
+          <th><label for="name">Nom</label></th>
+          <th><label for="type">Type</label></th>
+          <th><label for="externalId">Identifiant externe</label></th>
         </tr>
         <tr>
-          <th>
+          <td>
             <input id="id"
                    type="text"
                    value={{@id}}
                    oninput={{fn @triggerFiltering 'id'}}
                    class="table-admin-input form-control" />
-          </th>
-          <th>
+          </td>
+          <td>
             <input id="name"
                    type="text"
                    value={{@name}}
                    oninput={{fn @triggerFiltering 'name'}}
                    class="table-admin-input form-control" />
-          </th>
-          <th>
+          </td>
+          <td>
             <input id="type"
                    type="text"
                    value={{@type}}
                    oninput={{fn @triggerFiltering 'type'}}
                    class="table-admin-input form-control" />
-          </th>
-          <th>
+          </td>
+          <td>
             <input id="externalId"
                    type="text"
                    value={{@externalId}}
                    oninput={{fn @triggerFiltering 'externalId'}}
                    class="table-admin-input form-control" />
-          </th>
+          </td>
         </tr>
       </thead>
 

--- a/admin/app/controllers/authenticated/certification-centers/list.js
+++ b/admin/app/controllers/authenticated/certification-centers/list.js
@@ -2,7 +2,6 @@
 
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 import config from 'pix-admin/config/environment';
 
@@ -29,9 +28,4 @@ export default class ListController extends Controller {
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }).restartable()) triggerFiltering;
-
-  @action
-  goToCertificationCenterPage(certificationCenterId) {
-    this.transitionToRoute('authenticated.certification-centers.get', certificationCenterId);
-  }
 }

--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -29,9 +29,4 @@ export default class ListController extends Controller {
   triggerFiltering(fieldName, event) {
     this.debouncedUpdateFilters({ [fieldName]: event.target.value });
   }
-
-  @action
-  goToOrganizationPage(organizationId) {
-    this.transitionToRoute('authenticated.organizations.get', organizationId);
-  }
 }

--- a/admin/app/styles/misc/table-admin.scss
+++ b/admin/app/styles/misc/table-admin.scss
@@ -1,8 +1,17 @@
 .table-admin {
 
+  a {
+    color: $pix-blue;
+  }
+
+  thead label {
+    margin-bottom: 0;
+  }
+
   tbody > tr:nth-child(odd) {
     background-color: rgba(0, 0, 0, 0.03);
   }
+
   tbody > tr, thead > tr {
     border-bottom: 1px solid $grey-22;
 
@@ -38,3 +47,4 @@
   margin: 48px auto 36px auto;
   text-align: center;
 }
+

--- a/admin/app/templates/authenticated/certification-centers/list.hbs
+++ b/admin/app/templates/authenticated/certification-centers/list.hbs
@@ -17,6 +17,6 @@
       @type={{this.type}}
       @externalId={{this.externalId}}
       @triggerFiltering={{this.triggerFiltering}}
-      @goToCertificationCenterPage={{this.goToCertificationCenterPage}} />
+    />
   </section>
 </main>

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -17,6 +17,6 @@
       @type={{this.type}}
       @externalId={{this.externalId}}
       @triggerFiltering={{this.triggerFiltering}}
-      @goToOrganizationPage={{this.goToOrganizationPage}} />
+    />
   </section>
 </main>

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -13,6 +13,6 @@
       @lastName={{this.lastName}}
       @email={{this.email}}
       @triggerFiltering={{this.triggerFiltering}}
-      @goToUserDetailPage={{this.goToUserDetailPage}} />
+    />
   </section>
 </main>

--- a/admin/tests/acceptance/certification-centers-list_test.js
+++ b/admin/tests/acceptance/certification-centers-list_test.js
@@ -7,6 +7,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 module('Acceptance | Certification-centers List', function(hooks) {
+
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -66,7 +67,7 @@ module('Acceptance | Certification-centers List', function(hooks) {
       await visit('/certification-centers/list');
 
       // when
-      await click('tr[aria-label="Centre de certification"]:first-child');
+      await click('[data-test-certification="1"]');
 
       // then
       assert.equal(currentURL(), '/certification-centers/1');

--- a/admin/tests/acceptance/organization-list_test.js
+++ b/admin/tests/acceptance/organization-list_test.js
@@ -84,7 +84,7 @@ module('Acceptance | Organization List', function(hooks) {
       await visit('/organizations/list');
 
       // when
-      await click('.organization-list .table-admin tbody tr:first-child');
+      await click('[data-test-orga="1"]');
 
       // then
       assert.equal(currentURL(), '/organizations/1/members');

--- a/admin/tests/integration/components/routes/authenticated/certification-centers/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/certification-centers/list-items_test.js
@@ -1,46 +1,37 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import sinon from 'sinon';
 
 module('Integration | Component | routes/authenticated/certification-centers | list-items', function(hooks) {
 
   setupRenderingTest(hooks);
 
-  const certificationCenters = [
-    { id: 1, name: 'John', type: 'SCO', externalId: '123' },
-    { id: 2, name: 'Jane', type: 'SUP', externalId: '456' },
-    { id: 3, name: 'Lola', type: 'PRO', externalId: '789' },
-  ];
-  certificationCenters.meta = {
-    rowCount: 3,
-  };
-  const triggerFiltering = function() {};
-
   hooks.beforeEach(async function() {
-    this.set('certificationCenters', certificationCenters);
-    this.set('triggerFiltering', triggerFiltering);
-    this.goToCertificationCenterPage = sinon.spy();
-
-    await render(hbs `<CertificationCenters::ListItems @certificationCenters={{this.certificationCenters}} @triggerFiltering={{this.triggerFiltering}} @goToCertificationCenterPage={{this.goToCertificationCenterPage}} />`);
+    const triggerFiltering = function() {};
+    this.triggerFiltering = triggerFiltering;
   });
 
   test('it should display certification-centers list', async function(assert) {
+    // given
+    const certificationCenters = [
+      { id: 1, name: 'John', type: 'SCO', externalId: '123' },
+      { id: 2, name: 'Jane', type: 'SUP', externalId: '456' },
+      { id: 3, name: 'Lola', type: 'PRO', externalId: '789' },
+    ];
+    certificationCenters.meta = {
+      rowCount: 3,
+    };
+    this.certificationCenters = certificationCenters;
+
+    // when
+    await render(hbs `<CertificationCenters::ListItems @certificationCenters={{this.certificationCenters}} @triggerFiltering={{this.triggerFiltering}} />`);
+
     // then
     assert.dom('table tbody tr:first-child td:first-child').hasText('1');
     assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('John');
     assert.dom('table tbody tr:first-child td:nth-child(3)').hasText('SCO');
     assert.dom('table tbody tr:first-child td:nth-child(4)').hasText('123');
     assert.dom('table tbody tr').exists({ count: 3 });
-    assert.dom('tr[aria-label="Centre de certification"]').hasAttribute('role', 'button');
-  });
-
-  test('should call goToCertificationCenterPage function when a line is clicked', async function(assert) {
-    // when
-    await click('tr[aria-label="Centre de certification"]:first-child');
-
-    // then
-    assert.ok(this.goToCertificationCenterPage.calledWith(1));
   });
 });

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items_test.js
@@ -9,15 +9,12 @@ module('Integration | Component | routes/authenticated/organizations | list-item
 
   hooks.beforeEach(async function() {
     const triggerFiltering = function() {};
-    const goToOrganizationPage = function() {};
-
     this.triggerFiltering = triggerFiltering;
-    this.goToOrganizationPage = goToOrganizationPage;
   });
 
   test('it should display header with id, name, type and externalId', async function(assert) {
     // when
-    await render(hbs`<Organizations::ListItems @triggerFiltering={{this.triggerFiltering}} @goToOrganizationPage={{this.goToOrganizationPage}} />`);
+    await render(hbs `<Organizations::ListItems @triggerFiltering={{this.triggerFiltering}} />`);
 
     // then
     assert.dom('table thead tr:first-child th:first-child').hasText('ID');
@@ -28,7 +25,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
 
   test('if should display search inputs', async function(assert) {
     // when
-    await render(hbs`<Organizations::ListItems @triggerFiltering={{this.triggerFiltering}} @goToOrganizationPage={{this.goToOrganizationPage}} />`);
+    await render(hbs `<Organizations::ListItems @triggerFiltering={{this.triggerFiltering}} />`);
 
     // then
     assert.dom('table thead tr:nth-child(2) input#id').exists();
@@ -51,7 +48,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     this.organizations = organizations;
 
     // when
-    await render(hbs`<Organizations::ListItems @organizations={{this.organizations}} @triggerFiltering={{this.triggerFiltering}} @goToOrganizationPage={{this.goToOrganizationPage}} />`);
+    await render(hbs `<Organizations::ListItems @organizations={{this.organizations}} @triggerFiltering={{this.triggerFiltering}} />`);
 
     // then
     assert.dom('table tbody tr:first-child td:first-child').hasText('1');

--- a/admin/tests/integration/components/routes/authenticated/users/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/users/list-items_test.js
@@ -9,10 +9,7 @@ module('Integration | Component | routes/authenticated/users | list-items', func
 
   hooks.beforeEach(async function() {
     const triggerFiltering = function() {};
-    const goToUserDetailPage = function() {};
-
     this.triggerFiltering = triggerFiltering;
-    this.goToUserDetailPage = goToUserDetailPage;
   });
 
   test('it should display user list', async function(assert) {
@@ -29,7 +26,7 @@ module('Integration | Component | routes/authenticated/users | list-items', func
     this.users = users;
 
     // when
-    await render(hbs`<Users::ListItems @users={{this.users}} @triggerFiltering={{this.triggerFiltering}} @goToUserDetailPage={{this.goToUserDetailPage}} />`);
+    await render(hbs `<Users::ListItems @users={{this.users}} @triggerFiltering={{this.triggerFiltering}} />`);
 
     // then
     assert.dom('table tbody tr:first-child td:first-child').hasText('1');


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, à partir de la page listant toutes les organisations et tous les centres de certification, il n'est pas possible d'ouvrir la page de détail d'une organisation ou d'un centre de certification, dans un nouvel onglet.

## :robot: Solution
* Poser un lien vers l'organisation (avec l'`ID`), dans la première colonne du tableau listant toutes les organisations.
* Poser un lien vers le centre de certification (avec l'`ID`), dans la première colonne du tableau listant tous les centres de certification.

## :rainbow: Remarques
* Les erreurs A11y dans le menu de gauche ont été corrigées
* Les erreurs A11y sur les pages `/organizations/list` et `/certification-centers/list` ont été corrigées

## :100: Pour tester
Dans Pix Admin
1. Aller sur la page des organisations
    * Cliquer sur l'`ID` d'une organisation
    * Vérifier que la page de détail de cette organisation s'affiche correctement
2. Aller sur la page des organisations
    * Utiliser par exemple le clic droit sur l'`ID` d'une organisation
    * Vérifier que la page de détail de cette organisation s'affiche correctement
3. Aller sur la page des centres de certification
    * Cliquer sur l'`ID` d'un centre de certification
    * Vérifier que la page de détail de ce centre de certification s'affiche correctement
2. Aller sur la page des centres de certification
    * Utiliser par exemple le clic droit sur l'`ID` d'un centre de certification
    * Vérifier que la page de détail de ce centre de certification s'affiche correctement