### PR TITLE
[TECH] Supprimer des TODO.

### DIFF
--- a/api/lib/infrastructure/orm-models/User.js
+++ b/api/lib/infrastructure/orm-models/User.js
@@ -1,6 +1,3 @@
-const User = require('../../domain/models/User');
-const PixRole = require('../../domain/models/PixRole');
-
 const Bookshelf = require('../bookshelf');
 const BookshelfPixRole = require('./PixRole');
 const BookshelfUserPixRole = require('./UserPixRole');
@@ -51,21 +48,6 @@ module.exports = Bookshelf.model(modelName, {
   authenticationMethods() {
     return this.hasMany('AuthenticationMethod', 'userId');
   },
-
-  toDomainEntity() {
-    const model = this.toJSON();
-    if (model.pixRoles) {
-      model.pixRoles = model.pixRoles.map((pixRoleJson) => new PixRole(pixRoleJson));
-    }
-    model.cgu = Boolean(model.cgu);
-    model.pixOrgaTermsOfServiceAccepted = Boolean(model.pixOrgaTermsOfServiceAccepted);
-    model.pixCertifTermsOfServiceAccepted = Boolean(model.pixCertifTermsOfServiceAccepted);
-    model.hasSeenAssessmentInstructions = Boolean(model.hasSeenAssessmentInstructions);
-    model.hasSeenNewDashboardInfo = Boolean(model.hasSeenNewDashboardInfo);
-
-    return new User(model);
-  },
-
 }, {
   modelName,
 });

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -179,7 +179,7 @@ module.exports = {
     const userToCreate = _adaptModelToDb(user);
     return new BookshelfUser(userToCreate)
       .save(null, { transacting: domainTransaction.knexTransaction })
-      .then((bookshelfUser) => bookshelfUser.toDomainEntity());
+      .then((bookshelfUser) => _toDomain(bookshelfUser));
   },
 
   isEmailAvailable(email) {
@@ -209,7 +209,7 @@ module.exports = {
     return BookshelfUser
       .where({ id })
       .save({ password: hashedPassword }, { patch: true, method: 'update' })
-      .then((bookshelfUser) => bookshelfUser.toDomainEntity())
+      .then((bookshelfUser) => _toDomain(bookshelfUser))
       .catch((err) => {
         if (err instanceof BookshelfUser.NoRowsUpdatedError) {
           throw new UserNotFoundError(`User not found for ID ${id}`);
@@ -222,7 +222,7 @@ module.exports = {
     return BookshelfUser
       .where({ id })
       .save({ email }, { patch: true, method: 'update' })
-      .then((bookshelfUser) => bookshelfUser.toDomainEntity())
+      .then((bookshelfUser) => _toDomain(bookshelfUser))
       .catch((err) => {
         if (err instanceof BookshelfUser.NoRowsUpdatedError) {
           throw new UserNotFoundError(`User not found for ID ${id}`);
@@ -318,7 +318,7 @@ module.exports = {
           method: 'update',
         },
       )
-      .then((bookshelfUser) => bookshelfUser.toDomainEntity())
+      .then((bookshelfUser) => _toDomain(bookshelfUser))
       .catch((err) => {
         if (err instanceof BookshelfUser.NoRowsUpdatedError) {
           throw new UserNotFoundError(`User not found for ID ${id}`);
@@ -331,7 +331,7 @@ module.exports = {
     return BookshelfUser
       .where({ id })
       .save({ username }, { patch: true, method: 'update' })
-      .then((bookshelfUser) => bookshelfUser.toDomainEntity())
+      .then((bookshelfUser) => _toDomain(bookshelfUser))
       .catch((err) => {
         if (err instanceof BookshelfUser.NoRowsUpdatedError) {
           throw new UserNotFoundError(`User not found for ID ${id}`);
@@ -345,7 +345,7 @@ module.exports = {
       const bookshelfUser = await BookshelfUser
         .where({ id })
         .save(userAttributes, { patch: true, method: 'update' });
-      return bookshelfUser.toDomainEntity();
+      return _toDomain(bookshelfUser);
 
     } catch (err) {
       if (err instanceof BookshelfUser.NoRowsUpdatedError) {
@@ -521,6 +521,11 @@ function _toDomain(userBookshelf) {
     password: userBookshelf.get('password'),
     shouldChangePassword: Boolean(userBookshelf.get('shouldChangePassword')),
     cgu: Boolean(userBookshelf.get('cgu')),
+    lang: userBookshelf.get('lang'),
+    isAnonymous: Boolean(userBookshelf.get('isAnonymous')),
+    lastTermsOfServiceValidatedAt: userBookshelf.get('lastTermsOfServiceValidatedAt'),
+    hasSeenNewDashboardInfo: Boolean(userBookshelf.get('hasSeenNewDashboardInfo')),
+    mustValidateTermsOfService: Boolean(userBookshelf.get('mustValidateTermsOfService')),
     pixOrgaTermsOfServiceAccepted: Boolean(userBookshelf.get('pixOrgaTermsOfServiceAccepted')),
     pixCertifTermsOfServiceAccepted: Boolean(userBookshelf.get('pixCertifTermsOfServiceAccepted')),
     memberships: _toMembershipsDomain(userBookshelf.related('memberships')),

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -27,7 +27,6 @@ const PIX_MASTER_ROLE_ID = 1;
 
 module.exports = {
 
-  // TODO use _toDomain()
   getByEmail(email) {
     return BookshelfUser
       .query((qb) => {
@@ -35,7 +34,7 @@ module.exports = {
       })
       .fetch()
       .then((bookshelfUser) => {
-        return bookshelfUser.toDomainEntity();
+        return _toDomain(bookshelfUser);
       })
       .catch((err) => {
         if (err instanceof BookshelfUser.NotFoundError) {

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -34,8 +34,6 @@ export default class ChallengeEmbedSimulator extends Component {
   @action
   launchSimulator(event) {
     const iframe = this._getIframe(event);
-
-    // TODO: use correct targetOrigin once the embeds are hosted behind our domain
     iframe.contentWindow.postMessage('launch', '*');
     iframe.focus();
     this.isSimulatorLaunched = true;


### PR DESCRIPTION
## :unicorn: Problème
Il y a plusieurs TODO dans le code, dont:
1. on souhaitait filtrer les origines des embed des épreuves, mais maintenant les épreuves ont aussi des embed d'autres sites
2. le repository de User utilisait `toDomainEntity` du `BookshelfUser`. Le TODO proposait d'utiliser le `_toDomain` du repository, qui est déjà utilisé dans d'autres méthodes.

## :robot: Solution
1.  supprimer le filtrage, et indiquer la raison dans le commit
2.  utiliser le `_toDomain`

## :100: Pour tester
Vérifier que la CI passe
