### PR TITLE
[TECH] Contrôler le retour de l'ID token sur PoleEmploi (PIX-2639).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -151,6 +151,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.InvalidCertificationReportForFinalization) {
     return new HttpErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.InvalidExternalAPIResponseError) {
+    return new HttpErrors.ServiceUnavailableError(error.message);
+  }
   if (error instanceof DomainErrors.NoCertificationResultForDivision) {
     return new HttpErrors.NotFoundError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -825,6 +825,12 @@ class YamlParsingError extends DomainError {
   }
 }
 
+class InvalidExternalAPIResponseError extends DomainError {
+  constructor(message = 'L\'API externe a renvoyé une réponse incorrecte') {
+    super(message);
+  }
+}
+
 module.exports = {
   AlreadyExistingEntityError,
   AlreadyExistingCampaignParticipationError,
@@ -877,6 +883,7 @@ module.exports = {
   InvalidCertificationReportForFinalization,
   InvalidCertificationIssueReportForSaving,
   InvalidExternalUserTokenError,
+  InvalidExternalAPIResponseError,
   InvalidMembershipOrganizationRoleError,
   InvalidPasswordForUpdateEmailError,
   InvalidResultRecipientTokenError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -826,7 +826,7 @@ class YamlParsingError extends DomainError {
 }
 
 class InvalidExternalAPIResponseError extends DomainError {
-  constructor(message = 'L\'API externe a renvoyé une réponse incorrecte') {
+  constructor(message = 'L\'API externe a renvoyé une réponse incorrecte.') {
     super(message);
   }
 }

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -9,6 +9,7 @@ const {
   AlreadyRegisteredEmailError,
   AlreadyRegisteredUsernameError,
   EntityValidationError,
+  InvalidExternalAPIResponseError,
   MissingOrInvalidCredentialsError,
   UnexpectedUserAccountError,
   UserShouldChangePasswordError,
@@ -201,6 +202,19 @@ describe('Unit | Application | ErrorManager', () => {
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate ServiceUnavailableError when InvalidExternalAPIResponseError', async () => {
+      // given
+      const error = new InvalidExternalAPIResponseError();
+      sinon.stub(HttpErrors, 'ServiceUnavailableError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(error.message);
     });
   });
 

--- a/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
@@ -1,10 +1,12 @@
-const { domainBuilder, expect, sinon } = require('../../../test-helper');
+const { domainBuilder, expect, sinon, catchErr } = require('../../../test-helper');
 const createUserFromPoleEmploi = require('../../../../lib/domain/usecases/create-user-from-pole-emploi');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 const User = require('../../../../lib/domain/models/User');
 const authenticationCache = require('../../../../lib/infrastructure/caches/authentication-cache');
 const moment = require('moment');
+const { InvalidExternalAPIResponseError } = require('../../../../lib/domain/errors');
+const logger = require('../../../../lib/infrastructure/logger');
 
 describe('Unit | UseCase | create-user-from-pole-emploi', () => {
 
@@ -94,6 +96,41 @@ describe('Unit | UseCase | create-user-from-pole-emploi', () => {
       expect(authenticationMethodRepository.create).to.have.been.calledWith({ authenticationMethod: expectedAuthenticationMethod, domainTransaction });
       expect(response.userId).to.equal(userId);
       expect(response.idToken).to.equal(userCredentials.idToken);
+    });
+
+    it('should raise an error and log details if required properties are not returned by external API', async () => {
+      // given
+      const authenticationKey = 'authenticationKey';
+      const userCredentials = {
+        accessToken: 'accessToken',
+        idToken: 'idToken',
+        expiresIn: 10,
+        refreshToken: 'refreshToken',
+      };
+      authenticationCacheGetStub.withArgs(authenticationKey).resolves(userCredentials);
+      const decodedUserInfo = {
+        firstName: 'Jean',
+        lastName: undefined,
+        externalIdentityId: 'externalIdentityId',
+        nonce: 'nonce',
+      };
+
+      authenticationService.getPoleEmploiUserInfo.withArgs(userCredentials.idToken).resolves(decodedUserInfo);
+      sinon.stub(logger, 'error');
+
+      // when
+      const error = await catchErr(createUserFromPoleEmploi)({
+        authenticationKey,
+        userRepository,
+        authenticationMethodRepository,
+        authenticationService,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(InvalidExternalAPIResponseError);
+      expect(error.message).to.be.equal('API PE: les informations utilisateurs récupérées sont incorrectes.');
+      const expectedMessage = `Un des champs obligatoires n'a pas été renvoyé par /userinfo: ${JSON.stringify(decodedUserInfo)}.`;
+      expect(logger.error).to.have.been.calledWith(expectedMessage);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Le retour de /userinfo envoyé par l'API Pôle emploi comporte entre autres 3 champs qui sont par la suite obligatoires
- `given_name`
- `family_name`
- `externalIdentityId`

Actuellement, si l'un des deux premiers n'est pas renseigné, l'insertion en BDD sur la table `users` échoue et une erreur 500 est renvoyée
`null value in column "lastName" violates not-null constraint`

## :robot: Solution
Contrôler les champs reçus et renvoyer une erreur spécifique : 
- ni 400 car l'utilisateur a fourni des données cohérentes
- ni 500 car l'acteur en cause est PE et pas Pix

Tracer l'erreur sur le FS qu'elle soit disponible dans Datadog comme dans [cette autre PR PE](https://github.com/1024pix/pix/pull/3001)

## :rainbow: Remarques
L'erreur implémentée n'est pas la plus adaptéee (503)
Voir https://1024pix.slack.com/archives/CG9R2NSRJ/p1611322886008500

Ajouter un log pour transmettre des informations détaillées à PE pour résoudre la cause d'origine

## :100: Pour tester
En l'absence d'un simulateur OpenID local, vérifier la CI