### PR TITLE
[BUGFIX] Ajouter l'id de l'organisation dans le titre de certaines pages de Pix Admin (PIX-2627).

### DIFF
--- a/admin/app/routes/authenticated/organizations/get/all-tags.js
+++ b/admin/app/routes/authenticated/organizations/get/all-tags.js
@@ -3,9 +3,15 @@ import Route from '@ember/routing/route';
 export default class AllTags extends Route {
 
   async model() {
+    const organizationId = this.paramsFor('authenticated.organizations.get').organization_id;
+
     const organizationTags = this.modelFor('authenticated.organizations.get').tags;
     const allTags = await this.store.findAll('tag');
 
-    return { organizationTags, allTags };
+    return {
+      allTags,
+      organizationId,
+      organizationTags,
+    };
   }
 }

--- a/admin/app/routes/authenticated/organizations/get/campaigns.js
+++ b/admin/app/routes/authenticated/organizations/get/campaigns.js
@@ -14,6 +14,11 @@ export default class OrganizationCampaignsRoute extends Route {
       'page[number]': params.pageNumber || 1,
       'page[size]': params.pageSize || 10,
     };
-    return this.store.query('campaign', query);
+    const campaigns = await this.store.query('campaign', query);
+
+    return {
+      campaigns,
+      organizationId,
+    };
   }
 }

--- a/admin/app/templates/authenticated.hbs
+++ b/admin/app/templates/authenticated.hbs
@@ -1,4 +1,4 @@
-{{page-title "Pix admin" separator=" - "}}
+{{page-title "Pix Admin" separator=" - "}}
 <div class="app-container">
 
   <aside class="app-sidebar">

--- a/admin/app/templates/authenticated/organizations/get/all-tags.hbs
+++ b/admin/app/templates/authenticated/organizations/get/all-tags.hbs
@@ -1,1 +1,2 @@
-<OrganizationAllTags @model={{@model}}/>
+{{page-title "Orga " @model.organizationId " Tags"}}
+<OrganizationAllTags @model={{@model}} />

--- a/admin/app/templates/authenticated/organizations/get/campaigns.hbs
+++ b/admin/app/templates/authenticated/organizations/get/campaigns.hbs
@@ -1,4 +1,4 @@
-{{page-title "Orga " @model.id " Campagnes"}}
+{{page-title "Orga " @model.organizationId " Campagnes"}}
 <OrganizationCampaignsSection
-    @campaigns={{@model}}
+    @campaigns={{@model.campaigns}}
   />

--- a/admin/app/templates/authenticated/organizations/get/members.hbs
+++ b/admin/app/templates/authenticated/organizations/get/members.hbs
@@ -1,4 +1,4 @@
-{{page-title "Orga " @model.id}}
+{{page-title "Orga " @model.id " Membres"}}
 <OrganizationMembersSection
   @memberships={{@model.memberships}}
   @userEmailToAdd={{this.userEmailToAdd}}


### PR DESCRIPTION
## :unicorn: Problème
1. Il manque l'id de l'organisation dans les pages de Pix Admin : 
* `/organizations/id/all-tags`
* `/organizations/id/members`
* `/organizations/id/campaigns`

2. Modifier le titre `Pix admin` en `Pix Admin`

## :robot: Solution
Effectuer les corrections

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Vérifier que le titre de toutes les pages commence par `Pix Admin`
* Vérifier que le titre des pages `../all-tags`, `../members` et `../campaigns` comportent l'id de l'organisation