### PR TITLE
[FEATURE] Générer un jeton d'accès pour l'application Pôle Emploi afin de consommer l'API Pix (Pix-2679).

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -3,7 +3,6 @@ const { BadRequestError } = require('../http-errors');
 
 const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
-const { livretScolaireAuthentication } = require('../../config');
 
 const get = require('lodash/get');
 
@@ -85,15 +84,15 @@ module.exports = {
     return h.response(response).code(200);
   },
 
-  async authenticateApplicationLivretScolaire(request, h) {
+  async authenticateApplication(request, h) {
     const { client_id: clientId, client_secret: clientSecret, scope } = request.payload;
 
-    const accessToken = await usecases.authenticateApplicationLivretScolaire({ clientId, clientSecret, scope });
+    const accessToken = await usecases.authenticateApplication({ clientId, clientSecret, scope });
 
     return h.response({
       token_type: 'bearer',
       access_token: accessToken,
-      client_id: tokenService.extractClientId(accessToken, livretScolaireAuthentication.secret),
+      client_id: clientId,
     })
       .code(200)
       .header('Content-Type', 'application/json;charset=UTF-8')

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -60,7 +60,7 @@ exports.register = async (server) => {
             403: responseErrorObjectDoc,
           },
         },
-        handler: AuthenticationController.authenticateApplicationLivretScolaire,
+        handler: AuthenticationController.authenticateApplication,
         tags: ['api', 'authorization-server'],
       },
     },

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -89,9 +89,15 @@ module.exports = (function() {
       tokenForStudentReconciliationLifespan: '1h',
     },
 
-    livretScolaireAuthentication: {
-      secret: process.env.LIVRET_SCOLAIRE_AUTH_SECRET,
-      tokenLifespan: (process.env.TOKEN_LIFE_SPAN || '1h'),
+    jwtConfig: {
+      livretScolaire: {
+        secret: process.env.LIVRET_SCOLAIRE_AUTH_SECRET,
+        tokenLifespan: (process.env.TOKEN_LIFE_SPAN || '1h'),
+      },
+      poleEmploi: {
+        secret: process.env.POLE_EMPLOI_AUTH_SECRET,
+        tokenLifespan: (process.env.TOKEN_LIFE_SPAN || '1h'),
+      },
     },
 
     saml: {
@@ -173,7 +179,13 @@ module.exports = (function() {
         clientId: process.env.GRAVITEE_OSMOSE_CLIENT_ID,
         clientSecret: process.env.GRAVITEE_OSMOSE_CLIENT_SECRET,
         scope: 'organizations-certifications-result',
-        source: 'osmose',
+        source: 'livretScolaire',
+      },
+      {
+        clientId: process.env.GRAVITEE_POLE_EMPLOI_CLIENT_ID,
+        clientSecret: process.env.GRAVITEE_POLE_EMPLOI_CLIENT_SECRET,
+        scope: 'pole-emploi-participants-result',
+        source: 'poleEmploi',
       },
     ],
   };
@@ -210,7 +222,6 @@ module.exports = (function() {
     config.mailing.sendinblue.templates.emailChangeTemplateId = 'test-email-change-template-id';
 
     config.authentication.secret = 'test-jwt-key';
-    config.livretScolaireAuthentication.secret = 'test-livret-scolaire-secret';
     config.authentication.tokenLifespan = '1d';
 
     config.temporaryKey.secret = 'test-jwt-key';
@@ -223,8 +234,12 @@ module.exports = (function() {
     config.graviteeRegisterApplicationsCredentials = [
       { clientId: 'lsuClientId', clientSecret: 'lsuClientSecret', scope: 'organizations-certifications-result', source: 'lsu' },
       { clientId: 'lslClientId', clientSecret: 'lslClientSecret', scope: 'organizations-certifications-result', source: 'lsl' },
-      { clientId: 'graviteeOsmoseClientId', clientSecret: 'graviteeOsmoseClientSecret', scope: 'organizations-certifications-result', source: 'ósmose' },
+      { clientId: 'graviteeOsmoseClientId', clientSecret: 'graviteeOsmoseClientSecret', scope: 'organizations-certifications-result', source: 'livretScolaire' },
+      { clientId: 'poleEmploiClientId', clientSecret: 'poleEmploiClientSecret', scope: 'pole-emploi-participants-result', source: 'poleEmploi' },
     ];
+
+    config.jwtConfig.livretScolaire = { secret: 'secretosmose', tokenLifespan: '1h' };
+    config.jwtConfig.poleEmploi = { secret: 'secretPoleEmploi', tokenLifespan: '1h' };
 
     config.logging.enabled = false;
 

--- a/api/lib/domain/usecases/authenticate-application.js
+++ b/api/lib/domain/usecases/authenticate-application.js
@@ -5,7 +5,7 @@ const {
 } = require('../../domain/errors');
 
 const { find } = require('lodash');
-const { graviteeRegisterApplicationsCredentials, livretScolaireAuthentication } = require('../../config');
+const { graviteeRegisterApplicationsCredentials, jwtConfig } = require('../../config');
 
 function _checkClientId(application, clientId) {
   if (!application || application.clientId !== clientId) {
@@ -25,7 +25,7 @@ function _checkAppScope(application, scope) {
   }
 }
 
-module.exports = async function authenticateApplicationLivretScolaire({
+module.exports = async function authenticateApplication({
   clientId,
   clientSecret,
   scope,
@@ -36,6 +36,6 @@ module.exports = async function authenticateApplicationLivretScolaire({
   _checkClientSecret(application, clientSecret);
   _checkAppScope(application, scope);
 
-  return tokenService.createAccessTokenFromApplication(clientId, application.source, scope, livretScolaireAuthentication.secret, livretScolaireAuthentication.tokenLifespan);
+  return tokenService.createAccessTokenFromApplication(clientId, application.source, scope, jwtConfig[application.source].secret, jwtConfig[application.source].tokenLifespan);
 
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -132,7 +132,7 @@ module.exports = injectDependencies({
   authenticatePoleEmploiUser: require('./authenticate-pole-emploi-user'),
   authenticateUser: require('./authenticate-user'),
   authenticateExternalUser: require('./authenticate-external-user'),
-  authenticateApplicationLivretScolaire: require('./authenticate-application-livret-scolaire'),
+  authenticateApplication: require('./authenticate-application'),
   beginCampaignParticipationImprovement: require('./begin-campaign-participation-improvement'),
   cancelCertificationCourse: require('./cancel-certification-course'),
   completeAssessment: require('./complete-assessment'),

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -66,8 +66,13 @@ module.exports = {
        },
      }, {
        name: 'jwt-livret-scolaire', configuration: {
-         //TODO rename var env to clientApplicationAuthentication
-         key: config.livretScolaireAuthentication.secret,
+         key: config.jwtConfig.livretScolaire.secret,
+         validate: validateClientApplication,
+       },
+     },
+     {
+       name: 'jwt-pole-emploi', configuration: {
+         key: config.jwtConfig.poleEmploi.secret,
          validate: validateClientApplication,
        },
      },

--- a/api/tests/acceptance/application/certifications-livret-scolaire/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications-livret-scolaire/certification-controller_test.js
@@ -13,7 +13,7 @@ describe('Acceptance | API | Certifications', () => {
   let server, options;
   const OSMOSE_CLIENT_ID = 'graviteeOsmoseClientId';
   const OSMOSE_SCOPE = 'organizations-certifications-result';
-  const OSMOSE_SOURCE = 'osmose';
+  const OSMOSE_SOURCE = 'livretScolaire';
 
   describe('GET /api/organizations/:id/certifications', () => {
     const pixScore = 400;

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.use(require('chai-sorted'));
 chai.use(require('sinon-chai'));
 const cache = require('../lib/infrastructure/caches/learning-content-cache');
-const { livretScolaireAuthentication } = require('../lib/config');
+const { graviteeRegisterApplicationsCredentials, jwtConfig } = require('../lib/config');
 
 const { knex, disconnect } = require('../db/knex-database-connection');
 
@@ -37,9 +37,12 @@ function generateValidRequestAuthorizationHeader(userId = 1234, source = 'pix') 
   return `Bearer ${accessToken}`;
 }
 
-function generateValidRequestAuthorizationHeaderForApplication(clientId = 'client-id-name', source = 'osmose', scope = 'scope') {
-  const accessToken = tokenService.createAccessTokenFromApplication(clientId, source, scope, livretScolaireAuthentication.secret);
-  return `Bearer ${accessToken}`;
+function generateValidRequestAuthorizationHeaderForApplication(clientId = 'client-id-name', source, scope) {
+  const application = _.find(graviteeRegisterApplicationsCredentials, { clientId });
+  if (application) {
+    const accessToken = tokenService.createAccessTokenFromApplication(application.clientId, source, scope, jwtConfig[application.source].secret);
+    return `Bearer ${accessToken}`;
+  }
 }
 
 function generateIdTokenForExternalUser(externalUser) {

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -177,7 +177,7 @@ describe('Unit | Application | Controller | Authentication', () => {
     });
   });
 
-  describe('#authenticateApplicationLivretScolaire', () => {
+  describe('#authenticateApplication', () => {
 
     const access_token = 'jwt.access.token';
 
@@ -203,12 +203,12 @@ describe('Unit | Application | Controller | Authentication', () => {
 
     it('should return an OAuth 2 token response', async () => {
       // given
-      sinon.stub(usecases, 'authenticateApplicationLivretScolaire')
+      sinon.stub(usecases, 'authenticateApplication')
         .withArgs({ clientId: client_id, clientSecret: client_secret, scope })
         .resolves(access_token);
 
       // when
-      const response = await authenticationController.authenticateApplicationLivretScolaire(request, hFake);
+      const response = await authenticationController.authenticateApplication(request, hFake);
 
       // then
       const expectedResponseResult = {


### PR DESCRIPTION
## :unicorn: Problème
L'endpoint /api/application/token permet d'authentifier les applications du livret scolaire avec le flow client credential grant d'oauth2.
Dans le cadre de l'interconnexion avec PE, des applications Pole emploi veulent consommer notre API Pix pour récupérer les résultats de fin parcours pour les demandeurs d'emplois. Le problème est que l'endpoint n'est pas assez générique pour identifier toutes les applications de différents partenaires.

## :robot: Solution
Rendre générique la gestion de l'authentification des applications qui vont consommer les apis Pix avec le flow client credentiel grants de Oauth2.

## :rainbow: Remarques
Une séparation de la configuration des jetons JWT a été effectuée pour pouvoir rollback séparément les jetons d'accès.

## :100: Pour tester

1- Doit générer un jeton valide pour l'application Pole Emploi

```
curl -X POST \
  https://api-pr3077.review.pix.fr/api/application/token \
  -H 'content-type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=poleemploi&client_secret=secret&scope=pole-emploi-participants-result'
```

2- Doit générer un client Id non valide pour l'application Pole Emploi

```
curl -X POST \
  https://api-pr3077.review.pix.fr/api/application/token \
  -H 'content-type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pole&client_secret=secret&scope=pole-emploi-participants-result'
```

3- Doit générer un secret non valide pour l'application Pole Emploi

```
curl -X POST \
  https://api-pr3077.review.pix.fr/api/application/token \
  -H 'content-type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=poleemploi&client_secret=secretinvalide&scope=pole-emploi-participants-result'
```

4- Doit générer un secret non autorisé pour l'application Pole Emploi

```
curl -X POST \
  https://api-pr3077.review.pix.fr/api/application/token \
  -H 'content-type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=poleemploi&client_secret=secret&scope=scope-invalide'
```

4- Non régression: Doit générer un jeton valide pour l'application OSMOSE pour le livret scolaire


```
curl -X POST \
  https://api-pr3077.review.pix.fr/api/application/token \
  -H 'content-type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=osmose&client_secret=youyou&scope=organizations-certifications-result'
```

5- Remplacer ce jeton et vérifier qu'avec ce jeton livret scolaire généré, on accède bien au résultat de certification

```
curl -X GET \
  https://api-pr3077.review.pix.fr/api/organizations/0382495F/certifications \
  -H 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJwb2xlZW1wbG9pIiwic291cmNlIjoicG9sZWVtcGxvaSIsInNjb3BlIjoicG9sZS1lbXBsb2ktcGFydGljaXBhbnRzLXJlc3VsdCIsImlhdCI6MTYyMzA3NDgzNSwiZXhwIjoxNjIzMDc4NDM1fQ.gT1Bf7s28XFUBUqdQAMl_5D9u1ELEKX65Dk_M2QHAZI'
```

6- Vérifier que le jeton généré pour l'application Pole emploi ne permet pas d'accéder au résultats des livrets scolaire.