### PR TITLE
[TECH] Changer la manière d'afficher les RT dans la liste des participants dans Pix Orga (PIX-2624)

### DIFF
--- a/api/lib/domain/usecases/find-paginated-campaign-assessment-participation-summaries.js
+++ b/api/lib/domain/usecases/find-paginated-campaign-assessment-participation-summaries.js
@@ -18,10 +18,10 @@ module.exports = async function findPaginatedCampaignAssessmentParticipationSumm
 
   const paginatedParticipations = await campaignAssessmentParticipationSummaryRepository.findPaginatedByCampaignId({ page, campaignId, filters });
 
-  const userIds = paginatedParticipations.campaignAssessmentParticipationSummaries.map((participation) => participation.userId);
-  const acquiredBadgesByUsers = await badgeAcquisitionRepository.getCampaignAcquiredBadgesByUsers({ campaignId, userIds });
+  const campaignParticipationsIds = paginatedParticipations.campaignAssessmentParticipationSummaries.map((participation) => participation.campaignParticipationId);
+  const acquiredBadgesByCampaignParticipations = await badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({ campaignParticipationsIds });
   paginatedParticipations.campaignAssessmentParticipationSummaries.forEach((participation) => {
-    const badges = acquiredBadgesByUsers[participation.userId];
+    const badges = acquiredBadgesByCampaignParticipations[participation.campaignParticipationId];
     participation.setBadges(badges);
   });
 

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
@@ -128,11 +128,7 @@ function _filterByBadgeAcquisitionsIn(qb, filters) {
     qb.select(
       knex.raw('ARRAY_AGG("badgeId") OVER (PARTITION BY "campaign-participations"."id") as badges_acquired'),
     )
-      .join('badges', 'badges.targetProfileId', 'campaigns.targetProfileId')
-      .join('badge-acquisitions', function() {
-        this.on({ 'badge-acquisitions.badgeId': 'badges.id' })
-          .andOn({ 'badge-acquisitions.userId': 'campaign-participations.userId' });
-      })
+      .join('badge-acquisitions', 'badge-acquisitions.campaignParticipationId', 'campaign-participations.id')
       .where('campaign-participations.isShared', '=', true);
   }
 }

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -67,36 +67,79 @@ describe('Integration | Repository | Badge Acquisition', () => {
   });
 
   describe('#getAcquiredBadgesByCampaignParticipations', () => {
-    let campaign;
-    let user1;
-    let badge1;
-    let badge2;
-    let campaignParticipationId;
+    context('when there is just one campaignParticipionId', () => {
+      let campaign;
+      let user1;
+      let badge1;
+      let badge2;
+      let campaignParticipationId;
 
-    beforeEach(async () => {
-      user1 = databaseBuilder.factory.buildUser();
-      const targetProfile = databaseBuilder.factory.buildTargetProfile();
-      campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
-      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId: user1.id, campaignId: campaign.id }).id;
-      badge1 = databaseBuilder.factory.buildBadge({ key: 'badge1', targetProfileId: targetProfile.id });
-      badge2 = databaseBuilder.factory.buildBadge({ key: 'badge2', targetProfileId: targetProfile.id });
-      databaseBuilder.factory.buildBadge({ key: 'badge3', targetProfileId: targetProfile.id });
-      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, campaignParticipationId, userId: user1.id });
-      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge2.id, campaignParticipationId, userId: user1.id });
+      beforeEach(async () => {
+        user1 = databaseBuilder.factory.buildUser();
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId: user1.id, campaignId: campaign.id }).id;
+        badge1 = databaseBuilder.factory.buildBadge({ key: 'badge1', targetProfileId: targetProfile.id });
+        badge2 = databaseBuilder.factory.buildBadge({ key: 'badge2', targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildBadge({ key: 'badge3', targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, campaignParticipationId, userId: user1.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge2.id, campaignParticipationId, userId: user1.id });
 
-      await databaseBuilder.commit();
-    });
-
-    it('should return badge ids acquired by user for a campaignParticipation', async () => {
-      // when
-      const acquiredBadgeIdsByUsers = await badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({
-        campaignParticipationsIds: [campaignParticipationId],
+        await databaseBuilder.commit();
       });
 
-      // then
-      expect(acquiredBadgeIdsByUsers[campaignParticipationId][0]).to.includes(badge1);
-      expect(acquiredBadgeIdsByUsers[campaignParticipationId][1]).to.includes(badge2);
-      expect(acquiredBadgeIdsByUsers[campaignParticipationId].length).to.eq(2);
+      it('should return badge ids acquired by user for a campaignParticipation', async () => {
+        // when
+        const acquiredBadgesByCampaignParticipations = await badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({
+          campaignParticipationsIds: [campaignParticipationId],
+        });
+
+        // then
+        expect(acquiredBadgesByCampaignParticipations[campaignParticipationId][0]).to.includes(badge1);
+        expect(acquiredBadgesByCampaignParticipations[campaignParticipationId][1]).to.includes(badge2);
+        expect(acquiredBadgesByCampaignParticipations[campaignParticipationId].length).to.eq(2);
+      });
+    });
+
+    context('when there are several campaignParticipationsIds', () => {
+      let campaign;
+      let user1;
+      let user2;
+      let badge1;
+      let badge2;
+      let badge3;
+      let campaignParticipationId1;
+      let campaignParticipationId2;
+
+      beforeEach(async () => {
+        user1 = databaseBuilder.factory.buildUser();
+        user2 = databaseBuilder.factory.buildUser();
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        campaignParticipationId1 = databaseBuilder.factory.buildCampaignParticipation({ userId: user1.id, campaignId: campaign.id }).id;
+        campaignParticipationId2 = databaseBuilder.factory.buildCampaignParticipation({ userId: user2.id, campaignId: campaign.id }).id;
+        badge1 = databaseBuilder.factory.buildBadge({ key: 'badge1', targetProfileId: targetProfile.id });
+        badge2 = databaseBuilder.factory.buildBadge({ key: 'badge2', targetProfileId: targetProfile.id });
+        badge3 = databaseBuilder.factory.buildBadge({ key: 'badge3', targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, campaignParticipationId: campaignParticipationId2, userId: user2.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge2.id, campaignParticipationId: campaignParticipationId1, userId: user1.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge3.id, campaignParticipationId: campaignParticipationId2, userId: user2.id });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return badge ids acquired by user for a campaignParticipation', async () => {
+        // when
+        const campaignParticipationsIds = [campaignParticipationId1, campaignParticipationId2];
+        const acquiredBadgesByCampaignParticipations = await badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({ campaignParticipationsIds });
+
+        // then
+        expect(acquiredBadgesByCampaignParticipations[campaignParticipationId2][0]).to.includes(badge1);
+        expect(acquiredBadgesByCampaignParticipations[campaignParticipationId2][1]).to.includes(badge3);
+        expect(acquiredBadgesByCampaignParticipations[campaignParticipationId2].length).to.eq(2);
+        expect(acquiredBadgesByCampaignParticipations[campaignParticipationId1][0]).to.includes(badge2);
+        expect(acquiredBadgesByCampaignParticipations[campaignParticipationId1].length).to.eq(1);
+      });
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-summary-repository_test.js
@@ -344,19 +344,27 @@ describe('Integration | Repository | Campaign Assessment Participation Summary',
     });
 
     context('when there is a filter on badges', () => {
-      it('returns participants which have one badge', async () => {
+      let badge1;
+      let badge2;
+      let user1;
+      let user2;
+
+      beforeEach(() => {
         campaign = databaseBuilder.factory.buildAssessmentCampaign({});
-        const badge1 = databaseBuilder.factory.buildBadge({ key: 'badge1', targetProfileId: campaign.targetProfileId });
-        const badge2 = databaseBuilder.factory.buildBadge({ key: 'badge2', targetProfileId: campaign.targetProfileId });
+        badge1 = databaseBuilder.factory.buildBadge({ key: 'badge1', targetProfileId: campaign.targetProfileId });
+        badge2 = databaseBuilder.factory.buildBadge({ key: 'badge2', targetProfileId: campaign.targetProfileId });
+        user1 = databaseBuilder.factory.buildUser();
+        user2 = databaseBuilder.factory.buildUser();
 
-        const participation1 = { participantExternalId: 'The good', campaignId: campaign.id };
-        const assessment1 = databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
-        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: assessment1.userId });
+      });
+      it('returns participants which have one badge', async () => {
+        const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: user1.id, participantExternalId: 'The good' });
+        databaseBuilder.factory.buildAssessment({ userId: user1.id, campaignParticipationId: campaignParticipation1.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: user1.id, campaignParticipationId: campaignParticipation1.id });
 
-        const participation2 = { participantExternalId: 'The bad', campaignId: campaign.id };
-        const assessment2 = databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
-        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge2.id, userId: assessment2.userId });
-
+        const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: user2.id, participantExternalId: 'The bad' });
+        databaseBuilder.factory.buildAssessment({ userId: user2.id, campaignParticipationId: campaignParticipation2.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge2.id, userId: user2.id, campaignParticipationId: campaignParticipation2.id });
         await databaseBuilder.commit();
 
         // when
