### PR TITLE
[TECH] Afficher les RT dans le détail d'un participant,  à partir de l'id de la campaignParticipation (PIX-2623)

### DIFF
--- a/api/lib/domain/usecases/get-campaign-assessment-participation.js
+++ b/api/lib/domain/usecases/get-campaign-assessment-participation.js
@@ -7,8 +7,8 @@ module.exports = async function getCampaignAssessmentParticipation({ userId, cam
 
   const campaignAssessmentParticipation = await campaignAssessmentParticipationRepository.getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId });
 
-  const acquiredBadgesByUser = await badgeAcquisitionRepository.getCampaignAcquiredBadgesByUsers({ campaignId, userIds: [campaignAssessmentParticipation.userId] });
-  const badges = acquiredBadgesByUser[campaignAssessmentParticipation.userId];
+  const acquiredBadgesByCampaignParticipations = await badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({ campaignParticipationsIds: [campaignParticipationId] });
+  const badges = acquiredBadgesByCampaignParticipations[campaignAssessmentParticipation.campaignParticipationId];
   campaignAssessmentParticipation.setBadges(badges);
 
   return campaignAssessmentParticipation;

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -66,6 +66,40 @@ describe('Integration | Repository | Badge Acquisition', () => {
     });
   });
 
+  describe('#getAcquiredBadgesByCampaignParticipations', () => {
+    let campaign;
+    let user1;
+    let badge1;
+    let badge2;
+    let campaignParticipationId;
+
+    beforeEach(async () => {
+      user1 = databaseBuilder.factory.buildUser();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId: user1.id, campaignId: campaign.id }).id;
+      badge1 = databaseBuilder.factory.buildBadge({ key: 'badge1', targetProfileId: targetProfile.id });
+      badge2 = databaseBuilder.factory.buildBadge({ key: 'badge2', targetProfileId: targetProfile.id });
+      databaseBuilder.factory.buildBadge({ key: 'badge3', targetProfileId: targetProfile.id });
+      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, campaignParticipationId, userId: user1.id });
+      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge2.id, campaignParticipationId, userId: user1.id });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return badge ids acquired by user for a campaignParticipation', async () => {
+      // when
+      const acquiredBadgeIdsByUsers = await badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({
+        campaignParticipationsIds: [campaignParticipationId],
+      });
+
+      // then
+      expect(acquiredBadgeIdsByUsers[campaignParticipationId][0]).to.includes(badge1);
+      expect(acquiredBadgeIdsByUsers[campaignParticipationId][1]).to.includes(badge2);
+      expect(acquiredBadgeIdsByUsers[campaignParticipationId].length).to.eq(2);
+    });
+  });
+
   describe('#getCampaignAcquiredBadgesByUsers', () => {
     let campaign;
     let user1;

--- a/api/tests/unit/domain/usecases/get-campaign-assessment-participation_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-assessment-participation_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | get-campaign-assessment-participation', () => {
       getByCampaignIdAndCampaignParticipationId: sinon.stub(),
     };
     badgeAcquisitionRepository = {
-      getCampaignAcquiredBadgesByUsers: sinon.stub(),
+      getAcquiredBadgesByCampaignParticipations: sinon.stub(),
     };
   });
 
@@ -34,7 +34,7 @@ describe('Unit | UseCase | get-campaign-assessment-participation', () => {
       const participantId = domainBuilder.buildUser().id;
       const campaignAssessmentParticipation = new CampaignAssessmentParticipation({ userId: participantId });
       campaignAssessmentParticipationRepository.getByCampaignIdAndCampaignParticipationId.withArgs({ campaignId, campaignParticipationId }).resolves(campaignAssessmentParticipation);
-      badgeAcquisitionRepository.getCampaignAcquiredBadgesByUsers.withArgs({ campaignId, userIds: [participantId] }).resolves({});
+      badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations.withArgs({ campaignParticipationsIds: [campaignParticipationId] }).resolves({});
 
       // when
       const result = await getCampaignAssessmentParticipation({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationRepository, badgeAcquisitionRepository });
@@ -46,10 +46,9 @@ describe('Unit | UseCase | get-campaign-assessment-participation', () => {
     it('should set badges', async () => {
       // given
       const badges = Symbol('badges');
-      const participantId = domainBuilder.buildUser().id;
-      const campaignAssessmentParticipation = new CampaignAssessmentParticipation({ userId: participantId });
+      const campaignAssessmentParticipation = new CampaignAssessmentParticipation({ campaignParticipationId });
       campaignAssessmentParticipationRepository.getByCampaignIdAndCampaignParticipationId.withArgs({ campaignId, campaignParticipationId }).resolves(campaignAssessmentParticipation);
-      badgeAcquisitionRepository.getCampaignAcquiredBadgesByUsers.withArgs({ campaignId, userIds: [participantId] }).resolves({ [participantId]: badges });
+      badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations.withArgs({ campaignParticipationsIds: [campaignParticipationId] }).resolves({ [campaignParticipationId]: badges });
 
       // when
       const result = await getCampaignAssessmentParticipation({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationRepository, badgeAcquisitionRepository });


### PR DESCRIPTION
## :unicorn: Problème
Avant les RT appartenaient aux users mais maintenant ils appartiennent à une campaignParticipation.

## :robot: Solution
Changer la requête qui récupère les RT pour qu'elle se base sur le camapignParticipationId et non plus sur le userId

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur PixOrga avec le mail `pro.admin@example.net`et aller voir la campagne `Pro - Campagne d’évaluation 5.1` et voir si les badges acquis sont là.
