### PR TITLE
[FEATURE] Etendre la capacité de stockage des knowledge elements.

### DIFF
--- a/api/db/database-builder/factory/build-knowledge-element.js
+++ b/api/db/database-builder/factory/build-knowledge-element.js
@@ -6,7 +6,6 @@ const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
 const _ = require('lodash');
 
 module.exports = function buildKnowledgeElement({
-  id = databaseBuffer.getNextId(),
   source = KnowledgeElement.SourceType.DIRECT,
   status = KnowledgeElement.StatusType.VALIDATED,
   createdAt = new Date('2020-01-01'),
@@ -23,7 +22,6 @@ module.exports = function buildKnowledgeElement({
   answerId = _.isUndefined(answerId) ? buildAnswer({ assessmentId }).id : answerId;
 
   const values = {
-    id,
     source,
     status,
     createdAt,

--- a/api/db/migrations/20210623084347_alter-knowledge-elements-drop-column-id.js
+++ b/api/db/migrations/20210623084347_alter-knowledge-elements-drop-column-id.js
@@ -1,0 +1,8 @@
+exports.up = function(knex) {
+  return knex.schema.table('knowledge-elements', (table) => {
+    table.dropColumn('id');
+  });
+};
+
+exports.down = function() {
+};

--- a/api/lib/domain/models/KnowledgeElement.js
+++ b/api/lib/domain/models/KnowledgeElement.js
@@ -20,7 +20,6 @@ const sources = {
 class KnowledgeElement {
 
   constructor({
-    id,
     createdAt,
     source,
     status,
@@ -31,7 +30,6 @@ class KnowledgeElement {
     userId,
     competenceId,
   } = {}) {
-    this.id = id;
     this.createdAt = createdAt;
     this.source = source;
     this.status = status;

--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -317,7 +317,7 @@ describe('Integration | Repository | answerRepository', () => {
       });
 
       it('should save knowledge elements', async () => {
-        const knowledgeElementsInDB = await knex('knowledge-elements').where({ answerId: savedAnswer.id }).orderBy('id');
+        const knowledgeElementsInDB = await knex('knowledge-elements').where({ answerId: savedAnswer.id }).orderBy('createdAt');
 
         expect(knowledgeElementsInDB).to.length(2);
         compareDatabaseObject(knowledgeElementsInDB[0], firstKnowledgeElement);

--- a/api/tests/tooling/domain-builder/factory/build-knowledge-element.js
+++ b/api/tests/tooling/domain-builder/factory/build-knowledge-element.js
@@ -1,7 +1,6 @@
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 
 const buildKnowledgeElement = function({
-  id = 123,
   source = KnowledgeElement.SourceType.DIRECT,
   status = KnowledgeElement.StatusType.VALIDATED,
   earnedPix = 4,
@@ -13,7 +12,6 @@ const buildKnowledgeElement = function({
   competenceId = 'recCOMP456',
 } = {}) {
   return new KnowledgeElement({
-    id,
     source,
     status,
     earnedPix,
@@ -27,7 +25,6 @@ const buildKnowledgeElement = function({
 };
 
 buildKnowledgeElement.directlyValidated = function({
-  id = 123,
   earnedPix = 4,
   createdAt,
   answerId = 456,
@@ -37,7 +34,6 @@ buildKnowledgeElement.directlyValidated = function({
   competenceId = 'recCOMP456',
 } = {}) {
   return new KnowledgeElement({
-    id,
     source: KnowledgeElement.SourceType.DIRECT,
     status: KnowledgeElement.StatusType.VALIDATED,
     earnedPix,
@@ -51,7 +47,6 @@ buildKnowledgeElement.directlyValidated = function({
 };
 
 buildKnowledgeElement.directlyInvalidated = function({
-  id = 123,
   earnedPix = 4,
   createdAt,
   answerId = 456,
@@ -61,7 +56,6 @@ buildKnowledgeElement.directlyInvalidated = function({
   competenceId = 'recCOMP456',
 } = {}) {
   return new KnowledgeElement({
-    id,
     source: KnowledgeElement.SourceType.DIRECT,
     status: KnowledgeElement.StatusType.INVALIDATED,
     earnedPix,
@@ -75,7 +69,6 @@ buildKnowledgeElement.directlyInvalidated = function({
 };
 
 buildKnowledgeElement.inferredValidated = function({
-  id = 123,
   earnedPix = 4,
   createdAt,
   answerId = 456,
@@ -85,7 +78,6 @@ buildKnowledgeElement.inferredValidated = function({
   competenceId = 'recCOMP456',
 } = {}) {
   return new KnowledgeElement({
-    id,
     source: KnowledgeElement.SourceType.INFERRED,
     status: KnowledgeElement.StatusType.VALIDATED,
     earnedPix,

--- a/api/tests/unit/domain/models/KnowledgeElement_test.js
+++ b/api/tests/unit/domain/models/KnowledgeElement_test.js
@@ -185,7 +185,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
             userId: 3,
             competenceId: skill.competenceId,
           });
-          directKnowledgeElement.id = undefined;
 
           expect(createdKnowledgeElements).to.deep.equal([directKnowledgeElement]);
         });
@@ -230,7 +229,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: skill.competenceId,
             });
-            directKnowledgeElement.id = undefined;
             const inferredKnowledgeElementForEasierSkill = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.VALIDATED,
@@ -242,7 +240,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: easierSkill.competenceId,
             });
-            inferredKnowledgeElementForEasierSkill.id = undefined;
             const inferredKnowledgeElementForMuchEasierSkill = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.VALIDATED,
@@ -254,7 +251,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: muchEasierSkill.competenceId,
             });
-            inferredKnowledgeElementForMuchEasierSkill.id = undefined;
             const expectedKnowledgeElements = [
               directKnowledgeElement,
               inferredKnowledgeElementForMuchEasierSkill,
@@ -294,7 +290,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: skill.competenceId,
             });
-            directKnowledgeElement.id = undefined;
             const inferredKnowledgeElementForHarderSkill = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.INVALIDATED,
@@ -305,7 +300,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: harderSkill.competenceId,
             });
-            inferredKnowledgeElementForHarderSkill.id = undefined;
             const inferredKnowledgeElementForMuchHarderSkill = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.INVALIDATED,
@@ -316,7 +310,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: muchHarderSkill.competenceId,
             });
-            inferredKnowledgeElementForMuchHarderSkill.id = undefined;
             const expectedKnowledgeElements = [
               directKnowledgeElement,
               inferredKnowledgeElementForHarderSkill,
@@ -413,7 +406,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
             userId,
             competenceId: skillFromTube1.competenceId,
           });
-          directKnowledgeElementFromTube1.id = undefined;
           const directKnowledgeElementFromTube3 = domainBuilder.buildKnowledgeElement({
             source: KnowledgeElement.SourceType.DIRECT,
             status: KnowledgeElement.StatusType.VALIDATED,
@@ -424,7 +416,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
             userId,
             competenceId: skillFromTube3.competenceId,
           });
-          directKnowledgeElementFromTube3.id = undefined;
           const expectedKnowledgeElements = [directKnowledgeElementFromTube1, directKnowledgeElementFromTube3];
 
           expect(createdKnowledgeElements).to.deep.equal(expectedKnowledgeElements);
@@ -483,7 +474,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: skillFromTube1.competenceId,
             });
-            directKnowledgeElementFromTube1.id = undefined;
             const inferredKnowledgeElementForEasierSkillFromTube1 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.VALIDATED,
@@ -494,7 +484,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: easierSkillFromTube1.competenceId,
             });
-            inferredKnowledgeElementForEasierSkillFromTube1.id = undefined;
             const inferredKnowledgeElementForMuchEasierSkillFromTube1 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.VALIDATED,
@@ -505,7 +494,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: muchEasierSkillFromTube1.competenceId,
             });
-            inferredKnowledgeElementForMuchEasierSkillFromTube1.id = undefined;
 
             const directKnowledgeElementFromTube2 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.DIRECT,
@@ -517,7 +505,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: skillFromTube2.competenceId,
             });
-            directKnowledgeElementFromTube2.id = undefined;
             const inferredKnowledgeElementForEasierSkillFromTube2 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.VALIDATED,
@@ -528,7 +515,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: easierSkillFromTube2.competenceId,
             });
-            inferredKnowledgeElementForEasierSkillFromTube2.id = undefined;
             const inferredKnowledgeElementForMuchEasierSkillFromTube2 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.VALIDATED,
@@ -539,7 +525,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: muchEasierSkillFromTube2.competenceId,
             });
-            inferredKnowledgeElementForMuchEasierSkillFromTube2.id = undefined;
 
             const directKnowledgeElementFromTube3 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.DIRECT,
@@ -551,7 +536,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: skillFromTube3.competenceId,
             });
-            directKnowledgeElementFromTube3.id = undefined;
             const inferredKnowledgeElementForEasierSkillFromTube3 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.VALIDATED,
@@ -562,7 +546,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: easierSkillFromTube3.competenceId,
             });
-            inferredKnowledgeElementForEasierSkillFromTube3.id = undefined;
             const inferredKnowledgeElementForMuchEasierSkillFromTube3 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.VALIDATED,
@@ -573,7 +556,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: muchEasierSkillFromTube3.competenceId,
             });
