### PR TITLE
[FEATURE] Auto neutraliser les questions portant sur les images ou simulateurs (PIX-2589).

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -48,18 +48,13 @@ async function _autoNeutralizeChallenges({
 
   const neutralizableIssueReports = certificationIssueReports.filter((issueReport) => issueReport.isAutoNeutralizable);
 
-  let certificationImpacted = 0;
-  for (const neutralizableIssueReport of neutralizableIssueReports) {
-    const questionNumber = neutralizableIssueReport.questionNumber;
-    const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(questionNumber);
-    if (neutralizationAttempt.hasSucceeded()) {
-      neutralizableIssueReport.resolve('Cette question a été neutralisée automatiquement');
-      await certificationIssueReportRepository.save(neutralizableIssueReport);
-      certificationImpacted++;
-    }
+  let numberOfCertificationsImpacted = 0;
+  for (const certificationIssueReport of neutralizableIssueReports) {
+    const isCertificationImpacted = await certificationIssueReport.resolutionStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+    if (isCertificationImpacted) numberOfCertificationsImpacted++;
   }
 
-  if (certificationImpacted > 0) {
+  if (numberOfCertificationsImpacted > 0) {
     await certificationAssessmentRepository.save(certificationAssessment);
     return new CertificationJuryDone({ certificationCourseId: certificationCourse.id });
   }

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -51,7 +51,7 @@ async function _autoNeutralizeChallenges({
     return certificationIssueReport.resolutionStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
   });
 
-  if (resolutionAttempts.some((attempt) => attempt.hasSucceeded())) {
+  if (resolutionAttempts.some((attempt) => attempt.isResolvedWithEffect())) {
     await certificationAssessmentRepository.save(certificationAssessment);
     return new CertificationJuryDone({ certificationCourseId: certificationCourse.id });
   }

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -1,5 +1,6 @@
 const { checkEventTypes } = require('./check-event-types');
 const SessionFinalized = require('./SessionFinalized');
+const CertificationIssueReportResolutionAttempt = require('../models/CertificationIssueReportResolutionAttempt');
 const AutoJuryDone = require('./AutoJuryDone');
 const CertificationJuryDone = require('./CertificationJuryDone');
 const bluebird = require('bluebird');
@@ -11,6 +12,7 @@ async function handleAutoJury({
   certificationIssueReportRepository,
   certificationAssessmentRepository,
   certificationCourseRepository,
+  logger,
 }) {
   checkEventTypes(event, eventTypes);
   const certificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({ sessionId: event.sessionId });
@@ -20,6 +22,7 @@ async function handleAutoJury({
       certificationCourse,
       certificationIssueReportRepository,
       certificationAssessmentRepository,
+      logger,
     })));
 
   const filteredCertificationJuryDoneEvents = certificationJuryDoneEvents.filter((certificationJuryDoneEvent) => Boolean(certificationJuryDoneEvent));
@@ -40,6 +43,7 @@ async function _autoNeutralizeChallenges({
   certificationCourse,
   certificationIssueReportRepository,
   certificationAssessmentRepository,
+  logger,
 }) {
   const certificationIssueReports = await certificationIssueReportRepository.findByCertificationCourseId(certificationCourse.id);
   if (certificationIssueReports.length === 0) {
@@ -48,7 +52,12 @@ async function _autoNeutralizeChallenges({
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: certificationCourse.id });
 
   const resolutionAttempts = await bluebird.mapSeries(certificationIssueReports, async (certificationIssueReport) => {
-    return certificationIssueReport.resolutionStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+    try {
+      return await certificationIssueReport.resolutionStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+    } catch (e) {
+      logger.error(e);
+      return CertificationIssueReportResolutionAttempt.unresolved();
+    }
   });
 
   if (resolutionAttempts.some((attempt) => attempt.isResolvedWithEffect())) {

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -28,6 +28,7 @@ const dependencies = {
   poleEmploiNotifier: require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier'),
   juryCertificationSummaryRepository: require('../../infrastructure/repositories/jury-certification-summary-repository'),
   finalizedSessionRepository: require('../../infrastructure/repositories/finalized-session-repository'),
+  logger: require('../../infrastructure/logger'),
 };
 
 const partnerCertificationScoringRepository = injectDependencies(

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -107,6 +107,10 @@ class CertificationAssessment {
   isCompleted() {
     return this.state === states.COMPLETED;
   }
+
+  getChallengeRecIdByQuestionNumber(questionNumber) {
+    return this.certificationAnswersByDate[questionNumber - 1]?.challengeId || null;
+  }
 }
 
 function _isAnswerKoOrSkipped(answerStatus) {

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -62,13 +62,13 @@ class CertificationAssessment {
     }
   }
 
-  neutralizeChallengeByNumberIfKoOrSkipped(questionNumber) {
+  neutralizeChallengeByNumberIfKoOrSkippedOrPartially(questionNumber) {
     const toBeNeutralizedChallengeAnswer = this.certificationAnswersByDate[questionNumber - 1];
     if (!toBeNeutralizedChallengeAnswer) {
       return NeutralizationAttempt.failure(questionNumber);
     }
 
-    if (_isAnswerKoOrSkipped(toBeNeutralizedChallengeAnswer.result.status)) {
+    if (_isAnswerKoOrSkippedOrPartially(toBeNeutralizedChallengeAnswer.result.status)) {
       const challengeToBeNeutralized = _.find(this.certificationChallenges, { challengeId: toBeNeutralizedChallengeAnswer.challengeId });
       challengeToBeNeutralized.neutralize();
       return NeutralizationAttempt.neutralized(questionNumber);
@@ -113,10 +113,11 @@ class CertificationAssessment {
   }
 }
 
-function _isAnswerKoOrSkipped(answerStatus) {
+function _isAnswerKoOrSkippedOrPartially(answerStatus) {
   const isKo = AnswerStatus.isKO(answerStatus);
   const isSkipped = AnswerStatus.isSKIPPED(answerStatus);
-  return (isKo || isSkipped);
+  const isPartially = AnswerStatus.isPARTIALLY(answerStatus);
+  return (isKo || isSkipped || isPartially);
 }
 
 CertificationAssessment.states = states;

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -72,36 +72,38 @@ const categorySchemas = {
   [CertificationIssueReportCategories.TECHNICAL_PROBLEM]: categoryTechnicalProblemJoiSchema,
 };
 
-const categoryCodeImpactful = {
-  [CertificationIssueReportCategories.TECHNICAL_PROBLEM]: 'A1',
-  [CertificationIssueReportCategories.OTHER]: 'A2',
-  [CertificationIssueReportCategories.FRAUD]: 'C6',
-};
+const categoryCodeImpactful = [
+  CertificationIssueReportCategories.TECHNICAL_PROBLEM,
+  CertificationIssueReportCategories.OTHER,
+  CertificationIssueReportCategories.FRAUD,
+];
 
-const subcategoryCodeImpactful = {
-  [CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'C1',
-  [CertificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'C3',
-  [CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'E1',
-  [CertificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E2',
-  [CertificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E3',
-  [CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E4',
-  [CertificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E5',
-  [CertificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E6',
-  [CertificationIssueReportSubcategories.OTHER]: 'E7',
-  [CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED]: 'E8',
-  [CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]: 'E9',
-};
+const subcategoryCodeImpactful = [
+  CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
+  CertificationIssueReportSubcategories.LEFT_EXAM_ROOM,
+  CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+  CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+  CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+  CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
+  CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+  CertificationIssueReportSubcategories.LINK_NOT_WORKING,
+  CertificationIssueReportSubcategories.OTHER,
+  CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+  CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+];
 
-const deprecatedSubcategories = {
-  [CertificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E6',
-  [CertificationIssueReportSubcategories.OTHER]: 'E7',
-};
+const deprecatedSubcategories = [
+  CertificationIssueReportSubcategories.LINK_NOT_WORKING,
+  CertificationIssueReportSubcategories.OTHER,
+];
 
-const autoNeutralizableSubcategories = {
-  [CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E4',
-  [CertificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E5',
-  [CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]: 'E9',
-};
+const autoNeutralizableSubcategories = [
+  CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
+  CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+  CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+  CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+  CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+];
 
 class CertificationIssueReport {
   constructor(
@@ -190,13 +192,14 @@ class CertificationIssueReport {
 module.exports = CertificationIssueReport;
 
 function _isImpactful({ category, subcategory }) {
-  return Boolean(subcategoryCodeImpactful[subcategory] || categoryCodeImpactful[category]);
+  return categoryCodeImpactful.includes(category)
+  || subcategoryCodeImpactful.includes(subcategory);
 }
 
 function _isSubcategoryDeprecated(subcategory) {
-  return Boolean(deprecatedSubcategories[subcategory]);
+  return deprecatedSubcategories.includes(subcategory);
 }
 
 function _isSubcategoryAutoNeutralizable(subcategory) {
-  return Boolean(autoNeutralizableSubcategories[subcategory]);
+  return autoNeutralizableSubcategories.includes(subcategory);
 }

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const { InvalidCertificationIssueReportForSaving, DeprecatedCertificationIssueReportSubcategory } = require('../errors');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('./CertificationIssueReportCategory');
+const CertificationIssueReportStrategies = require('./CertificationIssueReportResolutionStrategies');
 
 const categoryOtherJoiSchema = Joi.object({
   certificationCourseId: Joi.number().required().empty(null),
@@ -127,6 +128,7 @@ class CertificationIssueReport {
     this.resolution = resolution;
     this.isImpactful = _isImpactful({ category, subcategory });
     this.isAutoNeutralizable = _isSubcategoryAutoNeutralizable(subcategory);
+    this.resolutionStrategy = _getResolutionStrategy(subcategory);
 
     if ([CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN, CertificationIssueReportCategories.OTHER].includes(this.category)) {
       this.subcategory = null;
@@ -202,4 +204,28 @@ function _isSubcategoryDeprecated(subcategory) {
 
 function _isSubcategoryAutoNeutralizable(subcategory) {
   return autoNeutralizableSubcategories.includes(subcategory);
+}
+
+function _getResolutionStrategy(subcategory) {
+  if (
+    subcategory === CertificationIssueReportSubcategories.WEBSITE_BLOCKED ||
+    subcategory === CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE ||
+    subcategory === CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING
+  ) {
+    return CertificationIssueReportStrategies.NEUTRALIZE_WITHOUT_CHECKING;
+  }
+
+  if (
+    subcategory === CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING
+  ) {
+    return CertificationIssueReportStrategies.NEUTRALIZE_IF_IMAGE;
+  }
+
+  if (
+    subcategory === CertificationIssueReportSubcategories.EMBED_NOT_WORKING
+  ) {
+    return CertificationIssueReportStrategies.NEUTRALIZE_IF_EMBED;
+  }
+
+  return CertificationIssueReportStrategies.NONE;
 }

--- a/api/lib/domain/models/CertificationIssueReportResolutionAttempt.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionAttempt.js
@@ -1,0 +1,26 @@
+module.exports = class CertificationIssueReportResolutionAttempt {
+  constructor(status) {
+    this.status = status;
+  }
+
+  static succeeded() {
+    return new CertificationIssueReportResolutionAttempt(ResolutionStatus.SUCCEEDED);
+  }
+
+  static failure() {
+    return new CertificationIssueReportResolutionAttempt(ResolutionStatus.FAILURE);
+  }
+
+  hasFailed() {
+    return this.status === ResolutionStatus.FAILURE;
+  }
+
+  hasSucceeded() {
+    return this.status === ResolutionStatus.SUCCEEDED;
+  }
+};
+
+const ResolutionStatus = {
+  SUCCEEDED: 'SUCCEEDED',
+  FAILURE: 'FAILURE',
+};

--- a/api/lib/domain/models/CertificationIssueReportResolutionAttempt.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionAttempt.js
@@ -3,24 +3,25 @@ module.exports = class CertificationIssueReportResolutionAttempt {
     this.status = status;
   }
 
-  static succeeded() {
-    return new CertificationIssueReportResolutionAttempt(ResolutionStatus.SUCCEEDED);
+  static resolvedWithEffect() {
+    return new CertificationIssueReportResolutionAttempt(ResolutionStatus.RESOLVED_WITH_EFFECT);
   }
 
-  static failure() {
-    return new CertificationIssueReportResolutionAttempt(ResolutionStatus.FAILURE);
+  static resolvedWithoutEffect() {
+    return new CertificationIssueReportResolutionAttempt(ResolutionStatus.RESOLVED_WITHOUT_EFFECT);
   }
 
-  hasFailed() {
-    return this.status === ResolutionStatus.FAILURE;
+  static unresolved() {
+    return new CertificationIssueReportResolutionAttempt(ResolutionStatus.UNRESOLVED);
   }
 
-  hasSucceeded() {
-    return this.status === ResolutionStatus.SUCCEEDED;
+  isResolvedWithEffect() {
+    return this.status === ResolutionStatus.RESOLVED_WITH_EFFECT;
   }
 };
 
 const ResolutionStatus = {
-  SUCCEEDED: 'SUCCEEDED',
-  FAILURE: 'FAILURE',
+  RESOLVED_WITH_EFFECT: 'RESOLVED_WITH_EFFECT',
+  RESOLVED_WITHOUT_EFFECT: 'RESOLVED_WITHOUT_EFFECT',
+  UNRESOLVED: 'UNRESOLVED',
 };

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -1,15 +1,23 @@
+const CertificationIssueReportResolutionAttempt = require('./CertificationIssueReportResolutionAttempt');
+
 module.exports = {
-  NEUTRALIZE_IF_EMBED: 'NEUTRALIZE_IF_EMBED',
-  NEUTRALIZE_IF_IMAGE: 'NEUTRALIZE_IF_IMAGE',
+  NEUTRALIZE_IF_EMBED: async () => {
+    return CertificationIssueReportResolutionAttempt.failure();
+  },
+  NEUTRALIZE_IF_IMAGE: async () => {
+    return CertificationIssueReportResolutionAttempt.failure();
+  },
   NEUTRALIZE_WITHOUT_CHECKING: async ({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository }) => {
     const questionNumber = certificationIssueReport.questionNumber;
     const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(questionNumber);
     if (neutralizationAttempt.hasSucceeded()) {
       certificationIssueReport.resolve('Cette question a été neutralisée automatiquement');
       await certificationIssueReportRepository.save(certificationIssueReport);
-      return true;
+      return CertificationIssueReportResolutionAttempt.succeeded();
     }
-    return false;
+    return CertificationIssueReportResolutionAttempt.failure();
   },
-  NONE: 'NONE',
+  NONE: async () => {
+    return CertificationIssueReportResolutionAttempt.failure();
+  },
 };

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -4,7 +4,26 @@ module.exports = {
   NEUTRALIZE_IF_EMBED: async () => {
     return CertificationIssueReportResolutionAttempt.failure();
   },
-  NEUTRALIZE_IF_IMAGE: async () => {
+  NEUTRALIZE_IF_IMAGE: async ({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository }) => {
+    const questionNumber = certificationIssueReport.questionNumber;
+    const recId = certificationAssessment.getChallengeRecIdByQuestionNumber(questionNumber);
+
+    if (!recId) {
+      return CertificationIssueReportResolutionAttempt.failure();
+    }
+
+    const challenge = await challengeRepository.get(recId);
+
+    if (!challenge.illustrationUrl) {
+      return CertificationIssueReportResolutionAttempt.failure();
+    }
+
+    const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(questionNumber);
+    if (neutralizationAttempt.hasSucceeded()) {
+      certificationIssueReport.resolve('Cette question a été neutralisée automatiquement');
+      await certificationIssueReportRepository.save(certificationIssueReport);
+      return CertificationIssueReportResolutionAttempt.succeeded();
+    }
     return CertificationIssueReportResolutionAttempt.failure();
   },
   NEUTRALIZE_WITHOUT_CHECKING: async ({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository }) => {

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -1,0 +1,15 @@
+module.exports = {
+  NEUTRALIZE_IF_EMBED: 'NEUTRALIZE_IF_EMBED',
+  NEUTRALIZE_IF_IMAGE: 'NEUTRALIZE_IF_IMAGE',
+  NEUTRALIZE_WITHOUT_CHECKING: async ({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository }) => {
+    const questionNumber = certificationIssueReport.questionNumber;
+    const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(questionNumber);
+    if (neutralizationAttempt.hasSucceeded()) {
+      certificationIssueReport.resolve('Cette question a été neutralisée automatiquement');
+      await certificationIssueReportRepository.save(certificationIssueReport);
+      return true;
+    }
+    return false;
+  },
+  NONE: 'NONE',
+};

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -18,7 +18,7 @@ module.exports = {
       return CertificationIssueReportResolutionAttempt.failure();
     }
 
-    const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(questionNumber);
+    const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(questionNumber);
     if (neutralizationAttempt.hasSucceeded()) {
       certificationIssueReport.resolve('Cette question a été neutralisée automatiquement');
       await certificationIssueReportRepository.save(certificationIssueReport);
@@ -28,7 +28,7 @@ module.exports = {
   },
   NEUTRALIZE_WITHOUT_CHECKING: async ({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository }) => {
     const questionNumber = certificationIssueReport.questionNumber;
-    const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(questionNumber);
+    const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(questionNumber);
     if (neutralizationAttempt.hasSucceeded()) {
       certificationIssueReport.resolve('Cette question a été neutralisée automatiquement');
       await certificationIssueReportRepository.save(certificationIssueReport);

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -107,6 +107,14 @@ class Challenge {
     return _(this.skills).differenceWith(alreadyAssessedSkills, Skill.areEqual).size() > 0;
   }
 
+  hasIllustration() {
+    return Boolean(this.illustrationUrl);
+  }
+
+  hasEmbed() {
+    return Boolean(this.embedUrl);
+  }
+
   static createValidatorForChallengeType({ challengeType, solution }) {
     switch (challengeType) {
       case ChallengeType.QCU:

--- a/api/lib/domain/models/NeutralizationAttempt.js
+++ b/api/lib/domain/models/NeutralizationAttempt.js
@@ -23,6 +23,10 @@ module.exports = class NeutralizationAttempt {
   hasSucceeded() {
     return this.status === NeutralizationStatus.NEUTRALIZED;
   }
+
+  wasSkipped() {
+    return this.status === NeutralizationStatus.SKIPPED;
+  }
 };
 
 const NeutralizationStatus = {

--- a/api/lib/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-issue-report-repository.js
@@ -6,7 +6,7 @@ const omit = require('lodash/omit');
 module.exports = {
   async save(certificationIssueReport) {
     const newCertificationIssueReport = await new CertificationIssueReportBookshelf(
-      omit(certificationIssueReport, ['isImpactful', 'isAutoNeutralizable']),
+      omit(certificationIssueReport, ['isImpactful', 'isAutoNeutralizable', 'resolutionStrategy']),
     ).save();
     return bookshelfToDomainConverter.buildDomainObject(CertificationIssueReportBookshelf, newCertificationIssueReport);
   },

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -4,6 +4,7 @@ const CertificationReport = require('../../../../lib/domain/models/Certification
 const certificationReportRepository = require('../../../../lib/infrastructure/repositories/certification-report-repository');
 const { CertificationCourseUpdateError } = require('../../../../lib/domain/errors');
 const { CertificationIssueReportCategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
+const CertificationIssueReportResolutionStrategies = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 describe('Integration | Repository | CertificationReport', function() {
 
@@ -36,7 +37,13 @@ describe('Integration | Repository | CertificationReport', function() {
           certificationCourseId: certificationCourse1.id,
           firstName: certificationCourse1.firstName,
           lastName: certificationCourse1.lastName,
-          certificationIssueReports: [ { ...certificationIssueReport1, isImpactful: true, isAutoNeutralizable: false } ],
+          certificationIssueReports: [
+            { ...certificationIssueReport1,
+              isImpactful: true,
+              isAutoNeutralizable: false,
+              resolutionStrategy: CertificationIssueReportResolutionStrategies.NONE,
+            },
+          ],
           hasSeenEndTestScreen: certificationCourse1.hasSeenEndTestScreen,
         });
         const expectedCertificationReport2 = domainBuilder.buildCertificationReport({

--- a/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
@@ -1,6 +1,7 @@
 const { catchErr, expect, databaseBuilder } = require('../../../test-helper');
 const generalCertificationInformationRepository = require('../../../../lib/infrastructure/repositories/general-certification-information-repository');
 const { NotFoundError } = require('../../../../lib/domain/errors');
+const CertificationIssueReportResolutionStrategies = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 const GeneralCertificationInformation = require('../../../../lib/domain/read-models/GeneralCertificationInformation');
 
@@ -57,8 +58,20 @@ describe('Integration | Repository | General certification information', functio
           birthdate: certificationCourseDTO.birthdate,
           birthplace: certificationCourseDTO.birthplace,
           certificationIssueReports: [
-            { ...firstCertificationReport, isAutoNeutralizable: false, isImpactful: true, resolution: 'challenge neutralized', resolvedAt: new Date('2021-01-01T00:00:00Z') },
-            { ...secondCertificationReport, isAutoNeutralizable: false, isImpactful: true, resolution: null, resolvedAt: null },
+            { ...firstCertificationReport,
+              isAutoNeutralizable: false,
+              isImpactful: true,
+              resolution: 'challenge neutralized',
+              resolvedAt: new Date('2021-01-01T00:00:00Z'),
+              resolutionStrategy: CertificationIssueReportResolutionStrategies.NONE,
+            },
+            { ...secondCertificationReport,
+              isAutoNeutralizable: false,
+              isImpactful: true,
+              resolution: null,
+              resolvedAt: null,
+              resolutionStrategy: CertificationIssueReportResolutionStrategies.NONE,
+            },
           ],
         };
         expect(result).to.be.instanceOf(GeneralCertificationInformation);

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -43,8 +43,8 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     const certificationCourse = domainBuilder.buildCertificationCourse();
     const certificationIssueReport = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, questionNumber: 1 });
     const certificationIssueReport2 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.FRAUD, subcategory: undefined, questionNumber: 1 });
-    sinon.stub(certificationIssueReport, 'resolutionStrategy').resolves(CertificationIssueReportResolutionAttempt.succeeded());
-    sinon.stub(certificationIssueReport2, 'resolutionStrategy').resolves(CertificationIssueReportResolutionAttempt.failure());
+    sinon.stub(certificationIssueReport, 'resolutionStrategy').resolves(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
+    sinon.stub(certificationIssueReport2, 'resolutionStrategy').resolves(CertificationIssueReportResolutionAttempt.unresolved());
     certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
     certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([ certificationIssueReport, certificationIssueReport2 ]);
     certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.id }).resolves(certificationAssessment);
@@ -205,7 +205,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
         ],
       });
       const certificationCourse = domainBuilder.buildCertificationCourse();
-      const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, questionNumber: 1 });
+      const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.FRAUD, subcategory: null, questionNumber: 1 });
       certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
       certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.id).resolves([ certificationIssueReport1 ]);
       certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.id }).resolves(certificationAssessment);

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -25,9 +25,9 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
     const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-    const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
-    const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal456', isNeutralized: false });
-    const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal789', isNeutralized: false });
+    const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false });
+    const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false });
+    const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789', isNeutralized: false });
     const certificationAssessment = domainBuilder.buildCertificationAssessment({
       certificationAnswersByDate: [
         domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
@@ -116,7 +116,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
     const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-    const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
+    const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false });
     const certificationAssessment = domainBuilder.buildCertificationAssessment({
       certificationAnswersByDate: [
         domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
@@ -195,7 +195,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
       const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const challenge = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
+      const challenge = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.OK }),
@@ -239,9 +239,9 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
       const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal123', isNeutralized: false });
-      const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal456', isNeutralized: false });
-      const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallenge({ challengeId: 'recChal789', isNeutralized: false });
+      const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false });
+      const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false });
+      const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789', isNeutralized: false });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -246,7 +246,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
     });
   });
 
-  describe('#neutralizeChallengeByNumberIfKoOrSkipped', () => {
+  describe('#neutralizeChallengeByNumberIfKoOrSkippedOrPartially', () => {
 
     it('should neutralize the challenge when the answer is ko', () => {
       // given
@@ -269,7 +269,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       });
 
       // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(1);
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(1);
 
       // then
       expect(challengeKoToBeNeutralized.isNeutralized).to.be.true;
@@ -297,14 +297,42 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       });
 
       // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(1);
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(1);
 
       // then
       expect(challengeSkippedToBeNeutralized.isNeutralized).to.be.true;
       expect(neutralizationAttempt).to.deep.equal(NeutralizationAttempt.neutralized(1));
     });
 
-    it('should not neutralize the challenge when the answer is neither skipped nor ko', () => {
+    it('should neutralize the challenge when the answer is partially answered', () => {
+      // given
+      const challengeSkippedToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: false });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        id: 123,
+        userId: 123,
+        certificationCourseId: 123,
+        createdAt: new Date('2020-01-01'),
+        completedAt: new Date('2020-01-01'),
+        state: CertificationAssessment.states.STARTED,
+        isV2Certification: true,
+        certificationChallenges: [
+          challengeSkippedToBeNeutralized,
+        ],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: challengeSkippedToBeNeutralized.challengeId, result: AnswerStatus.PARTIALLY.status, assessmentId: CertificationAssessment.id }),
+        ],
+      });
+
+      // when
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(1);
+
+      // then
+      expect(challengeSkippedToBeNeutralized.isNeutralized).to.be.true;
+      expect(neutralizationAttempt).to.deep.equal(NeutralizationAttempt.neutralized(1));
+    });
+
+    it('should not neutralize the challenge when the answer is neither skipped nor ko nor partially', () => {
       // given
       const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec3', isNeutralized: false });
 
@@ -325,7 +353,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       });
 
       // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(1);
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(1);
 
       // then
       expect(challengeNotToBeNeutralized.isNeutralized).to.be.false;
@@ -353,7 +381,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       });
 
       // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(66);
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(66);
 
       // then
       expect(neutralizationAttempt).to.deep.equal(NeutralizationAttempt.failure(66));
@@ -468,9 +496,9 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
   describe('#getChallengeRecIdByQuestionNumber', () => {
     it('returns the recId when question number exists', () => {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1234' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
-      const certificationChallenge3 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec789' });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1234' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456' });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789' });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge1, certificationChallenge2, certificationChallenge3],

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -464,4 +464,46 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       expect(certificationAssessment.isCompleted()).to.be.false;
     });
   });
+
+  describe('#getChallengeRecIdByQuestionNumber', () => {
+    it('returns the recId when question number exists', () => {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1234' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec789' });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1, certificationChallenge2, certificationChallenge3],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: certificationChallenge1.challengeId, result: AnswerStatus.KO.status }),
+          domainBuilder.buildAnswer({ challengeId: certificationChallenge2.challengeId, result: AnswerStatus.KO.status }),
+          domainBuilder.buildAnswer({ challengeId: certificationChallenge3.challengeId, result: AnswerStatus.KO.status }),
+        ],
+      });
+
+      // when
+      const recId = certificationAssessment.getChallengeRecIdByQuestionNumber(2);
+
+      // then
+      expect(recId).to.equal('rec456');
+    });
+
+    it('returns null when question number does not exist', () => {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1234' });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: certificationChallenge1.challengeId, result: AnswerStatus.KO.status }),
+        ],
+      });
+
+      // when
+      const recId = certificationAssessment.getChallengeRecIdByQuestionNumber(2);
+
+      // then
+      expect(recId).to.equal(null);
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -3,7 +3,9 @@ const { CertificationIssueReportCategories, CertificationIssueReportSubcategorie
 const CertificationIssueReportResolutionAttempt = require('../../../../lib/domain/models/CertificationIssueReportResolutionAttempt');
 const {
   NEUTRALIZE_WITHOUT_CHECKING: neutralizeWithoutChecking,
-  NEUTRALIZE_IF_IMAGE: neutralizeIfImage,
+  NEUTRALIZE_IF_ILLUSTRATION: neutralizeIfIllustration,
+  NEUTRALIZE_IF_EMBED: neutralizeIfEmbed,
+  NONE: doNotResolve,
 } = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies', () => {
@@ -114,7 +116,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
   });
 
-  context('#NEUTRALIZE_IF_IMAGE', () => {
+  context('#NEUTRALIZE_IF_ILLUSTRATION', () => {
 
     context('When challenge is neutralizable', () => {
 
@@ -131,16 +133,16 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const challengeWithIllustration = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithImage),
+          get: sinon.stub().resolves(challengeWithIllustration),
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.succeeded());
@@ -159,12 +161,17 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
+        const challengeWithIllustration = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithIllustration),
+        };
 
         // when
-        await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -190,7 +197,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        const neutralizationAttempt = await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
@@ -206,12 +213,12 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithoutImage = domainBuilder.buildChallenge({ illustrationUrl: null });
+        const challengeWithoutIllustration = domainBuilder.buildChallenge({ illustrationUrl: null });
         const certificationIssueReportRepository = {
           save: () => {},
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithoutImage),
+          get: sinon.stub().resolves(challengeWithoutIllustration),
         };
         const certificationChallenge = domainBuilder.buildCertificationChallenge();
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -220,7 +227,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
@@ -242,16 +249,16 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const challengeWithIllustration = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithImage),
+          get: sinon.stub().resolves(challengeWithIllustration),
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
@@ -270,20 +277,215 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const challengeWithIllustration = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithImage),
+          get: sinon.stub().resolves(challengeWithIllustration),
         };
 
         // when
-        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.false;
       });
+    });
+  });
+  context('#NEUTRALIZE_IF_EMBED', () => {
+
+    context('When challenge is neutralizable', () => {
+
+      it('neutralizes successfully', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithEmbed),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.succeeded());
+      });
+
+      it('resolves the issue report', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+
+        const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
+
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithEmbed),
+        };
+
+        // when
+        await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('the challenge does not contain the question designated by the question number', () => {
+
+      it('returns a failed neutralization attempt', async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: () => {},
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [domainBuilder.buildCertificationChallenge()],
+          certificationAnswersByDate: [],
+        });
+
+        // when
+        const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
+      });
+    });
+
+    context('the challenge does not contain an embed', () => {
+
+      it('returns a failed neutralization attempt', async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithoutEmbed = domainBuilder.buildChallenge({ embedUrl: null });
+        const certificationIssueReportRepository = {
+          save: () => {},
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithoutEmbed),
+        };
+        const certificationChallenge = domainBuilder.buildCertificationChallenge();
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
+        });
+
+        // when
+        const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
+      });
+    });
+
+    context('When challenge is not neutralizable', () => {
+
+      it('returns a failed neutralization attempt', async () => {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithEmbed),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
+      });
+
+      it('does not resolve the certification issue report', async () => {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithEmbed),
+        };
+
+        // when
+        await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.false;
+      });
+    });
+  });
+  context('#NONE', () => {
+    it('does not resolve the certification issue report', async () => {
+      // given
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+        subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+        category: CertificationIssueReportCategories.IN_CHALLENGE,
+        questionNumber: 1,
+      });
+
+      // when
+      await doNotResolve({ certificationIssueReport, certificationAssessment: null, certificationIssueReportRepository: null, challengeRepository: null });
+
+      // then
+      expect(certificationIssueReport.isResolved()).to.be.false;
     });
   });
 });

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -1,7 +1,10 @@
 const { expect, domainBuilder, sinon } = require('../../../test-helper');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const CertificationIssueReportResolutionAttempt = require('../../../../lib/domain/models/CertificationIssueReportResolutionAttempt');
