### PR TITLE
[TECH] Prévenir les faux positifs liés à la BDD dans les tests.

### DIFF
--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -83,7 +83,7 @@ describe('Integration | Repository | answerRepository', () => {
 
         // then
         expect(foundAnswers[0]).to.be.an.instanceof(Answer);
-        expect(_.map(foundAnswers, 'id')).to.deep.equal(answerIds);
+        expect(_.map(foundAnswers, 'id')).to.have.members(answerIds);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -1,3 +1,4 @@
+const { omit } = require('lodash');
 const { expect, databaseBuilder, mockLearningContent, domainBuilder, catchErr } = require('../../../test-helper');
 const TargetProfileWithLearningContent = require('../../../../lib/domain/models/TargetProfileWithLearningContent');
 const targetProfileWithLearningContentRepository = require('../../../../lib/infrastructure/repositories/target-profile-with-learning-content-repository');
@@ -37,6 +38,12 @@ async function buildDomainAndDatabaseStage(targetProfileId) {
 
   return stage;
 }
+
+const checkBadge = (actual, expected) => {
+  expect(omit(actual, ['badgeCriteria', 'badgePartnerCompetences'])).to.deep.include(omit(expected, ['badgeCriteria', 'badgePartnerCompetences']));
+  expect(actual.badgeCriteria).to.have.deep.members(expected.badgeCriteria);
+  expect(actual.badgePartnerCompetences).to.have.deep.members(expected.badgePartnerCompetences);
+};
 
 describe('Integration | Repository | Target-profile-with-learning-content', () => {
 
@@ -211,7 +218,16 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       const targetProfile = await targetProfileWithLearningContentRepository.get({ id: targetProfileDB.id });
 
       // then
-      expect(targetProfile.badges).to.have.deep.members([ { ...badge1, imageUrl: null }, { ...badge2, imageUrl: null } ]);
+      const actualBadge1 = targetProfile.badges.find((badge) => badge.id === badge1.id);
+      checkBadge(actualBadge1, {
+        ...badge1,
+        imageUrl: null,
+      });
+      const actualBadge2 = targetProfile.badges.find((badge) => badge.id === badge2.id);
+      checkBadge(actualBadge2, {
+        ...badge2,
+        imageUrl: null,
+      });
     });
 
     it('should return target profile stages', async () => {
@@ -588,7 +604,17 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
 
       // then
-      expect(targetProfile.badges).to.have.deep.members([ { ...badge1, imageUrl: null }, { ...badge2, imageUrl: null } ]);
+      const actualBadge1 = targetProfile.badges.find((badge) => badge.id === badge1.id);
+      checkBadge(actualBadge1, {
+        ...badge1,
+        imageUrl: null,
+      });
+      const actualBadge2 = targetProfile.badges.find((badge) => badge.id === badge2.id);
+      checkBadge(actualBadge2, {
+        ...badge2,
+        imageUrl: null,
+      });
+
     });
 
     it('should return target profile filled with objects with appropriate translation', async () => {

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -91,7 +91,7 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
 
       // then
       const expectedUserIds = [adminUserId1, adminUserId2];
-      expect(userIds).exactlyContainInOrder(expectedUserIds);
+      expect(userIds).to.have.deep.members(expectedUserIds);
     });
 
     it('should return an empty array if organization has no admin membership', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Certains tests dépendent de l'ordre des données renvoyées par la BDD, ce qui peut faire échouer un test à tord

## :robot: Solution
Utiliser  des assertions tolérantes  à l'ordre

## :rainbow: Remarques
Cas de test fragile détectés sur https://github.com/1024pix/pix/tree/tech-flakify-users
Schéma de principe [disponible ici](https://github.com/GradedJestRisk/js-training/blob/master/node/persistence/db/flakify/README.md)

## :100: Pour tester
Exécuter plusieurs fois la CI ou les tests en local
