### PR TITLE
[TECH] Bump ember-simple-auth de 3.0.1 à 3.1.0 dans Pix Admin (PIX-2450).

### DIFF
--- a/admin/app/adapters/application.js
+++ b/admin/app/adapters/application.js
@@ -1,10 +1,12 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import { inject as service } from '@ember/service';
 import ENV from 'pix-admin/config/environment';
 
-export default class ApplicationAdapter extends JSONAPIAdapter.extend(DataAdapterMixin) {
+export default class ApplicationAdapter extends JSONAPIAdapter {
+
   @service ajaxQueue;
+  @service session;
+
   host = ENV.APP.API_HOST;
   namespace = 'api';
 

--- a/admin/app/routes/authenticated.js
+++ b/admin/app/routes/authenticated.js
@@ -1,4 +1,11 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default class AuthenticatedRoute extends Route.extend(AuthenticatedRouteMixin) {}
+export default class AuthenticatedRoute extends Route {
+
+  @service session;
+
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'login');
+  }
+}

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -2,9 +2,8 @@ import RSVP from 'rsvp';
 
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default class CertificationCentersGetRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class CertificationCentersGetRoute extends Route {
 
   async model(params) {
     const certificationCenter = await this.store.findRecord('certification-center', params.certification_center_id);

--- a/admin/app/routes/authenticated/certification-centers/list.js
+++ b/admin/app/routes/authenticated/certification-centers/list.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class ListRoute extends Route {
 
   queryParams = {
     pageNumber: { refreshModel: true },

--- a/admin/app/routes/authenticated/organizations/list.js
+++ b/admin/app/routes/authenticated/organizations/list.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class ListRoute extends Route {
 
   queryParams = {
     pageNumber: { refreshModel: true },

--- a/admin/app/routes/authenticated/sessions/index.js
+++ b/admin/app/routes/authenticated/sessions/index.js
@@ -1,11 +1,9 @@
-/* eslint-disable ember/no-classic-classes */
-
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class AuthenticatedSessionsRoute extends Route {
 
   beforeModel() {
     this.transitionTo('authenticated.sessions.list');
-  },
+  }
 
-});
+}

--- a/admin/app/routes/authenticated/sessions/list/all.js
+++ b/admin/app/routes/authenticated/sessions/list/all.js
@@ -1,12 +1,10 @@
-/* eslint-disable ember/no-classic-classes */
-
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { FINALIZED } from 'pix-admin/models/session';
 import trim from 'lodash/trim';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-  queryParams: {
+export default class AuthenticatedSessionsAllRoute extends Route {
+
+  queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
@@ -15,7 +13,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     status: { refreshModel: true },
     resultsSentToPrescriberAt: { refreshModel: true },
     assignedToSelfOnly: { refreshModel: true },
-  },
+  };
 
   async model(params) {
     let sessions;
@@ -39,7 +37,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     }
 
     return sessions;
-  },
+  }
 
   resetController(controller, isExiting) {
     if (isExiting) {
@@ -52,5 +50,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
       controller.resultsSentToPrescriberAt = null;
       controller.assignedToSelfOnly = false;
     }
-  },
-});
+  }
+}

--- a/admin/app/routes/authenticated/target-profiles/list.js
+++ b/admin/app/routes/authenticated/target-profiles/list.js
@@ -1,9 +1,9 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import isEmpty from 'lodash/isEmpty';
 
