### PR TITLE
[FEATURE] Afficher la date de création et le nom du créateur d'une campagne dans le détail d'une campagne (PIX-2672)

### DIFF
--- a/orga/app/components/campaign-creation-details.hbs
+++ b/orga/app/components/campaign-creation-details.hbs
@@ -1,0 +1,13 @@
+<div class="campaign-details-header-report__created-on">
+  <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.created-on'}}</h4>
+  <span class="content-text campaign-details-content__text">
+    {{moment-format @creationDate 'DD/MM/YYYY' allow-empty=true}}
+  </span>
+</div>
+
+<div class="campaign-details-header-report__created-by">
+  <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.created-by'}}</h4>
+  <span class="content-text campaign-details-content__text">
+    {{@creatorName}}
+  </span>
+</div>

--- a/orga/app/components/campaign-participants-details.hbs
+++ b/orga/app/components/campaign-participants-details.hbs
@@ -1,0 +1,19 @@
+<div class="campaign-details-header-report__info">
+  <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.participations-count'}}</h4>
+  <span class="content-text campaign-details-content__text">
+    {{@participationsCount}}
+  </span>
+</div>
+
+<div class="campaign-details-header-report__shared">
+  <h4 class="label-text campaign-details-content__label">
+    {{#if (eq @campaign.type "PROFILES_COLLECTION")}}
+      {{t 'pages.campaign.shared-profiles-count'}}
+    {{else}}
+      {{t 'pages.campaign.shared-results-count'}}
+    {{/if}}
+  </h4>
+  <span class="content-text campaign-details-content__text">
+    {{@sharedParticipationsCount}}
+  </span>
+</div>

--- a/orga/app/components/routes/authenticated/campaign/details/tab.js
+++ b/orga/app/components/routes/authenticated/campaign/details/tab.js
@@ -10,7 +10,7 @@ export default class Tab extends Component {
   @service url;
   @service intl;
 
-  @tracked tooltipText = this.intl.t('pages.campaign-details.actions.copy-link.copy');
+  @tracked tooltipText = this.intl.t('pages.campaign-details.actions.copy-link');
 
   get campaignsRootUrl() {
     return `${this.url.campaignsRootUrl}${this.args.campaign.code}`;
@@ -18,12 +18,12 @@ export default class Tab extends Component {
 
   @action
   clipboardSuccess() {
-    this.tooltipText = this.intl.t('pages.campaign-details.actions.copy-link.copied');
+    this.tooltipText = this.intl.t('pages.campaign-details.actions.copied');
   }
 
   @action
   clipboardOut() {
-    this.tooltipText = this.intl.t('pages.campaign-details.actions.copy-link.copy');
+    this.tooltipText = this.intl.t('pages.campaign-details.actions.copy-link');
   }
 
   @action

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -13,30 +13,46 @@
     <div class="campaign-details-header__report">
       <div class="campaign-details-header-report__info">
         <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.code'}}</h4>
-        <span class="content-text content-text--big campaign-details-content__text">
+        <span class="content-text campaign-details-content__text">
           {{@campaign.code}}
         </span>
       </div>
 
-      <div class="campaign-details-header-report__info">
-        <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.participations-count'}}</h4>
-        <span class="content-text content-text--big campaign-details-content__text">
-          {{this.participationsCount}}
-        </span>
-      </div>
+      {{#if this.participationsCount}}
+        <div class="campaign-details-header-report__info">
+          <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.participations-count'}}</h4>
+          <span class="content-text campaign-details-content__text">
+            {{this.participationsCount}}
+          </span>
+        </div>
 
-      <div class="campaign-details-header-report__shared">
-        <h4 class="label-text campaign-details-content__label">
-          {{#if (eq @campaign.type "PROFILES_COLLECTION")}}
-            {{t 'pages.campaign.shared-profiles-count'}}
-          {{else}}
-            {{t 'pages.campaign.shared-results-count'}}
-          {{/if}}
-        </h4>
-        <span class="content-text content-text--big campaign-details-content__text">
-          {{this.sharedParticipationsCount}}
-        </span>
-      </div>
+        <div class="campaign-details-header-report__shared">
+          <h4 class="label-text campaign-details-content__label">
+            {{#if (eq @campaign.type "PROFILES_COLLECTION")}}
+              {{t 'pages.campaign.shared-profiles-count'}}
+            {{else}}
+              {{t 'pages.campaign.shared-results-count'}}
+            {{/if}}
+          </h4>
+          <span class="content-text campaign-details-content__text">
+            {{this.sharedParticipationsCount}}
+          </span>
+        </div>
+      {{else}}
+        <div class="campaign-details-header-report__created-on">
+          <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.created-on'}}</h4>
+          <span class="content-text campaign-details-content__text">
+            {{moment-format this.creationDate 'DD/MM/YYYY' allow-empty=true}}
+          </span>
+        </div>
+
+        <div class="campaign-details-header-report__created-by">
+          <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.created-by'}}</h4>
+          <span class="content-text campaign-details-content__text">
+            {{this.creatorName}}
+          </span>
+        </div>
+      {{/if}}
     </div>
   </div>
 

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -11,9 +11,15 @@
     </div>
 
     <div class="campaign-details-header__report">
-      <div class="campaign-details-header-report__info">
+       {{#if this.participationsCount}}
+        <CampaignParticipantsDetails @campaign={{@campaign}} @participationsCount={{this.participationsCount}} @sharedParticipationsCount={{this.sharedParticipationsCount}} />
+      {{else}}
+        <CampaignCreationDetails @creationDate={{this.creationDate}} @creatorName={{this.creatorName}} />
+      {{/if}}
+
+      <div class="campaign-details-header-report__campaign-code">
         <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.code'}}</h4>
-        <span class="content-text campaign-details-content__text campaign-details-content--code">
+        <span class="content-text campaign-details-content__text">
           {{@campaign.code}}
           {{#if (is-clipboard-supported)}}
             <PixTooltip
@@ -32,42 +38,6 @@
           {{/if}}
         </span>
       </div>
-
-      {{#if this.participationsCount}}
-        <div class="campaign-details-header-report__info">
-          <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.participations-count'}}</h4>
-          <span class="content-text campaign-details-content__text">
-            {{this.participationsCount}}
-          </span>
-        </div>
-
-        <div class="campaign-details-header-report__shared">
-          <h4 class="label-text campaign-details-content__label">
-            {{#if (eq @campaign.type "PROFILES_COLLECTION")}}
-              {{t 'pages.campaign.shared-profiles-count'}}
-            {{else}}
-              {{t 'pages.campaign.shared-results-count'}}
-            {{/if}}
-          </h4>
-          <span class="content-text campaign-details-content__text">
-            {{this.sharedParticipationsCount}}
-          </span>
-        </div>
-      {{else}}
-        <div class="campaign-details-header-report__created-on">
-          <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.created-on'}}</h4>
-          <span class="content-text campaign-details-content__text">
-            {{moment-format this.creationDate 'DD/MM/YYYY' allow-empty=true}}
-          </span>
-        </div>
-
-        <div class="campaign-details-header-report__created-by">
-          <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.created-by'}}</h4>
-          <span class="content-text campaign-details-content__text">
-            {{this.creatorName}}
-          </span>
-        </div>
-      {{/if}}
     </div>
   </div>
 

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -13,8 +13,23 @@
     <div class="campaign-details-header__report">
       <div class="campaign-details-header-report__info">
         <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.code'}}</h4>
-        <span class="content-text campaign-details-content__text">
+        <span class="content-text campaign-details-content__text campaign-details-content--code">
           {{@campaign.code}}
+          {{#if (is-clipboard-supported)}}
+            <PixTooltip
+              @text={{this.tooltipText}}
+              @position='top'
+              @isInline={{true}}
+              class="campaign-details-content__tooltip">
+              <CopyButton
+                @clipboardText={{@campaign.code}}
+                @success={{this.clipboardSuccess}}
+                {{on 'mouseLeave' this.clipboardOut}}
+                @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey campaign-details-content__clipboard-button">
+                <FaIcon @icon='copy' @prefix='far'/>
+              </CopyButton>
+            </PixTooltip>
+          {{/if}}
         </span>
       </div>
 

--- a/orga/app/components/routes/authenticated/campaign/report.js
+++ b/orga/app/components/routes/authenticated/campaign/report.js
@@ -1,12 +1,15 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
-
+import { tracked } from '@glimmer/tracking';
 export default class Report extends Component {
 
   @service store;
   @service notifications;
   @service currentUser;
+  @service intl;
+
+  @tracked tooltipText = this.intl.t('pages.campaign-details.actions.copy-code');
 
   get participationsCount() {
     const participationsCount = this.args.campaign.participationsCount;
@@ -40,5 +43,15 @@ export default class Report extends Component {
     } catch (err) {
       this.notifications.error('Une erreur est survenue');
     }
+  }
+
+  @action
+  clipboardSuccess() {
+    this.tooltipText = this.intl.t('pages.campaign-details.actions.copied');
+  }
+
+  @action
+  clipboardOut() {
+    this.tooltipText = this.intl.t('pages.campaign-details.actions.copy-code');
   }
 }

--- a/orga/app/components/routes/authenticated/campaign/report.js
+++ b/orga/app/components/routes/authenticated/campaign/report.js
@@ -11,7 +11,7 @@ export default class Report extends Component {
   get participationsCount() {
     const participationsCount = this.args.campaign.participationsCount;
 
-    return participationsCount > 0 ? participationsCount : '-';
+    return participationsCount > 0 ? participationsCount : false;
   }
 
   get sharedParticipationsCount() {
@@ -22,6 +22,14 @@ export default class Report extends Component {
 
   get downloadUrl() {
     return this.args.campaign.urlToResult + `&lang=${this.currentUser.prescriber.lang}`;
+  }
+
+  get creatorName() {
+    return this.args.campaign.creatorFullName;
+  }
+
+  get creationDate() {
+    return this.args.campaign.createdAt;
   }
 
   @action

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -32,6 +32,12 @@
     padding-right: 10px;
     padding-left: 10px;
     min-width: 345px;
+
+    & > *  {
+      padding-right: 15px;
+      margin-right: 15px;
+      border-right: 1px solid $grey-20;
+    }
   }
 
   &__title {
@@ -40,13 +46,11 @@
 }
 
 .campaign-details-header-report {
-  &__info, &__created-on, &__created-by {
-    padding-right: 15px;
-    margin-right: 15px;
-  }
-
-  &__info, &__created-on {
-    border-right: 1px solid $grey-20;
+  &__campaign-code {
+    border-right: 0px;
+    span {
+      display: inline-flex;
+    }
   }
 }
 
@@ -62,9 +66,6 @@
   }
 }
 
-.campaign-details-content--code {
-  display: flex;
-}
 
 .campaign-archived-banner {
   font-family: $open-sans;

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -62,6 +62,10 @@
   }
 }
 
+.campaign-details-content--code {
+  display: flex;
+}
+
 .campaign-archived-banner {
   font-family: $open-sans;
   font-weight: 600;

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -40,9 +40,13 @@
 }
 
 .campaign-details-header-report {
-  &__info {
+  &__info, &__created-on, &__created-by {
     padding-right: 15px;
     margin-right: 15px;
+  }
+
+  &__info, &__created-on {
+    border-right: 1px solid $grey-20;
   }
 }
 

--- a/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
@@ -40,13 +40,14 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     const campaign = store.createRecord('campaign', {
       code: '1234PixTest',
     });
+
     this.set('campaign', campaign);
 
     // when
     await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
 
     // then
-    assert.contains('1234PixTest');
+    assert.dom('.campaign-details-header-report__campaign-code').containsText('1234PixTest');
   });
 
   module('When there is some results', function() {
@@ -79,10 +80,12 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       // then
       assert.contains('4');
     });
+
     test('it should display correct label for a PROFILES_COLLECTION campaign ', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
         participationsCount: 1,
+        sharedParticipationsCount: 4,
         type: 'PROFILES_COLLECTION',
       });
       this.set('campaign', campaign);
@@ -93,6 +96,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       // then
       assert.contains('Profils reçus');
     });
+
     test('it should display correct label for an ASSESSMENT campaign ', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {

--- a/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
@@ -68,6 +68,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     test('it should display campaign shared participations number', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
+        participationsCount: 1,
         sharedParticipationsCount: 4,
       });
       this.set('campaign', campaign);
@@ -81,6 +82,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     test('it should display correct label for a PROFILES_COLLECTION campaign ', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
+        participationsCount: 1,
         type: 'PROFILES_COLLECTION',
       });
       this.set('campaign', campaign);
@@ -94,6 +96,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     test('it should display correct label for an ASSESSMENT campaign ', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
+        participationsCount: 1,
         type: 'ASSESSMENT',
       });
       this.set('campaign', campaign);
@@ -107,11 +110,13 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
   });
 
   module('When there is no results', function() {
-    test('it should display "-" when no one participated', async function(assert) {
+    test('it should display the creation date and the campaign creator when no one participated', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
         participationsCount: 0,
-        sharedParticipationsCount: 2,
+        createdAt: new Date('2021-04-14'),
+        creatorLastName: 'Fa',
+        creatorFirstName: 'Mulan',
       });
       this.set('campaign', campaign);
 
@@ -119,7 +124,8 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
 
       // then
-      assert.contains('-');
+      assert.contains('Mulan Fa');
+      assert.contains('14/04/2021');
     });
 
     test('it should display "-" when no one shared his participation', async function(assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -238,10 +238,9 @@
     "campaign-details": {
       "actions": {
         "archive": "Archive",
-        "copy-link": {
-          "copied": "Copied!",
-          "copy": "Copy direct link"
-        },
+        "copied": "Copied!",
+        "copy-code": "Copy code",
+        "copy-link": "Copy direct link",
         "edit": "Edit"
       },
       "direct-link": "Direct link",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -154,6 +154,8 @@
         "unarchive": "Unarchive the campaign"
       },
       "archived": "Archived campaign",
+      "created-by": "Created by",
+      "created-on": "Created on",
       "code": "Code",
       "filters": {
         "title": "Filters",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -154,6 +154,8 @@
         "unarchive": "Désarchiver la campagne"
       },
       "archived": "Campagne archivée",
+      "created-by": "Créée par",
+      "created-on": "Créée le",
       "code": "Code",
       "filters": {
         "title": "Filtres",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -238,10 +238,9 @@
     "campaign-details": {
       "actions": {
         "archive": "Archiver",
-        "copy-link": {
-          "copied": "Copié !",
-          "copy": "Copier le lien direct"
-        },
+        "copied": "Copié !",
+        "copy-code": "Copier le code",
+        "copy-link": "Copier le lien direct",
         "edit": "Modifier"
       },
       "direct-link": "Lien direct",


### PR DESCRIPTION

## :unicorn: Problème
Quand la campagne n'a toujours pas de participants, on souhaite afficher la date de création et le nom du créateur/ de la créatrice de la campagne au niveau du header de la page détails de la campagne

## :robot: Solution


## :rainbow: Remarques


## :100: Pour tester
Se connecter à pix Orga et regarder le header pour des campagnes avec et sans participants, de type évaluation et collecte de profils.
