### PR TITLE
[FEATURE] Ajouter sur le détail d'une session un lien vers le centre de certification associé (PIX-2644)

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -31,6 +31,7 @@ export default class Session extends Model {
 
   @attr() certificationCenterType;
   @attr() certificationCenterName;
+  @attr() certificationCenterId;
   @attr() address;
   @attr() room;
   @attr() examiner;

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -7,7 +7,14 @@
   <div class="session-info__details">
     <div class="row">
       <div class="col">Centre :</div>
-      <div class="col">{{this.sessionModel.certificationCenterName}}</div>
+      <div class="col">
+        <LinkTo
+          @route="authenticated.certification-centers.get"
+          @model={{this.sessionModel.certificationCenterId}}
+        >
+          {{this.sessionModel.certificationCenterName}}
+        </LinkTo>
+      </div>
     </div>
     <div class="row">
       <div class="col">Adresse :</div>

--- a/admin/mirage/factories/session.js
+++ b/admin/mirage/factories/session.js
@@ -13,6 +13,10 @@ export default Factory.extend({
     return 'SCO';
   },
 
+  certificationCenterId() {
+    return 1234;
+  },
+
   address() {
     return faker.address.streetName();
   },

--- a/admin/tests/acceptance/session_test.js
+++ b/admin/tests/acceptance/session_test.js
@@ -7,6 +7,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import sinon from 'sinon';
 
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 
 module('Acceptance | Session pages', function(hooks) {
   setupApplicationTest(hooks);
@@ -34,6 +35,7 @@ module('Acceptance | Session pages', function(hooks) {
       session = server.create('session', {
         id: 1,
         certificationCenterName: 'Centre des Staranne',
+        certificationCenterId: 1234,
         status: FINALIZED,
         finalizedAt: new Date('2020-01-01T03:00:00Z'),
         examinerGlobalComment: 'Commentaire du surveillant',
@@ -101,6 +103,17 @@ module('Acceptance | Session pages', function(hooks) {
           assert.dom('.session-info__details .row div:last-child').hasText(session.certificationCenterName);
           assert.dom('[data-test-id="session-info__finalized-at"]').hasText('01/01/2020');
           assert.dom('[data-test-id="session-info__examiner-global-comment"]').hasText(session.examinerGlobalComment);
+        });
+
+        test('it displays a link to a certification center and redirects to it', async function(assert) {
+          // given
+          server.create('certification-center', { id: 1234 });
+
+          // when
+          await clickByLabel(session.certificationCenterName);
+
+          // then
+          assert.equal(currentURL(), '/certification-centers/1234');
         });
       });
 

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -31,6 +31,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       // then
       assert.equal(currentURL(), `/sessions/${session.id}`);
       assert.dom('.session-info__details div:nth-child(1) div:last-child').hasText(session.certificationCenterName);
+      assert.dom('.session-info__details div:nth-child(1) div:last-child a').hasAttribute('href', '/certification-centers/' + session.certificationCenterId);
       assert.dom('.session-info__details div:nth-child(2) div:last-child').hasText(session.address);
       assert.dom('.session-info__details div:nth-child(3) div:last-child').hasText(session.room);
       assert.dom('.session-info__details div:nth-child(4) div:last-child').hasText(session.examiner);

--- a/api/lib/domain/models/JurySession.js
+++ b/api/lib/domain/models/JurySession.js
@@ -5,6 +5,7 @@ class JurySession {
     id,
     certificationCenterName,
     certificationCenterType,
+    certificationCenterId,
     address,
     room,
     examiner,
@@ -21,6 +22,7 @@ class JurySession {
     this.id = id;
     this.certificationCenterName = certificationCenterName;
     this.certificationCenterType = certificationCenterType;
+    this.certificationCenterId = certificationCenterId;
     this.address = address;
     this.room = room;
     this.examiner = examiner;

--- a/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
@@ -12,6 +12,7 @@ module.exports = {
       attributes: [
         'certificationCenterName',
         'certificationCenterType',
+        'certificationCenterId',
         'address',
         'room',
         'examiner',

--- a/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -12,13 +12,16 @@ describe('Integration | Repository | JurySession', function() {
 
     context('when id of session exists', () => {
       let sessionId;
+      let certificationCenterId;
+      let assignedCertificationOfficer;
 
       beforeEach(() => {
-        const assignedCertificationOfficerId = databaseBuilder.factory.buildUser({
+        assignedCertificationOfficer = databaseBuilder.factory.buildUser({
           firstName: 'Pix',
           lastName: 'Doe',
-        }).id;
-        sessionId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId }).id;
+        });
+        certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        sessionId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId: assignedCertificationOfficer.id, certificationCenterId: certificationCenterId }).id;
 
         return databaseBuilder.commit();
       });
@@ -29,7 +32,28 @@ describe('Integration | Repository | JurySession', function() {
 
         // then
         expect(expectedJurySession).to.be.an.instanceOf(JurySession);
-        expect(expectedJurySession.assignedCertificationOfficer).be.an.instanceOf(CertificationOfficer);
+        expect(expectedJurySession).to.deep.equal({
+          id: sessionId,
+          certificationCenterName: 'Centre de certif Pix',
+          certificationCenterType: 'SUP',
+          certificationCenterId: certificationCenterId,
+          address: '3 rue des églantines',
+          room: 'B315',
+          examiner: 'Ginette',
+          date: '2020-01-15',
+          time: '15:30:00',
+          accessCode: 'ACC123A',
+          description: 'La session se déroule dans le jardin',
+          examinerGlobalComment: '',
+          finalizedAt: null,
+          resultsSentToPrescriberAt: null,
+          publishedAt: null,
+          assignedCertificationOfficer: {
+            id: assignedCertificationOfficer.id,
+            firstName: assignedCertificationOfficer.firstName,
+            lastName: assignedCertificationOfficer.lastName,
+          },
+        });
       });
 
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
@@ -35,6 +35,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function() {
           attributes: {
             'certification-center-name': 'someCenterName',
             'certification-center-type': 'someCenterType',
+            'certification-center-id': 'someCenterId',
             address: 'someAddress',
             room: 'someRoom',
             examiner: 'someExaminer',
@@ -61,6 +62,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function() {
         id: 1,
         certificationCenterName: 'someCenterName',
         certificationCenterType: 'someCenterType',
+        certificationCenterId: 'someCenterId',
         address: 'someAddress',
         room: 'someRoom',
         examiner: 'someExaminer',


### PR DESCRIPTION
## :unicorn: Problème
Les équipes Certification souhaitent pouvoir se rendre sur le détail d'un centre de certification depuis le détail d'une session.

## :robot: Solution
Depuis la page de détails d’une session : 

- rendre cliquable le nom du centre de certification (champ “Centre”

- cliquer dessus redirige l’utilisateur sur la page de détails du centre correspondant 

## :100: Pour tester

- Se rendre sur Pix Admin
- Se rendre sur le détail d'une session de certification
- Constater la présence d'un lien sur la valeur du champ Centre
- Suivre ce lien vers le détail du centre de certification
