### PR TITLE
[BUGFIX] Suppression de la barre de défilement horizontal sur la page compétences (PIX-2726).

### DIFF
--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -101,6 +101,11 @@
       margin: 16px 10px;
       width: auto;
     }
+
+    &:first-child,
+    &:nth-child(4) {
+      margin: 16px 8px;
+    }
   }
 
   @include device-is('tablet') {


### PR DESCRIPTION
## :unicorn: Problème

Nous avons remarqué depuis quelques temps l'apparition d'une barre de défilement horizontal sur la page compétences au format Desktop pour les compétences de `communication` et de `création de contenu`.

<img width="960" alt="Capture d’écran 2021-06-14 à 16 15 50" src="https://user-images.githubusercontent.com/36371437/121906912-de316900-cd2b-11eb-964f-7d5d1ae9eb32.png">

## :robot: Solution

Première solution: (ECARTEE) : Nous ajoutons la propriété `overflow: visible` (valeur par défaut) à partir du format `large-screen` afin de conserver la barre de défilement au format tablette et la faire disparaitre à partir d'une taille d'écran supérieure.

Deuxième solution : Nous réduisons la marge latérale de la première et dernière carte afin de faire rentrer l'ensemble de la ligne de compétences dans le conteneur principal.

<img width="954" alt="Capture d’écran 2021-06-14 à 16 16 55" src="https://user-images.githubusercontent.com/36371437/121907018-f2756600-cd2b-11eb-86fa-de60cb8920d7.png">

## :rainbow: Remarques

Nous utilisons `nth-child` en lieu et place de `last-child` pour la dernière carte afin de ne pas impacter les autres lignes contenant moins de 4 cartes de compétences.

## :100: Pour tester

Aller sur la page compétences et constater de la disparition de la barre de défilement horizontale sur les compétences de `communication` et de `création de contenu`
