### PR TITLE
[FEATURE] Ajout des titres à toutes les pages de Pix Certif (PIX-2650)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/add-student.js
+++ b/certif/app/controllers/authenticated/sessions/add-student.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+
+export default class SessionsAddStudentController extends Controller {
+
+  get pageTitle() {
+    return `Inscription des candidats | Session ${this.model.session.id} | Pix Certif`;
+  }
+}

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -12,6 +12,10 @@ export default class SessionsDetailsController extends Controller {
   @alias('model.certificationCandidates') certificationCandidates;
   @alias('model.shouldDisplayPrescriptionScoStudentRegistrationFeature') shouldDisplayPrescriptionScoStudentRegistrationFeature;
 
+  get pageTitle() {
+    return `Détails | Session ${this.session.id} | Pix Certif`;
+  }
+
   @computed('certificationCandidates.length')
   get certificationCandidatesCount() {
     const certificationCandidatesCount = this.certificationCandidates.length;

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -13,6 +13,10 @@ export default class CertificationCandidatesController extends Controller {
   @alias('model.reloadCertificationCandidate') reloadCertificationCandidate;
   @alias('model.shouldDisplayPrescriptionScoStudentRegistrationFeature') shouldDisplayPrescriptionScoStudentRegistrationFeature;
 
+  get pageTitle() {
+    return `Candidats | Session ${this.currentSession.id} | Pix Certif`;
+  }
+
   @computed('certificationCandidates', 'certificationCandidates.@each.isLinked')
   get importAllowed() {
     return every(this.certificationCandidates.toArray(), (certificationCandidate) => {

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -22,6 +22,10 @@ export default class SessionsFinalizeController extends Controller {
   @tracked isLoading = false;
   @tracked showConfirmModal = false;
 
+  get pageTitle() {
+    return `Finalisation | Session ${this.session.id} | Pix Certif`;
+  }
+
   @computed('session.certificationReports.@each.hasSeenEndTestScreen')
   get uncheckedHasSeenEndTestScreenCount() {
     return sumBy(

--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -8,6 +8,10 @@ export default class SessionsNewController extends Controller {
 
   @alias('model') session;
 
+  get pageTitle() {
+    return 'Planification d\'une session | Pix Certif';
+  }
+
   @action
   async createSession(event) {
     event.preventDefault();

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -8,6 +8,10 @@ export default class SessionsUpdateController extends Controller {
 
   @alias('model') session;
 
+  get pageTitle() {
+    return 'Modification d\'une session | Session ${this.session.id} | Pix Certif';
+  }
+
   @action
   async updateSession(event) {
     event.preventDefault();

--- a/certif/app/templates/application.hbs
+++ b/certif/app/templates/application.hbs
@@ -1,0 +1,2 @@
+{{page-title 'Pix Certif'}}
+{{outlet}}

--- a/certif/app/templates/authenticated/sessions.hbs
+++ b/certif/app/templates/authenticated/sessions.hbs
@@ -1,2 +1,3 @@
+{{page-title "Sessions de certification"}}
 {{outlet}}
 

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -1,3 +1,4 @@
+{{page-title this.pageTitle replace=true}}
 <div class="add-student">
 
   <PixReturnTo

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -1,3 +1,4 @@
+{{page-title this.pageTitle replace=true}}
 <div class="session-details-page">
   <div class="page__title session-details__header">
     <div class="session-details-header__title">

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -1,3 +1,4 @@
+{{page-title this.pageTitle replace=true}}
 {{#if this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
   {{#unless this.hasOneOrMoreCandidates}}
     <CertificationCandidatesSco @sessionId={{this.currentSession.id}}></CertificationCandidatesSco>

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -1,3 +1,4 @@
+{{page-title this.pageTitle replace=true}}
 <div class="page__title finalize">
   <div class="finalize__title">
     <PixReturnTo @route="authenticated.sessions.details" @model={{this.session.id}} class="session-details-content__return-button" />

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -1,3 +1,4 @@
+{{page-title this.pageTitle replace=true}}
 <div class="new-session-page">
   <h1 class="page__title page-title">Création d'une session de certification</h1>
 

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -1,3 +1,4 @@
+{{page-title this.pageTitle replace=true}}
 <div class="update-session-page">
   <h1 class="page__title page-title">Modification d'une session de certification</h1>
 

--- a/certif/app/templates/login.hbs
+++ b/certif/app/templates/login.hbs
@@ -1,3 +1,4 @@
+{{page-title "Connectez-vous"}}
 <div class="login-page">
   <LoginForm />
 </div>

--- a/certif/app/templates/logout.hbs
+++ b/certif/app/templates/logout.hbs
@@ -1,1 +1,2 @@
+{{page-title "Déconnexion"}}
 {{outlet}}

--- a/certif/app/templates/terms-of-service.hbs
+++ b/certif/app/templates/terms-of-service.hbs
@@ -1,3 +1,4 @@
+{{page-title "Conditions générales"}}
 <div class="terms-of-service-page">
   <div class="terms-of-service-form">
 

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -15271,6 +15271,15 @@
         }
       }
     },
+    "ember-page-title": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ember-page-title/-/ember-page-title-6.2.2.tgz",
+      "integrity": "sha512-YTXA+cylZrh9zO0zwjlaAGReT2MVOxAMnVO1OOygFrs1JBs4D6CKV3tImoilg3AvIXFBeJfFNNUbJOdRd9IGGg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.23.1"
+      }
+    },
     "ember-qunit": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",
@@ -17958,6 +17967,7 @@
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -20223,7 +20233,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -20487,7 +20498,8 @@
     "neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -23870,7 +23882,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -25452,6 +25465,7 @@
       "version": "3.13.5",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.5.tgz",
       "integrity": "sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==",
+      "dev": true,
       "optional": true
     },
     "unbox-primitive": {
@@ -26533,7 +26547,8 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -73,6 +73,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-modal-dialog": "^3.0.2",
     "ember-moment": "^8.0.0",
+    "ember-page-title": "^6.2.2",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-simple-auth": "^3.1.0",


### PR DESCRIPTION
## :unicorn: Problème
L'accessibilité de Pix Certif va prochainement faire l'objet d'un audit et nous voulons au préalable effectuer un maximum de corrections faciles.

Des titres descriptifs aident les utilisateurs à comprendre rapidement le contenu des pages web. C'est un critère important d'accessibilité. Or, dans Pix Certif, aucune page n'a de titre spécifique (elles s'appellent toutes Pix Certif).

## :robot: Solution
Ajouter des titres uniques à toutes les pages, sur le modèle "{Titre de la page} | Pix Certif"

## :rainbow: Remarques
Echanges quant aux titres à choisir répertoriés dans le document [suivant](https://docs.google.com/spreadsheets/d/1P0HdCPtaJt_yiP-5Nho6TqBK36euCwU2jZt30a9b7v0/edit#gid=0)

## :100: Pour tester
- Se connecter à Pix Certif et constater les noms de page (présents en haut du navigateur ou dans l'onglet courant du navigateur).