@@ -369,18 +377,14 @@ describe('Integration | Repository | Campaign Assessment Participation Summary',
       });
 
       it('returns participants which have several badges', async () => {
-        campaign = databaseBuilder.factory.buildAssessmentCampaign({});
-        const badge1 = databaseBuilder.factory.buildBadge({ key: 'badge1', targetProfileId: campaign.targetProfileId });
-        const badge2 = databaseBuilder.factory.buildBadge({ key: 'badge2', targetProfileId: campaign.targetProfileId });
+        const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: user1.id, participantExternalId: 'The good' });
+        databaseBuilder.factory.buildAssessment({ userId: user1.id, campaignParticipationId: campaignParticipation1.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: user1.id, campaignParticipationId: campaignParticipation1.id });
 
-        const participation1 = { participantExternalId: 'The good', campaignId: campaign.id };
-        const assessment1 = databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
-        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: assessment1.userId });
-
-        const participation2 = { participantExternalId: 'The bad', campaignId: campaign.id };
-        const assessment2 = databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
-        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: assessment2.userId });
-        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge2.id, userId: assessment2.userId });
+        const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: user2.id, participantExternalId: 'The bad' });
+        databaseBuilder.factory.buildAssessment({ userId: user2.id, campaignParticipationId: campaignParticipation2.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: user2.id, campaignParticipationId: campaignParticipation2.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge2.id, userId: user2.id, campaignParticipationId: campaignParticipation2.id });
 
         await databaseBuilder.commit();
 
