### PR TITLE
[FEATURE] Reporter les informations CPF lors de l'inscription de candidats de certification dans le cadre de la prescription de certification SCO (PIX-2695)

### DIFF
--- a/api/lib/domain/models/SCOCertificationCandidate.js
+++ b/api/lib/domain/models/SCOCertificationCandidate.js
@@ -6,24 +6,29 @@ const scoCertificationCandidateValidationJoiSchema = Joi.object({
   firstName: Joi.string().required().empty(null),
   lastName: Joi.string().required().empty(null),
   birthdate: Joi.date().format('YYYY-MM-DD').greater('1900-01-01').required().empty(null),
+  birthINSEECode: Joi.string().allow(null).optional(),
+  sex: Joi.string().allow(null).optional(),
   sessionId: Joi.number().required().empty(null),
   schoolingRegistrationId: Joi.number().required().empty(null),
 });
 
 class SCOCertificationCandidate {
-  constructor(
-    {
-      id,
-      firstName,
-      lastName,
-      birthdate,
-      sessionId,
-      schoolingRegistrationId,
-    } = {}) {
+  constructor({
+    id,
+    firstName,
+    lastName,
+    birthdate,
+    birthINSEECode,
+    sex,
+    sessionId,
+    schoolingRegistrationId,
+  } = {}) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
     this.birthdate = birthdate;
+    this.birthINSEECode = birthINSEECode;
+    this.sex = sex;
     this.sessionId = sessionId;
     this.schoolingRegistrationId = schoolingRegistrationId;
     this.validate();

--- a/api/lib/domain/usecases/enroll-students-to-session.js
+++ b/api/lib/domain/usecases/enroll-students-to-session.js
@@ -31,6 +31,8 @@ module.exports = async function enrollStudentsToSession({
       firstName: student.firstName.trim(),
       lastName: student.lastName.trim(),
       birthdate: student.birthdate,
+      birthINSEECode: student.birthCityCode,
+      sex: student.sex,
       sessionId,
       schoolingRegistrationId: student.id,
     });

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -39,7 +39,8 @@ module.exports = {
 
 function _scoCandidateToDTOForSession(sessionId) {
   return (scoCandidate) => {
-    const pickedAttributes = _.pick(scoCandidate, ['firstName', 'lastName', 'birthdate', 'schoolingRegistrationId']);
+    const pickedAttributes = _.pick(scoCandidate,
+      ['firstName', 'lastName', 'birthdate', 'schoolingRegistrationId', 'sex', 'birthINSEECode']);
     return {
       ...pickedAttributes,
       sessionId,

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -39,9 +39,9 @@ module.exports = {
 
 function _scoCandidateToDTOForSession(sessionId) {
   return (scoCandidate) => {
-    const dto = _.omit(scoCandidate, 'id');
+    const pickedAttributes = _.pick(scoCandidate, ['firstName', 'lastName', 'birthdate', 'schoolingRegistrationId']);
     return {
-      ...dto,
+      ...pickedAttributes,
       sessionId,
       birthCity: '',
     };

--- a/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -39,6 +39,11 @@ describe('Integration | Repository | SCOCertificationCandidate', function() {
         domainBuilder.buildSCOCertificationCandidate(scoCandidateAlreadySaved2),
         domainBuilder.buildSCOCertificationCandidate({
           id: null,
+          firstName: 'Bobby',
+          lastName: 'LaPointe',
+          birthdate: '2001-01-04',
+          sex: 'M',
+          birthINSEECode: '75005',
           schoolingRegistrationId: schoolingRegistrationId3,
           sessionId,
         }),
@@ -210,7 +215,7 @@ describe('Integration | Repository | SCOCertificationCandidate', function() {
 });
 
 function fieldsToBeCompared(candidate) {
-  return _.pick(candidate, ['firstName', 'lastName', 'birthdate', 'schoolingRegistrationId', 'sessionId']);
+  return _.pick(candidate, ['firstName', 'lastName', 'birthdate', 'sex', 'birthINSEECode', 'schoolingRegistrationId', 'sessionId']);
 }
 
 function candidatesToBeCompared(candidates) {

--- a/api/tests/tooling/domain-builder/factory/build-sco-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-sco-certification-candidate.js
@@ -5,18 +5,19 @@ module.exports = function buildSCOCertificationCandidate({
   firstName = 'Myriam',
   lastName = 'Meilleure',
   birthdate = '2006-06-06',
+  sex = 'F',
+  birthINSEECode = '66001',
   sessionId = 456,
   schoolingRegistrationId = 789,
 } = {}) {
-
-  const scoCertificationCandidate = new SCOCertificationCandidate({
+  return new SCOCertificationCandidate({
     id,
     firstName,
     lastName,
     birthdate,
+    sex,
+    birthINSEECode,
     sessionId,
     schoolingRegistrationId,
   });
-
-  return scoCertificationCandidate;
 };

--- a/api/tests/unit/domain/models/SCOCertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/SCOCertificationCandidate_test.js
@@ -12,6 +12,8 @@ describe('Unit | Domain | Models | SCO Certification Candidate', () => {
       firstName: 'Oren',
       lastName: 'Ishii',
       birthdate: '2010-01-01',
+      sex: 'F',
+      birthINSEECode: '75001',
       sessionId: 123,
       schoolingRegistrationId: 456,
     };
@@ -53,6 +55,19 @@ describe('Unit | Domain | Models | SCO Certification Candidate', () => {
         expect(error).to.be.instanceOf(InvalidCertificationCandidate);
         expect(error.key).to.equal(field);
         expect(error.why).to.equal('required');
+      });
+    });
+
+    [
+      'sex',
+      'birthINSEECode',
+    ].forEach((field) => {
+      it(`should throw an error when field ${field} is not a string`, async () => {
+        const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, [field]: 123 });
+
+        expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+        expect(error.key).to.equal(field);
+        expect(error.why).to.equal('not_a_string');
       });
     });
 

--- a/api/tests/unit/domain/models/SCOCertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/SCOCertificationCandidate_test.js
@@ -1,0 +1,120 @@
+const { expect, catchErr } = require('../../../test-helper');
+const SCOCertificationCandidate = require('../../../../lib/domain/models/SCOCertificationCandidate');
+const {
+  InvalidCertificationCandidate,
+} = require('../../../../lib/domain/errors');
+
+describe('Unit | Domain | Models | SCO Certification Candidate', () => {
+
+  describe('validate', () => {
+    const buildSCOCertificationCandidate = (attributes) => new SCOCertificationCandidate(attributes);
+    const validAttributes = {
+      firstName: 'Oren',
+      lastName: 'Ishii',
+      birthdate: '2010-01-01',
+      sessionId: 123,
+      schoolingRegistrationId: 456,
+    };
+
+    context('when all required fields are presents', () => {
+
+      it('should be ok when object is valid', () => {
+        try {
+          buildSCOCertificationCandidate(validAttributes);
+        } catch (e) {
+          expect.fail('scoCertificationCandidate is valid when all required fields are present');
+        }
+      });
+    });
+
+    [
+      'firstName',
+      'lastName',
+    ].forEach((field) => {
+      it(`should throw an error when field ${field} is not a string`, async () => {
+        const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, [field]: 123 });
+
+        expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+        expect(error.key).to.equal(field);
+        expect(error.why).to.equal('not_a_string');
+      });
+
+      it(`should throw an error when field ${field} is not present`, async () => {
+        const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, [field]: undefined });
+
+        expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+        expect(error.key).to.equal(field);
+        expect(error.why).to.equal('required');
+      });
+
+      it(`should throw an error when field ${field} is not present because null`, async () => {
+        const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, [field]: null });
+
+        expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+        expect(error.key).to.equal(field);
+        expect(error.why).to.equal('required');
+      });
+    });
+
+    [
+      'sessionId',
+      'schoolingRegistrationId',
+    ].forEach((field) => {
+      it(`should throw an error when field ${field} is not a number`, async () => {
+        const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, [field]: 'salut' });
+
+        expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+        expect(error.key).to.equal(field);
+        expect(error.why).to.equal('not_a_number');
+      });
+
+      it(`should throw an error when field ${field} is not present`, async () => {
+        const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, [field]: undefined });
+
+        expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+        expect(error.key).to.equal(field);
+        expect(error.why).to.equal('required');
+      });
+
+      it(`should throw an error when field ${field} is not present because null`, async () => {
+        const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, [field]: null });
+
+        expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+        expect(error.key).to.equal(field);
+        expect(error.why).to.equal('required');
+      });
+    });
+
+    it('should throw an error when birthdate is not a date', async () => {
+      const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, birthdate: 'je mange des fruits' });
+
+      expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+      expect(error.key).to.equal('birthdate');
+      expect(error.why).to.equal('date_format');
+    });
+
+    it('should throw an error when birthdate is not a valid format', async () => {
+      const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, birthdate: '2020/02/02' });
+
+      expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+      expect(error.key).to.equal('birthdate');
+      expect(error.why).to.equal('date_format');
+    });
+
+    it('should throw an error when birthdate is null', async () => {
+      const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, birthdate: null });
+
+      expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+      expect(error.key).to.equal('birthdate');
+      expect(error.why).to.equal('required');
+    });
+
+    it('should throw an error when birthdate is not present', async () => {
+      const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, birthdate: undefined });
+
+      expect(error).to.be.instanceOf(InvalidCertificationCandidate);
+      expect(error.key).to.equal('birthdate');
+      expect(error.why).to.equal('required');
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/enroll-students-to-session_test.js
+++ b/api/tests/unit/domain/usecases/enroll-students-to-session_test.js
@@ -25,6 +25,8 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
           firstName: sr.firstName,
           lastName: sr.lastName,
           birthdate: sr.birthdate,
