### PR TITLE
[TECH] Documenter la configuration Sentry.

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -221,6 +221,57 @@ LOG_ENABLED=true
 # default: `false`
 # SHOULD_LOG_5XX_ERRORS=true
 
+# =================
+# Error collecting
+# =================
+
+# SENTRY_ENABLED
+# Activate error collecting by Sentry
+# presence: optional
+#
+# type: boolean (true / false)
+# default: false
+# sample: SENTRY_ENABLED=true
+# SENTRY_ENABLED=
+
+# SENTRY_DSN
+# Project-dedicated endpoint to sent collected errors
+# https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+#
+# presence: required if Sentry is enabled
+# type: SentryDsn
+# default: none
+# sample: SENTRY_DSN=https://public@sentry.example.com/1
+# SENTRY_DSN=
+
+# SENTRY_ENVIRONMENT
+# Reporting environment
+#
+# presence: optional, as a default is provided
+# type: string
+# default : development
+# sample: SENTRY_ENVIRONMENT=production
+# SENTRY_ENVIRONMENT=
+
+# SENTRY_MAX_BREADCRUMBS
+# Depth of the stack trace to collect
+#
+# presence: optional, as a default is provided
+# type: integer
+# default : 100
+# sample: SENTRY_MAX_BREADCRUMBS=500
+# SENTRY_MAX_BREADCRUMBS=
+
+# SENTRY_DEBUG
+# Enable debug mode : log details if error sending to Sentry fails
+# https://docs.sentry.io/platforms/javascript/configuration/options/#debug
+
+# presence: optional, as a default is provided
+# type: SentryDebug
+# default : false
+# sample: SENTRY_DEBUG=true
+# SENTRY_DEBUG=
+
 # ========
 # SECURITY
 # ========


### PR DESCRIPTION
## :unicorn: Problème
La configuration Sentry n'est pas documentée

## :robot: Solution
Mettre à jour le sample.env

## :100: Pour tester
Configurer l'envoi d'erreur avec Sentry sur l'environnement local et vérifier que les erreurs sont reçues dans Sentry sur cet environnement
` SENTRY_ENVIRONMENT=development`