### PR TITLE
[FEATURE] Prise en compte auto des signalements sur les fichiers qui ne s'ouvrent pas (PIX-2590)

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -12,6 +12,7 @@ async function handleAutoJury({
   certificationIssueReportRepository,
   certificationAssessmentRepository,
   certificationCourseRepository,
+  challengeRepository,
   logger,
 }) {
   checkEventTypes(event, eventTypes);
@@ -22,6 +23,7 @@ async function handleAutoJury({
       certificationCourse,
       certificationIssueReportRepository,
       certificationAssessmentRepository,
+      challengeRepository,
       logger,
     })));
 
@@ -43,6 +45,7 @@ async function _autoNeutralizeChallenges({
   certificationCourse,
   certificationIssueReportRepository,
   certificationAssessmentRepository,
+  challengeRepository,
   logger,
 }) {
   const certificationIssueReports = await certificationIssueReportRepository.findByCertificationCourseId(certificationCourse.id);
@@ -53,7 +56,7 @@ async function _autoNeutralizeChallenges({
 
   const resolutionAttempts = await bluebird.mapSeries(certificationIssueReports, async (certificationIssueReport) => {
     try {
-      return await certificationIssueReport.resolutionStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+      return await certificationIssueReport.resolutionStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
     } catch (e) {
       logger.error(e);
       return CertificationIssueReportResolutionAttempt.unresolved();

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -28,6 +28,7 @@ const dependencies = {
   poleEmploiNotifier: require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier'),
   juryCertificationSummaryRepository: require('../../infrastructure/repositories/jury-certification-summary-repository'),
   finalizedSessionRepository: require('../../infrastructure/repositories/finalized-session-repository'),
+  challengeRepository: require('../../infrastructure/repositories/challenge-repository'),
   logger: require('../../infrastructure/logger'),
 };
 

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -218,7 +218,7 @@ function _getResolutionStrategy(subcategory) {
   if (
     subcategory === CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING
   ) {
-    return CertificationIssueReportStrategies.NEUTRALIZE_IF_IMAGE;
+    return CertificationIssueReportStrategies.NEUTRALIZE_IF_ILLUSTRATION;
   }
 
   if (

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -227,5 +227,11 @@ function _getResolutionStrategy(subcategory) {
     return CertificationIssueReportStrategies.NEUTRALIZE_IF_EMBED;
   }
 
+  if (
+    subcategory === CertificationIssueReportSubcategories.FILE_NOT_OPENING
+  ) {
+    return CertificationIssueReportStrategies.NEUTRALIZE_IF_ATTACHMENT;
+  }
+
   return CertificationIssueReportStrategies.NONE;
 }

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -218,7 +218,7 @@ function _getResolutionStrategy(subcategory) {
   if (
     subcategory === CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING
   ) {
-    return CertificationIssueReportStrategies.NEUTRALIZE_IF_ILLUSTRATION;
+    return CertificationIssueReportStrategies.NEUTRALIZE_IF_IMAGE;
   }
 
   if (

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -75,7 +75,7 @@ async function _resolveWithNoImageInChallenge(certificationIssueReportRepository
 }
 
 async function _resolveWithNoEmbedInChallenge(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve('Cette question n\' a pas été neutralisée car elle ne contient pas d\'embed');
+  certificationIssueReport.resolve('Cette question n\' a pas été neutralisée car elle ne contient pas d\'application/simulateur');
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -18,7 +18,7 @@ module.exports = {
     return _neutralizeAndResolve(certificationAssessment, certificationIssueReportRepository, certificationIssueReport);
   },
 
-  NEUTRALIZE_IF_ILLUSTRATION: async ({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository }) => {
+  NEUTRALIZE_IF_IMAGE: async ({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository }) => {
     const questionNumber = certificationIssueReport.questionNumber;
     const recId = certificationAssessment.getChallengeRecIdByQuestionNumber(questionNumber);
 

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -115,6 +115,10 @@ class Challenge {
     return Boolean(this.embedUrl);
   }
 
+  hasAtLeastOneAttachment() {
+    return Array.isArray(this.attachments) && this.attachments.length > 0;
+  }
+
   static createValidatorForChallengeType({ challengeType, solution }) {
     switch (challengeType) {
       case ChallengeType.QCU:

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -25,6 +25,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
     const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+    const challengeRepository = { get: sinon.stub() };
     const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false });
     const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false });
     const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789', isNeutralized: false });
@@ -64,10 +65,11 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
       certificationIssueReportRepository,
       certificationAssessmentRepository,
       certificationCourseRepository,
+      challengeRepository,
     });
 
     // then
-    expect(certificationIssueReport.resolutionStrategy).to.have.been.calledWith({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+    expect(certificationIssueReport.resolutionStrategy).to.have.been.calledWith({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
     expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
   });
 

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -485,6 +485,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
+        expect(certificationIssueReport.resolution).to.equal('Cette question n\' a pas été neutralisée car elle ne contient pas d\'application/simulateur');
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -5,6 +5,7 @@ const {
   NEUTRALIZE_WITHOUT_CHECKING: neutralizeWithoutChecking,
   NEUTRALIZE_IF_ILLUSTRATION: neutralizeIfIllustration,
   NEUTRALIZE_IF_EMBED: neutralizeIfEmbed,
+  NEUTRALIZE_IF_ATTACHMENT: neutralizeIfAttachment,
   NONE: doNotResolve,
 } = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
@@ -346,6 +347,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       });
     });
   });
+
   context('#NEUTRALIZE_IF_EMBED', () => {
 
     context('When challenge is neutralizable', () => {
@@ -578,6 +580,247 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       });
     });
   });
+
+  context('#NEUTRALIZE_IF_ATTACHMENT', () => {
+
+    context('When challenge is neutralizable', () => {
+
+      it('neutralizes successfully', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithAttachment = domainBuilder.buildChallenge({
+          attachments: ['some/attachment/url'],
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithAttachment),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
+      });
+
+      it('resolves the issue report', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+
+        const challengeWithAttachment = domainBuilder.buildChallenge({
+          attachments: ['some/attachment/url'],
+        });
+
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithAttachment),
+        };
+
+        // when
+        await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('the challenge does not contain the question designated by the question number', () => {
+
+      it('returns a successful resolution attempt without effect', async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: () => {},
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
+          certificationAnswersByDate: [],
+        });
+
+        // when
+        const neutralizationAttempt = await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+      });
+
+      it('resolves the certification issue report anyway', async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
+          certificationAnswersByDate: [],
+        });
+
+        // when
+        await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('the challenge does not contain an attachment', () => {
+
+      it('returns a successful resolution without effect', async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithoutAttachment = domainBuilder.buildChallenge({ attachments: [] });
+        const certificationIssueReportRepository = {
+          save: () => {},
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithoutAttachment),
+        };
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
+        });
+
+        // when
+        const neutralizationAttempt = await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+      });
+
+      it('resolves the certtification issue report anyway', async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithoutAttachment = domainBuilder.buildChallenge({ attachments: [] });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithoutAttachment),
+        };
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
+        });
+
+        // when
+        await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('When challenge is not neutralizable', () => {
+
+      it('returns a successful resolution without effect', async () => {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithAttachment = domainBuilder.buildChallenge({
+          attachments: ['some/attachment/url'],
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithAttachment),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+      });
+
+      it('resolves the certification issue report anyway', async () => {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const challengeWithAttachment = domainBuilder.buildChallenge({
+          attachments: ['some/attachment/url'],
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(challengeWithAttachment),
+        };
+
+        // when
+        await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+  });
+
   context('#NONE', () => {
     it('returns an unresolved resolution attempt', async () => {
       // given

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -3,7 +3,7 @@ const { CertificationIssueReportCategories, CertificationIssueReportSubcategorie
 const CertificationIssueReportResolutionAttempt = require('../../../../lib/domain/models/CertificationIssueReportResolutionAttempt');
 const {
   NEUTRALIZE_WITHOUT_CHECKING: neutralizeWithoutChecking,
-  NEUTRALIZE_IF_ILLUSTRATION: neutralizeIfIllustration,
+  NEUTRALIZE_IF_IMAGE: neutralizeIfImage,
   NEUTRALIZE_IF_EMBED: neutralizeIfEmbed,
   NEUTRALIZE_IF_ATTACHMENT: neutralizeIfAttachment,
   NONE: doNotResolve,
@@ -118,7 +118,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
   });
 
-  context('#NEUTRALIZE_IF_ILLUSTRATION', () => {
+  context('#NEUTRALIZE_IF_IMAGE', () => {
 
     context('When challenge is neutralizable', () => {
 
@@ -135,16 +135,16 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithIllustration = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithIllustration),
+          get: sinon.stub().resolves(challengeWithImage),
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
@@ -163,17 +163,17 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithIllustration = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
 
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithIllustration),
+          get: sinon.stub().resolves(challengeWithImage),
         };
 
         // when
-        await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -199,7 +199,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -221,7 +221,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -252,7 +252,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -279,7 +279,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -302,16 +302,16 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithIllustration = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithIllustration),
+          get: sinon.stub().resolves(challengeWithImage),
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -330,16 +330,16 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithIllustration = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithIllustration),
+          get: sinon.stub().resolves(challengeWithImage),
         };
 
         // when
-        await neutralizeIfIllustration({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -594,7 +594,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -624,7 +624,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -677,7 +677,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async () => {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -703,7 +703,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution without effect', async () => {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -730,7 +730,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async () => {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -767,7 +767,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -797,7 +797,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -491,7 +491,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
-      it('resolves the certtification issue report anyway', async () => {
+      it('resolves the certification issue report anyway', async () => {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
           subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
@@ -727,7 +727,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
-      it('resolves the certtification issue report anyway', async () => {
+      it('resolves the certification issue report anyway', async () => {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
           subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -405,11 +405,11 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         });
       });
 
-      it('for IN_CHALLENGE IMAGE_NOT_DISPLAYING should match with NEUTRALIZE_IF_IMAGE', () => {
+      it('for IN_CHALLENGE IMAGE_NOT_DISPLAYING should match with NEUTRALIZE_IF_ILLUSTRATION', () => {
         expect(new CertificationIssueReport({
           category: 'IN_CHALLENGE',
           subcategory: 'IMAGE_NOT_DISPLAYING',
-        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_IMAGE);
+        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_ILLUSTRATION);
       });
 
       it('for IN_CHALLENGE EMBED_NOT_WORKING should match with NEUTRALIZE_IF_EMBED', () => {

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -405,11 +405,11 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         });
       });
 
-      it('for IN_CHALLENGE IMAGE_NOT_DISPLAYING should match with NEUTRALIZE_IF_ILLUSTRATION', () => {
+      it('for IN_CHALLENGE IMAGE_NOT_DISPLAYING should match with NEUTRALIZE_IF_IMAGE', () => {
         expect(new CertificationIssueReport({
           category: 'IN_CHALLENGE',
           subcategory: 'IMAGE_NOT_DISPLAYING',
-        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_ILLUSTRATION);
+        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_IMAGE);
       });
 
       it('for IN_CHALLENGE EMBED_NOT_WORKING should match with NEUTRALIZE_IF_EMBED', () => {

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -418,6 +418,14 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
           subcategory: 'EMBED_NOT_WORKING',
         }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_EMBED);
       });
+
+      it('for IN_CHALLENGE FILE_NOT_OPENING should match with NEUTRALIZE_IF_ATTACHMENT', () => {
+        expect(new CertificationIssueReport({
+          category: 'IN_CHALLENGE',
+          subcategory: 'FILE_NOT_OPENING',
+        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_ATTACHMENT);
+      });
+
     });
   });
 

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -248,4 +248,34 @@ describe('Unit | Domain | Models | Challenge', () => {
       expect(challenge.hasEmbed()).to.be.false;
     });
   });
+
+  describe('#hasAtLeastOneAttachment', () => {
+    it('returns true when attachments is not empty', () => {
+      // given
+      const challenge = domainBuilder.buildChallenge({
+        attachments: ['some/attachment/url'],
+      });
+
+      // when then
+      expect(challenge.hasAtLeastOneAttachment()).to.be.true;
+    });
+
+    it('returns false when attachment is empty', () => {
+      // given
+      const challenge = domainBuilder.buildChallenge({
+        attachments: [],
+      });
+      // when then
+      expect(challenge.hasAtLeastOneAttachment()).to.be.false;
+    });
+
+    it('returns false when attachment is not an array (null, undefined, ...)', () => {
+      // given
+      const challenge = domainBuilder.buildChallenge({
+        attachments: 'not an array',
+      });
+      // when then
+      expect(challenge.hasAtLeastOneAttachment()).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Avec la massification des certifications, il devient de plus en plus compliqué pour le pôle certif de traiter manuellement tous les types de signalements, notamment ceux de la catégorie “Problème technique sur une question” qui représentent la plus grand majorité. 

L’idée est donc d’automatiser la prise en compte des signalements de ce type.

## :robot: Solution
A la finalisation d’une session, si il y a un signalement de type “Problème technique sur une question”, avec la sous-catégorie suivante : 

    E3 : Le fichier à télécharger ne s’ouvre pas

Vérifier si l'épreuve en question contient un lien de téléchargement

    SI l'épreuve contient effectivement un lien de téléchargement ET la question concernée est au statut “Echec” ou “Abandon” ou “Partially”, ALORS on neutralise

    SINON SI l'épreuve ne contient pas de lien de téléchargement, ALORS on ne modifie par le statut de la question

## :rainbow: Remarques
- Cette PR répare également des erreurs de rebase de la PR #3074 😿

## :100: Pour tester
**Dans Pix Certif**

    Créer une session de certification et ajouter un candidat

**Dans Pix App**

Avec l'utilisateur certif-success@example.net, rejoindre la session de certification, puis :

    - Répondre incorrectement à la question 1 (image)
    - Répondre incorrectement à la question 2 (simulateur)
    - Passer la question 4 (image)
    - Répondre incorrectement à la question 5 (fichier à télécharger)
    - Passer la question 7 (fichier à télécharger)
    - Passer la question 14 (simulateur)
    - Passer toutes les autres questions

**Dans Pix Certif**

Finaliser la session en ajoutant :

- un signalement auto-neutralisable (sous-catégories E1) à la question 1
- un signalement auto-neutralisable (sous-catégories E1) à la question 4
- un signalement auto-neutralisable (sous-catégories E2) à la question 2
- un signalement auto-neutralisable (sous-catégories E2) à la question 14
- un signalement auto-neutralisable (sous-catégories E3) à la question 5
- signalement auto-neutralisable (sous-catégories E3) à la question 7

Marquer l'écran de fin de test comme ayant été vu.

**Dans Pix Admin**

Constater que :

- la session est bien finalisée et publiable
- tous les signalements impactant sont résolus (✅)
- les questions 1,2,4,5,7 et 14 sont neutralisées.

