### PR TITLE
[BUGFIX] Stocker les données d'authentification PE temporairement (PIX-2607).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -161,6 +161,10 @@ module.exports = (function() {
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
       userInfoUrl: process.env.POLE_EMPLOI_USER_INFO_URL,
+      temporaryStorage: {
+        expirationDelaySeconds: parseInt(process.env.POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 1140,
+        redisUrl: process.env.REDIS_URL,
+      },
     },
 
     graviteeRegisterApplicationsCredentials: [

--- a/api/lib/domain/models/PoleEmploiTokens.js
+++ b/api/lib/domain/models/PoleEmploiTokens.js
@@ -1,0 +1,15 @@
+class PoleEmploiTokens {
+  constructor({
+    accessToken,
+    idToken,
+    expiresIn,
+    refreshToken,
+  }) {
+    this.accessToken = accessToken;
+    this.idToken = idToken;
+    this.expiresIn = expiresIn;
+    this.refreshToken = refreshToken;
+  }
+}
+
+module.exports = PoleEmploiTokens;

--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -6,6 +6,8 @@ const httpAgent = require('../../infrastructure/http/http-agent');
 
 const { GeneratePoleEmploiTokensError } = require('../errors');
 
+const PoleEmploiTokens = require('../models/PoleEmploiTokens');
+
 const encryptionService = require('./encryption-service');
 const tokenService = require('./token-service');
 
@@ -45,12 +47,12 @@ async function generatePoleEmploiTokens({ code, clientId, redirectUri }) {
     throw new GeneratePoleEmploiTokensError(errorMessage, tokensResponse.code);
   }
 
-  return {
+  return new PoleEmploiTokens({
     accessToken: tokensResponse.data['access_token'],
     idToken: tokensResponse.data['id_token'],
     expiresIn: tokensResponse.data['expires_in'],
     refreshToken: tokensResponse.data['refresh_token'],
-  };
+  });
 }
 
 async function getPoleEmploiUserInfo(idToken) {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -77,6 +77,7 @@ const dependencies = {
   pixPlusDroitExpertCertificationResultRepository: require('../../infrastructure/repositories/pix-plus-droit-expert-certification-result-repository'),
   placementProfileService: require('../../domain/services/placement-profile-service'),
   poleEmploiSendingRepository: require('../../infrastructure/repositories/pole-emploi-sending-repository'),
+  poleEmploiTokensRepository: require('../../infrastructure/repositories/pole-emploi-tokens-repository'),
   prescriberRepository: require('../../infrastructure/repositories/prescriber-repository'),
   privateCertificateRepository: require('../../infrastructure/repositories/private-certificate-repository'),
   resetPasswordService: require('../../domain/services/reset-password-service'),

--- a/api/lib/infrastructure/repositories/pole-emploi-tokens-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-tokens-repository.js
@@ -1,0 +1,19 @@
+const settings = require('../../config');
+
+const temporaryStorage = require('../temporary-storage');
+
+const EXPIRATION_DELAY_SECONDS = settings.poleEmploi.temporaryStorage.expirationDelaySeconds;
+
+module.exports = {
+
+  save(poleEmploiTokens) {
+    return temporaryStorage.save({
+      value: poleEmploiTokens,
+      expirationDelaySeconds: EXPIRATION_DELAY_SECONDS,
+    });
+  },
+
+  getByKey(key) {
+    return temporaryStorage.get(key);
+  },
+};

--- a/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
@@ -1,0 +1,23 @@
+const NodeCache = require('node-cache');
+const { v4: uuidv4 } = require('uuid');
+const TemporaryStorage = require('./TemporaryStorage');
+
+class InMemoryTemporaryStorage extends TemporaryStorage {
+
+  constructor() {
+    super();
+    this._client = new NodeCache();
+  }
+
+  save({ value, expirationDelaySeconds }) {
+    const key = uuidv4();
+    this._client.set(key, value, expirationDelaySeconds);
+    return key;
+  }
+
+  get(key) {
+    return this._client.get(key);
+  }
+}
+
+module.exports = InMemoryTemporaryStorage;

--- a/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
@@ -1,0 +1,32 @@
+const { v4: uuidv4 } = require('uuid');
+
+const TemporaryStorage = require('./TemporaryStorage');
+const RedisClient = require('../utils/RedisClient');
+
+const EXPIRATION_PARAMETER = 'ex';
+
+class RedisTemporaryStorage extends TemporaryStorage {
+
+  constructor(redisUrl) {
+    super();
+    this._client = RedisTemporaryStorage.createClient(redisUrl);
+  }
+
+  static createClient(redisUrl) {
+    return new RedisClient(redisUrl, 'temporary-storage');
+  }
+
+  async save({ value, expirationDelaySeconds }) {
+    const key = uuidv4();
+    const objectAsString = JSON.stringify(value);
+    await this._client.set(key, objectAsString, EXPIRATION_PARAMETER, expirationDelaySeconds);
+    return key;
+  }
+
+  async get(key) {
+    const value = await this._client.get(key);
+    return JSON.parse(value);
+  }
+}
+
+module.exports = RedisTemporaryStorage;

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -1,0 +1,11 @@
+class TemporaryStorage {
+  async save(/* value, expirationDelaySeconds */) {
+    throw new Error('Method #save({ value, expirationDelaySeconds }) must be overridden');
+  }
+
+  async get(/* key */) {
+    throw new Error('Method #get(key) must be overridden');
+  }
+}
+
+module.exports = TemporaryStorage;

--- a/api/lib/infrastructure/temporary-storage/index.js
+++ b/api/lib/infrastructure/temporary-storage/index.js
@@ -1,0 +1,15 @@
+const settings = require('../../config');
+const REDIS_URL = settings.poleEmploi.temporaryStorage.redisUrl;
+
+const InMemoryTemporaryStorage = require('./InMemoryTemporaryStorage');
+const RedisTemporaryStorage = require('./RedisTemporaryStorage');
+
+function _createTemporaryStorage() {
+  if (REDIS_URL) {
+    return new RedisTemporaryStorage(REDIS_URL);
+  } else {
+    return new InMemoryTemporaryStorage();
+  }
+}
+
+module.exports = _createTemporaryStorage();

--- a/api/package.json
+++ b/api/package.json
@@ -127,7 +127,7 @@
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
-    "test:api:unit": "TEST_DATABASE_URL=bad_url npm run test:api:path -- tests/unit",
+    "test:api:unit": "TEST_DATABASE_URL=postgres://foo REDIS_URL=redis://bar npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-tokens-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-tokens-repository_test.js
@@ -1,0 +1,47 @@
+const { expect } = require('../../../test-helper');
+
+const PoleEmploiTokens = require('../../../../lib/domain/models/PoleEmploiTokens');
+const poleEmploiTokensRepository = require('../../../../lib/infrastructure/repositories/pole-emploi-tokens-repository');
+
+describe('Integration | Repository | PoleEmploiTokensRepository', () => {
+
+  describe('#save', () => {
+
+    it('should save PoleEmploiTokens and return a key', async () => {
+      // given
+      const poleEmploiTokens = new PoleEmploiTokens({
+        accessToken: 'accessToken',
+        idToken: 'idToken',
+        expiresIn: 10,
+        refreshToken: 'refreshToken',
+      });
+
+      // when
+      const key = await poleEmploiTokensRepository.save(poleEmploiTokens);
+
+      // then
+      expect(key).to.exist;
+    });
+  });
+
+  describe('#getByKey', () => {
+
+    it('should retrieve the PoleEmploiTokens if it exists', async () => {
+      // given
+      const poleEmploiTokens = new PoleEmploiTokens({
+        accessToken: 'accessToken',
+        idToken: 'idToken',
+        expiresIn: 10,
+        refreshToken: 'refreshToken',
+      });
+      const key = await poleEmploiTokensRepository.save(poleEmploiTokens);
+
+      // when
+      const result = await poleEmploiTokensRepository.getByKey(key);
+
+      // then
+      expect(result).to.be.an.instanceof(PoleEmploiTokens);
+      expect(result).to.deep.equal(poleEmploiTokens);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/PoleEmploiTokens_test.js
+++ b/api/tests/unit/domain/models/PoleEmploiTokens_test.js
@@ -1,0 +1,25 @@
+const { expect } = require('../../../test-helper');
+const PoleEmploiTokens = require('../../../../lib/domain/models/PoleEmploiTokens');
+
+describe('Unit | Domain | Models | PoleEmploiTokens', () => {
+
+  describe('#constructor', () => {
+
+    it('should construct a model PoleEmploiTokens from attributes', () => {
+      // given
+      const attributes = {
+        accessToken: 'accessToken',
+        idToken: 'idToken',
+        expiresIn: 60,
+        refreshToken: 'refreshToken',
+      };
+
+      // when
+      const poleEmploiTokens = new PoleEmploiTokens(attributes);
+
+      // then
+      expect(poleEmploiTokens).to.be.an.instanceof(PoleEmploiTokens);
+      expect(poleEmploiTokens).to.deep.equal(attributes);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -2,7 +2,9 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper
 
 const authenticatePoleEmploiUser = require('../../../../lib/domain/usecases/authenticate-pole-emploi-user');
 
+const PoleEmploiTokens = require('../../../../lib/domain/models/PoleEmploiTokens');
 const User = require('../../../../lib/domain/models/User');
+
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 const { UnexpectedUserAccountError, UnexpectedPoleEmploiStateError, UserAccountNotFoundForPoleEmploiError } = require('../../../../lib/domain/errors');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
@@ -51,7 +53,12 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
       set: sinon.stub().resolves() };
 
     authenticationService = {
-      generatePoleEmploiTokens: sinon.stub().resolves({ accessToken, idToken, expiresIn, refreshToken }),
+      generatePoleEmploiTokens: sinon.stub().resolves(new PoleEmploiTokens({
+        accessToken,
+        expiresIn,
+        idToken,
+        refreshToken,
+      })),
       getPoleEmploiUserInfo: sinon.stub().resolves(userInfo),
     };
 

--- a/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -1,0 +1,77 @@
+const NodeCache = require('node-cache');
+const { expect, sinon } = require('../../../test-helper');
+const InMemoryTemporaryStorage = require('../../../../lib/infrastructure/temporary-storage/InMemoryTemporaryStorage');
+
+describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage', () => {
+
+  describe('#constructor', () => {
+
+    it('should create an InMemoryTemporaryStorage instance', () => {
+      // when
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+
+      // then
+      expect(inMemoryTemporaryStorage._client).to.be.an.instanceOf(NodeCache);
+    });
+  });
+
+  describe('#save', () => {
+
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should resolve with the generated key', () => {
+      // given
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+
+      // when
+      const key = inMemoryTemporaryStorage.save({ value: {}, expirationDelaySeconds: 1000 });
+
+      // then
+      expect(key).to.exist;
+    });
+
+    it('should save key valu with a defined ttl in seconds', async () => {
+      // given
+      const TWO_MINUTES_IN_SECONDS = 2 * 60;
+      const TWO_MINUTES_IN_MILLISECONDS = 2 * 60 * 1000;
+
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+
+      // when
+      const key = await inMemoryTemporaryStorage.save({
+        value: { name: 'name' },
+        expirationDelaySeconds: TWO_MINUTES_IN_SECONDS,
+      });
+
+      // then
+      const expirationKeyInTimestamp = inMemoryTemporaryStorage._client.getTtl(key);
+      expect(expirationKeyInTimestamp).to.equal(TWO_MINUTES_IN_MILLISECONDS);
+    });
+  });
+
+  describe('#get', () => {
+
+    it('should retrieve the value if it exists', async () => {
+      // given
+      const value = { name: 'name' };
+      const expirationDelaySeconds = 1000;
+
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+      const key = await inMemoryTemporaryStorage.save({ value, expirationDelaySeconds });
+
+      // when
+      const result = await inMemoryTemporaryStorage.get(key);
+
+      // then
+      expect(result).to.deep.equal(value);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -1,0 +1,73 @@
+const { expect, sinon } = require('../../../test-helper');
+const RedisTemporaryStorage = require('../../../../lib/infrastructure/temporary-storage/RedisTemporaryStorage');
+
+describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', () => {
+
+  const REDIS_URL = 'redis_url';
+
+  let clientStub;
+
+  beforeEach(() => {
+    clientStub = {
+      get: sinon.stub(),
+      set: sinon.stub(),
+    };
+
+    sinon.stub(RedisTemporaryStorage, 'createClient')
+      .withArgs(REDIS_URL)
+      .returns(clientStub);
+  });
+
+  describe('#constructor', () => {
+
+    it('should call static method createClient', () => {
+      // when
+      const redisTemporaryStorage = new RedisTemporaryStorage(REDIS_URL);
+
+      // then
+      expect(RedisTemporaryStorage.createClient).to.have.been.called;
+      expect(redisTemporaryStorage._client).to.exist;
+    });
+  });
+
+  describe('#save', () => {
+
+    it('should call client set with value and EX parameters', async () => {
+      // given
+      const EXPIRATION_PARAMETER = 'ex';
+      const value = { name: 'name' };
+      const expirationDelaySeconds = 1000;
+      clientStub.set.resolves();
+      const redisTemporaryStorage = new RedisTemporaryStorage(REDIS_URL);
+
+      // when
+      await redisTemporaryStorage.save({ value, expirationDelaySeconds });
+
+      // then
+      expect(clientStub.set).to.have.been.calledWith(
+        sinon.match.any,
+        JSON.stringify(value),
+        EXPIRATION_PARAMETER,
+        expirationDelaySeconds,
+      );
+    });
+  });
+
+  describe('#get', () => {
+
+    it('should call client set and retrieve value', async () => {
+      // given
+      const key = 'valueKey';
+      const value = { name: 'name' };
+      clientStub.get.withArgs(key).resolves(JSON.stringify(value));
+      const redisTemporaryStorage = new RedisTemporaryStorage(REDIS_URL);
+
+      // when
+      const result = await redisTemporaryStorage.get(key);
+
+      // then
+      expect(clientStub.get).to.have.been.called;
+      expect(result).to.deep.equal(value);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -1,0 +1,34 @@
+const { expect } = require('../../../test-helper');
+const TemporaryStorage = require('../../../../lib/infrastructure/temporary-storage/TemporaryStorage');
+
+describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', () => {
+
+  describe('#save', () => {
+
+    it('should reject an error (because this class actually mocks an interface)', () => {
+      // given
+      const temporaryStorageInstance = new TemporaryStorage();
+
+      // when
+      const result = temporaryStorageInstance.save({ value: {}, expirationDelaySeconds: 1000 });
+
+      // then
+      expect(result).to.be.rejected;
+    });
+  });
+
+  describe('#get', () => {
+
+    it('should reject an error (because this class actually mocks an interface)', () => {
+      // given
+      const temporaryStorageInstance = new TemporaryStorage();
+
+      // when
+      const result = temporaryStorageInstance.get('key');
+
+      // then
+      expect(result).to.be.rejected;
+    });
+  });
+
+});

--- a/docs/adr/0023-suppression-du-support-mailjet-pour-le-mailing.md
+++ b/docs/adr/0023-suppression-du-support-mailjet-pour-le-mailing.md
@@ -1,4 +1,4 @@
-# 21. Suppression du support Mailjet pour le mailing
+# 23. Suppression du support Mailjet pour le mailing
 
 Date : 2021-02-26
 

--- a/docs/adr/0024-encapsuler-appel-http.md
+++ b/docs/adr/0024-encapsuler-appel-http.md
@@ -1,4 +1,4 @@
-# 23. Faut-il encapsuler les appels http dans l'API ?
+# 24. Faut-il encapsuler les appels http dans l'API ?
 
 Date : 2020-04-22
 

--- a/docs/adr/0025-precisions-sur-les-transactions-et-les-evenements-metier.md
+++ b/docs/adr/0025-precisions-sur-les-transactions-et-les-evenements-metier.md
@@ -1,4 +1,4 @@
-# 23. Précision sur les transactions et les événements métier
+# 25. Précision sur les transactions et les événements métier
 
 ## État
 

--- a/docs/adr/0026-tester-routeur-api.md
+++ b/docs/adr/0026-tester-routeur-api.md
@@ -1,4 +1,4 @@
-# 24. Comment tester le routeur API ?
+# 26. Comment tester le routeur API ?
 
 Date : 2021-04-16
 

--- a/docs/adr/0027-stocker-temporairement-api.md
+++ b/docs/adr/0027-stocker-temporairement-api.md
@@ -1,0 +1,100 @@
+# 27. Comment stocker temporairement des données dans l'API ?
+
+Date : 2021-05-28
+
+## État
+Adopté
+
+## Contexte 
+
+### Besoin fonctionnel
+
+Nous avons besoin de stocker des données PE entre le moment où l'utilisateur :
+- se connecte à son compte PE;
+- accepte les CGU Pix, ce qui mène à la création de son compte Pix.
+
+Ces données PE :
+- sont issues du protocole OpenID, et ne peuvent être stockées dans le front;
+- sont obtenues par un appel à l'API externe Pôle emploi;
+- sont volatiles : au bout d'un certain temps, elles ne sont plus utilisables;
+- peuvent n'être jamais lues, par exemple si l'utilisateur refuse les CGU
+
+### Besoin technique
+
+Nous avons besoin de partager des données volatiles entre deux appels API.
+
+Les données seront : 
+- écrites une fois;
+- supprimées automatiquement au bout d'un certain délai
+
+### Recherche de solution
+
+Les appels à l'API externe Pôle emploi peuvent être opérés par des conteneurs API PIX différents, 
+et les conteneurs étant par définition `stateless`, il n'est pas possible de stocker des données PE. 
+- On ne peut pas stocker des données dans la mémoire du conteneur API PIX
+- On ne peut pas stocker des données sur le filesystem du conteneur API PIX
+
+Il faut donc stocker ces données en dehors des conteneurs API PIX.
+
+Les données peuvent être stockées dans la base de données, mais leur caractère volatile
+et la possibilité qu'elles ne soient jamais lues, confèrent de nombreux inconvénients 
+à cette solution.
+
+Les solutions restantes reposent sur le data-store [redis](https://en.wikipedia.org/wiki/Redis),
+extérieur aux conteneurs API PIX et déjà utilisé.
+
+L'utilisation existante est un [cache](./0005-ajout-d-un-cache-memoire-distribute-pour-le-contenu-pedagogique.md).
+Il ne répond pas totalement à notre demande, car un cache :
+- est conçu pour être lu de nombreuses fois;
+- ne possède pas de mécanisme d'expiration si la donnée n'est plus utilisable
+
+Par contre, le data-store lui-même offre les fonctionnalités suivantes :
+- Sauvegarder une donnée pendant une certaine période, indiquée par un délai d'expiration (nombre de secondes) [cf. EX](https://redis.io/commands/set)
+
+Deux possibilités s'offrent à nous :
+- créer un composant dédié qui invoquera ces commandes sur le data-store;
+- modifier le cache pour qu'il ne les invoque que dans un cas particulier
+
+### Solution 1 : créer un composant dédié
+
+Utiliser la class `RedisClient` 
+
+Implémenter un composant avec le contrat suivant :
+- `save`: écrire une clef avec une durée d'expiration;
+- `get`: lire une clef
+ 
+Avantage :
+- explicite le comportement (pas de mention du cache)
+
+Inconvénient :
+- coût de développement d'un nouveau composant
+
+### Solution 2 : modifier la solution de cache existante
+
+Modifier la solution existante de [cache](./0005-ajout-d-un-cache-memoire-distribute-pour-le-contenu-pedagogique.md)
+pour fournir un délai d'expiration.
+
+Garder le contrat pour les clients existants.
+
+Modifier le contrat pour un nouveau client :
+- `set`: écrire une clef avec une durée d'expiration;
+- `get`: lire une clef puis la supprimer
+
+Avantages :
+- le comportement attendu est contre-intuitif (le composant se nomme cache);
+- pas de développement d'un nouveau composant
+
+Inconvénient :
+- couplage: risque de régression, d'évolutions hors scope
+
+## Décision
+
+La solution n°1 est adoptée, car elle est la plus maintenable
+
+## Conséquences
+
+Création d'un dossier `temporary-storage` sous le dossier `infrastructure`.
+
+Afin de gérer les changements de délai d'expiration de l'API externe 
+sans modifier le code, celui-ci sera paramétrable dans une variable d'environnement.
+Celle-ci aura une valeur par défaut correspondant au délai connu à ce jour.


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de stocker des données PE entre le moment où l'utilisateur :
- se connecte à son compte PE
- accepte les CGU Pix, ce qui mène à la création de son compte Pix

L'implémentation d'utilisation existante est un [cache](./0005-ajout-d-un-cache-memoire-distribute-pour-le-contenu-pedagogique.md), en l'occurence [authentication-cache](https://github.com/1024pix/pix/blob/dev/api/lib/infrastructure/caches/authentication-cache.js).

Cela ne correspond pas au besoin et entraîne une saturation de Redis avec des informations inutiles et périmées.

## :robot: Solution
Remplacer le cache par un stockage volatile, voir l'ADR correspondant.

## :rainbow: Remarques
* Côté API, création d'une variable d'env : `POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS`
* Suppression de la connexion Redis pour les TU via une variable d'environnement incorrecte
* Cela serait intéressant d'introduire un builder pour Redis

## :100: Pour tester

### Outillage
Pour se connecter en CLI :
- local : utiliser docker compose
  ```sh
  docker compose exec redis redis-cli
  ``` 
Pour lister les données PE, utiliser [KEYS](https://redis.io/commands/KEYS) : 

 `KEYS *` donne par exemple `"97f4b855-81df-4365-ac02-d2201cb7b616"`

Pour obtenir la durée de vie restante, utiliser [TTL](https://redis.io/commands/TTL)

`TTL "97f4b855-81df-4365-ac02-d2201cb7b616"` donne par exemple
- ` (integer) 30 ` si 30 secondes
- ` (integer) -1 ` si éternelle
- ` (integer) -2 ` si périmée

### Scénario
Scénario nominal
- se connecter avec un compte PE inconnu
- accepter les CGU
- vérifier dans Redis que la donnée n'est plus là

Péremption des données non utilisées :
- se connecter avec un compte PE inconnu
- refuser les CGU ou fermer la fenêtre (il y a un courant d'air)
- vérifier dans Redis que la donnée disparaît au bout du délai d'expiration
