### PR TITLE
[BUGFIX] Corriger le problème d'affichage du filtre de classes lorsqu'il n'y en a aucune (PIX-2605).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/participation-filters.js
+++ b/orga/app/components/routes/authenticated/campaign/participation-filters.js
@@ -38,7 +38,7 @@ export default class ParticipationFilters extends Component {
   }
 
   get isDivisionsLoaded() {
-    return this.args.campaign.divisions.content.isLoaded;
+    return this.args.campaign.divisions.content.length > 0;
   }
 
   get displayDivisionFilter() {

--- a/orga/tests/integration/components/routes/authenticated/campaign/participation-filters_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/participation-filters_test.js
@@ -33,52 +33,67 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       isSCOManagingStudents = true;
     }
 
-    test('it displays the division filter', async function(assert) {
-      this.owner.register('service:current-user', CurrentUserStub);
+    module('when there is no division', function() {
+      test('it should not display division filter', async function(assert) {
+        this.owner.register('service:current-user', CurrentUserStub);
+        const campaign = store.createRecord('campaign', { id: 1 });
+        campaign.set('divisions', []);
+        this.set('campaign', campaign);
 
-      // given
-      const division = store.createRecord('division', {
-        id: 'd1',
-        name: 'd1',
-      });
-      const campaign = store.createRecord('campaign', {
-        id: 1,
-      });
-      campaign.set('divisions', [division]);
-      this.set('campaign', campaign);
+        // when
+        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
 
-      // when
-      await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
-      // then
-      assert.contains('Classes');
-      assert.contains('d1');
+        // then
+        assert.notContains('Classes');
+      });
     });
 
-    test('it triggers the filter when a division is selected', async function(assert) {
-      this.owner.register('service:current-user', CurrentUserStub);
+    module('when there are some divisions', function() {
+      test('it displays the division filter', async function(assert) {
+        this.owner.register('service:current-user', CurrentUserStub);
 
-      // given
-      const division = store.createRecord('division', {
-        id: 'd1',
-        name: 'd1',
+        // given
+        const division = store.createRecord('division', {
+          id: 'd1',
+          name: 'd1',
+        });
+        const campaign = store.createRecord('campaign', { id: 1 });
+        campaign.set('divisions', [division]);
+        this.set('campaign', campaign);
+
+        // when
+        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+        // then
+        assert.contains('Classes');
+        assert.contains('d1');
       });
-      const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        stages: [],
+
+      test('it triggers the filter when a division is selected', async function(assert) {
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        // given
+        const division = store.createRecord('division', {
+          id: 'd1',
+          name: 'd1',
+        });
+        const campaign = store.createRecord('campaign', {
+          id: 1,
+          name: 'campagne 1',
+          stages: [],
+        });
+        campaign.set('divisions', [division]);
+
+        const triggerFiltering = sinon.stub();
+        this.set('campaign', campaign);
+        this.set('triggerFiltering', triggerFiltering);
+
+        // when
+        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} @triggerFiltering={{triggerFiltering}}/>`);
+        await click('[for="division-d1"]');
+
+        // then
+        assert.ok(triggerFiltering.calledWith({ divisions: ['d1'] }));
       });
-      campaign.set('divisions', [division]);
-
-      const triggerFiltering = sinon.stub();
-      this.set('campaign', campaign);
-      this.set('triggerFiltering', triggerFiltering);
-
-      // when
-      await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} @triggerFiltering={{triggerFiltering}}/>`);
-      await click('[for="division-d1"]');
-
-      // then
-      assert.ok(triggerFiltering.calledWith({ divisions: ['d1'] }));
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'il n'y a aucune classe (donc aucun participant en somme), le filtre sur la classe ne s'affiche pas avant d'avoir cliqué sur "effacer les filtres". Reproduction :

1. aller sur l'onglet "résultats collectifs"
2. cliquer sur l'onglet "participants"
3. Alors il n'y a pas de filtre "Classes"
4. cliquer sur "effacer les filtres"
5. Alors que le filtre "Classes" s'affiche désormais 🤪

## :robot: Solution
Gérer le cas.

## :rainbow: Remarques
RAS

## :100: Pour tester
Aller voir la campagne BADGES123 du sco (sco.admin@example.net) et faire la reproduction ci-dessus.
