### PR TITLE
[INFRA] Corriger des erreurs dans les seeds

### DIFF
--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -12,7 +12,7 @@ const DROIT_CERTIF_CENTER_NAME = 'Centre DROIT des Anne-Étoiles';
 const SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID = 6;
 const SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_NAME = 'Centre SCO NO MANAGING STUDENTS des Anne-Étoiles';
 const SCO_EXTERNAL_ID = '1237457A';
-const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = 'AEFE';
+const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = '1237457E';
 
 function certificationCentersBuilder({ databaseBuilder }) {
 

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -14,7 +14,7 @@ function organizationsScoBuilder({ databaseBuilder }) {
   /* COLLEGE */
   const scoUser1 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 4,
-    firstName: 'John',
+    firstName: 'Jon',
     lastName: 'Snow',
     email: 'sco.admin@example.net',
     rawPassword: DEFAULT_PASSWORD,


### PR DESCRIPTION
## :unicorn: Problème

En développement, lorsqu'on essaie de rejoindre une session de certification du centre "Centre SCO NO MANAGING STUDENTS des Anne-Étoiles", on obtient une erreur :

> Could not find organization for externalId AEFE.

La raison est que, dans les seeds, le centre de certification est associé à l'orga en utilisant son `name` ("AEFE") plutôt que son `externalId` ("1237457E").

## :robot: Solution

Associer le centre de certification en utilisant son `externalId`

## :rainbow: Remarques

J'en ai profité pour corriger une autre erreur sans importance mais qui me pique les yeux à chaque fois 🤓 

## :100: Pour tester

En développement ou en RA uniquement :

1. Se connecter à Pix Certif avec `certifsco@example.net`
2. Selectionner le centre de certif "Centre SCO NO MANAGING STUDENTS des Anne-Étoiles (1237457E)"
3. Créer une session et ajouter un candidat
4. Tenter de rejoindre la session
5. Constater que la session peut être rejointe

