### PR TITLE
[FEATURE] Modifier bouton vert de l'écran intermédiaire (PIX-2701).

### DIFF
--- a/mon-pix/app/styles/components/_focused-challenge-instructions.scss
+++ b/mon-pix/app/styles/components/_focused-challenge-instructions.scss
@@ -26,6 +26,8 @@
   }
 
   &__action {
+    display: flex;
+    justify-content: center;
     text-align: center;
   }
 }
@@ -33,15 +35,7 @@
 .focused-challenge-instructions-action {
 
   &__confirmation-button {
-    width: 234px;
-    height: 46px;
-    border-radius: 5px;
-    margin-top: 22px;
-    border: none;
-    background-color: $green-hover;
-    color: $white;
     text-transform: uppercase;
     font-size: 0.875rem;
-    cursor: pointer;
   }
 }

--- a/mon-pix/app/styles/components/_timed-challenge-instructions.scss
+++ b/mon-pix/app/styles/components/_timed-challenge-instructions.scss
@@ -37,6 +37,8 @@
   }
 
   &__action {
+    display: flex;
+    justify-content: center;
     text-align: center;
   }
 }
@@ -73,15 +75,8 @@
 .timed-challenge-instructions-action {
 
   &__confirmation-button {
-    width: 234px;
-    height: 46px;
-    border-radius: 5px;
     margin-top: 22px;
-    border: none;
-    background-color: $green-hover;
-    color: $white;
     text-transform: uppercase;
     font-size: 0.875rem;
-    cursor: pointer;
   }
 }

--- a/mon-pix/app/templates/components/focused-challenge-instructions.hbs
+++ b/mon-pix/app/templates/components/focused-challenge-instructions.hbs
@@ -9,10 +9,12 @@
 
 
   <div class="focused-challenge-instructions__action">
-    <button {{on "click" @hasUserConfirmedWarning}}
+    <PixButton {{on "click" @hasUserConfirmedWarning}}
             class="focused-challenge-instructions-action__confirmation-button"
-            type="button">
+            @shape="rounded"
+            @backgroundColor="green"
+    >
       {{t 'pages.focused-challenge-instructions.action'}}
-    </button>
+    </PixButton>
   </div>
 </div>

--- a/mon-pix/app/templates/components/timed-challenge-instructions.hbs
+++ b/mon-pix/app/templates/components/timed-challenge-instructions.hbs
@@ -18,10 +18,12 @@
   </div>
 
   <div class="timed-challenge-instructions__action">
-    <button {{on "click" @hasUserConfirmedWarning}}
+    <PixButton {{on "click" @hasUserConfirmedWarning}}
             class="timed-challenge-instructions-action__confirmation-button"
-            type="button">
+            @shape="rounded"
+            @backgroundColor="green"
+    >
       {{t 'pages.timed-challenge-instructions.action'}}
-    </button>
+    </PixButton>
   </div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Le bouton est carré alors qu'il devrait être ovale selon pix UI

## :robot: Solution
- Utiliser PixButton sur les écran intermédiaires des épreuves focus et timée

## :rainbow: Remarques
La branche part de celle des épreuves focus pour avoir accès à l'édition de son bouton.

## :100: Pour tester
Se rendre sur une épreuve timée (ex: recqBuazz0O9mhm5e) et constater que le bouton vert est maintenant rond au lieu de carré.