+          birthINSEECode: sr.birthCityCode,
+          sex: sr.sex,
           sessionId: sessionId,
           schoolingRegistrationId: sr.id,
         });
@@ -72,6 +74,8 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
         firstName: 'Sarah Michelle ',
         lastName: ' Gellar',
         birthdate: '2020-01-01',
+        sex: 'F',
+        birthCityCode: '48512',
         organization: organizationForReferent,
       });
 
@@ -79,6 +83,8 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
         firstName: 'Sarah Michelle',
         lastName: 'Gellar',
         birthdate: '2020-01-01',
+        sex: 'F',
+        birthINSEECode: '48512',
         sessionId: sessionId,
         schoolingRegistrationId: 1,
       });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'envoi des données CPF, il est nécessaire d'inscrire au préalable l'ensemble des informations requises dans le certification-candidate lors de l'inscription en certification.
Au préalable, nous nous sommes assurés que côté SCO (Siecle + Fregata) nous avons récupéré toutes les données dans les schooling-registrations

## :robot: Solution
Reporter ces données depuis la schooling-registration vers le certification-candidate lors de l'inscription en certification

## :rainbow: Remarques

## :100: Pour tester
Inscrire des candidats en certification dans le cadre de la prescription de certif SCO, avec des schooling registrations aux champs sex et birthCityCode remplis.
S'assurer que les certification-candidates ainsi créés contiennent également ces données, respectivement dans les champs sex et birthINSEECode
