### PR TITLE
[POC] Créer des `profile-snapshot` pour améliorer les performances liées au profile.

### DIFF
--- a/api/db/migrations/20210623084957_create-profile-snapshot.js
+++ b/api/db/migrations/20210623084957_create-profile-snapshot.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'profile-snapshots';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable(TABLE_NAME, (table) => {
+      table.increments('id').primary();
+      table.integer('userId').unsigned().references('users.id').notNullable().index();
+      table.integer('knowledgeElementsSnapshotId').unsigned().references('knowledge-element-snapshots.id').notNullable();
+      table.dateTime('snappedAt').notNullable();
+      table.jsonb('snapshot').notNullable();
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .dropTable(TABLE_NAME);
+};

--- a/api/scripts/create-profile-snapshots.js
+++ b/api/scripts/create-profile-snapshots.js
@@ -1,0 +1,48 @@
+const _ = require('lodash');
+
+async function main() {
+
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}
+
+module.exports = {
+  createProfileSnapshot,
+};
+
+function createProfileSnapshot({
+  userId,
+  knowledgeElements,
+  competences,
+  scoringService
+}) {
+  const scorecards = competences.map((competence) => {
+    const {
+      realTotalPixScoreForCompetence,
+      pixScoreForCompetence,
+      currentLevel,
+      pixAheadForNextLevel,
+    } = scoringService.calculateScoringInformationForCompetence({ knowledgeElements, allowExcessPix: false, allowExcessLevel: false });
+
+    return {
+      id: `${userId}_${competence.id}`,
+      competenceId: competence.id,
+      earnedPix: pixScoreForCompetence,
+    };
+  });
+
+  const pixScore = _.sumBy(scorecards, 'earnedPix');
+
+  return {
+    pixScore,
+    scorecards,
+  };
+}

--- a/api/scripts/create-profile-snapshots.js
+++ b/api/scripts/create-profile-snapshots.js
@@ -5,7 +5,10 @@ const competenceRepository = require('../lib/infrastructure/repositories/compete
 const scoringService = require('../lib/domain/services/scoring/scoring-service');
 
 async function main() {
-
+  const knowledgeElementSnapshots = await knex('knowledge-element-snapshots').select();
+  for (const knowledgeElementSnapshot of knowledgeElementSnapshots) {
+    await createProfileSnapshot(knowledgeElementSnapshot);
+  }
 }
 
 if (require.main === module) {
@@ -51,7 +54,7 @@ function createProfileSnapshotJSON({
 
 function _toKnowledgeElementCollection({ snapshot } = {}) {
   if (!snapshot) return null;
-  return JSON.parse(snapshot).map((data) => new KnowledgeElement({
+  return snapshot.map((data) => new KnowledgeElement({
     ...data,
     createdAt: new Date(data.createdAt),
   }));

--- a/api/tests/integration/scripts/create-profile-snapshots_tests.js
+++ b/api/tests/integration/scripts/create-profile-snapshots_tests.js
@@ -20,8 +20,10 @@ describe('Integration | Scripts | create profile snapshots', () => {
     mockLearningContent(learningContentObjects);
 
     const knowledgeElements = Array.from({ length: 4 }, () => databaseBuilder.factory.buildKnowledgeElement({ competenceId: 'competence_id' }));
-    const knowledgeElementSnapshot = databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId: user.id, snapshot: JSON.stringify(knowledgeElements) });
+    databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId: user.id, snapshot: JSON.stringify(knowledgeElements) });
     await databaseBuilder.commit();
+
+    const knowledgeElementSnapshot = await knex('knowledge-element-snapshots').select().first();
 
     // when
     await createProfileSnapshot(knowledgeElementSnapshot);

--- a/api/tests/integration/scripts/create-profile-snapshots_tests.js
+++ b/api/tests/integration/scripts/create-profile-snapshots_tests.js
@@ -1,0 +1,33 @@
+const { expect, databaseBuilder, knex, learningContentBuilder, mockLearningContent, sinon } = require('../../test-helper');
+const { createProfileSnapshot } = require('../../../scripts/create-profile-snapshots');
+
+describe('Integration | Scripts | create profile snapshots', () => {
+  afterEach(async () => {
+    await knex('profile-snapshots').delete();
+  });
+
+  it('create a profile snapshot for a user', async () => {
+    // given
+    const user = databaseBuilder.factory.buildUser();
+    const learningContent = [{
+      id: '1. Information et données',
+      competences: [{
+        id: 'competence_id',
+      }],
+    }];
+
+    const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+    mockLearningContent(learningContentObjects);
+
+    const knowledgeElements = Array.from({ length: 4 }, () => databaseBuilder.factory.buildKnowledgeElement({ competenceId: 'competence_id' }));
+    const knowledgeElementSnapshot = databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId: user.id, snapshot: JSON.stringify(knowledgeElements) });
+    await databaseBuilder.commit();
+
+    // when
+    await createProfileSnapshot(knowledgeElementSnapshot);
+
+    // then
+    const { count: profileSnapshotsCount } = (await knex('profile-snapshots').count())[0];
+    expect(profileSnapshotsCount).to.equal(1);
+  });
+});

--- a/api/tests/unit/scripts/create-profile-snapshots_test.js
+++ b/api/tests/unit/scripts/create-profile-snapshots_test.js
@@ -1,0 +1,38 @@
+const { expect, domainBuilder, sinon } = require('../../test-helper');
+const { createProfileSnapshot } = require('../../../scripts/create-profile-snapshots');
+
+describe('create profile snapshots', () => {
+  describe('#createProfileSnapshot', () => {
+    it('returns a json with pixScore and score cards', () => {
+      // given
+      const competences = [domainBuilder.buildCompetence({ id: 'recCompetencePix' })];
+
+      const knowledgeElements = [
+        domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetencePix' }),
+        domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetencePix' }),
+      ];
+
+      const userId = 'userid';
+
+      const scoringService = {
+        calculateScoringInformationForCompetence: sinon.stub().returns({
+          realTotalPixScoreForCompetence: 4,
+          pixScoreForCompetence: 9,
+          currentLevel: 5,
+          pixAheadForNextLevel: 3,
+        }),
+      };
+
+      // when
+      const profileJson = createProfileSnapshot({ userId, knowledgeElements, competences, scoringService });
+
+      // then
+      expect(profileJson.pixScore).to.equal(9);
+      expect(profileJson.scorecards).to.deep.equal([{
+        id: 'userid_recCompetencePix',
+        competenceId: 'recCompetencePix',
+        earnedPix: 9,
+      }]);
+    });
+  });
+});

--- a/api/tests/unit/scripts/create-profile-snapshots_test.js
+++ b/api/tests/unit/scripts/create-profile-snapshots_test.js
@@ -1,5 +1,5 @@
 const { expect, domainBuilder, sinon } = require('../../test-helper');
-const { createProfileSnapshot } = require('../../../scripts/create-profile-snapshots');
+const { createProfileSnapshotJSON } = require('../../../scripts/create-profile-snapshots');
 
 describe('create profile snapshots', () => {
   describe('#createProfileSnapshot', () => {
@@ -24,7 +24,7 @@ describe('create profile snapshots', () => {
       };
 
       // when
-      const profileJson = createProfileSnapshot({ userId, knowledgeElements, competences, scoringService });
+      const profileJson = createProfileSnapshotJSON({ userId, knowledgeElements, competences, scoringService });
 
       // then
       expect(profileJson.pixScore).to.equal(9);


### PR DESCRIPTION
## :unicorn: Problème
On manipule beaucoup les KE dans le code alors que la plupart du temps on s'intéresse plutot au nombre pix par compétence ou d'autres détails s'y afférant.

## :robot: Solution
On rajoute un profil-snapshot qui calcule les données nécessaire.

## :rainbow: Remarques
Ceci est un POC

## :100: Pour tester
Lancer le script `api/scripts/create-profile-snapshots.js` pour générer des `profile-snapshots` a partir des ke-snaphots présent en base.