### PR TITLE
[FEATURE][A11Y] Rendre accessible la liste des campagnes sur Pix Orga (PIX-2633)

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/list.hbs
@@ -43,8 +43,14 @@
 
         <tbody>
         {{#each @campaigns as |campaign|}}
-          <tr aria-label={{t 'pages.campaigns-list.table.row-title'}} role="button" {{on 'click' (fn @goToCampaignPage campaign.id)}} class="tr--clickable">
-            <td>{{campaign.name}}</td>
+          <tr aria-label={{t 'pages.campaigns-list.table.row-title'}} {{on 'click' (fn @goToCampaignPage campaign.id)}} class="tr--clickable">
+            <td class="table__column table__column--no-padding">
+              <LinkTo @route="authenticated.campaigns.campaign"
+                      @model={{campaign}} 
+                      class="campaign-list__link">
+                {{campaign.name}}
+              </LinkTo>
+            </td>
             <td class="table__column--truncated">{{campaign.creatorFullName}}</td>
             <td>{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
             <td>{{campaign.participationsCount}}</td>

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -55,7 +55,8 @@ export default class ListController extends Controller {
   }
 
   @action
-  goToCampaignPage(campaignId) {
+  goToCampaignPage(campaignId, event) {
+    event.preventDefault();
     this.transitionToRoute('authenticated.campaigns.campaign', campaignId);
   }
 }

--- a/orga/app/styles/components/campaign-list.scss
+++ b/orga/app/styles/components/campaign-list.scss
@@ -2,6 +2,13 @@
   display: flex;
   flex-direction: column;
 
+  &__link {
+    color: $grey-80;
+    display: block;
+    padding: 20px 24px;
+    text-decoration: none;
+  }
+
   &__item {
     // position
     margin-bottom: 18px;

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -41,6 +41,12 @@ thead {
 tbody {
   color: $grey-60;
 
+  tr {
+    &:focus-within, &:hover {
+      background-color: $grey-15;
+    }
+  }
+
   tr.tr--clickable {
     cursor: pointer;
 
@@ -77,6 +83,10 @@ th::first-letter {
 
 .table__column {
   width: 16%;
+  
+  &--no-padding {
+    padding: 0;
+  }
 
   &--center {
     text-align: center;

--- a/orga/tests/integration/components/routes/authenticated/campaign/list_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/list_test.js
@@ -7,8 +7,8 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    this.set('goToCampaignPageSpy', () => {});
     this.set('triggerFilteringSpy', () => {});
+    this.set('goToCampaignPageSpy', () => {});
   });
 
   module('When there are no campaigns to display', function() {
@@ -21,8 +21,8 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
                   @campaigns={{campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
-                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+                  @triggerFiltering={{this.triggerFilteringSpy}} 
+@goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
       // then
       assert.contains('Aucune campagne');
@@ -44,17 +44,45 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
                   @campaigns={{this.campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
-                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+                  @triggerFiltering={{this.triggerFilteringSpy}} 
+@goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
       // then
       assert.notContains('Aucune campagne');
       assert.dom('[aria-label="Campagne"]').exists({ count: 2 });
     });
 
+    test('it should display a link to access campaign detail', async function(assert) {
+      // given
+      this.owner.setupRouter();
+
+      const store = this.owner.lookup('service:store');
+      const campaign1 = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+      });
+
+      const campaigns = [campaign1];
+      campaigns.meta = {
+        rowCount: 2,
+      };
+      this.set('campaigns', campaigns);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::List
+                  @campaigns={{this.campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}} 
+@goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+
+      // then
+      assert.dom('a[href="/campagnes/1"]').exists();
+    });
+
     test('it should display the name of the campaigns', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
+
       const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
@@ -62,7 +90,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       });
       const campaign2 = store.createRecord('campaign', {
         id: 2,
-        name: 'campagne 1',
+        name: 'campagne 2',
         code: 'BBBBBB222',
       });
       const campaigns = [campaign1, campaign2];
@@ -76,9 +104,9 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
                   @campaigns={{campaigns}}
                   @triggerFiltering={{this.triggerFilteringSpy}}
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
       // then
       assert.contains('campagne 1');
+      assert.contains('campagne 2');
     });
 
     test('it should display the creator of the campaigns', async function(assert) {
@@ -133,7 +161,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
                   @campaigns={{campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @triggerFiltering={{this.triggerFilteringSpy}} 
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
       // then
@@ -156,7 +184,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
                   @campaigns={{campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @triggerFiltering={{this.triggerFilteringSpy}} 
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
       // then
@@ -179,7 +207,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
                   @campaigns={{campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @triggerFiltering={{this.triggerFilteringSpy}} 
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
       // then
@@ -195,7 +223,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
                   @campaigns={{this.campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @triggerFiltering={{this.triggerFilteringSpy}} 
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
       // then
@@ -211,7 +239,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
                   @campaigns={{this.campaigns}}
-                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @triggerFiltering={{this.triggerFilteringSpy}} 
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
       // then

--- a/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
@@ -7,6 +7,10 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
   setupIntlRenderingTest(hooks);
   let controller;
 
+  const event = {
+    preventDefault: sinon.stub(),
+  };
+
   hooks.beforeEach(function() {
     controller = this.owner.lookup('controller:authenticated/campaigns/list');
   });
@@ -145,9 +149,10 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
       controller.transitionToRoute = sinon.stub();
 
       // when
-      controller.send('goToCampaignPage', 123);
+      controller.send('goToCampaignPage', 123, event);
 
       // then
+      assert.ok(event.preventDefault.called);
       assert.equal(controller.transitionToRoute.calledWith('authenticated.campaigns.campaign', 123), true);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Pour accèder aux informations d'une campagne, il suffisait de cliquer sur la ligne de la liste. Or ceci n'est pas recommandé en terme d'accessibilité

## :robot: Solution
* Le nom de la campagne cliquable via un lien `href` . 
* Son `focus`/`hover ` doit être évident. 
* Qu'il soit selectionnable via les tabulations.

## :100: Pour tester
Allez sur Pix Orga, vérifier que dans la liste des campagnes . les noms de campagnes doivent rediriger vers les infos de la campagne.
