### PR TITLE
[FEATURE] Afficher une fin de parcours personnalisé à la fin d'une campagne à accès simplifié (PIX-2613).

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -209,8 +209,11 @@ __Plus d'infos :)__
     organizationId: PRO_MED_NUM_ID,
     creatorId: 2,
     targetProfileId: TARGET_PROFILE_SIMPLIFIED_ACCESS_ID,
-    customLandingPageText: '',
     idPixLabel: null,
+    customLandingPageText: null,
+    customResultPageText: 'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.',
+    customResultPageButtonUrl: 'https://pix.fr/',
+    customResultPageButtonText: 'Voir Pix !',
     createdAt: new Date('2020-01-13'),
   });
 

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -59,7 +59,7 @@
             </div>
           {{else}}
             {{#if @model.campaign.isForAbsoluteNovice}}
-              <a href="#" {{on "click" this.redirectForNoviceCampaign}}
+              <a href="#" {{on "click" this.redirectToSignupIfUserIsAnonymous}}
                       class="skill-review-share__back-to-home link" data-link-to-continue-pix>
                 {{t 'pages.skill-review.actions.continue'}}
               </a>
@@ -68,6 +68,7 @@
                       @isShared={{this.isShared}}
                       @displayPixLink={{this.displayPixLink}}
                       @shareCampaignParticipation={{this.shareCampaignParticipation}}
+                      @redirectToSignupIfUserIsAnonymous={{this.redirectToSignupIfUserIsAnonymous}}
               />
             {{/if}}
           {{/if}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -132,10 +132,6 @@ export default class SkillReview extends Component {
     }
 
     campaignParticipationResult.isShared = true;
-    const isSimplifiedAccessCampaign = this.args.model.campaign.isSimplifiedAccess;
-    if (isSimplifiedAccessCampaign) {
-      return this.disconnectUser();
-    }
   }
 
   @action
@@ -144,11 +140,6 @@ export default class SkillReview extends Component {
     const adapter = this.store.adapterFor('campaign-participation-result');
     await adapter.beginImprovement(campaignParticipationResult.id);
     return this.router.transitionTo('campaigns.start-or-resume', this.args.model.campaign.code);
-  }
-
-  async disconnectUser() {
-    await this.session.invalidate();
-    return window.location.replace(this.url.homeUrl);
   }
 
   @action

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -143,7 +143,7 @@ export default class SkillReview extends Component {
   }
 
   @action
-  async redirectForNoviceCampaign() {
+  async redirectToSignupIfUserIsAnonymous() {
     if (this.currentUser.user.isAnonymous) {
       await this.session.invalidate();
       this.router.transitionTo('inscription');

--- a/mon-pix/app/templates/components/campaign-share-button.hbs
+++ b/mon-pix/app/templates/components/campaign-share-button.hbs
@@ -3,10 +3,11 @@
     <div class="skill-review-share__thanks">
       {{t 'pages.skill-review.already-shared'}}
     </div>
-    <LinkTo @route="index" class="skill-review-share__back-to-home link">
+    <a href="#" {{on "click" @redirectToSignupIfUserIsAnonymous}}
+       class="skill-review-share__back-to-home link" data-link-to-continue-pix>
       <FaIcon @icon='arrow-right' aria-hidden="true"></FaIcon>
       {{t 'pages.skill-review.actions.continue'}}
-    </LinkTo>
+    </a>
   {{/if}}
 {{else}}
   <PixButton

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
@@ -28,7 +28,6 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
     sinon.stub(adapter, 'beginImprovement').resolves();
 
     component.router.transitionTo = sinon.stub();
-    component.disconnectUser = sinon.stub();
   });
 
   describe('#shareCampaignParticipation', function() {
@@ -42,27 +41,16 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
     });
 
     context('when share is effective', function() {
-      beforeEach(() => {
-        adapter.share.resolves();
-      });
 
       it('should set isShared to true', async function() {
+        // given
+        adapter.share.resolves();
+
         // when
         await component.actions.shareCampaignParticipation.call(component);
 
         // then
         expect(component.args.model.campaignParticipationResult.isShared).to.equal(true);
-      });
-
-      it('should disconnect user if campaign has simplified access', async function() {
-        // given
-        component.args.model.campaign.isSimplifiedAccess = true;
-
-        // when
-        await component.actions.shareCampaignParticipation.call(component);
-
-        // then
-        sinon.assert.called(component.disconnectUser);
       });
     });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
@@ -4,6 +4,7 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+import Service from '@ember/service';
 
 describe('Unit | component | Campaigns | Evaluation | Skill Review', function() {
 
@@ -442,6 +443,37 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
 
       // then
       expect(result).to.be.true;
+    });
+  });
+
+  describe('#redirectToSignupIfUserIsAnonymous', function() {
+
+    it('should redirect to sign up page on click when user is anonymous', async function() {
+      // given
+      const session = this.owner.lookup('service:session');
+      class currentUser extends Service { user = { isAnonymous: true }}
+      this.owner.register('service:currentUser', currentUser);
+
+      session.invalidate = sinon.stub();
+
+      // when
+      await component.actions.redirectToSignupIfUserIsAnonymous.call(component);
+
+      // then
+      sinon.assert.called(session.invalidate);
+      sinon.assert.calledWith(component.router.transitionTo, 'inscription');
+    });
+
+    it('should redirect to home page when user is not anonymous', async function() {
+      // given
+      class currentUser extends Service { user = { isAnonymous: false }}
+      this.owner.register('service:currentUser', currentUser);
+
+      // when
+      await component.actions.redirectToSignupIfUserIsAnonymous.call(component);
+
+      // then
+      sinon.assert.calledWith(component.router.transitionTo, 'index');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre d’un partenariat avec la Banque des territoires, Pix doit pouvoir proposer des parcours à accès simplifié (PAS) disposant d’une fin de parcours personnalisée.Aujourd’hui, dans un PAS classique, l’utilisateur est déconnecté après avoir cliqué sur le bouton d’envoi des résultats. Il est donc impossible de voir les liens affichés dans le cadre des fins de parcours personnalisées.

## :robot: Solution
Pour répondre à cette problématique, nous avons décidé de faire un premier POC en supprimant la déconnexion automatique dès l'envoi des résultats d'un parcours accès simplifié.
On a estimé que supprimer cette déconnexion (initialement mise en place pour éviter les risques d’accès aux comptes dans le cadre d'ordinateurs partagés ) ne représentait probablement plus de risques puisque nous avons implémenté un système de whitelist qui déconnecte lorsqu’on tente d’accéder à une page hors campagne si on est anonyme, et une déconnexion à l’entrée dans un PAS si on est connecté et anonyme.

## :rainbow: Remarques
Un Whimsical qui liste les types de parcours existants : https://whimsical.com/typologie-de-parcours-3E42hyrsnMq1q17QvduqyD

## :100: Pour tester

1. Tester la non régression d'un **parcours classique** ( AZERTY123 ) et **parcours ABCDiag** ( NOVICE123 ).

2. Tester un **parcours accès simplifié classique** ( SIMPLIFIE ) ( sans `customResultPageText`, `customResultPageButtonText`, `customResultPageButtonUrl` ) : 

Envoyer ses résultats, pas de bulle d'info de l'orga et un lien "continuer votre expérience Pix" qui déconnecte et mène vers la page d'inscription.

3. Tester un **parcours accès simplifié personnalisé sans bouton** ( avec `customResultPageText`, sans `customResultPageButtonText` et `customResultPageButtonUrl` ) :

Envoyer ses résultats, bulle d'info de l'orga avec un message et un lien "continuer votre expérience Pix" qui déconnecte et mène vers la page d'inscription.

4. Tester un **parcours accès simplifié personnalisé avec bouton** ( avec `customResultPageText`, `customResultPageButtonText` et `customResultPageButtonUrl` ) :

Envoyer ses résultats, bulle d'info de l'orga avec un message et un bouton avec un lien externe, pas de "continuer votre expérience Pix" présent.
