### PR TITLE
[FEATURE] Renommer le libellé "Profils Reçus" pour les campagnes d'évaluation en "Résultats reçus" (PIX-2603).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -26,7 +26,13 @@
       </div>
 
       <div class="campaign-details-header-report__shared">
-        <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.shared-participations-count'}}</h4>
+        <h4 class="label-text campaign-details-content__label">
+          {{#if (eq @campaign.type "PROFILES_COLLECTION")}}
+            {{t 'pages.campaign.shared-profiles-count'}}
+          {{else}}
+            {{t 'pages.campaign.shared-results-count'}}
+          {{/if}}
+        </h4>
         <span class="content-text content-text--big campaign-details-content__text">
           {{this.sharedParticipationsCount}}
         </span>

--- a/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
@@ -78,6 +78,32 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       // then
       assert.contains('4');
     });
+    test('it should display correct label for a PROFILES_COLLECTION campaign ', async function(assert) {
+      // given
+      const campaign = store.createRecord('campaign', {
+        type: 'PROFILES_COLLECTION',
+      });
+      this.set('campaign', campaign);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
+
+      // then
+      assert.contains('Profils reçus');
+    });
+    test('it should display correct label for an ASSESSMENT campaign ', async function(assert) {
+      // given
+      const campaign = store.createRecord('campaign', {
+        type: 'ASSESSMENT',
+      });
+      this.set('campaign', campaign);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
+
+      // then
+      assert.contains('Résultats reçus');
+    });
   });
 
   module('When there is no results', function() {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -173,7 +173,8 @@
       },
       "name": "Name of the campaign",
       "participations-count": "Participants",
-      "shared-participations-count": "Profiles submitted",
+      "shared-profiles-count": "Profiles submitted",
+      "shared-results-count": "Results submitted",
       "tab": {
         "collective-results": "Collective results",
         "details": "Details",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -173,7 +173,8 @@
       },
       "name": "Nom de la campagne",
       "participations-count": "Participants",
-      "shared-participations-count": "Profils reçus",
+      "shared-profiles-count": "Profils reçus",
+      "shared-results-count": "Résultats reçus",
       "tab": {
         "collective-results": "Résultats collectifs",
         "details": "Détails",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous voyons le même wording pour le label 'Shared-campaign-participation-count' sur les deux campagnes , Cependant, Dans une campagne d'évaluation, nous ne parlons pas de profil mais de résultat. 

## :robot: Solution
Changer le wording "Profils Reçus" pour les campagnes d'évaluation en "Résultats reçus" et garder "Profils Reçus" pour les campagnes de collecte de profils.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
se connectez à Pix Orga, cliquez sur campagne, sélectionnez une campagne , selon le type de campagne sélectionné, le libellé en haut à droite de l'écran qui décrit le 'shared-campaign-participation-count' sera  :-
- Campagne d’évaluation :  "Résultats reçus"
- Campagne de collect de profils : "Profils reçus"