### PR TITLE
[FEATURE] Marquer des signalements comme étant "résolus" (PIX-2620)

### DIFF
--- a/admin/app/components/certification/certification-list.js
+++ b/admin/app/components/certification/certification-list.js
@@ -24,7 +24,7 @@ export default class CertificationList extends Component {
 
     {
       propertyName: 'numberOfCertificationIssueReportsWithRequiredActionLabel',
-      title: 'Signalements impactants',
+      title: 'Signalements impactants non résolus',
       className: 'certification-list-page__cell--important',
     },
     {

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -37,29 +37,29 @@ export default class CertificationInformationsController extends Controller {
     return this.certification.status !== 'missing-assessment';
   }
 
-  @computed('certification.certificationIssueReports.@each.isActionRequired')
-  get certificationIssueReportsWithRequiredAction() {
-    return this.certification.certificationIssueReports.filter((issueReport) => issueReport.isActionRequired);
+  @computed('certification.certificationIssueReports.@each.isImpactful')
+  get impactfulCertificationIssueReports() {
+    return this.certification.certificationIssueReports.filter((issueReport) => issueReport.isImpactful);
   }
 
-  @computed('certification.certificationIssueReports.@each.isActionRequired')
-  get certificationIssueReportsWithoutRequiredAction() {
-    return this.certification.certificationIssueReports.filter((issueReport) => !issueReport.isActionRequired);
+  @computed('certification.certificationIssueReports.@each.isImpactful')
+  get unimpactfulCertificationIssueReports() {
+    return this.certification.certificationIssueReports.filter((issueReport) => !issueReport.isImpactful);
   }
 
-  @computed('certification.certificationIssueReports.@each.isActionRequired')
+  @computed('certification.certificationIssueReports.@each.isImpactful')
   get hasIssueReports() {
     return Boolean(this.certification.certificationIssueReports.length);
   }
 
-  @computed('certification.certificationIssueReports.@each.isActionRequired')
-  get hasIssueReportsWithRequiredAction() {
-    return Boolean(this.certification.certificationIssueReports.filter((issueReport) => issueReport.isActionRequired).length);
+  @computed('certification.certificationIssueReports.@each.isImpactful')
+  get hasImpactfulIssueReports() {
+    return Boolean(this.certification.certificationIssueReports.filter((issueReport) => issueReport.isImpactful).length);
   }
 
-  @computed('certification.certificationIssueReports.@each.isActionRequired')
-  get hasIssueReportsWithoutRequiredAction() {
-    return Boolean(this.certification.certificationIssueReports.filter((issueReport) => !issueReport.isActionRequired).length);
+  @computed('certification.certificationIssueReports.@each.isImpactful')
+  get hasUnimpactfulIssueReports() {
+    return Boolean(this.certification.certificationIssueReports.filter((issueReport) => !issueReport.isImpactful).length);
   }
 
   @computed('certification.status')

--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -90,7 +90,9 @@ export default class CertificationIssueReportModel extends Model {
   @attr('string') subcategory;
   @attr('string') description;
   @attr('string') questionNumber;
-  @attr('boolean') isActionRequired;
+  @attr('boolean') isImpactful;
+  @attr() resolvedAt;
+  @attr() resolution;
 
   @belongsTo('certification') certification;
 

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -34,4 +34,19 @@
     font-weight: bold;
     color: $information-dark;
   }
+
+  &__certification-issue-reports-list {
+    list-style-type: none;
+    padding-left: 16px;
+  }
+
+  &__certification-issue-report--resolved::before {
+    content: "✅";
+    margin-right: 8px;
+  }
+
+  &__certification-issue-report--unresolved::before {
+    content: "🚨";
+    margin-right: 8px;
+  }
 }

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -58,12 +58,12 @@
           <div class="card-body">
             <h5 class="card-title">Signalements</h5>
 
-            {{#if this.hasIssueReportsWithRequiredAction}}
+            {{#if this.hasImpactfulIssueReports}}
               <div class="card-text">
                 <h6 class="certification-informations__certification-issue-report-title--with-required-action">Signalement(s) impactant(s)</h6>
-                <ul>
-                  {{#each this.certificationIssueReportsWithRequiredAction as |issueReport| }}
-                    <li>
+                <ul class="certification-informations__certification-issue-reports-list">
+                  {{#each this.impactfulCertificationIssueReports as |issueReport| }}
+                    <li class={{if issueReport.resolvedAt "certification-informations__certification-issue-report--resolved" "certification-informations__certification-issue-report--unresolved"}}>
                       {{issueReport.categoryLabel}}
                       {{#if issueReport.subcategoryLabel}}: {{issueReport.subcategoryLabel}}{{/if}}
                       {{#if issueReport.description}}- {{issueReport.description}}{{/if}}
@@ -74,11 +74,11 @@
               </div>
             {{/if}}
 
-            {{#if this.hasIssueReportsWithoutRequiredAction}}
+            {{#if this.hasUnimpactfulIssueReports}}
               <div class="card-text">
                 <h6>Signalement(s) non impactant(s)</h6>
                 <ul>
-                  {{#each this.certificationIssueReportsWithoutRequiredAction as |issueReport| }}
+                  {{#each this.unimpactfulCertificationIssueReports as |issueReport| }}
                     <li>
                       {{issueReport.categoryLabel}}
                       {{#if issueReport.subcategoryLabel}}: {{issueReport.subcategoryLabel}}{{/if}}

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -66,7 +66,7 @@
   {{#if this.sessionModel.finalizedAt}}
   <div class="session-info__stats">
     <div class="row">
-      <div class="col">Nombre de signalements impactants :</div>
+      <div class="col">Nombre de signalements impactants non résolus:</div>
       <div class="col" data-test-id="session-info__number-of-blocking-report">{{this.sessionModel.countCertificationIssueReportsWithActionRequired}}</div>
     </div>
     <div class="row">

--- a/admin/tests/integration/components/routes/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/certification/informations_test.js
@@ -92,14 +92,14 @@ module('Integration | Component | routes/authenticated/certifications/certificat
 
     module('when there are certification issue reports', function() {
 
-      module('when there are only certification issue reports with required action', function() {
+      module('when there are only impactful certification issue reports', function() {
 
-        test('it renders only certifications issue reports with required action', async function(assert) {
+        test('it renders only impactful certifications issue reports', async function(assert) {
           // given
           const certificationIssueReport = this.server.create('certification-issue-report', {
             category: 'OTHER',
             description: 'Un signalement impactant',
-            isActionRequired: true,
+            isImpactful: true,
           });
           const certification = this.server.create('certification', {
             competencesWithMark: [
@@ -133,17 +133,65 @@ module('Integration | Component | routes/authenticated/certifications/certificat
           assert.dom('.card-text ul li').hasText('Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement impactant');
           assert.notContains('Signalement(s) non impactant(s)');
         });
+
+        module('when the impactful certification issue report is resolved', function() {
+
+          test('it renders the certifications issue report with the resolved icon', async function(assert) {
+            // given
+            const resolvedCertificationIssueReport = this.server.create('certification-issue-report', {
+              category: 'OTHER',
+              description: 'Un signalement impactant',
+              isImpactful: true,
+              resolvedAt: Date.now(),
+            });
+            const certification = this.server.create('certification', {
+              competencesWithMark: [],
+              certificationIssueReports: [resolvedCertificationIssueReport],
+            });
+
+            // when
+            await visit(`/certifications/${certification.id}`);
+
+            // then
+            assert.dom('.certification-informations__certification-issue-report--resolved').exists();
+            assert.dom('.certification-informations__certification-issue-report--unresolved').doesNotExist();
+          });
+        });
+
+        module('when the impactful certification issue report is not resolved', function() {
+
+          test('it renders the certifications issue report with the unresolved icon', async function(assert) {
+            // given
+            const unresolvedCertificationIssueReport = this.server.create('certification-issue-report', {
+              category: 'OTHER',
+              description: 'Un signalement impactant',
+              isImpactful: true,
+              resolvedAt: null,
+            });
+            const certification = this.server.create('certification', {
+              competencesWithMark: [],
+              certificationIssueReports: [unresolvedCertificationIssueReport],
+            });
+
+            // when
+            await visit(`/certifications/${certification.id}`);
+
+            // then
+            assert.dom('.certification-informations__certification-issue-report--unresolved').exists();
+            assert.dom('.certification-informations__certification-issue-report--resolved').doesNotExist();
+          });
+        });
       });
 
-      module('when there are only certification issue reports without required action', function() {
+      module('when there are only unimpactful certification issue reports', function() {
 
-        test('it renders only certifications issue reports without required action', async function(assert) {
+        test('it renders only unimpactful certifications issue reports', async function(assert) {
           // given
           const certificationIssueReport = this.server.create('certification-issue-report', {
             category: 'CANDIDATE_INFORMATIONS_CHANGES',
             subcategory: 'EXTRA_TIME_PERCENTAGE',
             description: 'Un signalement non impactant',
-            isActionRequired: false,
+            isImpactful: false,
           });
           const certification = this.server.create('certification', {
             competencesWithMark: [
@@ -186,7 +234,7 @@ module('Integration | Component | routes/authenticated/certifications/certificat
           subcategory: 'IMAGE_NOT_DISPLAYING',
           description: 'image disparue',
           questionNumber: 666,
-          isActionRequired: true,
+          isImpactful: true,
         });
         const certification = this.server.create('certification', {
           competencesWithMark: [

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -54,71 +54,71 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
-  module('#hasIssueReportsWithRequiredAction', () => {
+  module('#hasImpactfulIssueReports', () => {
     test('it should return true when there are some issue reports with required action', async function(assert) {
       // given
       const certificationIssueReports = [
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: false }),
       ];
       controller.certification = EmberObject.create({
         certificationIssueReports,
       });
 
       // when/then
-      assert.equal(controller.hasIssueReportsWithRequiredAction, true);
+      assert.equal(controller.hasImpactfulIssueReports, true);
     });
 
     test('it should return false when there are no issue reports with required action', async function(assert) {
       // given
       const certificationIssueReports = [
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: false }),
       ];
       controller.certification = EmberObject.create({
         certificationIssueReports,
       });
 
       // when/then
-      assert.equal(controller.hasIssueReportsWithRequiredAction, false);
+      assert.equal(controller.hasImpactfulIssueReports, false);
     });
   });
 
-  module('#hasIssueReportsWithoutRequiredAction', () => {
+  module('#hasUnimpactfulIssueReports', () => {
     test('it should return true when there are some issue reports without required action', async function(assert) {
       // given
       const certificationIssueReports = [
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: true }),
       ];
       controller.certification = EmberObject.create({
         certificationIssueReports,
       });
 
       // when/then
-      assert.equal(controller.hasIssueReportsWithoutRequiredAction, true);
+      assert.equal(controller.hasUnimpactfulIssueReports, true);
     });
 
     test('it should return false when there are no issue reports without required action', async function(assert) {
       // given
       const certificationIssueReports = [
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: true }),
       ];
       controller.certification = EmberObject.create({
         certificationIssueReports,
       });
 
       // when/then
-      assert.equal(controller.hasIssueReportsWithoutRequiredAction, false);
+      assert.equal(controller.hasUnimpactfulIssueReports, false);
     });
   });
 
@@ -126,10 +126,10 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     test('it should return true when there are some issue reports', async function(assert) {
       // given
       const certificationIssueReports = [
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: false }),
       ];
       controller.certification = EmberObject.create({
         certificationIssueReports,
@@ -164,40 +164,40 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
-  module('#certificationIssueReportsWithRequiredAction', () => {
+  module('#impactfulCertificationIssueReports', () => {
     test('it should return certification issue reports with action required', async function(assert) {
       // given
       const certificationIssueReports = [
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: false }),
       ];
       controller.certification = EmberObject.create({
         certificationIssueReports,
       });
 
       // when/then
-      assert.equal(controller.certificationIssueReportsWithRequiredAction.length, 2);
+      assert.equal(controller.impactfulCertificationIssueReports.length, 2);
     });
   });
 
-  module('#certificationIssueReportsWithoutRequiredAction', () => {
+  module('#unimpactfulCertificationIssueReports', () => {
     test('it should return certification issue reports without action required', async function(assert) {
       // given
       const certificationIssueReports = [
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: true }),
-        EmberObject.create({ isActionRequired: false }),
-        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: true }),
+        EmberObject.create({ isImpactful: false }),
+        EmberObject.create({ isImpactful: false }),
       ];
       controller.certification = EmberObject.create({
         certificationIssueReports,
       });
 
       // when/then
-      assert.equal(controller.certificationIssueReportsWithoutRequiredAction.length, 3);
+      assert.equal(controller.unimpactfulCertificationIssueReports.length, 3);
     });
   });
 

--- a/api/db/database-builder/factory/build-certification-issue-report.js
+++ b/api/db/database-builder/factory/build-certification-issue-report.js
@@ -10,6 +10,8 @@ module.exports = function buildCertificationIssueReport({
   description = 'Une super description',
   subcategory = null,
   questionNumber = null,
+  resolvedAt = null,
+  resolution = null,
 } = {}) {
 
   certificationCourseId = _.isUndefined(certificationCourseId)
@@ -23,6 +25,8 @@ module.exports = function buildCertificationIssueReport({
     description,
     subcategory,
     questionNumber,
+    resolvedAt,
+    resolution,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-issue-reports',

--- a/api/db/migrations/20210525140944_add-column-processed-at-table-certification-issue-reports.js
+++ b/api/db/migrations/20210525140944_add-column-processed-at-table-certification-issue-reports.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.table('certification-issue-reports', (table) => {
+    table.dateTime('resolvedAt');
+    table.string('resolution');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('certification-issue-reports', (table) => {
+    table.dropColumn('resolvedAt');
+    table.dropColumn('resolution');
+  });
+};

--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -63,6 +63,17 @@ function _buildCertificationCourse(databaseBuilder, { id, assessmentId, userId, 
       category: CertificationIssueReportCategories.OTHER,
       description: examinerComment,
     });
+    databaseBuilder.factory.buildCertificationIssueReport({
+      certificationCourseId,
+      category: CertificationIssueReportCategories.OTHER,
+      description: examinerComment,
+      resolvedAt: '2020-05-01T00:00:00Z',
+    });
+    databaseBuilder.factory.buildCertificationIssueReport({
+      certificationCourseId,
+      category: CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
+      description: examinerComment,
+    });
   }
   databaseBuilder.factory.buildAssessment({
     id: assessmentId, certificationCourseId, type: 'CERTIFICATION', state: 'completed', userId, competenceId: null,

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -106,6 +106,8 @@ class CertificationIssueReport {
       description,
       subcategory,
       questionNumber,
+      resolvedAt,
+      resolution,
     } = {}) {
     this.id = id;
     this.certificationCourseId = certificationCourseId;
@@ -113,6 +115,8 @@ class CertificationIssueReport {
     this.subcategory = subcategory;
     this.description = description;
     this.questionNumber = questionNumber;
+    this.resolvedAt = resolvedAt;
+    this.resolution = resolution;
     this.isActionRequired = _isActionRequired({ category, subcategory });
 
     if ([CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN, CertificationIssueReportCategories.OTHER].includes(this.category)) {
@@ -143,6 +147,8 @@ class CertificationIssueReport {
       description,
       subcategory,
       questionNumber,
+      resolvedAt: null,
+      resolution: null,
     });
     certificationIssueReport.validate();
     return certificationIssueReport;

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -72,13 +72,13 @@ const categorySchemas = {
   [CertificationIssueReportCategories.TECHNICAL_PROBLEM]: categoryTechnicalProblemJoiSchema,
 };
 
-const categoryCodeWithRequiredAction = {
+const categoryCodeImpactful = {
   [CertificationIssueReportCategories.TECHNICAL_PROBLEM]: 'A1',
   [CertificationIssueReportCategories.OTHER]: 'A2',
   [CertificationIssueReportCategories.FRAUD]: 'C6',
 };
 
-const subcategoryCodeRequiredAction = {
+const subcategoryCodeImpactful = {
   [CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'C1',
   [CertificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'C3',
   [CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'E1',
@@ -117,7 +117,7 @@ class CertificationIssueReport {
     this.questionNumber = questionNumber;
     this.resolvedAt = resolvedAt;
     this.resolution = resolution;
-    this.isActionRequired = _isActionRequired({ category, subcategory });
+    this.isImpactful = _isImpactful({ category, subcategory });
 
     if ([CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN, CertificationIssueReportCategories.OTHER].includes(this.category)) {
       this.subcategory = null;
@@ -173,8 +173,8 @@ class CertificationIssueReport {
 
 module.exports = CertificationIssueReport;
 
-function _isActionRequired({ category, subcategory }) {
-  return Boolean(subcategoryCodeRequiredAction[subcategory] || categoryCodeWithRequiredAction[category]);
+function _isImpactful({ category, subcategory }) {
+  return Boolean(subcategoryCodeImpactful[subcategory] || categoryCodeImpactful[category]);
 }
 
 function _isSubcategoryDeprecated(subcategory) {

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -132,7 +132,7 @@ class CertificationIssueReport {
     }
   }
 
-  static new({
+  static create({
     id,
     certificationCourseId,
     category,

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -169,6 +169,10 @@ class CertificationIssueReport {
       throw new DeprecatedCertificationIssueReportSubcategory();
     }
   }
+
+  isResolved() {
+    return Boolean(this.resolvedAt);
+  }
 }
 
 module.exports = CertificationIssueReport;

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -36,7 +36,7 @@ class JuryCertificationSummary {
   }
 
   isActionRequired() {
-    return this.certificationIssueReports.some((issueReport) => issueReport.isActionRequired);
+    return this.certificationIssueReports.some((issueReport) => (issueReport.isImpactful && issueReport.resolvedAt === null));
   }
 
   hasScoringError() {

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -36,7 +36,7 @@ class JuryCertificationSummary {
   }
 
   isActionRequired() {
-    return this.certificationIssueReports.some((issueReport) => (issueReport.isImpactful && issueReport.resolvedAt === null));
+    return this.certificationIssueReports.some((issueReport) => (issueReport.isImpactful && !issueReport.isResolved()));
   }
 
   hasScoringError() {

--- a/api/lib/domain/usecases/save-certification-issue-report.js
+++ b/api/lib/domain/usecases/save-certification-issue-report.js
@@ -15,6 +15,6 @@ module.exports = async function saveCertificationIssueReport({
     throw new NotFoundError('Erreur lors de la sauvegarde du signalement. Veuillez vous connecter et réessayer.');
   }
 
-  const certificationIssueReport = CertificationIssueReport.new(certificationIssueReportDTO);
+  const certificationIssueReport = CertificationIssueReport.create(certificationIssueReportDTO);
   return certificationIssueReportRepository.save(certificationIssueReport);
 };

--- a/api/lib/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-issue-report-repository.js
@@ -6,7 +6,7 @@ const omit = require('lodash/omit');
 module.exports = {
   async save(certificationIssueReport) {
     const newCertificationIssueReport = await new CertificationIssueReportBookshelf(
-      omit(certificationIssueReport, ['isActionRequired']),
+      omit(certificationIssueReport, ['isImpactful']),
     ).save();
     return bookshelfToDomainConverter.buildDomainObject(CertificationIssueReportBookshelf, newCertificationIssueReport);
   },

--- a/api/lib/infrastructure/repositories/general-certification-information-repository.js
+++ b/api/lib/infrastructure/repositories/general-certification-information-repository.js
@@ -32,6 +32,8 @@ function _toDomain({ certificationCourseDTO, certificationIssueReportsDTO }) {
         description: certificationIssueReport.description,
         subcategory: certificationIssueReport.subcategory,
         questionNumber: certificationIssueReport.questionNumber,
+        resolvedAt: certificationIssueReport.resolvedAt,
+        resolution: certificationIssueReport.resolution,
       }),
     );
 

--- a/api/lib/infrastructure/serializers/jsonapi/certification-result-information-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-result-information-serializer.js
@@ -43,7 +43,9 @@ module.exports = {
           'description',
           'subcategory',
           'questionNumber',
-          'isActionRequired',
+          'isImpactful',
+          'resolvedAt',
+          'resolution',
         ],
       },
     }).serialize(certificationResultInformation);

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer.js
@@ -12,7 +12,7 @@ module.exports = {
         result.examinerComment =
           get(juryCertificationSummary, 'certificationIssueReports[0].description');
         result.numberOfCertificationIssueReports = juryCertificationSummary.certificationIssueReports.length;
-        result.numberOfCertificationIssueReportsWithRequiredAction = juryCertificationSummary.certificationIssueReports.filter((issueReport) => issueReport.isActionRequired).length;
+        result.numberOfCertificationIssueReportsWithRequiredAction = juryCertificationSummary.certificationIssueReports.filter((issueReport) => issueReport.isImpactful && issueReport.resolvedAt === null).length;
         result.cleaCertificationStatus = result.cleaCertificationResult.status;
         result.pixPlusDroitMaitreCertificationStatus = result.pixPlusDroitMaitreCertificationResult.status;
         result.pixPlusDroitExpertCertificationStatus = result.pixPlusDroitExpertCertificationResult.status;

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { expect, databaseBuilder, knex, catchErr } = require('../../../test-helper');
+const { expect, domainBuilder, databaseBuilder, knex, catchErr } = require('../../../test-helper');
 const certificationIssueReportRepository = require('../../../../lib/infrastructure/repositories/certification-issue-report-repository');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
@@ -16,29 +16,34 @@ describe('Integration | Repository | Certification Issue Report', function() {
     it('should persist the certif issue report in db', async () => {
       // given
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
-      const certificationIssueReport = new CertificationIssueReport({
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
         certificationCourseId,
         category: CertificationIssueReportCategories.IN_CHALLENGE,
         description: 'Un gros problème',
         subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
         questionNumber: 5,
+        resolvedAt: new Date('2020-01-01'),
+        resolution: 'coucou',
       });
+      certificationIssueReport.id = undefined;
       await databaseBuilder.commit();
 
       // when
       const savedCertificationIssueReport = await certificationIssueReportRepository.save(certificationIssueReport);
 
       // then
-      const expectedSavedCertificationIssueReport = {
+      const expectedSavedCertificationIssueReport = domainBuilder.buildCertificationIssueReport({
         certificationCourseId,
         category: CertificationIssueReportCategories.IN_CHALLENGE,
         description: 'Un gros problème',
         isActionRequired: true,
         subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
         questionNumber: 5,
-      };
+        resolvedAt: new Date('2020-01-01'),
+        resolution: 'coucou',
+      });
 
-      expect(_.omit(savedCertificationIssueReport, 'id')).to.deep.equal(expectedSavedCertificationIssueReport);
+      expect(_.omit(savedCertificationIssueReport, 'id')).to.deep.equal(_.omit(expectedSavedCertificationIssueReport, 'id'));
       expect(savedCertificationIssueReport).to.be.an.instanceOf(CertificationIssueReport);
     });
   });

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -98,7 +98,7 @@ describe('Integration | Repository | Certification Issue Report', function() {
       const result = await certificationIssueReportRepository.get(issueReport.id);
 
       // then
-      const expectedIssueReport = { ...issueReport, isActionRequired: true };
+      const expectedIssueReport = domainBuilder.buildCertificationIssueReport(issueReport);
       expect(result).to.deep.equal(expectedIssueReport);
       expect(result).to.be.instanceOf(CertificationIssueReport);
     });

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -36,7 +36,7 @@ describe('Integration | Repository | CertificationReport', function() {
           certificationCourseId: certificationCourse1.id,
           firstName: certificationCourse1.firstName,
           lastName: certificationCourse1.lastName,
-          certificationIssueReports: [ { ...certificationIssueReport1, isActionRequired: true } ],
+          certificationIssueReports: [ { ...certificationIssueReport1, isImpactful: true } ],
           hasSeenEndTestScreen: certificationCourse1.hasSeenEndTestScreen,
         });
         const expectedCertificationReport2 = domainBuilder.buildCertificationReport({

--- a/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
@@ -4,7 +4,7 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 
 const GeneralCertificationInformation = require('../../../../lib/domain/read-models/GeneralCertificationInformation');
 
-describe('Integration | Repository | Certification Course', function() {
+describe('Integration | Repository | General certification information', function() {
 
   describe('#get', function() {
 

--- a/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
@@ -53,8 +53,8 @@ describe('Integration | Repository | General certification information', functio
           birthdate: certificationCourseDTO.birthdate,
           birthplace: certificationCourseDTO.birthplace,
           certificationIssueReports: [
-            { ...firstCertificationReport, isActionRequired: true },
-            { ...secondCertificationReport, isActionRequired: true },
+            { ...firstCertificationReport, isImpactful: true },
+            { ...secondCertificationReport, isImpactful: true },
           ],
         };
         expect(result).to.be.instanceOf(GeneralCertificationInformation);

--- a/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
@@ -30,10 +30,14 @@ describe('Integration | Repository | General certification information', functio
         const firstCertificationReport = databaseBuilder.factory.buildCertificationIssueReport({
           certificationCourseId,
           description: 'Houston nous avons un problème',
+          resolvedAt: new Date('2021-01-01T00:00:00Z'),
+          resolution: 'challenge neutralized',
         });
         const secondCertificationReport = databaseBuilder.factory.buildCertificationIssueReport({
           certificationCourseId,
           description: 'Un autre problème',
+          resolvedAt: null,
+          resolution: null,
         });
         await databaseBuilder.commit();
 
@@ -53,8 +57,8 @@ describe('Integration | Repository | General certification information', functio
           birthdate: certificationCourseDTO.birthdate,
           birthplace: certificationCourseDTO.birthplace,
           certificationIssueReports: [
-            { ...firstCertificationReport, isImpactful: true },
-            { ...secondCertificationReport, isImpactful: true },
+            { ...firstCertificationReport, isImpactful: true, resolution: 'challenge neutralized', resolvedAt: new Date('2021-01-01T00:00:00Z') },
+            { ...secondCertificationReport, isImpactful: true, resolution: null, resolvedAt: null },
           ],
         };
         expect(result).to.be.instanceOf(GeneralCertificationInformation);

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -91,6 +91,8 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
             subcategory: null,
             questionNumber: null,
             category: CertificationIssueReportCategories.OTHER,
+            resolvedAt: null,
+            resolution: null,
           })],
         });
         expect(juryCertificationSummaries).to.have.length(3);
@@ -195,6 +197,8 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
             description: 'first certification issue report',
             subcategory: null,
             questionNumber: null,
+            resolvedAt: null,
+            resolution: null,
           }),
           new CertificationIssueReport({
             id: issueReport2.id,
@@ -203,6 +207,8 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
             description: 'second certification issue report',
             subcategory: null,
             questionNumber: null,
+            resolvedAt: null,
+            resolution: null,
           }),
         ]);
       });

--- a/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
@@ -8,6 +8,8 @@ module.exports = function buildCertificationIssueReport({
   subcategory = CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
   description = 'Une super description',
   questionNumber = null,
+  resolvedAt = null,
+  resolution = null,
 } = {}) {
   return new CertificationIssueReport({
     id,
@@ -16,5 +18,7 @@ module.exports = function buildCertificationIssueReport({
     subcategory,
     description,
     questionNumber,
+    resolvedAt,
+    resolution,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
@@ -1,7 +1,7 @@
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 
-module.exports = function buildCertificationIssueReport({
+const buildCertificationIssueReport = function({
   id = 123,
   certificationCourseId,
   category = CertificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
@@ -22,3 +22,45 @@ module.exports = function buildCertificationIssueReport({
     resolution,
   });
 };
+
+buildCertificationIssueReport.impactful = function({
+  id,
+  certificationCourseId,
+  description,
+  questionNumber,
+  resolvedAt,
+  resolution,
+} = {}) {
+  return buildCertificationIssueReport({
+    id,
+    certificationCourseId,
+    description,
+    questionNumber,
+    resolvedAt,
+    resolution,
+    category: CertificationIssueReportCategories.FRAUD,
+    subcategory: null,
+  });
+};
+
+buildCertificationIssueReport.notImpactful = function({
+  id,
+  certificationCourseId,
+  description,
+  questionNumber,
+  resolvedAt,
+  resolution,
+} = {}) {
+  return buildCertificationIssueReport({
+    id,
+    certificationCourseId,
+    description,
+    questionNumber,
+    resolvedAt,
+    resolution,
+    category: CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
+    subcategory: null,
+  });
+};
+
+module.exports = buildCertificationIssueReport;

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -303,7 +303,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       });
     });
 
-    context('Adds isActionRequired boolean to certif issue report when an action is needed', function() {
+    context('Adds isImpactful boolean to certif issue report when the category or subcategory is impactful', function() {
       [
         { certificationCourseId: 42, category: 'OTHER', subcategory: undefined, description: 'toto' },
         { certificationCourseId: 42, category: 'CANDIDATE_INFORMATIONS_CHANGES', subcategory: 'NAME_OR_BIRTHDATE', description: 'toto' },
@@ -319,8 +319,8 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'SOFTWARE_NOT_WORKING', questionNumber: 42 },
         { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
       ].forEach((certificationIssueReportDTO) => {
-        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isActionRequired to true`, () => {
-          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isActionRequired).to.be.true;
+        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isImpactful to true`, () => {
+          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isImpactful).to.be.true;
         });
       });
 
@@ -329,8 +329,8 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         { certificationCourseId: 42, category: 'LATE_OR_LEAVING', subcategory: 'SIGNATURE_ISSUE' },
         { certificationCourseId: 42, category: 'CONNECTION_OR_END_SCREEN' },
       ].forEach((certificationIssueReportDTO) => {
-        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isActionRequired to false`, () => {
-          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isActionRequired).to.be.false;
+        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isImpactful to false`, () => {
+          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isImpactful).to.be.false;
         });
       });
     });

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -10,7 +10,7 @@ const UNDEFINED_VALUE = undefined;
 
 describe('Unit | Domain | Models | CertificationIssueReport', () => {
 
-  describe('#new', () => {
+  describe('#create', () => {
 
     context('CATEGORY: OTHER', () => {
       const certificationIssueReportDTO = {
@@ -20,7 +20,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should create an OTHER CertificationIssueReport', () => {
-        expect(CertificationIssueReport.new(certificationIssueReportDTO)).to.be.an.instanceOf(CertificationIssueReport);
+        expect(CertificationIssueReport.create(certificationIssueReportDTO)).to.be.an.instanceOf(CertificationIssueReport);
       });
 
       [
@@ -31,7 +31,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, () => {
           // when
-          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, description: emptyValue }))
+          expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, description: emptyValue }))
             .to.throw(InvalidCertificationIssueReportForSaving);
         });
       });
@@ -43,7 +43,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should create an OTHER CertificationIssueReport when subcategory is empty with value ${emptyValue}`, () => {
           // when
-          expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory: emptyValue }))
+          expect(CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory: emptyValue }))
             .to.be.an.instanceOf(CertificationIssueReport);
         });
       });
@@ -58,7 +58,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should create a LATE_OR_LEAVING CertificationIssueReport of category', () => {
-        expect(CertificationIssueReport.new(certificationIssueReportDTO))
+        expect(CertificationIssueReport.create(certificationIssueReportDTO))
           .to.be.an.instanceOf(CertificationIssueReport);
       });
 
@@ -70,7 +70,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, () => {
           // when
-          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, description: emptyValue }))
+          expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, description: emptyValue }))
             .to.throw(InvalidCertificationIssueReportForSaving);
         });
       });
@@ -80,13 +80,13 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         if ([CertificationIssueReportSubcategories.LEFT_EXAM_ROOM, CertificationIssueReportSubcategories.SIGNATURE_ISSUE].includes(subcategory)) {
           it(`should create a LATE_OR_LEAVING CertificationIssueReport when subcategory is of value ${subcategory}`, () => {
             // when
-            expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
+            expect(CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory }))
               .to.be.an.instanceOf(CertificationIssueReport);
           });
         } else {
           it(`should throw an InvalidCertificationIssueReportForSaving when subcategory is ${subcategory}`, () => {
             // when
-            expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
+            expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory }))
               .to.throw(InvalidCertificationIssueReportForSaving);
           });
         }
@@ -102,7 +102,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should create a CANDIDATE_INFORMATIONS_CHANGES CertificationIssueReport', () => {
-        expect(CertificationIssueReport.new(certificationIssueReportDTO))
+        expect(CertificationIssueReport.create(certificationIssueReportDTO))
           .to.be.an.instanceOf(CertificationIssueReport);
       });
 
@@ -114,7 +114,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, () => {
           // when
-          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, description: emptyValue }))
+          expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, description: emptyValue }))
             .to.throw(InvalidCertificationIssueReportForSaving);
         });
       });
@@ -124,13 +124,13 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         if ([CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE, CertificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE].includes(subcategory)) {
           it(`should create a CANDIDATE_INFORMATIONS_CHANGES CertificationIssueReport when subcategory is of value ${subcategory}`, () => {
             // when
-            expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
+            expect(CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory }))
               .to.be.an.instanceOf(CertificationIssueReport);
           });
         } else {
           it(`should throw an InvalidCertificationIssueReportForSaving when subcategory is ${subcategory}`, () => {
             // when
-            expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
+            expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory }))
               .to.throw(InvalidCertificationIssueReportForSaving);
           });
         }
@@ -144,7 +144,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should create a CONNECTION_OR_END_SCREEN CertificationIssueReport', () => {
-        expect(CertificationIssueReport.new(certificationIssueReportDTO))
+        expect(CertificationIssueReport.create(certificationIssueReportDTO))
           .to.be.an.instanceOf(CertificationIssueReport);
       });
 
@@ -156,7 +156,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should create a CONNECTION_OR_END_SCREEN CertificationIssueReport when description is empty with value ${emptyValue}`, () => {
           // when
-          expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, description: emptyValue }))
+          expect(CertificationIssueReport.create({ ...certificationIssueReportDTO, description: emptyValue }))
             .to.be.an.instanceOf(CertificationIssueReport);
         });
       });
@@ -168,7 +168,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should create CONNECTION_OR_END_SCREEN CertificationIssueReport when subcategory is empty with value ${emptyValue}`, () => {
           // when
-          expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory: emptyValue }))
+          expect(CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory: emptyValue }))
             .to.be.an.instanceOf(CertificationIssueReport);
         });
       });
@@ -183,7 +183,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should create an IN_CHALLENGE CertificationIssueReport', () => {
-        expect(CertificationIssueReport.new(certificationIssueReportDTO))
+        expect(CertificationIssueReport.create(certificationIssueReportDTO))
           .to.be.an.instanceOf(CertificationIssueReport);
       });
 
@@ -200,7 +200,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         ].includes(subcategory)) {
           it(`should create an IN_CHALLENGE CertificationIssueReport when subcategory is of value ${subcategory}`, () => {
             // when
-            expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory, description: subcategory === CertificationIssueReportSubcategories.OTHER ? 'salut' : null }))
+            expect(CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory, description: subcategory === CertificationIssueReportSubcategories.OTHER ? 'salut' : null }))
               .to.be.an.instanceOf(CertificationIssueReport);
           });
         }
@@ -211,7 +211,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         ].includes(subcategory)) {
           it(`should throw a deprecated error when using subcategory ${subcategory}`, () => {
             // when
-            const createIssueReport = () => CertificationIssueReport.new({
+            const createIssueReport = () => CertificationIssueReport.create({
               ...certificationIssueReportDTO,
               category: CertificationIssueReportCategories.IN_CHALLENGE,
               subcategory: CertificationIssueReportSubcategories.LINK_NOT_WORKING,
@@ -225,7 +225,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         else {
           it(`should throw an InvalidCertificationIssueReportForSaving when subcategory is ${subcategory}`, () => {
             // when
-            expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
+            expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory }))
               .to.throw(InvalidCertificationIssueReportForSaving);
           });
         }
@@ -238,20 +238,20 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when questionNumber is empty with value ${emptyValue}`, () => {
           // when
-          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, questionNumber: emptyValue }))
+          expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, questionNumber: emptyValue }))
             .to.throw(InvalidCertificationIssueReportForSaving);
         });
       });
 
       it('should throw an InvalidCertificationIssueReportForSaving when questionNumber is over 500', () => {
         // when
-        expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, questionNumber: 501 }))
+        expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, questionNumber: 501 }))
           .to.throw(InvalidCertificationIssueReportForSaving);
       });
 
       it('should throw an InvalidCertificationIssueReportForSaving when questionNumber is under 1', () => {
         // when
-        expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, questionNumber: 0 }))
+        expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, questionNumber: 0 }))
           .to.throw(InvalidCertificationIssueReportForSaving);
       });
     });
@@ -262,7 +262,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should be valid', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).not.to.throw();
+        expect(() => CertificationIssueReport.create(certificationIssueReportDTO)).not.to.throw();
       });
     });
 
@@ -274,7 +274,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should create an TECHNICAL_PROBLEM CertificationIssueReport', () => {
-        expect(CertificationIssueReport.new(certificationIssueReportDTO)).to.be.an.instanceOf(CertificationIssueReport);
+        expect(CertificationIssueReport.create(certificationIssueReportDTO)).to.be.an.instanceOf(CertificationIssueReport);
       });
 
       [
@@ -285,7 +285,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, () => {
           // when
-          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, description: emptyValue }))
+          expect(() => CertificationIssueReport.create({ ...certificationIssueReportDTO, description: emptyValue }))
             .to.throw(InvalidCertificationIssueReportForSaving);
         });
       });
@@ -297,7 +297,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       ].forEach((emptyValue) => {
         it(`should create an TECHNICAL_PROBLEM CertificationIssueReport when subcategory is empty with value ${emptyValue}`, () => {
           // when
-          expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory: emptyValue }))
+          expect(CertificationIssueReport.create({ ...certificationIssueReportDTO, subcategory: emptyValue }))
             .to.be.an.instanceOf(CertificationIssueReport);
         });
       });

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories, DeprecatedCertificationIssueReportCategory } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const { InvalidCertificationIssueReportForSaving } = require('../../../../lib/domain/errors');
@@ -333,6 +333,35 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
           expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isImpactful).to.be.false;
         });
       });
+    });
+  });
+
+  describe('#isResolved', () => {
+
+    it('returns false when the certification issue report is not resolved', () => {
+      // given
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+        resolvedAt: null,
+      });
+
+      // when
+      const isResolved = certificationIssueReport.isResolved();
+
+      // then
+      expect(isResolved).to.be.false;
+    });
+
+    it('returns true when the certification issue report is resolved', () => {
+      // given
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+        resolvedAt: new Date(),
+      });
+
+      // when
+      const isResolved = certificationIssueReport.isResolved();
+
+      // then
+      expect(isResolved).to.be.true;
     });
   });
 });

--- a/api/tests/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/unit/domain/models/FinalizedSession_test.js
@@ -7,6 +7,7 @@ const { CertificationIssueReportCategories, CertificationIssueReportSubcategorie
 describe('Unit | Domain | Models | FinalizedSession', () => {
 
   context('#isPublishable', () => {
+
     it('is not publishable when session has an examiner global comment', () => {
       // given / when
       const finalizedSession = FinalizedSession.from({
@@ -37,7 +38,7 @@ describe('Unit | Domain | Models | FinalizedSession', () => {
       expect(finalizedSession.isPublishable).to.be.false;
     });
 
-    it('is not publishable when at least one issue report require action', () => {
+    it('is not publishable when has at least one unresolved issue report that requires action', () => {
       // given / when
       const finalizedSession = FinalizedSession.from({
         sessionId: 1234,
@@ -45,7 +46,7 @@ describe('Unit | Domain | Models | FinalizedSession', () => {
         sessionDate: '2021-01-29',
         sessionTime: '16:00',
         hasExaminerGlobalComment: false,
-        juryCertificationSummaries: _someWithRequiredActionButNoErrorOrStartedStatus(),
+        juryCertificationSummaries: _someWithUnresolvedRequiredActionButNoErrorOrStartedStatus(),
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
       // then
@@ -96,6 +97,21 @@ describe('Unit | Domain | Models | FinalizedSession', () => {
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
 
+      // then
+      expect(finalizedSession.isPublishable).to.be.true;
+    });
+
+    it('is publishable when has no unresolved issue reports that requires action', () => {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _someWithResolvedRequiredActionButNoErrorOrStartedStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
       // then
       expect(finalizedSession.isPublishable).to.be.true;
     });
@@ -286,7 +302,7 @@ function _noneWithRequiredActionButSomeStartedStatus() {
   ];
 }
 
-function _someWithRequiredActionButNoErrorOrStartedStatus() {
+function _someWithUnresolvedRequiredActionButNoErrorOrStartedStatus() {
   return [
     new JuryCertificationSummary({
       id: 1,
@@ -302,6 +318,32 @@ function _someWithRequiredActionButNoErrorOrStartedStatus() {
       certificationIssueReports: [
         domainBuilder.buildCertificationIssueReport({
           category: CertificationIssueReportCategories.FRAUD,
+          resolvedAt: null,
+          resolution: null,
+        }),
+      ],
+    }),
+  ];
+}
+
+function _someWithResolvedRequiredActionButNoErrorOrStartedStatus() {
+  return [
+    new JuryCertificationSummary({
+      id: 1,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: 'validated',
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: new Date(),
+      isPublished: false,
+      hasSeenEndTestScreen: true,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.FRAUD,
+          resolvedAt: new Date('2020-01-01'),
+          resolution: 'des points gratos offerts',
         }),
       ],
     }),

--- a/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -2,7 +2,6 @@ const { expect, domainBuilder } = require('../../../test-helper');
 const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const forIn = require('lodash/forIn');
-const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 
 describe('Unit | Domain | Models | JuryCertificationSummary', () => {
 
@@ -34,29 +33,66 @@ describe('Unit | Domain | Models | JuryCertificationSummary', () => {
   });
 
   describe('#isActionRequired', () => {
-    context('when at least one issue report requires action', () => {
-      it('should return true', () => {
-        // given
-        const juryCertificationSummary = new JuryCertificationSummary({ certificationIssueReports: [
-          domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.FRAUD }),
-        ] });
 
-        // when
-        const isRequired = juryCertificationSummary.isActionRequired();
+    context('when the issue report is unresolved', () => {
 
-        // then
-        expect(isRequired).to.be.true;
+      context('when the issue report is impactful', () => {
+
+        it('should return true', () => {
+          // given
+          const juryCertificationSummary = new JuryCertificationSummary({ certificationIssueReports: [
+            domainBuilder.buildCertificationIssueReport.impactful({ resolvedAt: null }),
+          ] });
+
+          // when
+          const isRequired = juryCertificationSummary.isActionRequired();
+
+          // then
+          expect(isRequired).to.be.true;
+        });
       });
 
-      context('when no issues require action', () => {
+      context('when the issue report is not impactful', () => {
 
         it('should return false', () => {
           // given
           const juryCertificationSummary = new JuryCertificationSummary({ certificationIssueReports: [
-            domainBuilder.buildCertificationIssueReport({
-              category: CertificationIssueReportCategories.LATE_OR_LEAVING,
-              subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
-            }),
+            domainBuilder.buildCertificationIssueReport.notImpactful({ resolvedAt: null }),
+          ] });
+
+          // when
+          const isRequired = juryCertificationSummary.isActionRequired();
+
+          // then
+          expect(isRequired).to.be.false;
+        });
+      });
+    });
+
+    context('when the issue report is resolved', () => {
+
+      context('when the issue report is impactful', () => {
+
+        it('should return false', () => {
+          // given
+          const juryCertificationSummary = new JuryCertificationSummary({ certificationIssueReports: [
+            domainBuilder.buildCertificationIssueReport.impactful({ resolvedAt: new Date('2020-01-01'), resolution: 'coucou' }),
+          ] });
+
+          // when
+          const isRequired = juryCertificationSummary.isActionRequired();
+
+          // then
+          expect(isRequired).to.be.false;
+        });
+      });
+
+      context('when the issue report is not impactful', () => {
+
+        it('should return false', () => {
+          // given
+          const juryCertificationSummary = new JuryCertificationSummary({ certificationIssueReports: [
+            domainBuilder.buildCertificationIssueReport.notImpactful({ resolvedAt: new Date('2020-01-01') }),
           ] });
 
           // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-information-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-information-serializer_test.js
@@ -10,7 +10,11 @@ describe('Unit | Serializer | JSONAPI | certification-result-information-seriali
     it('should serialize results of a certification', () => {
       // given
       const certificationCourseId = 123;
-      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({ certificationCourseId });
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport.impactful({
+        certificationCourseId,
+        resolvedAt: new Date(),
+        resolution: 'le challenge est neutralisé',
+      });
       const certificationIssueReports = [ certificationIssueReport ];
       const competenceMarks = [ domainBuilder.buildCompetenceMark() ];
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
@@ -85,7 +89,9 @@ describe('Unit | Serializer | JSONAPI | certification-result-information-seriali
           attributes: {
             category: certificationIssueReport.category,
             description: certificationIssueReport.description,
-            'is-action-required': certificationIssueReport.isActionRequired,
+            'is-impactful': true,
+            'resolved-at': certificationIssueReport.resolvedAt,
+            'resolution': certificationIssueReport.resolution,
             'question-number': certificationIssueReport.questionNumber,
             subcategory: certificationIssueReport.subcategory,
           },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-summary-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-summary-serializer_test.js
@@ -1,8 +1,6 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer');
 const JuryCertificationSummary = require('../../../../../lib/domain/read-models/JuryCertificationSummary');
-const CertificationIssueReport = require('../../../../../lib/domain/models/CertificationIssueReport');
-const { CertificationIssueReportCategories } = require('../../../../../lib/domain/models/CertificationIssueReportCategory');
 
 describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', function() {
 
@@ -12,10 +10,10 @@ describe('Unit | Serializer | JSONAPI | jury-certification-summary-serializer', 
     let expectedJsonApi;
 
     beforeEach(() => {
-      const issueReport = new CertificationIssueReport({
+      const issueReport = domainBuilder.buildCertificationIssueReport.impactful({
         certificationCourseId: 1,
         description: 'someComment',
-        category: CertificationIssueReportCategories.OTHER,
+        resolvedAt: null,
       });
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
       const pixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();


### PR DESCRIPTION
## :unicorn: Problème
Avec la massification des certifications, il devient de plus en plus compliqué pour le pôle certif de traiter manuellement tous les types de signalements, notamment ceux de la catégorie “Problème technique sur une question” qui représentent la plus grand majorité. 

L’idée est donc d’automatiser la prise en compte des signalements de ce type.

## :robot: Solution
A la finalisation d’une session, si il y a un signalement de type “Problème technique sur une question”, avec l’une des sous-catégories suivantes : 

E4 - Le site à visiter est indisponible/en maintenance/inaccessible

E5 - Le site est bloqué par les restrictions réseau de l’établissement

E9 - Le logiciel installé sur l’ordinateur n’a pas fonctionné

Neutraliser la question concernée si celle-ci est au statut “Echec” ou “Abandon”

## :rainbow: Remarques
Cette PR ne concerne que le fait de marquer un signalement comme étant "résolu" ce qui est une étape préliminaire à la prise en compte automatique des signalements. A terme une session sera publiable lorsqu'elle n'aura plus de signalements impactant non résolus.

## :100: Pour tester
- dans pix admin, visualiser une certification avec un signalement impactant
- constater qu'il est affiché avec un 🚨
- dans la base de données, remplir le champ `resolvedAt` de la table `certification-issue-reports` avec une date
- constater qu'il est maintenant affiché avec un ✅
