### PR TITLE
[FEATURE] Ajout des tooltips et traduction sur le graphique des statuts (PIX-2728)

### DIFF
--- a/orga/app/components/charts/participants-by-status.hbs
+++ b/orga/app/components/charts/participants-by-status.hbs
@@ -12,7 +12,10 @@
     <ul class="participants-by-status__legend" aria-hidden="true">
       {{#each this.datasets as |dataset|}}
         <li class="participants-by-status__legend--{{dataset.key}}">
-          {{dataset.legend}}
+          <span>{{dataset.legend}}</span>
+          <PixTooltip @text={{dataset.legendTooltip}} @isWide="true" @position="top-left">
+            <FaIcon @icon="question-circle" class="participants-by-status__legend-tooltip" />
+          </PixTooltip>
         </li>
       {{/each}}
     </ul>

--- a/orga/app/components/charts/participants-by-status.js
+++ b/orga/app/components/charts/participants-by-status.js
@@ -65,6 +65,7 @@ export default class ParticipantsByStatus extends Component {
     return {
       tooltip: this.intl.t(datasetLabels.tooltip, { percentage }),
       legend: this.intl.t(datasetLabels.legend, { count }),
+      legendTooltip: this.intl.t(datasetLabels.legendTooltip, { count }),
       a11y: this.intl.t(datasetLabels.a11y, { count }),
       color: datasetLabels.color,
     };
@@ -75,18 +76,21 @@ const LABELS_ASSESSMENT = {
   started: {
     tooltip: 'charts.participants-by-status.labels-tooltip.started',
     legend: 'charts.participants-by-status.labels-legend.started',
+    legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.started',
     color: '#FFBE00',
   },
   completed: {
     tooltip: 'charts.participants-by-status.labels-tooltip.completed',
     legend: 'charts.participants-by-status.labels-legend.completed',
+    legendTooltip: 'charts.participants-by-status.labels-legend.completed-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.completed',
     color: '#8a49ff',
   },
   shared: {
     tooltip: 'charts.participants-by-status.labels-tooltip.shared',
     legend: 'charts.participants-by-status.labels-legend.shared',
+    legendTooltip: 'charts.participants-by-status.labels-legend.shared-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.shared',
     color: '#038a25',
   },
@@ -96,18 +100,21 @@ const LABELS_PROFILE_COLLECTIONS = {
   started: {
     tooltip: 'charts.participants-by-status.labels-tooltip.started',
     legend: 'charts.participants-by-status.labels-legend.started',
+    legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.started',
     color: '#FFBE00',
   },
   completed: {
     tooltip: 'charts.participants-by-status.labels-tooltip.completed',
     legend: 'charts.participants-by-status.labels-legend.completed',
+    legendTooltip: 'charts.participants-by-status.labels-legend.completed-profile-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.completed',
     color: '#8a49ff',
   },
   shared: {
     tooltip: 'charts.participants-by-status.labels-tooltip.shared-profile',
     legend: 'charts.participants-by-status.labels-legend.shared-profile',
+    legendTooltip: 'charts.participants-by-status.labels-legend.shared-profile-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.shared-profile',
     color: '#038a25',
   },

--- a/orga/app/styles/components/charts/participants-by-status.scss
+++ b/orga/app/styles/components/charts/participants-by-status.scss
@@ -6,6 +6,7 @@
     font-size: 0.875rem;
 
     > li {
+      display: flex;
       position: relative;
       padding-bottom: 8px;
       padding-left: 24px;
@@ -49,6 +50,11 @@
       height: 20px;
       margin-top: 8px;
     }
+  }
+
+  &__legend-tooltip {
+    margin-left: 8px;
+    color: $grey-30;
   }
 
   &--loader {

--- a/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
@@ -1,6 +1,7 @@
 .activity {
   &__stats {
     display: flex;
+    flex-flow: row-reverse;
     &--participations-by-status {
       width: 200px;
     }

--- a/orga/tests/integration/components/charts/participants-by-status_test.js
+++ b/orga/tests/integration/components/charts/participants-by-status_test.js
@@ -34,8 +34,28 @@ module('Integration | Component | Charts::ParticipantsByStatus', function(hooks)
     await render(hbs`<Charts::ParticipantsByStatus @campaignId={{campaignId}} @isTypeAssessment={{true}} />`);
 
     assert.contains('En cours (1)');
-    assert.contains('En attente d\'envois (1)');
+    assert.contains('En attente d\'envoi (1)');
     assert.contains('Résultats reçus (1)');
+  });
+
+  test('it should contains tooltips for assessment campaign', async function(assert) {
+    // given
+    dataFetcher.withArgs(campaignId).resolves({
+      data: {
+        attributes: {
+          started: 1,
+          completed: 1,
+          shared: 1,
+        },
+      },
+    });
+
+    // when
+    await render(hbs`<Charts::ParticipantsByStatus @campaignId={{campaignId}} @isTypeAssessment={{true}} />`);
+
+    assert.contains('En cours : Ces participants n’ont pas encore terminé leur parcours.');
+    assert.contains('En attente d’envoi : Ces participants ont terminé leur parcours mais n’ont pas encore envoyé leurs résultats.');
+    assert.contains('Résultats reçus : Ces participants ont terminé leur parcours et envoyé leurs résultats.');
   });
 
   test('it should display status for profile collection campaign', async function(assert) {
@@ -53,7 +73,25 @@ module('Integration | Component | Charts::ParticipantsByStatus', function(hooks)
     await render(hbs`<Charts::ParticipantsByStatus @campaignId={{campaignId}} @isTypeAssessment={{false}} />`);
 
     assert.notContains('En cours (1)');
-    assert.contains('En attente d\'envois (1)');
+    assert.contains('En attente d\'envoi (1)');
     assert.contains('Profils reçus (1)');
+  });
+
+  test('it should contains tooltips for profile collection campaign', async function(assert) {
+    // given
+    dataFetcher.withArgs(campaignId).resolves({
+      data: {
+        attributes: {
+          completed: 1,
+          shared: 1,
+        },
+      },
+    });
+
+    // when
+    await render(hbs`<Charts::ParticipantsByStatus @campaignId={{campaignId}} @isTypeAssessment={{false}} />`);
+
+    assert.contains('En attente d’envoi : Ces participants n’ont pas encore envoyé leurs profils.');
+    assert.contains('Profils reçus : Ces participants ont envoyé leurs profils.');
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -84,19 +84,24 @@
         "started": "In progress: {percentage, number, ::percent .0}",
         "completed": "Pending results: {percentage, number, ::percent .0}",
         "shared": "Submitted results: {percentage, number, ::percent .0}",
-        "shared-profile": "Shared profiles: {percentage, number, ::percent .0}"
+        "shared-profile": "Submitted profiles: {percentage, number, ::percent .0}"
       },
       "labels-a11y": {
         "started": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} in progress",
         "completed": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with pending results",
         "shared": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with submitted results",
-        "shared-profile": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with shared profiles"
+        "shared-profile": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with submitted profiles"
       },
       "labels-legend": {
         "started": "In progress ({count})",
+        "started-tooltip": "In progress: These participants haven’t finished their customised test yet.",
         "completed": "Pending results ({count})",
+        "completed-tooltip": "Pending results: These participants have finished their customised test but haven’t submitted their results yet.",
+        "completed-profile-tooltip": "Pending results: These participants haven’t submitted their profiles yet.",
         "shared": "Submitted results ({count})",
-        "shared-profile": "Shared profiles ({count})"
+        "shared-tooltip": "Submitted results: These participants have finished their customised test and submitted their results.",
+        "shared-profile": "Submitted profiles ({count})",
+        "shared-profile-tooltip": "Submitted profiles: These participants have submitted their profiles."
       },
       "loader": "Loading statuses distribution",
       "title": "Statuses"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -81,25 +81,25 @@
     },
     "participants-by-status": {
       "labels-tooltip": {
-        "started": "Started: {percentage, number, ::percent .0}",
-        "completed": "Completed: {percentage, number, ::percent .0}",
-        "shared": "Shared: {percentage, number, ::percent .0}",
+        "started": "In progress: {percentage, number, ::percent .0}",
+        "completed": "Pending results: {percentage, number, ::percent .0}",
+        "shared": "Submitted results: {percentage, number, ::percent .0}",
         "shared-profile": "Shared profiles: {percentage, number, ::percent .0}"
       },
       "labels-a11y": {
-        "started": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} started",
-        "completed": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} completed",
-        "shared": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} shared",
-        "shared-profile": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} shared profiles"
+        "started": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} in progress",
+        "completed": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with pending results",
+        "shared": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with submitted results",
+        "shared-profile": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with shared profiles"
       },
       "labels-legend": {
-        "started": "Started ({count})",
-        "completed": "Completed ({count})",
-        "shared": "Shared ({count})",
+        "started": "In progress ({count})",
+        "completed": "Pending results ({count})",
+        "shared": "Submitted results ({count})",
         "shared-profile": "Shared profiles ({count})"
       },
       "loader": "Loading statuses distribution",
-      "title": "Statuses distribution"
+      "title": "Statuses"
     }
   },
   "navigation": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -82,21 +82,26 @@
     "participants-by-status": {
       "labels-tooltip": {
         "started": "En cours : {percentage, number, ::percent .0}",
-        "completed": "En attente d'envois : {percentage, number, ::percent .0}",
+        "completed": "En attente d'envoi : {percentage, number, ::percent .0}",
         "shared": "Résultats reçus : {percentage, number, ::percent .0}",
         "shared-profile": "Profils reçus : {percentage, number, ::percent .0}"
       },
       "labels-a11y": {
         "started": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} en cours de test",
-        "completed": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} en attente d'envois",
+        "completed": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} en attente d'envoi",
         "shared": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} ayant envoyés leurs résultats",
         "shared-profile": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} ayant envoyés leurs profils"
       },
       "labels-legend": {
         "started": "En cours ({count})",
-        "completed": "En attente d'envois ({count})",
+        "started-tooltip": "En cours : Ces participants n’ont pas encore terminé leur parcours.",
+        "completed": "En attente d'envoi ({count})",
+        "completed-tooltip": "En attente d’envoi : Ces participants ont terminé leur parcours mais n’ont pas encore envoyé leurs résultats.",
+        "completed-profile-tooltip": "En attente d’envoi : Ces participants n’ont pas encore envoyé leurs profils.",
         "shared": "Résultats reçus ({count})",
-        "shared-profile": "Profils reçus ({count})"
+        "shared-tooltip": "Résultats reçus : Ces participants ont terminé leur parcours et envoyé leurs résultats.",
+        "shared-profile": "Profils reçus ({count})",
+        "shared-profile-tooltip": "Profils reçus : Ces participants ont envoyé leurs profils."
       },
       "loader": "Chargement des proportions par statut",
       "title": "Statuts"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -99,7 +99,7 @@
         "shared-profile": "Profils reçus ({count})"
       },
       "loader": "Chargement des proportions par statut",
-      "title": "Proportions par statut"
+      "title": "Statuts"
     }
   },
   "navigation": {


### PR DESCRIPTION
## :unicorn: Problème

Il n'y a pas d'explication et de description des différents statuts des participations à une campagne.
Les traductions anglaises n'ont pas été complètement réalisées.

## :robot: Solution

Ajouter une description dans une tooltip pour chaque statut affiché dans la légende et ajouter les traductions anglaises des libellés du graphique.

## :rainbow: Remarques

![image](https://user-images.githubusercontent.com/516360/122058700-2ca63c80-cdec-11eb-8aa9-376919cb0083.png)


## :100: Pour tester

Se connecter à Pix Orga avec le compte pro.admin@example.net

Aller sur une campagne d'évaluation avec cette URL : https://orga-pr3106.review.pix.fr/campagnes/1/activite

Aller sur une campagne de collecte de profil avec cette URL : https://orga-pr3106.review.pix.fr/campagnes/6/activite

Changer la langue avec le paramètre `?lang=en` dans l'URL
