### PR TITLE
[FEATURE] Améliorer l'accessibilité de la bannière d'info de Pix Certif (PIX-2632)

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -23,7 +23,7 @@
         </li>
       </ul>
     </nav>
-    
+
   </aside>
 
   <div class="app__main-content main-content">
@@ -41,7 +41,7 @@
             <a href="https://view.genial.ly/6077017b8b37870d98620200" target="_blank" rel="noopener noreferrer"> En savoir plus <FaIcon @icon="external-link-alt"/></a>
           </p>
         </span>
-        <button type="button" class="sco-temporary-banner-button" {{on 'click' this.closeBanner}}>
+        <button type="button" class="sco-temporary-banner-button" aria-label="Fermer la bannière d'informations" {{on 'click' this.closeBanner}}>
           <FaIcon @icon="times" class="sco-temporary-banner-button__times-icon" />
         </button>
       </PixBanner>

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -56,7 +56,8 @@ module('Acceptance | authenticated', function(hooks) {
       await visit('/sessions/liste');
 
       // then
-      assert.dom('.sco-temporary-banner').hasText('La certification en collège et lycée est possible jusqu\'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ». En savoir plus');
+      assert.dom('.sco-temporary-banner').includesText('La certification en collège et lycée est possible jusqu\'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ». En savoir plus');
+      assert.dom('[aria-label="Fermer la bannière d\'informations"]').exists();
     });
 
     test('it should not display the banner when User is NOT SCO isManagingStudent', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème

L'accessibilité de Pix Certif va prochainement faire l'objet d'un audit et nous voulons au préalable effectuer un maximum de corrections faciles. Wave remonte un problème dans le bandeau d'informations qui s'affiche sur la page de la liste des sessions dans Pix Certif : le bouton de fermeture n'a pas de texte et n'est donc pas utilisable avec un lecteur d'écran.

![Capture d’écran 2021-05-26 à 16 59 30](https://user-images.githubusercontent.com/5627688/119685844-040ed080-be46-11eb-87ae-a92ca6b11e73.png)

## :robot: Solution

Ajouter un texte "Fermer" à ce bouton.

## :rainbow: Remarques

*RAS*

## :100: Pour tester

1. Dans Pix Certif, accéder à la page de la liste des sessions
2. Activer l'extension [Wave](https://wave.webaim.org/extension/)
3. Constater le bouton fermer de la bannière d'infos ne provoque pas d'erreur
