### PR TITLE
[FEATURE] Afficher les fichiers microsoft en premier dans les épreuves (PIX-2612).

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -91,7 +91,7 @@ class Challenge {
   }
 
   _orderAttachments(attachments) {
-    if (!attachments) {
+    if (!attachments || !Array.isArray(attachments)) {
       return [];
     }
     const openSourceFormats = ['odp', 'ods', 'odt'];

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -69,7 +69,7 @@ class Challenge {
     } = {}) {
     this.id = id;
     this.answer = answer;
-    this.attachments = attachments;
+    this.attachments = this._orderAttachments(attachments);
     this.embedHeight = embedHeight;
     this.embedTitle = embedTitle;
     this.embedUrl = embedUrl;
@@ -88,6 +88,20 @@ class Challenge {
     this.validator = validator;
     this.competenceId = competenceId;
     this.focused = focused;
+  }
+
+  _orderAttachments(attachments) {
+    if (!attachments) {
+      return [];
+    }
+    const openSourceFormats = ['odp', 'ods', 'odt'];
+    return attachments.sort((attachmentA, attachmentB) => {
+      const formatB = attachmentB.split('.').pop();
+      if (openSourceFormats.includes(formatB)) {
+        return -1;
+      }
+      return 1;
+    });
   }
 
   addSkill(skill) {

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -48,6 +48,24 @@ describe('Unit | Domain | Models | Challenge', () => {
       expect(challengeDataObject).to.be.an.instanceof(Challenge);
       expect(challengeDataObject).to.deep.equal(challengeRawData);
     });
+
+    it('should order the attachments with microsoft files first', () => {
+      // given
+      const challengeRawData = {
+        attachments: [
+          'https://dl.airtable.com/rsXNJrSPuepuJQDByFVA_navigationdiaporama5.odp',
+          'https://dl.airtable.com/nHWKNZZ7SQeOKsOvVykV_navigationdiaporama5.docx',
+        ],
+      };
+
+      // when
+      const challengeDataObject = new Challenge(challengeRawData);
+
+      // then
+      expect(challengeDataObject.attachments.length).to.equal(challengeRawData.attachments.length);
+      expect(challengeDataObject.attachments[0]).to.contains('docx');
+      expect(challengeDataObject.attachments[1]).to.contains('odp');
+    });
   });
 
   describe('#hasSkill', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -73,6 +73,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
             type: 'challenges',
             id: '1',
             attributes: {
+              attachments: [],
               competence: 'competence_id',
             },
           },
@@ -93,6 +94,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
             type: 'challenges',
             id: '1',
             attributes: {
+              attachments: [],
               competence: 'N/A',
             },
           },


### PR DESCRIPTION
## :unicorn: Problème
Dans les épreuves, l'ordre d'affichage des fichiers n'est pas toujours le même: parfois on affiche d'abord le fichier .odt puis .docx et parfois on affiche d'abord .docx puis .odt.
Il faudrait homogénéiser cela et affciher d'abord les fichiers de type Microsoft.

## :robot: Solution
Un tri est fait dans le constructeur du model Challenge côté api, au moment de remplir la propriété `attachments`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier l'épreuve recLjZbBA6EMjloAK sur intégration, voir que le fichier .ods s'affiche avant .xlsx.
Sur la RA, l'affichage est inversé: le fichier .xlsx s'affiche en premier.
