### PR TITLE
[CLEANUP]  Suppression des toggles : recalcule des score dans l'onglet "détail" de Pix-Admin & téléchargement des résultats de certif dans Pix-Orga (PIX-2588)

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,5 +1,4 @@
-import Model, { attr } from '@ember-data/model';
+import Model from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isNeutralizationAutoEnabled;
 }

--- a/admin/app/serializers/certification-details.js
+++ b/admin/app/serializers/certification-details.js
@@ -6,7 +6,7 @@ export default class CertificationDetails extends JSONAPISerializer {
   @service featureToggles;
 
   normalizeFindRecordResponse(store, primaryModelClass, payload, id) {
-    if (!this.featureToggles.featureToggles.isNeutralizationAutoEnabled && !payload.data) {
+    if (!payload.data) {
       payload.data = {
         attributes: {
           competencesWithMark: payload.competencesWithMark,
@@ -23,13 +23,6 @@ export default class CertificationDetails extends JSONAPISerializer {
       payload.data.id = id;
     }
     return this.normalizeSingleResponse(...arguments);
-  }
-
-  keyForAttribute(key) {
-    if (!this.featureToggles.featureToggles.isNeutralizationAutoEnabled) {
-      return key;
-    }
-    return super.keyForAttribute(...arguments);
   }
 
   modelNameFromPayloadKey() {

--- a/admin/mirage/factories/feature-toggle.js
+++ b/admin/mirage/factories/feature-toggle.js
@@ -2,5 +2,4 @@ import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   id: 0,
-  isNeutralizationAutoEnabled: false,
 });

--- a/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
@@ -19,7 +19,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
     test('it renders "Aucune épreuve posée"', async function(assert) {
       // given
-      this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
       const certificationId = this.server.create('certification').id;
       this.server.create('certification-detail', {
         id: certificationId,
@@ -68,7 +67,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           },
         ];
 
-        this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
         const certificationId = this.server.create('certification').id;
         this.server.create('certification-detail', {
           id: certificationId,
@@ -95,7 +93,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           skill: '',
         }];
 
-        this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
         const certificationId = this.server.create('certification').id;
         this.server.create('certification-detail', {
           id: certificationId,
@@ -123,7 +120,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           isNeutralized: false,
         }];
 
-        this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
         const certificationId = this.server.create('certification').id;
         this.server.create('certification-detail', {
           id: certificationId,
@@ -150,7 +146,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           isNeutralized: true,
         }];
 
-        this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
         const certificationId = this.server.create('certification').id;
         this.server.create('certification-detail', {
           id: certificationId,
@@ -177,7 +172,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           isNeutralized: true,
         }];
 
-        this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
         const certificationId = this.server.create('certification').id;
         this.server.create('certification-detail', {
           id: certificationId,
@@ -205,7 +199,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           isNeutralized: false,
         }];
 
-        this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
         const certificationId = this.server.create('certification').id;
         this.server.create('certification-detail', {
           id: certificationId,
@@ -258,7 +251,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         },
       ];
 
-      this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
       const certificationId = this.server.create('certification').id;
       this.server.create('certification-detail', {
         id: certificationId,

--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -75,8 +75,12 @@ function _buildCertificationCourse(databaseBuilder, { id, assessmentId, userId, 
       description: examinerComment,
     });
   }
+  let assessmentState = 'completed';
+  if (assessmentId === ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID) {
+    assessmentState = 'started';
+  }
   databaseBuilder.factory.buildAssessment({
-    id: assessmentId, certificationCourseId, type: 'CERTIFICATION', state: 'completed', userId, competenceId: null,
+    id: assessmentId, certificationCourseId, type: 'CERTIFICATION', state: assessmentState, userId, competenceId: null,
     campaignParticipationId: null, isImproving: false, createdAt,
   });
   _.each(CERTIFICATION_CHALLENGES_DATA, (challenge) => {

--- a/api/db/seeds/data/certification/certification-scores-builder.js
+++ b/api/db/seeds/data/certification/certification-scores-builder.js
@@ -24,7 +24,7 @@ function certificationScoresBuilder({ databaseBuilder }) {
   // Idem for the "failed" user, but in a "failed" way.
   const createdAt = new Date('2020-01-31T00:00:00Z');
   _.each(
-    [ ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID, ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID, ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID, ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, ASSESSMENT_SUCCESS_PUBLISHED_SESSION_SCO_ID ],
+    [ ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID, ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID, ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, ASSESSMENT_SUCCESS_PUBLISHED_SESSION_SCO_ID ],
     (assessmentId) => {
       _buildSuccessScore(databaseBuilder, createdAt, assessmentId);
     });
@@ -33,33 +33,35 @@ function certificationScoresBuilder({ databaseBuilder }) {
     (assessmentId) => {
       _buildFailureScore(databaseBuilder, createdAt, assessmentId);
     });
+
+  // Special case : build answers only, has for this one, the assessment has not been completed
+  _buildAnswers({
+    answerData: CERTIFICATION_SUCCESS_ANSWERS_DATA.slice(0, -1),
+    databaseBuilder,
+    assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID,
+    createdAt,
+  });
+}
+
+function _buildAnswers({ answerData, databaseBuilder, assessmentId, createdAt }) {
+  _.each(answerData, (answerData) => {
+    databaseBuilder.factory.buildAnswer({ ...answerData, value: 'Dummy value', assessmentId, createdAt });
+  });
 }
 
 function _buildSuccessScore(databaseBuilder, createdAt, assessmentId) {
-  _.each(CERTIFICATION_SUCCESS_ANSWERS_DATA, (answerData) => {
-    databaseBuilder.factory.buildAnswer({ ...answerData, value: 'Dummy value', assessmentId, createdAt });
-  });
-  let assessmentResultId;
-  if (assessmentId === ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID) {
-    assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-      level: null, pixScore: 518, emitter: 'PIX-ALGO', status: 'started', commentForJury: null,
-      commentForCandidate: null, commentForOrganization: null, juryId: null, assessmentId, createdAt,
-    }).id;
-  } else {
-    assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-      level: null, pixScore: 518, emitter: 'PIX-ALGO', status: 'validated', commentForJury: null,
-      commentForCandidate: null, commentForOrganization: null, juryId: null, assessmentId, createdAt,
-    }).id;
-  }
+  _buildAnswers({ answerData: CERTIFICATION_SUCCESS_ANSWERS_DATA, databaseBuilder, assessmentId, createdAt });
+  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
+    level: null, pixScore: 518, emitter: 'PIX-ALGO', status: 'validated', commentForJury: null,
+    commentForCandidate: null, commentForOrganization: null, juryId: null, assessmentId, createdAt,
+  }).id;
   _.each(CERTIFICATION_SUCCESS_COMPETENCE_MARKS_DATA, (competenceMarkData) => {
     databaseBuilder.factory.buildCompetenceMark({ ...competenceMarkData, assessmentResultId, createdAt });
   });
 }
 
 function _buildFailureScore(databaseBuilder, createdAt, assessmentId) {
-  _.each(CERTIFICATION_FAILURE_ANSWERS_DATA, (answerData) => {
-    databaseBuilder.factory.buildAnswer({ ...answerData, value: 'Dummy value', assessmentId, createdAt });
-  });
+  _buildAnswers({ answerData: CERTIFICATION_FAILURE_ANSWERS_DATA, databaseBuilder, assessmentId, createdAt });
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
     level: -1, pixScore: 0, emitter: 'PIX-ALGO', status: 'rejected', commentForJury: null,
     commentForCandidate: null, commentForOrganization: null, juryId: null, assessmentId, createdAt,

--- a/api/db/seeds/data/certification/certification-scores-builder.js
+++ b/api/db/seeds/data/certification/certification-scores-builder.js
@@ -44,9 +44,17 @@ function certificationScoresBuilder({ databaseBuilder }) {
 }
 
 function _buildAnswers({ answerData, databaseBuilder, assessmentId, createdAt }) {
+  let answerDate = createdAt;
   _.each(answerData, (answerData) => {
-    databaseBuilder.factory.buildAnswer({ ...answerData, value: 'Dummy value', assessmentId, createdAt });
+    databaseBuilder.factory.buildAnswer({ ...answerData, value: 'Dummy value', assessmentId, createdAt: answerDate });
+    answerDate = _addTenSeconds(answerDate);
   });
+}
+
+function _addTenSeconds(date) {
+  const returnedDate = new Date(date);
+  returnedDate.setSeconds(returnedDate.getSeconds() + 10);
+  return returnedDate;
 }
 
 function _buildSuccessScore(databaseBuilder, createdAt, assessmentId) {

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -4,7 +4,6 @@ const securityPreHandlers = require('../security-pre-handlers');
 const certificationCourseController = require('./certification-course-controller');
 
 const identifiersType = require('../../domain/types/identifiers-type');
-const config = require('../../config');
 
 exports.register = async function(server) {
   server.route([
@@ -21,13 +20,7 @@ exports.register = async function(server) {
             id: identifiersType.certificationCourseId,
           }),
         },
-        handler: (request) => {
-          if (config.featureToggles.isNeutralizationAutoEnabled) {
-            return certificationCourseController.getCertificationDetails(request);
-          } else {
-            return certificationCourseController.computeResult(request);
-          }
-        },
+        handler: certificationCourseController.getCertificationDetails,
         tags: ['api'],
         notes: [
           'Cette route est utilisé par Pix Admin',

--- a/api/lib/application/feature-toggles/feature-toggle-controller.js
+++ b/api/lib/application/feature-toggles/feature-toggle-controller.js
@@ -3,10 +3,6 @@ const serializer = require('../../infrastructure/serializers/jsonapi/feature-tog
 
 module.exports = {
   getActiveFeatures() {
-    const featureToggles = {
-      ...settings.featureToggles,
-      isCertificationResultsInOrgaEnabled: true,
-    };
-    return serializer.serialize(featureToggles);
+    return serializer.serialize(settings.featureToggles);
   },
 };

--- a/api/lib/application/feature-toggles/feature-toggle-controller.js
+++ b/api/lib/application/feature-toggles/feature-toggle-controller.js
@@ -3,6 +3,10 @@ const serializer = require('../../infrastructure/serializers/jsonapi/feature-tog
 
 module.exports = {
   getActiveFeatures() {
-    return serializer.serialize(settings.featureToggles);
+    const toggles = {
+      ...settings.featureToggles,
+      isNeutralizationAutoEnabled: true,
+    };
+    return serializer.serialize(toggles);
   },
 };

--- a/api/lib/application/feature-toggles/feature-toggle-controller.js
+++ b/api/lib/application/feature-toggles/feature-toggle-controller.js
@@ -3,6 +3,10 @@ const serializer = require('../../infrastructure/serializers/jsonapi/feature-tog
 
 module.exports = {
   getActiveFeatures() {
-    return serializer.serialize(settings.featureToggles);
+    const featureToggles = {
+      ...settings.featureToggles,
+      isCertificationResultsInOrgaEnabled: true,
+    };
+    return serializer.serialize(featureToggles);
   },
 };

--- a/api/lib/application/feature-toggles/feature-toggle-controller.js
+++ b/api/lib/application/feature-toggles/feature-toggle-controller.js
@@ -3,10 +3,6 @@ const serializer = require('../../infrastructure/serializers/jsonapi/feature-tog
 
 module.exports = {
   getActiveFeatures() {
-    const toggles = {
-      ...settings.featureToggles,
-      isNeutralizationAutoEnabled: true,
-    };
-    return serializer.serialize(toggles);
+    return serializer.serialize(settings.featureToggles);
   },
 };

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -183,10 +183,6 @@ exports.register = async (server) => {
       config: {
         pre: [
           {
-            method: securityPreHandlers.checkIsCertificationResultsInOrgaToggleEnabled,
-            assign: 'isCertificationResultsInOrgaEnabled',
-          },
-          {
             method: securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents,
             assign: 'belongsToOrganizationManagingStudents',
           },

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -4,7 +4,6 @@ const checkUserBelongsToOrganizationManagingStudentsUseCase = require('./usecase
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('./usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
 const checkUserBelongsToOrganizationUseCase = require('./usecases/checkUserBelongsToOrganization');
 const checkUserIsAdminAndManagingStudentsForOrganization = require('./usecases/checkUserIsAdminAndManagingStudentsForOrganization');
-const config = require('../config');
 const Organization = require('../../lib/domain/models/Organization');
 
 const JSONAPIError = require('jsonapi-serializer').Error;
@@ -85,15 +84,6 @@ async function checkUserBelongsToOrganizationOrHasRolePixMaster(request, h) {
 
   const hasRolePixMaster = await checkUserHasRolePixMasterUseCase.execute(userId);
   if (hasRolePixMaster) {
-    return h.response(true);
-  }
-
-  return _replyForbiddenError(h);
-}
-
-function checkIsCertificationResultsInOrgaToggleEnabled(request, h) {
-  const isCertificationResultsInOrgaEnabled = config.featureToggles.isCertificationResultsInOrgaEnabled;
-  if (isCertificationResultsInOrgaEnabled) {
     return h.response(true);
   }
 
@@ -204,7 +194,6 @@ module.exports = {
   checkUserBelongsToOrganizationManagingStudents,
   checkUserBelongsToScoOrganizationAndManagesStudents,
   checkUserHasRolePixMaster,
-  checkIsCertificationResultsInOrgaToggleEnabled,
   checkUserIsAdminInOrganization,
   checkUserIsAdminInOrganizationOrHasRolePixMaster,
   checkUserIsAdminInSCOOrganizationManagingStudents,

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -131,7 +131,6 @@ module.exports = (function() {
 
     featureToggles: {
       isPoleEmploiEnabled: isFeatureEnabled(process.env.IS_POLE_EMPLOI_ENABLED),
-      isCertificationResultsInOrgaEnabled: isFeatureEnabled(process.env.FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED),
     },
 
     infra: {
@@ -198,8 +197,6 @@ module.exports = (function() {
     config.features.dayBeforeImproving = 4;
     config.features.dayBeforeCompetenceResetV2 = 7;
     config.features.garAccessV2 = false;
-
-    config.featureToggles.isCertificationResultsInOrgaEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -130,7 +130,6 @@ module.exports = (function() {
     },
 
     featureToggles: {
-      isNeutralizationAutoEnabled: isFeatureEnabled(process.env.FT_IS_NEUTRALIZATION_AUTO_ENABLED),
       isPoleEmploiEnabled: isFeatureEnabled(process.env.IS_POLE_EMPLOI_ENABLED),
       isCertificationResultsInOrgaEnabled: isFeatureEnabled(process.env.FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED),
     },

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -1,6 +1,5 @@
 const { expect, databaseBuilder, knex, learningContentBuilder, mockLearningContent, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../test-helper');
 const createServer = require('../../../server');
-const config = require('../../../lib/config');
 
 const { CertificationIssueReportCategories } = require('../../../lib/domain/models/CertificationIssueReportCategory');
 const Assessment = require('../../../lib/domain/models/Assessment');
@@ -17,13 +16,7 @@ describe('Acceptance | API | Certification Course', () => {
 
     describe('GET /api/admin/certifications/{id}/details', () => {
 
-      afterEach(function() {
-        config.featureToggles.isNeutralizationAutoEnabled = false;
-      });
-
       it('Should respond with a status 200', async () => {
-
-        config.featureToggles.isNeutralizationAutoEnabled = true;
 
         // given
         await insertUserWithRolePixMaster();

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -25,7 +25,7 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
           attributes: {
             'is-pole-emploi-enabled': false,
             'is-certification-results-in-orga-enabled': false,
-            'is-neutralization-auto-enabled': false,
+            'is-neutralization-auto-enabled': true,
           },
           type: 'feature-toggles',
         },

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,7 +24,6 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
           id: '0',
           attributes: {
             'is-pole-emploi-enabled': false,
-            'is-certification-results-in-orga-enabled': true,
           },
           type: 'feature-toggles',
         },

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,7 +24,7 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
           id: '0',
           attributes: {
             'is-pole-emploi-enabled': false,
-            'is-certification-results-in-orga-enabled': false,
+            'is-certification-results-in-orga-enabled': true,
           },
           type: 'feature-toggles',
         },

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -25,7 +25,6 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
           attributes: {
             'is-pole-emploi-enabled': false,
             'is-certification-results-in-orga-enabled': false,
-            'is-neutralization-auto-enabled': true,
           },
           type: 'feature-toggles',
         },

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -15,7 +15,7 @@ describe('Unit | Application | Certifications Course | Route', function() {
     it('should exist', async () => {
       // given
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sinon.stub(certificationCoursesController, 'computeResult').returns('ok');
+      sinon.stub(certificationCoursesController, 'getCertificationDetails').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -8,8 +8,6 @@ const checkUserBelongsToOrganizationManagingStudentsUseCase = require('../../../
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('../../../lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
 const checkUserBelongsToOrganizationUseCase = require('../../../lib/application/usecases/checkUserBelongsToOrganization');
 
-const config = require('../../../lib/config');
-
 describe('Unit | Application | SecurityPreHandlers', () => {
 
   describe('#checkUserHasRolePixMaster', () => {
@@ -592,44 +590,6 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         // then
         expect(response.statusCode).to.equal(403);
         expect(response.isTakeOver).to.be.true;
-      });
-    });
-  });
-
-  describe('#checkIsCertificationResultsInOrgaToggleEnabled', () => {
-
-    const ft = config.featureToggles.isCertificationResultsInOrgaEnabled;
-
-    afterEach(() => {
-      config.featureToggles.isCertificationResultsInOrgaEnabled = ft;
-    });
-
-    context('when FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED is enabled', () => {
-
-      it('it returns true', () => {
-        // given
-        const request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } } };
-        config.featureToggles.isCertificationResultsInOrgaEnabled = true;
-
-        // when
-        const response = securityPreHandlers.checkIsCertificationResultsInOrgaToggleEnabled(request, hFake);
-
-        //then
-        expect(response.source).to.equal(true);
-      });
-    });
-
-    context('when FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED is not enabled', () => {
-
-      it('should forbid resource access', async () => {
-        // given
-        const request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } } };
-
-        // when
-        const response = await securityPreHandlers.checkIsCertificationResultsInOrgaToggleEnabled(request, hFake);
-
-        //then
-        expect(response.statusCode).to.equal(403);
       });
     });
   });

--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -4,7 +4,6 @@ import Component from '@glimmer/component';
 export default class SidebarMenu extends Component {
   @service currentUser;
   @service url;
-  @service featureToggles;
 
   get documentationUrl() {
     if (!this.url.isFrenchDomainExtension) {
@@ -39,6 +38,6 @@ export default class SidebarMenu extends Component {
   }
 
   get shouldDisplayCertificationsEntry() {
-    return this.featureToggles.isCertificationResultsInOrgaEnabled && (this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents);
+    return this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents;
   }
 }

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,5 +1,4 @@
-import Model, { attr } from '@ember-data/model';
+import Model from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isCertificationResultsInOrgaEnabled;
 }

--- a/orga/app/routes/authenticated/certifications.js
+++ b/orga/app/routes/authenticated/certifications.js
@@ -6,7 +6,7 @@ export default class AuthenticatedCertificationsRoute extends Route {
   @service featureToggles;
 
   beforeModel() {
-    if (!(this.featureToggles.isCertificationResultsInOrgaEnabled && (this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents))) {
+    if (!(this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents)) {
       this.replaceWith('application');
     }
   }

--- a/orga/app/services/feature-toggles.js
+++ b/orga/app/services/feature-toggles.js
@@ -1,12 +1,9 @@
 import Service, { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class FeatureTogglesService extends Service {
   @service store;
-  @tracked isCertificationResultsInOrgaEnabled;
 
   async load() {
     this.featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
-    this.isCertificationResultsInOrgaEnabled = this.featureToggles.isCertificationResultsInOrgaEnabled;
   }
 }

--- a/orga/mirage/factories/feature-toggle.js
+++ b/orga/mirage/factories/feature-toggle.js
@@ -2,5 +2,4 @@ import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   id: 0,
-  isCertificationResultsInOrgaEnabled: false,
 });

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -285,8 +285,9 @@ module('Acceptance | authentication', function(hooks) {
           await visit('/');
 
           // then
-          assert.dom('.sidebar-menu a').exists({ count: 4 });
+          assert.dom('.sidebar-menu a').exists({ count: 5 });
           assert.dom('.sidebar-menu').containsText('Campagnes');
+          assert.dom('.sidebar-menu').containsText('Certifications');
           assert.dom('.sidebar-menu').containsText('Équipe');
           assert.dom('.sidebar-menu').containsText('Élèves');
           assert.dom('.sidebar-menu a:first-child ').hasClass('active');
@@ -300,41 +301,22 @@ module('Acceptance | authentication', function(hooks) {
 
           // then
           assert.dom('.sidebar-menu').containsText('Campagnes');
+          assert.dom('.sidebar-menu').containsText('Certifications');
           assert.dom('.sidebar-menu').containsText('Équipe');
           assert.dom('.sidebar-menu').containsText('Élèves');
-          assert.dom('.sidebar-menu a:nth-child(2)').hasClass('active');
+          assert.dom('.sidebar-menu a:nth-child(3)').hasClass('active');
           assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
         });
 
-        module('when feature toggle for exporting certification results is enabled', function() {
+        test('should redirect to certifications page', async function(assert) {
+          // when
+          await visit('/');
+          await clickByLabel('Certifications');
 
-          test('should redirect to certifications page', async function(assert) {
-            // given
-            server.create('feature-toggle', { id: 0, isCertificationResultsInOrgaEnabled: true });
-
-            // when
-            await visit('/');
-            await clickByLabel('Certifications');
-
-            // then
-            assert.dom('.sidebar-menu').containsText('Certifications');
-            assert.dom('.sidebar-menu a:nth-child(2)').hasClass('active');
-            assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
-          });
-        });
-
-        module('when feature toggle for exporting certification results is not enabled', function() {
-
-          test('should not show Certifications menu', async function(assert) {
-            // given
-            server.create('feature-toggle', { id: 0, isCertificationResultsInOrgaEnabled: false });
-
-            // when
-            await visit('/');
-
-            // then
-            assert.notContains('Certifications');
-          });
+          // then
+          assert.dom('.sidebar-menu').containsText('Certifications');
+          assert.dom('.sidebar-menu a:nth-child(2)').hasClass('active');
+          assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
         });
 
         test('should have resources link', async function(assert) {

--- a/orga/tests/acceptance/certifications_test.js
+++ b/orga/tests/acceptance/certifications_test.js
@@ -22,40 +22,34 @@ module('Acceptance | Certifications page', function(hooks) {
     });
   });
 
-  module('When feature toggle for exporting certification results is enabled', function() {
-    hooks.beforeEach(async () => {
-      server.create('feature-toggle', { id: 0, isCertificationResultsInOrgaEnabled: true });
+  module('When user arrives on certifications page', function() {
+
+    test('should show Certifications page', async function(assert) {
+      // given / when
+      await visit('/certifications');
+
+      // then
+      assert.dom('.certifications-page__text').containsText('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv. Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.');
+      assert.contains('Exporter les résultats');
+      assert.contains('Certifications');
+      assert.contains('Classe');
     });
 
-    module('When user arrives on certifications page', function() {
+    test('should not show any banner', async function(assert) {
+      // given / when
+      await visit('/certifications');
 
-      test('should show Certifications page', async function(assert) {
-        // given / when
-        await visit('/certifications');
+      // then
+      assert.dom('.information-banner').doesNotExist();
+      assert.dom('.pix-banner').doesNotExist();
+    });
 
-        // then
-        assert.dom('.certifications-page__text').containsText('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv. Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.');
-        assert.contains('Exporter les résultats');
-        assert.contains('Certifications');
-        assert.contains('Classe');
-      });
+    test('should show documentation about certification results link', async function(assert) {
+      // given / when
+      await visit('/certifications');
 
-      test('should not show any banner', async function(assert) {
-        // given / when
-        await visit('/certifications');
-
-        // then
-        assert.dom('.information-banner').doesNotExist();
-        assert.dom('.pix-banner').doesNotExist();
-      });
-
-      test('should show documentation about certification results link', async function(assert) {
-        // given / when
-        await visit('/certifications');
-
-        // then
-        assert.dom('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]').exists();
-      });
+      // then
+      assert.dom('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]').exists();
     });
   });
 });

--- a/orga/tests/integration/components/sidebar-menu_test.js
+++ b/orga/tests/integration/components/sidebar-menu_test.js
@@ -152,7 +152,7 @@ module('Integration | Component | sidebar-menu', function(hooks) {
     });
   });
 
-  test('it should display Certifications menu in the sidebar-menu when FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED is true and user is SCOManagingStudents', async function(assert) {
+  test('it should display Certifications menu in the sidebar-menu when user is SCOManagingStudents', async function(assert) {
     // given
     class CurrentUserStub extends Service {
       organization = Object.create({ id: 1, type: 'SCO' });
@@ -160,12 +160,7 @@ module('Integration | Component | sidebar-menu', function(hooks) {
       isSCOManagingStudents= true;
     }
 
-    class FeatureToggleStub extends Service {
-      isCertificationResultsInOrgaEnabled = true;
-    }
-
     this.owner.register('service:current-user', CurrentUserStub);
-    this.owner.register('service:feature-toggles', FeatureToggleStub);
     const intl = this.owner.lookup('service:intl');
     intl.setLocale(['fr', 'fr']);
 
@@ -184,12 +179,7 @@ module('Integration | Component | sidebar-menu', function(hooks) {
       isSCOManagingStudents= true;
     }
 
-    class FeatureToggleStub extends Service {
-      isCertificationResultsInOrgaEnabled = false;
-    }
-
     this.owner.register('service:current-user', CurrentUserStub);
-    this.owner.register('service:feature-toggles', FeatureToggleStub);
     const intl = this.owner.lookup('service:intl');
     intl.setLocale(['fr', 'fr']);
 

--- a/orga/tests/unit/routes/authenticated/certifications_test.js
+++ b/orga/tests/unit/routes/authenticated/certifications_test.js
@@ -9,30 +9,6 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
   setupTest(hooks);
 
   module('beforeModel', function() {
-    test('should redirect to application when featureToggles.isCertificationResultsInOrgaEnabled is false', function(assert) {
-      // given
-      class CurrentUserStub extends Service {
-        isAdminInOrganization = true;
-        isSCOManagingStudents = true;
-      }
-
-      class FeatureToggleStub extends Service {
-        isCertificationResultsInOrgaEnabled = false;
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-      this.owner.register('service:feature-toggles', FeatureToggleStub);
-      const route = this.owner.lookup('route:authenticated.certifications');
-      const replaceWithStub = sinon.stub();
-      route.replaceWith = replaceWithStub;
-
-      // when
-      route.beforeModel();
-
-      // then
-      sinon.assert.calledOnceWithExactly(replaceWithStub, 'application');
-      assert.ok(true);
-    });
 
     test('should redirect to application when currentUser.isAdminInOrganization is true && currentUser.isSCOManagingStudents is false', function(assert) {
       // given
@@ -41,12 +17,7 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
         isSCOManagingStudents = false;
       }
 
-      class FeatureToggleStub extends Service {
-        isCertificationResultsInOrgaEnabled = true;
-      }
-
       this.owner.register('service:current-user', CurrentUserStub);
-      this.owner.register('service:feature-toggles', FeatureToggleStub);
       const route = this.owner.lookup('route:authenticated.certifications');
       const replaceWithStub = sinon.stub();
       route.replaceWith = replaceWithStub;
@@ -66,12 +37,7 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
         isSCOManagingStudents = true;
       }
 
-      class FeatureToggleStub extends Service {
-        isCertificationResultsInOrgaEnabled = true;
-      }
-
       this.owner.register('service:current-user', CurrentUserStub);
-      this.owner.register('service:feature-toggles', FeatureToggleStub);
       const route = this.owner.lookup('route:authenticated.certifications');
       const replaceWithStub = sinon.stub();
       route.replaceWith = replaceWithStub;
@@ -84,19 +50,14 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
       assert.ok(true);
     });
 
-    test('should redirect to application when currentUser.isAdminInOrganization and featureToggles.isCertificationResultsInOrgaEnabled are false', function(assert) {
+    test('should redirect to application when currentUser.isAdminInOrganization is false', function(assert) {
       // given
       class CurrentUserStub extends Service {
         isAdminInOrganization = false;
         isSCOManagingStudents = true;
       }
 
-      class FeatureToggleStub extends Service {
-        isCertificationResultsInOrgaEnabled = false;
-      }
-
       this.owner.register('service:current-user', CurrentUserStub);
-      this.owner.register('service:feature-toggles', FeatureToggleStub);
       const route = this.owner.lookup('route:authenticated.certifications');
       const replaceWithStub = sinon.stub();
       route.replaceWith = replaceWithStub;
@@ -109,19 +70,14 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
       assert.ok(true);
     });
 
-    test('should not redirect to application when currentUser.isAdminInOrganization and featureToggles.isCertificationResultsInOrgaEnabled are true', function(assert) {
+    test('should not redirect to application when currentUser.isAdminInOrganization and currentUser.isSCOManagingStudents are true', function(assert) {
       // given
       class CurrentUserStub extends Service {
         isAdminInOrganization = true;
         isSCOManagingStudents = true;
       }
 
-      class FeatureToggleStub extends Service {
-        isCertificationResultsInOrgaEnabled = true;
-      }
-
       this.owner.register('service:current-user', CurrentUserStub);
-      this.owner.register('service:feature-toggles', FeatureToggleStub);
       const route = this.owner.lookup('route:authenticated.certifications');
       const replaceWithStub = sinon.stub();
       route.replaceWith = replaceWithStub;
@@ -147,12 +103,7 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
         }
       }
 
-      class FeatureToggleStub extends Service {
-        isCertificationResultsInOrgaEnabled = true;
-      }
-
       this.owner.register('service:current-user', CurrentUserStub);
-      this.owner.register('service:feature-toggles', FeatureToggleStub);
 
       const route = this.owner.lookup('route:authenticated/certifications');
       const divisions = [EmberObject.create({ name: '3èmeA' }), EmberObject.create({ name: '2ndE' })];

--- a/orga/tests/unit/services/feature-toggle_test.js
+++ b/orga/tests/unit/services/feature-toggle_test.js
@@ -13,7 +13,7 @@ module('Unit | Service | feature toggles', function(hooks) {
     test('should load the feature toggles', async function(assert) {
       // Given
       const featureToggles = Object.create({
-        isCertificationResultsInOrgaEnabled: false,
+        aFakeFeatureToggle: false,
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(featureToggles),
@@ -25,7 +25,7 @@ module('Unit | Service | feature toggles', function(hooks) {
       await featureToggleService.load();
 
       // Then
-      assert.equal(featureToggleService.featureToggles.isCertificationResultsInOrgaEnabled, false);
+      assert.equal(featureToggleService.featureToggles.aFakeFeatureToggle, false);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Deux toggles :
- Celui permettant de télécharger les résultats de certification depuis Pix-Orga (`FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED`)
- Celui permettant de ne pas recalculer les résultats de certification depuis l'onglet "détail" de Pix-Admin (`FT_IS_NEUTRALIZATION_AUTO_ENABLED`)
sont actifs en prod.

On ne souhaite pas pouvoir activer/désactiver ces features à la volée. Le code permettant d'activer ou désactiver ces features est donc superflu.

## :robot: Solution
Supprimer les toggles. 

## :rainbow: Remarques
- Dans la session de certification numéro 6 des seeds, la candidate AnneNormale5 était dans une situation anormale (pun intented) : sa certification était démarée alors que son test de certification lui, était complet. Pour coller davantage à une situation plausible, les seeds ont été modifiés pour que son test ne soit pas complet.

## :100: Pour tester
- Non regression sur l'onglet détail de Pix-Admin (pixmaster@example.net)
- Non regression sur la page de téléchargement des résultats de certification de Pix-Orga (sco.admin@example.net & sco.member@example.net)