-            inferredKnowledgeElementForMuchEasierSkillFromTube3.id = undefined;
 
             const expectedKnowledgeElements = [
               directKnowledgeElementFromTube1,
@@ -619,7 +601,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: skillFromTube1.competenceId,
             });
-            directKnowledgeElementFromTube1.id = undefined;
             const inferredKnowledgeElementForHarderSkillFromTube1 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.INVALIDATED,
@@ -630,7 +611,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: harderSkillFromTube1.competenceId,
             });
-            inferredKnowledgeElementForHarderSkillFromTube1.id = undefined;
             const inferredKnowledgeElementForMuchHarderSkillFromTube1 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.INVALIDATED,
@@ -641,7 +621,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: muchHarderSkillFromTube1.competenceId,
             });
-            inferredKnowledgeElementForMuchHarderSkillFromTube1.id = undefined;
 
             const directKnowledgeElementFromTube2 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.DIRECT,
@@ -653,7 +632,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: skillFromTube2.competenceId,
             });
-            directKnowledgeElementFromTube2.id = undefined;
             const inferredKnowledgeElementForHarderSkillFromTube2 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.INVALIDATED,
@@ -664,7 +642,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: harderSkillFromTube2.competenceId,
             });
-            inferredKnowledgeElementForHarderSkillFromTube2.id = undefined;
             const inferredKnowledgeElementForMuchHarderSkillFromTube2 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.INVALIDATED,
