### PR TITLE
[BUGFIX] Corriger le calcul du taux de repro (PIX-2651)

### DIFF
--- a/api/lib/domain/models/AnswerCollectionForScoring.js
+++ b/api/lib/domain/models/AnswerCollectionForScoring.js
@@ -2,16 +2,18 @@ const _ = require('lodash');
 const qrocmDepChallenge = 'QROCM-dep';
 
 module.exports = class AnswerCollectionForScoring {
-  constructor(answers) {
+  constructor(answers, challenges) {
     this.answers = answers;
+    this.challenges = challenges;
   }
 
   static from({ answers, challenges }) {
-    const answersForScoring = challenges.map((challenge) => {
-      const answer = _.find(answers, { challengeId: challenge.challengeId });
+    const answersForScoring = answers.map((answer) => {
+      const challenge = challenges.find((challenge) => answer.challengeId === challenge.challengeId);
       return new AnswerForScoring(answer, challenge);
     });
-    return new AnswerCollectionForScoring(answersForScoring);
+    const challengesForScoring = challenges.map((challenge) => new ChallengeForScoring(challenge));
+    return new AnswerCollectionForScoring(answersForScoring, challengesForScoring);
   }
 
   numberOfCorrectAnswers() {
@@ -37,9 +39,9 @@ module.exports = class AnswerCollectionForScoring {
   }
 
   numberOfChallengesForCompetence(competenceId) {
-    const answersForCompetence = this.answers.filter((answer) => answer.competenceId() === competenceId);
-    const numberOfChallenges = _(answersForCompetence).map((answer) => {
-      if (answersForCompetence.length < 3 && answer.isQROCMdep()) {
+    const challengesForCompetence = this.challenges.filter((challenge) => challenge.competenceId() === competenceId);
+    const numberOfChallenges = _(challengesForCompetence).map((challenge) => {
+      if (challengesForCompetence.length < 3 && challenge.isQROCMdep()) {
         return 2;
       } else {
         return 1;
@@ -109,6 +111,26 @@ class AnswerForScoring {
   isNeutralized() {
     return this.challenge.isNeutralized;
   }
+
+  competenceId() {
+    return this.challenge.competenceId;
+  }
+}
+
+class ChallengeForScoring {
+  constructor(challenge) {
+    this.challenge = challenge;
+  }
+
+  isQROCMdep() {
+    const challengeType = this.challenge ? this.challenge.type : '';
+    return challengeType === qrocmDepChallenge;
+  }
+
+  isNeutralized() {
+    return this.challenge.isNeutralized;
+  }
+
   competenceId() {
     return this.challenge.competenceId;
   }

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -55,18 +55,6 @@ class CertificationChallenge {
       certifiableBadgeKey,
     });
   }
-
-  neutralize() {
-    this.isNeutralized = true;
-  }
-
-  deneutralize() {
-    this.isNeutralized = false;
-  }
-
-  isPixPlus() {
-    return Boolean(this.certifiableBadgeKey);
-  }
 }
 
 module.exports = CertificationChallenge;

--- a/api/lib/domain/models/CertificationChallengeWithType.js
+++ b/api/lib/domain/models/CertificationChallengeWithType.js
@@ -1,0 +1,33 @@
+class CertificationChallengeWithType {
+  constructor({
+    id,
+    associatedSkillName,
+    challengeId,
+    type,
+    competenceId,
+    isNeutralized,
+    certifiableBadgeKey,
+  } = {}) {
+    this.id = id;
+    this.associatedSkillName = associatedSkillName;
+    this.challengeId = challengeId;
+    this.type = type;
+    this.competenceId = competenceId;
+    this.isNeutralized = isNeutralized;
+    this.certifiableBadgeKey = certifiableBadgeKey;
+  }
+
+  neutralize() {
+    this.isNeutralized = true;
+  }
+
+  deneutralize() {
+    this.isNeutralized = false;
+  }
+
+  isPixPlus() {
+    return Boolean(this.certifiableBadgeKey);
+  }
+}
+
+module.exports = CertificationChallengeWithType;

--- a/api/lib/domain/models/CertificationChallengeWithType.js
+++ b/api/lib/domain/models/CertificationChallengeWithType.js
@@ -1,3 +1,5 @@
+const { Type } = require('./Challenge');
+
 class CertificationChallengeWithType {
   constructor({
     id,
@@ -11,7 +13,10 @@ class CertificationChallengeWithType {
     this.id = id;
     this.associatedSkillName = associatedSkillName;
     this.challengeId = challengeId;
-    this.type = type;
+    const possibleTypeValues = Object.values(Type);
+    this.type = possibleTypeValues.includes(type)
+      ? type
+      : 'EmptyType';
     this.competenceId = competenceId;
     this.isNeutralized = isNeutralized;
     this.certifiableBadgeKey = certifiableBadgeKey;

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 
 const CertificationContract = require('../../domain/models/CertificationContract');
 const scoringService = require('./scoring/scoring-service');
-const challengeRepository = require('../../infrastructure/repositories/challenge-repository');
 const competenceRepository = require('../../infrastructure/repositories/competence-repository');
 const placementProfileService = require('./placement-profile-service');
 const { CertifiedLevel } = require('../models/CertifiedLevel');
@@ -135,7 +134,6 @@ async function _getTestedCompetences({ userId, limitDate, isV2Certification }) {
 module.exports = {
   async getCertificationResult({ certificationAssessment, continueOnError }) {
     const allPixCompetences = await competenceRepository.listPixCompetencesOnly();
-    const allChallenges = await challengeRepository.findOperative();
 
     // userService.getPlacementProfile() + filter level > 0 => avec allCompetence (bug)
     const testedCompetences = await _getTestedCompetences({
@@ -146,12 +144,6 @@ module.exports = {
 
     // map sur challenges filtre sur competence Id - S'assurer qu'on ne travaille que sur les compétences certifiables
     const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.certificationChallenges, testedCompetences);
-
-    // decoration des challenges en ajoutant le type
-    matchingCertificationChallenges.forEach((certifChallenge) => {
-      const challenge = _.find(allChallenges, { id: certifChallenge.challengeId });
-      certifChallenge.type = challenge ? challenge.type : 'EmptyType';
-    });
 
     // map sur challenges filtre sur challenge Id
     const matchingAnswers = _selectAnswersMatchingCertificationChallenges(certificationAssessment.certificationAnswersByDate, matchingCertificationChallenges);

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const DomainTransaction = require('../DomainTransaction');
 const CertificationAssessment = require('../../domain/models/CertificationAssessment');
-const CertificationChallenge = require('../../domain/models/CertificationChallenge');
+const CertificationChallengeWithType = require('../../domain/models/CertificationChallengeWithType');
 const Answer = require('../../domain/models/Answer');
 const answerStatusDatabaseAdapter = require('../adapters/answer-status-database-adapter');
 const { knex } = require('../bookshelf');
@@ -10,12 +10,14 @@ const { NotFoundError } = require('../../domain/errors');
 async function _getCertificationChallenges(certificationCourseId, knexConn) {
   const certificationChallengeRows = await knexConn('certification-challenges')
     .where({ courseId: certificationCourseId })
-    .orderBy('id', 'asc');
+    .orderBy('challengeId', 'asc');
 
-  return _.map(certificationChallengeRows, (certificationChallengeRow) => new CertificationChallenge({
-    ...certificationChallengeRow,
-    associatedSkillName: certificationChallengeRow.associatedSkill,
-  }));
+  return _.map(certificationChallengeRows, (certificationChallengeRow) => {
+    return new CertificationChallengeWithType({
+      ...certificationChallengeRow,
+      type: null,
+    });
+  });
 }
 
 async function _getCertificationAnswersByDate(certificationAssessmentId, knexConn) {

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -3,19 +3,22 @@ const DomainTransaction = require('../DomainTransaction');
 const CertificationAssessment = require('../../domain/models/CertificationAssessment');
 const CertificationChallengeWithType = require('../../domain/models/CertificationChallengeWithType');
 const Answer = require('../../domain/models/Answer');
+const challengeRepository = require('./challenge-repository');
 const answerStatusDatabaseAdapter = require('../adapters/answer-status-database-adapter');
 const { knex } = require('../bookshelf');
 const { NotFoundError } = require('../../domain/errors');
 
 async function _getCertificationChallenges(certificationCourseId, knexConn) {
+  const allChallenges = await challengeRepository.findOperative();
   const certificationChallengeRows = await knexConn('certification-challenges')
     .where({ courseId: certificationCourseId })
     .orderBy('challengeId', 'asc');
 
   return _.map(certificationChallengeRows, (certificationChallengeRow) => {
+    const challenge = _.find(allChallenges, { id: certificationChallengeRow.challengeId });
     return new CertificationChallengeWithType({
       ...certificationChallengeRow,
-      type: null,
+      type: challenge?.type,
     });
   });
 }

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -80,8 +80,6 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
     context('when the certification assessment exists', () => {
       let firstAnswerInTime;
       let secondAnswerInTime;
-      let firstChallengeId;
-      let secondChallengeId;
 
       beforeEach(() => {
         const dbf = databaseBuilder.factory;
@@ -109,8 +107,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
           createdAt: new Date('2020-06-24T00:00:00Z'),
         }).id;
 
-        secondChallengeId = dbf.buildCertificationChallenge({ courseId: certificationCourseId, id: 123 }).id;
-        firstChallengeId = dbf.buildCertificationChallenge({ courseId: certificationCourseId, id: 456 }).id;
+        dbf.buildCertificationChallenge({ challengeId: 'recChalA', courseId: certificationCourseId, id: 123 });
+        dbf.buildCertificationChallenge({ challengeId: 'recChalB', courseId: certificationCourseId, id: 456 });
 
         return databaseBuilder.commit();
       });
@@ -144,7 +142,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId });
 
         // then
-        expect(_.map(certificationAssessment.certificationChallenges, 'id')).to.deep.equal([secondChallengeId, firstChallengeId]);
+        expect(_.map(certificationAssessment.certificationChallenges, 'challengeId')).to.deep.equal(['recChalA', 'recChalB']);
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-assessment.js
@@ -1,5 +1,5 @@
 const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
-const buildCertificationChallenge = require('./build-certification-challenge');
+const buildCertificationChallengeWithType = require('./build-certification-challenge-with-type');
 
 module.exports = function buildCertificationAssessment(
   {
@@ -10,7 +10,7 @@ module.exports = function buildCertificationAssessment(
     completedAt = new Date('2020-01-01'),
     state = CertificationAssessment.states.STARTED,
     isV2Certification = true,
-    certificationChallenges = [buildCertificationChallenge()],
+    certificationChallenges = [buildCertificationChallengeWithType()],
     certificationAnswersByDate = [],
   } = {}) {
   return new CertificationAssessment({

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge-with-type.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge-with-type.js
@@ -1,0 +1,23 @@
+const CertificationChallengeWithType = require('../../../../lib/domain/models/CertificationChallengeWithType');
+const Challenge = require('../../../../lib/domain/models/Challenge');
+
+module.exports = function buildCertificationChallengeWithType({
+  id = 123,
+  challengeId = 'recCHAL',
+  competenceId = 'recCOMP',
+  type = Challenge.Type.QCU,
+  associatedSkillName = 'cueillir des fleurs',
+  isNeutralized = false,
+  certifiableBadgeKey = null,
+} = {}) {
+
+  return new CertificationChallengeWithType({
+    id,
+    challengeId,
+    competenceId,
+    associatedSkillName,
+    type,
+    isNeutralized,
+    certifiableBadgeKey,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -26,6 +26,7 @@ module.exports = {
   buildCertificationCenter: require('./build-certification-center'),
   buildCertificationCenterMembership: require('./build-certification-center-membership'),
   buildCertificationChallenge: require('./build-certification-challenge'),
+  buildCertificationChallengeWithType: require('./build-certification-challenge-with-type'),
   buildCertificationCourse: require('./build-certification-course'),
   buildCertificationDetails: require('./build-certification-details'),
   buildCertificationPointOfContact: require('./build-certification-point-of-contact'),

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -24,8 +24,8 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       state: CertificationAssessment.states.STARTED,
       isV2Certification: true,
       certificationChallenges: [
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
       ],
       certificationAnswersByDate: ['answer'],
     });
@@ -141,8 +141,8 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       state: CertificationAssessment.states.STARTED,
       isV2Certification: true,
       certificationChallenges: [
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
       ],
       certificationAnswersByDate: ['answer'],
     });

--- a/api/tests/unit/domain/events/handle-pix-plus-certifications-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-pix-plus-certifications-scoring_test.js
@@ -50,8 +50,8 @@ describe('Unit | Domain | Events | handle-pix-plus-certifications-scoring', () =
         certificationCourseId: 123,
         userId: 456,
         createdAt: new Date('2020-01-01'),
-        certificationChallenges: [domainBuilder.buildCertificationChallenge({ certifiableBadgeKey: null, challengeId: 'chal1' })],
-        certificationAnswersByDate: [domainBuilder.buildCertificationChallenge({ challengeId: 'chal1' })],
+        certificationChallenges: [domainBuilder.buildCertificationChallengeWithType({ certifiableBadgeKey: null, challengeId: 'chal1' })],
+        certificationAnswersByDate: [domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1' })],
       });
       certificationAssessmentRepository.getByCertificationCourseId
         .withArgs({ certificationCourseId: 123 })
@@ -73,8 +73,8 @@ describe('Unit | Domain | Events | handle-pix-plus-certifications-scoring', () =
         certificationCourseId: 123,
         userId: 456,
       });
-      const certificationChallengeMangue = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_MANGUE' });
-      const certificationChallengePasteque = domainBuilder.buildCertificationChallenge({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_PASTEQUE' });
+      const certificationChallengeMangue = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_MANGUE' });
+      const certificationChallengePasteque = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_PASTEQUE' });
       const certificationAnswerMangue = domainBuilder.buildAnswer({ challengeId: 'chal1' });
       const certificationAnswerPasteque = domainBuilder.buildAnswer({ challengeId: 'chal2' });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -106,7 +106,7 @@ describe('Unit | Domain | Events | handle-pix-plus-certifications-scoring', () =
           certificationCourseId: 123,
           userId: 456,
         });
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_MANGUE' });
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_MANGUE' });
         const certificationAnswer = domainBuilder.buildAnswer.ok({ challengeId: 'chal1' });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationCourseId: 123,
@@ -141,8 +141,8 @@ describe('Unit | Domain | Events | handle-pix-plus-certifications-scoring', () =
           certificationCourseId: 123,
           userId: 456,
         });
-        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_MANGUE' });
-        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_MANGUE' });
+        const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_MANGUE' });
+        const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_MANGUE' });
         const certificationAnswer1 = domainBuilder.buildAnswer.ko({ challengeId: 'chal1' });
         const certificationAnswer2 = domainBuilder.buildAnswer.ok({ challengeId: 'chal2' });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -178,8 +178,8 @@ describe('Unit | Domain | Events | handle-pix-plus-certifications-scoring', () =
           certificationCourseId: 123,
           userId: 456,
         });
-        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_MANGUE' });
-        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_MANGUE' });
+        const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_MANGUE' });
+        const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_MANGUE' });
         const certificationAnswer1 = domainBuilder.buildAnswer.ok({ challengeId: 'chal1' });
         const certificationAnswer2 = domainBuilder.buildAnswer.ok({ challengeId: 'chal2' });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({

--- a/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
@@ -587,7 +587,5 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
 });
 
 function _buildDecoratedCertificationChallenge({ challengeId, type, isNeutralized, competenceId }) {
-  const challenge = domainBuilder.buildCertificationChallenge({ challengeId, isNeutralized, competenceId });
-  challenge.type = type; // TODO : CertificationChallenge are decorated with type in certification-result-service, find a better way.
-  return challenge;
+  return domainBuilder.buildCertificationChallengeWithType({ type, challengeId, isNeutralized, competenceId });
 }

--- a/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
@@ -58,7 +58,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       expect(numberOfChallenges).to.equal(2);
     });
 
-    it('counts answered as well as unanswered challenges indifferently', () => {
+    it('counts only answered challenges and ignore unanswered ones', () => {
       // given
       const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1', type: 'QCM' });
       const challenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', type: 'QCM' });
@@ -73,7 +73,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       const numberOfChallenges = answerCollection.numberOfNonNeutralizedChallenges();
 
       // then
-      expect(numberOfChallenges).to.equal(3);
+      expect(numberOfChallenges).to.equal(0);
     });
   });
   context('#numberOfCorrectAnswers', () => {
@@ -292,21 +292,19 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       expect(numberOfChallenges).to.equal(3);
     });
 
-    it('counts answered as well as unanswered challenges indifferently for given competence', () => {
+    it('counts all challenges with or without answer for given competence', () => {
       // given
       const aCompetenceId = 'recIdOfACompetence';
       const anotherCompetenceId = 'recIdOfAnotherCompetence';
       const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1', competenceId: aCompetenceId, type: 'QCM' });
-      const challenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', competenceId: aCompetenceId, type: 'QCM' });
+      const challenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', competenceId: anotherCompetenceId, type: 'QCM' });
       const challenge3 = _buildDecoratedCertificationChallenge({ challengeId: 'chal3', competenceId: aCompetenceId, type: 'QCM' });
 
-      const challenge4 = _buildDecoratedCertificationChallenge({ challengeId: 'chal4', competenceId: anotherCompetenceId, type: 'QCM' });
-      const challenge5 = _buildDecoratedCertificationChallenge({ challengeId: 'chal5', competenceId: anotherCompetenceId, type: 'QCM' });
-      const answer4 = domainBuilder.buildAnswer({ challengeId: challenge4.challengeId });
-      const answer5 = domainBuilder.buildAnswer({ challengeId: challenge5.challengeId });
+      const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.challengeId });
+      const answer2 = domainBuilder.buildAnswer({ challengeId: challenge2.challengeId });
 
       const answerCollection = AnswerCollectionForScoring.from({
-        answers: [answer4, answer5],
+        answers: [answer1, answer2],
         challenges: [challenge1, challenge2, challenge3],
       });
 
@@ -314,7 +312,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       const numberOfChallenges = answerCollection.numberOfChallengesForCompetence(aCompetenceId);
 
       // then
-      expect(numberOfChallenges).to.equal(3);
+      expect(numberOfChallenges).to.equal(2);
     });
   });
   context('#numberOfCorrectAnswersForCompetence', () => {
@@ -331,7 +329,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       const answer3 = domainBuilder.buildAnswer({ challengeId: challenge3.challengeId });
       const answerCollection = AnswerCollectionForScoring.from({
         answers: [answer1, answer2, answer3],
-        challenges: [],
+        challenges: [challenge1, challenge2, challenge3],
       });
 
       // when

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -102,8 +102,8 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('returns the challenge for the given challengeId', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1234' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1234' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456' });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge1, certificationChallenge2],
@@ -118,8 +118,8 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('returns null if no certification challenge exists for challengeId', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1234' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1234' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456' });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge1, certificationChallenge2],
@@ -138,7 +138,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('neutralizes the challenge when the challenge was asked', () => {
       // given
-      const challengeToBeNeutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1', isNeutralized: false });
+      const challengeToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
       const certificationAssessment = new CertificationAssessment({
         id: 123,
@@ -150,8 +150,8 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
         isV2Certification: true,
         certificationChallenges: [
           challengeToBeNeutralized,
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec2', isNeutralized: false }),
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec3', isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec2', isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: false }),
         ],
         certificationAnswersByDate: ['answer'],
       });
@@ -167,7 +167,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('throws when the challenge was not asked', async () => {
       // given
-      const challengeNotAskedToBeNeutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1', isNeutralized: false });
+      const challengeNotAskedToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
       const certificationAssessment = new CertificationAssessment({
         id: 123,
@@ -178,8 +178,8 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
         state: CertificationAssessment.states.STARTED,
         isV2Certification: true,
         certificationChallenges: [
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec2', isNeutralized: false }),
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec3', isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec2', isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: false }),
         ],
         certificationAnswersByDate: ['answer'],
       });
@@ -194,7 +194,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('deneutralizes the challenge when the challenge was asked', () => {
       // given
-      const challengeToBeDeneutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1', isNeutralized: true });
+      const challengeToBeDeneutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: true });
 
       const certificationAssessment = new CertificationAssessment({
         id: 123,
@@ -206,8 +206,8 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
         isV2Certification: true,
         certificationChallenges: [
           challengeToBeDeneutralized,
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec2', isNeutralized: true }),
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec3', isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec2', isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: true }),
         ],
         certificationAnswersByDate: ['answer'],
       });
@@ -223,7 +223,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('throws when the challenge was not asked', async () => {
       // given
-      const challengeNotAskedToBeDeneutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1', isNeutralized: false });
+      const challengeNotAskedToBeDeneutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
       const certificationAssessment = new CertificationAssessment({
         id: 123,
@@ -234,8 +234,8 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
         state: CertificationAssessment.states.STARTED,
         isV2Certification: true,
         certificationChallenges: [
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec2', isNeutralized: false }),
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec3', isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec2', isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: false }),
         ],
         certificationAnswersByDate: ['answer'],
       });
@@ -250,7 +250,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('should neutralize the challenge when the answer is ko', () => {
       // given
-      const challengeKoToBeNeutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1', isNeutralized: false });
+      const challengeKoToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,
@@ -278,7 +278,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('should neutralize the challenge when the answer is skipped', () => {
       // given
-      const challengeSkippedToBeNeutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'rec3', isNeutralized: false });
+      const challengeSkippedToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: false });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,
@@ -306,7 +306,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('should not neutralize the challenge when the answer is neither skipped nor ko', () => {
       // given
-      const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'rec3', isNeutralized: false });
+      const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: false });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,
@@ -343,8 +343,8 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
         state: CertificationAssessment.states.STARTED,
         isV2Certification: true,
         certificationChallenges: [
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec2', isNeutralized: false }),
-          domainBuilder.buildCertificationChallenge({ challengeId: 'rec3', isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec2', isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: false }),
         ],
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({ challengeId: 'rec2', result: AnswerStatus.KO.status, assessmentId: CertificationAssessment.id }),
@@ -364,10 +364,10 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('returns the certifiable badge keys of those taken during this certification', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_2' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_1' });
-      const certificationChallenge3 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal3', certifiableBadgeKey: 'BADGE_2' });
-      const certificationChallenge4 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal4', certifiableBadgeKey: null });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_2' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_1' });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal3', certifiableBadgeKey: 'BADGE_2' });
+      const certificationChallenge4 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal4', certifiableBadgeKey: null });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge1, certificationChallenge2, certificationChallenge3, certificationChallenge4],
@@ -386,7 +386,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('returns an empty array if no certifiable badge exam was taken', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: null });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1', certifiableBadgeKey: null });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge1],
@@ -404,10 +404,10 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('returns the answers and challenges for a certifiableBadgeKey', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_1' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_2' });
-      const certificationChallenge3 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal3', certifiableBadgeKey: 'BADGE_1' });
-      const certificationChallenge4 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal4', certifiableBadgeKey: null });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_1' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal2', certifiableBadgeKey: 'BADGE_2' });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal3', certifiableBadgeKey: 'BADGE_1' });
+      const certificationChallenge4 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal4', certifiableBadgeKey: null });
       const certificationAnswer1 = domainBuilder.buildAnswer({ challengeId: 'chal1' });
       const certificationAnswer2 = domainBuilder.buildAnswer({ challengeId: 'chal2' });
       const certificationAnswer3 = domainBuilder.buildAnswer({ challengeId: 'chal3' });
@@ -428,7 +428,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('returns empty arrays if there are no answers nor challenges for given key', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_1' });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'chal1', certifiableBadgeKey: 'BADGE_1' });
       const certificationAnswer1 = domainBuilder.buildAnswer({ challengeId: 'chal1' });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({

--- a/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
+++ b/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
@@ -1,0 +1,79 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | CertificationChallengeWithType', () => {
+
+  describe('#neutralize', () => {
+
+    it('should neutralize a non neutralized certification challenge', () => {
+      // given
+      const certificationChallengeWithType = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false });
+
+      // when
+      certificationChallengeWithType.neutralize();
+
+      // then
+      expect(certificationChallengeWithType.isNeutralized).to.be.true;
+    });
+
+    it('should leave a neutralized certification challenge if it was neutralized already', () => {
+      // given
+      const certificationChallengeWithType = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true });
+
+      // when
+      certificationChallengeWithType.neutralize();
+
+      // then
+      expect(certificationChallengeWithType.isNeutralized).to.be.true;
+    });
+  });
+
+  describe('#deneutralize', () => {
+
+    it('should deneutralize a neutralized certification challenge', () => {
+      // given
+      const certificationChallengeWithType = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true });
+
+      // when
+      certificationChallengeWithType.deneutralize();
+
+      // then
+      expect(certificationChallengeWithType.isNeutralized).to.be.false;
+    });
+
+    it('should leave a deneutralized certification challenge if it was deneutralized already', () => {
+      // given
+      const certificationChallengeWithType = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false });
+
+      // when
+      certificationChallengeWithType.deneutralize();
+
+      // then
+      expect(certificationChallengeWithType.isNeutralized).to.be.false;
+    });
+  });
+
+  describe('#isPixPlus', () => {
+
+    it('return true when challenge was picked for a pix plus certification', () => {
+      // given
+      const certificationChallengeWithType = domainBuilder.buildCertificationChallengeWithType({ certifiableBadgeKey: 'someValue' });
+
+      // when
+      const isPixPlus = certificationChallengeWithType.isPixPlus();
+
+      // then
+      expect(isPixPlus).to.be.true;
+    });
+
+    it('return false when challenge was picked for a regular pix certification', () => {
+      // given
+      const certificationChallengeWithType = domainBuilder.buildCertificationChallengeWithType({ certifiableBadgeKey: null });
+
+      // when
+      const isPixPlus = certificationChallengeWithType.isPixPlus();
+
+      // then
+      expect(isPixPlus).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
+++ b/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
@@ -1,6 +1,30 @@
 const { expect, domainBuilder } = require('../../../test-helper');
+const CertificationChallengeWithType = require('../../../../lib/domain/models/CertificationChallengeWithType');
+const { Type } = require('../../../../lib/domain/models/Challenge');
 
 describe('Unit | Domain | Models | CertificationChallengeWithType', () => {
+
+  describe('#constructor', () => {
+
+    const validTypes = Object.values(Type);
+    validTypes.forEach((validType) => {
+      it(`should initialize CertificationChallengeWithType with type ${validType}`, () => {
+        // when
+        const certificationChallengeWithType = new CertificationChallengeWithType({ type: validType });
+
+        // then
+        expect(certificationChallengeWithType.type).to.equal(validType);
+      });
+    });
+
+    it('should initialize type to EmptyType when type is not valid', () => {
+      // when
+      const certificationChallengeWithType = new CertificationChallengeWithType({ type: 'COUCOUCOUCOCUCUO' });
+
+      // then
+      expect(certificationChallengeWithType.type).to.equal('EmptyType');
+    });
+  });
 
   describe('#neutralize', () => {
 

--- a/api/tests/unit/domain/models/CertificationChallenge_test.js
+++ b/api/tests/unit/domain/models/CertificationChallenge_test.js
@@ -1,57 +1,7 @@
-const { expect, domainBuilder } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const CertificationChallenge = require('../../../../lib/domain/models/CertificationChallenge');
 
 describe('Unit | Domain | Models | CertificationChallenge', () => {
-
-  describe('#neutralize', () => {
-
-    it('should neutralize a non neutralized certification challenge', () => {
-      // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ isNeutralized: false });
-
-      // when
-      certificationChallenge.neutralize();
-
-      // then
-      expect(certificationChallenge.isNeutralized).to.be.true;
-    });
-
-    it('should leave a neutralized certification challenge if it was neutralized already', () => {
-      // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ isNeutralized: true });
-
-      // when
-      certificationChallenge.neutralize();
-
-      // then
-      expect(certificationChallenge.isNeutralized).to.be.true;
-    });
-  });
-
-  describe('#deneutralize', () => {
-
-    it('should deneutralize a neutralized certification challenge', () => {
-      // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ isNeutralized: true });
-
-      // when
-      certificationChallenge.deneutralize();
-
-      // then
-      expect(certificationChallenge.isNeutralized).to.be.false;
-    });
-
-    it('should leave a deneutralized certification challenge if it was deneutralized already', () => {
-      // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ isNeutralized: false });
-
-      // when
-      certificationChallenge.deneutralize();
-
-      // then
-      expect(certificationChallenge.isNeutralized).to.be.false;
-    });
-  });
 
   describe('#static createForPixCertification', () => {
 
@@ -116,31 +66,6 @@ describe('Unit | Domain | Models | CertificationChallenge', () => {
         certifiableBadgeKey,
       });
       expect(certificationChallenge).to.deep.equal(expectedCertificationChallenge);
-    });
-  });
-
-  describe('#isPixPlus', () => {
-
-    it('return true when challenge was picked for a pix plus certification', () => {
-      // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ certifiableBadgeKey: 'someValue' });
-
-      // when
-      const isPixPlus = certificationChallenge.isPixPlus();
-
-      // then
-      expect(isPixPlus).to.be.true;
-    });
-
-    it('return false when challenge was picked for a regular pix certification', () => {
-      // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ certifiableBadgeKey: null });
-
-      // when
-      const isPixPlus = certificationChallenge.isPixPlus();
-
-      // then
-      expect(isPixPlus).to.be.false;
     });
   });
 });

--- a/api/tests/unit/domain/read-models/CertificationDetails_test.js
+++ b/api/tests/unit/domain/read-models/CertificationDetails_test.js
@@ -7,7 +7,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
   describe('static #from', () => {
     it('should return a CertificationDetails', () => {
       // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });
+      const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123' });
       const answer = domainBuilder.buildAnswer({ challengeId: 'rec123' });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,
@@ -34,7 +34,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
 
     it('should return a totalScore which is the sum of competence marks score', () => {
       // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });
+      const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123' });
       const answer = domainBuilder.buildAnswer({ challengeId: 'rec123' });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge],
@@ -59,9 +59,9 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
 
     it('should return a percentageCorrectAnswers using the reproducibility calculation', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123' });
       const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456' });
       const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456' });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge1, certificationChallenge2],
@@ -79,9 +79,9 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
 
     it('should take into account neutralized challenges when compution the reproducibility rate', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', isNeutralized: true });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123', isNeutralized: true });
       const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456' });
       const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456' });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge1, certificationChallenge2],
@@ -99,7 +99,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
 
     it('should create competencesWithMark', () => {
       // given
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });
+      const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123' });
       const answer = domainBuilder.buildAnswer({ challengeId: 'rec123' });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge],
@@ -147,9 +147,9 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
 
       it('should create listChallengesAndAnswers', () => {
         // given
-        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: true });
+        const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: true });
         const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
-        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit', isNeutralized: false });
+        const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit', isNeutralized: false });
         const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456', value: 'bidule' });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge1, certificationChallenge2],
@@ -191,9 +191,9 @@ describe('Unit | Domain | Read-models | CertificationDetails', () => {
 
       it('should ignore challenges that do not have answer', () => {
         // given
-        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: true });
+        const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: true });
         const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
-        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit', isNeutralized: true });
+        const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit', isNeutralized: true });
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge1, certificationChallenge2],
           certificationAnswersByDate: [answer1],

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -3,7 +3,6 @@ const { expect, sinon, domainBuilder } = require('../../../../test-helper');
 const certificationResultService = require('../../../../../lib/domain/services/certification-result-service');
 const CertificationAssessment = require('../../../../../lib/domain/models/CertificationAssessment');
 const { states } = require('../../../../../lib/domain/models/CertificationAssessment');
-const challengeRepository = require('../../../../../lib/infrastructure/repositories/challenge-repository');
 const competenceRepository = require('../../../../../lib/infrastructure/repositories/competence-repository');
 const placementProfileService = require('../../../../../lib/domain/services/placement-profile-service');
 const UserCompetence = require('../../../../../lib/domain/models/UserCompetence');
@@ -79,37 +78,20 @@ const answersWithReproducibilityRateLessThan80 = () => _.map([
   { challengeId: 'challenge_L_for_competence_4', result: 'ok' },
 ], domainBuilder.buildAnswer);
 
-const challengesFromLearningContent = _.map([
-  { id: 'challenge_A_for_competence_1', competenceId: 'competence_1', type: 'QCM' },
-  { id: 'challenge_B_for_competence_1', competenceId: 'competence_1', type: 'QCM' },
-  { id: 'challenge_C_for_competence_1', competenceId: 'competence_1', type: 'QCM' },
-  { id: 'challenge_D_for_competence_2', competenceId: 'competence_2', type: 'QCM' },
-  { id: 'challenge_E_for_competence_2', competenceId: 'competence_2', type: 'QCM' },
-  { id: 'challenge_F_for_competence_2', competenceId: 'competence_2', type: 'QCM' },
-  { id: 'challenge_G_for_competence_3', competenceId: 'competence_3', type: 'QCM' },
-  { id: 'challenge_H_for_competence_3', competenceId: 'competence_3', type: 'QCM' },
-  { id: 'challenge_I_for_competence_3', competenceId: 'competence_3', type: 'QCM' },
-  { id: 'challenge_J_for_competence_4', competenceId: 'competence_4', type: 'QCM' },
-  { id: 'challenge_K_for_competence_4', competenceId: 'competence_4', type: 'QCM' },
-  { id: 'challenge_L_for_competence_4', competenceId: 'competence_4', type: 'QCM' },
-  { id: 'challenge_M_for_competence_5', competenceId: 'competence_5', type: 'QCM' },
-  { id: 'challenge_N_for_competence_6', competenceId: 'competence_6', type: 'QCM' },
-], domainBuilder.buildChallenge);
-
 const challenges = _.map([
-  { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1' },
-  { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeC_1' },
-  { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeB_1' },
-  { challengeId: 'challenge_D_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeD_2' },
-  { challengeId: 'challenge_E_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeE_2' },
-  { challengeId: 'challenge_F_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeF_2' },
-  { challengeId: 'challenge_G_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeG_3' },
-  { challengeId: 'challenge_H_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeH_3' },
-  { challengeId: 'challenge_I_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeI_3' },
-  { challengeId: 'challenge_J_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeJ_4' },
-  { challengeId: 'challenge_K_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeK_4' },
-  { challengeId: 'challenge_L_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeL_4' },
-], domainBuilder.buildCertificationChallenge);
+  { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1', type: 'QCM' },
+  { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeC_1', type: 'QCM' },
+  { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeB_1', type: 'QCM' },
+  { challengeId: 'challenge_D_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeD_2', type: 'QCM' },
+  { challengeId: 'challenge_E_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeE_2', type: 'QCM' },
+  { challengeId: 'challenge_F_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeF_2', type: 'QCM' },
+  { challengeId: 'challenge_G_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeG_3', type: 'QCM' },
+  { challengeId: 'challenge_H_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeH_3', type: 'QCM' },
+  { challengeId: 'challenge_I_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeI_3', type: 'QCM' },
+  { challengeId: 'challenge_J_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeJ_4', type: 'QCM' },
+  { challengeId: 'challenge_K_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeK_4', type: 'QCM' },
+  { challengeId: 'challenge_L_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeL_4', type: 'QCM' },
+], domainBuilder.buildCertificationChallengeWithType);
 
 const competence_1 = domainBuilder.buildCompetence({ id: 'competence_1', index: '1.1', area: { code: '1' }, name: 'Mener une recherche' });
 const competence_2 = domainBuilder.buildCompetence({ id: 'competence_2', index: '2.2', area: { code: '2' }, name: 'Partager' });
@@ -202,7 +184,6 @@ describe('Unit | Service | Certification Result Service', function() {
         });
 
         sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves(allPixCompetencesFromLearningContent);
-        sinon.stub(challengeRepository, 'findOperative').resolves(challengesFromLearningContent);
         sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
@@ -216,14 +197,6 @@ describe('Unit | Service | Certification Result Service', function() {
 
         // then
         sinon.assert.calledOnce(placementProfileService.getPlacementProfile);
-      });
-
-      it('should retrieve validated challenges', async () => {
-        // when
-        await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
-
-        // then
-        sinon.assert.calledOnce(challengeRepository.findOperative);
       });
 
       it('should retrieve competences list', async () => {
@@ -625,7 +598,7 @@ describe('Unit | Service | Certification Result Service', function() {
                 { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1' },
                 { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeB_1' },
                 { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeC_1' },
-              ], domainBuilder.buildCertificationChallenge);
+              ], domainBuilder.buildCertificationChallengeWithType);
 
               const userCompetences = [
                 _buildUserCompetence(competence_1, positionedScore, positionedLevel),
@@ -662,20 +635,11 @@ describe('Unit | Service | Certification Result Service', function() {
         certificationAssessment.certificationAnswersByDate = wrongAnswersForAllChallenges();
         certificationAssessment.certificationChallenges = challenges;
         sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves(allPixCompetencesFromLearningContent);
-        sinon.stub(challengeRepository, 'findOperative').resolves(challengesFromLearningContent);
         sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
           isV2Certification: certificationAssessment.isV2Certification,
         }).resolves({ userCompetences });
-      });
-
-      it('should retrieve challenges list', async () => {
-        // when
-        await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
-
-        // then
-        sinon.assert.calledOnce(challengeRepository.findOperative);
       });
 
       it('should retrieve competences list', async () => {
@@ -954,12 +918,6 @@ describe('Unit | Service | Certification Result Service', function() {
       context('when only one challenge is asked for a competence', () => {
         it('certifies a level below the estimated one if reproducibility rate is < 70%', async () => {
           // given
-          const listChallengeComp5WithTwoChallenges = _.map([
-            { id: 'challenge_A_for_competence_5', competenceId: 'competence_5', type: 'QCM' },
-            { id: 'challenge_A_for_competence_6', competenceId: 'competence_6', type: 'QCM' },
-            { id: 'challenge_B_for_competence_6', competenceId: 'competence_6', type: 'QCM' },
-            { id: 'challenge_C_for_competence_6', competenceId: 'competence_6', type: 'QCM' },
-          ], domainBuilder.buildChallenge);
           const userCompetences = [
             _buildUserCompetence(competence_5, 50, 5),
             _buildUserCompetence(competence_6, 36, 3),
@@ -969,12 +927,10 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_A_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeA_6' },
             { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeB_6' },
             { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6' },
-          ], domainBuilder.buildCertificationChallenge);
+          ], domainBuilder.buildCertificationChallengeWithType);
           certificationAssessment.certificationChallenges = challenges;
 
-          challengeRepository.findOperative.restore();
           placementProfileService.getPlacementProfile.restore();
-          sinon.stub(challengeRepository, 'findOperative').resolves(listChallengeComp5WithTwoChallenges);
           sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
             userId: certificationAssessment.userId,
             limitDate: certificationAssessment.createdAt,
@@ -1019,31 +975,21 @@ describe('Unit | Service | Certification Result Service', function() {
 
       context('when challenges contains one QROCM-dep challenge to validate two skills', () => {
         beforeEach(() => {
-          const listChallengeComp5WithOneQROCMDEPChallengeAndAnother = _.map([
-            { id: 'challenge_A_for_competence_5', competenceId: 'competence_5', type: 'QCM' },
-            { id: 'challenge_B_for_competence_5', competenceId: 'competence_5', type: 'QROCM-dep' },
-            { id: 'challenge_A_for_competence_6', competenceId: 'competence_6', type: 'QCM' },
-            { id: 'challenge_B_for_competence_6', competenceId: 'competence_6', type: 'QCM' },
-            { id: 'challenge_C_for_competence_6', competenceId: 'competence_6', type: 'QCM' },
-          ], domainBuilder.buildChallenge);
-
           const userCompetences = [
             _buildUserCompetence(competence_5, 50, 5),
             _buildUserCompetence(competence_6, 36, 3),
           ];
 
           const challenges = _.map([
-            { challengeId: 'challenge_A_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeA_5' },
-            { challengeId: 'challenge_B_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeB_5' },
-            { challengeId: 'challenge_A_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeA_6' },
-            { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeB_6' },
-            { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6' },
-          ], domainBuilder.buildCertificationChallenge);
+            { challengeId: 'challenge_A_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeA_5', type: 'QCM' },
+            { challengeId: 'challenge_B_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeB_5', type: 'QROCM-dep' },
+            { challengeId: 'challenge_A_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeA_6', type: 'QCM' },
+            { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeB_6', type: 'QCM' },
+            { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6', type: 'QCM' },
+          ], domainBuilder.buildCertificationChallengeWithType);
           certificationAssessment.certificationChallenges = challenges;
 
-          challengeRepository.findOperative.restore();
           placementProfileService.getPlacementProfile.restore();
-          sinon.stub(challengeRepository, 'findOperative').resolves(listChallengeComp5WithOneQROCMDEPChallengeAndAnother);
           sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
             userId: certificationAssessment.userId,
             limitDate: certificationAssessment.createdAt,
@@ -1138,7 +1084,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
             { challengeId: 'challenge_M_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeM_5' },
             { challengeId: 'challenge_N_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeN_6' },
-          ], domainBuilder.buildCertificationChallenge);
+          ], domainBuilder.buildCertificationChallengeWithType);
           certificationAssessment.certificationChallenges = challenges;
 
           const answers = _.map([

--- a/api/tests/unit/domain/usecases/deneutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/deneutralize-challenge_test.js
@@ -19,12 +19,12 @@ describe('Unit | UseCase | deneutralize-challenge', () => {
       certificationAssessmentRepository,
     };
 
-    const challengeToBeDeneutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: true });
+    const challengeToBeDeneutralized = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true });
     const certificationAssessment = domainBuilder.buildCertificationAssessment({
       certificationChallenges: [
         challengeToBeDeneutralized,
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
       ],
     });
     sinon.stub(certificationAssessment, 'deneutralizeChallengeByRecId');
@@ -57,7 +57,7 @@ describe('Unit | UseCase | deneutralize-challenge', () => {
       certificationAssessmentRepository,
     };
 
-    const challengeToBeDeneutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: true });
+    const challengeToBeDeneutralized = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
@@ -68,8 +68,8 @@ describe('Unit | UseCase | deneutralize-challenge', () => {
       isV2Certification: true,
       certificationChallenges: [
         challengeToBeDeneutralized,
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
       ],
       certificationAnswersByDate: ['answer'],
     });

--- a/api/tests/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-details_test.js
@@ -25,7 +25,7 @@ describe('Unit | UseCase | get-certification-details', () => {
     it('should compute the certification details on the fly', async () => {
       // given
       const certificationCourseId = 1234;
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({
+      const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({
         challengeId: 'rec123',
         competenceId: 'recComp1',
         associatedSkillName: 'manger une mangue',
@@ -98,7 +98,7 @@ describe('Unit | UseCase | get-certification-details', () => {
     it('should return the certification details', async () => {
       // given
       const certificationCourseId = 1234;
-      const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: false });
+      const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: false });
       const answer = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({

--- a/api/tests/unit/domain/usecases/neutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/neutralize-challenge_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | neutralize-challenge', () => {
       certificationAssessmentRepository,
     };
 
-    const challengeToBeNeutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: false });
+    const challengeToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
@@ -30,8 +30,8 @@ describe('Unit | UseCase | neutralize-challenge', () => {
       isV2Certification: true,
       certificationChallenges: [
         challengeToBeNeutralized,
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
       ],
       certificationAnswersByDate: ['answer'],
     });
@@ -64,7 +64,7 @@ describe('Unit | UseCase | neutralize-challenge', () => {
       certificationAssessmentRepository,
     };
 
-    const challengeToBeNeutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: false });
+    const challengeToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
@@ -75,8 +75,8 @@ describe('Unit | UseCase | neutralize-challenge', () => {
       isV2Certification: true,
       certificationChallenges: [
         challengeToBeNeutralized,
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
       ],
       certificationAnswersByDate: ['answer'],
     });


### PR DESCRIPTION
## :unicorn: Problème

Le calcul du taux de repro pour une certification démarrée mais non terminée présente un problème : il se base le nombre de questions posées alors qu'il devrait se baser sur le nombre de questions répondues.

## :robot: Solution

Corriger le calcul pour prendre en compte uniquement le nombre de questions répondues.

## :rainbow: Remarques

*RAS*

## :100: Pour tester

1. Entrer en session de certification, répondre OK à quelques questions, et d'autre en KO
2. Ne PAS terminer le test afin que la certif reste au statut "Démarrée"
3. Aller dans Pix Admin sur la page de détails de la certif
4. Constater que le taux de repro est correctement calculé devrait être calculé selon la formule suivante : nombre de questions OK / nbre de questions répondues

+ Test de non-regression sur le passage de la certification
