### PR TITLE
[FEATURE] Afficher les fichiers microsoft en premier dans les épreuves (PIX-2729).

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -69,7 +69,7 @@ class Challenge {
     } = {}) {
     this.id = id;
     this.answer = answer;
-    this.attachments = this._orderAttachments(attachments);
+    this.attachments = attachments;
     this.embedHeight = embedHeight;
     this.embedTitle = embedTitle;
     this.embedUrl = embedUrl;
@@ -88,20 +88,6 @@ class Challenge {
     this.validator = validator;
     this.competenceId = competenceId;
     this.focused = focused;
-  }
-
-  _orderAttachments(attachments) {
-    if (!attachments || !Array.isArray(attachments)) {
-      return [];
-    }
-    const openSourceFormats = ['odp', 'ods', 'odt'];
-    return attachments.sort((attachmentA, attachmentB) => {
-      const formatB = attachmentB.split('.').pop();
-      if (openSourceFormats.includes(formatB)) {
-        return -1;
-      }
-      return 1;
-    });
   }
 
   addSkill(skill) {

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -48,24 +48,6 @@ describe('Unit | Domain | Models | Challenge', () => {
       expect(challengeDataObject).to.be.an.instanceof(Challenge);
       expect(challengeDataObject).to.deep.equal(challengeRawData);
     });
-
-    it('should order the attachments with microsoft files first', () => {
-      // given
-      const challengeRawData = {
-        attachments: [
-          'https://dl.airtable.com/rsXNJrSPuepuJQDByFVA_navigationdiaporama5.odp',
-          'https://dl.airtable.com/nHWKNZZ7SQeOKsOvVykV_navigationdiaporama5.docx',
-        ],
-      };
-
-      // when
-      const challengeDataObject = new Challenge(challengeRawData);
-
-      // then
-      expect(challengeDataObject.attachments.length).to.equal(challengeRawData.attachments.length);
-      expect(challengeDataObject.attachments[0]).to.contains('docx');
-      expect(challengeDataObject.attachments[1]).to.contains('odp');
-    });
   });
 
   describe('#hasSkill', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -73,7 +73,6 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
             type: 'challenges',
             id: '1',
             attributes: {
-              attachments: [],
               competence: 'competence_id',
             },
           },
@@ -94,7 +93,6 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
             type: 'challenges',
             id: '1',
             attributes: {
-              attachments: [],
               competence: 'N/A',
             },
           },

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -3,7 +3,9 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import config from 'mon-pix/config/environment';
 import Component from '@glimmer/component';