@@ -675,7 +652,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: muchHarderSkillFromTube2.competenceId,
             });
-            inferredKnowledgeElementForMuchHarderSkillFromTube2.id = undefined;
 
             const directKnowledgeElementFromTube3 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.DIRECT,
@@ -687,7 +663,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: skillFromTube3.competenceId,
             });
-            directKnowledgeElementFromTube3.id = undefined;
             const inferredKnowledgeElementForHarderSkillFromTube3 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.INVALIDATED,
@@ -698,7 +673,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: harderSkillFromTube3.competenceId,
             });
-            inferredKnowledgeElementForHarderSkillFromTube3.id = undefined;
             const inferredKnowledgeElementForMuchHarderSkillFromTube3 = domainBuilder.buildKnowledgeElement({
               source: KnowledgeElement.SourceType.INFERRED,
               status: KnowledgeElement.StatusType.INVALIDATED,
@@ -709,7 +683,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
               userId,
               competenceId: muchHarderSkillFromTube3.competenceId,
             });
-            inferredKnowledgeElementForMuchHarderSkillFromTube3.id = undefined;
 
             const expectedKnowledgeElements = [
               directKnowledgeElementFromTube1,
@@ -837,7 +810,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
                 userId,
                 competenceId: skillFromTube1.competenceId,
               });
-              directKnowledgeElementFromTube1.id = undefined;
 
               const directKnowledgeElementFromTube2 = domainBuilder.buildKnowledgeElement({
                 source: KnowledgeElement.SourceType.DIRECT,
@@ -849,7 +821,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
                 userId,
                 competenceId: skillFromTube2.competenceId,
               });
-              directKnowledgeElementFromTube2.id = undefined;
               const inferredKnowledgeElementForMuchEasierSkillFromTube2 = domainBuilder.buildKnowledgeElement({
                 source: KnowledgeElement.SourceType.INFERRED,
                 status: KnowledgeElement.StatusType.VALIDATED,
@@ -860,7 +831,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
                 userId,
                 competenceId: muchEasierSkillFromTube2.competenceId,
               });
