### PR TITLE
[BUGFIX] Afficher correctement le texte personnalisable d'une organisation à la fin d'un parcours prescrit (PIX-2676).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -97,7 +97,7 @@
         <p class="skill-review-organization-message__organization-name">{{@model.campaign.organizationName}}</p>
         {{#if this.showOrganizationMessage}}
           <div class="skill-review-organization-message__text">
-            <MarkdownToHtml @markdown={{this.organizationMessage}}/>
+            <MarkdownToHtml @markdown={{@model.campaign.customResultPageText}}/>
           </div>
         {{/if}}
         {{#if this.showOrganizationButton}}

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -126,9 +126,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         });
       });
 
-      context('when the organization has no message', function() {
+      context('when the organization has a customResultPageText', function() {
         beforeEach(async function() {
-          const campaign = { customResultPageText: null, organizationLogoUrl: 'www.logo-example.com', organizationName: 'Dragon & Co' };
+          const campaign = { customResultPageText: 'some message', organizationName: 'Dragon & Co' };
           const campaignParticipationResult = { isShared: true, campaignParticipationBadges: [] };
           this.set('model', { campaign, campaignParticipationResult });
 
@@ -136,9 +136,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
         });
 
-        it('should not display the block for the message', function() {
+        it('should display customResultPageText', function() {
           // Then
-          expect(contains(this.intl.t('pages.skill-review.organization-message'))).to.not.exist;
+          expect(contains('some message')).to.exist;
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une US récente #3021, la fin de parcours a été refactorée. Problème, il manquait un test sur le `customResultPageText`. Conséquence : il y a eu une régression, ce texte ne s'affiche plus.

## :robot: Solution
Remettre cet affichage et rajouter un test.

## :rainbow: Remarques
Un des test existant était en double, et donc a été supprimé.

## :100: Pour tester
passer la campagne AZERTY123, partager ses résultats. S'assurer que l'on voit bien et le texte, et le bouton personnalisé (avec l'url).