### PR TITLE
[BUGFIX] Stocker les données d'authentification PE temporairement (PIX-2707).

### DIFF
--- a/api/lib/domain/usecases/create-user-from-pole-emploi.js
+++ b/api/lib/domain/usecases/create-user-from-pole-emploi.js
@@ -2,15 +2,15 @@ const moment = require('moment');
 const User = require('../models/User');
 const AuthenticationMethod = require('../models/AuthenticationMethod');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
-const authenticationCache = require('../../infrastructure/caches/authentication-cache');
 
 module.exports = async function createUserFromPoleEmploi({
   authenticationKey,
   userRepository,
   authenticationMethodRepository,
   authenticationService,
+  poleEmploiAuthenticationTemporaryStorage,
 }) {
-  const userCredentials = await authenticationCache.get(authenticationKey);
+  const userCredentials = await poleEmploiAuthenticationTemporaryStorage.getdel(authenticationKey);
   const userInfo = await authenticationService.getPoleEmploiUserInfo(userCredentials.idToken);
 
   const authenticationMethod = await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -3,6 +3,7 @@ const dependencies = {
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
   authenticationCache: require('../../infrastructure/caches/authentication-cache'),
+  poleEmploiAuthenticationTemporaryStorage: require('../../infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage'),
   authenticationMethodRepository: require('../../infrastructure/repositories/authentication-method-repository'),
   authenticationService: require('../../domain/services/authentication-service'),
   badgeAcquisitionRepository: require('../../infrastructure/repositories/badge-acquisition-repository'),

--- a/api/lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage.js
+++ b/api/lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage.js
@@ -15,8 +15,9 @@ class PoleEmploiAuthenticationTemporaryStorage {
   }
 
   async getdel(key) {
-    await this._get(KEY_PREFIX + key);
+    const value = await this._get(KEY_PREFIX + key);
     await this._del(KEY_PREFIX + key);
+    return value;
   }
 
   async set(key, object) {
@@ -26,4 +27,4 @@ class PoleEmploiAuthenticationTemporaryStorage {
 
 }
 
-module.exports = PoleEmploiAuthenticationTemporaryStorage;
+module.exports = new PoleEmploiAuthenticationTemporaryStorage();

--- a/api/lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage.js
+++ b/api/lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage.js
@@ -1,0 +1,29 @@
+const redis = require('redis');
+const settings = require('../../config');
+const { promisify } = require('util');
+
+const KEY_PREFIX = 'authentication_';
+const expirationDelaySeconds = 10;
+
+class PoleEmploiAuthenticationTemporaryStorage {
+
+  constructor() {
+    this._client = redis.createClient(settings.caching.redisUrl);
+    this._del = promisify(this._client.del).bind(this._client);
+    this._get = promisify(this._client.get).bind(this._client);
+    this._set = promisify(this._client.set).bind(this._client);
+  }
+
+  async getdel(key) {
+    await this._get(KEY_PREFIX + key);
+    await this._del(KEY_PREFIX + key);
+  }
+
+  async set(key, object) {
+    const finalKey = KEY_PREFIX + key;
+    await this._set(finalKey, object, 'EX', expirationDelaySeconds);
+  }
+
+}
+
+module.exports = PoleEmploiAuthenticationTemporaryStorage;

--- a/api/package.json
+++ b/api/package.json
@@ -126,7 +126,7 @@
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
-    "test:api:unit": "TEST_DATABASE_URL=bad_url npm run test:api:path -- tests/unit",
+    "test:api:unit": "TEST_DATABASE_URL=postgres://foo REDIS_URL=redis://bar npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",

--- a/api/tests/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/acceptance/application/pole-emploi-controller_test.js
@@ -1,6 +1,6 @@
 const { expect, knex } = require('../../test-helper');
 const createServer = require('../../../server');
-const authenticationCache = require('../../../lib/infrastructure/caches/authentication-cache');
+const storage = require('../../../lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage');
 const jsonwebtoken = require('jsonwebtoken');
 
 describe('Acceptance | API | Pole Emploi Controller', () => {
@@ -19,7 +19,7 @@ describe('Acceptance | API | Pole Emploi Controller', () => {
     const lastName = 'lastName';
     const externalIdentifier = 'idIdentiteExterne';
 
-    beforeEach(() => {
+    beforeEach(async () => {
       const idToken = jsonwebtoken.sign({
         'given_name': firstName,
         'family_name': lastName,
@@ -33,7 +33,7 @@ describe('Acceptance | API | Pole Emploi Controller', () => {
         expiresIn: 10,
         refreshToken: 'refreshToken',
       };
-      authenticationCache.set(userAuthenticationKey, userCredentials);
+      await storage.set(userAuthenticationKey, userCredentials);
 
       request = {
         method: 'POST',

--- a/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
@@ -3,15 +3,14 @@ const createUserFromPoleEmploi = require('../../../../lib/domain/usecases/create
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 const User = require('../../../../lib/domain/models/User');
-const authenticationCache = require('../../../../lib/infrastructure/caches/authentication-cache');
+const poleEmploiAuthenticationTemporaryStorage = require('../../../../lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage');
 const moment = require('moment');
 
 describe('Unit | UseCase | create-user-from-pole-emploi', () => {
 
   const domainTransaction = Symbol();
-
   let clock;
-  let authenticationCacheGetStub;
+  let storageGetStub;
   let userRepository;
   let authenticationMethodRepository;
   let authenticationService;
@@ -19,7 +18,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', () => {
   beforeEach(() => {
     clock = sinon.useFakeTimers(Date.now());
     DomainTransaction.execute = (lambda) => { return lambda(domainTransaction); };
-    authenticationCacheGetStub = sinon.stub(authenticationCache, 'get');
+    storageGetStub = sinon.stub(poleEmploiAuthenticationTemporaryStorage, 'getdel');
     userRepository = {
       findByPoleEmploiExternalIdentifier: sinon.stub(),
       create: sinon.stub(),
@@ -49,7 +48,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', () => {
         expiresIn: 10,
         refreshToken: 'refreshToken',
       };
-      authenticationCacheGetStub.withArgs(authenticationKey).resolves(userCredentials);
+      storageGetStub.withArgs(authenticationKey).resolves(userCredentials);
       const decodedUserInfo = {
         firstName: 'Jean',
         lastName: 'Heymar',
@@ -87,6 +86,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', () => {
         userRepository,
         authenticationMethodRepository,
         authenticationService,
+        poleEmploiAuthenticationTemporaryStorage,
       });
 
       // then
@@ -109,7 +109,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', () => {
         expiresIn: 10,
         refreshToken: 'refreshToken',
       };
-      authenticationCacheGetStub.withArgs(authenticationKey).resolves(userCredentials);
+      storageGetStub.withArgs(authenticationKey).resolves(userCredentials);
       const decodedUserInfo = {
         firstName: 'Jean',
         lastName: 'Heymar',
@@ -129,6 +129,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', () => {
         userRepository,
         authenticationMethodRepository,
         authenticationService,
+        poleEmploiAuthenticationTemporaryStorage,
       });
 
       // then

--- a/api/tests/unit/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage_test.js
@@ -1,37 +1,17 @@
 const redis = require('redis');
 const { expect, sinon } = require('../../../test-helper');
 
-const PoleEmploiAuthenticationTemporaryStorage = require('../../../../lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage');
+const storage = require('../../../../lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage');
 
 describe('Unit | Infrastructure | PoleEmploiAuthenticationTemporaryStorage', () => {
 
   const KEY_PREFIX = 'authentication_';
-
-  describe('#constructor', () => {
-
-    it('should instantiate a redis client', async () => {
-      // given
-      sinon.stub(redis, 'createClient');
-      redis.createClient.returns({
-        del: () => {},
-        get: () => {},
-        set: () => {},
-      });
-
-      // when
-      new PoleEmploiAuthenticationTemporaryStorage();
-
-      // then
-      expect(redis.createClient).to.have.been.calledOnce;
-    });
-  });
 
   describe('#getdel', () => {
 
     it('should call _get method with prefixed key', async () => {
       // given
       const key = 'my_key';
-      const storage = new PoleEmploiAuthenticationTemporaryStorage();
       const getStub = sinon.stub(storage, '_get');
 
       // when
@@ -44,7 +24,6 @@ describe('Unit | Infrastructure | PoleEmploiAuthenticationTemporaryStorage', () 
     it('should call _del method with prefixed key', async () => {
       // given
       const key = 'my_key';
-      const storage = new PoleEmploiAuthenticationTemporaryStorage();
       const delStub = sinon.stub(storage, '_del');
 
       // when
@@ -62,7 +41,6 @@ describe('Unit | Infrastructure | PoleEmploiAuthenticationTemporaryStorage', () 
       const key = 'my_key';
       const value = 'value';
       const expirationDelaySeconds = 10;
-      const storage = new PoleEmploiAuthenticationTemporaryStorage();
       const setStub = sinon.stub(storage, '_set');
 
       // when

--- a/api/tests/unit/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage_test.js
@@ -1,0 +1,75 @@
+const redis = require('redis');
+const { expect, sinon } = require('../../../test-helper');
+
+const PoleEmploiAuthenticationTemporaryStorage = require('../../../../lib/infrastructure/temporary-storage/pole-emploi-authentication-temporary-storage');
+
+describe('Unit | Infrastructure | PoleEmploiAuthenticationTemporaryStorage', () => {
+
+  const KEY_PREFIX = 'authentication_';
+
+  describe('#constructor', () => {
+
+    it('should instantiate a redis client', async () => {
+      // given
+      sinon.stub(redis, 'createClient');
+      redis.createClient.returns({
+        del: () => {},
+        get: () => {},
+        set: () => {},
+      });
+
+      // when
+      new PoleEmploiAuthenticationTemporaryStorage();
+
+      // then
+      expect(redis.createClient).to.have.been.calledOnce;
+    });
+  });
+
+  describe('#getdel', () => {
+
+    it('should call _get method with prefixed key', async () => {
+      // given
+      const key = 'my_key';
+      const storage = new PoleEmploiAuthenticationTemporaryStorage();
+      const getStub = sinon.stub(storage, '_get');
+
+      // when
+      await storage.getdel(key);
+
+      // then
+      expect(getStub).to.have.been.calledWith(KEY_PREFIX + key);
+    });
+
+    it('should call _del method with prefixed key', async () => {
+      // given
+      const key = 'my_key';
+      const storage = new PoleEmploiAuthenticationTemporaryStorage();
+      const delStub = sinon.stub(storage, '_del');
+
+      // when
+      await storage.getdel(key);
+
+      // then
+      expect(delStub).to.have.been.calledWith(KEY_PREFIX + key);
+    });
+  });
+
+  describe('#set', () => {
+
+    it('should call _set method with prefixed key, value and an expiration delay', async () => {
+      // given
+      const key = 'my_key';
+      const value = 'value';
+      const expirationDelaySeconds = 10;
+      const storage = new PoleEmploiAuthenticationTemporaryStorage();
+      const setStub = sinon.stub(storage, '_set');
+
+      // when
+      await storage.set(key, value);
+
+      // then
+      expect(setStub).to.have.been.calledWith(KEY_PREFIX + key, value, 'EX', expirationDelaySeconds);
+    });
+  });
+});

--- a/docs/adr/0023-suppression-du-support-mailjet-pour-le-mailing.md
+++ b/docs/adr/0023-suppression-du-support-mailjet-pour-le-mailing.md
@@ -1,4 +1,4 @@
-# 21. Suppression du support Mailjet pour le mailing
+# 23. Suppression du support Mailjet pour le mailing
 
 Date : 2021-02-26
 

--- a/docs/adr/0024-encapsuler-appel-http.md
+++ b/docs/adr/0024-encapsuler-appel-http.md
@@ -1,4 +1,4 @@
-# 23. Faut-il encapsuler les appels http dans l'API ?
+# 24. Faut-il encapsuler les appels http dans l'API ?
 
 Date : 2020-04-22
 

--- a/docs/adr/0025-precisions-sur-les-transactions-et-les-evenements-metier.md
+++ b/docs/adr/0025-precisions-sur-les-transactions-et-les-evenements-metier.md
@@ -1,4 +1,4 @@
-# 23. Précision sur les transactions et les événements métier
+# 25. Précision sur les transactions et les événements métier
 
 ## État
 

--- a/docs/adr/0026-tester-routeur-api.md
+++ b/docs/adr/0026-tester-routeur-api.md
@@ -1,4 +1,4 @@
-# 24. Comment tester le routeur API ?
+# 26. Comment tester le routeur API ?
 
 Date : 2021-04-16
 

--- a/docs/adr/0027-stocker-temporairement-api.md
+++ b/docs/adr/0027-stocker-temporairement-api.md
@@ -1,0 +1,95 @@
+# 27. Comment stocker temporairement des données dans l'API ?
+
+Date : 2021-05-28
+
+## État
+Adopté
+
+## Contexte 
+
+### Besoin fonctionnel
+Nous avons besoin de stocker des données PE entre le moment où l'utilisateur:
+- se connecte à son compte PE;
+- accepte les CGU Pix, ce qui mène à la création de son compte Pix.
+
+Ces données:
+- sont issues du protocole OpenID, et ne peuvent être stockées dans le front;
+- sont obtenues par un appel à l'API externe PoleEmploi;
+- sont volatiles: au bout d'un certain temps, elles ne sont plus utilisables;
+- peuvent n'être jamais lues, par exemple si l'utilisateur refuse les CGU.
+
+### Besoin techniques
+
+Nous avons besoin de partager des données volatiles entre deux appels API.
+
+Les données seront: 
+- écrites une fois;
+- lues zéro ou une fois.
+
+### Recherche de solution
+Les appels API peuvent avoir lieu sur des conteneurs différents, 
+et les conteneurs étant par définition `stateless`, il n'est pas possible de stocker ces données 
+- stocker ces données en mémoire du conteneur API;
+- stocker ces données sur le filesystem du conteneur API.
+
+Il faut donc stocker ces données en dehors des conteneurs API.
+
+Les données peuvent être stockées dans la base de données, mais leur caractère volatile
+et la possibilité qu'elles ne soient jamais lues, confèrent de nombreux inconvénients 
+à cette solution.
+
+Les solutions restantes reposent sur le data-store [redis](https://en.wikipedia.org/wiki/Redis),
+extérieur aux conteneurs API et déjà utilisés.
+
+L'utilisation existante est un [cache](./0005-ajout-d-un-cache-memoire-distribute-pour-le-contenu-pedagogique.md).
+Il ne répond pas totalement à notre demande, car un cache:
+- est conçu pour être lu de nombreuses fois;
+- ne possède pas de mécanisme d'expiration si la donnée n'est plus utilisable.
+
+Par contre, le data-store lui-même offre les fonctionnalités suivantes:
+- retirer une donnée après lecture: [getdel](https://redis.io/commands/getdel);
+- retirer une donnée après un délai d'expiration [EX](https://redis.io/commands/set).
+
+Deux possibilités s'offrent à nous:
+- créer un composant dédié qui invoquera ces commandes sur le data-store;
+- modifier le cache pour qu'il ne les invoque que dans un cas particulier.
+
+### Solution 1: créer un composant dédié
+
+Implémenter un composant avec le contrat suivant:
+- `set`: écrire une clef avec une durée d'expiration;
+- `getdel`: lire une clef puis la supprimer. 
+ 
+Avantages :
+- explicite le comportement (pas de mention du cache)
+
+Inconvénients :
+- coût de développement d'un nouveau composant
+
+### Solution 2: modifier la solution de cache existante
+Modifier la solution existante de [cache](./0005-ajout-d-un-cache-memoire-distribute-pour-le-contenu-pedagogique.md)
+pour fournir un délai d'expiration.
+
+Garder le contrat pour les clients existants.
+
+Modifier le contrat pour un nouveau client:
+- `set`: écrire une clef avec une durée d'expiration;
+- `get`: lire une clef puis la supprimer.
+
+Avantages :
+- le comportement attendu est contre-intuitif (le composant se nomme cache);
+- pas de développement d'un nouveau composant.
+
+Inconvénients :
+- couplage: risque de régression, d'évolutions hors scope
+
+## Décision
+La solution n°1 est adoptée, car elle est la plus maintenable
+
+## Conséquences
+Création d'un dossier `temporary-storage` sous le dossier `interface`.
+Utilisation d'un préfixe de clef pour éviter les collisions `authentication_`
+
+Afin de gérer les changements de délai d'expiration de l'API externe 
+sans modifier le code, celui-ci sera paramétrable dans une variable d'environnement.
+Celle-ci aura une valeur par défaut correspondant au délai conn à ce jour.


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de stocker des données PE entre le moment où l'utilisateur:
- se connecte à son compte PE;
- accepte les CGU Pix, ce qui mène à la création de son compte Pix.

L'implémentation utilisation existante est un [cache](./0005-ajout-d-un-cache-memoire-distribute-pour-le-contenu-pedagogique.md), en l'occurence [authentication-cache](https://github.com/1024pix/pix/blob/dev/api/lib/infrastructure/caches/authentication-cache.js).

Cela ne correspond pas au besoin et entraîne une saturation de redis avec des informations inutiles et périmées.

## :robot: Solution
Remplacer le cache par un stockage volatil, voir l'ADR correspondant

## :rainbow: Remarques
Suppression de la connexion redis pour les TU via une variable d'environnement incorrecte

Cela serait intéressant d'introduire un builder pour redis

## :100: Pour tester

### Outillage
Pour se connecter en CLI:
- local: installer `redis-cli`
- review-app: utiliser `scalingo -a pix-api-review-pr3048 redis-console`

Pour lister les données PE, utiliser [KEYS](https://redis.io/commands/KEYS): 

 `KEYS authentication_*` donne par exemple `"authentication_97f4b855-81df-4365-ac02-d2201cb7b616"`

Pour obtenir la durée de vie restante, utiliser [TTL](https://redis.io/commands/TTL)

`TTL "authentication_97f4b855-81df-4365-ac02-d2201cb7b616"` donne par exemple
- ` (integer) 30 ` si 30 secondes
- ` (integer) -1 ` si éternelle
- ` (integer) -2 ` si périmée

### Scénario
Scénario nominal
- se connecter avec un compte PE inconnu
- accepter les CGU
- vérifier dans redis que la donnée n'est plus là

Péremption des données non utilisées:
- se connecter avec un compte PE inconnu
- refuser les CGU ou fermer la fenêtre (il y a un courant d'air)
- vérifier dans redis que la donnée disparaît au bout du délai d'expiration
