### PR TITLE
[FEATURE] Création d'un composant de carte d'indicateur dans Pix Orga (Pix-2663).

### DIFF
--- a/orga/app/components/indicator-card.hbs
+++ b/orga/app/components/indicator-card.hbs
@@ -1,7 +1,20 @@
 <section class="indicator-card">
   <div class="indicator-card__icon" aria-hidden="true"><FaIcon @icon={{@icon}}/></div>
   <div class="indicator-card__content">
-    <label class="indicator-card__title">{{@title}} <FaIcon @icon="question-circle" class="indicator-card__info"/></label>
+  <label class="indicator-card__title">
+    {{@title}}
+    {{#if @info}}
+      <PixTooltip
+        role="tooltip"
+        @text={{@info}}
+        @position="top"
+        @isWide={{true}}
+        @isLight={{true}}
+      >
+        <FaIcon @icon="question-circle" class="indicator-card__info"/>
+      </PixTooltip>
+    {{/if}}
+  </label>
   {{yield}}
   </div>
 </section>

--- a/orga/app/components/indicator-card.hbs
+++ b/orga/app/components/indicator-card.hbs
@@ -1,7 +1,7 @@
 <section class="indicator-card">
   <div class="indicator-card__icon" aria-hidden="true"><FaIcon @icon={{@icon}}/></div>
   <div class="indicator-card__content">
-    <label class="indicator-card__title">Title <FaIcon @icon="question-circle" class="indicator-card__info"/></label>
+    <label class="indicator-card__title">{{@title}} <FaIcon @icon="question-circle" class="indicator-card__info"/></label>
   {{yield}}
   </div>
 </section>

--- a/orga/app/components/indicator-card.hbs
+++ b/orga/app/components/indicator-card.hbs
@@ -1,0 +1,7 @@
+<section class="indicator-card">
+  <div class="indicator-card__icon" aria-hidden="true"><FaIcon @icon='icon'/></div>
+  <div class="indicator-card__content">
+    <label class="indicator-card__title">Title <FaIcon @icon="question-circle" class="indicator-card__info"/></label>
+  {{yield}}
+  </div>
+</section>

--- a/orga/app/components/indicator-card.hbs
+++ b/orga/app/components/indicator-card.hbs
@@ -1,5 +1,7 @@
 <section class="indicator-card">
-  <div class="indicator-card__icon" aria-hidden="true"><FaIcon @icon={{@icon}}/></div>
+  <div class="indicator-card__icon {{if @color (concat "indicator-card__icon--" @color)}}" aria-hidden="true">
+    <FaIcon @icon={{@icon}}/>
+  </div>
   <div class="indicator-card__content">
   <label class="indicator-card__title">
     {{@title}}

--- a/orga/app/components/indicator-card.hbs
+++ b/orga/app/components/indicator-card.hbs
@@ -1,5 +1,5 @@
 <section class="indicator-card">
-  <div class="indicator-card__icon" aria-hidden="true"><FaIcon @icon='icon'/></div>
+  <div class="indicator-card__icon" aria-hidden="true"><FaIcon @icon={{@icon}}/></div>
   <div class="indicator-card__content">
     <label class="indicator-card__title">Title <FaIcon @icon="question-circle" class="indicator-card__info"/></label>
   {{yield}}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -27,6 +27,7 @@
 @import "components/dissociate-user-modal";
 @import "components/edit-student-number-modal";
 @import "components/dropdown";
+@import "components/indicator-card";
 @import "components/join-request-form";
 @import "components/pagination-control";
 @import "components/previous-page-button";

--- a/orga/app/styles/components/indicator-card.scss
+++ b/orga/app/styles/components/indicator-card.scss
@@ -1,3 +1,8 @@
+@mixin colorize($color, $percentageDarkenForColor, $percentageLightenForBackground) {
+  color: darken($color, $percentageDarkenForColor);
+  background-color: lighten($color, $percentageLightenForBackground);
+}
+
 .indicator-card {
   display: flex;
   width: 100%;
@@ -16,6 +21,10 @@
     color: $grey-60;
     min-width: 96px;
     font-size: 1.5rem;
+
+    &--blue { @include colorize($blue, 0%, 32%); }
+    &--purple { @include colorize($purple, 6%, 32%); }
+    &--green { @include colorize($green, 0%, 70%); }
   }
 
   &__content {

--- a/orga/app/styles/components/indicator-card.scss
+++ b/orga/app/styles/components/indicator-card.scss
@@ -1,0 +1,45 @@
+.indicator-card {
+  display: flex;
+  width: 100%;
+  background-color: $white;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px 0 rgba($black, 0.05);
+  height: 112px;
+  padding: 0;
+
+  &__icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 8px 0 0 8px;
+    background-color: $grey-20;
+    color: $grey-60;
+    min-width: 96px;
+    font-size: 1.5rem;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    color: $grey-60;
+    font-family: $open-sans;
+    font-weight: 600;
+    font-size: 2rem;
+    margin: 16px 32px;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    font-family: $roboto;
+    font-weight: 500;
+    font-size: 0.875rem;
+  }
+
+  &__info {
+    font-size: 0.75rem;
+    color: $grey-30;
+    margin: 0 8px;
+  }
+}

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -20,6 +20,7 @@ module.exports = function() {
       'info-circle',
       'link',
       'power-off',
+      'question-circle',
       'search',
       'share-square',
       'sort',

--- a/orga/tests/integration/components/indicator-card-test.js
+++ b/orga/tests/integration/components/indicator-card-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | indicator-card', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders children', async function(assert) {
+    await render(hbs`<IndicatorCard>Text</IndicatorCard>`);
+
+    assert.contains('Text');
+  });
+});

