### PR TITLE
[CLEAN] Lever une erreur lorsque la réponse donnée contient une clé inexistante (PIX-2424).

### DIFF
--- a/api/lib/domain/services/solution-service-qrocm-ind.js
+++ b/api/lib/domain/services/solution-service-qrocm-ind.js
@@ -35,13 +35,14 @@ function _compareAnswersAndSolutions(answers, solutions, enabledTreatments) {
   const results = {};
   _.map(answers, (answer, answerKey) => {
     const solutionVariants = solutions[answerKey];
+    if (!solutionVariants) {
+      logger.warn(`[ERREUR CLE ANSWER] La clé ${answerKey} n'existe pas. Première clé de l'épreuve : ${Object.keys(solutions)[0]}`);
+      throw new YamlParsingError();
+    }
     if (enabledTreatments.includes('t3')) {
       results[answerKey] = _areApproximatelyEqualAccordingToLevenshteinDistanceRatio(answer, solutionVariants);
     } else if (solutionVariants) {
       results[answerKey] = solutionVariants.includes(answer);
-    }
-    if (!solutionVariants) {
-      logger.warn(`[PROBLÈME RÉPONSE ÉPREUVE] La clé ${answerKey} n'existe pas.`);
     }
   });
   return results;

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -78,17 +78,17 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       expect(actual).to.deep.equal(expected);
     });
 
-    it('should do nothing if there is no solutions for one input but answers', () => {
+    it('should throw an error if there is no solutions for one input but answers', async () => {
       // given
-      const answers = { 'phrase1': 'Le silence est d\'ours', 'phrase2': 'facebook', 'phraseSansSolution': 'lasagne' };
+      const answers = { 'phraseSansSolution': 'lasagne', 'phrase1': 'Le silence est d\'ours', 'phrase2': 'facebook' };
       const solutions = { 'phrase1': ['Le silence est d\'or'], 'phrase2': ['facebook'] };
-      const enabledTreatments = [];
+      const enabledTreatments = ['t3'];
 
       // when
-      const result = service._compareAnswersAndSolutions(answers, solutions, enabledTreatments);
-
+      const error = await catchErr(service._compareAnswersAndSolutions)(answers, solutions, enabledTreatments);
       // then
-      expect(result).to.deep.equal({ 'phrase1': false, 'phrase2': true });
+      expect(error).to.be.an.instanceOf(YamlParsingError);
+      expect(error.message).to.equal('Une erreur s\'est produite lors de l\'interprétation des réponses.');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsque la réponse de l'utilisateur sur un QROC possède des clés de champs inexistants dans l'épreuve, il y a une erreur qui remonte. Actuellement cette erreur est une 500, `Cannot read property 'forEach' of undefined`. 

## :robot: Solution
Remonter une vraie erreur : 
- On lève une erreur dès qu'on voit qu'une solution n'a pas été trouvé pour la clé
- Le message d'erreur a été modifié pour être plus précis
- Le test a été modifié car l'erreur ci-dessus apparaissait surtout lors d'un `t3`, qui boucle sur toutes les solutions

## :rainbow: Remarques
Cette erreur est reproductible en tentant d'appeler directement l'API avec des valeurs dans le POST qui ne convienne pas à l'épreuve ou en modifiant les valeurs de clés dans le front

## :100: Pour tester
Appel API sur une épreuves en cours.