### PR TITLE
[TECH] Ajout d'un index dans la table "certification-candidates" pour améliorer les performances d'affichage de la liste de candidats en prescription de certification SCO (PIX-2698)

### DIFF
--- a/api/db/migrations/20210609045948_add-index-on-table-certification-candidates-column-schooling-registration-id.js
+++ b/api/db/migrations/20210609045948_add-index-on-table-certification-candidates-column-schooling-registration-id.js
@@ -1,0 +1,11 @@
+exports.up = (knex) => {
+  return knex.schema.table('certification-candidates', (table) => {
+    table.index('schoolingRegistrationId');
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table('certification-candidates', (table) => {
+    table.dropIndex('schoolingRegistrationId');
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
On reste attentif sur les performances BDD des requêtes émises par l'API.
En l'occurrence, il se trouve que la requête permettant de récupérer la liste de candidats potentiels à l'inscription en certification pour un centre de certification / organisation SCO n'était pas très efficace.
https://explain.dalibo.com/plan/SOG#plan

Le parcours séquentiel de la table "certification-candidates" ici est évitable.

## :robot: Solution
Dans la requête, on indique au moteur BDD de joindre les tables "certification-candidates" et "schooling-registrations" via l'id de schooling-registration. Manque d'index sur cette colonne dans la table "certification-candidates", un scan séquentiel complet est effectué.
Il suffit d'ajouter un index sur la colonne "schoolingRegistrationId" pour résoudre le problème.
Plan après :
https://explain.dalibo.com/plan/739

## :rainbow: Remarques

## :100: Pour tester
Tester que l'affichage de candidats à l'inscription sur certifsco@example.net fonctionne bien
