### PR TITLE
[FEATURE] Documenter le endpoint de récupération des résultats Pôle emploi (PIX-2681).

### DIFF
--- a/api/lib/application/pole-emplois/index.js
+++ b/api/lib/application/pole-emplois/index.js
@@ -1,4 +1,8 @@
+const Joi = require('joi');
 const poleEmploiController = require('./pole-emploi-controller');
+
+const poleEmploiErreurDoc = require('../../infrastructure/open-api-doc/pole-emploi/erreur-doc');
+const poleEmploiEnvoisDoc = require('../../infrastructure/open-api-doc/pole-emploi/envois-doc');
 
 exports.register = async function(server) {
   server.route([
@@ -9,6 +13,43 @@ exports.register = async function(server) {
         auth: false,
         handler: poleEmploiController.createUser,
         tags: ['api'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/pole-emploi/envois',
+      config: {
+        auth: 'jwt-pole-emploi',
+        handler: console.log,
+        notes: [
+          '- **API Pôle emploi qui nécessite une authentification de type client credential grant**\n' +
+          '- Récupération des N derniers envois. Le résultat peut être paginé si plus de N entrées via le paramètre Link dans le header de la réponse\n',
+        ],
+        response: {
+          status: {
+            200: poleEmploiEnvoisDoc,
+            204: poleEmploiEnvoisDoc,
+            400: poleEmploiErreurDoc,
+            401: poleEmploiErreurDoc,
+            403: poleEmploiErreurDoc,
+          },
+        },
+        plugins: {
+          'hapi-swagger': {
+            produces: ['application/json'],
+          },
+        },
+        validate: {
+          headers: Joi.object({
+            'authorization': Joi.string().description('Bearer Access token to access to API '),
+            'link': Joi.string().optional().example('https://gateway.pix.fr/pole-emploi/envois?curseur=1234').description('Lien de récupération de la page suivante des résultats'),
+          }).unknown(),
+          query: Joi.object({
+            curseur: Joi.string().optional().description('Identifiant du curseur permettant de récupérer les résultats suivants.'),
+            enErreur: Joi.boolean().optional().description('Permet de récupérer uniquement les résultats des participants dont l\'envoi a échoué la première fois.'),
+          }).options({ allowUnknown: true }),
+        },
+        tags: ['api', 'pole-emploi'],
       },
     },
   ]);

--- a/api/lib/infrastructure/open-api-doc/pole-emploi/envois-doc.js
+++ b/api/lib/infrastructure/open-api-doc/pole-emploi/envois-doc.js
@@ -1,0 +1,62 @@
+const Joi = require('joi');
+
+const CAMPAIGN_TYPES = ['EVALUATION', 'COLLECTE_PROFILS'];
+const TEST_STATUS = [2, 3, 4];
+const TEST_TYPES = ['DI', 'PC', 'CP'];
+const UNITS = ['A', 'B'];
+
+const campagne = Joi.object({
+  nom: Joi.string().required().example('Campagne Pôle emploi').description('Nom de la campagne'),
+  dateDebut: Joi.date().required().example('2020-11-31T12:00:38.133Z').description('Date et heure de création de la campagne'),
+  dateFin: Joi.date().allow(null).example('2020-11-31T12:00:38.133Z').description('Date et heure de l\'archivage de la campagne'),
+  type: Joi.string().required().valid(...CAMPAIGN_TYPES).example('EVALUATION').description('Type de la campagne. EVALUATION ou COLLECTE_PROFILS'),
+  codeCampagne: Joi.string().max(255).required().example('POLEEMPLOI').description('Code de la campagne'),
+  urlCampagne: Joi.string().max(255).required().example('https://app.pix.fr/campagnes/POLEEMPLOI').description('URL campagne généré à partir de l\'URL de pix et le code campagne'),
+  nomOrganisme: Joi.string().required().valid('Pix').example('Pix').description('Nom de l\'organisme (Pix'),
+  typeOrganisme: Joi.string().required().valid('externe').example('externe').description('Type de l\'organisme'),
+}).required();
+
+const individu = Joi.object({
+  nom: Joi.string().required().max(255).example('Martin').description('Nom du participant'),
+  prenom: Joi.string().required().max(255).example('Paul').description('Prénom du participant'),
+  idPoleEmploi: Joi.string().required().max(255).example('XXX').description('Identifiant Pôle emploi du demandeur d\'emploi'),
+}).required();
+
+const evaluation = Joi.object({
+  scoreObtenu: Joi.number().example(3.14).description('Score sur l’ensemble des acquis évalués dans le test par compétence. Vide si pas encore partagé'),
+  uniteScore: Joi.string().valid(...UNITS).example('A').description('Unité de score. A: Pourcentage, B: Point'),
+  certifiable: Joi.boolean().example(true).description('Uniquement pour les campagnes de collecte de profils. Vide si pas encore partagé'),
+  niveau: Joi.number().min(1).max(8).example(1).description('Pour une campagne de collecte de profils, niveau de la compétence (entre 1 et 8). Vide si pas encore partagé'),
+  nbSousElementValide: Joi.number().example(10).description('Pour une campagne d\'évaluation, nombre d’acquis validés par compétence. Vide si pas encore partagé'),
+});
+
+const elementEvalue = Joi.object({
+  libelle: Joi.string().max(255).required().example('Mener une recherche et une veille d’information').description('Libellé de l\'élément évalué'),
+  categorie: Joi.string().required().max(50).valid('competence').example('competence').description('Catégorie de l\'élément évalué'),
+  type: Joi.string().required().max(50).valid('competence Pix').example('competence Pix').description('Type de l\'élément évalué'),
+  domaineRattachement: Joi.string().required().max(255).example('1. Information et données').description('Domaine de rattachement de l\'élément évalué'),
+  nbSousElements: Joi.number().example(2).description('Pour campagne d\'évaluation uniquement, nombre d’acquis total pour l\'élément évalué'),
+  evaluation,
+});
+
+const test = Joi.object({
+  etat: Joi.number().required().valid(...TEST_STATUS).example(2).description('État du test. 2: En cours, 3: En attente d\'envoi, 4: Validé'),
+  typeTest: Joi.string().required().valid(...TEST_TYPES).example('DI').description('Code du profil cible Pix. DI: Diagnostic initial, PC: Parcours complet, CP: Profil PIX complet'),
+  progression: Joi.number().min(0).max(100).example(3.14).description('Uniquement pour les campagnes d\'évaluation. Pourcentage de progression (obligatoire si état 2, si état > 2 alors 100%)'),
+  certifiable: Joi.boolean().example(true).description('Uniquement pour les campagnes de collecte de profils. Vide si pas encore partagé'),
+  referenceExterne: Joi.number().required().example(12345).description('Identifiant de la participation PIX d\'une personne au test'),
+  dateDebut: Joi.date().required().example('2020-11-31T12:00:38.133Z').description('Date de début du test'),
+  dateProgression: Joi.date().allow(null).example('2020-11-31T12:00:38.133Z').description('Date de la dernière réponse du test. Vide si pas encore commencé'),
+  dateValidation: Joi.date().allow(null).example('2020-11-31T12:00:38.133Z').description('Date du partage du test. Vide si pas encore partagé'),
+  evaluation: Joi.number().allow(null).example(3.14).description('Pour une campagne d\'évaluation, pourcentage de maîtrise de l\'ensemble des acquis du profil. Pour une campagne de collecte de profils, score du participant. Vide si pas encore partagé'),
+  uniteEvaluation: Joi.string().valid(...UNITS).example('A').description('Unité d\'évaluation. A: Pourcentage, B: Point'),
+  elementsEvalues: Joi.array().items(elementEvalue).description('Vide si pas de partage de résultats'),
+}).required();
+
+module.exports = Joi.array().items(
+  Joi.object({
+    idEnvoi: Joi.string().required().example('XXX').description('Identifiant unique de l\'envoi'),
+    dateEnvoi: Joi.date().required().example('2020-11-31T12:00:38.133Z').description('Instant de la demande d\'envoi'),
+    resultat: Joi.object({ campagne, individu, test }).required(),
+  }).label('Envoi'),
+).label('Envois');

--- a/api/lib/infrastructure/open-api-doc/pole-emploi/erreur-doc.js
+++ b/api/lib/infrastructure/open-api-doc/pole-emploi/erreur-doc.js
@@ -1,0 +1,8 @@
+const Joi = require('joi');
+
+module.exports = Joi.object({
+  code: Joi.string().required().description('Code erreur spécifique à l\'application.'),
+  titre: Joi.string().required().description('Un résumé court et lisible de l\'erreur'),
+  statut: Joi.string().required().description('le code d\'état HTTP lié à l\'erreur'),
+  detail: Joi.string().required().description('Une explication détaillé et lisible de l\'erreur'),
+}).label('Erreur');

--- a/api/lib/swaggers.js
+++ b/api/lib/swaggers.js
@@ -19,6 +19,15 @@ const swaggerOptionsLivretScolaire = {
   jsonPath: '/swagger.json',
 };
 
+const swaggerOptionsPoleEmploi = {
+  routeTag: 'pole-emploi',
+  info: {
+    'title': 'Pix Pôle emploi open api',
+    'version': applicationPackage.version,
+  },
+  jsonPath: '/swagger.json',
+};
+
 const swaggerOptionsIn = {
   basePath: '/api',
   grouping: 'tags',
@@ -41,6 +50,6 @@ function _buildSwaggerArgs(swaggerOptions)
   }];
 }
 
