### PR TITLE
[BUGFIX] Correction de référentiel en français alors que la langue est configurée comme l'anglais (PIX-2609).

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -213,10 +213,12 @@ module.exports = {
   async getUserProfileSharedForCampaign(request) {
     const authenticatedUserId = request.auth.credentials.userId;
     const campaignId = request.params.campaignId;
+    const locale = extractLocaleFromRequest(request);
 
     const sharedProfileForCampaign = await usecases.getUserProfileSharedForCampaign({
       userId: authenticatedUserId,
       campaignId,
+      locale,
     });
 
     return sharedProfileForCampaignSerializer.serialize(sharedProfileForCampaign);

--- a/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
+++ b/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
@@ -11,6 +11,7 @@ module.exports = async function getUserProfileSharedForCampaign({
   campaignRepository,
   knowledgeElementRepository,
   competenceRepository,
+  locale,
 }) {
   const campaignParticipation = await campaignParticipationRepository.findOneByCampaignIdAndUserId({ campaignId, userId });
 
@@ -21,7 +22,7 @@ module.exports = async function getUserProfileSharedForCampaign({
   const { multipleSendings: campaignAllowsRetry } = await campaignRepository.get(campaignId);
   const [knowledgeElementsGroupedByCompetenceId, competencesWithArea] = await Promise.all([
     knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId, limitDate: campaignParticipation.sharedAt }),
-    competenceRepository.listPixCompetencesOnly(),
+    competenceRepository.listPixCompetencesOnly({ locale }),
   ]);
 
   const scorecards = _.map(competencesWithArea, (competence) => {

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 const { UserNotAuthorizedToGetCampaignResultsError } = require('../errors');
-const CampaignProfilCollectionExport = require('../../infrastructure/serializers/csv/campaign-profile-collection-export');
+const CampaignProfilesCollectionExport = require('../../infrastructure/serializers/csv/campaign-profiles-collection-export');
 
 async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
   const user = await userRepository.getWithMemberships(userId);
@@ -37,13 +37,13 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
     campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id),
   ]);
 
-  const campaignProfilCollectionExport = new CampaignProfilCollectionExport(writableStream, organization, campaign, allPixCompetences, translate);
+  const campaignProfilesCollectionExport = new CampaignProfilesCollectionExport(writableStream, organization, campaign, allPixCompetences, translate);
 
   // No return/await here, we need the writing to continue in the background
   // after this function's returned promise resolves. If we await the map
   // function, node will keep all the data in memory until the end of the
   // complete operation.
-  campaignProfilCollectionExport.export(campaignParticipationResultDatas, placementProfileService).then(() => {
+  campaignProfilesCollectionExport.export(campaignParticipationResultDatas, placementProfileService).then(() => {
     writableStream.end();
   }).catch((error) => {
     writableStream.emit('error', error);

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -32,7 +32,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
 
   const [allPixCompetences, organization, campaignParticipationResultDatas] = await Promise.all([
-    competenceRepository.listPixCompetencesOnly(i18n.getLocale()),
+    competenceRepository.listPixCompetencesOnly({ locale: i18n.getLocale() }),
     organizationRepository.get(campaign.organizationId),
     campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id),
   ]);

--- a/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 
 const EMPTY_ARRAY = [];
 
-class CampaignProfileCollectionResultLine {
+class CampaignProfilesCollectionResultLine {
 
   constructor(campaign, organization, campaignParticipationResult, competences, placementProfile, translate) {
     this.organization = organization;
@@ -101,4 +101,4 @@ class CampaignProfileCollectionResultLine {
   }
 }
 
-module.exports = CampaignProfileCollectionResultLine;
+module.exports = CampaignProfilesCollectionResultLine;

--- a/api/lib/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/lib/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -2,8 +2,8 @@ const _ = require('lodash');
 const bluebird = require('bluebird');
 const csvSerializer = require('./csv-serializer');
 const constants = require('../../constants');
-const CampaignProfileCollectionResultLine = require('../../exports/campaigns/campaign-profile-collection-result-line');
-class CampaignProfileCollectionExport {
+const CampaignProfilesCollectionResultLine = require('../../exports/campaigns/campaign-profiles-collection-result-line');
+class CampaignProfilesCollectionExport {
 
   constructor(outputStream, organization, campaign, competences, translate) {
     this.stream = outputStream;
@@ -73,7 +73,7 @@ class CampaignProfileCollectionExport {
     for (const placementProfile of placementProfiles) {
       const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) => userId === placementProfile.userId);
 
-      const line = new CampaignProfileCollectionResultLine(this.campaign, this.organization, campaignParticipationResultData, this.competences, placementProfile, this.translate);
+      const line = new CampaignProfilesCollectionResultLine(this.campaign, this.organization, campaignParticipationResultData, this.competences, placementProfile, this.translate);
       csvLines = csvLines.concat(line.toCsvLine());
     }
     return csvLines;
@@ -87,4 +87,4 @@ class CampaignProfileCollectionExport {
   }
 }
 
-module.exports = CampaignProfileCollectionExport;
+module.exports = CampaignProfilesCollectionExport;

--- a/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
@@ -9,6 +9,8 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
   const userId = Symbol('user id');
   const campaignId = Symbol('campaign id');
   const expectedCampaignParticipation = { id: '1', sharedAt };
+  const locale = 'fr';
+
   let campaignParticipationRepository;
   let knowledgeElementRepository;
   let competenceRepository;
@@ -35,7 +37,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
       // given
       campaignParticipationRepository.findOneByCampaignIdAndUserId.withArgs({ userId, campaignId }).resolves(expectedCampaignParticipation);
       knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.withArgs({ userId, limitDate: sharedAt }).resolves(knowledgeElements);
-      competenceRepository.listPixCompetencesOnly.resolves(competences);
+      competenceRepository.listPixCompetencesOnly.withArgs({ locale: 'fr' }).resolves(competences);
       campaignRepository.get.withArgs(campaignId).resolves(campaign);
       Scorecard
         .buildFrom
@@ -54,6 +56,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', () => {
         knowledgeElementRepository,
         competenceRepository,
         campaignRepository,
+        locale,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -1,0 +1,92 @@
+const { PassThrough } = require('stream');
+const { expect, sinon, domainBuilder, streamToPromise, catchErr } = require('../../../test-helper');
+const startWritingCampaignProfilesCollectionResultsToStream = require('../../../../lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream');
+const { UserNotAuthorizedToGetCampaignResultsError } = require('../../../../lib/domain/errors');
+const CampaignProfilesCollectionExport = require('../../../../lib/infrastructure/serializers/csv/campaign-profiles-collection-export');
+const { getI18n } = require('../../../tooling/i18n/i18n');
+
+describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection-results-to-stream', () => {
+  const campaignRepository = { get: () => undefined };
+  const userRepository = { getWithMemberships: () => undefined };
+  const competenceRepository = { listPixCompetencesOnly: () => undefined };
+  const organizationRepository = { get: () => undefined };
+  const campaignParticipationRepository = { findProfilesCollectionResultDataByCampaignId: () => undefined };
+  let writableStream;
+  let csvPromise;
+  const placementProfileService = Symbol('placementProfileService');
+  const i18n = getI18n();
+
+  beforeEach(() => {
+    sinon.stub(campaignRepository, 'get').rejects('error for campaignRepository.get');
+    sinon.stub(userRepository, 'getWithMemberships').rejects('error for userRepository.getWithMemberships');
+    sinon.stub(competenceRepository, 'listPixCompetencesOnly').rejects('error for competenceRepository.listPixCompetencesOnly');
+    sinon.stub(organizationRepository, 'get').rejects('error for organizationRepository.get');
+    sinon.stub(campaignParticipationRepository, 'findProfilesCollectionResultDataByCampaignId').rejects('error for campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId');
+    sinon.stub(CampaignProfilesCollectionExport.prototype, 'export').rejects('CampaignProfilesCollectionExport.prototype.export');
+    writableStream = new PassThrough();
+    csvPromise = streamToPromise(writableStream);
+  });
+
+  it('should throw a UserNotAuthorizedToGetCampaignResultsError when user is not authorized', async () => {
+    // given
+    const notAuthorizedUser = domainBuilder.buildUser({ memberships: [] });
+    const campaign = domainBuilder.buildCampaign();
+    campaignRepository.get.withArgs(campaign.id).resolves(campaign);
+    userRepository.getWithMemberships.withArgs(notAuthorizedUser.id).resolves(notAuthorizedUser);
+
+    // when
+    const err = await catchErr(startWritingCampaignProfilesCollectionResultsToStream)({
+      userId: notAuthorizedUser.id,
+      campaignId: campaign.id,
+      writableStream,
+      i18n,
+      campaignRepository,
+      userRepository,
+      competenceRepository,
+      campaignParticipationRepository,
+      organizationRepository,
+      placementProfileService,
+    });
+
+    // then
+    expect(err).to.be.instanceOf(UserNotAuthorizedToGetCampaignResultsError);
+    expect(err.message).to.equal(`User does not have an access to the organization ${campaign.organization.id}`);
+  });
+
+  it('should process result for each participation and add it to csv', async () => {
+    // given
+    const competences = Symbol('competences');
+    const campaignParticipationResultDatas = Symbol('campaignParticipationResultDatas');
+    const organization = domainBuilder.buildOrganization();
+    const user = domainBuilder.buildUser();
+    domainBuilder.buildMembership({ user, organization });
+    const campaign = domainBuilder.buildCampaign();
+    campaignRepository.get.withArgs(campaign.id).resolves(campaign);
+    userRepository.getWithMemberships.withArgs(user.id).resolves(user);
+    organizationRepository.get.withArgs(organization.id).resolves(organization);
+    competenceRepository.listPixCompetencesOnly.withArgs({ locale: 'fr' }).resolves(competences);
+    campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId.withArgs(campaign.id).resolves(campaignParticipationResultDatas);
+    CampaignProfilesCollectionExport.prototype.export.withArgs(campaignParticipationResultDatas, placementProfileService).callsFake(async() => {
+      await writableStream.write('result');
+    });
+
+    // when
+    await startWritingCampaignProfilesCollectionResultsToStream({
+      userId: user.id,
+      campaignId: campaign.id,
+      writableStream,
+      i18n,
+      campaignRepository,
+      userRepository,
+      competenceRepository,
+      campaignParticipationRepository,
+      organizationRepository,
+      placementProfileService,
+    });
+    const csv = await csvPromise;
+
+    // then
+    expect(csv).to.equal('result');
+  });
+
+});

--- a/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
+++ b/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
@@ -1,10 +1,10 @@
 const { domainBuilder, expect, sinon } = require('../../../../test-helper');
 
-const CampaignProfileCollectionResultLine = require('../../../../../lib/infrastructure/exports/campaigns/campaign-profile-collection-result-line');
+const CampaignProfilesCollectionResultLine = require('../../../../../lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line');
 const PlacementProfile = require('../../../../../lib/domain/models/PlacementProfile');
 const { getI18n } = require('../../../../tooling/i18n/i18n');
 
-describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', () => {
+describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', () => {
   describe('#toCsvLine', () => {
     let organization, campaign, competences;
 
@@ -82,7 +82,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+        const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -125,7 +125,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+        const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -171,7 +171,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
           '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+        const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -222,7 +222,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
        '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+        const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -274,7 +274,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+        const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -327,7 +327,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
           //when
-          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+          const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
           //then
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -374,7 +374,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
           //when
-          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+          const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
           //then
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -427,7 +427,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
           '\n';
 
             //when
-            const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+            const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
             //then
             expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -482,7 +482,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
           //when
-          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+          const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
           //then
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -529,7 +529,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
           //when
-          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+          const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
           //then
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -582,7 +582,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
           '\n';
 
             //when
-            const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+            const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
             //then
             expect(line.toCsvLine()).to.equal(csvExcpectedLine);

--- a/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
@@ -1,10 +1,10 @@
 const { PassThrough } = require('stream');
 const { domainBuilder, expect, sinon, streamToPromise } = require('../../../../test-helper');
 
-const CampaignProfileCollectionExport = require('../../../../../lib/infrastructure/serializers/csv/campaign-profile-collection-export');
+const CampaignProfilesCollectionExport = require('../../../../../lib/infrastructure/serializers/csv/campaign-profiles-collection-export');
 const { getI18n } = require('../../../../tooling/i18n/i18n');
 
-describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
+describe('Unit | Serializer | CSV | campaign-profiles-collection-export', () => {
   describe('#export', () => {
     let writableStream, csvPromise, organization, campaign, competences;
 
@@ -42,7 +42,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
 
     it('should display common header parts of csv', async () => {
       //given
-      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences, translate);
+      const campaignProfile = new CampaignProfilesCollectionExport(writableStream, organization, campaign, competences, translate);
 
       const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +
@@ -74,7 +74,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
       organization.isSco = true;
       organization.isManagingStudents = true;
 
-      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences, translate);
+      const campaignProfile = new CampaignProfilesCollectionExport(writableStream, organization, campaign, competences, translate);
 
       const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +
@@ -107,7 +107,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
       organization.isSup = true;
       organization.isManagingStudents = true;
 
-      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences, translate);
+      const campaignProfile = new CampaignProfilesCollectionExport(writableStream, organization, campaign, competences, translate);
 
       const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +
@@ -138,7 +138,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
     it('should display idPixLabel header when campaign has one', async () => {
       //given
       campaign.idPixLabel = 'email';
-      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences, translate);
+      const campaignProfile = new CampaignProfilesCollectionExport(writableStream, organization, campaign, competences, translate);
 
       const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +


### PR DESCRIPTION
## :unicorn: Problème
Alors même que la langue est configurée comme la langue anglaise, 2 endroits ont encore le référentiel en français :
- la page d'un profil déjà envoyé à son prescripteur (Pix App) ;
- le CSV de collecte de profils (Pix Orga).

## :robot: Solution
Récupérer la locale pour ces 2 endroits.

## :rainbow: Remarques
Renommage en bonus.

## :100: Pour tester
Visiter la page d'un profil déjà envoyé à son prescripteur (Pix App : campagne SNAP123 en tant que jaune.attend@example.net) et télécharger le CSV d'une campagne de collecte de profils (Pix Orga : campagne SNAP123 en tant que pro.admin@example.net) en étant en langue anglaise.
