### PR TITLE
[TECH] Contrôler les requêtes entrantes uniquement dans le routeur.

### DIFF
--- a/api/lib/application/.eslintrc.js
+++ b/api/lib/application/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: '../.eslintrc.js',
+  rules: {
+    'no-restricted-syntax': ['error', {
+      selector:
+        'CallExpression[callee.name=\'parseInt\']',
+      message: 'parseInt is unnecessary here because Joi already casts string into number if the field is properly described (Joi.number())',
+    }],
+  },
+};

--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -24,7 +24,7 @@ module.exports = {
 
   async update(request) {
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const answerId = parseInt(request.params.id);
+    const answerId = request.params.id;
     const answer = await usecases.getAnswer({ answerId, userId });
 
     return answerSerializer.serialize(answer);

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -21,7 +21,7 @@ module.exports = {
   },
 
   async get(request) {
-    const assessmentId = parseInt(request.params.id);
+    const assessmentId = request.params.id;
     const locale = extractLocaleFromRequest(request);
 
     const assessment = await usecases.getAssessment({ assessmentId, locale });
@@ -30,7 +30,7 @@ module.exports = {
   },
 
   async getLastChallengeId(request, h) {
-    const assessmentId = parseInt(request.params.id);
+    const assessmentId = request.params.id;
 
     const lastChallengeId = await usecases.getLastChallengeIdFromAssessmentId({ assessmentId });
 
@@ -38,7 +38,7 @@ module.exports = {
   },
 
   async getChallengeForPixAutoAnswer(request, h) {
-    const assessmentId = parseInt(request.params.id);
+    const assessmentId = request.params.id;
 
     const challenge = await usecases.getChallengeForPixAutoAnswer({ assessmentId });
 
@@ -61,16 +61,17 @@ module.exports = {
   },
 
   async getNextChallenge(request) {
+    const assessmentId = request.params.id;
 
     const logContext = {
       zone: 'assessmentController.getNextChallenge',
       type: 'controller',
-      assessmentId: parseInt(request.params.id),
+      assessmentId,
     };
     logger.trace(logContext, 'tracing assessmentController.getNextChallenge()');
 
     try {
-      const assessment = await assessmentRepository.get(parseInt(request.params.id));
+      const assessment = await assessmentRepository.get(assessmentId);
       logContext.assessmentType = assessment.type;
       logger.trace(logContext, 'assessment loaded');
 
@@ -89,8 +90,7 @@ module.exports = {
   },
 
   async completeAssessment(request) {
-    const assessmentId = parseInt(request.params.id);
-
+    const assessmentId = request.params.id;
     const event = await usecases.completeAssessment({ assessmentId });
     await events.eventDispatcher.dispatch(event);
 
@@ -99,7 +99,7 @@ module.exports = {
 
   async findCompetenceEvaluations(request) {
     const userId = request.auth.credentials.userId;
-    const assessmentId = parseInt(request.params.id);
+    const assessmentId = request.params.id;
 
     const competenceEvaluations = await usecases.findCompetenceEvaluationsByAssessment({ userId, assessmentId });
 

--- a/api/lib/application/badges/badges-controller.js
+++ b/api/lib/application/badges/badges-controller.js
@@ -3,7 +3,7 @@ const badgeWithLearningContentSerializer = require('../../infrastructure/seriali
 
 module.exports = {
   async getBadge(request) {
-    const badgeId = parseInt(request.params.id);
+    const badgeId = request.params.id;
     const badgeWithLearningContent = await usecases.getBadgeDetails({ badgeId });
     return badgeWithLearningContentSerializer.serialize(badgeWithLearningContent);
   },

--- a/api/lib/application/campaign-participation-results/campaign-participation-result-controller.js
+++ b/api/lib/application/campaign-participation-results/campaign-participation-result-controller.js
@@ -6,7 +6,7 @@ const { extractLocaleFromRequest } = require('../../infrastructure/utils/request
 module.exports = {
   async get(request) {
     const locale = extractLocaleFromRequest(request);
-    const campaignParticipationId = parseInt(request.params.id);
+    const campaignParticipationId = request.params.id;
     const userId = request.auth.credentials.userId;
 
     const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId); // used only until deprecated route will be removed

--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -13,7 +13,7 @@ const { extractLocaleFromRequest } = require('../../infrastructure/utils/request
 module.exports = {
 
   async getById(request) {
-    const campaignParticipationId = parseInt(request.params.id);
+    const campaignParticipationId = request.params.id;
     const userId = request.auth.credentials.userId;
     const options = queryParamsUtils.extractParameters(request.query);
 
@@ -48,7 +48,7 @@ module.exports = {
 
   async shareCampaignResult(request) {
     const userId = request.auth.credentials.userId;
-    const campaignParticipationId = parseInt(request.params.id);
+    const campaignParticipationId = request.params.id;
 
     const event = await usecases.shareCampaignResult({
       userId,
@@ -60,7 +60,7 @@ module.exports = {
 
   async beginImprovement(request) {
     const userId = request.auth.credentials.userId;
-    const campaignParticipationId = parseInt(request.params.id);
+    const campaignParticipationId = request.params.id;
 
     await usecases.beginCampaignParticipationImprovement({
       campaignParticipationId,

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -28,7 +28,9 @@ module.exports = {
       'id-pix-label': idPixLabel,
       'custom-landing-page-text': customLandingPageText,
     } = request.payload.data.attributes;
+    // eslint-disable-next-line no-restricted-syntax
     const targetProfileId = parseInt(_.get(request, 'payload.data.relationships.target-profile.data.id')) || null;
+    // eslint-disable-next-line no-restricted-syntax
     const organizationId = parseInt(_.get(request, 'payload.data.relationships.organization.data.id')) || null;
 
     const campaign = { name, type, title, idPixLabel, customLandingPageText, creatorId: userId, organizationId, targetProfileId };
@@ -57,7 +59,7 @@ module.exports = {
   async getCsvAssessmentResults(request) {
     const token = request.query.accessToken;
     const userId = tokenService.extractUserIdForCampaignResults(token);
-    const campaignId = parseInt(request.params.id);
+    const campaignId = request.params.id;
 
     const writableStream = new PassThrough();
 
@@ -79,7 +81,7 @@ module.exports = {
   async getCsvProfilesCollectionResults(request) {
     const token = request.query.accessToken;
     const userId = tokenService.extractUserIdForCampaignResults(token);
-    const campaignId = parseInt(request.params.id);
+    const campaignId = request.params.id;
 
     const writableStream = new PassThrough();
 
@@ -100,7 +102,7 @@ module.exports = {
 
   update(request) {
     const { userId } = request.auth.credentials;
-    const campaignId = parseInt(request.params.id);
+    const campaignId = request.params.id;
     const { name, title, 'custom-landing-page-text': customLandingPageText } = request.payload.data.attributes;
 
     return usecases.updateCampaign({ userId, campaignId, name, title, customLandingPageText })
@@ -109,7 +111,7 @@ module.exports = {
 
   archiveCampaign(request) {
     const { userId } = request.auth.credentials;
-    const campaignId = parseInt(request.params.id);
+    const campaignId = request.params.id;
 
     return usecases.archiveCampaign({ userId, campaignId })
       .then(campaignReportSerializer.serialize);
@@ -117,7 +119,7 @@ module.exports = {
 
   unarchiveCampaign(request) {
     const { userId } = request.auth.credentials;
-    const campaignId = parseInt(request.params.id);
+    const campaignId = request.params.id;
 
     return usecases.unarchiveCampaign({ userId, campaignId })
       .then(campaignReportSerializer.serialize);
@@ -125,7 +127,7 @@ module.exports = {
 
   async getCollectiveResult(request) {
     const { userId } = request.auth.credentials;
-    const campaignId = parseInt(request.params.id);
+    const campaignId = request.params.id;
     const locale = extractLocaleFromRequest(request);
 
     const campaignCollectiveResult = await usecases.computeCampaignCollectiveResult({ userId, campaignId, locale });

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -17,7 +17,7 @@ module.exports = {
   },
 
   getById(request) {
-    const certificationCenterId = parseInt(request.params.id);
+    const certificationCenterId = request.params.id;
     return usecases.getCertificationCenter({ id: certificationCenterId })
       .then(certificationCenterSerializer.serialize);
   },
@@ -30,7 +30,9 @@ module.exports = {
   },
 
   async findPaginatedSessionSummaries(request) {
-    const certificationCenterId = parseInt(request.params.id);
+    const certificationCenterId = request.params.id;
+    // As route is authenticated, token always contains an userId, so parseInt in useless
+    // eslint-disable-next-line no-restricted-syntax
     const userId = parseInt(request.auth.credentials.userId);
     const options = queryParamsUtils.extractParameters(request.query);
 
@@ -44,8 +46,8 @@ module.exports = {
   },
 
   async getStudents(request) {
-    const certificationCenterId = parseInt(request.params.certificationCenterId);
-    const sessionId = parseInt(request.params.sessionId);
+    const certificationCenterId = request.params.certificationCenterId;
+    const sessionId = request.params.sessionId;
 
     const { filter, page } = queryParamsUtils.extractParameters(request.query);
     if (filter.divisions && !Array.isArray(filter.divisions)) {
@@ -62,7 +64,7 @@ module.exports = {
   },
 
   async getDivisions(request) {
-    const certificationCenterId = parseInt(request.params.certificationCenterId);
+    const certificationCenterId = request.params.certificationCenterId;
     const divisions = await usecases.findDivisionsByCertificationCenter({
       certificationCenterId,
     });
@@ -71,7 +73,7 @@ module.exports = {
   },
 
   async findCertificationCenterMembershipsByCertificationCenter(request) {
-    const certificationCenterId = parseInt(request.params.certificationCenterId);
+    const certificationCenterId = request.params.certificationCenterId;
     const certificationCenterMemberships = await usecases.findCertificationCenterMembershipsByCertificationCenter({
       certificationCenterId,
     });
@@ -80,7 +82,7 @@ module.exports = {
   },
 
   async createCertificationCenterMembershipByEmail(request, h) {
-    const certificationCenterId = parseInt(request.params.certificationCenterId);
+    const certificationCenterId = request.params.certificationCenterId;
     const { email } = request.payload;
 
     const certificationCenterMembership = await usecases.createCertificationCenterMembershipByEmail({

--- a/api/lib/application/certification-issue-reports/certification-issue-report-controller.js
+++ b/api/lib/application/certification-issue-reports/certification-issue-report-controller.js
@@ -3,7 +3,7 @@ const usecases = require('../../domain/usecases');
 module.exports = {
   async deleteCertificationIssueReport(request) {
     const userId = request.auth.credentials.userId;
-    const certificationIssueReportId = parseInt(request.params.id);
+    const certificationIssueReportId = request.params.id;
     await usecases.deleteCertificationIssueReport({
       certificationIssueReportId,
       userId,

--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -14,7 +14,7 @@ module.exports = {
 
   async getCertification(request) {
     const userId = request.auth.credentials.userId;
-    const certificationId = parseInt(request.params.id);
+    const certificationId = request.params.id;
 
     const privateCertificate = await usecases.getPrivateCertificate({
       userId,
@@ -32,7 +32,7 @@ module.exports = {
 
   async getPDFAttestation(request, h) {
     const userId = request.auth.credentials.userId;
-    const certificationId = parseInt(request.params.id);
+    const certificationId = request.params.id;
     const attestation = await usecases.getCertificationAttestation({
       userId,
       certificationId,

--- a/api/lib/application/memberships/membership-controller.js
+++ b/api/lib/application/memberships/membership-controller.js
@@ -19,7 +19,9 @@ module.exports = {
     const membershipId = request.params.id;
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
     const membership = membershipSerializer.deserialize(request.payload);
-    if (membershipId != membership.id) {
+    // eslint-disable-next-line no-restricted-syntax
+    const membershipIdFromPayload = parseInt(membership.id);
+    if (membershipId !== membershipIdFromPayload) {
       throw new BadRequestError();
     }
     membership.updatedByUserId = userId;

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -204,6 +204,11 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/organizations/{id}/target-profiles',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
         handler: organizationController.findTargetProfiles,
         tags: ['api', 'target-profile'],
         notes: [

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -20,7 +20,7 @@ const certificationResultUtils = require('../../infrastructure/utils/csv/certifi
 module.exports = {
 
   getOrganizationDetails: (request) => {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
 
     return usecases.getOrganizationDetails({ organizationId })
       .then(organizationSerializer.serialize);
@@ -57,7 +57,7 @@ module.exports = {
   },
 
   async findPaginatedFilteredCampaigns(request) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const options = queryParamsUtils.extractParameters(request.query);
 
     if (options.filter.status === 'archived') {
@@ -69,7 +69,7 @@ module.exports = {
   },
 
   async findPaginatedCampaignManagements(request) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const { filter, page } = queryParamsUtils.extractParameters(request.query);
 
     const { models: campaigns, meta } = await usecases.findPaginatedCampaignManagements({ organizationId, filter, page });
@@ -77,7 +77,7 @@ module.exports = {
   },
 
   async findPaginatedFilteredMemberships(request) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const options = queryParamsUtils.extractParameters(request.query);
 
     const { models: memberships, pagination } = await usecases.findPaginatedFilteredOrganizationMemberships({ organizationId, filter: options.filter, page: options.page });
@@ -85,7 +85,7 @@ module.exports = {
   },
 
   async downloadCertificationResults(request, h) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const { division } = request.query;
 
     const certificationResults = await usecases.getScoCertificationResultsByDivision({ organizationId, division });
@@ -101,28 +101,29 @@ module.exports = {
   },
 
   async findTargetProfiles(request) {
-    const requestedOrganizationId = parseInt(request.params.id);
+    const requestedOrganizationId = request.params.id;
 
     const targetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(requestedOrganizationId);
     return targetProfileSerializer.serialize(targetProfiles);
   },
 
   async attachTargetProfiles(request, h) {
-    const requestedOrganizationId = parseInt(request.params.id);
+    const requestedOrganizationId = request.params.id;
     const targetProfileIdsToAttach = request.payload.data.attributes['target-profiles-to-attach']
+      // eslint-disable-next-line no-restricted-syntax
       .map((targetProfileToAttach) => parseInt(targetProfileToAttach));
     await usecases.attachTargetProfilesToOrganization({ organizationId: requestedOrganizationId, targetProfileIdsToAttach });
     return h.response().code(204);
   },
 
   async getDivisions(request) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const divisions = await usecases.findDivisionsByOrganization({ organizationId });
     return divisionSerializer.serialize(divisions);
   },
 
   async findPaginatedFilteredSchoolingRegistrations(request) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const { filter, page } = queryParamsUtils.extractParameters(request.query);
 
     const { data, pagination } = await usecases.findPaginatedFilteredSchoolingRegistrations({ organizationId, filter, page });
@@ -130,7 +131,7 @@ module.exports = {
   },
 
   async importSchoolingRegistrationsFromSIECLE(request, h) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const { format } = request.query;
 
     await usecases.importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload: request.payload, format, i18n: request.i18n });
@@ -138,7 +139,7 @@ module.exports = {
   },
 
   async importHigherSchoolingRegistrations(request, h) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const buffer = request.payload;
     const higherSchoolingRegistrationParser = new HigherSchoolingRegistrationParser(buffer, organizationId, request.i18n);
     const warnings = await usecases.importHigherSchoolingRegistrations({ higherSchoolingRegistrationParser });
@@ -171,7 +172,7 @@ module.exports = {
   },
 
   async getSchoolingRegistrationsCsvTemplate(request, h) {
-    const organizationId = parseInt(request.params.id);
+    const organizationId = request.params.id;
     const token = request.query.accessToken;
     const userId = tokenService.extractUserId(token);
     const template = await usecases.getSchoolingRegistrationsCsvTemplate({ userId, organizationId, i18n: request.i18n });

--- a/api/lib/application/preHandlers/assessment-authorization.js
+++ b/api/lib/application/preHandlers/assessment-authorization.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 const assessmentRepository = require('../../infrastructure/repositories/assessment-repository');
 const validationErrorSerializer = require('../../infrastructure/serializers/jsonapi/validation-error-serializer');
 const { extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');

--- a/api/lib/application/preHandlers/session-authorization.js
+++ b/api/lib/application/preHandlers/session-authorization.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 const { NotFoundError } = require('../http-errors');
 const sessionAuthorizationService = require('../../domain/services/session-authorization-service');
 

--- a/api/lib/application/preHandlers/user-existence-verification.js
+++ b/api/lib/application/preHandlers/user-existence-verification.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 const userRepository = require('../../../lib/infrastructure/repositories/user-repository');
 const errorSerializer = require('../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
 const { UserNotFoundError } = require('../../domain/errors');

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -4,6 +4,7 @@ const XRegExp = require('xregexp');
 const securityPreHandlers = require('../security-pre-handlers');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const { passwordValidationPattern } = require('../../config').account;
+const identifiersType = require('../../domain/types/identifiers-type');
 
 const schoolingRegistrationDependentUserController = require('./schooling-registration-dependent-user-controller');
 
@@ -86,8 +87,8 @@ exports.register = async function(server) {
           payload: Joi.object({
             data: {
               attributes: {
-                'organization-id': Joi.number().required(),
-                'schooling-registration-id': Joi.number().required(),
+                'organization-id': identifiersType.campaignId,
+                'schooling-registration-id': identifiersType.schoolingRegistrationId,
               },
             },
           }),
@@ -118,8 +119,8 @@ exports.register = async function(server) {
           payload: Joi.object({
             data: {
               attributes: {
-                'organization-id': Joi.number().required(),
-                'schooling-registration-id': Joi.number().required(),
+                'organization-id': identifiersType.organizationId,
+                'schooling-registration-id': identifiersType.schoolingRegistrationId,
               },
             },
           }),

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -56,9 +56,10 @@ module.exports = {
 
   async updatePassword(request, h) {
     const payload = request.payload.data.attributes;
+    // eslint-disable-next-line no-restricted-syntax
     const userId = parseInt(request.auth.credentials.userId);
-    const organizationId = parseInt(payload['organization-id']);
-    const schoolingRegistrationId = parseInt(payload['schooling-registration-id']);
+    const organizationId = payload['organization-id'];
+    const schoolingRegistrationId = payload['schooling-registration-id'];
 
     const generatedPassword = await usecases.updateSchoolingRegistrationDependentUserPassword({
       userId,
@@ -80,8 +81,8 @@ module.exports = {
 
   async generateUsernameWithTemporaryPassword(request, h) {
     const payload = request.payload.data.attributes;
-    const organizationId = parseInt(payload['organization-id']);
-    const schoolingRegistrationId = parseInt(payload['schooling-registration-id']);
+    const organizationId = payload['organization-id'];
+    const schoolingRegistrationId = payload['schooling-registration-id'];
 
     const result = await usecases.generateUsernameWithTemporaryPassword({
       schoolingRegistrationId,

--- a/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
+++ b/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
@@ -53,6 +53,7 @@ module.exports = {
 
   findAssociation(request) {
     const authenticatedUserId = request.auth.credentials.userId;
+    // eslint-disable-next-line no-restricted-syntax
     const requestedUserId = parseInt(request.query.userId);
     const campaignCode = request.query.campaignCode;
 

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -1,3 +1,4 @@
+/* eslint-disable  no-restricted-syntax */
 const checkUserHasRolePixMasterUseCase = require('./usecases/checkUserHasRolePixMaster');
 const checkUserIsAdminInOrganizationUseCase = require('./usecases/checkUserIsAdminInOrganization');
 const checkUserBelongsToOrganizationManagingStudentsUseCase = require('./usecases/checkUserBelongsToOrganizationManagingStudents');

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -36,14 +36,14 @@ module.exports = {
   },
 
   async getJurySession(request) {
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
     const jurySession = await usecases.getJurySession({ sessionId });
 
     return jurySessionSerializer.serialize(jurySession);
   },
 
   async get(request) {
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
     const session = await usecases.getSession({ sessionId });
 
     return sessionSerializer.serialize(session);
@@ -61,7 +61,7 @@ module.exports = {
   async update(request) {
     const userId = request.auth.credentials.userId;
     const session = sessionSerializer.deserialize(request.payload);
-    session.id = parseInt(request.params.id);
+    session.id = request.params.id;
 
     const updatedSession = await usecases.updateSession({ userId, session });
 
@@ -69,7 +69,7 @@ module.exports = {
   },
 
   async getAttendanceSheet(request, h) {
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
     const token = request.query.accessToken;
     const userId = tokenService.extractUserId(token);
     const attendanceSheet = await usecases.getAttendanceSheet({ sessionId, userId });
@@ -81,7 +81,7 @@ module.exports = {
   },
 
   async getCandidatesImportSheet(request, h) {
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
     const token = request.query.accessToken;
     const userId = tokenService.extractUserId(token);
 
@@ -94,14 +94,14 @@ module.exports = {
   },
 
   async getCertificationCandidates(request) {
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
 
     return usecases.getSessionCertificationCandidates({ sessionId })
       .then((certificationCandidates) => certificationCandidateSerializer.serialize(certificationCandidates));
   },
 
   async addCertificationCandidate(request, h) {
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
     const certificationCandidate = await certificationCandidateSerializer.deserialize(request.payload);
     const addedCertificationCandidate = await usecases.addCertificationCandidateToSession({
       sessionId,
@@ -112,7 +112,7 @@ module.exports = {
   },
 
   async deleteCertificationCandidate(request) {
-    const certificationCandidateId = parseInt(request.params.certificationCandidateId);
+    const certificationCandidateId = request.params.certificationCandidateId;
 
     await usecases.deleteUnlinkedCertificationCandidate({ certificationCandidateId });
 
@@ -158,14 +158,14 @@ module.exports = {
   },
 
   async getCertificationReports(request) {
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
 
     return usecases.getSessionCertificationReports({ sessionId })
       .then((certificationReports) => certificationReportSerializer.serialize(certificationReports));
   },
 
   async importCertificationCandidatesFromCandidatesImportSheet(request) {
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
     const odsBuffer = request.payload.file;
 
     try {
@@ -182,7 +182,7 @@ module.exports = {
 
   async enrollStudentsToSession(request, h) {
     const referentId = requestResponseUtils.extractUserIdFromRequest(request);
-    const sessionId = parseInt(request.params.id);
+    const sessionId = request.params.id;
     const studentIds = request.payload.data.attributes['student-ids'];
 
     await usecases.enrollStudentsToSession({ sessionId, referentId, studentIds });

--- a/api/lib/application/stages/stages-controller.js
+++ b/api/lib/application/stages/stages-controller.js
@@ -9,7 +9,7 @@ module.exports = {
   },
 
   async updateStage(request, h) {
-    const stageId = parseInt(request.params.id);
+    const stageId = request.params.id;
     const prescriberTitle = request.payload.data.attributes['prescriber-title'];
     const prescriberDescription = request.payload.data.attributes['prescriber-description'];
     await usecases.updateStage({ stageId, prescriberTitle, prescriberDescription });
@@ -17,7 +17,7 @@ module.exports = {
   },
 
   async getStageDetails(request) {
-    const stageId = parseInt(request.params.id);
+    const stageId = request.params.id;
     const stage = await usecases.getStageDetails({ stageId });
     return stageSerializer.serialize(stage);
   },

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -15,13 +15,13 @@ module.exports = {
   },
 
   async getTargetProfileDetails(request) {
-    const targetProfileId = parseInt(request.params.id);
+    const targetProfileId = request.params.id;
     const targetProfilesDetails = await usecases.getTargetProfileDetails({ targetProfileId });
     return targetProfileWithLearningContentSerializer.serialize(targetProfilesDetails);
   },
 
   async findPaginatedFilteredTargetProfileOrganizations(request) {
-    const targetProfileId = parseInt(request.params.id);
+    const targetProfileId = request.params.id;
     const options = queryParamsUtils.extractParameters(request.query);
 
     const { models: organizations, pagination } = await usecases.findPaginatedFilteredTargetProfileOrganizations({ targetProfileId, filter: options.filter, page: options.page });
@@ -29,7 +29,7 @@ module.exports = {
   },
 
   async findTargetProfileBadges(request) {
-    const targetProfileId = parseInt(request.params.id);
+    const targetProfileId = request.params.id;
 
     const badges = await usecases.findTargetProfileBadges({ targetProfileId });
     return badgeSerializer.serialize(badges);
@@ -43,14 +43,14 @@ module.exports = {
   },
 
   async updateTargetProfileName(request, h) {
-    const id = parseInt(request.params.id);
+    const id = request.params.id;
     const { name } = request.payload.data.attributes;
     await usecases.updateTargetProfileName({ id, name });
     return h.response({}).code(204);
   },
 
   async outdateTargetProfile(request, h) {
-    const id = parseInt(request.params.id);
+    const id = request.params.id;
 
     await usecases.outdateTargetProfile({ id });
     return h.response({}).code(204);
@@ -65,7 +65,7 @@ module.exports = {
   },
 
   async findByTargetProfileId(request) {
-    const targetProfileId = parseInt(request.params.id);
+    const targetProfileId = request.params.id;
 
     const stages = await usecases.findTargetProfileStages({ targetProfileId });
     return stageSerializer.serialize(stages);

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -15,14 +15,14 @@ exports.register = async function(server) {
             allowUnknown: true,
           },
           params: Joi.object({
-            id: identifiersType.userOrgaSettingsId,
+            id: identifiersType.userId,
           }),
           payload: Joi.object({
             data: {
               relationships: {
                 organization: {
                   data: {
-                    id: Joi.number().integer().required(),
+                    id: identifiersType.organizationId,
                   },
                 },
               },

--- a/api/lib/application/user-orga-settings/user-orga-settings-controller.js
+++ b/api/lib/application/user-orga-settings/user-orga-settings-controller.js
@@ -6,7 +6,7 @@ module.exports = {
 
   async createOrUpdate(request) {
     const authenticatedUserId = request.auth.credentials.userId;
-    const userId = parseInt(request.params.id);
+    const userId = request.params.id;
     const organizationId = request.payload.data.relationships.organization.data.id;
 
     if (userId !== authenticatedUserId) {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -41,13 +41,13 @@ module.exports = {
   },
 
   async getUserDetailsForAdmin(request) {
-    const userId = parseInt(request.params.id);
+    const userId = request.params.id;
     const userDetailsForAdmin = await usecases.getUserDetailsForAdmin({ userId });
     return userDetailsForAdminSerializer.serialize(userDetailsForAdmin);
   },
 
   async updateEmail(request, h) {
-    const userId = parseInt(request.params.id);
+    const userId = request.params.id;
     const authenticatedUserId = request.auth.credentials.userId;
     const { email, password } = request.payload.data.attributes;
     const locale = extractLocaleFromRequest(request);
@@ -64,7 +64,7 @@ module.exports = {
   },
 
   async updatePassword(request) {
-    const userId = parseInt(request.params.id);
+    const userId = request.params.id;
     const password = request.payload.data.attributes.password;
 
     const updatedUser = await usecases.updateUserPassword({
@@ -77,7 +77,7 @@ module.exports = {
   },
 
   async updateUserDetailsForAdministration(request) {
-    const userId = parseInt(request.params.id);
+    const userId = request.params.id;
     const userDetailsForAdministration = userDetailsForAdminSerializer.deserialize(request.payload);
 
     const updatedUser = await usecases.updateUserDetailsForAdministration({
@@ -240,19 +240,19 @@ module.exports = {
   },
 
   async anonymizeUser(request, h) {
-    const userId = parseInt(request.params.id);
+    const userId = request.params.id;
     await usecases.anonymizeUser({ userId });
     return h.response({}).code(204);
   },
 
   async dissociateSchoolingRegistrations(request) {
-    const userId = parseInt(request.params.id);
+    const userId = request.params.id;
     const userDetailsForAdmin = await usecases.dissociateSchoolingRegistrations({ userId });
     return userDetailsForAdminSerializer.serialize(userDetailsForAdmin);
   },
 
   async removeAuthenticationMethod(request, h) {
-    const userId = parseInt(request.params.id);
+    const userId = request.params.id;
     const type = request.payload.data.attributes.type;
     await usecases.removeAuthenticationMethod({ userId, type });
     return h.response().code(204);

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
@@ -192,7 +192,7 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
 
     it('should return a 404 status when schoolingRegistration does not exist', async () => {
       // given
-      options.payload.data.attributes['schooling-registration-id'] = 0;
+      options.payload.data.attributes['schooling-registration-id'] = schoolingRegistrationId + 1;
 
       // when
       const response = await server.inject(options);
@@ -220,7 +220,7 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
 
     it('should return a 403 status when student does not belong to the same organization as schoolingRegistration', async () => {
       // given
-      options.payload.data.attributes['organization-id'] = 0;
+      options.payload.data.attributes['organization-id'] = organizationId + 1;
       options.payload.data.attributes['schooling-registration-id'] = schoolingRegistrationId;
 
       // when
@@ -295,7 +295,7 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
 
     it('should return a 404 status when schoolingRegistration does not exist', async () => {
       // given
-      options.payload.data.attributes['schooling-registration-id'] = 0;
+      options.payload.data.attributes['schooling-registration-id'] = 1;
 
       // when
       const response = await server.inject(options);

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -16,8 +16,8 @@ describe('Unit | Controller | certifications-center-controller', () => {
           credentials: { userId: '111' },
         },
         params: {
-          certificationCenterId: '99',
-          sessionId: '88',
+          certificationCenterId: 99,
+          sessionId: 88,
         },
         query: { 'page[size]': 10, 'page[number]': 1, 'filter[divisions][]': '3A' },
       };
@@ -59,10 +59,10 @@ describe('Unit | Controller | certifications-center-controller', () => {
       // given
       const request = {
         auth: {
-          credentials: { userId: '111' },
+          credentials: { userId: 111 },
         },
         params: {
-          certificationCenterId: '99',
+          certificationCenterId: 99,
         },
       };
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -118,7 +118,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
           credentials: { userId: '111' },
         },
         params: {
-          id: '99',
+          id: 99,
         },
       };
 
@@ -460,7 +460,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
   describe('#findTargetProfiles', () => {
     const connectedUserId = 1;
-    const organizationId = '145';
+    const organizationId = 145;
     let foundTargetProfiles;
 
     beforeEach(() => {
@@ -538,7 +538,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     beforeEach(() => {
       request = {
         auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId.toString() },
+        params: { id: organizationId },
       };
 
       sinon.stub(usecases, 'findPaginatedFilteredSchoolingRegistrations');
@@ -615,7 +615,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     beforeEach(() => {
       request = {
         auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId.toString() },
+        params: { id: organizationId },
         query: { format },
         payload: { path: 'path-to-file' },
         i18n,

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -113,7 +113,7 @@ describe('Unit | Controller | sessionController', () => {
       request = {
         auth: { credentials: { userId } },
         params: {
-          id: sessionId.toString(),
+          id: sessionId,
         },
       };
     });
@@ -146,7 +146,7 @@ describe('Unit | Controller | sessionController', () => {
       request = {
         auth: { credentials: { userId } },
         params: {
-          id: sessionId.toString(),
+          id: sessionId,
         },
       };
     });

--- a/api/tests/unit/application/stages/stages-controller_test.js
+++ b/api/tests/unit/application/stages/stages-controller_test.js
@@ -49,7 +49,7 @@ describe('Unit | Controller | stages-controller', () => {
       sinon.stub(usecases, 'updateStage');
       request = {
         params: {
-          id: '44',
+          id: 44,
         },
         payload: {
           data: {
@@ -81,7 +81,7 @@ describe('Unit | Controller | stages-controller', () => {
       sinon.stub(usecases, 'getStageDetails');
       request = {
         params: {
-          id: '44',
+          id: 44,
         },
       };
     });

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -14,7 +14,7 @@ describe('Unit | Controller | target-profile-controller', () => {
 
       request = {
         params: {
-          id: '123',
+          id: 123,
         },
         payload: {
           data: {

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -398,7 +398,7 @@ describe('Unit | Controller | user-controller', () => {
     let request;
 
     beforeEach(() => {
-      request = { params: { id: '123' } };
+      request = { params: { id: 123 } };
 
       sinon.stub(usecases, 'getUserDetailsForAdmin');
       sinon.stub(userDetailsForAdminSerializer, 'serialize');


### PR DESCRIPTION
## :unicorn: Problème
Le routeur, en présence d'une validation Joi, contrôle la requête en entrée (URL et payload).
Ce faisant, les propriétés déclarées `number` sont parsées [et mutées dans ce type](http://github.com/GradedJestRisk/js-training/blob/master/node/network/incoming/hapi/tests/server-test.js#L50), au lieu du type `string` par défaut.
[Une PR](https://github.com/1024pix/pix/pull/2464) a étendu cette validation aux identifiants présents dans les URL, de type `number`.

Néanmoins, les controleurs existants continuent à parser les valeurs alors qu'elles sont déjà au bon format.

## :robot: Solution
Supprimer le parsing qui n'est plus nécessaire dans les controleurs.
Ajouter une règle de lint sur `parseInt` dans les controleurs pour indiquer au développeur ce comportement non trivial de Joi.

## :rainbow: Remarques
Certains cas font exception et gardent le parsing explicite avec une exception de lint:
- payload complexes ;
- pre-handlers.

Dans ce cas, comment spécifier l'exception avec un filtre plus précis que `no-invalid-syntax` ?

## :100: Pour tester
Ajouter un parseInt dans un controlleur.
Vérifier que `npm run lint `sort en erreur
