### PR TITLE
[FEATURE] Ajout de liens vers la preview et les informations d'une épreuve sur la page de détails d'une certification dans PixAdmin (PIX-2727)

### DIFF
--- a/admin/app/components/certification/certification-details-answer.hbs
+++ b/admin/app/components/certification/certification-details-answer.hbs
@@ -3,8 +3,18 @@
     <div class="certification-details-answer-skill">
       {{@answer.skill}}
     </div>
-    <div class="certification-details-answer-id">
-      {{@answer.challengeId}}
+    <div class="certification-details-answer-challenge">
+      <div data-test-answer-challengeId>
+        {{@answer.challengeId}}
+      </div>
+      <div class="certification-details-answer-challenge-links">
+        <a href={{this.linkToChallengePreviewInPixApp}} target="_blank" rel="noreferrer noopener" data-test-link-preview>
+          Preview
+        </a>|
+        <a href={{this.linkToChallengeInfoInPixEditor}} target="_blank" rel="noreferrer noopener" data-test-link-info>
+          Info
+        </a>
+      </div>
     </div>
     <div class="certification-details-answer-order">
       (numéro : {{@answer.order}})

--- a/admin/app/components/certification/certification-details-answer.js
+++ b/admin/app/components/certification/certification-details-answer.js
@@ -31,6 +31,14 @@ export default class CertificationDetailsAnswer extends Component {
     return this.hasJuryResult ? 'answer-result jury' : 'answer-result';
   }
 
+  get linkToChallengePreviewInPixApp() {
+    return `https://app.recette.pix.fr/challenges/${this.args.answer.challengeId}/preview`;
+  }
+
+  get linkToChallengeInfoInPixEditor() {
+    return `https://editor.pix.fr/#/challenge/${this.args.answer.challengeId}`;
+  }
+
   @action
   selectOption(selected) {
     const answer = this.args.answer;

--- a/admin/app/styles/components/certification-details-answer.scss
+++ b/admin/app/styles/components/certification-details-answer.scss
@@ -1,11 +1,21 @@
 .certification-details-answer {
   .certification-details-answer-skill {
-    font-size: 0.8em;
+    font-size: 0.8125rem;
   }
 
-  .certification-details-answer-id,
+  .certification-details-answer-challenge {
+    display: flex;
+    justify-content: space-evenly;
+    font-size: 0.8125rem;
+  }
+
+  .certification-details-answer-challenge-link {
+    display: flex;
+    font-size: 0.8125rem;
+  }
+
   .certification-details-answer-order {
-    font-size: 10px;
+    font-size: 0.8125rem;
   }
 
 

--- a/admin/tests/integration/components/certification/certification-details-answer_test.js
+++ b/admin/tests/integration/components/certification/certification-details-answer_test.js
@@ -57,7 +57,7 @@ module('Integration | Component | Certification | CertificationDetailsAnswer', f
 
     // then
     assert.dom('.certification-details-answer-skill').hasText('@skill5');
-    assert.dom('.certification-details-answer-id').hasText('rec12345');
+    assert.dom('[data-test-answer-challengeId]').hasText('rec12345');
     assert.dom('.certification-details-answer-order').hasText('(numéro : 5)');
     assert.dom('.ember-power-select-selected-item').hasText('Succès partiel');
   });
@@ -109,4 +109,19 @@ module('Integration | Component | Certification | CertificationDetailsAnswer', f
     assert.equal(answerData.jury, null);
   });
 
+  test('it should render links to challenge preview and info', async function(assert) {
+    // given
+    this.setProperties({
+      answer: answerData,
+    });
+
+    // when
+    await render(hbs`<Certification::CertificationDetailsAnswer @answer={{answer}} />`);
+
+    // Then
+    assert.dom('[data-test-link-preview]').hasText('Preview');
+    assert.dom('[data-test-link-preview]').hasAttribute('href', 'https://app.recette.pix.fr/challenges/rec12345/preview');
+    assert.dom('[data-test-link-info]').hasText('Info');
+    assert.dom('[data-test-link-info]').hasAttribute('href', 'https://editor.pix.fr/#/challenge/rec12345');
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un membre du pôle certif traite le signalement d'une certification, il lui arrive souvent de vouloir avoir davantage d'informations sur l'épreuve signalée afin de vérifier la véracité / cohérence du signalement.
Il leur arrive donc de consulter les informations de l'épreuve sur PixEditor, mais aussi de vouloir voir la prévisualisation de l'épreuve sur PixApp.

## :robot: Solution
Afin de leur faire gagner un peu de temps, on propose d'accoler deux liens à côté de l'ID de l'épreuve, à savoir un lien vers la prévisualisation de l'épreuve :
`recette.app.pix.fr/challenges/:recIdChallenge/preview`
mais aussi un lien vers la page d'information de l'épreuve sur PixEditor :
`editor.pix.fr/#/challenge/:recIdChallenge`

## :rainbow: Remarques


## :100: Pour tester
Prérequis :
- Pour pouvoir tester le lien vers la preview, il faut être loggé sur app.recette.pix.fr
- Pour pouvoir tester le lien vers les informations, il faut être loggé sur editor.pix.fr (ça met un peu de temps à charger)

Sur PixAdmin (pixmaster@example.net / pix123), se rendre sur la page de détails d'une certification ([celle-ci](https://admin-pr3103.review.pix.fr/certifications/104360/details) par exemple), et faire joujou avec les deux liens accolés à chaque ID de challenge dans les sous-cartes
