### PR TITLE
[TECH] Séparer les routes commune d'Orga et Admin sur les memberships (PIX-2533).

### DIFF
--- a/admin/app/adapters/membership.js
+++ b/admin/app/adapters/membership.js
@@ -1,6 +1,7 @@
 import ApplicationAdapter from './application';
 
 export default class MembershipAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
 
   updateRecord(store, type, snapshot) {
     if (snapshot.adapterOptions && snapshot.adapterOptions.disable) {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -88,7 +88,7 @@ export default function() {
     });
   });
 
-  this.post('/memberships', createMembership);
+  this.post('/admin/memberships', createMembership);
   this.get('/organizations');
   this.get('/organizations/:id');
   this.get('/organizations/:id/memberships', findPaginatedOrganizationMemberships);

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -137,7 +137,7 @@ export default function() {
     return schema.organizationInvitations.where({ email });
   });
 
-  this.patch('/memberships/:id', (schema, request) => {
+  this.patch('/admin/memberships/:id', (schema, request) => {
     const membershipId = request.params.id;
     const params = JSON.parse(request.requestBody);
     const organizationRole = params.data.attributes['organization-role'];
@@ -146,7 +146,7 @@ export default function() {
     return membership.update({ organizationRole });
   });
 
-  this.post('/memberships/:id/disable', (schema, request) => {
+  this.post('/admin/memberships/:id/disable', (schema, request) => {
     const membershipId = request.params.id;
 
     const membership = schema.memberships.findBy({ id: membershipId });

--- a/admin/tests/unit/adapters/membership_test.js
+++ b/admin/tests/unit/adapters/membership_test.js
@@ -6,8 +6,10 @@ module('Unit | Adapter | membership', function(hooks) {
   setupTest(hooks);
 
   let adapter;
+  let store;
 
   hooks.beforeEach(function() {
+    store = this.owner.lookup('service:store');
     adapter = this.owner.lookup('adapter:membership');
     sinon.stub(adapter, 'ajax').resolves();
   });
@@ -18,15 +20,27 @@ module('Unit | Adapter | membership', function(hooks) {
 
   module('#updateRecord', function() {
 
+    test('it should trigger a PATCH request to /admin/memberships/{id}', async function(assert) {
+      // when
+      const serializer = { serializeIntoHash: sinon.stub().returns() };
+      store.serializerFor = sinon.stub().returns(serializer);
+
+      await adapter.updateRecord(store, { modelName: 'membership' }, { id: 1 });
+
+      // then
+      sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/admin/memberships/1', 'PATCH', { data: {} });
+      assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+    });
+
     module('when disabled adapter option is provided', function() {
 
-      test('it should trigger a POST request to /memberships/{id}/disable', async function(assert) {
+      test('it should trigger a POST request to /admin/memberships/{id}/disable', async function(assert) {
         // when
         const data = Symbol('membership');
         await adapter.updateRecord({}, { modelName: 'membership' }, { id: 1, adapterOptions: { disable: true }, serialize: sinon.stub().returns(data) });
 
         // then
-        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/memberships/1/disable', 'POST', { data });
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/admin/memberships/1/disable', 'POST', { data });
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
       });
     });

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -99,6 +99,26 @@ exports.register = async function(server) {
         },
         handler: membershipController.disable,
         notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant qu\'administrateur de l\'organisation et avec le rôle Pix Master**\n' +
+          '- Elle permet la désactivation d\'un membre',
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/memberships/{id}/disable',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.membershipId,
+          }),
+        },
+        handler: membershipController.disable,
+        notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
           '- Elle permet la désactivation d\'un membre',
         ],

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -57,6 +57,34 @@ exports.register = async function(server) {
       },
     },
     {
+      method: 'PATCH',
+      path: '/api/admin/memberships/{id}',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.membershipId,
+          }),
+        },
+        handler: membershipController.update,
+        description: 'Update organization role by admin for a organization members',
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant que Pix Master**\n' +
+          '- Elle permet de modifier le rôle d\'un membre de l\'organisation',
+        ],
+        plugins: {
+          'hapi-swagger': {
+            payloadType: 'form',
+            order: 2,
+          },
+        },
+        tags: ['api', 'memberships'],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/memberships/{id}/disable',
       config: {

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -33,8 +33,8 @@ exports.register = async function(server) {
       path: '/api/memberships/{id}',
       config: {
         pre: [{
-          method: securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster,
-          assign: 'isAdminInOrganizationOrHasRolePixMaster',
+          method: securityPreHandlers.checkUserIsAdminInOrganization,
+          assign: 'isAdminInOrganization',
         }],
         validate: {
           params: Joi.object({
@@ -44,7 +44,7 @@ exports.register = async function(server) {
         handler: membershipController.update,
         description: 'Update organization role by admin for a organization members',
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés en tant qu\'administrateur de l\'organisation ou ayant le rôle Pix Master**\n' +
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant qu\'administrateur de l\'organisation**\n' +
           '- Elle permet de modifier le rôle d\'un membre de l\'organisation',
         ],
         plugins: {
@@ -89,8 +89,8 @@ exports.register = async function(server) {
       path: '/api/memberships/{id}/disable',
       config: {
         pre: [{
-          method: securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster,
-          assign: 'isAdminInOrganizationOrHasRolePixMaster',
+          method: securityPreHandlers.checkUserIsAdminInOrganization,
+          assign: 'isAdminInOrganization',
         }],
         validate: {
           params: Joi.object({
@@ -99,7 +99,7 @@ exports.register = async function(server) {
         },
         handler: membershipController.disable,
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés en tant qu\'administrateur de l\'organisation et avec le rôle Pix Master**\n' +
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant qu\'administrateur de l\'organisation\n' +
           '- Elle permet la désactivation d\'un membre',
         ],
       },

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -8,7 +8,7 @@ exports.register = async function(server) {
   server.route([
     {
       method: 'POST',
-      path: '/api/memberships',
+      path: '/api/admin/memberships',
       config: {
         pre: [{
           method: securityPreHandlers.checkUserHasRolePixMaster,

--- a/api/tests/acceptance/application/membership-controller_test.js
+++ b/api/tests/acceptance/application/membership-controller_test.js
@@ -12,7 +12,7 @@ describe('Acceptance | Controller | membership-controller', () => {
     server = await createServer();
   });
 
-  describe('POST /api/memberships', () => {
+  describe('POST /api/admin/memberships', () => {
 
     let options;
     let userId;
@@ -26,7 +26,7 @@ describe('Acceptance | Controller | membership-controller', () => {
 
       options = {
         method: 'POST',
-        url: '/api/memberships',
+        url: '/api/admin/memberships',
         payload: {
           data: {
             type: 'memberships',

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -14,7 +14,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
     sinon.stub(usecases, 'updateMembership');
     sinon.stub(usecases, 'disableMembership');
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
-    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster');
+    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization');
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
   });
@@ -101,7 +101,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
         usecases.updateMembership
           .withArgs({ membership })
           .resolves(updatedMembership);
-        securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
+        securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response(true));
 
         // when
         const payload = {
@@ -134,7 +134,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
         it('should resolve a 400 HTTP response', async () => {
           // given
-          securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
+          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response(true));
           const idGivenInRequestParams = 1;
           const idGivenInPayload = 44;
 
@@ -179,7 +179,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
         it('should resolve a 403 HTTP response', async () => {
           // given
-          securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => {
+          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => {
             return Promise.resolve(h.response().code(403).takeover());
           });
 
@@ -195,7 +195,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
         it('should resolve a 400 HTTP response', async () => {
           // given
-          securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
+          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response(true));
           usecases.updateMembership.throws(new InvalidMembershipOrganizationRoleError());
 
           // when
@@ -232,7 +232,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
         // given
         const membershipId = domainBuilder.buildMembership().id;
         usecases.disableMembership.resolves();
-        securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
+        securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response(true));
 
         // when
         const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/disable`);
@@ -249,7 +249,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
         it('should resolve a 403 HTTP response', async () => {
           // given
           const membershipId = domainBuilder.buildMembership({ organizationRole: Membership.roles.MEMBER }).id;
-          securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => {
+          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => {
             return Promise.resolve(h.response().code(403).takeover());
           });
 

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -41,7 +41,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
         securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
 
         // when
-        const response = await httpTestServer.request('POST', '/api/memberships', payload);
+        const response = await httpTestServer.request('POST', '/api/admin/memberships', payload);
 
         // then
         expect(response.statusCode).to.equal(201);
@@ -55,7 +55,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
         securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
 
         // when
-        const response = await httpTestServer.request('POST', '/api/memberships', payload);
+        const response = await httpTestServer.request('POST', '/api/admin/memberships', payload);
 
         // then
         expect(response.result.data.type).to.equal('memberships');
@@ -73,7 +73,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
           });
 
           // when
-          const promise = httpTestServer.request('POST', '/api/memberships', payload);
+          const promise = httpTestServer.request('POST', '/api/admin/memberships', payload);
 
           // then
           return promise.then((response) => {

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -66,19 +66,15 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
       context('when user is not allowed to access resource', () => {
 
-        it('should resolve a 403 HTTP response', () => {
+        it('should resolve a 403 HTTP response', async () => {
           // given
-          securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => {
-            return Promise.resolve(h.response().code(403).takeover());
-          });
+          securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
 
           // when
-          const promise = httpTestServer.request('POST', '/api/admin/memberships', payload);
+          const response = await httpTestServer.request('POST', '/api/admin/memberships', payload);
 
           // then
-          return promise.then((response) => {
-            expect(response.statusCode).to.equal(403);
-          });
+          expect(response.statusCode).to.equal(403);
         });
       });
     });
@@ -179,9 +175,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
         it('should resolve a 403 HTTP response', async () => {
           // given
-          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => {
-            return Promise.resolve(h.response().code(403).takeover());
-          });
+          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response().code(403).takeover());
 
           // when
           const response = await httpTestServer.request('PATCH', '/api/memberships/1');
@@ -228,7 +222,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
     context('Success cases', () => {
 
-      it('should return a 200 HTTP response', async () => {
+      it('should return a 204 HTTP response', async () => {
         // given
         const membershipId = domainBuilder.buildMembership().id;
         usecases.disableMembership.resolves();
@@ -244,7 +238,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
     context('Error cases', () => {
 
-      context('when user is not admin of the organization nor has pix master role', () => {
+      context('when user is not allowed to access resource', () => {
 
         it('should resolve a 403 HTTP response', async () => {
           // given

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -171,20 +171,6 @@ describe('Integration | Application | Memberships | membership-controller', () =
         });
       });
 
-      context('when user is not allowed to access resource', () => {
-
-        it('should resolve a 403 HTTP response', async () => {
-          // given
-          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response().code(403).takeover());
-
-          // when
-          const response = await httpTestServer.request('PATCH', '/api/memberships/1');
-
-          // then
-          expect(response.statusCode).to.equal(403);
-        });
-      });
-
       context('when organization role is not valid', () => {
 
         it('should resolve a 400 HTTP response', async () => {
@@ -220,40 +206,17 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
   describe('#disable', () => {
 
-    context('Success cases', () => {
+    it('should return a 204 HTTP response', async () => {
+      // given
+      const membershipId = domainBuilder.buildMembership().id;
+      usecases.disableMembership.resolves();
+      securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response(true));
 
-      it('should return a 204 HTTP response', async () => {
-        // given
-        const membershipId = domainBuilder.buildMembership().id;
-        usecases.disableMembership.resolves();
-        securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response(true));
+      // when
+      const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/disable`);
 
-        // when
-        const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/disable`);
-
-        // then
-        expect(response.statusCode).to.equal(204);
-      });
-    });
-
-    context('Error cases', () => {
-
-      context('when user is not allowed to access resource', () => {
-
-        it('should resolve a 403 HTTP response', async () => {
-          // given
-          const membershipId = domainBuilder.buildMembership({ organizationRole: Membership.roles.MEMBER }).id;
-          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => {
-            return Promise.resolve(h.response().code(403).takeover());
-          });
-
-          // when
-          const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/disable`);
-
-          // then
-          expect(response.statusCode).to.equal(403);
-        });
-      });
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 

--- a/api/tests/unit/application/memberships/index_test.js
+++ b/api/tests/unit/application/memberships/index_test.js
@@ -1,0 +1,51 @@
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+const moduleUnderTest = require('../../../../lib/application/memberships');
+
+const membershipController = require('../../../../lib/application/memberships/membership-controller');
+
+describe('Unit | Router | membership-router', () => {
+
+  describe('PATCH /api/admin/memberships/{id}', () => {
+
+    it('should return 200 if user is Pix Admin', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(membershipController, 'update').callsFake((request, h) => h.response().code(200));
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.register(moduleUnderTest);
+      const id = 123;
+
+      // when
+      const response = await httpTestServer.request('PATCH', `/api/admin/memberships/${id}`);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(membershipController.update).to.have.been.called;
+    });
+
+    it('should return 403 if user is not Pix Admin', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(membershipController, 'update');
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.register(moduleUnderTest);
+      const id = 123;
+
+      // when
+      const response = await httpTestServer.request('PATCH', `/api/admin/memberships/${id}`);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(membershipController.update).to.have.not.been.called;
+    });
+  });
+});

--- a/api/tests/unit/application/memberships/index_test.js
+++ b/api/tests/unit/application/memberships/index_test.js
@@ -48,4 +48,41 @@ describe('Unit | Router | membership-router', () => {
       expect(membershipController.update).to.have.not.been.called;
     });
   });
+
+  describe('POST /api/admin/memberships/{id}/disable', () => {
+
+    it('should return 204 if user is Pix Admin', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(membershipController, 'disable').callsFake((request, h) => h.response().code(204));
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.register(moduleUnderTest);
+      const membershipId = 123;
+
+      // when
+      const response = await httpTestServer.request('POST', `/api/admin/memberships/${membershipId}/disable`);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      expect(membershipController.disable).to.have.been.called;
+    });
+
+    it('should return 403 if user is not Pix Admin', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(membershipController, 'disable');
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.register(moduleUnderTest);
+      const membershipId = 123;
+
+      // when
+      const response = await httpTestServer.request('POST', `/api/admin/memberships/${membershipId}/disable`);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(membershipController.disable).to.have.not.been.called;
+    });
+  });
 });

--- a/api/tests/unit/application/memberships/index_test.js
+++ b/api/tests/unit/application/memberships/index_test.js
@@ -49,6 +49,26 @@ describe('Unit | Router | membership-router', () => {
     });
   });
 
+  describe('PATCH /api/memberships/{id}', () => {
+
+    it('should return 403 if user is not admin in organization', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(membershipController, 'update');
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.register(moduleUnderTest);
+      const id = 123;
+
+      // when
+      const response = await httpTestServer.request('PATCH', `/api/memberships/${id}`);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(membershipController.update).to.have.not.been.called;
+    });
+  });
+
   describe('POST /api/admin/memberships/{id}/disable', () => {
 
     it('should return 204 if user is Pix Admin', async () => {
@@ -79,6 +99,26 @@ describe('Unit | Router | membership-router', () => {
 
       // when
       const response = await httpTestServer.request('POST', `/api/admin/memberships/${membershipId}/disable`);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(membershipController.disable).to.have.not.been.called;
+    });
+  });
+
+  describe('POST /api/memberships/{id}/disable', () => {
+
+    it('should return 403 if user is not admin in organization', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(membershipController, 'disable');
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.register(moduleUnderTest);
+      const membershipId = 123;
+
+      // when
+      const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/disable`);
 
       // then
       expect(response.statusCode).to.equal(403);

--- a/api/tests/unit/application/memberships/index_test.js
+++ b/api/tests/unit/application/memberships/index_test.js
@@ -20,7 +20,7 @@ describe('Unit | Router | membership-router', () => {
       sinon.stub(membershipController, 'update').callsFake((request, h) => h.response().code(200));
 
       const httpTestServer = new HttpTestServer();
-      httpTestServer.register(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
       const id = 123;
 
       // when
@@ -37,7 +37,7 @@ describe('Unit | Router | membership-router', () => {
       sinon.stub(membershipController, 'update');
 
       const httpTestServer = new HttpTestServer();
-      httpTestServer.register(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
       const id = 123;
 
       // when
@@ -51,13 +51,30 @@ describe('Unit | Router | membership-router', () => {
 
   describe('PATCH /api/memberships/{id}', () => {
 
+    it('should return 200 if user is admin in organization', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(membershipController, 'update').callsFake((request, h) => h.response().code(200));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      const membershipId = 123;
+
+      // when
+      const response = await httpTestServer.request('PATCH', `/api/memberships/${membershipId}`);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(membershipController.update).to.have.been.called;
+    });
+
     it('should return 403 if user is not admin in organization', async () => {
       // given
       sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response().code(403).takeover());
       sinon.stub(membershipController, 'update');
 
       const httpTestServer = new HttpTestServer();
-      httpTestServer.register(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
       const id = 123;
 
       // when
@@ -77,7 +94,7 @@ describe('Unit | Router | membership-router', () => {
       sinon.stub(membershipController, 'disable').callsFake((request, h) => h.response().code(204));
 
       const httpTestServer = new HttpTestServer();
-      httpTestServer.register(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
       const membershipId = 123;
 
       // when
@@ -94,7 +111,7 @@ describe('Unit | Router | membership-router', () => {
       sinon.stub(membershipController, 'disable');
 
       const httpTestServer = new HttpTestServer();
-      httpTestServer.register(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
       const membershipId = 123;
 
       // when
@@ -108,13 +125,30 @@ describe('Unit | Router | membership-router', () => {
 
   describe('POST /api/memberships/{id}/disable', () => {
 
+    it('should return 204 if user is admin in organization', async () => {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(membershipController, 'disable').callsFake((request, h) => h.response().code(204));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      const membershipId = 123;
+
+      // when
+      const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/disable`);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      expect(membershipController.disable).to.have.been.called;
+    });
+
     it('should return 403 if user is not admin in organization', async () => {
       // given
       sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response().code(403).takeover());
       sinon.stub(membershipController, 'disable');
 
       const httpTestServer = new HttpTestServer();
-      httpTestServer.register(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
       const membershipId = 123;
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Deux routes sur les memberships, `POST /api/memberships/{id}` et `PATCH /api/memberships/{id}/disable` sont actuellement utilisées par Pix Admin et Orga. 

## :robot: Solution
Scinder en 2 ces routes, afin d'en avoir une par application.
`PATCH /api/memberships/{id}` => Orga
`PATCH /api/admin/memberships/{id}` => Admin

`POST /api/memberships/{id}/disable` => Orga
`POST /api/admin/memberships/{id}/disable` => Admin

## :rainbow: Remarques
La route `POST api/memberships` qui n'est utilisé que sur Pix Admin, se voit modifié en `api/admin/memberships`

## :100: Pour tester
`PATCH /api/memberships/{id}` : 
Aller sur Pix Orga avec `sco.admin@example.net` => Equipe => Changer le rôle d'un membre.

`PATCH /api/admin/memberships/{id}` : 
Aller sur Pix Admin => Aller sur une organisation => Changer le rôle d'un membre dans le tableau Membres.

`POST /api/memberships/{id}/disable` : 
Aller sur Pix Orga avec `sco.admin@example.net` => Equipe => Supprimer/Désactiver un membre.

`PATCH /api/admin/memberships/{id}` : 
Aller sur Pix Admin => Aller sur une organisation =>Supprimer un membre dans le tableau Membres.

Vérifier que la route est bien appelé et s'assurer qu'il n'y ai pas de regression.