### PR TITLE
[TECH] Exposer les domaines Pix-app sur les PR/RA.

### DIFF
--- a/scripts/signal_deploy_to_pr.sh
+++ b/scripts/signal_deploy_to_pr.sh
@@ -21,7 +21,8 @@
 }
 
 PR_NUMBER=$(echo $APP | grep -Po '(?<=-pr)\d+')
-RA_APP_URL="https://app-pr$PR_NUMBER.review.pix.fr"
+RA_APP_FR_URL="https://app-pr$PR_NUMBER.review.pix.fr"
+RA_APP_ORG_URL="https://app-pr$PR_NUMBER.review.pix.org"
 RA_ORGA_URL="https://orga-pr$PR_NUMBER.review.pix.fr"
 RA_CERTIF_URL="https://certif-pr$PR_NUMBER.review.pix.fr"
 RA_ADMIN_URL="https://admin-pr$PR_NUMBER.review.pix.fr"
@@ -37,5 +38,5 @@ if [[ $existing_comments == *"${MESSAGE_PREFIX}"* ]]; then
 else
 	curl -Ssf -u $GITHUB_USER:$GITHUB_USER_TOKEN \
 		-X POST "https://api.github.com/repos/1024pix/pix/issues/${PR_NUMBER}/comments" \
-		--data "{\"body\":\"$MESSAGE_PREFIX\n\n- App: $RA_APP_URL\n- Orga: $RA_ORGA_URL\n- Certif: $RA_CERTIF_URL\n- Admin: $RA_ADMIN_URL\n- API: $RA_API_URL\n\n Please check it out!\"}"
+		--data "{\"body\":\"$MESSAGE_PREFIX\n\n- App (.fr): $RA_APP_FR_URL\n- App (.org): $RA_APP_ORG_URL\n- Orga: $RA_ORGA_URL\n- Certif: $RA_CERTIF_URL\n- Admin: $RA_ADMIN_URL\n- API: $RA_API_URL\n\n Please check it out!\"}"
 fi


### PR DESCRIPTION
## :unicorn: Problème
Depuis l'internationalisation de pix-app, il est fréquent de devoir accèder aux différents domaines en RA. Or, ceux-ci en sont pas mentionnés dans le commentaire de PR.

## :robot: Solution
Ajouter le domaine `.org`

## :rainbow: Remarques
Faut-il passer le paramètre `lang` avec `en` sur le domaine `.org `?
Faut-il l'ajouter aussi dans Jira ?

## :100: Pour tester
Consulter cette PR après déploiement
