### PR TITLE
[FEATURE] Ajout d'un lien vers la politique de confidentialité dans la page d'inscription sur Pix App (PIX-2694).

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
@@ -16,7 +16,7 @@ Given(`je m'inscris avec le prénom {string}, le nom {string}, le mail {string} 
   cy.get('input[id="lastName"]').type(lastname);
   cy.get('input[id=email]').type(email);
   cy.get('input[id=password]').type(password);
-  cy.get('input[id=pix-cgu]').check();
+  cy.get('.signup-form__cgu').check();
   cy.get('button[type=submit]').click();
 });
 

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -56,6 +56,10 @@ export default class SignupForm extends Component {
     return this.url.cguUrl;
   }
 
+  get dataProtectionPolicyUrl() {
+    return this.url.dataProtectionPolicyUrl;
+  }
+
   _getErrorMessage(status, key) {
     return (status === 'error') ? this.intl.t(ERROR_INPUT_MESSAGE_MAP[key]) : null;
   }

--- a/mon-pix/app/styles/components/_signup-form.scss
+++ b/mon-pix/app/styles/components/_signup-form.scss
@@ -23,7 +23,7 @@
   }
 
   &__cgu-label {
-    margin: 3px 15px;
+    margin: 3px 0 3px 15px;
   }
 
   &__legal-details-container {

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -79,16 +79,26 @@
     </div>
 
     <div class="signup-form__cgu-container">
-      <label for="pix-cgu" class="signup-form__cgu-label">
-        {{t 'pages.sign-up.fields.cgu.label' cguUrl=this.cguUrl htmlSafe=true}}
-        <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer"> {{t 'pages.sign-up.fields.cgu.cgu' cguUrl=this.cguUrl htmlSafe=true}} </a>
+      <p class="signup-form__cgu-label">
+        {{t 'pages.sign-up.fields.cgu.accept'}}
+        <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t 'pages.sign-up.fields.cgu.cgu'}}
+        </a>
+        {{t 'pages.sign-up.fields.cgu.and'}}
+        <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t 'pages.sign-up.fields.cgu.data-protection-policy'}}
+        </a>
         {{#if @user.errors.cgu}}
           <div id="validationMessage-cgu" class="sign-form__validation-error" aria-live="polite">
             {{t 'pages.sign-up.fields.cgu.error'}}
           </div>
         {{/if}}
-      </label>
-      <Input @type="checkbox" class="signup-form__cgu" id="pix-cgu" @checked={{@user.cgu}}/>
+      </p>
+      <Input
+        @type="checkbox"
+        class="signup-form__cgu"
+        @checked={{@user.cgu}}
+        aria-label={{t 'pages.sign-up.fields.cgu.label'}}/>
     </div>
 
     </fieldset>

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -56,7 +56,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await fillIn('#lastName', prescritUser.lastName);
             await fillIn('#email', prescritUser.email);
             await fillIn('#password', prescritUser.password);
-            await click('#pix-cgu');
+            await click('.signup-form__cgu');
             await click('.button');
           });
 
@@ -89,7 +89,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               await fillIn('#lastName', prescritUser.lastName);
               await fillIn('#email', prescritUser.email);
               await fillIn('#password', prescritUser.password);
-              await click('#pix-cgu');
+              await click('.signup-form__cgu');
               await click('.button');
             });
 
@@ -138,7 +138,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await fillIn('#lastName', prescritUser.lastName);
           await fillIn('#email', prescritUser.email);
           await fillIn('#password', prescritUser.password);
-          await click('#pix-cgu');
+          await click('.signup-form__cgu');
           await click('.button');
         });
 
@@ -156,7 +156,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await fillIn('#lastName', prescritUser.lastName);
           await fillIn('#email', prescritUser.email);
           await fillIn('#password', prescritUser.password);
-          await click('#pix-cgu');
+          await click('.signup-form__cgu');
           await click('.button');
         });
 

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -48,7 +48,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await fillIn('#lastName', campaignParticipant.lastName);
             await fillIn('#email', campaignParticipant.email);
             await fillIn('#password', campaignParticipant.password);
-            await click('#pix-cgu');
+            await click('.signup-form__cgu');
             await click('.button');
           });
 
@@ -72,7 +72,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#lastName', campaignParticipant.lastName);
               await fillIn('#email', campaignParticipant.email);
               await fillIn('#password', campaignParticipant.password);
-              await click('#pix-cgu');
+              await click('.signup-form__cgu');
               await click('.button');
             });
 
@@ -121,7 +121,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           await fillIn('#lastName', campaignParticipant.lastName);
           await fillIn('#email', campaignParticipant.email);
           await fillIn('#password', campaignParticipant.password);
-          await click('#pix-cgu');
+          await click('.signup-form__cgu');
           await click('.button');
         });
 
@@ -139,7 +139,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           await fillIn('#lastName', campaignParticipant.lastName);
           await fillIn('#email', campaignParticipant.email);
           await fillIn('#password', campaignParticipant.password);
-          await click('#pix-cgu');
+          await click('.signup-form__cgu');
           await click('.button');
         });
 

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -140,7 +140,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await fillIn('#lastName', prescritUser.lastName);
               await fillIn('#email', prescritUser.email);
               await fillIn('#password', prescritUser.password);
-              await click('#pix-cgu');
+              await click('.signup-form__cgu');
 
               // when
               await click('.button');
@@ -604,7 +604,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#lastName', prescritUser.lastName);
             await fillIn('#email', prescritUser.email);
             await fillIn('#password', prescritUser.password);
-            await click('#pix-cgu');
+            await click('.signup-form__cgu');
             await click('.button');
           });
 
@@ -624,7 +624,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await fillIn('#lastName', prescritUser.lastName);
               await fillIn('#email', prescritUser.email);
               await fillIn('#password', prescritUser.password);
-              await click('#pix-cgu');
+              await click('.signup-form__cgu');
               await click('.button');
             });
 
@@ -640,7 +640,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           await fillIn('#lastName', prescritUser.lastName);
           await fillIn('#email', prescritUser.email);
           await fillIn('#password', prescritUser.password);
-          await click('#pix-cgu');
+          await click('.signup-form__cgu');
           await click('.button');
         });
       });

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -25,10 +25,10 @@ const INPUT_TEXT_FIELD = '.sign-form-body__input';
 const INPUT_TEXT_FIELD_CLASS_DEFAULT = 'form-textfield__input-container--default';
 
 const CHECKBOX_CGU_CONTAINER = '.signup-form__cgu-container';
-const CHECKBOX_CGU_INPUT = '#pix-cgu';
+const CHECKBOX_CGU_INPUT = '.signup-form__cgu';
 const CHECKBOX_CGU_LABEL = '.signup-form__cgu-label';
 
-const CGU_LINK = '.signup-form__cgu-label .link';
+const CGU_LINKS = '.signup-form__cgu-label .link';
 
 const SUBMIT_BUTTON_CONTAINER = '.sign-form-body__bottom-button';
 const SUBMIT_BUTTON = '.button';
@@ -98,11 +98,13 @@ describe('Integration | Component | SignupForm', function() {
       });
     });
 
-    it('should have link to Pix\'s CGU', function() {
-      const cguText = this.intl.t('pages.sign-up.fields.cgu.label', { cguUrl: 'https://pix.localhost/conditions-generales-d-utilisation' });
+    it('should have links to Pix\'s CGU and data protection policy ', function() {
+      // given
+      const cguText = this.intl.t('pages.sign-up.fields.cgu.accept', { cguUrl: 'https://pix.localhost/conditions-generales-d-utilisation' });
 
+      // when & then
       expect(find('.signup-form__cgu-label').innerHTML).to.contains(cguText);
-      expect(findAll(CGU_LINK)).to.have.length(1);
+      expect(findAll(CGU_LINKS)).to.have.length(2);
     });
 
     it('should render a submit button', function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -984,9 +984,12 @@
       },
       "fields": {
         "cgu": {
+          "accept": "I agree to the ",
+          "and": "and ",
           "cgu": "Pix terms of use",
-          "error": "You must agree to the Pix terms of use to create an account.",
-          "label": "I agree to the "
+          "data-protection-policy": "personal data protection policy",
+          "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
+          "label": "Agree Pix terms of use and personal data protection policy"
         },
         "email": {
           "error": "Your email address is invalid.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -984,9 +984,12 @@
       },
       "fields": {
         "cgu": {
+          "accept": "J'accepte les ",
+          "and": "et ",
           "cgu": "conditions d'utilisation de Pix",
-          "error": "Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.",
-          "label": "J'accepte les "
+          "data-protection-policy": "la politique de confidentialité",
+          "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
+          "label": "Accepter les conditions d’utilisation de Pix et la politique de confidentialité"
         },
         "email": {
           "error": "Votre adresse e-mail n’est pas valide.",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur la page d'inscription sur Pix App, il n'y aucun lien et aucune indication sur notre Politique de confidentialité des données pour les utilisateurs de pix.fr, pix.org, app.pix.fr et app.pix.org.

## :robot: Solution
Ajouter ce lien avec celui des cgu. 👇
<img width="465" alt="Capture d’écran 2021-06-09 à 17 52 40" src="https://user-images.githubusercontent.com/58915422/121388131-82419b80-c94b-11eb-873c-9a36ad9f4722.png">

## :100: Pour tester
Aller sur la page d'inscription Pix App : 

1. En domaine **fr** 
S'assurer que le lien Politique de confidentialité pointe vers : `https://pix.fr/politique-protection-donnees-personnelles-app`

2. En domaine **org** en français
S'assurer que le lien pointe vers : `https://pix.org/fr/politique-protection-donnees-personnelles-app/ `

2. En domaine **org** en anglais
S'assurer que le lien pointe vers : `https://pix.org/en-gb/personal-data-protection-policy/ `
