### PR TITLE
Optimisation livret scolaire (PIX-2659)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -4,8 +4,8 @@ const { knex } = require('../bookshelf');
 module.exports = {
 
   async getCertificatesByOrganizationUAI(uai) {
-    const withName = 'last-certifications';
-    const result = await knex.with(withName, knex.select(
+
+    const result = await knex.select(
       {
         id: 'certification-courses.id',
         firstName: 'schooling-registrations.firstName',
@@ -50,12 +50,10 @@ module.exports = {
       .where('certification-courses.isCancelled', '=', false)
       .where('schooling-registrations.organizationId', '=', knex.select('id').from('organizations').whereRaw('LOWER("externalId") = LOWER(?)', uai))
 
-      .groupBy('schooling-registrations.id', 'certification-courses.id', 'sessions.id', 'assessments.id', 'assessment-results.id'),
-    )
-      .select(knex.ref('*').withSchema(withName))
-      .from(withName)
-      .orderBy(`${withName}.lastName`, 'ASC')
-      .orderBy(`${withName}.firstName`, 'ASC');
+      .groupBy('schooling-registrations.id', 'certification-courses.id', 'sessions.id', 'assessments.id', 'assessment-results.id')
+
+      .orderBy('lastName', 'ASC')
+      .orderBy('firstName', 'ASC');
 
     return result.map(Certificate.from);
   },

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -30,14 +30,13 @@ module.exports = {
         .select(knex.raw('\'[\' || (string_agg(\'{ "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\') over (partition by "assessment-results".id)) || \']\' as "competenceResultsJson"'))
         .from('certification-courses')
         .innerJoin('schooling-registrations', 'schooling-registrations.userId', 'certification-courses.userId')
-        .innerJoin('organizations', 'schooling-registrations.organizationId', 'organizations.id')
         .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
         .innerJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
         .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
         .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
         .modify(_filterMostRecentCertificationCourse)
         .where('certification-courses.isCancelled', '=', false)
-        .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai),
+        .where('schooling-registrations.organizationId', '=', knex.select('id').from('organizations').whereRaw('LOWER("externalId") = LOWER(?)', uai)),
     )
       .select(knex.ref('*').withSchema(withName))
       .from(withName)

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -4,7 +4,6 @@ const { knex } = require('../bookshelf');
 module.exports = {
 
   async getCertificatesByOrganizationUAI(uai) {
-
     const result = await knex.select(
       {
         id: 'certification-courses.id',
@@ -20,10 +19,7 @@ module.exports = {
         certificationCenter: 'sessions.certificationCenter',
         isPublished: 'certification-courses.isPublished',
         status: 'assessment-results.status',
-        assessmentResultsCreatedAt: 'assessment-results.createdAt',
         pixScore: 'assessment-results.pixScore',
-        userId: 'schooling-registrations.userId',
-        assessmentId: 'assessments.id',
       },
     )
       .select(knex.raw('\'[\' || (string_agg(\'{ "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\')) || \']\' as "competenceResultsJson"'))
@@ -53,7 +49,8 @@ module.exports = {
       .groupBy('schooling-registrations.id', 'certification-courses.id', 'sessions.id', 'assessments.id', 'assessment-results.id')
 
       .orderBy('lastName', 'ASC')
-      .orderBy('firstName', 'ASC');
+      .orderBy('firstName', 'ASC')
+      .orderBy('id', 'ASC');
 
     return result.map(Certificate.from);
   },


### PR DESCRIPTION
## :unicorn: Problème
La requête pour le livret scolaire prends trop de temps.

## :robot: Solution
- Mettre à jour la récupération de l'organisation via son id et non directement son externalID
- Supprimer la jointure inutile de l'organisation
- Remplacer le `DISTINCT` par un `group by` ce qui est beaucoup plus rapide pour PG
- Remplacer les sous requêtes qui filtre les dernières certifs et derniers `assessment-results` par des `NOT EXISTS`

## :rainbow: Remarques
Les corrections font suite à une analyse du query plan par @jonathanperret.
Le query plan est visible sur [explain.depesz](https://explain.depesz.com/s/P3xX).

> le filtre LOWER("organizations"."externalId")= LOWER('6200002H') est encore plus coûteux qu’il n’en a l’air, parce qu’en plus d’interdire l’utilisation d’un éventuel index sur externalId (qui d’ailleurs n’existe pas !), il amène l’optimiseur PG à scanner toutes les `certification-courses`, associer les  `schooling-registrations` correspondantes, trouver l’organisation et enfin appliquer le filtre sur `externalId` 😮 . Résultat, plus d’une seconde de temps d’exécution quelle que soit l’organisation demandée (y compris si elle n’existe pas !)
> • quand on remplace ce critère par `organizations.id = ( select id from "organizations" where LOWER("externalId") = LOWER('0382495F') )` on voit le plan se “retourner” : PG commence par résoudre le `organizationId` avec un scan de `organizations` (mais ça ne coûte que 5ms environ), puis il va trouver les `schooling-registrations` correspondant à cette orga et donc dès le départ on a massivement restreint le jeu de données. C’est ce changement qui fait passer la requête (sur pix-datawarehouse) de 1200ms à 15ms environ.
> • on gagne encore un pouillème en enlevant la jointure sur `organizations` et en écrivant directement `"schooling-registrations"."organizationId" = ( select id from "organizations" where LOWER("externalId") = LOWER('0382495F') ) `: ça évite un Index Scan à chaque ligne, qui vérifie que l’orga existe bien (alors qu’il y a une contrainte donc forcément elle existe)
> • on simplifie encore le plan en se débarrassant du `DISTINCT` (et de la window function) au profit d’un `GROUP BY "certification-courses"."id", "schooling-registrations"."id", "sessions"."id", "assessments"."id", "assessment-results".id` (il est suffisant de grouper sur ces colonnes car toutes les autres qui sont utilisées se dérivent de ces clés primaires)
> • pour ne garder que le dernier assessment-result on remplace le `LEFT JOIN… WHERE id IS NULL par un WHERE NOT EXISTS(…)` qui est sémantiquement équivalent mais qui apparaît dans le plan comme une Anti Join ce qui est bien ce qu’on veut, et a priori c’est bon signe que PG ait compris ce qu’on voulait (mais on a du mal à voir la différence dans le temps d’exécution parce que ça ne s’applique que sur les quelques dizaines de lignes qui restent à ce stade). On fait pareil sur l’autre filtre du même genre.
> • enfin pour garantir la stabilité de l’ordre des résultats, c’est bien d’ajouter un `"LAST-certifications".id` au `ORDER BY `principal afin d’éviter un ordre aléatoire au cas où deux élèves auraient le même couple nom+prénom.

## :100: Pour tester
Les tests du repository sont suffisants pour valider cette PR de refacto/optimisation.
