### PR TITLE
[FEATURE] Détecter lorsque l'utilisateur perd le focus de l'onglet actif (PIX-2616).

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -41,6 +41,7 @@ class Challenge {
    * @param format
    * @param locales
    * @param autoReply
+   * @param focused
    */
   constructor(
     {
@@ -64,6 +65,7 @@ class Challenge {
       skills = [],
       validator,
       competenceId,
+      focused,
     } = {}) {
     this.id = id;
     this.answer = answer;
@@ -85,6 +87,7 @@ class Challenge {
     this.skills = skills;
     this.validator = validator;
     this.competenceId = competenceId;
+    this.focused = focused;
   }
 
   addSkill(skill) {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -103,5 +103,6 @@ function _toDomain({ challengeDataObject, skillDataObjects }) {
     format: challengeDataObject.format,
     locales: challengeDataObject.locales,
     autoReply: challengeDataObject.autoReply,
+    focused: challengeDataObject.focusable,
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -21,6 +21,7 @@ module.exports = {
         'format',
         'autoReply',
         'alternativeInstruction',
+        'focused',
       ],
       transform: (record) => {
         const challenge = _.pickBy(record, (value) => !_.isUndefined(value));

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -38,6 +38,7 @@ describe('Unit | Domain | Models | Challenge', () => {
         locales: ['fr'],
         autoReply: true,
         alternativeInstruction: 'Pour aider les personnes ne pouvant voir ou afficher les instructions',
+        focused: false,
       };
 
       // when

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -11,6 +11,19 @@ export default class ChallengeItemGeneric extends Component {
   @tracked hasChallengeTimedOut = false;
   @tracked errorMessage = null;
 
+  constructor() {
+    super(...arguments);
+    if (this.args.challenge.focused) {
+      setInterval(this.verifyUserIsStillFocusingOnPage, 1000);
+    }
+  }
+
+  verifyUserIsStillFocusingOnPage() {
+    if (document.hasFocus() === false) {
+      console.log('user lost focus');
+    }
+  }
+
   get isTimedChallenge() {
     return isInteger(this.args.challenge.timer);
   }

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -22,6 +22,7 @@ export default class Challenge extends Model {
   @attr('number') timer;
   @attr('string') type;
   @attr('boolean') autoReply;
+  @attr('boolean') focused;
 
   // includes
   @belongsTo('answer') answer;


### PR DESCRIPTION
## :unicorn: Problème
Les épreuves focus sont des types d'épreuves où l'utilisateur ne devrait pas quitter la plateforme Pix pour aller chercher de l'information sur internet.
Pour ce type d'épreuve, nous avons besoin de détecter si l'utilisateur n'a plus le focus sur le site de Pix.

## :robot: Solution
Nous utilisons un `setInterval` pour vérifier constamment à l'aide de la méthode `document.hasFocus()` si l'utilisateur a toujours le focus sur Pix.

## :rainbow: Remarques
Nous avons testé avec [Page Visibility API](https://developer.mozilla.org/fr/docs/Web/API/Page_Visibility_API), mais la perte de focus n'était pas dectecté lorsue l'on mettait une autre application en premier plan.

## :100: Pour tester
Aller sur la RA et ouvrir la console.
Vérifier que l'on log bien dans la console si l'utilisateur perd le focus.