@@ -394,17 +398,13 @@ describe('Integration | Repository | Campaign Assessment Participation Summary',
       });
 
       it('should not return participants which has not shared but has the badge', async () => {
-        campaign = databaseBuilder.factory.buildAssessmentCampaign({});
-        const badge1 = databaseBuilder.factory.buildBadge({ targetProfileId: campaign.targetProfileId });
+        const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: user1.id, participantExternalId: 'The good', isShared: true });
+        databaseBuilder.factory.buildAssessment({ userId: user1.id, campaignParticipationId: campaignParticipation1.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: user1.id, campaignParticipationId: campaignParticipation1.id });
 
-        const participation1 = { participantExternalId: 'The good', campaignId: campaign.id, isShared: true };
-        const assessment1 = databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
-        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: assessment1.userId });
-
-        const participation2 = { participantExternalId: 'The bad', campaignId: campaign.id, isShared: false };
-        const assessment2 = databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
-        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: assessment2.userId });
-
+        const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: user2.id, participantExternalId: 'The bad', isShared: false });
+        databaseBuilder.factory.buildAssessment({ userId: user2.id, campaignParticipationId: campaignParticipation2.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge1.id, userId: user2.id, campaignParticipationId: campaignParticipation2.id });
         await databaseBuilder.commit();
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
Maintenant les RT appartiennent aux campaignParticipationId et non plus aux users.
De ce fait, la manière d'afficher les RT dans la liste des participants doit se baser maintenant sur les ids des campaignParticipation.
Cette PR fait suite à la PR (https://github.com/1024pix/pix/pull/3046).

## :robot: Solution
Modifier la méthode pour récupérer les RT via les campaignParticipationId

## :rainbow: Remarques

## :100: Pour tester
Se connecter à Pix en tant qu'un user
Faire un parcours qui a des RT et faire en sorte de ne pas valider de RT. 
Refaire le parcours et en valider certain. Vérifier dans Pix Orga que pour ce user on affiche bien les bon badges du deuxième parcours.
