### PR TITLE
[TECH] Supprimer les beforeEach des test unitaires des routes (PIX-2645).

### DIFF
--- a/api/tests/unit/application/cache/index_test.js
+++ b/api/tests/unit/application/cache/index_test.js
@@ -5,9 +5,7 @@ const {
 } = require('../../../test-helper');
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
-
 const moduleUnderTest = require('../../../../lib/application/cache');
-
 const cacheController = require('../../../../lib/application/cache/cache-controller');
 
 describe('Unit | Router | cache-router', () => {

--- a/api/tests/unit/application/cache/index_test.js
+++ b/api/tests/unit/application/cache/index_test.js
@@ -12,22 +12,18 @@ const cacheController = require('../../../../lib/application/cache/cache-control
 
 describe('Unit | Router | cache-router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(cacheController, 'refreshCacheEntries').callsFake((request, h) => h.response().code(204));
-    sinon.stub(cacheController, 'refreshCacheEntry').callsFake((request, h) => h.response().code(204));
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('PATCH /api/cache/{model}/{id}', () => {
 
     it('should exist', async () => {
-      // when
+      //given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(cacheController, 'refreshCacheEntry').callsFake((request, h) => h.response().code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const updatedRecord = { id: 'recId', param: 'updatedValue' };
+
+      // when
       const response = await httpTestServer.request('PATCH', '/api/cache/table/recXYZ1234', updatedRecord);
 
       // then
@@ -38,6 +34,12 @@ describe('Unit | Router | cache-router', () => {
   describe('PATCH /api/cache', () => {
 
     it('should exist', async () => {
+      //given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(cacheController, 'refreshCacheEntries').callsFake((request, h) => h.response().code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PATCH', '/api/cache');
 

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -6,7 +6,6 @@ const {
 
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const moduleUnderTest = require('../../../../lib/application/campaigns');
-
 const campaignController = require('../../../../lib/application/campaigns/campaign-controller');
 const campaignStatsController = require('../../../../lib/application/campaigns/campaign-stats-controller');
 

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -12,31 +12,14 @@ const campaignStatsController = require('../../../../lib/application/campaigns/c
 
 describe('Unit | Application | Router | campaign-router ', function() {
 
-  let httpTestServer;
-
-  beforeEach(async () => {
-    sinon.stub(campaignController, 'save').callsFake((request, h) => h.response('ok').code(201));
-    sinon.stub(campaignController, 'getByCode').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'getCsvAssessmentResults').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'getCsvProfilesCollectionResults').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
-    sinon.stub(campaignController, 'getCollectiveResult').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'archiveCampaign').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'unarchiveCampaign').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'findProfilesCollectionParticipations').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'division').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignStatsController, 'getParticipationsByStage').callsFake((request, h) => h.response('ok').code(200));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('POST /api/campaigns', () => {
 
     it('should return 201', async () => {
+      // given
+      sinon.stub(campaignController, 'save').callsFake((request, h) => h.response('ok').code(201));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('POST', '/api/campaigns');
 
@@ -49,6 +32,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
 
     it('should return 200', async () => {
       // given
+      sinon.stub(campaignController, 'getByCode').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // given
       campaignController.getByCode.returns('ok');
 
       // when
@@ -60,7 +48,9 @@ describe('Unit | Application | Router | campaign-router ', function() {
 
     it('should return 404 when controller throws a NotFound domain error', async () => {
       // given
-      campaignController.getByCode.rejects(new NotFoundError());
+      sinon.stub(campaignController, 'getByCode').rejects(new NotFoundError());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns?filter[code=SOMECODE]');
@@ -73,6 +63,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/1');
 
@@ -81,6 +76,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/invalid');
 
@@ -92,6 +91,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}/csv-assessment-results', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignController, 'getCsvAssessmentResults').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-assessment-results');
 
@@ -100,6 +104,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/invalid/csv-assessment-results');
 
@@ -111,6 +119,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}/csv-profiles-collection-results', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignController, 'getCsvProfilesCollectionResults').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-profiles-collection-results');
 
@@ -119,6 +132,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/invalid/csv-profiles-collection-results');
 
@@ -130,6 +147,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('PATCH /api/campaigns/{id}', () => {
 
     it('should return 201', async () => {
+      // given
+      sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PATCH', '/api/campaigns/1');
 
@@ -138,6 +160,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PATCH', '/api/campaigns/invalid');
 
@@ -149,6 +175,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}/collective-results', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignController, 'getCollectiveResult').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/1/collective-results');
 
@@ -157,6 +188,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/invalid/collective-results');
 
@@ -168,6 +203,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}/analyses', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/1/analyses');
 
@@ -176,6 +216,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/wrong_id/analyses');
 
@@ -187,6 +231,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('PUT /api/campaigns/{id}/archive', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignController, 'archiveCampaign').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PUT', '/api/campaigns/1/archive');
 
@@ -195,6 +244,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PUT', '/api/campaigns/invalid/archive');
 
@@ -206,6 +259,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('DELETE /api/campaigns/{id}/archive', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignController, 'unarchiveCampaign').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('DELETE', '/api/campaigns/1/archive');
 
@@ -214,6 +272,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('DELETE', '/api/campaigns/invalid/archive');
 
@@ -225,6 +287,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}/profiles-collection-participations', () => {
 
     it('should return 200 with empty query string', async () => {
+      // given
+      sinon.stub(campaignController, 'findProfilesCollectionParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/profiles-collection-participations');
 
@@ -233,6 +300,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with pagination', async () => {
+      // given
+      sinon.stub(campaignController, 'findProfilesCollectionParticipations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/profiles-collection-participations?page[number]=1&page[size]=25');
 
@@ -241,6 +313,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with a string array of one element as division filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findProfilesCollectionParticipations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/profiles-collection-participations?filter[divisions][]="3EMEB"');
 
@@ -249,6 +326,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with a string array of several elements as division filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findProfilesCollectionParticipations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/profiles-collection-participations?filter[divisions][]="3EMEB"&filter[divisions][]="3EMEA"');
 
@@ -257,6 +339,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with unexpected filters', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/profiles-collection-participations?filter[unexpected][]=5');
 
@@ -265,6 +351,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a division filter which is not an array', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/profiles-collection-participations?filter[divisions]="3EMEA"');
 
@@ -273,6 +363,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a page number which is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/profiles-collection-participations?page[number]=a');
 
@@ -281,6 +375,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a page size which is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/profiles-collection-participations?page[size]=a');
 
@@ -289,6 +387,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/invalid/profiles-collection-participations');
 
@@ -300,6 +402,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}/assessment-participations', () => {
 
     it('should return 200 with empty query string', async () => {
+      // given
+      sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations');
 
@@ -308,6 +415,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with pagination', async () => {
+      // given
+      sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?page[number]=1&page[size]=25');
 
@@ -316,6 +428,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with a string array of one element as division filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[divisions][]="3EMEB"');
 
@@ -324,6 +441,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with a string array of several elements as division filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[divisions][]="3EMEB"&filter[divisions][]="3EMEA"');
 
@@ -332,6 +454,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with a string array of one element as badge filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[badges][]=114');
 
@@ -340,6 +467,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with a string array of several elements as badge filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[badges][]=114&filter[badges][]=115');
 
@@ -348,6 +480,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with a string array of one element as stage filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[stages][]=114');
 
@@ -356,6 +493,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 200 with a string array of several elements as stage filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findAssessmentParticipations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[stages][]=114&filter[stages][]=115');
 
@@ -364,6 +506,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with unexpected filters', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[unexpected][]=5');
 
@@ -372,6 +518,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a division filter which is not an array', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[divisions]="3EMEA"');
 
@@ -380,6 +530,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a badge filter which is not an array', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[badges]=114');
 
@@ -388,6 +542,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a badge filter which is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[badges][]="truc"');
 
@@ -396,6 +554,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a stage filter which is not an array', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[stages]=114');
 
@@ -404,6 +566,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a stage filter which is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[stages][]="truc"');
 
@@ -412,6 +578,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a page number which is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?page[number]=a');
 
@@ -420,6 +590,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with a page size which is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?page[size]=a');
 
@@ -428,6 +602,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/invalid/assessment-participations');
 
@@ -439,6 +617,11 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}/divisions', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignController, 'division').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/divisions');
 
@@ -447,6 +630,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/invalid/divisions');
 
@@ -458,6 +645,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
   describe('GET /api/campaigns/{id}/stats/participations-by-stage', () => {
 
     it('should return 200', async () => {
+      // given
+      sinon.stub(campaignStatsController, 'getParticipationsByStage').callsFake((request, h) => h.response('ok').code(200)); const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/stats/participations-by-stage');
 
@@ -466,6 +657,10 @@ describe('Unit | Application | Router | campaign-router ', function() {
     });
 
     it('should return 400 with an invalid campaign id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/invalid/stats/participations-by-stage');
 

--- a/api/tests/unit/application/campaignParticipations/index_test.js
+++ b/api/tests/unit/application/campaignParticipations/index_test.js
@@ -5,7 +5,6 @@ const {
 } = require('../../../test-helper');
 
 const moduleUnderTest = require('../../../../lib/application/campaign-participations');
-
 const campaignParticipationController = require('../../../../lib/application/campaign-participations/campaign-participation-controller');
 
 describe('Unit | Application | Router | campaign-participation-router ', function() {

--- a/api/tests/unit/application/campaignParticipations/index_test.js
+++ b/api/tests/unit/application/campaignParticipations/index_test.js
@@ -10,18 +10,14 @@ const campaignParticipationController = require('../../../../lib/application/cam
 
 describe('Unit | Application | Router | campaign-participation-router ', function() {
 
-  let httpTestServer;
-
-  beforeEach(async () => {
-    sinon.stub(campaignParticipationController, 'save').callsFake((request, h) => h.response('ok').code(200));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('POST /api/campaign-participations', () => {
 
     it('should return 200 when participant have external id', async () => {
+      // given
+      sinon.stub(campaignParticipationController, 'save').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const participantExternalId = 'toto';
       const response = await httpTestServer.request('POST', '/api/campaign-participations', {
@@ -38,6 +34,10 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
     });
 
     it('should return 400 when participant external id exceeds 255 characters', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const participantExternalId256Characters = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
       const response = await httpTestServer.request('POST', '/api/campaign-participations', {

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -11,21 +11,13 @@ const certificationCenterController = require('../../../../lib/application/certi
 
 describe('Unit | Router | certification-center-router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async function() {
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').returns(true);
-    sinon.stub(certificationCenterController, 'createCertificationCenterMembershipByEmail').returns('ok');
-    sinon.stub(certificationCenterController, 'findCertificationCenterMembershipsByCertificationCenter').returns('ok');
-    sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('GET /api/certification-centers/{certificationCenterId}/divisions', () => {
 
     it('should reject an invalid certification center id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/invalid/divisions');
 
@@ -37,6 +29,10 @@ describe('Unit | Router | certification-center-router', () => {
   describe('GET /api/certification-centers/{certificationCenterId}/sessions/{sessionId}/students', () => {
 
     it('should reject unexpected filters ', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/2/students?filter[unexpected][]=5');
 
@@ -45,6 +41,11 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should accept a string array of one element as division filter ', async () => {
+      // given
+      sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/2/students?filter[divisions][]="3EMEB"');
 
@@ -53,6 +54,11 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should accept a string array of several elements as division filter ', async () => {
+      // given
+      sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/2/students?filter[divisions][]="3EMEB"&filter[divisions][]="3EMEA"');
 
@@ -61,6 +67,10 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should reject a division filter if it is not an array', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/2/students?filter[divisions]="3EMEA"');
 
@@ -69,6 +79,10 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should accept a pagination', async () => {
+      // given
+      sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/2/students?page[number]=1&page[size]=25');
 
@@ -77,6 +91,10 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should reject a page number which is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/2/students?page[number]=a');
 
@@ -85,6 +103,9 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should reject a page size which is not a number', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/2/students?page[size]=a');
 
@@ -93,6 +114,11 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should accept an empty query string', async () => {
+      // given
+      sinon.stub(certificationCenterController, 'getStudents').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/2/students');
 
@@ -101,6 +127,10 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should reject an invalid certification-centers id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/invalid/sessions/2/students');
 
@@ -109,6 +139,10 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should reject an invalid session id', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/1/sessions/invalid/students');
 
@@ -123,6 +157,12 @@ describe('Unit | Router | certification-center-router', () => {
     const url = '/api/certification-centers/1/certification-center-memberships';
 
     it('should exist', async () => {
+      //given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').returns(true);
+      sinon.stub(certificationCenterController, 'findCertificationCenterMembershipsByCertificationCenter').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request(method, url);
 
@@ -131,6 +171,9 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should reject an invalid certification-centers id', async () => {
+      //given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
       // when
       const result = await httpTestServer.request(method, '/api/certification-centers/invalid/certification-center-memberships');
 
@@ -147,6 +190,12 @@ describe('Unit | Router | certification-center-router', () => {
     const payload = { email };
 
     it('should return CREATED (200) when everything does as expected', async () => {
+      //given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').returns(true);
+      sinon.stub(certificationCenterController, 'createCertificationCenterMembershipByEmail').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request(method, url, payload);
 
@@ -156,8 +205,9 @@ describe('Unit | Router | certification-center-router', () => {
 
     it('should reject an user without PixMaster role', async () => {
       // given
-      securityPreHandlers.checkUserHasRolePixMaster
-        .callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const result = await httpTestServer.request(method, url, payload);
@@ -167,6 +217,10 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should reject an invalid certification-centers id', async () => {
+      //given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request(method, '/api/certification-centers/invalid/certification-center-memberships');
 
@@ -175,7 +229,10 @@ describe('Unit | Router | certification-center-router', () => {
     });
 
     it('should reject an invalid email', async () => {
-      // given
+      //given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       payload.email = 'invalid email';
 
       // when

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -6,7 +6,6 @@ const {
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const moduleUnderTest = require('../../../../lib/application/certification-centers');
-
 const certificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
 
 describe('Unit | Router | certification-center-router', () => {

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -6,7 +6,6 @@ const {
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const moduleUnderTest = require('../../../../lib/application/certification-courses');
-
 const certificationCoursesController = require('../../../../lib/application/certification-courses/certification-course-controller');
 
 describe('Unit | Application | Certifications Course | Route', function() {

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -11,24 +11,15 @@ const certificationCoursesController = require('../../../../lib/application/cert
 
 describe('Unit | Application | Certifications Course | Route', function() {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-    sinon.stub(certificationCoursesController, 'getCertificationResultInformation').returns('ok');
-    sinon.stub(certificationCoursesController, 'update').returns('ok');
-    sinon.stub(certificationCoursesController, 'computeResult').returns('ok');
-    sinon.stub(certificationCoursesController, 'save').returns('ok');
-    sinon.stub(certificationCoursesController, 'get').returns('ok');
-    sinon.stub(certificationCoursesController, 'getCertifiedProfile').returns('ok');
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('GET /api/admin/certifications/{id}/details', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(certificationCoursesController, 'computeResult').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/certifications/1234/details');
 
@@ -40,6 +31,12 @@ describe('Unit | Application | Certifications Course | Route', function() {
   describe('GET /api/admin/certifications/{id}/certified-profile', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(certificationCoursesController, 'getCertifiedProfile').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/certifications/1234/certified-profile');
 
@@ -51,6 +48,12 @@ describe('Unit | Application | Certifications Course | Route', function() {
   describe('GET /api/admin/certifications/id', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(certificationCoursesController, 'getCertificationResultInformation').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/certifications/1234');
 
@@ -62,6 +65,9 @@ describe('Unit | Application | Certifications Course | Route', function() {
   context('when certification ID params is not a number', () => {
 
     it('should return 400', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request('GET', '/api/admin/certifications/1234*');
@@ -74,6 +80,10 @@ describe('Unit | Application | Certifications Course | Route', function() {
   context('when session ID params is out of range for database integer (> 2147483647)', () => {
 
     it('should return 400', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/certifications/2147483648');
 
@@ -86,6 +96,11 @@ describe('Unit | Application | Certifications Course | Route', function() {
   describe('PATCH /api/certification-courses/id', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(certificationCoursesController, 'update').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PATCH', '/api/certification-courses/1234');
 
@@ -97,6 +112,11 @@ describe('Unit | Application | Certifications Course | Route', function() {
   describe('POST /api/certification-courses', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(certificationCoursesController, 'save').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('POST', '/api/certification-courses');
 
@@ -108,6 +128,11 @@ describe('Unit | Application | Certifications Course | Route', function() {
   describe('GET /api/certification-courses/{id}', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(certificationCoursesController, 'get').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/certification-courses/1234');
 
@@ -119,6 +144,11 @@ describe('Unit | Application | Certifications Course | Route', function() {
   describe('POST /api/admin/certification-courses/{id}/cancel', () => {
 
     it('should check pixMaster role', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       await httpTestServer.request('POST', '/api/admin/certification-courses/1/cancel');
 

--- a/api/tests/unit/application/certification-point-of-contacts/index_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/index_test.js
@@ -10,22 +10,15 @@ const securityPreHandlers = require('../../../../lib/application/security-pre-ha
 
 describe('Unit | Router | certification-point-of-contact-router', function() {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(certificationPointOfContactController, 'get').callsFake((request, h) => h.response().code(200));
-    sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').returns('ok');
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
-  afterEach(() => {
-    sinon.restore();
-  });
-
   describe('GET /api/certification-point-of-contacts/{userId}', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').returns('ok');
+      sinon.stub(certificationPointOfContactController, 'get').callsFake((request, h) => h.response().code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const result = await httpTestServer.request('GET', '/api/certification-point-of-contacts/123');
 
@@ -34,6 +27,11 @@ describe('Unit | Router | certification-point-of-contact-router', function() {
     });
 
     it('should call pre-handler', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       await httpTestServer.request('GET', '/api/certification-point-of-contacts/123');
 

--- a/api/tests/unit/application/challenges/index_test.js
+++ b/api/tests/unit/application/challenges/index_test.js
@@ -1,30 +1,23 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
-const ChallengeController = require('../../../../lib/application/challenges/challenge-controller');
-const route = require('../../../../lib/application/challenges');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+const challengeController = require('../../../../lib/application/challenges/challenge-controller');
+const moduleUnderTest = require('../../../../lib/application/challenges');
 
 describe('Unit | Router | challenge-router', function() {
 
-  let server;
-
-  beforeEach(function() {
-    server = Hapi.server();
-  });
-
   describe('GET /api/challenges/{id}', function() {
-
-    beforeEach(function() {
-      sinon.stub(ChallengeController, 'get').returns('ok');
-
-      return server.register(route);
-    });
 
     it('should exist', async () => {
       // given
-      const options = { method: 'GET', url: '/api/challenges/challenge_id' };
+      sinon.stub(challengeController, 'get').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/challenges/1');
 
       // then
       expect(response.statusCode).to.equal(200);

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -4,27 +4,20 @@ const {
   sinon,
 } = require('../../../test-helper');
 
-const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
-
 const moduleUnderTest = require('../../../../lib/application/courses');
 
 const courseController = require('../../../../lib/application/courses/course-controller');
 
 describe('Unit | Router | course-router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-    sinon.stub(courseController, 'get').returns('ok');
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('GET /api/courses/{id}', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(courseController, 'get').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/courses/course_id');
 

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -5,7 +5,6 @@ const {
 } = require('../../../test-helper');
 
 const moduleUnderTest = require('../../../../lib/application/courses');
-
 const courseController = require('../../../../lib/application/courses/course-controller');
 
 describe('Unit | Router | course-router', () => {

--- a/api/tests/unit/application/feedbacks/index_test.js
+++ b/api/tests/unit/application/feedbacks/index_test.js
@@ -10,18 +10,14 @@ const feedbackController = require('../../../../lib/application/feedbacks/feedba
 
 describe('Unit | Router | feedback-router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(feedbackController, 'save').returns('ok');
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('POST /api/feedbacks', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(feedbackController, 'save').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('POST', '/api/feedbacks');
 

--- a/api/tests/unit/application/feedbacks/index_test.js
+++ b/api/tests/unit/application/feedbacks/index_test.js
@@ -5,7 +5,6 @@ const {
 } = require('../../../test-helper');
 
 const moduleUnderTest = require('../../../../lib/application/feedbacks');
-
 const feedbackController = require('../../../../lib/application/feedbacks/feedback-controller');
 
 describe('Unit | Router | feedback-router', () => {

--- a/api/tests/unit/application/healthcheck/index_test.js
+++ b/api/tests/unit/application/healthcheck/index_test.js
@@ -5,7 +5,6 @@ const {
 } = require('../../../test-helper');
 
 const moduleUnderTest = require('../../../../lib/application/healthcheck');
-
 const healthcheckController = require('../../../../lib/application/healthcheck/healthcheck-controller');
 
 describe('Unit | Router | HealthcheckRouter', function() {

--- a/api/tests/unit/application/healthcheck/index_test.js
+++ b/api/tests/unit/application/healthcheck/index_test.js
@@ -10,18 +10,14 @@ const healthcheckController = require('../../../../lib/application/healthcheck/h
 
 describe('Unit | Router | HealthcheckRouter', function() {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(healthcheckController, 'get').returns('ok');
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('GET /api', function() {
 
     it('should exist', async function() {
+      // given
+      sinon.stub(healthcheckController, 'get').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api');
 

--- a/api/tests/unit/application/organization-invitations/index_test.js
+++ b/api/tests/unit/application/organization-invitations/index_test.js
@@ -5,7 +5,6 @@ const {
 } = require('../../../test-helper');
 
 const moduleUnderTest = require('../../../../lib/application/organization-invitations');
-
 const organizationInvitationController = require('../../../../lib/application/organization-invitations/organization-invitation-controller');
 
 describe('Unit | Router | organization-invitation-router', () => {

--- a/api/tests/unit/application/organization-invitations/index_test.js
+++ b/api/tests/unit/application/organization-invitations/index_test.js
@@ -10,20 +10,14 @@ const organizationInvitationController = require('../../../../lib/application/or
 
 describe('Unit | Router | organization-invitation-router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(organizationInvitationController, 'acceptOrganizationInvitation').callsFake((request, h) => h.response().code(204));
-    sinon.stub(organizationInvitationController, 'getOrganizationInvitation').callsFake((request, h) => h.response().code(200));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('POST /api/organization-invitations/{id}/response', () => {
 
     it('should exists', async () => {
       // given
+      sinon.stub(organizationInvitationController, 'acceptOrganizationInvitation').callsFake((request, h) => h.response().code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'POST';
       const url = '/api/organization-invitations/1/response';
       const payload = {
@@ -51,6 +45,10 @@ describe('Unit | Router | organization-invitation-router', () => {
 
     it('should exists', async () => {
       // given
+      sinon.stub(organizationInvitationController, 'getOrganizationInvitation').callsFake((request, h) => h.response().code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/organization-invitations/1?code=DZWMP7L5UM';
 
       // when
@@ -62,6 +60,9 @@ describe('Unit | Router | organization-invitation-router', () => {
 
     it('should return Bad Request Error when invitation identifier is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/organization-invitations/XXXXXXXXXXXXXXXX15812?code=DZWMP7L5UM';
 
       // when

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -1,10 +1,13 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const organizationController = require('../../../../lib/application/organizations/organization-controller');
 const usecases = require('../../../../lib/domain/usecases');
 const identifiersType = require('../../../../lib/domain/types/identifiers-type');
-
 const moduleUnderTest = require('../../../../lib/application/organizations');
 
 describe('Unit | Router | organization-router', () => {

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -9,28 +9,17 @@ const moduleUnderTest = require('../../../../lib/application/organizations');
 
 describe('Unit | Router | organization-router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(usecases, 'findPendingOrganizationInvitations').resolves([]);
-
-    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
-    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').returns(true);
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').returns(true);
-
-    sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
-    sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
-    sinon.stub(organizationController, 'getSchoolingRegistrationsCsvTemplate').callsFake((request, h) => h.response('ok').code(200));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('GET /api/organizations', () => {
 
     const method = 'GET';
 
     it('should return OK (200) when request is valid', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').returns(true);
+      sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // given
       const url = '/api/organizations?filter[id]=&filter[name]=DRA&filter[type]=SCO&page[number]=3&page[size]=25';
 
@@ -45,6 +34,9 @@ describe('Unit | Router | organization-router', () => {
 
       it('should return BadRequest (400) if id is not numeric', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const idNotNumeric = 'foo';
         const url = `/api/organizations?filter[id]=${idNotNumeric}`;
 
@@ -73,6 +65,9 @@ describe('Unit | Router | organization-router', () => {
         numbersOutsideLimits.forEach(({ expectedBehavior, wrongNumber }) => {
           it(expectedBehavior, async () => {
             // given
+            const httpTestServer = new HttpTestServer();
+            await httpTestServer.register(moduleUnderTest);
+
             const url = `/api/organizations?filter[id]=${wrongNumber}`;
 
             // when
@@ -90,10 +85,15 @@ describe('Unit | Router | organization-router', () => {
 
     const method = 'POST';
     const url = '/api/organizations/1/invitations';
-    let payload;
 
-    beforeEach(() => {
-      payload = {
+    it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').returns(true);
+      sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const payload = {
         data: {
           type: 'organization-invitations',
           attributes: {
@@ -101,9 +101,7 @@ describe('Unit | Router | organization-router', () => {
           },
         },
       };
-    });
 
-    it('should exist', async () => {
       // when
       const response = await httpTestServer.request(method, url, payload);
 
@@ -113,7 +111,19 @@ describe('Unit | Router | organization-router', () => {
 
     it('should accept multiple emails', async () => {
       // given
-      payload.data.attributes.email = 'user1@organization.org, user2@organization.org';
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').returns(true);
+      sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'user1@organization.org, user2@organization.org',
+          },
+        },
+      };
 
       // when
       const response = await httpTestServer.request(method, url, payload);
@@ -124,7 +134,17 @@ describe('Unit | Router | organization-router', () => {
 
     it('should reject request with HTTP code 400, when email is empty', async () => {
       // given
-      payload.data.attributes.email = '';
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: '',
+          },
+        },
+      };
 
       // when
       const response = await httpTestServer.request(method, url, payload);
@@ -135,7 +155,17 @@ describe('Unit | Router | organization-router', () => {
 
     it('should reject request with HTTP code 400, when input is not a email', async () => {
       // given
-      payload.data.attributes.email = 'azerty';
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'azerty',
+          },
+        },
+      };
 
       // when
       const response = await httpTestServer.request(method, url, payload);
@@ -149,6 +179,12 @@ describe('Unit | Router | organization-router', () => {
 
     it('should return an empty list when no organization is found', async () => {
       // given
+      sinon.stub(usecases, 'findPendingOrganizationInvitations').resolves([]);
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
+      sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/organizations/1/invitations';
 
@@ -166,6 +202,9 @@ describe('Unit | Router | organization-router', () => {
     context('when the id not an integer', () => {
       it('responds 400', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const method = 'POST';
         const url = '/api/organizations/qsdqsd/schooling-registrations/import-csv';
 
@@ -182,6 +221,10 @@ describe('Unit | Router | organization-router', () => {
 
     it('should call the organization controller to csv template', async () => {
       // given
+      sinon.stub(organizationController, 'getSchoolingRegistrationsCsvTemplate').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/organizations/1/schooling-registrations/csv-template?accessToken=token';
 
@@ -197,6 +240,9 @@ describe('Unit | Router | organization-router', () => {
 
       it('should throw an error when id is not a number', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const method = 'GET';
         const url = '/api/organizations/ABC/schooling-registrations/csv-template?accessToken=token';
 
@@ -209,6 +255,9 @@ describe('Unit | Router | organization-router', () => {
 
       it('should throw an error when id is null', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const method = 'GET';
         const url = '/api/organizations/null/schooling-registrations/csv-template?accessToken=token';
 
@@ -221,6 +270,9 @@ describe('Unit | Router | organization-router', () => {
 
       it('should throw an error when access token is not specified', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const method = 'GET';
         const url = '/api/organizations/ABC/schooling-registrations/csv-template';
 
@@ -233,6 +285,9 @@ describe('Unit | Router | organization-router', () => {
 
       it('should throw an error when access token is null', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const method = 'GET';
         const url = '/api/organizations/null/schooling-registrations/csv-template?accessToken=null';
 

--- a/api/tests/unit/application/passwords/index_test.js
+++ b/api/tests/unit/application/passwords/index_test.js
@@ -6,17 +6,6 @@ const passwordController = require('../../../../lib/application/passwords/passwo
 
 describe('Unit | Router | Password router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(passwordController, 'checkResetDemand');
-    sinon.stub(passwordController, 'createResetDemand');
-    sinon.stub(passwordController, 'updateExpiredPassword').callsFake((request, h) => h.response().created());
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('POST /api/password-reset-demands', () => {
 
     const method = 'POST';
@@ -24,7 +13,9 @@ describe('Unit | Router | Password router', () => {
 
     it('should return 200 http status code', async () => {
       // given
-      passwordController.createResetDemand.returns('ok');
+      sinon.stub(passwordController, 'createResetDemand').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       const payload = {
         data: {
@@ -47,6 +38,9 @@ describe('Unit | Router | Password router', () => {
 
       it('should return 400 http status code', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const payload = {
           data: {
             attributes: {},
@@ -69,7 +63,9 @@ describe('Unit | Router | Password router', () => {
 
     it('should return 201 http status code', async () => {
       // given
-      passwordController.checkResetDemand.resolves('ok');
+      sinon.stub(passwordController, 'checkResetDemand').resolves('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request(method, url);
@@ -86,6 +82,10 @@ describe('Unit | Router | Password router', () => {
 
     it('should return 201 http status code', async () => {
       // given
+      sinon.stub(passwordController, 'updateExpiredPassword').callsFake((request, h) => h.response().created());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           attributes: {
@@ -108,6 +108,9 @@ describe('Unit | Router | Password router', () => {
 
       it('should return 400 http status code', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const payload = {
           data: {
             attributes: {

--- a/api/tests/unit/application/passwords/index_test.js
+++ b/api/tests/unit/application/passwords/index_test.js
@@ -1,7 +1,10 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 
 const moduleUnderTest = require('../../../../lib/application/passwords');
-
 const passwordController = require('../../../../lib/application/passwords/password-controller');
 
 describe('Unit | Router | Password router', () => {

--- a/api/tests/unit/application/prescribers/index_test.js
+++ b/api/tests/unit/application/prescribers/index_test.js
@@ -5,9 +5,7 @@ const {
 } = require('../../../test-helper');
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
-
 const moduleUnderTest = require('../../../../lib/application/prescribers');
-
 const prescriberController = require('../../../../lib/application/prescribers/prescriber-controller');
 
 describe('Unit | Router | prescriber-router', () => {

--- a/api/tests/unit/application/prescribers/index_test.js
+++ b/api/tests/unit/application/prescribers/index_test.js
@@ -12,19 +12,15 @@ const prescriberController = require('../../../../lib/application/prescribers/pr
 
 describe('Unit | Router | prescriber-router', () => {
 
-  let httpTestServer;
-
   describe('GET /api/prescription/prescribers/{id}', () => {
 
-    beforeEach(async() => {
-      sinon.stub(prescriberController, 'get').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-
-      httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-    });
-
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
+      sinon.stub(prescriberController, 'get').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/prescription/prescribers/1');
 

--- a/api/tests/unit/application/progressions/index_test.js
+++ b/api/tests/unit/application/progressions/index_test.js
@@ -10,18 +10,14 @@ const progressionController = require('../../../../lib/application/progressions/
 
 describe('Unit | Router | progression-router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(progressionController, 'get').callsFake((request, h) => h.response().code(200));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('GET /api/progressions/{id}', function() {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(progressionController, 'get').callsFake((request, h) => h.response().code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/progressions/1');
 

--- a/api/tests/unit/application/progressions/index_test.js
+++ b/api/tests/unit/application/progressions/index_test.js
@@ -5,7 +5,6 @@ const {
 } = require('../../../test-helper');
 
 const moduleUnderTest = require('../../../../lib/application/progressions');
-
 const progressionController = require('../../../../lib/application/progressions/progression-controller');
 
 describe('Unit | Router | progression-router', () => {

--- a/api/tests/unit/application/schooling-registration-user-associations/index_test.js
+++ b/api/tests/unit/application/schooling-registration-user-associations/index_test.js
@@ -16,18 +16,6 @@ describe('Unit | Application | Router | schooling-registration-user-associations
   const studentId = '1234';
   const userId = 2;
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(preHandler, 'checkUserIsAdminInSUPOrganizationManagingStudents');
-
-    sinon.stub(schoolingRegistrationUserAssociationController, 'dissociate').returns('ok');
-    sinon.stub(schoolingRegistrationUserAssociationController, 'updateStudentNumber').returns('ok');
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('PATCH /api/organizations/id/schooling-registration-user-associations/studentId', () => {
 
     const method = 'PATCH';
@@ -35,33 +23,23 @@ describe('Unit | Application | Router | schooling-registration-user-associations
       authorization: generateValidRequestAuthorizationHeader(userId),
     };
 
-    let payload;
-    let url;
-
-    beforeEach(() => {
-      payload = {
-        data: {
-          attributes: {
-            'student-number': '1234',
-          },
-        },
-      };
-    });
-
-    afterEach(() => {
-      preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.restore();
-    });
-
     context('when the user is authenticated', () => {
-
-      beforeEach(() => {
-        preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) => h.response(true));
-      });
 
       it('should exist', async () => {
         // given
-        url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
+        sinon.stub(preHandler, 'checkUserIsAdminInSUPOrganizationManagingStudents').callsFake((request, h) => h.response(true));
+        sinon.stub(schoolingRegistrationUserAssociationController, 'updateStudentNumber').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
+        const url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
+        const payload = {
+          data: {
+            attributes: {
+              'student-number': '1234',
+            },
+          },
+        };
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
 
@@ -71,8 +49,17 @@ describe('Unit | Application | Router | schooling-registration-user-associations
 
       it('should return a 422 status error when student-number parameter is not a string', async () => {
         // given
-        url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
-        payload.data.attributes['student-number'] = 1234;
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
+        const payload = {
+          data: {
+            attributes: {
+              'student-number': 1234,
+            },
+          },
+        };
 
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -86,7 +73,17 @@ describe('Unit | Application | Router | schooling-registration-user-associations
 
       it('should return a 404 status error when organizationId parameter is not a number', async () => {
         // given
-        url = `/api/organizations/FAKE_ORGANIZATION_ID/schooling-registration-user-associations/${studentId}`;
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const url = `/api/organizations/FAKE_ORGANIZATION_ID/schooling-registration-user-associations/${studentId}`;
+        const payload = {
+          data: {
+            attributes: {
+              'student-number': '1234',
+            },
+          },
+        };
 
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -100,7 +97,17 @@ describe('Unit | Application | Router | schooling-registration-user-associations
 
       it('should return a 404 status error when studentId parameter is not a number', async () => {
         // given
-        url = `/api/organizations/${organizationId}/schooling-registration-user-associations/FAKE_STUDENT_ID`;
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const url = `/api/organizations/${organizationId}/schooling-registration-user-associations/FAKE_STUDENT_ID`;
+        const payload = {
+          data: {
+            attributes: {
+              'student-number': '1234',
+            },
+          },
+        };
 
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -115,13 +122,20 @@ describe('Unit | Application | Router | schooling-registration-user-associations
 
     context('when the user is not authenticated', () => {
 
-      beforeEach(() => {
-        preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) => h.response().code(403).takeover());
-      });
-
       it('should return an error when the user is not authenticated', async () => {
         // given
-        url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
+        sinon.stub(preHandler, 'checkUserIsAdminInSUPOrganizationManagingStudents').callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
+        const payload = {
+          data: {
+            attributes: {
+              'student-number': '1234',
+            },
+          },
+        };
 
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -140,11 +154,13 @@ describe('Unit | Application | Router | schooling-registration-user-associations
     };
     const payload = null;
 
-    let url;
-
     it('should return a HTTP status code 200', async () => {
       // given
-      url = '/api/schooling-registration-user-associations/1';
+      sinon.stub(schoolingRegistrationUserAssociationController, 'dissociate').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const url = '/api/schooling-registration-user-associations/1';
 
       // when
       const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -155,7 +171,10 @@ describe('Unit | Application | Router | schooling-registration-user-associations
 
     it('should return a HTTP status code 400 if id parameter is not a number', async () => {
       // given
-      url = '/api/schooling-registration-user-associations/ABC';
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const url = '/api/schooling-registration-user-associations/ABC';
 
       // when
       const response = await httpTestServer.request(method, url, payload, null, headers);

--- a/api/tests/unit/application/schooling-registration-user-associations/index_test.js
+++ b/api/tests/unit/application/schooling-registration-user-associations/index_test.js
@@ -7,7 +7,6 @@ const {
 
 const preHandler = require('../../../../lib/application/security-pre-handlers');
 const schoolingRegistrationUserAssociationController = require('../../../../lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller');
-
 const moduleUnderTest = require('../../../../lib/application/schooling-registration-user-associations');
 
 describe('Unit | Application | Router | schooling-registration-user-associations-router', function() {

--- a/api/tests/unit/application/scorecards/index_test.js
+++ b/api/tests/unit/application/scorecards/index_test.js
@@ -2,20 +2,16 @@ const { expect, sinon, HttpTestServer } = require('../../../test-helper');
 const scorecardController = require('../../../../lib/application/scorecards/scorecard-controller');
 const moduleUnderTest = require('../../../../lib/application/scorecards');
 
-let httpTestServer;
-
 describe('Unit | Router | scorecard-router', () => {
 
   describe('GET /api/scorecards/{id}', () => {
 
-    beforeEach(async() => {
-      sinon.stub(scorecardController, 'getScorecard').returns('ok');
-      httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-    });
-
     it('should exist', async () => {
       // given
+      sinon.stub(scorecardController, 'getScorecard').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const options = {
         method: 'GET',
         url: '/api/scorecards/foo',
@@ -31,14 +27,12 @@ describe('Unit | Router | scorecard-router', () => {
 
   describe('GET /api/scorecards/{id}/tutorials', () => {
 
-    beforeEach(async() => {
-      sinon.stub(scorecardController, 'findTutorials').returns('ok');
-      httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-    });
-
     it('should exist', async () => {
       // given
+      sinon.stub(scorecardController, 'findTutorials').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const options = {
         method: 'GET',
         url: '/api/scorecards/foo/tutorials',

--- a/api/tests/unit/application/scorecards/index_test.js
+++ b/api/tests/unit/application/scorecards/index_test.js
@@ -1,4 +1,8 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 const scorecardController = require('../../../../lib/application/scorecards/scorecard-controller');
 const moduleUnderTest = require('../../../../lib/application/scorecards');
 

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -19,41 +19,15 @@ const moduleUnderTest = require('../../../../lib/application/sessions');
 
 describe('Unit | Application | Sessions | Routes', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(sessionAuthorization, 'verify').returns(null);
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-
-    sinon.stub(sessionController, 'get').returns('ok');
-    sinon.stub(sessionController, 'getJurySession').returns('ok');
-    sinon.stub(sessionController, 'findPaginatedFilteredJurySessions').returns('ok');
-    sinon.stub(sessionController, 'save').returns('ok');
-    sinon.stub(sessionController, 'getAttendanceSheet').returns('ok');
-    sinon.stub(sessionController, 'update').returns('ok');
-    sinon.stub(sessionController, 'importCertificationCandidatesFromAttendanceSheet').returns('ok');
-    sinon.stub(sessionController, 'getCertificationCandidates').returns('ok');
-    sinon.stub(sessionController, 'addCertificationCandidate').returns('ok');
-    sinon.stub(sessionController, 'deleteCertificationCandidate').returns('ok');
-    sinon.stub(sessionController, 'getJuryCertificationSummaries').returns('ok');
-    sinon.stub(sessionController, 'createCandidateParticipation').returns('ok');
-    sinon.stub(sessionController, 'finalize').returns('ok');
-    sinon.stub(sessionController, 'publish').returns('ok');
-    sinon.stub(sessionController, 'unpublish').returns('ok');
-    sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
-    sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
-    sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
-    sinon.stub(sessionController, 'publishInBatch').returns('ok');
-    sinon.stub(finalizedSessionController, 'findFinalizedSessionsToPublish').returns('ok');
-    sinon.stub(finalizedSessionController, 'findFinalizedSessionsWithRequiredAction').returns('ok');
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('GET /api/sessions/{id}', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'get').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/sessions/3');
 
@@ -65,6 +39,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('GET /api/admin/sessions/{id}', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'getJurySession').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/sessions/123');
 
@@ -76,6 +56,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('GET /api/admin/sessions', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'findPaginatedFilteredJurySessions').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/sessions');
 
@@ -87,6 +73,11 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('POST /api/session', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionController, 'save').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       /// when
       const response = await httpTestServer.request('POST', '/api/sessions');
 
@@ -98,6 +89,11 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('GET /api/sessions/{id}/attendance-sheet', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionController, 'getAttendanceSheet').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/sessions/1/attendance-sheet');
 
@@ -109,6 +105,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('PATCH /api/sessions/{id}', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'update').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PATCH', '/api/sessions/1');
 
@@ -120,14 +122,10 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('POST /api/sessions/{id}/certification-candidates/import', () => {
 
     const testFilePath = `${__dirname}/testFile_temp.ods`;
-
     const method = 'POST';
 
     let headers;
-    let url;
     let payload;
-
-    let sessionId;
 
     beforeEach(async () => {
       await writeFile(testFilePath, Buffer.alloc(0));
@@ -145,8 +143,13 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('should exist', async () => {
       // given
-      sessionId = 3;
-      url = `/api/sessions/${sessionId}/certification-candidates/import`;
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'importCertificationCandidatesFromAttendanceSheet').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const sessionId = 3;
+      const url = `/api/sessions/${sessionId}/certification-candidates/import`;
 
       // when
       const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -159,8 +162,11 @@ describe('Unit | Application | Sessions | Routes', () => {
 
       it('should return 400', async () => {
         // given
-        sessionId = 'salut';
-        url = `/api/sessions/${sessionId}/certification-candidates/import`;
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const sessionId = 'salut';
+        const url = `/api/sessions/${sessionId}/certification-candidates/import`;
 
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -174,8 +180,11 @@ describe('Unit | Application | Sessions | Routes', () => {
 
       it('should return 400', async () => {
         // given
-        sessionId = 9999999999;
-        url = `/api/sessions/${sessionId}/certification-candidates/import`;
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const sessionId = 9999999999;
+        const url = `/api/sessions/${sessionId}/certification-candidates/import`;
 
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -189,6 +198,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('GET /api/sessions/{id}/certification-candidates', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'getCertificationCandidates').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/sessions/3/certification-candidates');
 
@@ -200,6 +215,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('POST /api/sessions/{id}/certification-candidates', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'addCertificationCandidate').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('POST', '/api/sessions/3/certification-candidates');
 
@@ -211,6 +232,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('DELETE /api/sessions/{id}/certification-candidates/{certificationCandidateId}', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'deleteCertificationCandidate').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('DELETE', '/api/sessions/3/certification-candidates/1');
 
@@ -222,6 +249,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('GET /api/admin/sessions/{id}/jury-certification-summaries', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'getJuryCertificationSummaries').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/sessions/1/jury-certification-summaries');
 
@@ -233,6 +266,11 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('POST /api/sessions/{id}/candidate-participation', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionController, 'createCandidateParticipation').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('POST', '/api/sessions/3/candidate-participation');
 
@@ -244,6 +282,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('PUT /api/sessions/{id}/finalization', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'finalize').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PUT', '/api/sessions/3/finalization');
 
@@ -256,6 +300,11 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('should exist', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'publish').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           attributes: {
@@ -275,6 +324,11 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('should exist', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'unpublish').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           attributes: {
@@ -295,7 +349,10 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('is protected by a prehandler checking the Pix Master role', async () => {
       // given
-      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           attributes: {
@@ -313,6 +370,11 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('should succeed with valid session ids', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'publishInBatch').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           attributes: {
@@ -330,6 +392,9 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('should validate the session ids in payload', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           attributes: {
@@ -350,6 +415,11 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('should exist', async () => {
       // when
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const response = await httpTestServer.request('PUT', '/api/admin/sessions/3/results-sent-to-prescriber');
 
       // then
@@ -360,6 +430,12 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('PATCH /api/admin/sessions/{id}/certification-officer-assignment', () => {
 
     it('should exist', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/certification-officer-assignment');
 
@@ -402,6 +478,10 @@ describe('Unit | Application | Sessions | Routes', () => {
       { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PATCH', url: '/api/admin/sessions/9999999999/certification-officer-assignment' } },
     ].forEach(({ condition, request }) => {
       it(`should return 400 when ${condition}`, async () => {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         // when
         const response = await httpTestServer.request(request.method, request.url, request.payload || null);
 
@@ -413,6 +493,12 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('PUT /api/session/{id}/enroll-students-to-session', () => {
     it('exists', async () => {
+      // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PUT', '/api/sessions/3/enroll-students-to-session');
 
@@ -421,6 +507,12 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
 
     it('validates the session id', async () => {
+      // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('PUT', '/api/sessions/invalidId/enroll-students-to-session');
 
@@ -430,7 +522,10 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('denies access if the session of the logged used is not authorized', async () => {
       // given
-      sessionAuthorization.verify.throws(new NotFoundError());
+      sinon.stub(sessionAuthorization, 'verify').throws(new NotFoundError());
+      sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request('PUT', '/api/sessions/3/enroll-students-to-session');
@@ -442,6 +537,12 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('GET /api/admin/sessions/to-publish', () => {
     it('exists', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(finalizedSessionController, 'findFinalizedSessionsToPublish').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/sessions/to-publish');
 
@@ -450,7 +551,9 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
     it('is protected by a prehandler checking the Pix Master role', async () => {
       // given
-      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request('GET', '/api/admin/sessions/to-publish');
@@ -462,6 +565,12 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('GET /api/admin/sessions/with-required-action', () => {
     it('exists', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(finalizedSessionController, 'findFinalizedSessionsWithRequiredAction').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       // when
       const response = await httpTestServer.request('GET', '/api/admin/sessions/with-required-action');
 
@@ -471,7 +580,9 @@ describe('Unit | Application | Sessions | Routes', () => {
 
     it('is protected by a prehandler checking the Pix Master role', async () => {
       // given
-      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request('GET', '/api/admin/sessions/with-required-action');

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -14,7 +14,6 @@ const securityPreHandlers = require('../../../../lib/application/security-pre-ha
 const sessionController = require('../../../../lib/application/sessions/session-controller');
 const finalizedSessionController = require('../../../../lib/application/sessions/finalized-session-controller');
 const sessionAuthorization = require('../../../../lib/application/preHandlers/session-authorization');
-
 const moduleUnderTest = require('../../../../lib/application/sessions');
 
 describe('Unit | Application | Sessions | Routes', () => {

--- a/api/tests/unit/application/stages/index_test.js
+++ b/api/tests/unit/application/stages/index_test.js
@@ -3,22 +3,7 @@ const securityPreHandlers = require('../../../../lib/application/security-pre-ha
 const stagesController = require('../../../../lib/application/stages/stages-controller');
 const moduleUnderTest = require('../../../../lib/application/stages');
 
-let httpTestServer;
-
-async function startServer() {
-  const server = new HttpTestServer();
-  await server.register(moduleUnderTest);
-  return server;
-}
-
 describe('Unit | Router | stages-router', () => {
-  beforeEach(async() => {
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-    sinon.stub(stagesController, 'create').returns('ok');
-    sinon.stub(stagesController, 'updateStage').callsFake((request, h) => h.response('ok').code(204));
-    sinon.stub(stagesController, 'getStageDetails').callsFake((request, h) => h.response('ok').code(200));
-    httpTestServer = await startServer();
-  });
 
   describe('POST /api/admin/stages', () => {
 
@@ -26,6 +11,11 @@ describe('Unit | Router | stages-router', () => {
 
     it('should exist', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(stagesController, 'create').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/admin/stages';
 
       // when
@@ -39,6 +29,11 @@ describe('Unit | Router | stages-router', () => {
   describe('GET /api/admin/stages/:id', () => {
     it('should exist', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(stagesController, 'getStageDetails').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/stages/34';
 
@@ -51,6 +46,9 @@ describe('Unit | Router | stages-router', () => {
 
     it('should return a 400 error when the id is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const unknownId = 'abcd45';
       const url = `/api/admin/stages/${unknownId}`;
@@ -66,6 +64,11 @@ describe('Unit | Router | stages-router', () => {
   describe('PATCH /api/admin/stages/:id', () => {
     it('should update the stage with attributes', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(stagesController, 'updateStage').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'PATCH';
       const payload = { data: {
         attributes: {
@@ -84,6 +87,11 @@ describe('Unit | Router | stages-router', () => {
 
     it('should update the stage even if there is null', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(stagesController, 'updateStage').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'PATCH';
       const payload = { data: {
         attributes: {
@@ -102,6 +110,9 @@ describe('Unit | Router | stages-router', () => {
 
     it('should return a 400 error when the id is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'PATCH';
       const unknownId = 'abcd45';
       const payload = { data: {
@@ -121,6 +132,9 @@ describe('Unit | Router | stages-router', () => {
 
     it('should return a 400 error when payload is undefined', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'PATCH';
       const payload = { data: {
         attributes: {
@@ -139,6 +153,9 @@ describe('Unit | Router | stages-router', () => {
 
     it('should return a 400 error when payload is empty strings', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'PATCH';
       const payload = { data: {
         attributes: {

--- a/api/tests/unit/application/stages/index_test.js
+++ b/api/tests/unit/application/stages/index_test.js
@@ -1,4 +1,8 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const stagesController = require('../../../../lib/application/stages/stages-controller');
 const moduleUnderTest = require('../../../../lib/application/stages');

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -1,4 +1,8 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const targetProfileController = require('../../../../lib/application/target-profiles/target-profile-controller');

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -6,27 +6,16 @@ const moduleUnderTest = require('../../../../lib/application/target-profiles');
 
 describe('Integration | Application | Target Profiles | Routes', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-    sinon.stub(targetProfileController, 'outdateTargetProfile').callsFake((request, h) => h.response('ok').code(204));
-    sinon.stub(targetProfileController, 'createTargetProfile').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfileOrganizations').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfiles').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(targetProfileController, 'getTargetProfileDetails').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(targetProfileController, 'updateTargetProfileName').callsFake((request, h) => h.response('ok').code(204));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('POST /api/target-profiles', () => {
     it('should resolve with owner organization id to null', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'createTargetProfile').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'POST';
       const url = '/api/admin/target-profiles';
-
       const payload = {
         data: {
           attributes: {
@@ -48,9 +37,13 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should resolve with owner organization id to empty', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'createTargetProfile').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'POST';
       const url = '/api/admin/target-profiles';
-
       const payload = {
         data: {
           attributes: {
@@ -71,9 +64,11 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should reject with alphanumeric owner organization id ', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'POST';
       const url = '/api/admin/target-profiles';
-
       const payload = {
         data: {
           attributes: {
@@ -97,6 +92,11 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should resolve when there is no filter nor pagination', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfiles').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles';
 
@@ -109,6 +109,11 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should resolve when there are filters and pagination', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfiles').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles?filter[id]=1&filter[name]=azerty&page[size]=10&page[number]=1';
 
@@ -121,6 +126,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should reject request with HTTP code 400, when id is not an integer', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles?filter[id]=azerty';
 
@@ -133,6 +141,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should reject request with HTTP code 400, when page size is not an integer', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles?page[size]=azerty';
 
@@ -145,6 +156,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should reject request with HTTP code 400, when page number is not an integer', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles?page[number]=azerty';
 
@@ -160,6 +174,11 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should resolve with correct id', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'getTargetProfileDetails').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles/1';
 
@@ -172,6 +191,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should reject request with HTTP code 400', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles/azerty';
 
@@ -187,6 +209,11 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should resolve when there is no filter nor pagination', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfileOrganizations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles/1/organizations';
 
@@ -199,6 +226,11 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should resolve when there are filters and pagination', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfileOrganizations').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles/1/organizations?filter[name]=azerty&filter[type]=sco&filter[external-id]=abc&page[size]=10&page[number]=1';
 
@@ -211,6 +243,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should reject request with HTTP code 400, when id is not an integer', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles/azerty/organizations';
 
@@ -223,6 +258,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should reject request with HTTP code 400, when page size is not an integer', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles/1/organizations?page[size]=azerty';
 
@@ -235,6 +273,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should reject request with HTTP code 400, when page number is not an integer', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'GET';
       const url = '/api/admin/target-profiles/1/organizations?page[number]=azerty';
 
@@ -250,6 +291,11 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should exist', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'updateTargetProfileName').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'PATCH';
       const payload = { data: {
         attributes: {
@@ -267,6 +313,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should return a 400 error when payload does not exist', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'PATCH';
       const payload = { data: {
         attributes: {
@@ -294,9 +343,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
       it('should resolve a 403 HTTP response', async () => {
         //Given
-        securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => {
-          return Promise.resolve(h.response().code(403).takeover());
-        });
+        sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
         // when
         const response = await httpTestServer.request(method, url, payload);
@@ -313,6 +362,11 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
     it('should exist', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'outdateTargetProfile').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const method = 'PUT';
       const payload = { };
       const url = '/api/admin/target-profiles/123/outdate';
@@ -332,9 +386,9 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
       it('should resolve a 403 HTTP response', async () => {
         //Given
-        securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => {
-          return Promise.resolve(h.response().code(403).takeover());
-        });
+        sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
         // when
         const response = await httpTestServer.request(method, url, payload);

--- a/api/tests/unit/application/tutorial-evaluations/index_test.js
+++ b/api/tests/unit/application/tutorial-evaluations/index_test.js
@@ -1,33 +1,26 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 const tutorialEvaluationsController = require('../../../../lib/application/tutorial-evaluations/tutorial-evaluations-controller');
-
-let server;
-
-function startServer() {
-  server = Hapi.server();
-  return server.register(require('../../../../lib/application/tutorial-evaluations'));
-}
+const moduleUnderTest = require('../../../../lib/application/tutorial-evaluations');
 
 describe('Unit | Router | tutorial-evaluations-router', () => {
 
   describe('PUT /api/users/tutorials/{tutorialId}/evaluate', () => {
 
-    beforeEach(() => {
-      sinon.stub(tutorialEvaluationsController, 'evaluate').
-        callsFake((request, h) => h.response().code(204));
-      startServer();
-    });
-
     it('should exist', async () => {
       // given
-      const options = {
-        method: 'PUT',
-        url: '/api/users/tutorials/{tutorialId}/evaluate',
-      };
+      sinon.stub(tutorialEvaluationsController, 'evaluate').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'PUT';
+      const url = '/api/users/tutorials/{tutorialId}/evaluate';
 
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request(method, url);
 
       // then
       expect(tutorialEvaluationsController.evaluate).have.been.called;

--- a/api/tests/unit/application/user-orga-settings/index_test.js
+++ b/api/tests/unit/application/user-orga-settings/index_test.js
@@ -1,6 +1,9 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 const userOrgaSettingsController = require('../../../../lib/application/user-orga-settings/user-orga-settings-controller');
-
 const moduleUnderTest = require('../../../../lib/application/user-orga-settings');
 
 describe('Unit | Router | user-orga-settings-router', () => {

--- a/api/tests/unit/application/user-orga-settings/index_test.js
+++ b/api/tests/unit/application/user-orga-settings/index_test.js
@@ -5,25 +5,19 @@ const moduleUnderTest = require('../../../../lib/application/user-orga-settings'
 
 describe('Unit | Router | user-orga-settings-router', () => {
 
-  let httpTestServer;
-
-  beforeEach(async() => {
-    sinon.stub(userOrgaSettingsController, 'createOrUpdate').returns('ok');
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('PUT /api/user-orga-settings/{id}', () => {
     const userId = 2;
     const auth = { credentials: { userId: userId }, strategy: {} };
-    let method;
-    let url;
-    let payload;
 
-    beforeEach(() => {
-      method = 'PUT';
-      url = `/api/user-orga-settings/${userId}`;
-      payload = {
+    it('should exist', async () => {
+      // given
+      sinon.stub(userOrgaSettingsController, 'createOrUpdate').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'PUT';
+      const url = `/api/user-orga-settings/${userId}`;
+      const payload = {
         data: {
           relationships: {
             organization: {
@@ -35,9 +29,7 @@ describe('Unit | Router | user-orga-settings-router', () => {
           },
         },
       };
-    });
 
-    it('should exist', async () => {
       // when
       const response = await httpTestServer.request(method, url, payload, auth);
 
@@ -49,7 +41,12 @@ describe('Unit | Router | user-orga-settings-router', () => {
 
       it('should be mandatory', async () => {
         // given
-        payload = undefined;
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'PUT';
+        const url = `/api/user-orga-settings/${userId}`;
+        const payload = undefined;
 
         // when
         const result = await httpTestServer.request(method, url, payload);
@@ -60,7 +57,23 @@ describe('Unit | Router | user-orga-settings-router', () => {
 
       it('should contain relationships.organization.data.id', async () => {
         // given
-        payload.data.relationships.organization.data.id = undefined;
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'PUT';
+        const url = `/api/user-orga-settings/${userId}`;
+        const payload = {
+          data: {
+            relationships: {
+              organization: {
+                data: {
+                  id: undefined,
+                  type: 'organizations',
+                },
+              },
+            },
+          },
+        };
 
         // when
         const response = await httpTestServer.request(method, url, payload);
@@ -71,7 +84,23 @@ describe('Unit | Router | user-orga-settings-router', () => {
 
       it('should contain relationships.organization.data.id as number', async () => {
         // given
-        payload.data.relationships.organization.data = { id: 'test' };
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'PUT';
+        const url = `/api/user-orga-settings/${userId}`;
+        const payload = {
+          data: {
+            relationships: {
+              organization: {
+                data: {
+                  id: 'test',
+                  type: 'organizations',
+                },
+              },
+            },
+          },
+        };
 
         // when
         const response = await httpTestServer.request(method, url, payload);

--- a/api/tests/unit/application/user-tutorials/index_test.js
+++ b/api/tests/unit/application/user-tutorials/index_test.js
@@ -1,33 +1,26 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 const userTutorialsController = require('../../../../lib/application/user-tutorials/user-tutorials-controller');
-
-let server;
-
-function startServer() {
-  server = Hapi.server();
-  return server.register(require('../../../../lib/application/user-tutorials'));
-}
+const moduleUnderTest = require('../../../../lib/application/user-tutorials');
 
 describe('Unit | Router | user-tutorials-router', () => {
 
   describe('PUT /api/users/tutorials/{tutorialId}', () => {
 
-    beforeEach(() => {
-      sinon.stub(userTutorialsController, 'add').
-        callsFake((request, h) => h.response().code(204));
-      startServer();
-    });
-
     it('should exist', async () => {
       // given
-      const options = {
-        method: 'PUT',
-        url: '/api/users/tutorials/{tutorialId}',
-      };
+      sinon.stub(userTutorialsController, 'add').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'PUT';
+      const url = '/api/users/tutorials/{tutorialId}';
 
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request(method, url);
 
       // then
       expect(userTutorialsController.add).have.been.called;
@@ -37,21 +30,17 @@ describe('Unit | Router | user-tutorials-router', () => {
 
   describe('GET /api/users/tutorials', () => {
 
-    beforeEach(() => {
-      sinon.stub(userTutorialsController, 'find').
-        callsFake((request, h) => h.response().code(200));
-      startServer();
-    });
-
     it('should exist', async () => {
       // given
-      const options = {
-        method: 'GET',
-        url: '/api/users/tutorials',
-      };
+      sinon.stub(userTutorialsController, 'find').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'GET';
+      const url = '/api/users/tutorials';
 
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request(method, url);
 
       // then
       expect(userTutorialsController.find).have.been.called;
@@ -61,21 +50,17 @@ describe('Unit | Router | user-tutorials-router', () => {
 
   describe('DELETE /api/users/tutorials/{tutorialId}', () => {
 
-    beforeEach(() => {
-      sinon.stub(userTutorialsController, 'removeFromUser').
-        callsFake((request, h) => h.response().code(204));
-      startServer();
-    });
-
     it('should exist', async () => {
       // given
-      const options = {
-        method: 'DELETE',
-        url: '/api/users/tutorials/tutorialId',
-      };
+      sinon.stub(userTutorialsController, 'removeFromUser').callsFake((request, h) => h.response().code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'DELETE';
+      const url = '/api/users/tutorials/tutorialId';
 
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request(method, url);
 
       // then
       expect(userTutorialsController.removeFromUser).have.been.called;

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -6,28 +6,19 @@ const userController = require('../../../../lib/application/users/user-controlle
 
 const moduleUnderTest = require('../../../../lib/application/users');
 
-let httpTestServer;
-
-async function startServer() {
-  const server = new HttpTestServer();
-  await server.register(moduleUnderTest);
-  return server;
-}
-
 describe('Unit | Router | user-router', () => {
 
   describe('GET /api/users', () => {
 
     const method = 'GET';
 
-    beforeEach(async () => {
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sinon.stub(userController, 'findPaginatedFilteredUsers').returns('ok');
-      httpTestServer = await startServer();
-    });
-
     it('should exist', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(userController, 'findPaginatedFilteredUsers').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/users?firstName=Bruce&lastName=Wayne&email=batman@gotham.city&page=3&pageSize=25';
 
       // when
@@ -43,15 +34,13 @@ describe('Unit | Router | user-router', () => {
     const method = 'POST';
     const url = '/api/users';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'save').returns('ok');
-      httpTestServer = await startServer();
-    });
-
     context('Payload schema validation', () => {
 
       it('should return HTTP 400 if payload does not exist', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const payload = null;
 
         // when
@@ -63,6 +52,10 @@ describe('Unit | Router | user-router', () => {
 
       it('should return HTTP 200 if payload is not empty and valid', async () => {
         // given
+        sinon.stub(userController, 'save').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const payload = { data: { attributes: {} } };
 
         // when
@@ -78,13 +71,12 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'getCurrentUser').returns('ok');
-      httpTestServer = await startServer();
-    });
-
     it('should exist', async () => {
       // given
+      sinon.stub(userController, 'getCurrentUser').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/users/me';
 
       // when
@@ -99,14 +91,13 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'getMemberships').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
-
     it('should exist', async () => {
       // given
+      sinon.stub(userController, 'getMemberships').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/users/12/memberships';
 
       // when
@@ -122,14 +113,13 @@ describe('Unit | Router | user-router', () => {
     const method = 'PATCH';
     const url = '/api/users/12344/password-update';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'updatePassword').returns('ok');
-      sinon.stub(userVerification, 'verifyById').returns('ok');
-      httpTestServer = await startServer();
-    });
-
     it('should exist and pass through user verification pre-handler', async () => {
       // given
+      sinon.stub(userController, 'updatePassword').returns('ok');
+      sinon.stub(userVerification, 'verifyById').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payloadAttributes = { password: 'Pix2019!' };
       const payload = { data: { attributes: payloadAttributes } };
 
@@ -145,6 +135,9 @@ describe('Unit | Router | user-router', () => {
 
       it('should have a payload', async () => {
         // when
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const result = await httpTestServer.request(method, url);
 
         // then
@@ -153,6 +146,9 @@ describe('Unit | Router | user-router', () => {
 
       it('should have a password attribute in payload', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const payload = { data: { attributes: {} } };
 
         // when
@@ -166,6 +162,9 @@ describe('Unit | Router | user-router', () => {
 
         it('should have a valid password format in payload', async () => {
           // given
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
           const payloadAttributes = {
             password: 'Mot de passe mal formé',
           };
@@ -186,13 +185,13 @@ describe('Unit | Router | user-router', () => {
     const method = 'GET';
     const url = '/api/users/42/is-certifiable';
 
-    beforeEach(async() => {
+    it('should exist', async () => {
+      // given
       sinon.stub(userController, 'isCertifiable').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
-    it('should exist', async () => {
       // when
       await httpTestServer.request(method, url);
 
@@ -206,13 +205,13 @@ describe('Unit | Router | user-router', () => {
     const method = 'GET';
     const url = '/api/users/42/profile';
 
-    beforeEach(async() => {
+    it('should exist', async () => {
+      // given
       sinon.stub(userController, 'getProfile').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
-    it('should exist', async () => {
       // when
       await httpTestServer.request(method, url);
 
@@ -225,14 +224,13 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'getUserProfileSharedForCampaign').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
-
     it('should return 200', async () => {
       // given
+      sinon.stub(userController, 'getUserProfileSharedForCampaign').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/users/12/campaigns/34/profile';
 
       // when
@@ -244,6 +242,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when userId is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const userId = 'wrongId';
       const url = `/api/users/${userId}/campaigns/34/profile`;
 
@@ -256,6 +257,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when campaignId is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const campaignId = 'wrongId';
       const url = `/api/users/12/campaigns/${campaignId}/profile`;
 
@@ -316,14 +320,13 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'GET';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'getUserCampaignParticipationToCampaign').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
-
     it('should return 200', async () => {
       // given
+      sinon.stub(userController, 'getUserCampaignParticipationToCampaign').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/users/12/campaigns/34/campaign-participations';
 
       // when
@@ -335,6 +338,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when userId is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const userId = 'wrongId';
       const url = `/api/users/${userId}/campaigns/34/campaign-participations`;
 
@@ -347,6 +353,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when campaignId is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const campaignId = 'wrongId';
       const url = `/api/users/12/campaigns/${campaignId}/campaign-participations`;
 
@@ -362,14 +371,13 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'PATCH';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'updateUserDetailsForAdministration').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
-
     it('should verify user identity and return sucess update', async () => {
       // given
+      sinon.stub(userController, 'updateUserDetailsForAdministration').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const userId = '12344';
       const url = `/api/admin/users/${userId}`;
       const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
@@ -390,6 +398,9 @@ describe('Unit | Router | user-router', () => {
 
       it('should return bad request when param id is not numeric', async () => {
         // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         const payload = { data: { attributes: { email: 'partial@update.net' } } };
 
         // when
@@ -400,6 +411,10 @@ describe('Unit | Router | user-router', () => {
       });
 
       it('should return bad request when payload is not found', async () => {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
         // when
         const result = await httpTestServer.request(method, url);
 
@@ -413,14 +428,13 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'POST';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'anonymizeUser').callsFake((request, h) => h.response({}).code(204));
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
-
     it('should exist', async () => {
       // given
+      sinon.stub(userController, 'anonymizeUser').callsFake((request, h) => h.response({}).code(204));
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/admin/users/1/anonymize';
 
       // when
@@ -432,6 +446,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when id is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/admin/users/wrongId/anonymize';
 
       // when
@@ -447,14 +464,13 @@ describe('Unit | Router | user-router', () => {
 
     const method = 'PATCH';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'dissociateSchoolingRegistrations').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
-
     it('should exist', async () => {
       // given
+      sinon.stub(userController, 'dissociateSchoolingRegistrations').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/admin/users/1/dissociate';
 
       // when
@@ -466,6 +482,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when id is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/admin/users/wrongId/dissociate';
 
       // when
@@ -479,16 +498,15 @@ describe('Unit | Router | user-router', () => {
 
   describe('POST /api/admin/users/{id}/remove-authentication', () => {
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
-
     ['GAR', 'EMAIL', 'USERNAME', 'POLE_EMPLOI']
       .forEach((type) => {
         it(`should return 200 when type is ${type}`, async () => {
           // given
+          sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+          sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
           const url = '/api/admin/users/1/remove-authentication';
           const payload = {
             data: {
@@ -508,6 +526,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when id is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/admin/users/wrongId/remove-authentication';
       const payload = {
         data: {
@@ -526,6 +547,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when type is not GAR or EMAIL or USERNAME or POLE_EMPLOI', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/admin/users/1/remove-authentication';
       const payload = {
         data: {

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -277,14 +277,13 @@ describe('Unit | Router | user-router', () => {
   describe('GET /api/users/{userId}/campaigns/{campaignId}/assessment-result', function() {
     const method = 'GET';
 
-    beforeEach(async() => {
-      sinon.stub(userController, 'getUserCampaignAssessmentResult').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      httpTestServer = await startServer();
-    });
-
     it('should return 200', async () => {
       // given
+      sinon.stub(userController, 'getUserCampaignAssessmentResult').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const url = '/api/users/12/campaigns/34/assessment-result';
 
       // when
@@ -296,6 +295,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when userId is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const userId = 'wrongId';
       const url = `/api/users/${userId}/campaigns/34/assessment-result`;
 
@@ -308,6 +310,9 @@ describe('Unit | Router | user-router', () => {
 
     it('should return 400 when campaignId is not a number', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const campaignId = 'wrongId';
       const url = `/api/users/12/campaigns/${campaignId}/assessment-result`;
 

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -1,9 +1,12 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const userVerification = require('../../../../lib/application/preHandlers/user-existence-verification');
 const userController = require('../../../../lib/application/users/user-controller');
-
 const moduleUnderTest = require('../../../../lib/application/users');
 
 describe('Unit | Router | user-router', () => {


### PR DESCRIPTION
## :unicorn: Problème
Suite de la [PR suivante](https://github.com/1024pix/pix/pull/3002) pour le nettoyage des tests unitaire existants pour les routes.

## :robot: Solution
Pour simplifier la review, ici je ne fait que supprimer les beforeEach existants sur ces tests.
D'autres PR seront prévues pour nettoyer le reste.

## :rainbow: Remarques

- Trois fichiers de tests (challenges, tutorial-evalutations et user-tutorials) n'utilisaient pas le [HttpTestServer mais encore le Hapi.server()](https://github.com/1024pix/pix/blob/dev/docs/adr/0024-tester-routeur-api.md), j'ai fait le changement ici. 

- Suppression des espaces inutiles en début de tests. 

Si cela complique la review, je supprimerais les deux commits liés à ces deux points, j'en ferais une autre PR.

## :100: Pour tester
Lancer les tests.
