### PR TITLE
[FEATURE] Afficher toujours les pages en français sur orga.pix.fr (PIX-2560).

### DIFF
--- a/orga/tests/unit/routes/application_test.js
+++ b/orga/tests/unit/routes/application_test.js
@@ -4,183 +4,341 @@ import Service from '@ember/service';
 import sinon from 'sinon';
 
 module('Unit | Route | application', function(hooks) {
+
   setupTest(hooks);
 
-  let saveStub;
   let prescriber;
   let store;
 
   hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
+
+    prescriber = store.createRecord('prescriber', { id: 1, lang: 'en' });
+    prescriber.save = sinon.stub();
+    prescriber.rollbackAttributes = sinon.stub();
   });
 
-  module('sessionAuthenticated', function(hooks) {
+  module('sessionAuthenticated', function() {
 
-    hooks.beforeEach(function() {
-      saveStub = sinon.stub().resolves();
-      prescriber = store.createRecord('prescriber', { id: 1, lang: 'en' });
-      prescriber.save = saveStub;
-    });
-
-    test('should set locales', async function(assert) {
+    test('should set locale to default french locale if lang parameter is not exist', async function(assert) {
       // given
-      const load = sinon.stub().resolves(prescriber);
-      const currentUserStub = Service.create({ load, prescriber });
-      const setLocaleStub = sinon.stub();
-      const intlStub = Service.create({
-        setLocale: setLocaleStub,
+      prescriber.save.resolves();
+      const currentUser = Service.create({
+        load: sinon.stub(),
+        prescriber,
       });
-      const transitionToStub = sinon.stub();
+      currentUser.load.resolves(prescriber);
+
+      const urlStub = Service.create({
+        isFrenchDomainExtension: false,
+      });
+      const intlStub = Service.create({
+        setLocale: sinon.stub(),
+        get: sinon.stub(),
+      });
+      intlStub.get.withArgs('locales').returns(['en', 'fr']);
+      const momentStub = Service.create({
+        setLocale: sinon.stub(),
+      });
+
       const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
+      route.set('transitionTo', sinon.stub());
+      route.set('currentUser', currentUser);
+      route.set('url', urlStub);
       route.set('intl', intlStub);
-      route.set('transitionTo', transitionToStub);
+      route.set('moment', momentStub);
 
       // when
       await route.sessionAuthenticated();
 
       // then
-      assert.ok(setLocaleStub.calledWith(['en', 'fr']));
+      assert.ok(route.intl.setLocale.calledWith(['fr', 'fr']));
+      assert.ok(route.moment.setLocale.calledWith('fr'));
     });
 
     test('it should load current user', async function(assert) {
       // given
-      const loadStub = sinon.stub().resolves(prescriber);
-      const currentUserStub = Service.create({ load: loadStub, prescriber });
-      const transitionToStub = sinon.stub();
+      prescriber.save.resolves();
+      const currentUser = Service.create({
+        load: sinon.stub(),
+        prescriber,
+      });
+      currentUser.load.resolves(prescriber);
+
       const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
-      route.set('transitionTo', transitionToStub);
+      route.set('transitionTo', sinon.stub());
+      route.set('currentUser', currentUser);
 
       // when
       await route.sessionAuthenticated();
 
       // then
-      assert.ok(loadStub.called);
+      assert.ok(route.currentUser.load.called);
     });
 
     test('it should transition to "routeAfterAuthenticated"', async function(assert) {
       // given
-      const loadStub = sinon.stub().resolves(prescriber);
-      const currentUserStub = Service.create({ load: loadStub, prescriber });
-      const transitionToStub = sinon.stub();
+      prescriber.save.resolves();
+      const currentUser = Service.create({
+        load: sinon.stub(),
+        prescriber,
+      });
+      currentUser.load.resolves(prescriber);
+
       const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
-      route.set('transitionTo', transitionToStub);
+      route.set('transitionTo', sinon.stub());
+      route.set('currentUser', currentUser);
       route.routeAfterAuthentication = 'some route';
 
       // when
       await route.sessionAuthenticated();
 
       // then
-      assert.ok(transitionToStub.calledWith('some route'));
+      assert.ok(route.transitionTo.calledWith('some route'));
     });
   });
 
   module('beforeModel', function(hooks) {
 
     hooks.beforeEach(function() {
-      saveStub = sinon.stub().resolves();
-      prescriber = store.createRecord('prescriber', { id: 1, lang: 'en' });
-      prescriber.save = saveStub;
       class FeatureTogglesMock extends Service {
         load = sinon.stub();
       }
       this.owner.register('service:feature-toggles', FeatureTogglesMock);
     });
 
-    test('should set the locales', async function(assert) {
-      // given
-      const transition = { to: { queryParams: {} } };
-      const load = sinon.stub().resolves(prescriber);
-      const currentUserStub = Service.create({ load, prescriber });
-      const setLocaleStub = sinon.stub();
-      const intlStub = Service.create({
-        setLocale: setLocaleStub,
+    module('Setting prescriber lang', function() {
+
+      module('When lang param exist', function() {
+
+        test('should update prescriber if lang param is different from prescriber lang', async function(assert) {
+          // given
+          const transition = { to: { queryParams: { lang: 'fr' } } };
+
+          prescriber.save.resolves();
+          const currentUser = Service.create({
+            load: sinon.stub(),
+            prescriber,
+          });
+          currentUser.load.resolves(prescriber);
+
+          const route = this.owner.lookup('route:application');
+          route.set('currentUser', currentUser);
+
+          // when
+          await route.beforeModel(transition);
+
+          // then
+          assert.ok(
+            route.currentUser.prescriber.save.calledWith({ adapterOptions: { lang: 'fr' } }),
+          );
+          assert.equal(route.currentUser.prescriber.lang, 'fr');
+        });
+
+        test('should not update prescriber if lang param is the same as the prescriber lang', async function(assert) {
+          // given
+          const transition = { to: { queryParams: { lang: 'en' } } };
+
+          prescriber.save.resolves();
+          const currentUser = Service.create({
+            load: sinon.stub(),
+            prescriber,
+          });
+          currentUser.load.resolves(prescriber);
+
+          const route = this.owner.lookup('route:application');
+          route.set('currentUser', currentUser);
+
+          // when
+          await route.beforeModel(transition);
+
+          // then
+          assert.notOk(route.currentUser.prescriber.save.called);
+          assert.equal(route.currentUser.prescriber.lang, 'en');
+        });
+
+        test('should call rollback prescriber attributes if update return error with http status 400', async function(assert) {
+          // given
+          const transition = { to: { queryParams: { lang: 'wrongLanguage' } } };
+
+          const error = {
+            errors: [{ status: '400' }],
+          };
+          prescriber.save.rejects(error);
+          prescriber.rollbackAttributes.resolves();
+          const currentUser = Service.create({
+            load: sinon.stub(),
+            prescriber,
+          });
+          currentUser.load.resolves(prescriber);
+
+          const route = this.owner.lookup('route:application');
+          route.set('currentUser', currentUser);
+
+          // when
+          await route.beforeModel(transition);
+
+          // then
+          assert.ok(route.currentUser.prescriber.rollbackAttributes.called);
+        });
       });
-      const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
-      route.set('intl', intlStub);
-
-      // when
-      await route.beforeModel(transition);
-
-      // then
-      assert.ok(setLocaleStub.calledWith(['en', 'fr']));
     });
 
-    test('should update user when there is lang param different from user lang', async function(assert) {
-      // given
-      const transition = { to: { queryParams: { lang: 'fr' } } };
-      const load = sinon.stub().resolves(prescriber);
-      const currentUserStub = Service.create({ load, prescriber });
-      const setLocaleStub = sinon.stub();
-      const intlStub = Service.create({
-        setLocale: setLocaleStub,
+    module('Setting locale', function() {
+
+      test('should set locale to fr if domain extension is fr', async function(assert) {
+        // given
+        const transition = { to: { queryParams: { lang: 'en' } } };
+
+        prescriber.save.resolves();
+        const currentUser = Service.create({
+          load: sinon.stub(),
+          prescriber,
+        });
+        currentUser.load.resolves(prescriber);
+
+        const urlStub = Service.create({
+          isFrenchDomainExtension: true,
+        });
+
+        const intlStub = Service.create({
+          setLocale: sinon.stub(),
+        });
+        const momentStub = Service.create({
+          setLocale: sinon.stub(),
+        });
+
+        const route = this.owner.lookup('route:application');
+        route.set('currentUser', currentUser);
+        route.set('url', urlStub);
+        route.set('intl', intlStub);
+        route.set('moment', momentStub);
+
+        // when
+        await route.beforeModel(transition);
+
+        // then
+        assert.ok(route.intl.setLocale.calledWith(['fr', 'fr']));
+        assert.ok(route.moment.setLocale.calledWith('fr'));
       });
-      const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
-      route.set('intl', intlStub);
 
-      // when
-      await route.beforeModel(transition);
+      test('should set locale to lang parameter if domain extension is not fr and lang is included into intl locales', async function(assert) {
+        // given
+        const transition = { to: { queryParams: { lang: 'en' } } };
 
-      // then
-      assert.ok(saveStub.calledWith({ adapterOptions: { lang: 'fr' } }));
-      assert.equal(prescriber.lang, 'fr');
-    });
+        prescriber.lang = undefined;
+        const currentUser = Service.create({
+          load: sinon.stub(),
+          prescriber,
+        });
+        currentUser.load.resolves(prescriber);
 
-    test('should not update user lang when the passed lang param is the same as the user lang', async function(assert) {
-      // given
-      const transition = { to: { queryParams: { lang: 'en' } } };
-      const load = sinon.stub().resolves(prescriber);
-      const currentUserStub = Service.create({ load, prescriber });
-      const setLocaleStub = sinon.stub();
-      const intlStub = Service.create({
-        setLocale: setLocaleStub,
+        const urlStub = Service.create({
+          isFrenchDomainExtension: false,
+        });
+
+        const intlStub = Service.create({
+          setLocale: sinon.stub(),
+          get: sinon.stub(),
+        });
+        intlStub.get.withArgs('locales').returns(['en', 'fr']);
+        const momentStub = Service.create({
+          setLocale: sinon.stub(),
+        });
+
+        const route = this.owner.lookup('route:application');
+        route.set('currentUser', currentUser);
+        route.set('url', urlStub);
+        route.set('intl', intlStub);
+        route.set('moment', momentStub);
+
+        // when
+        await route.beforeModel(transition);
+
+        // then
+        assert.ok(route.intl.setLocale.calledWith(['en', 'fr']));
+        assert.ok(route.moment.setLocale.calledWith('en'));
       });
-      const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
-      route.set('intl', intlStub);
 
-      // when
-      await route.beforeModel(transition);
+      test('should set locale to fr if domain extension is not fr and lang parameter is not included into intl locales', async function(assert) {
+        // given
+        const transition = { to: { queryParams: { lang: 'en-GB' } } };
 
-      // then
-      assert.notOk(saveStub.called);
-      assert.equal(prescriber.lang, 'en');
+        prescriber.lang = undefined;
+        const currentUser = Service.create({
+          load: sinon.stub(),
+          prescriber,
+        });
+        currentUser.load.resolves(prescriber);
+
+        const urlStub = Service.create({
+          isFrenchDomainExtension: false,
+        });
+
+        const intlStub = Service.create({
+          setLocale: sinon.stub(),
+          get: sinon.stub(),
+        });
+        intlStub.get.withArgs('locales').returns(['en', 'fr']);
+        const momentStub = Service.create({
+          setLocale: sinon.stub(),
+        });
+
+        const route = this.owner.lookup('route:application');
+        route.set('currentUser', currentUser);
+        route.set('url', urlStub);
+        route.set('intl', intlStub);
+        route.set('moment', momentStub);
+
+        // when
+        await route.beforeModel(transition);
+
+        // then
+        assert.ok(route.intl.setLocale.calledWith(['fr', 'fr']));
+        assert.ok(route.moment.setLocale.calledWith('fr'));
+      });
     });
 
     test('it should load the current user', async function(assert) {
       // given
       const transition = { to: { queryParams: {} } };
-      const loadStub = sinon.stub().resolves(prescriber);
-      const currentUserStub = Service.create({ load: loadStub, prescriber });
+
+      const currentUser = Service.create({
+        load: sinon.stub(),
+        prescriber,
+      });
+      currentUser.load.resolves(prescriber);
+
       const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
+      route.set('currentUser', currentUser);
 
       // when
       await route.beforeModel(transition);
 
       // then
-      assert.ok(loadStub.called);
+      assert.ok(route.currentUser.load.called);
     });
 
     test('it should load feature toggles', async function(assert) {
       // given
       const transition = { to: { queryParams: {} } };
-      const currentUserStub = Service.create({ load: sinon.stub(), prescriber });
+
+      const currentUser = Service.create({
+        load: sinon.stub(),
+        prescriber,
+      });
+      currentUser.load.resolves(prescriber);
+
       const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
+      route.set('currentUser', currentUser);
+
       const featureTogglesService = this.owner.lookup('service:feature-toggles');
-      const loadStub = sinon.stub();
-      featureTogglesService.load = loadStub;
 
       // when
       await route.beforeModel(transition);
 
       // then
-      assert.ok(loadStub.called);
+      assert.ok(featureTogglesService.load.called);
     });
   });
 });

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -3,30 +3,34 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
 module('Unit | Service | url', function(hooks) {
+
   setupTest(hooks);
 
-  test('should have a frenchDomainExtension when the current domain contains pix.fr', function(assert) {
-    // given
-    const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+  module('#isFrenchDomainExtension', function() {
 
-    // when
-    const domainExtension = service.isFrenchDomainExtension;
+    test('should have a frenchDomainExtension when the current domain contains pix.fr', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
 
-    // then
-    assert.equal(domainExtension, true);
-  });
+      // when
+      const domainExtension = service.isFrenchDomainExtension;
 
-  test('should not have frenchDomainExtension when the current domain contains pix.org', function(assert) {
-    // given
-    const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      // then
+      assert.equal(domainExtension, true);
+    });
 
-    // when
-    const domainExtension = service.isFrenchDomainExtension;
+    test('should not have frenchDomainExtension when the current domain contains pix.org', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
 
-    // then
-    assert.equal(domainExtension, false);
+      // when
+      const domainExtension = service.isFrenchDomainExtension;
+
+      // then
+      assert.equal(domainExtension, false);
+    });
   });
 
   module('#campaignsRootUrl', function() {


### PR DESCRIPTION
## :unicorn: Problème
Pour éviter une confusion entre les 2 plateformes/domaines  Pix Orga (**.fr** et **.org**), on souhaite conserver le français comme langue exclusive du domaine **.fr**, afin que les utilisateurs réalisent, si cela se produit, qu’ils ne sont pas sur le bon domaine.

Or, sur `orga.pix.fr`, selon certains paramètres, il est possible que l'affichage des pages ne soit pas en français.

## :robot: Solution
Fixer toujours la locale à `fr`si le nom de domaine de Pix Orga se termine par `.fr`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
En local ou sur la RA, aller sur Pix Orga : 
1. Se connecter à `... .fr`
    * Vérifier que l'affichage des pages est toujours en français
 2. Se connecter à `... .fr?lang=en`
     * Vérifier que l'affichage des pages est toujours en français
 3. Se connecter à `... .org?lang=en`
    * Vérifier que l'affichage des pages est toujours en anglais