### PR TITLE
[FEATURE] Recuperation des niveaux de compétence -1 (PIX-2737)

### DIFF
--- a/api/lib/domain/read-models/livret-scolaire/Certificate.js
+++ b/api/lib/domain/read-models/livret-scolaire/Certificate.js
@@ -85,8 +85,7 @@ function _isValidated(status) {
 
 function _getExtractValidatedCompetenceResults(competenceResultsJson) {
   const competenceResults = JSON
-    .parse(competenceResultsJson)
-    .map(({ competenceId, level }) => ({ competenceId, level: Math.max(0, level) }));
+    .parse(competenceResultsJson);
   return sortBy(competenceResults, 'competenceId');
 }
 

--- a/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -260,7 +260,7 @@ describe('Integration | Repository | Certification-ls ', () => {
       expect(certificationResults[0].id).to.equal(lastCertificationCourse.id);
     });
 
-    it('should return no negative competence level', async () => {
+    it('should return 0 (low level) and -1 (rejected) competence level', async () => {
       // given
       const organizationId = buildOrganization(uai).id;
       const user = buildUser();
@@ -270,7 +270,7 @@ describe('Integration | Repository | Certification-ls ', () => {
       buildValidatedPublishedCertificationData(
         {
           user, schoolingRegistration, verificationCode, pixScore, competenceMarks: [{
-            code: '1.1', level: 5,
+            code: '1.1', level: 0,
           }, {
             code: '5.2', level: -1,
           }],
@@ -280,9 +280,9 @@ describe('Integration | Repository | Certification-ls ', () => {
       await databaseBuilder.commit();
 
       const expectedCompetenceResults = [{
-        competenceId: '1.1', level: 5,
+        competenceId: '1.1', level: 0,
       }, {
-        competenceId: '5.2', level: 0,
+        competenceId: '5.2', level: -1,
       },
       ];
 


### PR DESCRIPTION
## :unicorn: Problème
Pour le livret scolaire, nous renvoyons actuellement pas de niveau négatif comme stocké en BDD. 
La valeur renvoyé est 0 au lieu de -1, cette information étant jugé interne à PIX.
Cependant, on s'est rendu compte qu'il n'était alors plus possible de différencier un niveau 0 certifié sur une compétence, d'une compétence rejeté. Cette distinction est nécessaire pour le livret scolaire (LSU/LSL)


## :robot: Solution
Renvoyer directement le niveau de compétence

## :rainbow: Remarques
Revert du commit d54d58a25805892f4e1e458acdc1a3af53f2e1b2

## :100: Pour tester
- passer une certification avec un niveau -1 sur une ou plusieurs compétence avec un profil SCO  (en passant une certification ou via pix-admin)
- récupérer les données livret scolaire via l'endpoint en fournissant l'UAI de l'organsation associé
- verifier qu'on a bien le niveau -1  