-const swaggers = [ swaggerOptionsAuthorizationServer, swaggerOptionsLivretScolaire, swaggerOptionsIn ].map(_buildSwaggerArgs);
+const swaggers = [ swaggerOptionsAuthorizationServer, swaggerOptionsLivretScolaire, swaggerOptionsPoleEmploi, swaggerOptionsIn ].map(_buildSwaggerArgs);
 
 module.exports = swaggers;

--- a/api/tests/acceptance/application/swagger_test.js
+++ b/api/tests/acceptance/application/swagger_test.js
@@ -46,4 +46,22 @@ describe('Acceptance | lib | swagger', () => {
       });
     });
   });
+
+  describe('GET /pole-emploi/swagger.json', () => {
+    describe('Resource access management', () => {
+      it('should respond with a 200', async () => {
+        // given
+        const options = {
+          method: 'GET',
+          url: '/pole-emploi/swagger.json',
+          headers: {},
+        };
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/open-api-doc/pole-emploi/envois-doc_test.js
+++ b/api/tests/unit/infrastructure/open-api-doc/pole-emploi/envois-doc_test.js
@@ -1,0 +1,68 @@
+const EnvoiDoc = require('../../../../../lib/infrastructure/open-api-doc/pole-emploi/envois-doc');
+const { expect } = require('../../../../test-helper');
+
+describe('Unit | Infrastructure | Open API Doc | Pole Emploi | Envois Documentation', () => {
+  it('should validate payload for a campaign participation', () => {
+    // given
+    const resultat = {
+      campagne: {
+        nom: 'Campagne Pôle Emploi',
+        dateDebut: '2020-01-01T00:00:00.000Z',
+        dateFin: '2020-02-01T00:00:00.000Z',
+        type: 'EVALUATION',
+        codeCampagne: 'CODEPE123',
+        urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
+        nomOrganisme: 'Pix',
+        typeOrganisme: 'externe',
+      },
+      individu: {
+        nom: 'Bonneau',
+        prenom: 'Jean',
+        idPoleEmploi: 'A11',
+      },
+      test: {
+        etat: 4,
+        progression: 100,
+        typeTest: 'DI',
+        referenceExterne: 55667788,
+        dateDebut: '2020-01-02T00:00:00.000Z',
+        dateProgression: '2020-01-03T00:00:00.000Z',
+        dateValidation: '2020-01-03T00:00:00.000Z',
+        evaluation: 70,
+        uniteEvaluation: 'A',
+        elementsEvalues: [
+          {
+            libelle: 'Gérer des données',
+            categorie: 'competence',
+            type: 'competence Pix',
+            domaineRattachement: 'Information et données',
+            nbSousElements: 4,
+            evaluation: {
+              scoreObtenu: 50,
+              uniteScore: 'A',
+              nbSousElementValide: 2,
+            },
+          },
+          {
+            libelle: 'Gérer des données 2',
+            categorie: 'competence',
+            type: 'competence Pix',
+            domaineRattachement: 'Information et données',
+            nbSousElements: 3,
+            evaluation: {
+              scoreObtenu: 100,
+              uniteScore: 'A',
+              nbSousElementValide: 3,
+            },
+          },
+        ],
+      },
+    };
+
+    // when
+    const result = EnvoiDoc.validate([{ idEnvoi: '1', dateEnvoi: '2020-11-31T12:00:38.133Z', resultat }]);
+
+    // then
+    expect(result.error).to.be.undefined;
+  });
+});

--- a/api/tests/unit/infrastructure/open-api-doc/pole-emploi/erreur-doc_test.js
+++ b/api/tests/unit/infrastructure/open-api-doc/pole-emploi/erreur-doc_test.js
@@ -1,0 +1,20 @@
+const ErreurDoc = require('../../../../../lib/infrastructure/open-api-doc/pole-emploi/erreur-doc');
+const { expect } = require('../../../../test-helper');
+
+describe('Unit | Infrastructure | Open API Doc | Pole Emploi | Erreur Documentation', () => {
+  it('should validate payload for a campaign participation', () => {
+    // given
+    const payload = {
+      code: 'A1',
+      titre: 'Titre de l\'erreur',
+      statut: '400',
+      detail: 'Description de l\'erreur',
+    };
+
+    // when
+    const result = ErreurDoc.validate(payload);
+
+    // then
+    expect(result.error).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

PE n'a pas de moyen pour récupérer les appels APIs de partage de résultats ou d'avancement qui auraient échoués. (résilience)

## :robot: Solution

Créer une API dédiée à Pole Emploi (via Gravitee) permettant de récupérer les résultats et les avancements en échec.
Cette PR a pour but de générer la documentation du contrat d'interface du endpoint.
Le endpoint est ajouté et configuré dans Gravitee. Il retourne un mock de la réponse (sans authentification pour le moment)

## :rainbow: Remarques

**En recette,** il faudra changer l'URL du proxy dans [la configuration de Gravitee](https://admin.developers.sandbox.pix.fr/#!/apis/41a4a203-fb5d-46d9-a4a2-03fb5d26d929/endpoints)

**En production,** il faudra exporter la configuration de recette pour ensuite l'importer dans le Gravitee de production.

## :100: Pour tester

Vérifier description Swagger sur la RA : 
https://api-pr3089.review.pix.fr/pole-emploi/swagger.json

Voir la documentation de l'API dans Gravitee : 
https://developers.sandbox.pix.fr/catalog/api/41a4a203-fb5d-46d9-a4a2-03fb5d26d929/doc

Appeler l'API pour vérifier le Mock : 
https://gateway.sandbox.pix.fr/pole-emploi/envois