--- a/orga/tests/integration/components/indicator-card-test.js
+++ b/orga/tests/integration/components/indicator-card-test.js
@@ -6,6 +6,12 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | indicator-card', function(hooks) {
   setupRenderingTest(hooks);
 
+  test('it renders title', async function(assert) {
+    await render(hbs`<IndicatorCard @title="some title" />`);
+
+    assert.contains('some title');
+  });
+
   test('it renders icon', async function(assert) {
     await render(hbs`<IndicatorCard @icon="archive" />`);
 

--- a/orga/tests/integration/components/indicator-card-test.js
+++ b/orga/tests/integration/components/indicator-card-test.js
@@ -6,6 +6,12 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | indicator-card', function(hooks) {
   setupRenderingTest(hooks);
 
+  test('it renders icon', async function(assert) {
+    await render(hbs`<IndicatorCard @icon="archive" />`);
+
+    assert.dom('[data-icon="archive"]').exists();
+  });
+
   test('it renders children', async function(assert) {
     await render(hbs`<IndicatorCard>Text</IndicatorCard>`);
 

--- a/orga/tests/integration/components/indicator-card-test.js
+++ b/orga/tests/integration/components/indicator-card-test.js
@@ -23,4 +23,23 @@ module('Integration | Component | indicator-card', function(hooks) {
 
     assert.contains('Text');
   });
+
+  module('when there is no additional information', async function() {
+    test('it does not display question mark and its tooltip', async function(assert) {
+      await render(hbs`<IndicatorCard>Text</IndicatorCard>`);
+
+      assert.dom('[data-icon="question-circle"]').doesNotExist();
+      assert.dom('[role="tooltip"]').doesNotExist();
+    });
+  });
+
+  module('when there is some additional information', async function() {
+    test('it display question mark and its tooltip', async function(assert) {
+      await render(hbs`<IndicatorCard @info="some additional information">Text</IndicatorCard>`);
+
+      assert.dom('[data-icon="question-circle"]').exists();
+      assert.dom('[role="tooltip"]').exists();
+      assert.contains('some additional information');
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous commençons l'epix de Dataviz pour une campagne donnée et nous allons avoir besoin d'une carte mettant en scène un indicateur donné.

## :robot: Solution
Ajouter ce composant dans Pix Orga.

## :rainbow: Remarques
Ce n'est pour l'instant pas pertinent de l'ajouter dans Pix UI puisque cette carte d'indicateur n'a pas vocation à être utilisée ailleurs que dans Pix Orga.

NB : le dernier commit sera supprimé avant merge.

## :100: Pour tester
Se connecter à Pix Orga en tant que sco.admin@pix.fr, prendre la campagne "Sco - Collège - Campagne d’évaluation Badges", et vérifier que sur la page de détail on voie les 4 typologies de cartes (affichées ici de manière momentanée pour la review).
