### PR TITLE
[BUGFIX] Permettre la mise à jour du logo d'une organisation (PIX-2711).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -60,7 +60,7 @@ module.exports = {
       type: attributes.type,
       email: attributes.email,
       credit: attributes.credit,
-      logoUrl: attributes.logoUrl,
+      logoUrl: attributes['logo-url'],
       externalId: attributes['external-id'],
       provinceCode: attributes['province-code'],
       isManagingStudents: attributes['is-managing-students'],

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -165,7 +165,7 @@ describe('Acceptance | Application | organization-controller', () => {
         email: 'sco.generic.newaccount@example.net',
         credit: 50,
         canCollectProfiles: false,
-        logoUrl : logo,
+        logoUrl: logo,
       };
       const organization = databaseBuilder.factory.buildOrganization({ ...organizationAttributes });
       const tag1 = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
@@ -209,8 +209,7 @@ describe('Acceptance | Application | organization-controller', () => {
       expect(response.result.data.attributes['can-collect-profiles']).to.equal(true);
       expect(response.result.data.attributes['email']).to.equal('sco.generic.newaccount@example.net');
       expect(response.result.data.attributes['credit']).to.equal(50);
-      // should update image, but does not (bug to fix)
-      expect(response.result.data.attributes['logo-url']).to.not.equal(newLogo);
+      expect(response.result.data.attributes['logo-url']).to.equal(newLogo);
       expect(response.result.data.relationships.tags.data[0]).to.deep.equal({ type: 'tags', id: tag1.id.toString() });
       expect(parseInt(response.result.data.id)).to.equal(organization.id);
     });

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const dragonLogo = require('../../../../db/seeds/src/dragonAndCoBase64');
 
 const {
   expect, knex, learningContentBuilder, databaseBuilder, mockLearningContent,
@@ -157,17 +158,20 @@ describe('Acceptance | Application | organization-controller', () => {
 
     it('should return the updated organization and status code 200', async () => {
       // given
+      const logo = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
       const organizationAttributes = {
         externalId: '0446758F',
         provinceCode: '044',
         email: 'sco.generic.newaccount@example.net',
         credit: 50,
         canCollectProfiles: false,
+        logoUrl : logo,
       };
       const organization = databaseBuilder.factory.buildOrganization({ ...organizationAttributes });
       const tag1 = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
       await databaseBuilder.commit();
 
+      const newLogo = dragonLogo;
       const newAttribute = 'true';
       const payload = {
         data: {
@@ -179,6 +183,7 @@ describe('Acceptance | Application | organization-controller', () => {
             'email': organizationAttributes.email,
             'credit': organizationAttributes.credit,
             'can-collect-profiles': newAttribute,
+            'logo-url': newLogo,
           },
           relationships: {
             tags: {
@@ -204,6 +209,8 @@ describe('Acceptance | Application | organization-controller', () => {
       expect(response.result.data.attributes['can-collect-profiles']).to.equal(true);
       expect(response.result.data.attributes['email']).to.equal('sco.generic.newaccount@example.net');
       expect(response.result.data.attributes['credit']).to.equal(50);
+      // should update image, but does not (bug to fix)
+      expect(response.result.data.attributes['logo-url']).to.not.equal(newLogo);
       expect(response.result.data.relationships.tags.data[0]).to.deep.equal({ type: 'tags', id: tag1.id.toString() });
       expect(parseInt(response.result.data.id)).to.equal(organization.id);
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -125,7 +125,7 @@ describe('Unit | Serializer | organization-serializer', () => {
             type: organizationAttributes.type,
             email: organizationAttributes.email,
             credit: organizationAttributes.credit,
-            logoUrl: organizationAttributes.logoUrl,
+            'logo-url': organizationAttributes.logoUrl,
             'external-id': organizationAttributes.externalId,
             'province-code': organizationAttributes.provinceCode,
             'is-managing-students': organizationAttributes.isManagingStudents,


### PR DESCRIPTION
## :unicorn: Problème
[La PR suivante](https://github.com/1024pix/pix/pull/3031) cause une régression sur la mise à jour du logo d'une organisation.

## :robot: Solution
Modifier le deserializer

## :rainbow: Remarques
Ajout d'un test au préalable

## :100: Pour tester
[Sur Pix admin](https://admin-pr3095.review.pix.fr/organizations/4), modifier le logo de l'organisation 
Vérifier que la valeur en BDD a bien changé
```sql
SELECT 
  o."logoUrl"
FROM
     organizations o
WHERE o.id = 4
```
