### PR TITLE
[FEATURE] Valider les données de pays et villes saisis lors de l'inscription d'un candidat à une session de certification (PIX-2657).

### DIFF
--- a/api/db/database-builder/factory/build-certification-cpf-city.js
+++ b/api/db/database-builder/factory/build-certification-cpf-city.js
@@ -1,0 +1,23 @@
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildCertificationCpfCity({
+  id = databaseBuffer.getNextId(),
+  name = 'PARIS 19',
+  postalCode = '75019',
+  INSEECode = '75119',
+  isActualName = true,
+} = {}) {
+
+  const values = {
+    id,
+    name,
+    postalCode,
+    INSEECode,
+    isActualName,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'certification-cpf-cities',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -23,6 +23,7 @@ module.exports = {
   buildCertificationChallenge: require('./build-certification-challenge'),
   buildPartnerCertification: require('./build-partner-certification'),
   buildCertificationCourse: require('./build-certification-course'),
+  buildCertificationCpfCity: require('./build-certification-cpf-city'),
   buildCertificationIssueReport: require('./build-certification-issue-report'),
   buildCertificationReport: require('./build-certification-report'),
   buildCertificationCpfCountry: require('./build-certification-cpf-country'),

--- a/api/lib/domain/models/CertificationCpfCity.js
+++ b/api/lib/domain/models/CertificationCpfCity.js
@@ -1,0 +1,18 @@
+class CertificationCpfCity {
+
+  constructor({
+    id,
+    name,
+    postalCode,
+    INSEECode,
+    isActualName,
+  } = {}) {
+    this.id = id;
+    this.name = name;
+    this.postalCode = postalCode;
+    this.INSEECode = INSEECode;
+    this.isActualName = isActualName;
+  }
+}
+
+module.exports = CertificationCpfCity;

--- a/api/lib/domain/models/CertificationCpfCountry.js
+++ b/api/lib/domain/models/CertificationCpfCountry.js
@@ -18,6 +18,10 @@ class CertificationCpfCountry {
     return this.code === '99100';
   }
 
+  isForeign() {
+    return this.code !== '99100';
+  }
+
 }
 
 module.exports = CertificationCpfCountry;

--- a/api/lib/domain/models/CertificationCpfCountry.js
+++ b/api/lib/domain/models/CertificationCpfCountry.js
@@ -1,0 +1,23 @@
+class CertificationCpfCountry {
+
+  constructor({
+    id,
+    code,
+    commonName,
+    originalName,
+    matcher,
+  } = {}) {
+    this.id = id;
+    this.code = code;
+    this.commonName = commonName;
+    this.originalName = originalName;
+    this.matcher = matcher;
+  }
+
+  isFrance() {
+    return this.code === '99100';
+  }
+
+}
+
+module.exports = CertificationCpfCountry;

--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -1,0 +1,114 @@
+const { sanitizeAndSortChars } = require('../../infrastructure/utils/string-utils');
+const isEmpty = require('lodash/isEmpty');
+
+const CpfValidationStatus = {
+  FAILURE: 'FAILURE',
+  SUCCESS: 'SUCCESS',
+};
+
+class CpfBirthInformationValidation {
+  constructor({ message, status, countryName, INSEECode, postalCode, cityName }) {
+    this.message = message;
+    this.status = status;
+    this.countryName = countryName;
+    this.INSEECode = INSEECode;
+    this.postalCode = postalCode;
+    this.cityName = cityName;
+  }
+
+  static failure(message) {
+    return new CpfBirthInformationValidation({ message, status: CpfValidationStatus.FAILURE });
+  }
+
+  static success({ countryName, INSEECode, postalCode, cityName }) {
+    return new CpfBirthInformationValidation({ countryName, INSEECode, postalCode, cityName, status: CpfValidationStatus.SUCCESS });
+  }
+
+  hasFailed() {
+    return this.status === CpfValidationStatus.FAILURE;
+  }
+}
+
+async function getBirthInformation({
+  countryName,
+  cityName,
+  postalCode,
+  INSEECode,
+  certificationCpfCountryRepository,
+  certificationCpfCityRepository,
+}) {
+  if (!countryName) {
+    return CpfBirthInformationValidation.failure('Le champ pays est obligatoire.');
+  }
+
+  const matcher = sanitizeAndSortChars(countryName);
+  const country = await certificationCpfCountryRepository.getByMatcher({ matcher });
+
+  if (!country) {
+    return CpfBirthInformationValidation.failure(`Le pays ${countryName} n'a pas été trouvé.`);
+  }
+
+  if (!INSEECode && !postalCode) {
+    return CpfBirthInformationValidation.failure('Le champ code postal ou code INSEE doit être renseigné.');
+  }
+
+  if (country.isForeign()) {
+    if (!cityName) {
+      return CpfBirthInformationValidation.failure('Le champ ville est obligatoire.');
+    }
+
+    return CpfBirthInformationValidation.success({
+      countryName: country.commonName,
+      INSEECode: country.code,
+      postalCode: null,
+      cityName,
+    });
+  }
+
+  if (INSEECode) {
+    const cities = await certificationCpfCityRepository.findByINSEECode({ INSEECode });
+
+    if (isEmpty(cities)) {
+      return CpfBirthInformationValidation.failure(`Le code INSEE ${INSEECode} n'est pas valide.`);
+    }
+
+    return CpfBirthInformationValidation.success({
+      countryName: country.commonName,
+      INSEECode,
+      postalCode: null,
+      cityName: _getActualCityName(cities),
+    });
+  }
+
+  if (postalCode) {
+    const cities = await certificationCpfCityRepository.findByPostalCode({ postalCode });
+
+    if (isEmpty(cities)) {
+      return CpfBirthInformationValidation.failure(`Le code postal ${postalCode} n'est pas valide.`);
+    }
+
+    const sanitizedCityName = sanitizeAndSortChars(cityName);
+    const doesCityMatchPostalCode = cities.some((city) => sanitizeAndSortChars(city.name) === sanitizedCityName);
+
+    if (!doesCityMatchPostalCode) {
+      return CpfBirthInformationValidation.failure(`Le code postal ${postalCode} ne correspond pas à la ville ${cityName}`);
+    }
+
+    return CpfBirthInformationValidation.success({
+      countryName: country.commonName,
+      INSEECode: null,
+      postalCode,
+      cityName: _getActualCityName(cities),
+    });
+  }
+}
+
+function _getActualCityName(cities) {
+  const actualCity = cities.find((city) => city.isActualName);
+  return actualCity.name;
+}
+
+module.exports = {
+  getBirthInformation,
+  CpfBirthInformationValidation,
+};

--- a/api/lib/infrastructure/repositories/certification-cpf-city-repository.js
+++ b/api/lib/infrastructure/repositories/certification-cpf-city-repository.js
@@ -1,0 +1,23 @@
+const { knex } = require('../bookshelf');
+const CertificationCpfCity = require('../../domain/models/CertificationCpfCity');
+
+module.exports = {
+
+  async findByINSEECode({ INSEECode }) {
+    const COLUMNS = [
+      'id',
+      'name',
+      'postalCode',
+      'INSEECode',
+      'isActualName',
+    ];
+
+    const result = await knex
+      .select(COLUMNS)
+      .from('certification-cpf-cities')
+      .where({ INSEECode })
+      .orderBy('isActualName', 'desc');
+
+    return result.map((city) => new CertificationCpfCity(city));
+  },
+};

--- a/api/lib/infrastructure/repositories/certification-cpf-city-repository.js
+++ b/api/lib/infrastructure/repositories/certification-cpf-city-repository.js
@@ -1,22 +1,35 @@
 const { knex } = require('../bookshelf');
 const CertificationCpfCity = require('../../domain/models/CertificationCpfCity');
 
+const COLUMNS = [
+  'id',
+  'name',
+  'postalCode',
+  'INSEECode',
+  'isActualName',
+];
+
 module.exports = {
 
   async findByINSEECode({ INSEECode }) {
-    const COLUMNS = [
-      'id',
-      'name',
-      'postalCode',
-      'INSEECode',
-      'isActualName',
-    ];
 
     const result = await knex
       .select(COLUMNS)
       .from('certification-cpf-cities')
       .where({ INSEECode })
-      .orderBy('isActualName', 'desc');
+      .orderBy('isActualName', 'desc')
+      .orderBy('id');
+
+    return result.map((city) => new CertificationCpfCity(city));
+  },
+
+  async findByPostalCode({ postalCode }) {
+    const result = await knex
+      .select(COLUMNS)
+      .from('certification-cpf-cities')
+      .where({ postalCode })
+      .orderBy('isActualName', 'desc')
+      .orderBy('id');
 
     return result.map((city) => new CertificationCpfCity(city));
   },

--- a/api/lib/infrastructure/repositories/certification-cpf-country-repository.js
+++ b/api/lib/infrastructure/repositories/certification-cpf-country-repository.js
@@ -4,14 +4,16 @@ const CertificationCpfCountry = require('../../domain/models/CertificationCpfCou
 module.exports = {
 
   async getByMatcher({ matcher }) {
+    const COLUMNS = [
+      'id',
+      'code',
+      'commonName',
+      'originalName',
+      'matcher',
+    ];
+
     const result = await knex
-      .select(
-        'id',
-        'code',
-        'commonName',
-        'originalName',
-        'matcher',
-      )
+      .select(COLUMNS)
       .from('certification-cpf-countries')
       .where({ matcher })
       .first();

--- a/api/lib/infrastructure/repositories/certification-cpf-country-repository.js
+++ b/api/lib/infrastructure/repositories/certification-cpf-country-repository.js
@@ -1,0 +1,25 @@
+const { knex } = require('../bookshelf');
+const CertificationCpfCountry = require('../../domain/models/CertificationCpfCountry');
+
+module.exports = {
+
+  async getByMatcher({ matcher }) {
+    const result = await knex
+      .select(
+        'id',
+        'code',
+        'commonName',
+        'originalName',
+        'matcher',
+      )
+      .from('certification-cpf-countries')
+      .where({ matcher })
+      .first();
+
+    if (!result) {
+      return null;
+    }
+
+    return new CertificationCpfCountry(result);
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/certification-cpf-city-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-cpf-city-repository_test.js
@@ -1,0 +1,57 @@
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
+const certificationCpfCityRepository = require('../../../../lib/infrastructure/repositories/certification-cpf-city-repository');
+const CertificationCpfCity = require('../../../../lib/domain/models/CertificationCpfCity');
+
+describe('Integration | Repository | certificationCpfCityRepository', () => {
+
+  describe('#findByINSEECode', () => {
+
+    context('when there are cities matching the INSEE code', () => {
+
+      it('should return an array of certificationCPFCity', async () => {
+        // given
+        const INSEECode = '12345';
+
+        const actualCity = domainBuilder.buildCertificationCpfCity({
+          id: 1,
+          INSEECode,
+          name: 'ACTUAL NAME',
+          postalCode: '56789',
+          isActualName: true,
+        });
+
+        const oldCity = domainBuilder.buildCertificationCpfCity({
+          id: 2,
+          INSEECode,
+          name: 'OLD NAME',
+          postalCode: '56789',
+          isActualName: false,
+        });
+
+        databaseBuilder.factory.buildCertificationCpfCity(actualCity);
+        databaseBuilder.factory.buildCertificationCpfCity(oldCity);
+        await databaseBuilder.commit();
+
+        // when
+        const result = await certificationCpfCityRepository.findByINSEECode({ INSEECode });
+
+        // then
+        expect(result).to.be.an.instanceOf(Array);
+        expect(result[0]).to.be.an.instanceOf(CertificationCpfCity);
+        expect(result).to.deep.equal([actualCity, oldCity]);
+      });
+    });
+
+    context('when there is no city matching the INSEE code', () => {
+
+      it('should return an empty array', async () => {
+        // when
+        const result = await certificationCpfCityRepository.findByINSEECode({ INSEECode: 'unknown_INSEE_code' });
+
+        // then
+        expect(result).to.be.an.instanceOf(Array);
+        expect(result).to.have.lengthOf(0);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/certification-cpf-city-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-cpf-city-repository_test.js
@@ -12,24 +12,33 @@ describe('Integration | Repository | certificationCpfCityRepository', () => {
         // given
         const INSEECode = '12345';
 
-        const actualCity = domainBuilder.buildCertificationCpfCity({
+        const olderCity = domainBuilder.buildCertificationCpfCity({
           id: 1,
+          postalCode: '12345',
           INSEECode,
-          name: 'ACTUAL NAME',
-          postalCode: '56789',
-          isActualName: true,
+          name: 'OLDER NAME',
+          isActualName: false,
         });
 
         const oldCity = domainBuilder.buildCertificationCpfCity({
           id: 2,
+          postalCode: '12345',
           INSEECode,
           name: 'OLD NAME',
-          postalCode: '56789',
           isActualName: false,
+        });
+
+        const actualCity = domainBuilder.buildCertificationCpfCity({
+          id: 3,
+          postalCode: '12345',
+          INSEECode,
+          name: 'ACTUAL NAME',
+          isActualName: true,
         });
 
         databaseBuilder.factory.buildCertificationCpfCity(actualCity);
         databaseBuilder.factory.buildCertificationCpfCity(oldCity);
+        databaseBuilder.factory.buildCertificationCpfCity(olderCity);
         await databaseBuilder.commit();
 
         // when
@@ -38,7 +47,7 @@ describe('Integration | Repository | certificationCpfCityRepository', () => {
         // then
         expect(result).to.be.an.instanceOf(Array);
         expect(result[0]).to.be.an.instanceOf(CertificationCpfCity);
-        expect(result).to.deep.equal([actualCity, oldCity]);
+        expect(result).to.deep.equal([actualCity, olderCity, oldCity]);
       });
     });
 
@@ -54,4 +63,65 @@ describe('Integration | Repository | certificationCpfCityRepository', () => {
       });
     });
   });
+
+  describe('#findByPostalCode', () => {
+
+    context('when there are cities matching the postal code', () => {
+
+      it('should return an array of certificationCpfCity', async () => {
+        // given
+        const postalCode = '12345';
+
+        const olderCity = domainBuilder.buildCertificationCpfCity({
+          id: 1,
+          postalCode,
+          INSEECode: '56789',
+          name: 'OLDER NAME',
+          isActualName: false,
+        });
+
+        const oldCity = domainBuilder.buildCertificationCpfCity({
+          id: 2,
+          postalCode,
+          INSEECode: '56789',
+          name: 'OLD NAME',
+          isActualName: false,
+        });
+
+        const actualCity = domainBuilder.buildCertificationCpfCity({
+          id: 3,
+          postalCode,
+          INSEECode: '56789',
+          name: 'ACTUAL NAME',
+          isActualName: true,
+        });
+
+        databaseBuilder.factory.buildCertificationCpfCity(actualCity);
+        databaseBuilder.factory.buildCertificationCpfCity(oldCity);
+        databaseBuilder.factory.buildCertificationCpfCity(olderCity);
+        await databaseBuilder.commit();
+
+        // when
+        const result = await certificationCpfCityRepository.findByPostalCode({ postalCode });
+
+        // then
+        expect(result).to.be.an.instanceOf(Array);
+        expect(result[0]).to.be.an.instanceOf(CertificationCpfCity);
+        expect(result).to.deep.equal([actualCity, olderCity, oldCity]);
+      });
+    });
+
+    context('when there is no city matching the postal code', () => {
+
+      it('should return an empty array', async () => {
+        // when
+        const result = await certificationCpfCityRepository.findByPostalCode({ postalCode: 'unknown_postal_code' });
+
+        // then
+        expect(result).to.be.an.instanceOf(Array);
+        expect(result).to.have.lengthOf(0);
+      });
+    });
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/certification-cpf-country-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-cpf-country-repository_test.js
@@ -1,5 +1,6 @@
 const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const certificationCpfCountryRepository = require('../../../../lib/infrastructure/repositories/certification-cpf-country-repository');
+const CertificationCpfCountry = require('../../../../lib/domain/models/CertificationCpfCountry');
 
 describe('Integration | Repository | certificationCpfCountryRepository', () => {
 
@@ -24,6 +25,7 @@ describe('Integration | Repository | certificationCpfCountryRepository', () => {
 
         // then
         expect(result).to.deep.equal(country);
+        expect(result).to.be.instanceOf(CertificationCpfCountry);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/certification-cpf-country-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-cpf-country-repository_test.js
@@ -1,0 +1,41 @@
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
+const certificationCpfCountryRepository = require('../../../../lib/infrastructure/repositories/certification-cpf-country-repository');
+
+describe('Integration | Repository | certificationCpfCountryRepository', () => {
+
+  describe('#getByMatcher', () => {
+
+    context('when the country exists', () => {
+
+      it('should return the country', async () => {
+        // given
+        const country = domainBuilder.buildCertificationCpfCountry({
+          id: 1,
+          code: '99100',
+          commonName: 'FRANCE',
+          originalName: 'FRANCE',
+          matcher: 'ACEFNR',
+        });
+        databaseBuilder.factory.buildCertificationCpfCountry(country);
+        await databaseBuilder.commit();
+
+        // when
+        const result = await certificationCpfCountryRepository.getByMatcher({ matcher: country.matcher });
+
+        // then
+        expect(result).to.deep.equal(country);
+      });
+    });
+
+    context('when the country does not exist', () => {
+
+      it('should return null', async () => {
+        // when
+        const result = await certificationCpfCountryRepository.getByMatcher({ matcher: 'unknown_matcher' });
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-certification-cpf-city.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-cpf-city.js
@@ -1,0 +1,19 @@
+const CertificationCpfCity = require('../../../../lib/domain/models/CertificationCpfCity');
+
+function buildCertificationCpfCity({
+  id = 123,
+  name = 'PARIS 19',
+  postalCode = '75019',
+  INSEECode = '75119',
+  isActualName = true,
+} = {}) {
+  return new CertificationCpfCity({
+    id,
+    name,
+    postalCode,
+    INSEECode,
+    isActualName,
+  });
+}
+
+module.exports = buildCertificationCpfCity;

--- a/api/tests/tooling/domain-builder/factory/build-certification-cpf-country.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-cpf-country.js
@@ -1,0 +1,35 @@
+const CertificationCpfCountry = require('../../../../lib/domain/models/CertificationCpfCountry');
+
+function buildCertificationCpfCountry({
+  id = 123,
+  code = '99139',
+  commonName = 'PORTUGAL',
+  originalName = 'PORTUGAL',
+  matcher = 'AGLOPRTU',
+} = {}) {
+  return new CertificationCpfCountry({
+    id,
+    code,
+    commonName,
+    originalName,
+    matcher,
+  });
+}
+
+buildCertificationCpfCountry.FRANCE = function({
+  id = 123,
+  code = '99100',
+  commonName = 'FRANCE',
+  originalName = 'FRANCE',
+  matcher = 'ACEFNR',
+} = {}) {
+  return new CertificationCpfCountry({
+    id,
+    code,
+    commonName,
+    originalName,
+    matcher,
+  });
+};
+
+module.exports = buildCertificationCpfCountry;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -31,6 +31,7 @@ module.exports = {
   buildCertificationChallengeWithType: require('./build-certification-challenge-with-type'),
   buildCertificationCourse: require('./build-certification-course'),
   buildCountry: require('./build-country'),
+  buildCertificationCpfCity: require('./build-certification-cpf-city'),
   buildCertificationCpfCountry: require('./build-certification-cpf-country'),
   buildCertificationDetails: require('./build-certification-details'),
   buildCertificationPointOfContact: require('./build-certification-point-of-contact'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -31,6 +31,7 @@ module.exports = {
   buildCertificationChallengeWithType: require('./build-certification-challenge-with-type'),
   buildCertificationCourse: require('./build-certification-course'),
   buildCountry: require('./build-country'),
+  buildCertificationCpfCountry: require('./build-certification-cpf-country'),
   buildCertificationDetails: require('./build-certification-details'),
   buildCertificationPointOfContact: require('./build-certification-point-of-contact'),
   buildCertifiableProfileForLearningContent: require('./build-certifiable-profile-for-learning-content'),

--- a/api/tests/unit/domain/services/certification-cpf-service_test.js
+++ b/api/tests/unit/domain/services/certification-cpf-service_test.js
@@ -1,0 +1,342 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { CpfBirthInformationValidation, getBirthInformation } = require('../../../../lib/domain/services/certification-cpf-service');
+
+describe('Unit | Service | Certification CPF service', () => {
+
+  let certificationCpfCountryRepository;
+  let certificationCpfCityRepository;
+
+  beforeEach(() => {
+    certificationCpfCountryRepository = {
+      getByMatcher: sinon.stub(),
+    };
+    certificationCpfCityRepository = {
+      findByINSEECode: sinon.stub(),
+      findByPostalCode: sinon.stub(),
+    };
+  });
+
+  describe('#getBirthInformation', () => {
+
+    context('when country name is not defined', () => {
+
+      it('should return a validation failure', async () => {
+        // when
+        const result = await getBirthInformation({
+          countryName: null,
+          cityName: 'GOTHAM CITY',
+          postalCode: '12345',
+          INSEECode: '12345',
+          certificationCpfCountryRepository,
+          certificationCpfCityRepository,
+        });
+
+        // then
+        expect(result).to.deep.equal(CpfBirthInformationValidation.failure('Le champ pays est obligatoire.'));
+      });
+    });
+
+    context('when country does not exist', () => {
+
+      it('should return a validation failure', async () => {
+        // given
+        const countryName = 'ABCD';
+        const cityName = 'GOTHAM CITY';
+        const postalCode = null;
+        const INSEECode = '12345';
+
+        certificationCpfCountryRepository.getByMatcher.resolves(null);
+
+        // when
+        const result = await getBirthInformation({
+          countryName,
+          cityName,
+          postalCode,
+          INSEECode,
+          certificationCpfCountryRepository,
+          certificationCpfCityRepository,
+        });
+
+        // then
+        expect(result).to.deep.equal(CpfBirthInformationValidation.failure(`Le pays ${countryName} n'a pas été trouvé.`));
+      });
+    });
+
+    context('when country exists', () => {
+
+      context('when country is not FRANCE', () => {
+
+        it('should return a validation failure when city name is not defined', async() => {
+          // given
+          const countryName = 'PORTUGAL';
+          const cityName = null;
+          const postalCode = null;
+          const INSEECode = '99';
+
+          const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry({ code: '1234', name: 'PORTUGAL' });
+
+          certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'AGLOPRTU' }).resolves(certificationCPFCountry);
+
+          // when
+          const result = await getBirthInformation({
+            countryName,
+            cityName,
+            postalCode,
+            INSEECode,
+            certificationCpfCountryRepository,
+            certificationCpfCityRepository,
+          });
+
+          // then
+          expect(result).to.deep.equal(CpfBirthInformationValidation.failure('Le champ ville est obligatoire.'));
+        });
+
+        it('should return a validation failure when Insee code is not defined', async() => {
+          // given
+          const countryName = 'PORTUGAL';
+          const cityName = 'Porto';
+          const postalCode = null;
+          const INSEECode = null;
+
+          const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry({ code: '1234', name: 'PORTUGAL' });
+
+          certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'AGLOPRTU' }).resolves(certificationCPFCountry);
+
+          // when
+          const result = await getBirthInformation({
+            countryName,
+            cityName,
+            postalCode,
+            INSEECode,
+            certificationCpfCountryRepository,
+            certificationCpfCityRepository,
+          });
+
+          // then
+          expect(result).to.deep.equal(CpfBirthInformationValidation.failure('Le champ code postal ou code INSEE doit être renseigné.'));
+        });
+
+        it('should return birth information when city name is defined', async() => {
+          // given
+          const countryName = 'PORTUGAL';
+          const cityName = 'Porto';
+          const postalCode = null;
+          const INSEECode = '99';
+
+          const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry({ code: '1234', name: 'PORTUGAL' });
+
+          certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'AGLOPRTU' }).resolves(certificationCPFCountry);
+
+          // when
+          const result = await getBirthInformation({
+            countryName,
+            cityName,
+            postalCode,
+            INSEECode,
+            certificationCpfCountryRepository,
+            certificationCpfCityRepository,
+          });
+
+          // then
+          expect(result).to.deep.equal(CpfBirthInformationValidation.success({
+            countryName: 'PORTUGAL',
+            INSEECode: '1234',
+            postalCode: null,
+            cityName: 'Porto',
+          }));
+        });
+      });
+
+      context('when country is FRANCE', () => {
+
+        context('when postal code and INSEE code are not defined', async () => {
+
+          it('should return a validation failure', async () => {
+            // given
+            const countryName = 'FRANCE';
+            const cityName = null;
+            const postalCode = null;
+            const INSEECode = null;
+
+            const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+            certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'ACEFNR' }).resolves(certificationCPFCountry);
+
+            // when
+            const result = await getBirthInformation({
+              countryName,
+              cityName,
+              postalCode,
+              INSEECode,
+              certificationCpfCountryRepository,
+              certificationCpfCityRepository,
+            });
+
+            // then
+            expect(result).to.deep.equal(CpfBirthInformationValidation.failure('Le champ code postal ou code INSEE doit être renseigné.'));
+          });
+        });
+
+        context('when INSEE code is provided', () => {
+
+          it('should return birth information when INSEE code is valid', async () => {
+            // given
+            const countryName = 'FRANCE';
+            const cityName = 'GOTHAM CITY';
+            const postalCode = null;
+            const INSEECode = '12345';
+
+            const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+            const certificationCPFCity = domainBuilder.buildCertificationCpfCity({
+              INSEECode,
+              name: 'GOTHAM CITY',
+            });
+
+            certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'ACEFNR' }).resolves(certificationCPFCountry);
+            certificationCpfCityRepository.findByINSEECode.resolves([certificationCPFCity]);
+
+            // when
+            const result = await getBirthInformation({
+              countryName,
+              cityName,
+              postalCode,
+              INSEECode,
+              certificationCpfCountryRepository,
+              certificationCpfCityRepository,
+            });
+
+            // then
+            expect(result).to.deep.equal(CpfBirthInformationValidation.success({
+              countryName: 'FRANCE',
+              INSEECode: '12345',
+              postalCode: null,
+              cityName: 'GOTHAM CITY',
+            }));
+            expect(certificationCpfCityRepository.findByINSEECode).to.have.been.calledWith({ INSEECode });
+          });
+
+          it('should return a validation failure when INSEE code is not valid', async () => {
+            // given
+            const countryName = 'FRANCE';
+            const cityName = 'GOTHAM CITY';
+            const postalCode = null;
+            const INSEECode = '12345';
+
+            const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+
+            certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'ACEFNR' }).resolves(certificationCPFCountry);
+            certificationCpfCityRepository.findByINSEECode.resolves([]);
+
+            // when
+            const result = await getBirthInformation({
+              countryName,
+              cityName,
+              postalCode,
+              INSEECode,
+              certificationCpfCountryRepository,
+              certificationCpfCityRepository,
+            });
+
+            // then
+            expect(result).to.deep.equal(CpfBirthInformationValidation.failure(`Le code INSEE ${INSEECode} n'est pas valide.`));
+          });
+        });
+
+        context('when postal code is provided', () => {
+
+          it('should return birth information when postal code is valid', async () => {
+            // given
+            const countryName = 'FRANCE';
+            const cityName = 'GOTHAM CITY';
+            const postalCode = '12345';
+            const INSEECode = null;
+
+            const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+            const certificationCPFCity = domainBuilder.buildCertificationCpfCity({
+              postalCode,
+              name: 'GOTHAM CITY',
+            });
+
+            certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'ACEFNR' }).resolves(certificationCPFCountry);
+            certificationCpfCityRepository.findByPostalCode.resolves([certificationCPFCity]);
+
+            // when
+            const result = await getBirthInformation({
+              countryName,
+              cityName,
+              postalCode,
+              INSEECode,
+              certificationCpfCountryRepository,
+              certificationCpfCityRepository,
+            });
+
+            // then
+            expect(result).to.deep.equal(CpfBirthInformationValidation.success({
+              countryName: 'FRANCE',
+              INSEECode: null,
+              postalCode: '12345',
+              cityName: 'GOTHAM CITY',
+            }));
+            expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWith({ postalCode });
+          });
+
+          it('should return a validation failure when postal code is not valid', async () => {
+            // given
+            const countryName = 'FRANCE';
+            const cityName = 'GOTHAM CITY';
+            const postalCode = '12345';
+            const INSEECode = null;
+
+            const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+
+            certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'ACEFNR' }).resolves(certificationCPFCountry);
+            certificationCpfCityRepository.findByPostalCode.resolves([]);
+
+            // when
+            const result = await getBirthInformation({
+              countryName,
+              cityName,
+              postalCode,
+              INSEECode,
+              certificationCpfCountryRepository,
+              certificationCpfCityRepository,
+            });
+
+            // then
+            expect(result).to.deep.equal(CpfBirthInformationValidation.failure(`Le code postal ${postalCode} n'est pas valide.`));
+          });
+
+          it('should return a validation failure when postal code does not match city name', async () => {
+            // given
+            const countryName = 'FRANCE';
+            const cityName = 'METROPOLIS';
+            const postalCode = '12345';
+            const INSEECode = null;
+
+            const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+
+            const certificationCPFCity = domainBuilder.buildCertificationCpfCity({
+              postalCode,
+              name: 'GOTHAM CITY',
+            });
+
+            certificationCpfCountryRepository.getByMatcher.withArgs({ matcher: 'ACEFNR' }).resolves(certificationCPFCountry);
+            certificationCpfCityRepository.findByPostalCode.resolves([certificationCPFCity]);
+
+            // when
+            const result = await getBirthInformation({
+              countryName,
+              cityName,
+              postalCode,
+              INSEECode,
+              certificationCpfCountryRepository,
+              certificationCpfCityRepository,
+            });
+
+            // then
+            expect(result).to.deep.equal(CpfBirthInformationValidation.failure(`Le code postal ${postalCode} ne correspond pas à la ville ${cityName}`));
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l’accrochage Mon Compte Formation, des infos perso des candidats à la certification Pix sont nécessaires. Parmi ces infos, non devons communiquer un code du pays et de la commune de naissance qui doivent être vérifiés. Nous avons, dans une PR précédente, importé les pays et leur code INSEE ainsi que les villes françaises et leur code postal et INSEE. Cette PR à pour but la mise en place d'un service de vérification de validité des données pays et ville saisis. 

## :robot: Solution
Ajouter un service permettant de valider les données pays de naissance et commune de naissance saisis pour chacun des candidats à une session de certification. Les vérifications se déroulent ainsi:
- Si pays étranger:
    -  vérifier l'existence du pays saisi
- Si France:
    - Si commune de naissance définie par son code INSEE:
        - vérifier l'existence d'au moins une ville possédant ce code INSEE
    - Si commune de naissance définie par son code postal:
        - vérifier l'existence d'au moins une ville possédant ce code postal
        - vérification de l'égalité entre la commune de naissance saisie et l'une des villes de la liste