### PR TITLE
[BUGFIX] Le commentaire global n'était pas pris en compte lorsqu'on calculait si une session finalisée était publiable immédiatement (PIX-2749).

### DIFF
--- a/api/lib/domain/events/AutoJuryDone.js
+++ b/api/lib/domain/events/AutoJuryDone.js
@@ -12,6 +12,6 @@ module.exports = class AutoJuryDone {
     this.certificationCenterName = certificationCenterName;
     this.sessionDate = sessionDate;
     this.sessionTime = sessionTime;
-    this.hasExaminerlobalComment = hasExaminerGlobalComment;
+    this.hasExaminerGlobalComment = hasExaminerGlobalComment;
   }
 };

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -283,7 +283,7 @@ describe('Acceptance | Controller | sessions-controller', () => {
           payload: {
             data: {
               attributes: {
-                'examiner-global-comment': examinerGlobalComment,
+                'examiner-global-comment': '',
               },
               included: [
                 {
@@ -310,7 +310,7 @@ describe('Acceptance | Controller | sessions-controller', () => {
             id: session.id.toString(),
             attributes: {
               'status': 'finalized',
-              'examiner-global-comment': examinerGlobalComment,
+              'examiner-global-comment': '',
             },
           },
         };


### PR DESCRIPTION
## :unicorn: Problème
Le commentaire global n'était pas pris en compte lorsqu'on calculait si une session finalisée était publiable immédiatement 

## :robot: Solution
Corriger la typo

## :100: Pour tester
Tester que le commentaire global est pris en compte.