### PR TITLE
[BUGFIX] Ne pas afficher de tooltip vide sur le graphique de répartition des participants par paliers lorsqu'il n'y a ni titre ni description pour le prescripteur (PIX-2629).

### DIFF
--- a/api/db/seeds/data/stages-builder.js
+++ b/api/db/seeds/data/stages-builder.js
@@ -7,10 +7,10 @@ module.exports = function stagesBuilder({ databaseBuilder }) {
 
 function _buildStagesForTargetProfileId(databaseBuilder, targetProfileId) {
   const stages = [
-    { title: 'Bravo !', message: 'Tu as le palier 1', prescriberDescription: 'palier 1 c’est nul', threshold: 0, targetProfileId },
+    { title: 'Bravo !', message: 'Tu as le palier 1', threshold: 0, targetProfileId },
     { title: 'Félicitations !', message: 'Tu as le palier 2', prescriberTitle: 'palier 2', prescriberDescription: 'Maîtrise partielle', threshold: 5, targetProfileId },
     { title: 'Bien joué !', message: 'Tu as le palier 3', prescriberTitle: 'palier 3', prescriberDescription: 'Maîtrise complète', threshold: 40, targetProfileId },
-    { title: 'Trop fort(e) !', message: 'Tu as le palier 4', prescriberTitle: 'palier 4', prescriberDescription: 'Maîtrise experte', threshold: 60, targetProfileId },
+    { title: 'Trop fort(e) !', message: 'Tu as le palier 4', prescriberTitle: 'palier 4', threshold: 60, targetProfileId },
     { title: 'Quel(le) expert(e) !', message: 'Tu as le palier 5', prescriberDescription: 'Maîtrise absolue', threshold: 80, targetProfileId },
   ];
 

--- a/orga/app/components/charts/participants-by-stage-bar.hbs
+++ b/orga/app/components/charts/participants-by-stage-bar.hbs
@@ -1,0 +1,6 @@
+<div class="participants-by-stage__graph" role="button" {{on "click" (fn @onClickBar @stageId)}}>
+  <div class="participants-by-stage__bar" style={{@barWidth}} />
+  <div class="participants-by-stage__percentage">
+    {{yield}}
+  </div>
+</div>

--- a/orga/app/components/charts/participants-by-stage.hbs
+++ b/orga/app/components/charts/participants-by-stage.hbs
@@ -13,21 +13,26 @@
         <div class="participants-by-stage__values">
           {{t 'charts.participants-by-stage.participants' count=stage.value}}
         </div>
-        <PixTooltip
-          role="tooltip"
-          @text={{stage.tooltip}}
-          @position="bottom-right"
-          @isWide={{true}}
-          @isLight={{true}}
-          class="participants-by-stage__tooltip"
-          >
-          <div class="participants-by-stage__graph" role="button" {{on "click" (fn this.onClickBar stage.id)}}>
-            <div class="participants-by-stage__bar" style={{stage.barWidth}} />
-            <div class="participants-by-stage__percentage">
+        {{#if stage.displayTooltip}}
+          <PixTooltip
+            role="tooltip"
+            @text={{stage.tooltip}}
+            @position="bottom-right"
+            @isWide={{true}}
+            @isLight={{true}}
+            class="participants-by-stage__container"
+            >
+              <Charts::ParticipantsByStageBar @onClickBar={{this.onClickBar}} @stageId={{stage.id}} @barWidth={{stage.barWidth}}>
+                {{t 'charts.participants-by-stage.percentage' percentage=stage.percentage}}
+              </Charts::ParticipantsByStageBar>
+          </PixTooltip>
+        {{else}}
+          <div class="participants-by-stage__container">
+            <Charts::ParticipantsByStageBar @onClickBar={{this.onClickBar}} @stageId={{stage.id}} @barWidth={{stage.barWidth}}>
               {{t 'charts.participants-by-stage.percentage' percentage=stage.percentage}}
-            </div>
+            </Charts::ParticipantsByStageBar>
           </div>
-        </PixTooltip>
+        {{/if}}
       </div>
     {{/each}}
   {{/if}}

--- a/orga/app/components/charts/participants-by-stage.js
+++ b/orga/app/components/charts/participants-by-stage.js
@@ -38,6 +38,7 @@ export default class ParticipantsByStage extends Component {
             percentage,
             barWidth: `width: ${width}%`,
             tooltip: buildTooltipText(stage.title, stage.description),
+            displayTooltip: stage.title || stage.description,
           };
         });
         this.loading = false;

--- a/orga/app/styles/components/charts/participants-by-stage.scss
+++ b/orga/app/styles/components/charts/participants-by-stage.scss
@@ -30,7 +30,7 @@
     }
   }
 
-  &__tooltip {
+  &__container {
     flex-grow: 1;
 
     .pix-tooltip__content {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement si un palier ne possède ni titre ni description pour le prescripteur, alors on a :
<img width="1406" alt="Capture d’écran 2021-05-26 à 12 02 32" src="https://user-images.githubusercontent.com/23451175/119698662-bef09b80-be51-11eb-8393-196d2c5a4918.png">

## :robot: Solution
Ne pas afficher cette tooltip dans ce cas.

## :rainbow: Remarques
Mise à jour des seeds.

## :100: Pour tester
- Se connecter à Pix Orga en tant que pro.admin@example.net
- Choisir la campagne d'évaluation 5.1
- Aller dans l'onglet résultats collectifs
- Vérifier que pour le palier 1 aucune tooltip ne s'affiche, mais que pour les autres, 1 tooltip apparaît.
