### PR TITLE
[FEATURE] Activer inconditionnellement la connexion PE (PIX-2752).

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -1,7 +1,6 @@
 const get = require('lodash/get');
 
-const { featureToggles } = require('../../config');
-const { BadRequestError, UnauthorizedError } = require('../http-errors');
+const { UnauthorizedError } = require('../http-errors');
 
 const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
@@ -54,9 +53,6 @@ module.exports = {
   },
 
   async authenticatePoleEmploiUser(request) {
-    if (!featureToggles.isPoleEmploiEnabled) {
-      throw new BadRequestError('This feature is not enable!');
-    }
     const authenticatedUserId = get(request.auth, 'credentials.userId');
     const {
       code,

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -136,7 +136,6 @@ module.exports = (function() {
     },
 
     featureToggles: {
-      isPoleEmploiEnabled: isFeatureEnabled(process.env.IS_POLE_EMPLOI_ENABLED),
       isScoAccountRecoveryEnabled: isFeatureEnabled(process.env.IS_SCO_ACCOUNT_RECOVERY_ENABLED),
       isNewCPFDataEnabled: isFeatureEnabled(process.env.FT_IS_NEW_CPF_DATA_ENABLED),
     },

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -22,7 +22,6 @@ const schema = Joi.object({
   LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
   AUTH_SECRET: Joi.string().required(),
-  IS_POLE_EMPLOI_ENABLED: Joi.string().optional().valid('true', 'false'),
   IS_SCO_ACCOUNT_RECOVERY_ENABLED: Joi.string().optional().valid('true', 'false'),
 }).options({ allowUnknown: true });
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -29,14 +29,6 @@
 
 IS_SCO_ACCOUNT_RECOVERY_ENABLED=false
 
-# Enable Pole Emploi authentication in Pix App
-#
-# presence: optionnal
-# type: boolean
-# default: false
-
-IS_POLE_EMPLOI_ENABLED=false
-
 # =======
 # CACHING
 # =======

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -218,7 +218,6 @@ describe('Acceptance | Controller | authentication-controller', () => {
     const externalIdentifier = 'idIdentiteExterne';
 
     beforeEach(() => {
-      sinon.stub(settings.featureToggles, 'isPoleEmploiEnabled').value(true);
 
       clock = sinon.useFakeTimers({
         now: Date.now(),

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,7 +23,6 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
         data: {
           id: '0',
           attributes: {
-            'is-pole-emploi-enabled': false,
             'is-sco-account-recovery-enabled': false,
             'is-new-cpf-data-enabled': false,
           },

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -1,11 +1,9 @@
 const { sinon, expect, catchErr, hFake } = require('../../../test-helper');
-
-const { featureToggles } = require('../../../../lib/config');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const usecases = require('../../../../lib/domain/usecases');
 const PoleEmploiTokens = require('../../../../lib/domain/models/PoleEmploiTokens');
 
-const { BadRequestError, UnauthorizedError } = require('../../../../lib/application/http-errors');
+const { UnauthorizedError } = require('../../../../lib/application/http-errors');
 
 const authenticationController = require('../../../../lib/application/authentication/authentication-controller');
 
@@ -124,7 +122,6 @@ describe('Unit | Application | Controller | Authentication', () => {
     let request;
 
     beforeEach(() => {
-      featureToggles.isPoleEmploiEnabled = true;
       request = {
         payload: {
           code,
@@ -136,20 +133,6 @@ describe('Unit | Application | Controller | Authentication', () => {
       };
 
       sinon.stub(usecases, 'authenticatePoleEmploiUser');
-    });
-
-    it('should return 400 if feature is off', async () => {
-      // given
-      usecases.authenticatePoleEmploiUser.resolves();
-      featureToggles.isPoleEmploiEnabled = false;
-      const expectedErrorMessage = 'This feature is not enable!';
-
-      // when
-      const error = await catchErr(authenticationController.authenticatePoleEmploiUser)(request, hFake);
-
-      // then
-      expect(error).to.be.an.instanceOf(BadRequestError);
-      expect(error.message).to.equal(expectedErrorMessage);
     });
 
     it('should call usecase with payload parameters', async () => {

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -23,7 +23,7 @@ export default class SigninForm extends Component {
   }
 
   get displayPoleEmploiButton() {
-    return this.url.isFrenchDomainExtension && this.featureToggles.featureToggles.isPoleEmploiEnabled;
+    return this.url.isFrenchDomainExtension;
   }
 
   @action

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -1,6 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isPoleEmploiEnabled;
   @attr('boolean') isScoAccountRecoveryEnabled;
 }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -157,7 +157,6 @@ module.exports = function(environment) {
       ENV.matomo.debug = true;
     }
 
-    ENV.APP.IS_POLE_EMPLOI_ENABLED = true;
     ENV['ember-simple-auth-oidc'].host = 'https://authentification-candidat-r.pe-qvr.fr';
     ENV['ember-simple-auth-oidc'].afterLogoutUri = 'http://localhost:8080/';
   }

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -25,15 +25,6 @@ describe('Integration | Component | signin form', function() {
 
   setupIntlRenderingTest();
 
-  beforeEach(function() {
-    const featureTogglesStub = Service.extend({
-      featureToggles: {
-        isPoleEmploiEnabled: false,
-      },
-    });
-    this.owner.register('service:featureToggles', featureTogglesStub);
-  });
-
   describe('Rendering', async function() {
 
     it('should display an input for identifiant field', async function() {
@@ -136,13 +127,7 @@ describe('Integration | Component | signin form', function() {
             return false;
           }
         }
-        const featureTogglesStub = Service.extend({
-          featureToggles: {
-            isPoleEmploiEnabled: true,
-          },
-        });
 
-        this.owner.register('service:featureToggles', featureTogglesStub);
         this.owner.register('service:url', UrlServiceStub);
 
         // when
@@ -155,9 +140,8 @@ describe('Integration | Component | signin form', function() {
 
     context('when domain is pix.fr', function() {
 
-      let linkText ;
-
-      beforeEach(function() {
+      it('should display a Pole emploi button', async function() {
+        // given
         class UrlServiceStub extends Service {
           get isFrenchDomainExtension() {
             return true;
@@ -165,25 +149,7 @@ describe('Integration | Component | signin form', function() {
         }
         this.owner.register('service:url', UrlServiceStub);
 
-        linkText = this.intl.t('pages.sign-in.pole-emploi.title');
-      });
-
-      it('should not display a Pole emploi button when Pole emploi connection is disabled', async function() {
-        // when
-        await render(hbs `<SigninForm />`);
-
-        // then
-        expect(contains(linkText)).not.exist;
-      });
-
-      it('should display a Pole emploi button when Pole emploi connection is enabled', async function() {
-        // given
-        const featureTogglesStub = Service.extend({
-          featureToggles: {
-            isPoleEmploiEnabled: true,
-          },
-        });
-        this.owner.register('service:featureToggles', featureTogglesStub);
+        const linkText = this.intl.t('pages.sign-in.pole-emploi.title');
 
         // when
         await render(hbs `<SigninForm />`);

--- a/mon-pix/tests/unit/services/feature-toggles_test.js
+++ b/mon-pix/tests/unit/services/feature-toggles_test.js
@@ -13,7 +13,6 @@ describe('Unit | Service | feature-toggles', function() {
   describe('feature toggles are loaded', function() {
 
     const featureToggles = Object.create({
-      isPoleEmploiEnabled: false,
       isScoAccountRecoveryEnabled: false,
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Le FT mis en place depuis quelques mois est devenu inutile.

## :robot: Solution
Le supprimer, c'est à dire activer inconditionellement la connexion PE

## :rainbow: Remarques
Wiki déjà mis à jour
Après déploiement, supprimer la variable d'environnmement `IS_POLE_EMPLOI_ENABLED` + restart
- intégration :heavy_check_mark: 
- recette :heavy_check_mark: 

## :100: Pour tester
Vérifier en local la connexion vers PE sur le domaine .fr (se connecter réellement)

Vérifier en RA:
- la CI
- la connexion vers PE [sur le domaine .fr](https://app-pr3123.review.pix.fr/) (affichage, pas la connexion réelle qui demande une configuration côté PE)
- le non-affichage du bouton [sur .org](https://app-pr3123.review.pix.org/connexion)