### PR TITLE
[BUGFIX] Une erreur lors du re-scoring d'une certification après une finalisation de session pouvait ne pas être pris en compte dans l'évaluation de la session comme étant directement publiable ou pas (PIX-2751)

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -35,15 +35,16 @@ async function handleAutoJury({
 
   const filteredCertificationJuryDoneEvents = certificationJuryDoneEvents.filter((certificationJuryDoneEvent) => Boolean(certificationJuryDoneEvent));
 
-  return [new AutoJuryDone({
-    sessionId: event.sessionId,
-    finalizedAt: event.finalizedAt,
-    certificationCenterName: event.certificationCenterName,
-    sessionDate: event.sessionDate,
-    sessionTime: event.sessionTime,
-    hasExaminerGlobalComment: event.hasExaminerGlobalComment,
-  }),
-  ...filteredCertificationJuryDoneEvents,
+  return [
+    ...filteredCertificationJuryDoneEvents,
+    new AutoJuryDone({
+      sessionId: event.sessionId,
+      finalizedAt: event.finalizedAt,
+      certificationCenterName: event.certificationCenterName,
+      sessionDate: event.sessionDate,
+      sessionTime: event.sessionTime,
+      hasExaminerGlobalComment: event.hasExaminerGlobalComment,
+    }),
   ];
 }
 

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -71,7 +71,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
   });
 
-  it('returns an AutoJuryDone event', async () => {
+  it('returns an AutoJuryDone event as last event', async () => {
     // given
     const now = Date.now();
     const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
@@ -100,8 +100,9 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     });
 
     // then
-    expect(resultEvents[0]).to.be.an.instanceof(AutoJuryDone);
-    expect(resultEvents[0]).to.deep.equal(new AutoJuryDone({
+    const autoJuryDoneEvent = resultEvents[resultEvents.length - 1];
+    expect(autoJuryDoneEvent).to.be.an.instanceof(AutoJuryDone);
+    expect(autoJuryDoneEvent).to.deep.equal(new AutoJuryDone({
       sessionId: 1234,
       finalizedAt: now,
       hasExaminerGlobalComment: false,
@@ -111,7 +112,7 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     }));
   });
 
-  it('returns a CertificationJuryDone event', async () => {
+  it('returns a CertificationJuryDone event first in returned collection', async () => {
     // given
     const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
     const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
@@ -149,8 +150,8 @@ describe('Unit | Domain | Events | handle-auto-jury', () => {
     });
 
     // then
-    expect(events[1]).to.be.an.instanceof(CertificationJuryDone);
-    expect(events[1]).to.deep.equal(new CertificationJuryDone({
+    expect(events[0]).to.be.an.instanceof(CertificationJuryDone);
+    expect(events[0]).to.deep.equal(new CertificationJuryDone({
       certificationCourseId: certificationCourse.id,
     }));
   });


### PR DESCRIPTION
## :unicorn: Problème
Le système d'event-dispatcher prend les événements les uns après les autres, et les exécutent de façon synchrone. Donc, lorsqu'on souhaite dispatcher des events de différents types, il faut s'assurer de faire passer en premier ceux qui peuvent avoir un impact sur les suivants en priorité.

Lorsque la session est finalisée, un autojury est déclenché pour prendre en compte automatiquement les signalements d'une session. Cet autojury retourne deux types d'événements : CertificationJuryDone (lesquels provoquent un rescoring d'une certification pour prendre en compte les épreuves neutralisées) et AutoJuryDone (lequel permet de calculer si une session est publiable directement ou bien nécessite un traitement jury).
Aujourd'hui, le AutoJuryDone est dispatché **avant** les CertificationJuryDone. Ce devrait être le contraire car dans le calcul de publiabilité de la session se trouve la condition "Est-ce qu'il y a eu une erreur lors du scoring d'une certification ?".

![ici](https://user-images.githubusercontent.com/48727874/122714506-af554e80-d267-11eb-8ff0-8753be813438.png)


## :robot: Solution
Inverser l'ordre des events renvoyés par l'auto jury

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
