### PR TITLE
[FEATURE] Renommer l'onglet Détails en Paramètres et le placer à droite dans le nav menu d'une campagne (PIX-2673).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -58,10 +58,6 @@
 
   <div class="panel campaign-details__controls">
     <nav class="navbar campaign-details-controls__navbar-tabs">
-      <LinkTo @route="authenticated.campaigns.campaign.details" class="navbar-item" @model={{@campaign}} >
-        {{t 'pages.campaign.tab.details'}}
-      </LinkTo>
-
       <LinkTo
         @route={{if @campaign.isTypeAssessment "authenticated.campaigns.campaign.assessments" "authenticated.campaigns.campaign.profiles"}}
         @model={{@campaign}}
@@ -77,6 +73,11 @@
           {{t 'pages.campaign.tab.review'}}
         </LinkTo>
       {{/if}}
+
+      <div class="navbar-item-separator" aria-hidden="true"></div>
+      <LinkTo @route="authenticated.campaigns.campaign.details" class="navbar-item" @model={{@campaign}} >
+        {{t 'pages.campaign.tab.settings'}}
+      </LinkTo>
     </nav>
 
     <div class="campaign-details-controls__export-button">

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -150,6 +150,12 @@
     &:hover {
       color: $blue;
     }
+
+    &-separator {
+      height: 30px;
+      border-left: 1px solid $grey-25;
+      margin: 15px 0px;
+    }
   }
 
   &-item.active {

--- a/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
@@ -144,7 +144,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       this.owner.setupRouter();
     });
 
-    test('it should display campaign details item', async function(assert) {
+    test('it should display campaign settings item', async function(assert) {
 
       const campaign = store.createRecord('campaign', {
         id: 12,
@@ -153,7 +153,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       this.set('campaign', campaign);
 
       await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
-      assert.dom('nav a[href="/campagnes/12"]').hasText('Détails');
+      assert.dom('nav a[href="/campagnes/12"]').hasText('Paramètres');
     });
 
     module('When campaign type is ASSESSMENT', function(hooks) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -177,9 +177,9 @@
       "shared-results-count": "Results submitted",
       "tab": {
         "collective-results": "Collective results",
-        "details": "Details",
         "participants": "Participants ({count})",
-        "review": "Review"
+        "review": "Review",
+        "settings": "Settings"
       }
     },
     "campaign-collective-results": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -177,9 +177,9 @@
       "shared-results-count": "Résultats reçus",
       "tab": {
         "collective-results": "Résultats collectifs",
-        "details": "Détails",
         "participants": "Participants ({count})",
-        "review": "Analyse"
+        "review": "Analyse",
+        "settings": "Paramètres"
       }
     },
     "campaign-collective-results": {


### PR DESCRIPTION
## :unicorn: Problème
Suite d'un changement de graphique  pour le menu campagnes sur Pix Orga, le bouton détails doit être changé en paramètres et déplacé à droite 

## :robot: Solution
Renommer l'onglet détail en “Paramètres”, le déplacer à droite.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
connectez-vous à pix Orga, sélectionnez le menu campagne puis sélectionnez une campagne, vous pouvez remarquer que l'onglet détails n'est plus visible et qu'un nouvel onglet appelé paramètres se trouve à droite du menu des onglets.