### PR TITLE
[FEATURE] Permettre de choisir la langue d'envoie des invitation par email sur Pix Admin (PIX-2559).

### DIFF
--- a/admin/app/adapters/organization-invitation.js
+++ b/admin/app/adapters/organization-invitation.js
@@ -1,6 +1,7 @@
 import ApplicationAdapter from './application';
 
 export default class OrganizationInvitation extends ApplicationAdapter {
+  namespace = 'api/admin';
 
   urlForCreateRecord(modelName, { adapterOptions }) {
     const { organizationId } = adapterOptions;

--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -29,7 +29,8 @@
         <PixSelect
           @options={{this.languagesOptions}}
           @selectedOption={{this.organizationInvitationLang}}
-          @onChange={{this.changeOrganizationInvitationLang}} />
+          @onChange={{this.changeOrganizationInvitationLang}}
+          aria-label="Choisir la langue de l’email d’invitation"/>
 
         <PixButton
           type="button"
@@ -57,33 +58,36 @@
             <th class="table__column">ID Membre</th>
             <th class="table__column table__column--wide">Prénom</th>
             <th class="table__column table__column--wide">Nom</th>
-            <th class="table__column table__column--wide">Adresse email</th>
+            <th class="table__column table__column--wide">Adresse e-mail</th>
             <th class="table__column">Rôle</th>
             <th class="table__column">Actions</th>
           </tr>
           <tr>
-            <th class="table__column"></th>
-            <th class="table__column table__column--wide">
+            <td class="table__column"></td>
+            <td class="table__column table__column--wide">
               <input id="firstName"
                      type="text"
+                     aria-label="Rechercher par prénom"
                      value={{@firstName}}
                      oninput={{fn @triggerFiltering 'firstName'}}
                      class="table-admin-input form-control"/>
-            </th>
-            <th class="table__column table__column--wide">
+            </td>
+            <td class="table__column table__column--wide">
               <input id="lastName"
                      type="text"
+                     aria-label="Rechercher par nom"
                      value={{@lastName}}
                      oninput={{fn @triggerFiltering 'lastName'}}
                      class="table-admin-input form-control"/>
-            </th>
-            <th class="table__column table__column--wide">
+            </td>
+            <td class="table__column table__column--wide">
               <input id="email"
                      type="text"
+                     aria-label="Rechercher par adresse e-mail"
                      value={{@email}}
                      oninput={{fn @triggerFiltering 'email'}}
                      class="table-admin-input form-control"/>
-            </th>
+            </td>
             <th class="table__column">
               <select id="organizationRole" class="table-admin-input form-control" {{on 'change' this.selectRole}} aria-label="Rechercher par rôle">
                 <option value="">Tous</option>
@@ -91,7 +95,7 @@
                 <option value="MEMBER" selected={{eq @organizationRole "MEMBER"}}>Membre</option>
               </select>
             </th>
-            <th class="table__column"></th>
+            <td class="table__column"></td>
           </tr>
         </thead>
 

--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -8,16 +8,16 @@
     <form aria-label="Ajouter un membre">
       <div class="organization__sub-form">
         <Input
-                id="userEmailToAdd"
-                aria-label="Adresse email"
-                @value={{@userEmailToAdd}}
-                class="organization-sub-form__input form-field__text form-control"
-                @placeholder="Adresse email de l'utilisateur à ajouter" />
+          id="userEmailToAdd"
+          aria-label="Adresse email"
+          @value={{@userEmailToAdd}}
+          class="organization-sub-form__input form-field__text form-control"
+          @placeholder="Adresse email de l'utilisateur à ajouter" />
         <button
-                type="button"
+          type="button"
           {{on "click" @addMembership}}
-                class="organization-sub-form__validate-button btn btn-outline-default">
-          Valider
+          class="organization-sub-form__validate-button btn btn-outline-default">
+            Valider
         </button>
       </div>
     </form>
@@ -25,20 +25,22 @@
     <form aria-label="Inviter un membre">
       <div class="organization__sub-form">
         <Input
-                id="userEmailToInvite"
-                aria-label="Adresse email"
-                @value={{@userEmailToInvite}}
-                class={{if @userEmailToInviteError "organization-sub-form__input organization-sub-form__input__error form-control" "organization-sub-form__input form-control"}}
-                @placeholder="Adresse email de l'utilisateur à inviter" />
-        {{#if @isLoading}}
-          <button type="button" class="organization-sub-form__validate-button btn btn-outline-default">
+          id="userEmailToInvite"
+          aria-label="Adresse email"
+          @value={{@userEmailToInvite}}
+          class={{if @userEmailToInviteError "organization-sub-form__input organization-sub-form__input__error form-control" "organization-sub-form__input form-control"}}
+          @placeholder="Adresse email de l'utilisateur à inviter" />
+
+        <PixSelect
+          @options={{this.languages}}
+          @selectedOption={{this.organizationInvitationLang}}
+          @onChange={{this.changeOrganizationInvitationLang}} />
+
+        <PixButton
+          type="button"
+          @triggerAction={{fn @createOrganizationInvitation this.organizationInvitationLang}}>
             Inviter
-          </button>
-        {{else}}
-          <button type="button" {{on "click" @createOrganizationInvitation}} class="organization-sub-form__validate-button btn btn-outline-default">
-            Inviter
-          </button>
-        {{/if}}
+        </PixButton>
       </div>
       {{#if @userEmailToInviteError}}
         <div class="organization-sub-form__error-message">{{@userEmailToInviteError}}</div>

--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -1,32 +1,30 @@
 <section class="page-section mb_10 organization-members-section">
   <div class="organization__forms-section">
     <form aria-label="Ajouter un membre">
-      <label for="userEmailToAdd">Inviter un membre</label>
+      <label for="userEmailToAdd">Ajouter un membre</label>
       <div class="organization__sub-form">
         <Input
           id="userEmailToAdd"
-          aria-label="Adresse email"
           @value={{@userEmailToAdd}}
-          class="organization-sub-form__input form-field__text form-control"
-          @placeholder="Adresse email de l'utilisateur à ajouter" />
-        <button
+          class="form-field__text form-control"
+          placeholder="Adresse email de l'utilisateur à ajouter" />
+        <PixButton
           type="button"
-          {{on "click" @addMembership}}
-          class="organization-sub-form__validate-button btn btn-outline-default">
+          @size="small"
+          @triggerAction={{@addMembership}}>
             Valider
-        </button>
+        </PixButton>
       </div>
     </form>
 
     <form aria-label="Inviter un membre">
-      <label for="userEmailToInvite">Ajouter un membre</label>
+      <label for="userEmailToInvite">Inviter un membre</label>
       <div class="organization__sub-form">
         <Input
           id="userEmailToInvite"
-          aria-label="Adresse email"
           @value={{@userEmailToInvite}}
           class="form-control {{if @userEmailToInviteError "organization-sub-form__input__error"}}"
-          @placeholder="Adresse email de l'utilisateur à inviter" />
+          placeholder="Adresse email de l'utilisateur à inviter" />
 
         <PixSelect
           @options={{this.languagesOptions}}

--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -1,11 +1,7 @@
-<section class="page-section mb_10">
-  <header class="page-section__header">
-    <h2 class="page-section__title">Ajouter un membre</h2>
-    <h2 class="page-section__title">Inviter un membre</h2>
-  </header>
-
+<section class="page-section mb_10 organization-members-section">
   <div class="organization__forms-section">
     <form aria-label="Ajouter un membre">
+      <label for="userEmailToAdd">Inviter un membre</label>
       <div class="organization__sub-form">
         <Input
           id="userEmailToAdd"
@@ -23,21 +19,23 @@
     </form>
 
     <form aria-label="Inviter un membre">
+      <label for="userEmailToInvite">Ajouter un membre</label>
       <div class="organization__sub-form">
         <Input
           id="userEmailToInvite"
           aria-label="Adresse email"
           @value={{@userEmailToInvite}}
-          class={{if @userEmailToInviteError "organization-sub-form__input organization-sub-form__input__error form-control" "organization-sub-form__input form-control"}}
+          class="form-control {{if @userEmailToInviteError "organization-sub-form__input__error"}}"
           @placeholder="Adresse email de l'utilisateur à inviter" />
 
         <PixSelect
-          @options={{this.languages}}
+          @options={{this.languagesOptions}}
           @selectedOption={{this.organizationInvitationLang}}
           @onChange={{this.changeOrganizationInvitationLang}} />
 
         <PixButton
           type="button"
+          @size="small"
           @triggerAction={{fn @createOrganizationInvitation this.organizationInvitationLang}}>
             Inviter
         </PixButton>

--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -6,9 +6,9 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class OrganizationMembersSection extends Component {
-  @tracked organizationInvitationLang = this.languages[0].value;
+  @tracked organizationInvitationLang = this.languagesOptions[0].value;
 
-  get languages() {
+  get languagesOptions() {
     return [
       {
         'label': 'Français',

--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -12,6 +12,10 @@ export default class OrganizationMembersSection extends Component {
     return [
       {
         'label': 'Français',
+        'value': 'fr-fr',
+      },
+      {
+        'label': 'Francophone',
         'value': 'fr',
       },
       {

--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -3,11 +3,31 @@
 
 import Component from '@ember/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class OrganizationMembersSection extends Component {
+  @tracked organizationInvitationLang = this.languages[0].value;
+
+  get languages() {
+    return [
+      {
+        'label': 'Français',
+        'value': 'fr',
+      },
+      {
+        'label': 'Anglais',
+        'value': 'en',
+      },
+    ];
+  }
 
   @action
   selectRole(event) {
     return this.selectRoleForSearch(event.target.value || null);
+  }
+
+  @action
+  changeOrganizationInvitationLang(event) {
+    this.organizationInvitationLang = event.target.value;
   }
 }

--- a/admin/app/controllers/authenticated/organizations/get/members.js
+++ b/admin/app/controllers/authenticated/organizations/get/members.js
@@ -107,7 +107,7 @@ export default class GetMembersController extends Controller {
   }
 
   @action
-  async createOrganizationInvitation() {
+  async createOrganizationInvitation(lang) {
     this.isLoading = true;
     const email = this.userEmailToInvite ? this.userEmailToInvite.trim() : null;
     if (!this._isEmailToInviteValid(email)) {
@@ -116,7 +116,7 @@ export default class GetMembersController extends Controller {
     }
 
     try {
-      const organizationInvitation = await this.store.createRecord('organization-invitation', { email })
+      const organizationInvitation = await this.store.createRecord('organization-invitation', { email, lang })
         .save({ adapterOptions: { organizationId: this.model.id } });
 
       this.notifications.success(`Un email a bien a été envoyé à l'adresse ${organizationInvitation.email}.`);

--- a/admin/app/models/organization-invitation.js
+++ b/admin/app/models/organization-invitation.js
@@ -9,6 +9,7 @@ export default class OrganizationInvitation extends Model {
   @attr status;
   @attr createdAt;
   @attr organizationName;
+  @attr lang;
 
   @belongsTo('organization') organization;
 

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -45,6 +45,7 @@
 @import 'components/menu-bar';
 @import 'components/organization-form';
 @import 'components/organization-information-section';
+@import 'components/organization-members-section';
 @import 'components/pagination-control';
 @import 'components/publish-session-button';
 @import 'components/user-detail-personal-information-section';

--- a/admin/app/styles/components/organization-members-section.scss
+++ b/admin/app/styles/components/organization-members-section.scss
@@ -10,7 +10,7 @@
     input {
       min-width: 300px;
     }
-    
+
     .pix-select {
       max-height: 38px;
       margin: 0 10px;
@@ -24,6 +24,19 @@
     .pix-button {
       padding: 0 20px;
       max-height: 38px;
+    }
+  }
+
+  form[aria-label="Ajouter un membre"]{
+
+    input {
+      min-width: 300px;
+    }
+
+    .pix-button {
+      padding: 0 20px;
+      max-height: 38px;
+      margin-left: 10px;
     }
   }
 }

--- a/admin/app/styles/components/organization-members-section.scss
+++ b/admin/app/styles/components/organization-members-section.scss
@@ -1,0 +1,29 @@
+.organization-members-section {
+
+  label {
+    font-weight: bold;
+    font-size: 1.125rem;
+  }
+
+  form[aria-label="Inviter un membre"] {
+
+    input {
+      min-width: 300px;
+    }
+    
+    .pix-select {
+      max-height: 38px;
+      margin: 0 10px;
+      min-width: 120px;
+
+      select {
+        max-height: 38px;
+      }
+    }
+
+    .pix-button {
+      padding: 0 20px;
+      max-height: 38px;
+    }
+  }
+}

--- a/admin/app/styles/misc/nav.scss
+++ b/admin/app/styles/misc/nav.scss
@@ -20,7 +20,7 @@
     display: flex;
     justify-content: center;
     cursor: pointer;
-    color: $grey-35;
+    color: $grey-45;
     font-weight: 500;
     transition: all ease-in-out .2s;
 

--- a/admin/app/styles/misc/page.scss
+++ b/admin/app/styles/misc/page.scss
@@ -17,8 +17,12 @@
     .page-title {
       font-weight: 500;
 
+      a {
+        color: $pix-blue;
+      }
+
       .wire {
-        color: $grey-20;
+        color: $grey-45;
       }
     }
   }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -128,11 +128,12 @@ export default function() {
 
   this.get('/admin/sessions/:id/generate-results-download-link', { sessionResultsLink: 'http://link-to-results.fr' });
 
-  this.post('/organizations/:id/invitations', (schema, request) => {
+  this.post('/admin/organizations/:id/invitations', (schema, request) => {
     const params = JSON.parse(request.requestBody);
     const email = params.data.attributes.email;
+    const lang = params.data.attributes.lang;
 
-    schema.organizationInvitations.create({ email });
+    schema.organizationInvitations.create({ email, lang });
 
     return schema.organizationInvitations.where({ email });
   });

--- a/admin/tests/acceptance/organization-memberships-management_test.js
+++ b/admin/tests/acceptance/organization-memberships-management_test.js
@@ -131,7 +131,7 @@ module('Acceptance | organization memberships management', function(hooks) {
 
     test('should display an error if the creation has failed', async function(assert) {
       // given
-      this.server.post('/organizations/:id/invitations', () => new Response(500, {}, { errors: [{ status: '500' }] }));
+      this.server.post('/admin/organizations/:id/invitations', () => new Response(500, {}, { errors: [{ status: '500' }] }));
 
       // when
       await visit(`/organizations/${organization.id}`);

--- a/admin/tests/integration/components/organization-members-section_test.js
+++ b/admin/tests/integration/components/organization-members-section_test.js
@@ -3,11 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
+import sinon from 'sinon';
+import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 
 module('Integration | Component | organization-members-section', function(hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function() {
+  test('it should display a list of members', async function(assert) {
+    // given
     this.set('noop', () => {});
     const user1 = EmberObject.create({ firstName: 'Jojo', lastName: 'La Gringue', email: 'jojo@lagringue.fr' });
     const user2 = EmberObject.create({ firstName: 'Froufrou', lastName: 'Le froussard', email: 'froufrou@lefroussard.fr' });
@@ -16,13 +19,37 @@ module('Integration | Component | organization-members-section', function(hooks)
     const memberships = [membership1, membership2];
     this.set('memberships', memberships);
     memberships.meta = { rowCount: 2 };
-  });
 
-  test('it should display a list of members', async function(assert) {
     // when
-    await render(hbs`<OrganizationMembersSection @memberships={{memberships}} @addMembership={{noop}} @createOrganizationInvitation={{noop}} @triggerFiltering={{noop}} @selectRoleForSearch={{noop}}/>`);
+    await render(hbs`<OrganizationMembersSection
+      @memberships={{memberships}}
+      @addMembership={{noop}}
+      @createOrganizationInvitation={{noop}}
+      @triggerFiltering={{noop}}
+      @selectRoleForSearch={{noop}}/>`);
 
     // then
     assert.dom('[aria-label="Membre"]').exists({ count: 2 });
+  });
+
+  test('it should create organization invitation with choosen language', async function(assert) {
+    // given
+    const createOrganizationInvitationStub = sinon.stub();
+    this.set('createOrganizationInvitation', createOrganizationInvitationStub);
+    this.set('memberships', []);
+    this.set('noop', () => {});
+
+    // when
+    await render(hbs`<OrganizationMembersSection
+      @memberships={{memberships}}
+      @addMembership={{noop}}
+      @createOrganizationInvitation={{createOrganizationInvitation}}
+      @triggerFiltering={{noop}}
+      @selectRoleForSearch={{noop}}/>`);
+    await clickByLabel('Inviter');
+
+    // then
+    sinon.assert.neverCalledWith(createOrganizationInvitationStub, 'fr');
+    assert.ok(true);
   });
 });

--- a/admin/tests/unit/controllers/authenticated/organizations/get/members_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/members_test.js
@@ -23,12 +23,13 @@ module('Unit | Controller | authenticated/organizations/get/members', function(h
       controller.model = { organization: { id: 1 } };
 
       controller.userEmailToInvite = 'test@example.net';
+      const lang = 'en';
 
       // when
-      controller.createOrganizationInvitation();
+      controller.createOrganizationInvitation(lang);
 
       // then
-      assert.ok(createRecordStub.calledWith('organization-invitation', { email: 'test@example.net' }));
+      assert.ok(createRecordStub.calledWith('organization-invitation', { email: 'test@example.net', lang }));
       assert.equal(saveStub.callCount, 1);
     });
 

--- a/admin/tests/unit/controllers/authenticated/organizations/get/members_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/members_test.js
@@ -14,6 +14,7 @@ module('Unit | Controller | authenticated/organizations/get/members', function(h
   module('#createOrganizationInvitation', function() {
 
     test('it should create an organization-invitation if the email is valid', function(assert) {
+      // given
       const saveStub = sinon.stub().resolves();
       const createRecordStub = sinon.stub().returns({
         save: saveStub,
@@ -23,33 +24,44 @@ module('Unit | Controller | authenticated/organizations/get/members', function(h
 
       controller.userEmailToInvite = 'test@example.net';
 
+      // when
       controller.createOrganizationInvitation();
 
+      // then
       assert.ok(createRecordStub.calledWith('organization-invitation', { email: 'test@example.net' }));
       assert.equal(saveStub.callCount, 1);
     });
 
     test('it should fail if userEmailToInvite is undefined', function(assert) {
+      // given
       controller.userEmailToInvite = undefined;
 
+      // when
       controller.createOrganizationInvitation();
 
+      // then
       assert.equal(controller.userEmailToInviteError, 'Ce champ est requis.');
     });
 
     test('it should fail if userEmailToInvite is empty', function(assert) {
+      // given
       controller.userEmailToInvite = '';
 
+      // when
       controller.createOrganizationInvitation();
 
+      // then
       assert.equal(controller.userEmailToInviteError, 'Ce champ est requis.');
     });
 
     test('it should fail if userEmailToInvite is not a valid email address', function(assert) {
+      // given
       controller.userEmailToInvite = 'not_valid_email';
 
+      // when
       controller.createOrganizationInvitation();
 
+      // then
       assert.equal(controller.userEmailToInviteError, 'L\'adresse email saisie n\'est pas valide.');
     });
   });

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -330,8 +330,8 @@ exports.register = async (server) => {
       path: '/api/organizations/{id}/invitations',
       config: {
         pre: [{
-          method: securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster,
-          assign: 'isAdminInOrganizationOrHasRolePixMaster',
+          method: securityPreHandlers.checkUserIsAdminInOrganization,
+          assign: 'isAdminInOrganization',
         }],
         handler: organizationController.sendInvitations,
         validate: {
@@ -350,7 +350,38 @@ exports.register = async (server) => {
           }),
         },
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés en tant que responsables de l\'organisation ou ayant le rôle Pix Master**\n' +
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant que responsables de l\'organisation**\n' +
+          '- Elle permet d\'inviter des personnes, déjà utilisateurs de Pix ou non, à être membre d\'une organisation, via leur **email**',
+        ],
+        tags: ['api', 'invitations'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/organizations/{id}/invitations',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: organizationController.sendInvitations,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                email: Joi.string().email({ multiple: true }).required(),
+              },
+            },
+          }),
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant que Pix Master**\n' +
           '- Elle permet d\'inviter des personnes, déjà utilisateurs de Pix ou non, à être membre d\'une organisation, via leur **email**',
         ],
         tags: ['api', 'invitations'],

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -364,7 +364,7 @@ exports.register = async (server) => {
           method: securityPreHandlers.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',
         }],
-        handler: organizationController.sendInvitations,
+        handler: organizationController.sendInvitationsByLang,
         validate: {
           params: Joi.object({
             id: identifiersType.organizationId,
@@ -375,7 +375,8 @@ exports.register = async (server) => {
           payload: Joi.object({
             data: {
               attributes: {
-                email: Joi.string().email({ multiple: true }).required(),
+                email: Joi.string().email().required(),
+                lang: Joi.string().valid('fr-fr', 'fr', 'en'),
               },
             },
           }),

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -155,6 +155,14 @@ module.exports = {
     return h.response(organizationInvitationSerializer.serialize(organizationInvitations)).created();
   },
 
+  async sendInvitationsByLang(request, h) {
+    const organizationId = request.params.id;
+    const { email, lang } = request.payload.data.attributes;
+
+    const organizationInvitation = await usecases.createOrganizationInvitations({ organizationId, emails: [email], locale: lang });
+    return h.response(organizationInvitationSerializer.serialize(organizationInvitation)).created();
+  },
+
   async findPendingInvitations(request) {
     const organizationId = request.params.id;
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1087,11 +1087,11 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if user is not ADMIN in organization or PIXMASTER', async () => {
+      it('should respond with a 403 - forbidden access - if user is not ADMIN in organization', async () => {
         // given
-        const nonPixMasterUserId = databaseBuilder.factory.buildUser().id;
+        const nonAdminUserId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();
-        options.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMasterUserId);
+        options.headers.authorization = generateValidRequestAuthorizationHeader(nonAdminUserId);
 
         // when
         const response = await server.inject(options);
@@ -1100,10 +1100,7 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(403);
       });
 
-      it('should respond with a 201 - created - if user is PIXMASTER', async () => {
-        // given
-        options.headers.authorization = generateValidRequestAuthorizationHeader();
-
+      it('should respond with a 201 - created - if user is ADMIN in organization', async () => {
         // when
         const response = await server.inject(options);
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -970,40 +970,40 @@ describe('Acceptance | Application | organization-controller', () => {
     let user2;
     let options;
 
-    context('Expected output', () => {
+    beforeEach(async () => {
+      const adminUserId = databaseBuilder.factory.buildUser().id;
+      organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildMembership({
+        userId: adminUserId,
+        organizationId: organization.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
 
-      beforeEach(async () => {
-        const adminUserId = databaseBuilder.factory.buildUser().id;
-        organization = databaseBuilder.factory.buildOrganization();
-        databaseBuilder.factory.buildMembership({
-          userId: adminUserId,
-          organizationId: organization.id,
-          organizationRole: Membership.roles.ADMIN,
-        });
+      user1 = databaseBuilder.factory.buildUser();
+      user2 = databaseBuilder.factory.buildUser();
 
-        user1 = databaseBuilder.factory.buildUser();
-        user2 = databaseBuilder.factory.buildUser();
-
-        options = {
-          method: 'POST',
-          url: `/api/organizations/${organization.id}/invitations`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(adminUserId) },
-          payload: {
-            data: {
-              type: 'organization-invitations',
-              attributes: {
-                email: `${user1.email},${user2.email}`,
-              },
+      options = {
+        method: 'POST',
+        url: `/api/organizations/${organization.id}/invitations`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(adminUserId) },
+        payload: {
+          data: {
+            type: 'organization-invitations',
+            attributes: {
+              email: `${user1.email},${user2.email}`,
             },
           },
-        };
+        },
+      };
 
-        await databaseBuilder.commit();
-      });
+      await databaseBuilder.commit();
+    });
 
-      afterEach(async () => {
-        await knex('organization-invitations').delete();
-      });
+    afterEach(async () => {
+      await knex('organization-invitations').delete();
+    });
+
+    context('Expected output', () => {
 
       it('should return the matching organization-invitations as JSON API', async () => {
         // given
@@ -1041,40 +1041,6 @@ describe('Acceptance | Application | organization-controller', () => {
     });
 
     context('Resource access management', () => {
-
-      let user;
-
-      beforeEach(async () => {
-        const adminUserId = databaseBuilder.factory.buildUser().id;
-        organization = databaseBuilder.factory.buildOrganization();
-        databaseBuilder.factory.buildMembership({
-          userId: adminUserId,
-          organizationId: organization.id,
-          organizationRole: Membership.roles.ADMIN,
-        });
-
-        user = databaseBuilder.factory.buildUser();
-
-        options = {
-          method: 'POST',
-          url: `/api/organizations/${organization.id}/invitations`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(adminUserId) },
-          payload: {
-            data: {
-              type: 'organization-invitations',
-              attributes: {
-                email: user.email,
-              },
-            },
-          },
-        };
-
-        await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await knex('organization-invitations').delete();
-      });
 
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
         // given

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -1,5 +1,4 @@
 const { expect, sinon, domainBuilder, HttpTestServer } = require('../../../test-helper');
-const _ = require('lodash');
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const usecases = require('../../../../lib/domain/usecases');
@@ -206,59 +205,6 @@ describe('Integration | Application | Organizations | organization-controller', 
           // then
           expect(response.statusCode).to.equal(403);
         });
-      });
-    });
-  });
-
-  describe('#sendInvitations', () => {
-
-    context('Success cases', () => {
-
-      const status = OrganizationInvitation.StatusType.PENDING;
-      const invitation = domainBuilder.buildOrganizationInvitation({ status });
-
-      const payload = {
-        data: {
-          type: 'organization-invitations',
-          attributes: {
-            email: invitation.email,
-          },
-        },
-      };
-
-      beforeEach(() => {
-        securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.returns(true);
-      });
-
-      it('should return an HTTP response with status code 201', async () => {
-        // given
-        usecases.createOrganizationInvitations.resolves([invitation]);
-
-        // when
-        const response = await httpTestServer.request('POST', '/api/organizations/1/invitations', payload);
-
-        // then
-        expect(response.statusCode).to.equal(201);
-      });
-
-      it('should return the created invitation with status pending', async () => {
-        // given
-        const expectedResult = {
-          type: 'organization-invitations',
-          attributes: {
-            'organization-id': invitation.organizationId,
-            email: invitation.email,
-            status,
-            'updated-at': invitation.updatedAt,
-          },
-        };
-        usecases.createOrganizationInvitations.resolves([invitation]);
-
-        // when
-        const response = await httpTestServer.request('POST', `/api/organizations/${invitation.organizationId}/invitations`, payload);
-
-        // then
-        expect(_.omit(response.result.data[0], 'id', 'attributes.organization-name')).to.deep.equal(expectedResult);
       });
     });
   });

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -105,6 +105,7 @@ describe('Unit | Router | organization-router', () => {
         },
       };
 
+    it('should return HTTP code 201', async () => {
       // when
       const response = await httpTestServer.request(method, url, payload);
 
@@ -175,6 +176,115 @@ describe('Unit | Router | organization-router', () => {
 
       // then
       expect(response.statusCode).to.equal(400);
+    });
+
+    it('should check if user admin in organization', async () => {
+      // given
+      securityPreHandlers.checkUserIsAdminInOrganization.resolves(false);
+
+      // when
+      await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(securityPreHandlers.checkUserIsAdminInOrganization).to.have.be.called;
+    });
+  });
+
+  describe('POST /api/admin/organizations/{id}/invitations', () => {
+
+    const method = 'POST';
+    const url = '/api/admin/organizations/1/invitations';
+
+    it('should return HTTP code 201', async () => {
+      // given
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'user1@organization.org',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+
+    it('should accept multiple emails', async () => {
+      // given
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'user1@organization.org, user2@organization.org',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+
+    it('should reject request with HTTP code 400, when email is empty', async () => {
+      // given
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: '',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should reject request with HTTP code 400, when input is not a email', async () => {
+      // given
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'azerty',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should check if user is Pix Master', async () => {
+      // given
+      securityPreHandlers.checkUserHasRolePixMaster.resolves(false);
+
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'user1@organization.org',
+          },
+        },
+      };
+
+      // when
+      await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(securityPreHandlers.checkUserHasRolePixMaster).to.have.be.called;
     });
   });
 

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -202,24 +202,7 @@ describe('Unit | Router | organization-router', () => {
           type: 'organization-invitations',
           attributes: {
             email: 'user1@organization.org',
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(201);
-    });
-
-    it('should accept multiple emails', async () => {
-      // given
-      const payload = {
-        data: {
-          type: 'organization-invitations',
-          attributes: {
-            email: 'user1@organization.org, user2@organization.org',
+            lang: 'fr',
           },
         },
       };
@@ -238,6 +221,7 @@ describe('Unit | Router | organization-router', () => {
           type: 'organization-invitations',
           attributes: {
             email: '',
+            lang: 'fr',
           },
         },
       };
@@ -256,6 +240,26 @@ describe('Unit | Router | organization-router', () => {
           type: 'organization-invitations',
           attributes: {
             email: 'azerty',
+            lang: 'fr',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should reject request with HTTP code 400, when lang is unknown', async () => {
+      // given
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'user1@organization.org',
+            lang: 'pt',
           },
         },
       };

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -89,9 +89,9 @@ describe('Unit | Router | organization-router', () => {
     const method = 'POST';
     const url = '/api/organizations/1/invitations';
 
-    it('should exist', async () => {
+    it('should return HTTP code 201', async () => {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').returns(true);
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
       sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -105,7 +105,6 @@ describe('Unit | Router | organization-router', () => {
         },
       };
 
-    it('should return HTTP code 201', async () => {
       // when
       const response = await httpTestServer.request(method, url, payload);
 
@@ -115,7 +114,7 @@ describe('Unit | Router | organization-router', () => {
 
     it('should accept multiple emails', async () => {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').returns(true);
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
       sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -178,9 +177,20 @@ describe('Unit | Router | organization-router', () => {
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should check if user admin in organization', async () => {
+    it('should check if user is admin in organization', async () => {
       // given
-      securityPreHandlers.checkUserIsAdminInOrganization.resolves(false);
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').resolves(false);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'user1@organization.org',
+          },
+        },
+      };
 
       // when
       await httpTestServer.request(method, url, payload);
@@ -197,6 +207,11 @@ describe('Unit | Router | organization-router', () => {
 
     it('should return HTTP code 201', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').returns(true);
+      sinon.stub(organizationController, 'sendInvitationsByLang').callsFake((request, h) => h.response().created());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           type: 'organization-invitations',
@@ -216,6 +231,9 @@ describe('Unit | Router | organization-router', () => {
 
     it('should reject request with HTTP code 400, when email is empty', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           type: 'organization-invitations',
@@ -235,6 +253,9 @@ describe('Unit | Router | organization-router', () => {
 
     it('should reject request with HTTP code 400, when input is not a email', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           type: 'organization-invitations',
@@ -254,6 +275,9 @@ describe('Unit | Router | organization-router', () => {
 
     it('should reject request with HTTP code 400, when lang is unknown', async () => {
       // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
       const payload = {
         data: {
           type: 'organization-invitations',
@@ -273,13 +297,16 @@ describe('Unit | Router | organization-router', () => {
 
     it('should check if user is Pix Master', async () => {
       // given
-      securityPreHandlers.checkUserHasRolePixMaster.resolves(false);
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').resolves(false);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       const payload = {
         data: {
           type: 'organization-invitations',
           attributes: {
             email: 'user1@organization.org',
+            lang: 'fr',
           },
         },
       };

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -671,6 +671,41 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     });
   });
 
+  describe('#sendInvitationsByLang', () => {
+
+    it('should call the usecase to create invitation with organizationId, email and lang', async () => {
+      //given
+      const userId = 1;
+      const invitation = domainBuilder.buildOrganizationInvitation();
+
+      const organizationId = invitation.organizationId;
+      const email = invitation.email;
+      const lang = 'en';
+
+      sinon.stub(usecases, 'createOrganizationInvitations').resolves([{ id: 1 }]);
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { id: organizationId },
+        payload: {
+          data: {
+            type: 'organization-invitations',
+            attributes: {
+              email: invitation.email,
+              lang,
+            },
+          },
+        },
+      };
+
+      // when
+      await organizationController.sendInvitationsByLang(request, hFake);
+
+      // then
+      expect(usecases.createOrganizationInvitations).to.have.been.calledWith({ organizationId, emails: [email], locale: lang });
+    });
+  });
+
   describe('#findPendingInvitations', () => {
 
     const userId = 1;


### PR DESCRIPTION
## :unicorn: Problème
Actuellement lorsqu'un Pix Master (admin de Pix Admin), envoie une invitation pour rejoindre une organisation, la langue de cette invitation est choisie en fonction de la locale du navigateur.
Il est donc arrivé que les e-mails soient envoyés en anglais alors que le destinataire était Français etc.

## :robot: Solution
Permettre aux utilisateurs de Pix Admin de choisir la langue dans laquelle est écrite le mail d'invitation lorsqu'ils essaient d'ajouter un membre à une organisation.

## :rainbow: Remarques
Une passe accessibilité a été fait sur la page de détail d'une organisation : 
- Correction des contrastes sur les titres des sous menus, sur le lien pour revenir sur toutes les organisation.
- Ajout de labels pour les champs de recherches dans le sous menu Membres

## :100: Pour tester
- Lancer l'API avec le setup d'envoie d'email ON (demander la config pour le `.env` si besoin)
- Aller sur Pix Admin
- Aller dans la liste des orga
- Cliquer sur n'importe qu'elle orga
- Remplir la partie "Ajouter un membre" avec sa propre adresse email
<img width="704" alt="image" src="https://user-images.githubusercontent.com/38167520/121028628-46ba9c00-c7a8-11eb-9e40-74f69c6847ec.png">
- Constater que l'email reçu est bien en Français (fr-fr), en Français francophone (fr) ou Anglais (en) selon la langue choisie précédemment.

