### PR TITLE
[FEATURE] Rattraper la prise en compte auto des signalements de certif sur les session finalisées (PIX-2591)

### DIFF
--- a/api/db/migrations/20210614142832_audit-table-for-autojury.js
+++ b/api/db/migrations/20210614142832_audit-table-for-autojury.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'autojury-script-audit';
+
+exports.up = (knex) => {
+
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments('sessionId').primary();
+    t.text('certificationCenterName');
+    t.dateTime('finalizedAt');
+    t.date('sessionDate');
+    t.time('sessionTime');
+    t.boolean('hasExaminerGlobalComment', 500);
+    t.string('error', 1000);
+    t.enu('status', ['TO DO', 'DOING', 'DONE', 'TO RETRY']);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -1,7 +1,6 @@
 const Joi = require('joi');
 const { InvalidCertificationIssueReportForSaving, DeprecatedCertificationIssueReportSubcategory } = require('../errors');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('./CertificationIssueReportCategory');
-const CertificationIssueReportStrategies = require('./CertificationIssueReportResolutionStrategies');
 
 const categoryOtherJoiSchema = Joi.object({
   certificationCourseId: Joi.number().required().empty(null),
@@ -128,7 +127,6 @@ class CertificationIssueReport {
     this.resolution = resolution;
     this.isImpactful = _isImpactful({ category, subcategory });
     this.isAutoNeutralizable = _isSubcategoryAutoNeutralizable(subcategory);
-    this.resolutionStrategy = _getResolutionStrategy(subcategory);
 
     if ([CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN, CertificationIssueReportCategories.OTHER].includes(this.category)) {
       this.subcategory = null;
@@ -204,34 +202,4 @@ function _isSubcategoryDeprecated(subcategory) {
 
 function _isSubcategoryAutoNeutralizable(subcategory) {
   return autoNeutralizableSubcategories.includes(subcategory);
-}
-
-function _getResolutionStrategy(subcategory) {
-  if (
-    subcategory === CertificationIssueReportSubcategories.WEBSITE_BLOCKED ||
-    subcategory === CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE ||
-    subcategory === CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING
-  ) {
-    return CertificationIssueReportStrategies.NEUTRALIZE_WITHOUT_CHECKING;
-  }
-
-  if (
-    subcategory === CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING
-  ) {
-    return CertificationIssueReportStrategies.NEUTRALIZE_IF_IMAGE;
-  }
-
-  if (
-    subcategory === CertificationIssueReportSubcategories.EMBED_NOT_WORKING
-  ) {
-    return CertificationIssueReportStrategies.NEUTRALIZE_IF_EMBED;
-  }
-
-  if (
-    subcategory === CertificationIssueReportSubcategories.FILE_NOT_OPENING
-  ) {
-    return CertificationIssueReportStrategies.NEUTRALIZE_IF_ATTACHMENT;
-  }
-
-  return CertificationIssueReportStrategies.NONE;
 }

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -97,14 +97,6 @@ const deprecatedSubcategories = [
   CertificationIssueReportSubcategories.OTHER,
 ];
 
-const autoNeutralizableSubcategories = [
-  CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
-  CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
-  CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-  CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
-  CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
-];
-
 class CertificationIssueReport {
   constructor(
     {
@@ -126,7 +118,6 @@ class CertificationIssueReport {
     this.resolvedAt = resolvedAt;
     this.resolution = resolution;
     this.isImpactful = _isImpactful({ category, subcategory });
-    this.isAutoNeutralizable = _isSubcategoryAutoNeutralizable(subcategory);
 
     if ([CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN, CertificationIssueReportCategories.OTHER].includes(this.category)) {
       this.subcategory = null;
@@ -198,8 +189,4 @@ function _isImpactful({ category, subcategory }) {
 
 function _isSubcategoryDeprecated(subcategory) {
   return deprecatedSubcategories.includes(subcategory);
-}
-
-function _isSubcategoryAutoNeutralizable(subcategory) {
-  return autoNeutralizableSubcategories.includes(subcategory);
 }

--- a/api/lib/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-issue-report-repository.js
@@ -6,7 +6,7 @@ const omit = require('lodash/omit');
 module.exports = {
   async save(certificationIssueReport) {
     const newCertificationIssueReport = await new CertificationIssueReportBookshelf(
-      omit(certificationIssueReport, ['isImpactful', 'isAutoNeutralizable']),
+      omit(certificationIssueReport, ['isImpactful']),
     ).save();
     return bookshelfToDomainConverter.buildDomainObject(CertificationIssueReportBookshelf, newCertificationIssueReport);
   },

--- a/api/lib/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-issue-report-repository.js
@@ -6,7 +6,7 @@ const omit = require('lodash/omit');
 module.exports = {
   async save(certificationIssueReport) {
     const newCertificationIssueReport = await new CertificationIssueReportBookshelf(
-      omit(certificationIssueReport, ['isImpactful', 'isAutoNeutralizable', 'resolutionStrategy']),
+      omit(certificationIssueReport, ['isImpactful', 'isAutoNeutralizable']),
     ).save();
     return bookshelfToDomainConverter.buildDomainObject(CertificationIssueReportBookshelf, newCertificationIssueReport);
   },

--- a/api/scripts/trigger-autojury-on-finalized-sessions.js
+++ b/api/scripts/trigger-autojury-on-finalized-sessions.js
@@ -1,0 +1,173 @@
+const { knex } = require('../db/knex-database-connection');
+const bluebird = require('bluebird');
+const handleAutoJury = require('../lib/domain/events/handle-auto-jury');
+const certificationIssueReportRepository = require('../lib/infrastructure/repositories/certification-issue-report-repository');
+const certificationAssessmentRepository = require('../lib/infrastructure/repositories/certification-assessment-repository');
+const certificationCourseRepository = require('../lib/infrastructure/repositories/certification-course-repository');
+const challengeRepository = require('../lib/infrastructure/repositories/challenge-repository');
+const logger = require('../lib/infrastructure/logger');
+const SessionFinalized = require('../lib/domain/events/SessionFinalized');
+const { eventDispatcher } = require('../lib/domain/events');
+const IS_FROM_SCRATCH = (process.env.IS_FROM_SCRATCH === 'true');
+const AUDIT_TABLE = 'autojury-script-audit';
+
+const _triggerAutoJury = async (event) => {
+  return await handleAutoJury({
+    event,
+    certificationIssueReportRepository,
+    certificationAssessmentRepository,
+    certificationCourseRepository,
+    challengeRepository,
+    logger,
+  });
+};
+
+async function _retrieveFinalizedUnpublishedUnassignedSessionsData() {
+  return await knex('sessions').select(
+    'sessions.id',
+    'sessions.certificationCenter',
+    'sessions.finalizedAt',
+    'sessions.date',
+    'sessions.time',
+    'sessions.examinerGlobalComment')
+    .join('finalized-sessions', 'finalized-sessions.sessionId', 'sessions.id')
+    .where('isPublishable', '=', 'false')
+    .whereNotNull('sessions.finalizedAt')
+    .whereNull('sessions.publishedAt')
+    .whereNull('sessions.assignedCertificationOfficerId');
+}
+
+async function _triggerAutoJuryFromEvents(events) {
+  console.error(`\nWork in progress (${events.length})...`);
+  return await bluebird.map(events, async (event) => {
+    try {
+      await _doing(event.sessionId);
+      const resultingEvents = await _triggerAutoJury(event);
+      for (const resultingEvent of resultingEvents) {
+        await eventDispatcher.dispatch(resultingEvent);
+      }
+      await _done(event.sessionId);
+      process.stderr.write('😻');
+    } catch (err) {
+      await _toRetry(event.sessionId, err);
+      process.stderr.write('👹');
+    }
+  }, { concurrency: ~~process.env.CONCURRENCY || 10 });
+}
+
+function _sessionDataToEvent(sessionData) {
+  return new SessionFinalized({
+    sessionId: sessionData.id,
+    finalizedAt: sessionData.finalizedAt,
+    hasExaminerGlobalComment: Boolean(sessionData.examinerGlobalComment),
+    sessionDate: sessionData.date,
+    sessionTime: sessionData.time,
+    certificationCenterName: sessionData.certificationCenter,
+  });
+}
+
+async function _writeEventsToAuditTable(events) {
+  const dtos = events.map((event) => {
+    return {
+      ...event,
+      status: 'TO DO',
+    };
+  });
+  return await knex.batchInsert(AUDIT_TABLE, dtos);
+}
+
+async function _retrieveEventsFromAuditTable() {
+  const dtos = await knex(AUDIT_TABLE)
+    .select(
+      'sessionId',
+      'certificationCenterName',
+      'finalizedAt',
+      'sessionDate',
+      'sessionTime',
+      'hasExaminerGlobalComment')
+    .where('status', '!=', 'DONE');
+  return dtos.map((dto) => new SessionFinalized(dto));
+}
+
+async function _printAudit() {
+  const dtos = await knex(AUDIT_TABLE)
+    .select('sessionId', 'status', 'error');
+
+  const todos = dtos.filter((dto) => dto.status === 'TO DO');
+  const doings = dtos.filter((dto) => dto.status === 'DOING');
+  const dones = dtos.filter((dto) => dto.status === 'DONE');
+  const toRetrys = dtos.filter((dto) => dto.status === 'TO RETRY');
+
+  console.error(`😴 TO DO (${todos.length})`);
+  todos.forEach((todo) => console.error(' ' + todo.sessionId));
+  console.error('\n\n');
+  console.error(`🤪 DOING (${doings.length})`);
+  doings.forEach((doing) => console.error(' ' + doing.sessionId));
+  console.error('\n\n');
+  console.error(`😻 DONE (${dones.length})`);
+  dones.forEach((done) => console.error(' ' + done.sessionId));
+  console.error('\n\n');
+  console.error(`👹 TO RETRY (${toRetrys.length})`);
+  toRetrys.forEach((toRetry) => {
+    console.error(' ' + toRetry.sessionId);
+    console.error(' ' + toRetry.error);
+  });
+}
+
+async function main() {
+  try {
+
+    let finalizedSessionEvents;
+
+    if (IS_FROM_SCRATCH) {
+      await _emptyAuditTable();
+      const sessionsData = await _retrieveFinalizedUnpublishedUnassignedSessionsData();
+      finalizedSessionEvents = sessionsData.map(_sessionDataToEvent);
+      await _writeEventsToAuditTable(finalizedSessionEvents);
+    } else {
+      finalizedSessionEvents = await _retrieveEventsFromAuditTable();
+    }
+
+    await _triggerAutoJuryFromEvents(finalizedSessionEvents);
+
+    console.log('\n\nDone.');
+    console.log('\n***** Results *****');
+    await _printAudit();
+
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+async function _emptyAuditTable() {
+  await knex(AUDIT_TABLE).delete();
+}
+
+async function _doing(sessionId) {
+  await knex(AUDIT_TABLE)
+    .update({ error: '', status: 'DOING' })
+    .where({ sessionId });
+}
+
+async function _done(sessionId) {
+  await knex(AUDIT_TABLE)
+    .update({ status: 'DONE' })
+    .where({ sessionId });
+}
+
+async function _toRetry(sessionId, error) {
+  await knex(AUDIT_TABLE)
+    .update({ status: 'TO RETRY', error: (error.stack).toString().substring(0, 700) })
+    .where({ sessionId });
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -37,7 +37,6 @@ describe('Integration | Repository | Certification Issue Report', function() {
         category: CertificationIssueReportCategories.IN_CHALLENGE,
         description: 'Un gros problème',
         isActionRequired: true,
-        isAutoNeutralizable: false,
         subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
         questionNumber: 5,
         resolvedAt: new Date('2020-01-01'),
@@ -101,7 +100,6 @@ describe('Integration | Repository | Certification Issue Report', function() {
       // then
       const expectedIssueReport = domainBuilder.buildCertificationIssueReport({
         ...issueReport,
-        isAutoNeutralizable: false,
       });
       expect(result).to.deep.equal(expectedIssueReport);
       expect(result).to.be.instanceOf(CertificationIssueReport);

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -4,7 +4,6 @@ const CertificationReport = require('../../../../lib/domain/models/Certification
 const certificationReportRepository = require('../../../../lib/infrastructure/repositories/certification-report-repository');
 const { CertificationCourseUpdateError } = require('../../../../lib/domain/errors');
 const { CertificationIssueReportCategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
-const CertificationIssueReportResolutionStrategies = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 describe('Integration | Repository | CertificationReport', function() {
 
@@ -41,7 +40,6 @@ describe('Integration | Repository | CertificationReport', function() {
             { ...certificationIssueReport1,
               isImpactful: true,
               isAutoNeutralizable: false,
-              resolutionStrategy: CertificationIssueReportResolutionStrategies.NONE,
             },
           ],
           hasSeenEndTestScreen: certificationCourse1.hasSeenEndTestScreen,

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -39,7 +39,6 @@ describe('Integration | Repository | CertificationReport', function() {
           certificationIssueReports: [
             { ...certificationIssueReport1,
               isImpactful: true,
-              isAutoNeutralizable: false,
             },
           ],
           hasSeenEndTestScreen: certificationCourse1.hasSeenEndTestScreen,

--- a/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
@@ -1,7 +1,6 @@
 const { catchErr, expect, databaseBuilder } = require('../../../test-helper');
 const generalCertificationInformationRepository = require('../../../../lib/infrastructure/repositories/general-certification-information-repository');
 const { NotFoundError } = require('../../../../lib/domain/errors');
-const CertificationIssueReportResolutionStrategies = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 const GeneralCertificationInformation = require('../../../../lib/domain/read-models/GeneralCertificationInformation');
 
@@ -63,14 +62,12 @@ describe('Integration | Repository | General certification information', functio
               isImpactful: true,
               resolution: 'challenge neutralized',
               resolvedAt: new Date('2021-01-01T00:00:00Z'),
-              resolutionStrategy: CertificationIssueReportResolutionStrategies.NONE,
             },
             { ...secondCertificationReport,
               isAutoNeutralizable: false,
               isImpactful: true,
               resolution: null,
               resolvedAt: null,
-              resolutionStrategy: CertificationIssueReportResolutionStrategies.NONE,
             },
           ],
         };

--- a/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/general-certification-information-repository_test.js
@@ -58,13 +58,11 @@ describe('Integration | Repository | General certification information', functio
           birthplace: certificationCourseDTO.birthplace,
           certificationIssueReports: [
             { ...firstCertificationReport,
-              isAutoNeutralizable: false,
               isImpactful: true,
               resolution: 'challenge neutralized',
               resolvedAt: new Date('2021-01-01T00:00:00Z'),
             },
             { ...secondCertificationReport,
-              isAutoNeutralizable: false,
               isImpactful: true,
               resolution: null,
               resolvedAt: null,

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -1,12 +1,13 @@
 const { expect, domainBuilder, sinon } = require('../../../test-helper');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const CertificationIssueReportResolutionAttempt = require('../../../../lib/domain/models/CertificationIssueReportResolutionAttempt');
+const { CertificationIssueReportResolutionStrategies } = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 const {
-  NEUTRALIZE_WITHOUT_CHECKING: neutralizeWithoutChecking,
-  NEUTRALIZE_IF_IMAGE: neutralizeIfImage,
-  NEUTRALIZE_IF_EMBED: neutralizeIfEmbed,
-  NEUTRALIZE_IF_ATTACHMENT: neutralizeIfAttachment,
-  NONE: doNotResolve,
+  neutralizeWithoutCheckingStrategy,
+  neutralizeIfImageStrategy,
+  neutralizeIfEmbedStrategy,
+  neutralizeIfAttachmentStrategy,
+  doNotResolveStrategy,
 } = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies', () => {
@@ -33,7 +34,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        const neutralizationAttempt = await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        const neutralizationAttempt = await neutralizeWithoutCheckingStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
@@ -57,7 +58,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        await neutralizeWithoutCheckingStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -85,7 +86,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        const neutralizationAttempt = await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        const neutralizationAttempt = await neutralizeWithoutCheckingStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -109,7 +110,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        await neutralizeWithoutChecking({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        await neutralizeWithoutCheckingStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -144,7 +145,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
@@ -173,7 +174,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -199,7 +200,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        const neutralizationAttempt = await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -221,7 +222,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -252,7 +253,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -279,7 +280,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -311,7 +312,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -339,7 +340,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        await neutralizeIfImage({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -374,7 +375,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
@@ -405,7 +406,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -431,7 +432,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        const neutralizationAttempt = await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -453,7 +454,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -484,7 +485,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.resolution).to.equal('Cette question n\' a pas été neutralisée car elle ne contient pas d\'application/simulateur');
@@ -512,7 +513,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -544,7 +545,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -572,7 +573,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        await neutralizeIfEmbed({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -609,7 +610,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
@@ -642,7 +643,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -668,7 +669,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        const neutralizationAttempt = await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -690,7 +691,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+        await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -721,7 +722,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -748,7 +749,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -782,7 +783,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        const neutralizationAttempt = await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
@@ -812,7 +813,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         };
 
         // when
-        await neutralizeIfAttachment({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+        await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
@@ -821,7 +822,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
   });
 
-  context('#NONE', () => {
+  context('#DO_NOT_RESOLVE', () => {
     it('returns an unresolved resolution attempt', async () => {
       // given
       const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
@@ -831,7 +832,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       });
 
       // when
-      const resolutionAttempt = await doNotResolve({ certificationIssueReport, certificationAssessment: null, certificationIssueReportRepository: null, challengeRepository: null });
+      const resolutionAttempt = await doNotResolveStrategy({ certificationIssueReport, certificationAssessment: null, certificationIssueReportRepository: null, challengeRepository: null });
 
       // then
       expect(resolutionAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.unresolved());
@@ -846,10 +847,55 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       });
 
       // when
-      await doNotResolve({ certificationIssueReport, certificationAssessment: null, certificationIssueReportRepository: null, challengeRepository: null });
+      await doNotResolveStrategy({ certificationIssueReport, certificationAssessment: null, certificationIssueReportRepository: null, challengeRepository: null });
 
       // then
       expect(certificationIssueReport.isResolved()).to.be.false;
+    });
+  });
+
+  context('#resolve', () => {
+    [
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE, strategyToBeApplied: 'doNotResolve' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE, strategyToBeApplied: 'doNotResolve' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.LEFT_EXAM_ROOM, strategyToBeApplied: 'doNotResolve' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.SIGNATURE_ISSUE, strategyToBeApplied: 'doNotResolve' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING, strategyToBeApplied: 'neutralizeIfImage' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.LINK_NOT_WORKING, strategyToBeApplied: 'doNotResolve' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.EMBED_NOT_WORKING, strategyToBeApplied: 'neutralizeIfEmbed' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.FILE_NOT_OPENING, strategyToBeApplied: 'neutralizeIfAttachment' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE, strategyToBeApplied: 'neutralizeWithoutChecking' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, strategyToBeApplied: 'neutralizeWithoutChecking' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED, strategyToBeApplied: 'doNotResolve' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING, strategyToBeApplied: 'neutralizeWithoutChecking' },
+      { subCategoryToBeResolved: CertificationIssueReportSubcategories.OTHER, strategyToBeApplied: 'doNotResolve' },
+    ].forEach(({
+      subCategoryToBeResolved,
+      strategyToBeApplied,
+    }) => {
+      it(`apply strategy "${strategyToBeApplied}" when resolving issue report of subcategory "${subCategoryToBeResolved}"`, async () => {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: subCategoryToBeResolved,
+        });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment();
+        const certificationIssueReportRepository = {};
+        const challengeRepository = {};
+        const strategyStub = sinon.stub();
+        strategyStub.resolves();
+
+        const strategies = new CertificationIssueReportResolutionStrategies({
+          [strategyToBeApplied]: strategyStub,
+          certificationIssueReportRepository,
+          challengeRepository,
+        });
+
+        // when
+        await strategies.resolve({ certificationIssueReport, certificationAssessment });
+
+        // then
+        expect(strategyStub).to.have.been.calledWith({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+      });
     });
   });
 });

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -882,7 +882,6 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const certificationIssueReportRepository = {};
         const challengeRepository = {};
         const strategyStub = sinon.stub();
-        strategyStub.resolves();
 
         const strategies = new CertificationIssueReportResolutionStrategies({
           [strategyToBeApplied]: strategyStub,

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -355,38 +355,6 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         });
       });
     });
-
-    context('Adds isAutoneutralizable boolean to certif issue report when an subcategory is neutralizable', function() {
-      [
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_BLOCKED', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_UNAVAILABLE', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'SOFTWARE_NOT_WORKING', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'IMAGE_NOT_DISPLAYING', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EMBED_NOT_WORKING', questionNumber: 42 },
-      ].forEach((certificationIssueReportDTO) => {
-        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isAutoneutralizable to true`, () => {
-          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isAutoNeutralizable).to.be.true;
-        });
-      });
-
-      [
-        { certificationCourseId: 42, category: 'CANDIDATE_INFORMATIONS_CHANGES', subcategory: 'EXTRA_TIME_PERCENTAGE', description: 'toto' },
-        { certificationCourseId: 42, category: 'LATE_OR_LEAVING', subcategory: 'SIGNATURE_ISSUE' },
-        { certificationCourseId: 42, category: 'CONNECTION_OR_END_SCREEN' },
-        { certificationCourseId: 42, category: 'OTHER', subcategory: undefined, description: 'toto' },
-        { certificationCourseId: 42, category: 'CANDIDATE_INFORMATIONS_CHANGES', subcategory: 'NAME_OR_BIRTHDATE', description: 'toto' },
-        { certificationCourseId: 42, category: 'LATE_OR_LEAVING', subcategory: 'LEFT_EXAM_ROOM', description: 'toto' },
-        { certificationCourseId: 42, category: 'FRAUD' },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'FILE_NOT_OPENING', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'LINK_NOT_WORKING', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EXTRA_TIME_EXCEEDED', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
-      ].forEach((certificationIssueReportDTO) => {
-        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isAutoneutralizable to false`, () => {
-          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isAutoNeutralizable).to.be.false;
-        });
-      });
-    });
   });
 
   describe('#isResolved', () => {

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -2,7 +2,6 @@ const { expect, domainBuilder } = require('../../../test-helper');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories, DeprecatedCertificationIssueReportCategory } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const { InvalidCertificationIssueReportForSaving } = require('../../../../lib/domain/errors');
-const CertificationIssueReportResolutionStrategies = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
 const MISSING_VALUE = null;
 const EMPTY_VALUE = '';
@@ -387,45 +386,6 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
           expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isAutoNeutralizable).to.be.false;
         });
       });
-    });
-
-    context('Matches resolution strategy with issue report subcategory', function() {
-      [
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_BLOCKED', questionNumber: 42 },
-        { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'WEBSITE_UNAVAILABLE', questionNumber: 42 },
-        {
-          certificationCourseId: 42,
-          category: 'IN_CHALLENGE',
-          subcategory: 'SOFTWARE_NOT_WORKING',
-          questionNumber: 42,
-        },
-      ].forEach((certificationIssueReportDTO) => {
-        it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should match with NEUTRALIZE_WITHOUT_CHECKING`, () => {
-          expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_WITHOUT_CHECKING);
-        });
-      });
-
-      it('for IN_CHALLENGE IMAGE_NOT_DISPLAYING should match with NEUTRALIZE_IF_IMAGE', () => {
-        expect(new CertificationIssueReport({
-          category: 'IN_CHALLENGE',
-          subcategory: 'IMAGE_NOT_DISPLAYING',
-        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_IMAGE);
-      });
-
-      it('for IN_CHALLENGE EMBED_NOT_WORKING should match with NEUTRALIZE_IF_EMBED', () => {
-        expect(new CertificationIssueReport({
-          category: 'IN_CHALLENGE',
-          subcategory: 'EMBED_NOT_WORKING',
-        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_EMBED);
-      });
-
-      it('for IN_CHALLENGE FILE_NOT_OPENING should match with NEUTRALIZE_IF_ATTACHMENT', () => {
-        expect(new CertificationIssueReport({
-          category: 'IN_CHALLENGE',
-          subcategory: 'FILE_NOT_OPENING',
-        }).resolutionStrategy).to.equal(CertificationIssueReportResolutionStrategies.NEUTRALIZE_IF_ATTACHMENT);
-      });
-
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
La prise en compte de certains types de signalement est en cours d'automatisation afin d’aider le pôle certif dans le traitement des sessions de certification.
Un grand nombre de sessions a déjà été finalisée et donc ne bénéficiera pas de cette nouvelle fonctionnalité.

## :robot: Solution
Permettre de façon rétroactive la prise en compte des signalements pour les sessions déjà finalisées

## :rainbow: Remarques
Statistiques
```
SELECT COUNT("sessions"."id") FROM "sessions"
WHERE "sessions"."finalizedAt" IS NOT null
AND "sessions"."publishedAt" IS null
AND "sessions"."assignedCertificationOfficerId" IS NULL
```
2469

```
SELECT COUNT("sessions"."id") FROM "sessions"
JOIN "finalized-sessions" ON "finalized-sessions"."sessionId" = "sessions"."id"
WHERE "sessions"."finalizedAt" IS NOT null
AND "sessions"."publishedAt" IS null
AND "sessions"."assignedCertificationOfficerId" IS NULL
AND "finalized-sessions"."isPublishable" IS FALSE
```
1357

----

### Données mesurées sur la réplication

Avant le script :
```
> select count(*) from "finalized-sessions" where "publishedAt" is null and "isPublishable" is false;
 count
-------
  1424
```

Après le script :

```
> select count(*) from "finalized-sessions" where "publishedAt" is null and "isPublishable" is false;
 count
-------
   896
```

Il semblerait que le script traite 528 sessions sur les 1424 sessions à traiter.

## :100: Pour tester
Le script a été testé sur la replication de prod.