-const { NEUTRALIZE_WITHOUT_CHECKING: neutralizeWithoutChecking } = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
+const {
+  NEUTRALIZE_WITHOUT_CHECKING: neutralizeWithoutChecking,
+  NEUTRALIZE_IF_IMAGE: neutralizeIfImage,
+} = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies', () => {
 
@@ -60,6 +63,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
 
     context('When challenge is not neutralizable', () => {
+
       it('returns a failed neutralization attempt', async () => {
         // given
         const certificationChallenge = domainBuilder.buildCertificationChallenge({});
@@ -103,6 +107,179 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
         // when
         await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.false;
+      });
+    });
+  });
+
+  context('#NEUTRALIZE_IF_IMAGE', () => {
+
+    context('When challenge is neutralizable', () => {
+
+      it('neutralizes successfully', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithImage),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.succeeded());
+      });
+
+      it('resolves the issue report', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+
+        // when
+        await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('the challenge does not contain the question designated by the question number', () => {
+
+      it('returns a failed neutralization attempt', async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: () => {},
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [domainBuilder.buildCertificationChallenge()],
+          certificationAnswersByDate: [],
+        });
+
+        // when
+        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
+      });
+    });
+
+    context('the challenge does not contain an image', () => {
+
+      it('returns a failed neutralization attempt', async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithoutImage = domainBuilder.buildChallenge({ illustrationUrl: null });
+        const certificationIssueReportRepository = {
+          save: () => {},
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithoutImage),
+        };
+        const certificationChallenge = domainBuilder.buildCertificationChallenge();
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
+        });
+
+        // when
+        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
+      });
+    });
+
+    context('When challenge is not neutralizable', () => {
+
+      it('returns a failed neutralization attempt', async () => {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithImage),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
+      });
+
+      it('does not resolve the certification issue report', async () => {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithImage),
+        };
+
+        // when
+        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.false;

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -1,0 +1,112 @@
+const { expect, domainBuilder, sinon } = require('../../../test-helper');
+const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
+const CertificationIssueReportResolutionAttempt = require('../../../../lib/domain/models/CertificationIssueReportResolutionAttempt');
+const { NEUTRALIZE_WITHOUT_CHECKING: neutralizeWithoutChecking } = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
+
+describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies', () => {
+
+  context('#NEUTRALIZE_WITHOUT_CHECKING', () => {
+
+    context('When challenge is neutralizable', () => {
+
+      it('neutralizes successfully', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.succeeded());
+      });
+
+      it('resolves the issue report', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+
+        // when
+        await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('When challenge is not neutralizable', () => {
+      it('returns a failed neutralization attempt', async () => {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.failure());
+      });
+
+      it('does not resolve the certification issue report', async () => {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+
+        // when
+        await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.false;
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -16,7 +16,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('neutralizes successfully', async function() {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -40,7 +40,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('resolves the issue report', async function() {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -68,7 +68,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('returns a successful resolution without effect', async () => {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -92,7 +92,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('resolves the certification issue report anyway', async () => {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -123,7 +123,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('neutralizes successfully', async function() {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -151,7 +151,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('resolves the issue report', async function() {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -193,7 +193,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           save: () => {},
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [domainBuilder.buildCertificationChallenge()],
+          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
           certificationAnswersByDate: [],
         });
 
@@ -215,7 +215,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           save: sinon.stub(),
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [domainBuilder.buildCertificationChallenge()],
+          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
           certificationAnswersByDate: [],
         });
 
@@ -244,7 +244,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const challengeRepository = {
           get: sinon.stub().resolves(challengeWithoutIllustration),
         };
-        const certificationChallenge = domainBuilder.buildCertificationChallenge();
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
           certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
@@ -271,7 +271,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const challengeRepository = {
           get: sinon.stub().resolves(challengeWithoutIllustration),
         };
-        const certificationChallenge = domainBuilder.buildCertificationChallenge();
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
           certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
@@ -290,7 +290,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('returns a successful resolution attempt without effect', async () => {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -318,7 +318,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('resolves the certification issue report anyway', async () => {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -352,7 +352,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('neutralizes successfully', async function() {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -380,7 +380,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('resolves the issue report', async function() {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -424,7 +424,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           save: () => {},
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [domainBuilder.buildCertificationChallenge()],
+          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
           certificationAnswersByDate: [],
         });
 
@@ -446,7 +446,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           save: sinon.stub(),
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [domainBuilder.buildCertificationChallenge()],
+          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
           certificationAnswersByDate: [],
         });
 
@@ -475,7 +475,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const challengeRepository = {
           get: sinon.stub().resolves(challengeWithoutEmbed),
         };
-        const certificationChallenge = domainBuilder.buildCertificationChallenge();
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
           certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
@@ -502,7 +502,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const challengeRepository = {
           get: sinon.stub().resolves(challengeWithoutEmbed),
         };
-        const certificationChallenge = domainBuilder.buildCertificationChallenge();
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
           certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
@@ -521,7 +521,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('returns a successful resolution without effect', async () => {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],
@@ -549,7 +549,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
       it('resolves the certification issue report anyway', async () => {
         // given
-        const certificationChallenge = domainBuilder.buildCertificationChallenge({});
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [certificationChallenge],

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -2,6 +2,7 @@ const { expect, domainBuilder } = require('../../../test-helper');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories, DeprecatedCertificationIssueReportCategory } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const { InvalidCertificationIssueReportForSaving } = require('../../../../lib/domain/errors');
+const CertificationIssueReportResolutionStrategies = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 const MISSING_VALUE = null;
 const EMPTY_VALUE = '';
@@ -255,6 +256,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
           .to.throw(InvalidCertificationIssueReportForSaving);
       });
     });
+
     context('CATEGORY: FRAUD', () => {
       const certificationIssueReportDTO = {
         certificationCourseId: 123,
@@ -387,6 +389,36 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       });
     });
 
+    context('Matches resolution strategy with issue report subcategory', function() {
+      [
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_BLOCKED', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_UNAVAILABLE', questionNumber: 42 },
+        {
+          certificationCourseId: 42,
+          category: 'IN_CHALLENGE',
+          subcategory: 'SOFTWARE_NOT_WORKING',
+          questionNumber: 42,
+        },
+      ].forEach((certificationIssueReportDTO) => {
+        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should match with NEUTRALIZE_WITHOUT_CHECKING`, () => {
+          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_WITHOUT_CHECKING);
+        });
+      });
+
+      it('for IN_CHALLENGE IMAGE_NOT_DISPLAYING should match with NEUTRALIZE_IF_IMAGE', () => {
+        expect(new CertificationIssueReport({
+          category: 'IN_CHALLENGE',
+          subcategory: 'IMAGE_NOT_DISPLAYING',
+        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_IMAGE);
+      });
+
+      it('for IN_CHALLENGE EMBED_NOT_WORKING should match with NEUTRALIZE_IF_EMBED', () => {
+        expect(new CertificationIssueReport({
+          category: 'IN_CHALLENGE',
+          subcategory: 'EMBED_NOT_WORKING',
+        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_EMBED);
+      });
+    });
   });
 
   describe('#isResolved', () => {

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -360,6 +360,8 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_BLOCKED', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_UNAVAILABLE', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'SOFTWARE_NOT_WORKING', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'IMAGE_NOT_DISPLAYING', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EMBED_NOT_WORKING', questionNumber: 42 },
       ].forEach((certificationIssueReportDTO) => {
         it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isAutoneutralizable to true`, () => {
           expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isAutoNeutralizable).to.be.true;
@@ -376,8 +378,6 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         { certificationCourseId: 42, category: 'FRAUD' },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'FILE_NOT_OPENING', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'LINK_NOT_WORKING', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'IMAGE_NOT_DISPLAYING', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EMBED_NOT_WORKING', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EXTRA_TIME_EXCEEDED', questionNumber: 42 },
         { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
       ].forEach((certificationIssueReportDTO) => {

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -212,4 +212,40 @@ describe('Unit | Domain | Models | Challenge', () => {
       });
     });
   });
+
+  describe('#hasIllustration', () => {
+    it('returns true when has illustration', () => {
+      // given
+      const challenge = domainBuilder.buildChallenge({ illustrationUrl: 'A_LINK' });
+
+      // when then
+      expect(challenge.hasIllustration()).to.be.true;
+    });
+
+    it('returns false when does not have illustration', () => {
+      // given
+      const challenge = domainBuilder.buildChallenge({ illustrationUrl: null });
+
+      // when then
+      expect(challenge.hasIllustration()).to.be.false;
+    });
+  });
+
+  describe('#hasEmbed', () => {
+    it('returns true when has embed', () => {
+      // given
+      const challenge = domainBuilder.buildChallenge({ embedUrl: 'A_LINK' });
+
+      // when then
+      expect(challenge.hasEmbed()).to.be.true;
+    });
+
+    it('returns false when does not have embed', () => {
+      // given
+      const challenge = domainBuilder.buildChallenge({ embedUrl: null });
+
+      // when then
+      expect(challenge.hasEmbed()).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Avec la massification des certifications, il devient de plus en plus compliqué pour le pôle certif de traiter manuellement tous les types de signalements, notamment ceux de la catégorie “Problème technique sur une question” qui représentent la plus grand majorité.
L’idée est donc d’automatiser la prise en compte des signalements de ce type.

Suite du #3006

## :robot: Solution
A la finalisation d’une session, si il y a un signalement de type “Problème technique sur une question”, avec l’une des sous-catégories suivantes :

E1 - L'image ne s'affiche pas
E2 - Le simulateur / l’application a un autre problème

=> Neutraliser la question concernée si celle-ci est au statut “Echec” ou “Abandon” ou "Passée"

## :100: Pour tester
**Dans Pix Certif**

1. Créer une session de certification et ajouter un candidat

**Dans Pix App**

Rejoindre la session de certification, puis :

1. Répondre incorrectement à une question contenant une image
2. Répondre incorrectement à une question contenant un simulateur
3. Passer une question contenant une image
4. Passer une question contenant un simulateur

**Dans Pix Certif**

Finaliser la session en ajoutant  :

- un signalement auto-neutralisable (sous-catégories E1) à la question répondue incorrectement contenant une image
- un signalement auto-neutralisable (sous-catégories E2) à la question répondue incorrectement contenant un simulateur
- un signalement auto-neutralisable (sous-catégories E1) à la question passée contenant une image
- un signalement auto-neutralisable (sous-catégories E2) à la question répondue incorrectement contenant un simulateur


**Dans Pix Admin**

Constater que : 
- la session est bien finalisée
- les 4 questions concernées par les signalements sont neutralizées

