### PR TITLE
[FEATURE] Importer l'information sur le sexe lors de l'import CSV (PIX-2638)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/csv-registration-parser.js
@@ -129,12 +129,15 @@ class CsvRegistrationParser {
     const missingMandatoryColumn = this._columns
       .filter((c) => c.isRequired)
       .find((c) => !parsedColumns.includes(c.label));
+
     if (missingMandatoryColumn) {
       throw new CsvImportError(ERRORS.HEADER_REQUIRED, { field: missingMandatoryColumn.label });
     }
 
     // Expected columns
-    if (this._columns.some((column) => !parsedColumns.includes(column.label))) {
+    const acceptedColumns = this._columns.map((column) => column.label);
+
+    if (_atLeastOneParsedColumnDoesNotMatchAcceptedColumns(parsedColumns, acceptedColumns)) {
       throw new CsvImportError(ERRORS.HEADER_UNKNOWN);
     }
   }
@@ -171,6 +174,14 @@ class CsvRegistrationParser {
     }
     throw err;
   }
+}
+
+function _atLeastOneParsedColumnDoesNotMatchAcceptedColumns(parsedColumns, acceptedColumns) {
+  return parsedColumns.some((parsedColumn) => {
+    if (parsedColumn !== '') {
+      return !acceptedColumns.includes(parsedColumn);
+    }
+  });
 }
 
 module.exports = {

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-columns.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-columns.js
@@ -14,6 +14,7 @@ class SchoolingRegistrationColumns {
       new CsvColumn({ name: 'thirdName', label: this.translate('csv-template.schooling-registrations.third-name') }),
       new CsvColumn({ name: 'lastName', label: this.translate('csv-template.schooling-registrations.last-name'), isRequired: true }),
       new CsvColumn({ name: 'preferredLastName', label: this.translate('csv-template.schooling-registrations.preferred-last-name') }),
+      new CsvColumn({ name: 'sex', label: this.translate('csv-template.schooling-registrations.sex'), isRequired: false }),
       new CsvColumn({ name: 'birthdate', label: this.translate('csv-template.schooling-registrations.birthdate'), isRequired: true, isDate: true }),
       new CsvColumn({ name: 'birthCityCode', label: this.translate('csv-template.schooling-registrations.birth-city-code') }),
       new CsvColumn({ name: 'birthCity', label: this.translate('csv-template.schooling-registrations.birth-city') }),

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -31,6 +31,7 @@ class SchoolingRegistrationSet {
   _transform(registrationAttributes) {
     let nationalStudentId;
     let nationalApprenticeId;
+    let sex;
     const { birthCountryCode, nationalIdentifier, status } = registrationAttributes;
 
     if (!this.hasApprentice || status === STATUS.STUDENT) {
@@ -39,13 +40,26 @@ class SchoolingRegistrationSet {
       nationalApprenticeId = nationalIdentifier;
     }
 
+    if (registrationAttributes.sex) {
+      sex = _convertSexCode(registrationAttributes.sex);
+    } else {
+      sex = null;
+    }
+
     return {
       ...registrationAttributes,
       birthCountryCode: birthCountryCode.slice(-3),
       nationalApprenticeId,
       nationalStudentId,
+      sex,
     };
   }
+}
+
+function _convertSexCode(sexCode) {
+  if (sexCode === '1') return 'M';
+  if (sexCode === '2') return 'F';
+  return null;
 }
 
 class SchoolingRegistrationParser extends CsvRegistrationParser {

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -778,9 +778,41 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
       context('SCO : when no schooling registration has been imported yet, and the file is well formatted', () => {
         beforeEach(() => {
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
-          456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+          456F;O-Ren;;;Ishii;Cottonmouth;;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
           `;
+          const buffer = iconv.encode(input, 'UTF-8');
+
+          options.url = `/api/organizations/${organizationId}/schooling-registrations/import-siecle?format=csv`,
+          options.payload = buffer;
+        });
+
+        it('should respond with a 204 - no content', async () => {
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(204);
+        });
+
+        it('should create all schoolingRegistrations', async () => {
+          // when
+          await server.inject(options);
+
+          // then
+          const schoolingRegistrations = await knex('schooling-registrations').where({ organizationId });
+          expect(schoolingRegistrations).to.have.lengthOf(2);
+          expect(_.map(schoolingRegistrations, 'firstName')).to.have.members(['Beatrix', 'O-Ren']);
+        });
+      });
+
+      context('SCO : when no schooling registration has been imported yet', () => {
+
+        beforeEach(() => {
+          const input = `${schoolingRegistrationCsvColumns}
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+            456F;O-Ren;;;Ishii;Cottonmouth;2;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
+            `;
           const buffer = iconv.encode(input, 'UTF-8');
 
           options.url = `/api/organizations/${organizationId}/schooling-registrations/import-siecle?format=csv`,
@@ -814,9 +846,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           await databaseBuilder.commit();
 
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
-          0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
-          `;
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+            0123456789F;O-Ren;;;Ishii;Cottonmouth;2;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
+            `;
           const buffer = iconv.encode(input, 'UTF-8');
 
           options.url = `/api/organizations/${organizationId}/schooling-registrations/import-siecle?format=csv`,
@@ -846,8 +878,8 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
         it('should not save any schooling registration with missing family name', async () => {
           // given
           const input = `${schoolingRegistrationCsvColumns}
-           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
-           456F;O-Ren;;;;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
+           123F;Beatrix;The;Bride;Kiddo;Black Mamba;;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+           456F;O-Ren;;;;Cottonmouth;;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
            `;
           const buffer = iconv.encode(input, 'UTF-8');
 
@@ -869,7 +901,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const wrongData = 'FRANC';
           // given
           const input = `${schoolingRegistrationCsvColumns}
-           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;51430;Reims;200;${wrongData};ST;MEF1;Division 1;
+           123F;Beatrix;The;Bride;Kiddo;Black Mamba;;01/01/1970;51430;Reims;200;${wrongData};ST;MEF1;Division 1;
            `;
           const buffer = iconv.encode(input, 'UTF-8');
 
@@ -892,7 +924,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const wrongData = 'A1234';
           // given
           const input = `${schoolingRegistrationCsvColumns}
-           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;${wrongData};Reims;200;99100;ST;MEF1;Division 1;
+           123F;Beatrix;The;Bride;Kiddo;Black Mamba;;01/01/1970;${wrongData};Reims;200;99100;ST;MEF1;Division 1;
            `;
           const buffer = iconv.encode(input, 'UTF-8');
 
@@ -915,8 +947,8 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
       context('when a schooling registration has the same national student id than an other one in the file', () => {
         beforeEach(() => {
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
-          123F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+          123F;O-Ren;;;Ishii;Cottonmouth;;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
           `;
           const buffer = iconv.encode(input, 'UTF-8');
 

--- a/api/tests/integration/scripts/prod/import-apprentices_test.js
+++ b/api/tests/integration/scripts/prod/import-apprentices_test.js
@@ -75,8 +75,8 @@ describe('Integration | Scripts | import-apprentices', () => {
           };
 
           const input = `${schoolingRegistrationCsvColumns}
-          9876543210F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;
-          0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;54321;
+          9876543210F;Beatrix;The;Bride;Kiddo;Black Mamba;;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;
+          0123456789F;O-Ren;;;Ishii;Cottonmouth;;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;54321;
           `;
 
           const encodedInput = iconv.encode(input, 'utf8');
@@ -97,8 +97,8 @@ describe('Integration | Scripts | import-apprentices', () => {
             await databaseBuilder.commit();
 
             const input = `${schoolingRegistrationCsvColumns}
-            9876543210F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;
-            0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;54321;
+            9876543210F;Beatrix;The;Bride;Kiddo;Black Mamba;;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;
+            0123456789F;O-Ren;;;Ishii;Cottonmouth;;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;54321;
             `;
 
             const encodedInput = iconv.encode(input, 'utf8');
@@ -115,7 +115,7 @@ describe('Integration | Scripts | import-apprentices', () => {
             await databaseBuilder.commit();
 
             const header = schoolingRegistrationCsvColumns;
-            const lineWithoutUniqueIdentifier = ';Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;';
+            const lineWithoutUniqueIdentifier = ';Beatrix;The;Bride;Kiddo;Black Mamba;;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;';
             const input =
             `${header}
             ${lineWithoutUniqueIdentifier}`;
@@ -131,7 +131,7 @@ describe('Integration | Scripts | import-apprentices', () => {
     });
     context('when the header is not correctly formed', () => {
       const columns = new SchoolingRegistrationColumns(i18n).columns;
-      const requiredColumns = [...columns, { label: 'UAI*' }].map((column) => column.label);
+      const requiredColumns = [...columns, { label: 'UAI*' }].filter((column) => column.isRequired).map((column) => column.label);
 
       requiredColumns.forEach((missingColumn) => {
         it('throws a CsvImportError', async () => {

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -83,6 +83,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
         '"Troisième prénom";' +
         '"Nom de famille*";' +
         '"Nom d\'usage";' +
+        '"Code sexe";' +
         '"Date de naissance (jj/mm/aaaa)*";' +
         '"Code commune naissance**";' +
         '"Libellé commune naissance**";' +

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -56,60 +56,131 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
 
     context('when there are lines', () => {
       context('when the data are correct', () => {
-        it('returns a schooling registration for each line', () => {
-          const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
-          456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
-          `;
-          const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, 456, i18n);
 
-          const { registrations } = parser.parse();
-          expect(registrations).to.have.lengthOf(2);
-        });
+        context('when csv has \'Sex code\' column', () => {
 
-        it('returns schooling registrations for each line using the CSV column', () => {
-          const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
-          0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
-          `;
-          const organizationId = 789;
-          const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, organizationId, i18n);
+          it('returns a schooling registration for each line', () => {
+            const input = `${schoolingRegistrationCsvColumns}
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+            456F;O-Ren;;;Ishii;Cottonmouth;2;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
+            `;
+            const encodedInput = iconv.encode(input, 'utf8');
+            const parser = new SchoolingRegistrationParser(encodedInput, 456, i18n);
 
-          const { registrations } = parser.parse();
-          expect(registrations[0]).to.includes({
-            nationalStudentId: '123F',
-            nationalApprenticeId: undefined,
-            firstName: 'Beatrix',
-            middleName: 'The',
-            thirdName: 'Bride',
-            lastName: 'Kiddo',
-            preferredLastName: 'Black Mamba',
-            birthdate: '1970-01-01',
-            birthCityCode: '97422',
-            birthProvinceCode: '974',
-            birthCountryCode: '100',
-            status: 'ST',
-            MEFCode: 'MEF1',
-            division: 'Division 1',
-            organizationId,
+            const { registrations } = parser.parse();
+            expect(registrations).to.have.lengthOf(2);
           });
 
-          expect(registrations[1]).to.includes({
-            nationalStudentId: '0123456789F',
-            nationalApprenticeId: undefined,
-            firstName: 'O-Ren',
-            lastName: 'Ishii',
-            preferredLastName: 'Cottonmouth',
-            birthdate: '1980-01-01',
-            birthCity: 'Shangai',
-            birthProvinceCode: '99',
-            birthCountryCode: '132',
-            status: 'AP',
-            MEFCode: 'MEF1',
-            division: 'Division 2',
-            organizationId,
+          it('returns schooling registrations for each line using the CSV column', () => {
+            const input = `${schoolingRegistrationCsvColumns}
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
+            0123456789F;O-Ren;;;Ishii;Cottonmouth;2;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
+            `;
+            const organizationId = 789;
+            const encodedInput = iconv.encode(input, 'utf8');
+            const parser = new SchoolingRegistrationParser(encodedInput, organizationId, i18n);
+
+            const { registrations } = parser.parse();
+            expect(registrations[0]).to.includes({
+              nationalStudentId: '123F',
+              nationalApprenticeId: undefined,
+              firstName: 'Beatrix',
+              middleName: 'The',
+              thirdName: 'Bride',
+              lastName: 'Kiddo',
+              preferredLastName: 'Black Mamba',
+              sex: 'M',
+              birthdate: '1970-01-01',
+              birthCityCode: '97422',
+              birthProvinceCode: '974',
+              birthCountryCode: '100',
+              status: 'ST',
+              MEFCode: 'MEF1',
+              division: 'Division 1',
+              organizationId,
+            });
+
+            expect(registrations[1]).to.includes({
+              nationalStudentId: '0123456789F',
+              nationalApprenticeId: undefined,
+              firstName: 'O-Ren',
+              lastName: 'Ishii',
+              preferredLastName: 'Cottonmouth',
+              sex: 'F',
+              birthdate: '1980-01-01',
+              birthCity: 'Shangai',
+              birthProvinceCode: '99',
+              birthCountryCode: '132',
+              status: 'AP',
+              MEFCode: 'MEF1',
+              division: 'Division 2',
+              organizationId,
+            });
+          });
+        });
+
+        context('when csv does not have \'Sex code\' column', () => {
+
+          const COL_TO_REMOVE = 'Code sexe';
+          const schoolingRegistrationCsvColumnsWithoutSexCode = new SchoolingRegistrationColumns(i18n).columns.map((column) => column.label).filter((col) => col !== COL_TO_REMOVE).join(';');
+
+          it('returns a schooling registration for each line', () => {
+            const input = `${schoolingRegistrationCsvColumnsWithoutSexCode}
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+            456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
+            `;
+            const encodedInput = iconv.encode(input, 'utf8');
+            const parser = new SchoolingRegistrationParser(encodedInput, 456, i18n);
+
+            const { registrations } = parser.parse();
+            expect(registrations).to.have.lengthOf(2);
+          });
+
+          it('returns schooling registrations for each line using the CSV column', () => {
+            const input = `${schoolingRegistrationCsvColumnsWithoutSexCode}
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
+            0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
+            `;
+            const organizationId = 789;
+            const encodedInput = iconv.encode(input, 'utf8');
+            const parser = new SchoolingRegistrationParser(encodedInput, organizationId, i18n);
+
+            const { registrations } = parser.parse();
+            expect(registrations[0]).to.includes({
+              nationalStudentId: '123F',
+              nationalApprenticeId: undefined,
+              firstName: 'Beatrix',
+              middleName: 'The',
+              thirdName: 'Bride',
+              lastName: 'Kiddo',
+              preferredLastName: 'Black Mamba',
+              sex: null,
+              birthdate: '1970-01-01',
+              birthCityCode: '97422',
+              birthProvinceCode: '974',
+              birthCountryCode: '100',
+              status: 'ST',
+              MEFCode: 'MEF1',
+              division: 'Division 1',
+              organizationId,
+            });
+
+            expect(registrations[1]).to.includes({
+              nationalStudentId: '0123456789F',
+              nationalApprenticeId: undefined,
+              firstName: 'O-Ren',
+              lastName: 'Ishii',
+              preferredLastName: 'Cottonmouth',
+              sex: null,
+              birthdate: '1980-01-01',
+              birthCity: 'Shangai',
+              birthProvinceCode: '99',
+              birthCountryCode: '132',
+              status: 'AP',
+              MEFCode: 'MEF1',
+              division: 'Division 2',
+              organizationId,
+            });
           });
         });
       });
@@ -118,7 +189,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
         it('should throw an EntityValidationError with malformated National Apprentice Id', async () => {
           //given
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;aaaaa;97422;;200;99100;AP;MEF1;Division 1;
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;aaaaa;97422;;200;99100;AP;MEF1;Division 1;
           `;
           const encodedInput = iconv.encode(input, 'utf8');
           const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
@@ -134,7 +205,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           //given
           const wrongData = 'FRANC';
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1980;97422;;200;${wrongData};ST;MEF1;Division 1;
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1980;97422;;200;${wrongData};ST;MEF1;Division 1;
           `;
           const encodedInput = iconv.encode(input, 'utf8');
           const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
@@ -150,7 +221,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           //given
           const wrongData = 'A1234';
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1980;${wrongData};;974;99100;ST;MEF1;Division 1;
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1980;${wrongData};;974;99100;ST;MEF1;Division 1;
           `;
           const encodedInput = iconv.encode(input, 'utf8');
           const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
@@ -166,7 +237,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
         context('When the organization is Agriculture and file contain status AP', () => {
           it('should return schooling registration with nationalApprenticeId', () => {
             const input = `${schoolingRegistrationCsvColumns}
-            0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
+            0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
             `;
             const organizationId = 789;
             const encodedInput = iconv.encode(input, 'utf8');
@@ -185,8 +256,8 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           context('when organization is SCO', () => {
             it('should throw an CsvImportError even with different status', async () => {
               const input = `${schoolingRegistrationCsvColumns}
-              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;ST;MEF1;Division 1;
-              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/05/1986;97422;;200;99100;ST;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
               `;
 
               const encodedInput = iconv.encode(input, 'utf8');
@@ -205,8 +276,8 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
 
             it('should not return error given nationalIdentifier with different status', () => {
               const input = `${schoolingRegistrationCsvColumns}
-              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
-              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
               `;
               const organizationId = 789;
               const encodedInput = iconv.encode(input, 'utf8');
@@ -229,8 +300,8 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
 
             it('should throw an CsvImportError, with same status', async () => {
               const input = `${schoolingRegistrationCsvColumns}
-              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
-              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
               `;
 
               const encodedInput = iconv.encode(input, 'utf8');

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -73,6 +73,7 @@
       "division": "Class*",
       "first-name": "First name*",
       "last-name": "Last name*",
+      "sex": "Sex code",
       "mef-code": "MEF code*",
       "middle-name": "Middle name #1",
       "national-identifier": "Unique identifier*",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -73,6 +73,7 @@
       "division": "Division*",
       "first-name": "Premier prénom*",
       "last-name": "Nom de famille*",
+			"sex": "Code sexe",
       "mef-code": "Code MEF*",
       "middle-name": "Deuxième prénom",
       "national-identifier": "Identifiant unique*",


### PR DESCRIPTION
## :unicorn: Problème
En préparation à notre obligation envers le Compte Professionnel Formation d'envoyer les données de certification de tous nos candidat(e)s de certification (SCO / SUP / PRO) et ce dès le 1er juillet, nous devons nous assurer d'avoir à notre disposition toutes les données candidat demandées par le CPF.
Côté SCO, nous devons nous occuper des imports SIECLE et FREGATA.
Concernant FREGATA, il ne manque la colonne Code sexe dans le csv d'import.

Suite du #3043

## :robot: Solution

- Import de l'information Code sexe depuis le csv de FREGATA vers une conversion :
1 -> 'M'
2 -> 'F'

## :rainbow: Remarques
Le csv de FREGATA ne contient pas encore la colonne 'Code sexe'. Le code doit donc fonctionner avec et sans cette colonne

## :100: Pour tester
Depuis orga, pour une orga AGRI (par exemple sco.admin@example.net => Lycée Agricole): 

- Créer un csv selon ce modèle
```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
4581234567F;Léa;;;Corse;Cottonmouth;01/01/1780;2A214;Corse;99;99100;AP;MEF1;Division 2
```
- Le remplir et essayer d'importer des candidats
- Constater que les schooling registrations sont crées

- Ajouter la colonne 'Code sexe' au csv
- l'éditer et ajouter 1 (M) ou 2 (F) aux élèves
- Constater que les schooling registrations sont crées