### PR TITLE
[TECH] Forcer les tests unitaire HTTP à signaler leur échec.

### DIFF
--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -33,7 +33,7 @@ describe('Integration | API | Controller Error', () => {
         }]);
       },
     };
-    server = new HttpTestServer();
+    server = new HttpTestServer({ mustThrowOn5XXError: false });
     await server.register(moduleUnderTest);
   });
 
@@ -667,7 +667,9 @@ describe('Integration | API | Controller Error', () => {
     const INTERNAL_SERVER_ERROR = 500;
 
     it('responds Internal Server Error error when another error occurs', async () => {
+      // given
       routeHandler.throws(new Error('Unexpected Error'));
+
       // when
       const response = await server.requestObject(request);
 
@@ -682,6 +684,7 @@ describe('Integration | API | Controller Error', () => {
     const SERVICE_UNAVAILABLE_ERROR = 503;
     it('responds ServiceUnavailable when a SendingEmailToResultRecipientError error occurs', async () => {
       routeHandler.throws(new DomainErrors.SendingEmailToResultRecipientError(['toto@pix.fr', 'titi@pix.fr']));
+
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -79,6 +79,7 @@ describe('Unit | Application | Router | assessment-router', () => {
     it('should call pre-handler', async () => {
       // given
       sinon.stub(assessmentAuthorization, 'verify').callsFake((request, h) => h.response(null));
+      sinon.stub(assessmentController, 'get').callsFake((request, h) => h.response('ok').code(200));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -146,6 +146,7 @@ describe('Unit | Application | Certifications Course | Route', function() {
     it('should check pixMaster role', async () => {
       // given
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(certificationCoursesController, 'cancel').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/unit/application/certification-point-of-contacts/index_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/index_test.js
@@ -29,6 +29,7 @@ describe('Unit | Router | certification-point-of-contact-router', function() {
     it('should call pre-handler', async () => {
       // given
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').returns('ok');
+      sinon.stub(certificationPointOfContactController, 'get').callsFake((request, h) => h.response().code(200));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -36,7 +37,7 @@ describe('Unit | Router | certification-point-of-contact-router', function() {
       await httpTestServer.request('GET', '/api/certification-point-of-contacts/123');
 
       // then
-      sinon.assert.called(securityPreHandlers.checkRequestedUserIsAuthenticatedUser);
+      expect(securityPreHandlers.checkRequestedUserIsAuthenticatedUser).to.have.been.called;
     });
   });
 });

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -180,6 +180,7 @@ describe('Unit | Router | organization-router', () => {
     it('should check if user is admin in organization', async () => {
       // given
       sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').resolves(false);
+      sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -298,6 +299,7 @@ describe('Unit | Router | organization-router', () => {
     it('should check if user is Pix Master', async () => {
       // given
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').resolves(false);
+      sinon.stub(organizationController, 'sendInvitationsByLang').callsFake((request, h) => h.response().created());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 


### PR DESCRIPTION
## :unicorn: Problème

Quand on lance les tests unitaires, on a ce log qui signale un échec, mais qui ne fait pas échouer le test en question :
```
Debug: internal, implementation, error
    TypeError: Cannot read property 'userId' of null
    at get (lib/application/certification-point-of-contacts/certification-point-of-contact-controller.js:7:58)
    at exports.Manager.execute (node_modules/@hapi/hapi/lib/toolkit.js:57:29)
    at Object.internals.handler (node_modules/@hapi/hapi/lib/handler.js:46:48)
    at exports.execute (node_modules/@hapi/hapi/lib/handler.js:31:36)
    at async Request._lifecycle (node_modules/@hapi/hapi/lib/request.js:372:32)
    at async Request._execute (node_modules/@hapi/hapi/lib/request.js:280:9)
```

## :robot: Solution

Il manquait un stub dans le test en question, ajouter ce stub corrige le problème.

Mais plus généralement, les appels à `hapiServer.inject` pouvaient causer des erreurs attrapées par Hapi et transformées en résultats de type `{statusCode: 500, ...}`.

Donc solution supplémentaire : faire que `HttpTestServer` lance une exception quand `hapiServer.inject` renvoie une erreur 500.
Donc solution supplémentaire : faire que `HttpTestServer` lance une exception quand `hapiServer.inject` renvoie une erreur 5xx. Désactiver ce comportement lorsque l'envoi d'une erreur HTTP est le comportement attendu.
Et également corriger quatre stubs manquants similaires dans d'autres tests. 

## :100: Pour tester

Lancer les tests unitaires et les tests d'intégration, constater qu'il n'y a ni erreur ni log chelou.