-export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class ListRoute extends Route {
+
   @service notifications;
 
   queryParams = {

--- a/admin/app/routes/authenticated/target-profiles/new.js
+++ b/admin/app/routes/authenticated/target-profiles/new.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default class NewRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class NewRoute extends Route {
+
   model() {
     return this.store.createRecord('target-profile');
   }

--- a/admin/app/routes/authenticated/users/list.js
+++ b/admin/app/routes/authenticated/users/list.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class ListRoute extends Route {
 
   queryParams = {
     pageNumber: { refreshModel: true },

--- a/admin/app/routes/login.js
+++ b/admin/app/routes/login.js
@@ -1,5 +1,11 @@
 import Route from '@ember/routing/route';
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) {
+export default class LoginRoute extends Route {
+
+  @service session;
+
+  beforeModel() {
+    this.session.prohibitAuthentication('index');
+  }
 }

--- a/admin/app/routes/logout.js
+++ b/admin/app/routes/logout.js
@@ -1,13 +1,13 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default class LogoutRoute extends Route.extend(UnauthenticatedRouteMixin) {
+export default class LogoutRoute extends Route {
 
   @service session;
 
   beforeModel() {
-    super.beforeModel(...arguments);
+    this.session.prohibitAuthentication('index');
+
     this.session.invalidate();
     return this.transitionTo('login');
   }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -19714,9 +19714,9 @@
       }
     },
     "ember-simple-auth": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-3.0.1.tgz",
-      "integrity": "sha512-7D5s23nA5Nsonf37CyeQtksadV6Rgiz2rgCgRDnUObp3xnV71ljPtaUcZuq6kqqaZANYJi3uM8i4zVzmAHlKFQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-3.1.0.tgz",
+      "integrity": "sha512-JS8NtYAlSftkoQh36Kxps6iLHTP/InIgKt8w21QBHCTqDx07af4aka59GojaBvc+8GubQuGKldk6vvw3R8bwxA==",
       "dev": true,
       "requires": {
         "base-64": "^0.1.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -80,7 +80,7 @@
     "ember-power-select": "^4.0.5",
     "ember-qunit": "^5.1.2",
     "ember-resolver": "^8.0.2",
-    "ember-simple-auth": "^3.0.1",
+    "ember-simple-auth": "^3.1.0",
     "ember-sinon": "^5.0.0",
     "ember-source": "~3.25.1",
     "ember-test-selectors": "^5.0.0",

--- a/admin/tests/acceptance/routes-protection_test.js
+++ b/admin/tests/acceptance/routes-protection_test.js
@@ -6,83 +6,85 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { createAuthenticateSession } from '../helpers/test-init';
 
 module('Acceptance | routes protection', function(hooks) {
+
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('guest users can visit /about', async function(assert) {
-    // when
-    await visit('/about');
+  module('When route is /about', function() {
 
-    // then
-    assert.equal(currentURL(), '/about');
+    test('guest users can visit /about', async function(assert) {
+      // when
+      await visit('/about');
+
+      // then
+      assert.equal(currentURL(), '/about');
+    });
   });
 
-  //
-  // route /organizations/new
-  //
+  module('When route is /organizations/new', function() {
 
-  test('guest users are redirected to login page when visiting /organizations/new', async function(assert) {
-    // when
-    await visit('/organizations/new');
+    test('guest users are redirected to login page when visiting /organizations/new', async function(assert) {
+      // when
+      await visit('/organizations/new');
 
-    // then
-    assert.equal(currentURL(), '/login');
+      // then
+      assert.equal(currentURL(), '/login');
+    });
+
+    test('authenticated users can visit /organizations/new', async function(assert) {
+      // given
+      const user = this.server.create('user');
+      await createAuthenticateSession({ userId: user.id });
+
+      // when
+      await visit('/organizations/new');
+
+      // then
+      assert.equal(currentURL(), '/organizations/new');
+    });
   });
 
-  test('authenticated users can visit /organizations/new', async function(assert) {
-    // given
-    const user = this.server.create('user');
-    await createAuthenticateSession({ userId: user.id });
+  module('When route is /organizations/list', function() {
 
-    // when
-    await visit('/organizations/new');
+    test('guest users are redirected to login page when visiting /organizations/list', async function(assert) {
+      // when
+      await visit('/organizations/list');
 
-    // then
-    assert.equal(currentURL(), '/organizations/new');
+      // then
+      assert.equal(currentURL(), '/login');
+    });
   });
 
-  //
-  // route /organizations/list
-  //
+  module('When route is /certifications/menu', function() {
 
-  test('guest users are redirected to login page when visiting /organizations/list', async function(assert) {
-    // when
-    await visit('/organizations/list');
+    test('guest users are redirected to login page when visiting /certifications', async function(assert) {
+      // when
+      await visit('/certifications');
 
-    // then
-    assert.equal(currentURL(), '/login');
+      // then
+      assert.equal(currentURL(), '/login');
+    });
   });
 
-  //
-  // route /certifications/menu
-  //
-  test('guest users are redirected to login page when visiting /certifications', async function(assert) {
-    // when
-    await visit('/certifications');
+  module('When route is /certifications/single', function() {
 
-    // then
-    assert.equal(currentURL(), '/login');
+    test('guest users are redirected to login page when visiting /certifications/single', async function(assert) {
+      // when
+      await visit('/certifications/single');
+
+      // then
+      assert.equal(currentURL(), '/login');
+    });
   });
 
-  //
-  // route /certifications/single
-  //
-  test('guest users are redirected to login page when visiting /certifications/single', async function(assert) {
-    // when
-    await visit('/certifications/single');
+  module('When route is /sessions', function() {
 
-    // then
-    assert.equal(currentURL(), '/login');
-  });
+    test('guest users are redirected to login page when visiting /sessions', async function(assert) {
+      // when
+      await visit('/sessions');
 
-  //
-  // route /sessions
-  //
-  test('guest users are redirected to login page when visiting /sessions', async function(assert) {
-    // when
-    await visit('/sessions');
-
-    // then
-    assert.equal(currentURL(), '/login');
+      // then
+      assert.equal(currentURL(), '/login');
+    });
   });
 });

--- a/admin/tests/unit/adapters/application_test.js
+++ b/admin/tests/unit/adapters/application_test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapters | ApplicationAdapter', function(hooks) {
+module('Unit | Adapters | ApplicationAdapter', function(hooks) {
+
   setupTest(hooks);
 
   test('should specify /api as the root url', function(assert) {
@@ -40,6 +41,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
   });
 
   module('ajax()', function() {
+
     test('should queue ajax calls', function(assert) {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');

--- a/admin/tests/unit/routes/about_test.js
+++ b/admin/tests/unit/routes/about_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 module('Unit | Route | about', function(hooks) {
+
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/application_test.js
+++ b/admin/tests/unit/routes/application_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 module('Unit | Route | application', function(hooks) {
+
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated_test.js
+++ b/admin/tests/unit/routes/authenticated_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 module('Unit | Route | authenticated', function(hooks) {
+
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/index_test.js
+++ b/admin/tests/unit/routes/index_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 module('Unit | Route | index', function(hooks) {
+
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/logout_test.js
+++ b/admin/tests/unit/routes/logout_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 module('Unit | Route | logout', function(hooks) {
+
   setupTest(hooks);
 
   test('it exists', function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
* Le module Ember-Simple-Auth de nos applications fronts ne sont pas à jour
* Les mixins sont `deprecated`

## :robot: Solution
* Mettre à jour ce module, en commençant par Pix Admin

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Recette globale de Pix Admin, surtout les pages `login`, `logout`, les pages accessibles uniquement si l'utilisateur est authentifié
