### PR TITLE
[BUGFIX] Corriger le dysfonctionnement de la page login de Pix Admin (PIX-2133).

### DIFF
--- a/admin/app/routes/index.js
+++ b/admin/app/routes/index.js
@@ -1,3 +1,8 @@
 import Route from '@ember/routing/route';
 
-export default class IndexRoute extends Route {}
+export default class IndexRoute extends Route {
+
+  redirect() {
+    this.replaceWith('authenticated');
+  }
+}

--- a/admin/app/routes/login.js
+++ b/admin/app/routes/login.js
@@ -1,0 +1,5 @@
+import Route from '@ember/routing/route';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+
+export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) {
+}

--- a/admin/tests/unit/routes/login_test.js
+++ b/admin/tests/unit/routes/login_test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | login', function(hooks) {
+
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const route = this.owner.lookup('route:login');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, lorsqu'un utilisateur est connecté, et que l'URL est modifiée manuellement en `.../login` , l'utilisateur reste constamment sur la même page (de connexion).
L'utilisateur devrait se retrouver sur la page des organisations.

## :robot: Solution
Ajouter la route `login.js` avec la mixin `UnauthenticatedRouteMixin`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Se connecter à Pix Admin (ex. avec pixmaster)
* Modifier l'URL en `.../login`
* Vérifier que la page des organisations est bien affichée
