### PR TITLE
[TECH] Fix test requiring role pixMaster

### DIFF
--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -96,6 +96,7 @@ describe('Unit | Application | Certifications Course | Route', function() {
 
     it('should exist', async () => {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(certificationCoursesController, 'update').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);


### PR DESCRIPTION
## :unicorn: Problème
Un test unitaire est KO suite l'ajout de droit sur la route liée

## :robot: Solution
Ajouter les droits pixMaster dans le test


## :100: Pour tester
Test apis ✅
