### PR TITLE
[BUGFIX] Inverser le nom et prénom en anglais dans la liste des participants (PIX-2652).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -13,8 +13,8 @@
     <table>
       <thead>
         <tr>
-          <th>{{t 'pages.assessment-participants-list.table.column.first-name'}}</th>
           <th>{{t 'pages.assessment-participants-list.table.column.last-name'}}</th>
+          <th>{{t 'pages.assessment-participants-list.table.column.first-name'}}</th>
           {{#if @campaign.idPixLabel}}
             <th>{{@campaign.idPixLabel}}</th>
           {{/if}}

--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -11,8 +11,8 @@
     <table>
       <thead>
         <tr>
-          <th>{{t 'pages.profiles-list.table.column.first-name'}}</th>
           <th>{{t 'pages.profiles-list.table.column.last-name'}}</th>
+          <th>{{t 'pages.profiles-list.table.column.first-name'}}</th>
           {{#if @campaign.idPixLabel}}
             <th>{{@campaign.idPixLabel}}</th>
           {{/if}}

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -135,8 +135,8 @@
       "table": {
         "column": {
           "badges": "Résultats Thématiques",
-          "first-name": "Nom",
-          "last-name": "Prénom",
+          "first-name": "Prénom",
+          "last-name": "Nom",
           "results": {
             "label": "Résultats",
             "on-hold": " En attente d'envoi",
@@ -429,8 +429,8 @@
         "column": {
           "certifiable": "Certifiable",
           "competences-certifiables": "Comp. certifiables",
-          "first-name": "Nom",
-          "last-name": "Prénom",
+          "first-name": "Prénom",
+          "last-name": "Nom",
           "pix-score": {
             "label": "Score Pix",
             "value": "{score, number}"


### PR DESCRIPTION
## :unicorn: Problème
En anglais First name / Last name sont inversés.

## :robot: Solution
Inverser les clés sans le template.
Remettre Nom/Prénom dans fr.json dans les bonnes clés.

## :rainbow: Remarques

## :100: Pour tester
Se connecter a Pix Orga ( `pro.admin@example.net` ) . aller sur une campagne de chaque type. verifier qu'en FR / EN que les colonnes Nom Prénom / Last name First name soient au bon endroit.