-import get from 'lodash/get';
+import sortBy from 'lodash/sortBy';
+
+const PREFERRED_ATTACHMENT_FORMATS = ['docx', 'xlsx', 'pptx'];
 
 export default class ChallengeStatement extends Component {
   @service mailGenerator;
@@ -57,8 +59,21 @@ export default class ChallengeStatement extends Component {
     this.selectedAttachmentUrl = attachementUrl;
   }
 
+  get orderedAttachments() {
+    if (!this.args.challenge.attachments || !Array.isArray(this.args.challenge.attachments)) {
+      return [];
+    }
+
+    return sortBy(this.args.challenge.attachments,
+      (attachmentUrl) => {
+        const extension = attachmentUrl.split('.').pop();
+        const newFirstChar = PREFERRED_ATTACHMENT_FORMATS.indexOf(extension) >= 0 ? 'A' : 'Z';
+        return newFirstChar + extension;
+      });
+  }
+
   _initialiseDefaultAttachment() {
-    this.selectedAttachmentUrl = get(this.args.challenge, 'attachments.firstObject');
+    this.selectedAttachmentUrl = this.orderedAttachments[0];
   }
 
   _formattedEmailForInstruction() {

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -18,7 +18,7 @@
       {{#if @challenge.hasSingleAttachment}}
         <div class="challenge-statement__action">
           <a class="challenge-statement__action-link"
-             href="{{@challenge.attachments.firstObject}}"
+             href="{{this.orderedAttachments.firstObject}}"
              target="_blank"
              rel="noopener noreferrer"
              download>
@@ -39,7 +39,7 @@
         </div>
         </p>
         <ul class="challenge-statement__file-options">
-          {{#each @challenge.attachments as |attachmentUrl index|}}
+          {{#each this.orderedAttachments as |attachmentUrl index|}}
             <li class="challenge-statement__file-option">
 
               {{!-- This radiobutton is hidden  - SVG displayed instead - but needed to handle behaviour. --}}

--- a/mon-pix/tests/unit/components/challenge-statement_test.js
+++ b/mon-pix/tests/unit/components/challenge-statement_test.js
@@ -48,4 +48,58 @@ describe('Unit | Component | challenge statement', function() {
     });
   });
 
+  describe('#orderedAttachments', () => {
+
+    it('should return empty array if no attachments', () => {
+      // given
+      const challenge = EmberObject.create({});
+      const component = createGlimmerComponent('component:challenge-statement', { challenge });
+
+      // when
+      const orderedAttachments = component.orderedAttachments;
+
+      // then
+      expect(orderedAttachments.length).to.equal(0);
+    });
+
+    it('should return files using the preferred formats first, then the others', () => {
+      // given
+      const attachments = [
+        'https://dl.airtable.com/test.odp',
+        'https://dl.airtable.com/test.docx',
+      ];
+      const challenge = EmberObject.create({ attachments });
+      const component = createGlimmerComponent('component:challenge-statement', { challenge });
+
+      // when
+      const orderedAttachments = component.orderedAttachments;
+
+      // then
+      expect(orderedAttachments.length).to.equal(attachments.length);
+      expect(orderedAttachments[0]).to.contains('docx');
+      expect(orderedAttachments[1]).to.contains('odp');
+    });
+
+    it('should return the attachments ordered alphabetically in each group', () => {
+      // given
+      const attachments = [
+        'https://dl.airtable.com/test1.ods',
+        'https://dl.airtable.com/test2.odp',
+        'https://dl.airtable.com/test3.pptx',
+        'https://dl.airtable.com/test6.docx',
+      ];
+      const challenge = EmberObject.create({ attachments });
+      const component = createGlimmerComponent('component:challenge-statement', { challenge });
+
+      // when
+      const orderedAttachments = component.orderedAttachments;
+
+      // then
+      expect(orderedAttachments.length).to.equal(attachments.length);
+      expect(orderedAttachments[0]).to.contain('docx');
+      expect(orderedAttachments[1]).to.contain('pptx');
+      expect(orderedAttachments[2]).to.contain('odp');
+      expect(orderedAttachments[3]).to.contain('ods');
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Cette feature est une réédition de https://github.com/1024pix/pix/pull/3094:
Dans les épreuves, l'ordre d'affichage des fichiers n'est pas toujours le même: parfois on affiche d'abord le fichier .odt puis .docx et parfois on affiche d'abord .docx puis .odt.
Il faudrait homogénéiser cela et **afficher d'abord les fichiers de type Microsoft.**

Dans la PR précédente, nous avions fait le choix de faire le sort dans le model Challenge côté api.
Or, ce n'est pas judicieux car ce bout de code est appelé très fréquemment.

## :robot: Solution
- Déplacer le sort dans mon-pix
- Appeler cette méthode de sort au moment de l'affichage des attachments dans les épreuves
- Cette méthode affiche d'abord les attachments de formats microsoft, puis ceux open-source, puis les autres formats. Dans chacun de ces trois groupes, les fichiers sont affichés par ordre alphabétiques de leurs format.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier l'épreuve recLjZbBA6EMjloAK sur intégration, voir que le fichier .ods s'affiche avant .xlsx.
Sur la RA, l'affichage est inversé: le fichier .xlsx s'affiche en premier.
