### PR TITLE
[CLEAN] N'utiliser que deux critères de Badges au lieu de trois critères (PIX-2707).

### DIFF
--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -34,7 +34,6 @@ export default class Badge extends Component {
   scopeExplanation(criterionScope) {
     switch (criterionScope) {
       case 'SomePartnerCompetences': return 'tous les groupes d‘acquis suivants :';
-      case 'EveryPartnerCompetences': return 'l‘ensemble des groupes d‘acquis liés au badge :';
       case 'CampaignParticipation': return 'l‘ensemble des acquis du target profile.';
     }
   }

--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -33,7 +33,7 @@ export default class Badge extends Component {
 
   scopeExplanation(criterionScope) {
     switch (criterionScope) {
-      case 'SomePartnerCompetences': return 'tous les groupes d‘acquis suivants :';
+      case 'SkillSet': return 'tous les groupes d‘acquis suivants :';
       case 'CampaignParticipation': return 'l‘ensemble des acquis du target profile.';
     }
   }

--- a/api/db/migrations/20210610172018_fill_badge_partner_competence_for_critera.js
+++ b/api/db/migrations/20210610172018_fill_badge_partner_competence_for_critera.js
@@ -1,0 +1,29 @@
+const bluebird = require('bluebird');
+const _ = require('lodash');
+
+exports.up = async function(knex) {
+  const badgesAndPartnerCompetences = await knex('badges')
+    .select('badges.id as badgeId', 'badge-partner-competences.id as partnerCompetenceId')
+    .leftJoin('badge-criteria', 'badges.id', 'badge-criteria.badgeId')
+    .leftJoin('badge-partner-competences', 'badges.id', 'badge-partner-competences.badgeId')
+    .where({
+      'badge-criteria.scope': 'EveryPartnerCompetence',
+    });
+
+  let badgesWithPartnerCompetences = _.groupBy(badgesAndPartnerCompetences, 'badgeId');
+  badgesWithPartnerCompetences = _.map(badgesWithPartnerCompetences, (partnerCompetencesInfos, badgeId)=> {
+    const partnerCompetenceIds = _(partnerCompetencesInfos).map('partnerCompetenceId').filter(null).value();
+    return [badgeId, partnerCompetenceIds];
+  });
+
+  await bluebird.mapSeries(badgesWithPartnerCompetences,
+    async (badgeWithPartnerCompetences) => {
+      const badgeId = badgeWithPartnerCompetences[0];
+      const partnerCompetenceIds = badgeWithPartnerCompetences[1];
+      await knex('badge-criteria').update({ partnerCompetenceIds, scope: 'SomePartnerCompetences' }).where({ badgeId, scope: 'EveryPartnerCompetence' });
+    });
+};
+
+exports.down = function() {
+  return;
+};

--- a/api/db/migrations/20210616111928_rename-badge-criteria-scope.js
+++ b/api/db/migrations/20210616111928_rename-badge-criteria-scope.js
@@ -1,0 +1,8 @@
+
+exports.up = async function(knex) {
+  return knex('badge-criteria').update({ scope: 'SkillSet' }).where({ scope: 'SomePartnerCompetences' });
+};
+
+exports.down = function(knex) {
+  return knex('badge-criteria').update({ scope: 'SomePartnerCompetences' }).where({ scope: 'SkillSet' });
+};

--- a/api/db/seeds/data/badges-builder.js
+++ b/api/db/seeds/data/badges-builder.js
@@ -257,7 +257,7 @@ function _associateBadgeCriteria(databaseBuilder, badge, badgePartnerCompetences
   });
 
   databaseBuilder.factory.buildBadgeCriterion({
-    scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+    scope: BadgeCriterion.SCOPES.SKILL_SET,
     threshold: 75,
     badgeId: badge.id,
     partnerCompetenceIds: badgePartnerCompetencesIds,
@@ -323,19 +323,19 @@ function _associatePixDroitExpertBadgePartnerCompetences(databaseBuilder, target
 
 function _associatePixDroitMasterBadgeCriteria(databaseBuilder, badge, badgePartnerCompetencesIds) {
   databaseBuilder.factory.buildBadgeCriterion({
-    scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+    scope: BadgeCriterion.SCOPES.SKILL_SET,
     threshold: 70,
     badgeId: badge.id,
     partnerCompetenceIds: [badgePartnerCompetencesIds[0]],
   });
   databaseBuilder.factory.buildBadgeCriterion({
-    scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+    scope: BadgeCriterion.SCOPES.SKILL_SET,
     threshold: 60,
     badgeId: badge.id,
     partnerCompetenceIds: [badgePartnerCompetencesIds[1]],
   });
   databaseBuilder.factory.buildBadgeCriterion({
-    scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+    scope: BadgeCriterion.SCOPES.SKILL_SET,
     threshold: 40,
     badgeId: badge.id,
     partnerCompetenceIds: [badgePartnerCompetencesIds[2], badgePartnerCompetencesIds[3]],
@@ -344,19 +344,19 @@ function _associatePixDroitMasterBadgeCriteria(databaseBuilder, badge, badgePart
 
 function _associatePixDroitExpertBadgeCriteria(databaseBuilder, badge, badgePartnerCompetencesIds) {
   databaseBuilder.factory.buildBadgeCriterion({
-    scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+    scope: BadgeCriterion.SCOPES.SKILL_SET,
     threshold: 70,
     badgeId: badge.id,
     partnerCompetenceIds: [badgePartnerCompetencesIds[0]],
   });
   databaseBuilder.factory.buildBadgeCriterion({
-    scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+    scope: BadgeCriterion.SCOPES.SKILL_SET,
     threshold: 80,
     badgeId: badge.id,
     partnerCompetenceIds: [badgePartnerCompetencesIds[1]],
   });
   databaseBuilder.factory.buildBadgeCriterion({
-    scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+    scope: BadgeCriterion.SCOPES.SKILL_SET,
     threshold: 40,
     badgeId: badge.id,
     partnerCompetenceIds: [badgePartnerCompetencesIds[2], badgePartnerCompetencesIds[3]],

--- a/api/db/seeds/data/badges-builder.js
+++ b/api/db/seeds/data/badges-builder.js
@@ -120,7 +120,7 @@ function _createProfessionalBasicsBadge(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_ONE_COMPETENCE_ID,
   });
 
-  _associateBadgeCriteria(databaseBuilder, basicsBadge);
+  _associateBadgeCriteria(databaseBuilder, basicsBadge, []);
 }
 
 function _createProfessionalToolsBadge(databaseBuilder) {
@@ -134,7 +134,7 @@ function _createProfessionalToolsBadge(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_ONE_COMPETENCE_ID,
   });
 
-  _associateBadgeCriteria(databaseBuilder, toolsBadge);
+  _associateBadgeCriteria(databaseBuilder, toolsBadge, []);
 }
 
 function _createPixDroitBadge(databaseBuilder) {
@@ -257,7 +257,7 @@ function _associateBadgeCriteria(databaseBuilder, badge, badgePartnerCompetences
   });
 
   databaseBuilder.factory.buildBadgeCriterion({
-    scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+    scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
     threshold: 75,
     badgeId: badge.id,
     partnerCompetenceIds: badgePartnerCompetencesIds,

--- a/api/lib/domain/models/BadgeCriterion.js
+++ b/api/lib/domain/models/BadgeCriterion.js
@@ -15,7 +15,6 @@ class BadgeCriterion {
 
 BadgeCriterion.SCOPES = {
   CAMPAIGN_PARTICIPATION: 'CampaignParticipation',
-  EVERY_PARTNER_COMPETENCE: 'EveryPartnerCompetence',
   SOME_PARTNER_COMPETENCES: 'SomePartnerCompetences',
 };
 

--- a/api/lib/domain/models/BadgeCriterion.js
+++ b/api/lib/domain/models/BadgeCriterion.js
@@ -15,7 +15,7 @@ class BadgeCriterion {
 
 BadgeCriterion.SCOPES = {
   CAMPAIGN_PARTICIPATION: 'CampaignParticipation',
-  SOME_PARTNER_COMPETENCES: 'SomePartnerCompetences',
+  SKILL_SET: 'SkillSet',
 };
 
 module.exports = BadgeCriterion;

--- a/api/lib/domain/services/badge-criteria-service.js
+++ b/api/lib/domain/services/badge-criteria-service.js
@@ -33,28 +33,23 @@ function verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults,
     return false;
   }
   return _.every(badge.badgeCriteria, (criterion) => {
-    switch (criterion.scope) {
-      case BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION:
-        return masteryPercentage >= criterion.threshold;
-
-      case BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE:
-        return _.every(partnerCompetenceResults, (partnerCompetenceResult) =>
-          partnerCompetenceResult.masteryPercentage >= criterion.threshold);
-
-      case BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES:
-        return _verifySomePartnerCompetenceResultsMasteryPercentageCriterion(
-          partnerCompetenceResults,
-          criterion.threshold,
-          criterion.partnerCompetenceIds,
-        );
+    if (criterion.scope === BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION) {
+      return masteryPercentage >= criterion.threshold;
+    } else if (criterion.scope === BadgeCriterion.SCOPES.SKILL_SET) {
+      return _verifyListOfPartnerCompetenceResultsMasteryPercentageCriterion({
+        allPartnerCompetenceResults: partnerCompetenceResults,
+        threshold: criterion.threshold,
+        partnerCompetenceIds: criterion.partnerCompetenceIds,
+      });
+    } else {
+      return false;
     }
-    return false;
   });
 }
 
-function _verifySomePartnerCompetenceResultsMasteryPercentageCriterion(partnerCompetenceResults, threshold, criterionPartnerCompetenceIds) {
-  const filteredPartnerCompetenceResults = _.filter(partnerCompetenceResults,
-    (partnerCompetenceResult) => criterionPartnerCompetenceIds.includes(partnerCompetenceResult.id));
+function _verifyListOfPartnerCompetenceResultsMasteryPercentageCriterion({ allPartnerCompetenceResults, threshold, partnerCompetenceIds }) {
+  const filteredPartnerCompetenceResults = _.filter(allPartnerCompetenceResults,
+    (partnerCompetenceResult) => partnerCompetenceIds.includes(partnerCompetenceResult.id));
 
   return _.every(filteredPartnerCompetenceResults,
     (partnerCompetenceResult) => partnerCompetenceResult.masteryPercentage >= threshold);

--- a/api/lib/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer.js
@@ -1,5 +1,4 @@
 const { Serializer } = require('jsonapi-serializer');
-const BadgeCriterion = require('../../../domain/models/BadgeCriterion');
 
 const mapType = {
   badgeCriteria: 'badge-criteria',
@@ -42,15 +41,9 @@ module.exports = {
       transform(record) {
         const badge = record.badge;
         badge.badgeCriteria.forEach((badgeCriterion) => {
-          if (badgeCriterion.scope === BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE) {
-            badgeCriterion.partnerCompetences = badge.badgePartnerCompetences.map(({ id }) => {
-              return { id };
-            });
-          } else {
-            badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds?.map((partnerCompetenceId) => {
-              return { id: partnerCompetenceId };
-            });
-          }
+          badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds?.map((partnerCompetenceId) => {
+            return { id: partnerCompetenceId };
+          });
         });
         badge.badgePartnerCompetences.forEach((badgePartnerCompetence) => {
           badgePartnerCompetence.skills = badgePartnerCompetence.skillIds.map((skillId) => {

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -51,7 +51,7 @@ describe('Integration | Service | Certification-Badges Service', () => {
       const badge = databaseBuilder.factory.buildBadge({ isCertifiable: true, targetProfileId: targetProfileId });
       databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge.id });
       const badgeCriterion = databaseBuilder.factory.buildBadgeCriterion({
-        scope: 'EveryPartnerCompetence',
+        scope: 'CampaignParticipation',
         badgeId: badge.id,
         threshold: 40,
       });

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -53,7 +53,7 @@ describe('Integration | Repository | Badge', () => {
 
     badgeCriterionForBadgeWithPartnerCompetences = {
       id: 123,
-      scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+      scope: BadgeCriterion.SCOPES.SKILL_SET,
       threshold: 53,
       partnerCompetenceIds: [1, 2],
     };

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -53,9 +53,9 @@ describe('Integration | Repository | Badge', () => {
 
     badgeCriterionForBadgeWithPartnerCompetences = {
       id: 123,
-      scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+      scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
       threshold: 53,
-      partnerCompetenceIds: [],
+      partnerCompetenceIds: [1, 2],
     };
 
     databaseBuilder.factory.buildBadgeCriterion({ ...badgeCriterionForBadgeWithPartnerCompetences, badgeId: badgeWithBadgePartnerCompetences.id });
@@ -76,7 +76,7 @@ describe('Integration | Repository | Badge', () => {
     });
     badgeCriterionForBadgeWithSameTargetProfile_1 = {
       id: 456,
-      scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+      scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
       threshold: 88,
       partnerCompetenceIds: [],
     };

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -232,7 +232,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           badgeCriteria: [
             domainBuilder.buildBadgeCriterion({
               id: 17,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
             }),
           ],
@@ -282,7 +282,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             key: 'YELLOW',
             badgeCriteria: [{
               id: 17,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
               partnerCompetenceIds: [],
             }],
@@ -344,8 +344,9 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           badgeCriteria: [
             domainBuilder.buildBadgeCriterion({
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.SKILL_SET,
               threshold: 54,
+              partnerCompetenceIds: [42],
             }),
           ],
           badgePartnerCompetences: [
@@ -369,7 +370,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           badgeCriteria: [
             domainBuilder.buildBadgeCriterion({
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
             }),
           ],
@@ -413,9 +414,9 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             key: 'GREEN',
             badgeCriteria: [{
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.SKILL_SET,
               threshold: 54,
-              partnerCompetenceIds: [],
+              partnerCompetenceIds: [42],
             }],
             badgePartnerCompetences: [{
               id: 42,
@@ -444,7 +445,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             isCertifiable: false,
             badgeCriteria: [{
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
               partnerCompetenceIds: [],
             }],
@@ -489,7 +490,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           badgeCriteria: [
             domainBuilder.buildBadgeCriterion({
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
             }),
           ],
@@ -514,7 +515,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           badgeCriteria: [
             domainBuilder.buildBadgeCriterion({
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
             }),
           ],
@@ -567,7 +568,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             key: 'GREEN',
             badgeCriteria: [{
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
               partnerCompetenceIds: [],
             }],
@@ -599,7 +600,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             badgeCriteria: [
               domainBuilder.buildBadgeCriterion({
                 id: 15,
-                scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+                scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
                 threshold: 54,
                 partnerCompetenceIds: [],
               }),
@@ -658,7 +659,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           badgeCriteria: [
             domainBuilder.buildBadgeCriterion({
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
             }),
           ],
@@ -676,7 +677,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           badgeCriteria: [
             domainBuilder.buildBadgeCriterion({
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
             }),
           ],
@@ -720,7 +721,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             isCertifiable: false,
             badgeCriteria: [{
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
               partnerCompetenceIds: [],
             }],
@@ -738,7 +739,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             isCertifiable: false,
             badgeCriteria: [{
               id: 15,
-              scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
               threshold: 54,
               partnerCompetenceIds: [],
             }],

--- a/api/tests/unit/domain/services/badge-criteria-service_test.js
+++ b/api/tests/unit/domain/services/badge-criteria-service_test.js
@@ -6,7 +6,7 @@ const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement
 
 const CRITERION_THRESHOLD = {
   CAMPAIGN_PARTICIPATION: 70,
-  SOME_PARTNER_COMPETENCES: 60,
+  SKILL_SET: 60,
 };
 
 const COMPETENCE_RESULT_ID = {
@@ -32,8 +32,8 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         }),
         domainBuilder.buildBadgeCriterion({
           id: 3,
-          scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
-          threshold: CRITERION_THRESHOLD.SOME_PARTNER_COMPETENCES,
+          scope: BadgeCriterion.SCOPES.SKILL_SET,
+          threshold: CRITERION_THRESHOLD.SKILL_SET,
           partnerCompetenceIds: [COMPETENCE_RESULT_ID.SECOND],
         }),
       ];
@@ -121,13 +121,13 @@ describe('Unit | Domain | Services | badge-criteria', () => {
       });
     });
 
-    context('when the SOME_PARTNER_COMPETENCES is the only badge criterion', function() {
+    context('when the SKILL_SET is the only badge criterion', function() {
       context('when the list of partnerCompetencesIds contains one partnerCompetence', () => {
         const badgeCriteria = [
           domainBuilder.buildBadgeCriterion({
             id: 1,
-            scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
-            threshold: CRITERION_THRESHOLD.SOME_PARTNER_COMPETENCES,
+            scope: BadgeCriterion.SCOPES.SKILL_SET,
+            threshold: CRITERION_THRESHOLD.SKILL_SET,
             partnerCompetenceIds: [COMPETENCE_RESULT_ID.SECOND],
           }),
         ];
@@ -168,8 +168,8 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         const badgeCriteria = [
           domainBuilder.buildBadgeCriterion({
             id: 1,
-            scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
-            threshold: CRITERION_THRESHOLD.SOME_PARTNER_COMPETENCES,
+            scope: BadgeCriterion.SCOPES.SKILL_SET,
+            threshold: CRITERION_THRESHOLD.SKILL_SET,
             partnerCompetenceIds: [COMPETENCE_RESULT_ID.FIRST, COMPETENCE_RESULT_ID.SECOND],
           }),
         ];
@@ -301,7 +301,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
           }),
           domainBuilder.buildBadgeCriterion({
             id: 17,
-            scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+            scope: BadgeCriterion.SCOPES.SKILL_SET,
             partnerCompetenceIds: [18, 19],
             threshold: 50,
           }),

--- a/api/tests/unit/domain/services/badge-criteria-service_test.js
+++ b/api/tests/unit/domain/services/badge-criteria-service_test.js
@@ -6,7 +6,6 @@ const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement
 
 const CRITERION_THRESHOLD = {
   CAMPAIGN_PARTICIPATION: 70,
-  EVERY_PARTNER_COMPETENCE: 40,
   SOME_PARTNER_COMPETENCES: 60,
 };
 
@@ -113,48 +112,6 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         // given
         const masteryPercentage = 20;
         const partnerCompetenceResults = [];
-
-        // when
-        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
-
-        // then
-        expect(result).to.be.equal(false);
-      });
-    });
-
-    context('when the EVERY_PARTNER_COMPETENCE is the only badge criterion', function() {
-      const badgeCriteria = [
-        domainBuilder.buildBadgeCriterion({
-          id: 1,
-          scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
-          threshold: CRITERION_THRESHOLD.EVERY_PARTNER_COMPETENCE,
-        }),
-      ];
-
-      const badge = domainBuilder.buildBadge({ badgeCriteria });
-
-      it('should return true when fulfilled', async () => {
-        // given
-        const masteryPercentage = 10;
-        const partnerCompetenceResults = [
-          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 40 },
-          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 40 },
-        ];
-
-        // when
-        const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
-
-        // then
-        expect(result).to.be.equal(true);
-      });
-
-      it('should return false when not fulfilled', async () => {
-        // given
-        const masteryPercentage = 10;
-        const partnerCompetenceResults = [
-          { id: COMPETENCE_RESULT_ID.FIRST, masteryPercentage: 30 },
-          { id: COMPETENCE_RESULT_ID.SECOND, masteryPercentage: 40 },
-        ];
 
         // when
         const result = await badgeCriteriaService.verifyCriteriaFulfilment({ masteryPercentage, partnerCompetenceResults, badge });
@@ -293,7 +250,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         badgeCriteria: [
           domainBuilder.buildBadgeCriterion({
             id: 17,
-            scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
+            scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
             threshold: 54,
           }),
         ],
@@ -320,6 +277,7 @@ describe('Unit | Domain | Services | badge-criteria', () => {
       const knowledgeElements = [
         new KnowledgeElement({ skillId: 1, status: 'validated' }),
         new KnowledgeElement({ skillId: 2, status: 'validated' }),
+        new KnowledgeElement({ skillId: 4, status: 'validated' }),
         new KnowledgeElement({ skillId: 7, status: 'validated' }),
       ];
       const skills = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
@@ -338,16 +296,26 @@ describe('Unit | Domain | Services | badge-criteria', () => {
         badgeCriteria: [
           domainBuilder.buildBadgeCriterion({
             id: 17,
-            scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
-            threshold: 54,
+            scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
+            threshold: 50,
+          }),
+          domainBuilder.buildBadgeCriterion({
+            id: 17,
+            scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
+            partnerCompetenceIds: [18, 19],
+            threshold: 50,
           }),
         ],
         badgePartnerCompetences: [
           domainBuilder.buildBadgePartnerCompetence({
             id: 18,
             name: 'Yellow',
-            color: 'emerald',
-            skillIds: [1, 2, 4],
+            skillIds: [1, 2],
+          }),
+          domainBuilder.buildBadgePartnerCompetence({
+            id: 18,
+            name: 'Darken Yellow',
+            skillIds: [3, 4],
           }),
         ],
         targetProfileId: targetProfile.id,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -93,8 +93,9 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
         isCertifiable: false,
         badgeCriteria: [
           domainBuilder.buildBadgeCriterion({
-            scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
-            partnerCompetenceIds: null,
+            scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
+            threshold: 40,
+            partnerCompetenceIds: [],
           }),
         ],
       });


### PR DESCRIPTION
## :unicorn: Problème
Il existe actuellement trois critères de réussites pour les `Badges` : 
- le `CampaignParticipation` qui regarder le % de réussite sur toute la campagne, 
- l'`EveryPartnerCompetence` qui vérifie le % de réussite sur tous les `PartnerCompetences` reliés au Badges,  
- le `SomePartnerCompetences` qui vérifie le % de réussite sur une liste définie de `PartnerCompetences`.

Les deux derniers critères sont très proches (% de réussite sur chacun des `PartnerCompetences` d'une liste, celle définie ou celle du badge). Cela a pu créé de l'incompréhension et du flou lors de la création des `Badges`.

## :robot: Solution
- Ne faire qu'un seul critère `SomePartnerCompetences` (possiblement renommé `SkillSet`) qui permettrait de faire les deux 
- Faire une migration pour transformer les `EveryPartnerCompetence` en `SomePartnerCompetences` en remplissant la liste des `PartnerCompetencesIds`

## :rainbow: Remarques
Dans cette PR, je propose de commencer le renommage des `PartnerCompetences` en `SkillSet` en renommant ce critère unique en `SkillSet`

## :100: Pour tester
- Passer des campagnes avec des badges
- Créer un badge et passer les tests
- Voir l'affichage du badge coté PixOrga