### PR TITLE
[BUGFIX] Corriger les soucis d'affichage des boutons dans Pix App suite à une montée de version de Pix-UI

### DIFF
--- a/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
@@ -12,7 +12,11 @@
         <Input required @id="id-pix-label" @value={{this.participantExternalId}} />
       </div>
 
-      <PixButton @type="submit" class="button button--big" @triggerAction={{action this.submit}} @loading-color="white">
+      <PixButton
+        @type="submit"
+        class="button button--big fill-in-participant-external-id__button"
+        @triggerAction={{action this.submit}}
+        @loading-color="white">
           {{t 'pages.fill-in-participant-external-id.buttons.continue'}}
       </PixButton>
       {{#if this.errorMessage}}

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -43,6 +43,8 @@
   padding: 5px;
   text-align: center;
   font-family: $font-open-sans;
+  display: flex;
+  flex-direction: column;
 
   @include device-is('tablet') {
     padding: 5px 20px;
@@ -97,6 +99,7 @@
 
 .campaign-landing-page__start-button {
   margin: 30px 0;
+  align-self: center;
 
   @include device-is('tablet') {
     margin: 30px;

--- a/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
+++ b/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
@@ -69,6 +69,10 @@
   margin-right: 5px;
 }
 
+.fill-in-participant-external-id__button {
+  display: inline-block;
+}
+
 .fill-in-participant-external-id__help {
   margin-top: 32px;
 }

--- a/mon-pix/app/templates/components/campaign-start-block.hbs
+++ b/mon-pix/app/templates/components/campaign-start-block.hbs
@@ -10,24 +10,18 @@
       </div>
     {{/if}}
   </div>
-  <div class="campaign-landing-page__start__text">
-    <h1 class="campaign-landing-page__start__text__title">
-      {{@titleText}}
-    </h1>
-    <h2 class="campaign-landing-page__start__text__announcement">
-      {{{@announcementText}}}
-    </h2>
-      <PixButton
-         @type="submit"
-         class="campaign-landing-page__start-button button button--big"
-         @triggerAction={{action @startCampaignParticipation on="submit"}}
-         @loading-color='white'>
-        {{@buttonText}}
-      </PixButton>
 
-    <p class="campaign-landing-page__start__text__legal">
-      {{@legalText}}
-    </p>
+  <div class="campaign-landing-page__start__text">
+    <h1 class="campaign-landing-page__start__text__title">{{@titleText}}</h1>
+    <h2 class="campaign-landing-page__start__text__announcement">{{{@announcementText}}}</h2>
+    <PixButton
+      @type="submit"
+      class="campaign-landing-page__start-button button button--big"
+      @triggerAction={{action @startCampaignParticipation on="submit"}}
+      @loading-color='white'>
+      {{@buttonText}}
+    </PixButton>
+    <p class="campaign-landing-page__start__text__legal">{{@legalText}}</p>
   </div>
 
   {{#if @campaign.customLandingPageText}}

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -10,12 +10,15 @@ import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'ember-cli-mirage';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 const PROFILES_COLLECTION = 'PROFILES_COLLECTION';
 
 describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collection', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let campaign;
 
   beforeEach(function() {
@@ -183,7 +186,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
             await click('button[aria-label="Associer"]');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.campaign-landing.profiles-collection.action'));
             await fillIn('#id-pix-label', 'truc');
 
             // when


### PR DESCRIPTION
## :unicorn: Problème
Suite à la mise à jour de Pix-UI (https://github.com/1024pix/pix/commit/b210ad8b1d0e513c3f26fb2e22f827a405b66056#diff-be94b3f976eb5e488ce63dfc9fd8fb04140e0e66cef56163ec444c450e93de1f) , le bouton pour commencer une campagne a été décalé. Il se retrouve à gauche au lieu d'être centré.

![image](https://user-images.githubusercontent.com/38167520/122765070-68377f80-d2a0-11eb-8613-f4e150149c3c.png)


## :robot: Solution
Centrer le bouton.

## :rainbow: Remarques
D'autres endroits pourraient avoir été impacté par cette mise à jour. N'hésitez pas à signaler ces changements.

## :100: Pour tester
- lancer l'api et mon-pix
- aller sur /campagnes
- rentrer un code de parcourt (ex: SIMPLIFIE)
- constater que le bouton est de nouveau centré 
