### PR TITLE
[BUGFIX] Corriger l'affichage du détail d'une certification après sa modification (PIX-2661)

### DIFF
--- a/api/db/migrations/20210607142018_fix-certifications-version-v2.js
+++ b/api/db/migrations/20210607142018_fix-certifications-version-v2.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'certification-courses';
+
+exports.up = function(knex) {
+  return knex(TABLE_NAME)
+    .where('createdAt', '>', '2021-01-01')
+    .andWhere('isV2Certification', false)
+    .update({
+      'isV2Certification': true,
+    });
+};
+
+exports.down = function(_) {
+  // un rollback serait contre-productif
+  return Promise.resolve();
+};

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -68,7 +68,7 @@ module.exports = {
   },
 
   async update(certificationCourse) {
-    const certificationCourseData = _adaptModelToDb(certificationCourse);
+    const certificationCourseData = _pickUpdatableProperties(certificationCourse);
     const certificationCourseBookshelf = new CertificationCourseBookshelf(certificationCourseData);
     try {
       const certificationCourse = await certificationCourseBookshelf.save();
@@ -160,6 +160,21 @@ function _adaptModelToDb(certificationCourse) {
     'challenges',
     'createdAt',
     '_isCancelled',
+  ]);
+
+  dto.isCancelled = certificationCourse.isCancelled();
+
+  return dto;
+}
+
+function _pickUpdatableProperties(certificationCourse) {
+
+  const dto = _.pick(certificationCourse, [
+    'id',
+    'firstName',
+    'lastName',
+    'birthdate',
+    'birthplace',
   ]);
 
   dto.isCancelled = certificationCourse.isCancelled();

--- a/api/tests/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/unit/domain/models/CertificationCourse_test.js
@@ -1,7 +1,6 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | CertificationCourse', () => {
-
   describe('#cancel #isCancelled', () => {
 
     it('should cancel a certification course', () => {


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'on enregistre la modification d'une certification dans Pix Admin, et qu'on se rend ensuite dans l'onglet Détails, aucune information n'apparaît.

La raison est que la modification d'un `certification-course` change son champ `isV2Certification` de `true` à `false`. La valeur actuelle du champ n'étant pas envoyée par Pix Admin, le `certification-course` est enregistré avec la valeur par défaut, soit `false`.
Or, la certification étant en réalité bien une v2, il y a une incohérence et l'affichage des détails ne fonctionne pas. 

## :robot: Solution

- [x] Filtrer les champs qui peuvent être modifiés (white list) dans la méthode `update` du `certification-repository`.
- [x] Ajouter une migration pour passer les certification v1 à v2 si elles ont été crées en 2021

## :rainbow: Remarques

Il reste un bug : quand on modifie une certification annulée, elle perd le statut annulée (elle est désannulée). Comme il est à la fois moins grave et plus compliqué à corriger, il a été décidé de le traiter dans une prochaine PR pour soulager le pôle certif aussi rapidement que possible.

## :100: Pour tester

1. Passer un test de certif en répondant à suffisamment de question pour avoir un taux de repro d’au moins 50% mais ne PAS le finaliser de façon à ce que la certif reste au statut “Démarrée”
2. Dans pix admin > ouvrir la page de détails de cette certif : l’onglet “Détails” affiche bien les questions et le statut des réponses apportées par le candidat
3. Cliquer sur le bouton “Modifier”
4. Changer le statut de la certif de “Démarrée” à “Validée” puis modifier le score pour l’une des compétences
5. Enregistrer les modifications
6. Constater que les épreuves apparaissent dans l'onglet Détails