-              inferredKnowledgeElementForMuchEasierSkillFromTube2.id = undefined;
 
               const directKnowledgeElementFromTube3 = domainBuilder.buildKnowledgeElement({
                 source: KnowledgeElement.SourceType.DIRECT,
@@ -872,7 +842,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
                 userId,
                 competenceId: skillFromTube3.competenceId,
               });
-              directKnowledgeElementFromTube3.id = undefined;
               const inferredKnowledgeElementForEasierSkillFromTube3 = domainBuilder.buildKnowledgeElement({
                 source: KnowledgeElement.SourceType.INFERRED,
                 status: KnowledgeElement.StatusType.VALIDATED,
@@ -883,7 +852,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
                 userId,
                 competenceId: easierSkillFromTube3.competenceId,
               });
-              inferredKnowledgeElementForEasierSkillFromTube3.id = undefined;
               const inferredKnowledgeElementForMuchEasierSkillFromTube3 = domainBuilder.buildKnowledgeElement({
                 source: KnowledgeElement.SourceType.INFERRED,
                 status: KnowledgeElement.StatusType.VALIDATED,
@@ -895,7 +863,6 @@ describe('Unit | Domain | Models | KnowledgeElement', () => {
                 competenceId: muchEasierSkillFromTube3.competenceId,
 
               });
-              inferredKnowledgeElementForMuchEasierSkillFromTube3.id = undefined;
 
               const expectedKnowledgeElements = [
                 directKnowledgeElementFromTube1,

--- a/high-level-tests/e2e/cypress/fixtures/knowledge-elements.json
+++ b/high-level-tests/e2e/cypress/fixtures/knowledge-elements.json
@@ -1,6 +1,5 @@
 [
   {
-    "id": 1,
     "userId": 4,
     "assessmentId": 1,
     "source": "direct",
@@ -12,7 +11,6 @@
     "earnedPix": 0.65
   },
   {
-    "id": 2,
     "userId": 4,
     "assessmentId": 1,
     "source": "direct",
@@ -24,7 +22,6 @@
     "earnedPix": 0
   },
   {
-    "id": 3,
     "userId": 5,
     "assessmentId": 2,
     "source": "direct",
@@ -36,7 +33,6 @@
     "earnedPix": 0.65
   },
   {
-    "id": 4,
     "userId": 5,
     "assessmentId": 2,
     "source": "direct",
@@ -48,7 +44,6 @@
     "earnedPix": 0.35
   },
   {
-    "id": 5,
     "userId": 6,
     "assessmentId": 3,
     "source": "direct",
@@ -60,7 +55,6 @@
     "earnedPix": 0.65
   },
   {
-    "id": 6,
     "userId": 5,
     "assessmentId": 4,
     "source": "direct",
@@ -72,7 +66,6 @@
     "earnedPix": 0.65
   },
   {
-    "id": 7,
     "userId": 5,
     "assessmentId": 4,
     "source": "direct",


### PR DESCRIPTION
## :unicorn: Problème
Le type de données [INTEGER](https://www.postgresql.org/docs/current/datatype-numeric.html) utilisé comme identifiant de la table `knowledge-elements` ne permet pas de stocker plus de [2 milliards](https://www.vaughns-1-pagers.com/computer/powers-of-2.htm) d'enregistrements. Or cette limite sera atteinte courant 2022.

## :robot: Solution

### Contournement
Supprimer cet identifiant, car cette table n'est pas référencée.

Implémenter [une stratégie de réplication](https://github.com/1024pix/pix-db-replication/blob/dev/src/replicate-incrementally.js) sans utiliser ce champ (ne pas merger cette PR sans que cette fonctionnalité soit réalisée côté application).

### Définitive
Migrer le type de cet identifant vers `BIGINT`


## :rainbow: Remarques
Une contrainte d'unicité est-celle nécessaire sur cette table ?
Les snapshots KE effectués après MEP ne contiendront plus l'id (et les anciens le gardent)
- il semble qu'aucune question Metabase ne les exploite
- voir pour tester cex deux cas (ex: KE snapshot repo)

## :100: Pour tester
Effectuer un parcours
