### PR TITLE
[BUGFIX] Le critère "SomePartnerCompetences" pouvait ne pas prendre toutes les compétences (PIX-2720).

### DIFF
--- a/api/lib/domain/services/badge-criteria-service.js
+++ b/api/lib/domain/services/badge-criteria-service.js
@@ -53,11 +53,11 @@ function verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults,
 }
 
 function _verifySomePartnerCompetenceResultsMasteryPercentageCriterion(partnerCompetenceResults, threshold, criterionPartnerCompetenceIds) {
-  const filteredPartnerCompetenceResults = _.filter(partnerCompetenceResults, (partnerCompetenceResult) => {
-    return criterionPartnerCompetenceIds.includes(partnerCompetenceResult.id) && partnerCompetenceResult.masteryPercentage >= threshold;
-  });
+  const filteredPartnerCompetenceResults = _.filter(partnerCompetenceResults,
+    (partnerCompetenceResult) => criterionPartnerCompetenceIds.includes(partnerCompetenceResult.id));
 
-  return !_.isEmpty(filteredPartnerCompetenceResults);
+  return _.every(filteredPartnerCompetenceResults,
+    (partnerCompetenceResult) => partnerCompetenceResult.masteryPercentage >= threshold);
 }
 
 function _removeUntargetedKnowledgeElements(knowledgeElements, targetProfileSkillsIds) {

--- a/api/tests/unit/domain/services/badge-criteria-service_test.js
+++ b/api/tests/unit/domain/services/badge-criteria-service_test.js
@@ -165,44 +165,88 @@ describe('Unit | Domain | Services | badge-criteria', () => {
     });
 
     context('when the SOME_PARTNER_COMPETENCES is the only badge criterion', function() {
-      const badgeCriteria = [
-        domainBuilder.buildBadgeCriterion({
-          id: 1,
-          scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
-          threshold: CRITERION_THRESHOLD.SOME_PARTNER_COMPETENCES,
-          partnerCompetenceIds: [COMPETENCE_RESULT_ID.SECOND],
-        }),
-      ];
-      const badge = domainBuilder.buildBadge({ badgeCriteria });
-
-      it('should return true when fulfilled', async () => {
-        // given
-        const masteryPercentage = 10;
-        const partnerCompetenceResults = [
-          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 10 },
-          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 60 },
+      context('when the list of partnerCompetencesIds contains one partnerCompetence', () => {
+        const badgeCriteria = [
+          domainBuilder.buildBadgeCriterion({
+            id: 1,
+            scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+            threshold: CRITERION_THRESHOLD.SOME_PARTNER_COMPETENCES,
+            partnerCompetenceIds: [COMPETENCE_RESULT_ID.SECOND],
+          }),
         ];
+        const badge = domainBuilder.buildBadge({ badgeCriteria });
 
-        // when
-        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
+        it('should return true when fulfilled', async () => {
+          // given
+          const masteryPercentage = 10;
+          const partnerCompetenceResults = [
+            { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 10 },
+            { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 61 },
+          ];
 
-        // then
-        expect(result).to.be.equal(true);
+          // when
+          const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
+
+          // then
+          expect(result).to.be.equal(true);
+        });
+
+        it('should return false when not fulfilled', async () => {
+
+          const masteryPercentage = 10;
+          const partnerCompetenceResults = [
+            { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 70 },
+            { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 50 },
+          ];
+
+          // when
+          const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
+
+          // then
+          expect(result).to.be.equal(false);
+        });
       });
 
-      it('should return false when not fulfilled', async () => {
-
-        const masteryPercentage = 10;
-        const partnerCompetenceResults = [
-          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 10 },
-          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 50 },
+      context('when the list of partnerCompetencesIds contains more than one', () => {
+        const badgeCriteria = [
+          domainBuilder.buildBadgeCriterion({
+            id: 1,
+            scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+            threshold: CRITERION_THRESHOLD.SOME_PARTNER_COMPETENCES,
+            partnerCompetenceIds: [COMPETENCE_RESULT_ID.FIRST, COMPETENCE_RESULT_ID.SECOND],
+          }),
         ];
+        const badge = domainBuilder.buildBadge({ badgeCriteria });
 
-        // when
-        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
+        it('should return true when fulfilled for all partnerCompetence', async () => {
+          // given
+          const masteryPercentage = 10;
+          const partnerCompetenceResults = [
+            { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 62 },
+            { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 60 },
+          ];
 
-        // then
-        expect(result).to.be.equal(false);
+          // when
+          const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
+
+          // then
+          expect(result).to.be.equal(true);
+        });
+
+        it('should return false when one is not fulfilled', async () => {
+
+          const masteryPercentage = 10;
+          const partnerCompetenceResults = [
+            { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 10 },
+            { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 65 },
+          ];
+
+          // when
+          const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
+
+          // then
+          expect(result).to.be.equal(false);
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Le critère SomePartnerCompetences des badges doit vérifier que le % de réussite est atteint pour une liste précise des partner competences, et pas pour toutes les partnerCompetences du badge.
Hors, il vérifiait uniquement qu'un des partnerCompetences étaient validés de la liste.

## :robot: Solution
- Modifier la comparaison qui valide le badge
- Ajout des tests

## :rainbow: Remarques
Actuellement, en production, nous avons des SomePartnerCompetences avec une seule compétence, et une seule avec 3 compétences.

## :100: Pour tester
