### PR TITLE
[TECH] Permettre a PE de récupérer les résultats(PIX-2682)

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -9,12 +9,18 @@ const {
 const { PRO_COMPANY_ID, PRO_POLE_EMPLOI_ID, PRO_MED_NUM_ID } = require('./organizations-pro-builder');
 const { SCO_MIDDLE_SCHOOL_ID, SCO_HIGH_SCHOOL_ID, SCO_AGRI_ID } = require('./organizations-sco-builder');
 const { SUP_UNIVERSITY_ID } = require('./organizations-sup-builder');
+const POLE_EMPLOI_CAMPAIGN_ID = 5;
 
-module.exports = function campaignsBuilder({ databaseBuilder }) {
+module.exports = {
+  campaignsBuilder,
+  POLE_EMPLOI_CAMPAIGN_ID,
+};
+
+function campaignsBuilder({ databaseBuilder }) {
   _buildCampaignForSco(databaseBuilder);
   _buildCampaignForSup(databaseBuilder);
   _buildCampaignForPro(databaseBuilder);
-};
+}
 
 function _buildCampaignForSco(databaseBuilder) {
   databaseBuilder.factory.buildCampaign({
@@ -172,7 +178,7 @@ __Plus d'infos :)__
   });
 
   databaseBuilder.factory.buildCampaign({
-    id: 5,
+    id: POLE_EMPLOI_CAMPAIGN_ID,
     name: 'Pro - Campagne Pix Emploi',
     code: 'QWERTY789',
     type: 'ASSESSMENT',

--- a/api/db/seeds/data/pole-emploi-sendings-builder.js
+++ b/api/db/seeds/data/pole-emploi-sendings-builder.js
@@ -1,0 +1,43 @@
+const _ = require('lodash');
+const { POLE_EMPLOI_CAMPAIGN_ID } = require('./campaigns-builder');
+
+module.exports = function poleEmploisSendingsBuilder({ databaseBuilder }) {
+  const _generateStatus = () => {
+    const possibleChoices = [{ isSuccessful: true, responseCode: '200' }, { isSuccessful: false, responseCode: '400' }];
+    return _.sample(possibleChoices);
+  };
+
+  const _generateDate = () => {
+    const mounth = Math.floor(Math.random() * 12) + 1;
+    const day = Math.floor(Math.random() * 29) + 1;
+    return new Date(`2020-${mounth}-${day}`);
+  };
+
+  _.times(300, async (index) => {
+    const user = await databaseBuilder.factory.buildUser({ firstName: `FirstName-${index}`, lastName: `LastName-${index}` });
+    await databaseBuilder.factory.buildAuthenticationMethod({ userId: user.id, identityProvider: 'POLE_EMPLOI', externalIdentifier: `externalUserId${user.id}` });
+    const campaignParticipationId = await databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, campaignId: POLE_EMPLOI_CAMPAIGN_ID }).id;
+    await databaseBuilder.factory.buildPoleEmploiSending({ ..._generateStatus(), campaignParticipationId, createdAt: _generateDate(), payload: {
+      campagne: {
+        nom: 'Campagne PE',
+        dateDebut: '2019-08-01T00:00:00.000Z',
+        type: 'EVALUATION',
+        codeCampagne: 'QWERTY789',
+        urlCampagne: 'https://app.pix.fr/campagnes/QWERTY789',
+        nomOrganisme: 'Pix',
+        typeOrganisme: 'externe',
+      },
+      individu: {
+        nom: user.lastName,
+        prenom: user.firstName,
+      },
+      test: {
+        etat: 2,
+        typeTest: 'DI',
+        referenceExterne: 123456,
+        dateDebut: '2019-09-01T00:00:00.000Z',
+        elementsEvalues: [],
+      },
+    } });
+  });
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -6,7 +6,7 @@ const answersBuilder = require('./data/answers-builder');
 const assessmentsBuilder = require('./data/assessments-builder');
 const buildPixAileProfile = require('./data/pix-aile-profile-builder');
 const campaignParticipationsBuilder = require('./data/campaign-participations-builder');
-const campaignsBuilder = require('./data/campaigns-builder');
+const { campaignsBuilder } = require('./data/campaigns-builder');
 const { certificationCandidatesBuilder } = require('./data/certification/certification-candidates-builder');
 const { badgeAcquisitionBuilder } = require('./data/certification/badge-acquisition-builder');
 const { partnerCertificationBuilder } = require('./data/certification/partner-certification-builder');
@@ -32,6 +32,7 @@ const {
   generateKnowledgeElementSnapshots,
 } = require('../../scripts/prod/generate-knowledge-element-snapshots-for-campaigns');
 
+const poleEmploisSendingsBuilder = require('./data/pole-emploi-sendings-builder');
 const SEQUENCE_RESTART_AT_NUMBER = 10000000;
 
 exports.seed = async (knex) => {
@@ -74,6 +75,9 @@ exports.seed = async (knex) => {
 
   // Éléments de parcours pour l'utilisateur Pix Aile
   buildPixAileProfile({ databaseBuilder });
+
+  // Création d'envois pole emploi
+  poleEmploisSendingsBuilder({ databaseBuilder });
 
   await databaseBuilder.commit();
   await alterSequenceIfPG(knex);

--- a/api/lib/application/pole-emplois/index.js
+++ b/api/lib/application/pole-emplois/index.js
@@ -1,6 +1,5 @@
 const Joi = require('joi');
 const poleEmploiController = require('./pole-emploi-controller');
-
 const poleEmploiErreurDoc = require('../../infrastructure/open-api-doc/pole-emploi/erreur-doc');
 const poleEmploiEnvoisDoc = require('../../infrastructure/open-api-doc/pole-emploi/envois-doc');
 
@@ -20,12 +19,13 @@ exports.register = async function(server) {
       path: '/api/pole-emploi/envois',
       config: {
         auth: 'jwt-pole-emploi',
-        handler: console.log,
+        handler: poleEmploiController.getSendings,
         notes: [
           '- **API Pôle emploi qui nécessite une authentification de type client credential grant**\n' +
           '- Récupération des N derniers envois. Le résultat peut être paginé si plus de N entrées via le paramètre Link dans le header de la réponse\n',
         ],
         response: {
+          failAction: 'ignore',
           status: {
             200: poleEmploiEnvoisDoc,
             204: poleEmploiEnvoisDoc,

--- a/api/lib/application/pole-emplois/pole-emploi-controller.js
+++ b/api/lib/application/pole-emplois/pole-emploi-controller.js
@@ -1,6 +1,5 @@
 const usecases = require('../../domain/usecases');
 const tokenService = require('../../domain/services/token-service');
-
 module.exports = {
 
   async createUser(request, h) {
@@ -15,5 +14,10 @@ module.exports = {
       id_token: idToken,
     };
     return h.response(response).code(200);
+  },
+
+  async getSendings(_request, h) {
+    const sendings = await usecases.getPoleEmploiSendings();
+    return h.response(sendings).code(200);
   },
 };

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -165,6 +165,8 @@ module.exports = (function() {
         expirationDelaySeconds: parseInt(process.env.POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 1140,
         redisUrl: process.env.REDIS_URL,
       },
+      poleEmploiSendingsLimit: _getNumber(process.env.POLE_EMPLOI_SENDING_LIMIT, 100),
+      poleEmploiIdentityProvider: (process.env.POLE_EMPLOI_IDENTITY_PROVIDER || 'POLE_EMPLOI'),
     },
 
     graviteeRegisterApplicationsCredentials: [

--- a/api/lib/domain/usecases/get-pole-emploi-sendings.js
+++ b/api/lib/domain/usecases/get-pole-emploi-sendings.js
@@ -1,0 +1,3 @@
+module.exports = function getPoleEmploiSendings({ poleEmploiSendingRepository }) {
+  return poleEmploiSendingRepository.get();
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -243,6 +243,7 @@ module.exports = injectDependencies({
   getOrganizationDetails: require('./get-organization-details'),
   getOrganizationInvitation: require('./get-organization-invitation'),
   getParticipantsDivision: require('./get-participants-division'),
+  getPoleEmploiSendings: require('./get-pole-emploi-sendings'),
   getPrescriber: require('./get-prescriber'),
   getPrivateCertificate: require('./certificate/get-private-certificate'),
   getProgression: require('./get-progression'),

--- a/api/lib/infrastructure/open-api-doc/pole-emploi/envois-doc.js
+++ b/api/lib/infrastructure/open-api-doc/pole-emploi/envois-doc.js
@@ -55,7 +55,7 @@ const test = Joi.object({
 
 module.exports = Joi.array().items(
   Joi.object({
-    idEnvoi: Joi.string().required().example('XXX').description('Identifiant unique de l\'envoi'),
+    idEnvoi: Joi.number().required().example(1234).description('Identifiant unique de l\'envoi'),
     dateEnvoi: Joi.date().required().example('2020-11-31T12:00:38.133Z').description('Instant de la demande d\'envoi'),
     resultat: Joi.object({ campagne, individu, test }).required(),
   }).label('Envoi'),

--- a/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -1,7 +1,30 @@
+const settings = require('../../../lib/config');
+const Bookshelf = require('../bookshelf');
 const BookshelfPoleEmploiSending = require('../orm-models/PoleEmploiSending');
 
 module.exports = {
   create({ poleEmploiSending }) {
     return new BookshelfPoleEmploiSending(poleEmploiSending).save();
+  },
+
+  async get() {
+    const POLE_EMPLOI_SENDINGS_LIMIT = settings.poleEmploi.poleEmploiSendingsLimit;
+    const IDENTITY_PROVIDER_POLE_EMPLOI = settings.poleEmploi.poleEmploiIdentityProvider;
+
+    const rawSendings = await Bookshelf.knex('pole-emploi-sendings')
+      .select('pole-emploi-sendings.id AS idEnvoi', 'pole-emploi-sendings.createdAt AS dateEnvoi', 'pole-emploi-sendings.payload AS resultat', 'authentication-methods.externalIdentifier AS idPoleEmploi')
+      .join('campaign-participations', 'campaign-participations.id', 'pole-emploi-sendings.campaignParticipationId')
+      .join('authentication-methods', 'authentication-methods.userId', 'campaign-participations.userId')
+      .where('authentication-methods.identityProvider', IDENTITY_PROVIDER_POLE_EMPLOI)
+      .orderBy([{ column: 'pole-emploi-sendings.createdAt', order: 'desc' }, { column: 'pole-emploi-sendings.id', order: 'desc' }])
+      .limit(POLE_EMPLOI_SENDINGS_LIMIT);
+
+    const sendings = rawSendings.map((rawSending) => {
+      const { idPoleEmploi, ...sending } = rawSending;
+      sending.resultat.individu['idPoleEmploi'] = idPoleEmploi;
+      return sending;
+    });
+
+    return sendings;
   },
 };

--- a/api/tests/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/acceptance/application/pole-emploi-controller_test.js
@@ -1,6 +1,6 @@
 const jsonwebtoken = require('jsonwebtoken');
 
-const { expect, knex } = require('../../test-helper');
+const { expect, knex, databaseBuilder, generateValidRequestAuthorizationHeaderForApplication, generateValidRequestAuthorizationHeader } = require('../../test-helper');
 
 const PoleEmploiTokens = require('../../../lib/domain/models/PoleEmploiTokens');
 const poleEmploiTokensRepository = require('../../../lib/infrastructure/repositories/pole-emploi-tokens-repository');
@@ -9,7 +9,11 @@ const createServer = require('../../../server');
 
 describe('Acceptance | API | Pole Emploi Controller', () => {
 
-  let server;
+  let server, options;
+
+  const POLE_EMPLOI_CLIENT_ID = 'poleEmploiClientId';
+  const POLE_EMPLOI_SCOPE = 'pole-emploi-participants-result';
+  const POLE_EMPLOI_SOURCE = 'poleEmploi';
 
   beforeEach(async () => {
     server = await createServer();
@@ -60,6 +64,84 @@ describe('Acceptance | API | Pole Emploi Controller', () => {
 
       const createdAuthenticationMethod = await knex('authentication-methods').first();
       expect(createdAuthenticationMethod.externalIdentifier).to.equal(externalIdentifier);
+    });
+  });
+
+  describe('GET /api/pole-emploi/envois', () => {
+
+    it('should return 200 HTTP status code', async () => {
+      const organizationId = databaseBuilder.factory.buildOrganization({ name: 'Pole emploi' }).id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod({ userId, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId' });
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId }).id;
+      const sending = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId, createdAt: new Date('2021-05-01'), payload: { campagne: { nom: 'Campagne PE', dateDebut: new Date('2020-08-01'), type: 'EVALUATION', codeCampagne: 'POLEEMPLOI123', urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123', nomOrganisme: 'Pix', typeOrganisme: 'externe' }, individu: { nom: 'Kamado', prenom: 'Tanjiro' }, test: { etat: 2, typeTest: 'DI', referenceExterne: 123456, dateDebut: new Date('2020-09-01'), elementsEvalues: [] } } });
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'GET',
+        url: '/api/pole-emploi/envois',
+        headers: { authorization: generateValidRequestAuthorizationHeaderForApplication(POLE_EMPLOI_CLIENT_ID, POLE_EMPLOI_SOURCE, POLE_EMPLOI_SCOPE) },
+      };
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal([{
+        'idEnvoi': sending.id,
+        'dateEnvoi': new Date('2021-05-01'),
+        'resultat': {
+          'campagne': {
+            'nom': 'Campagne PE',
+            'dateDebut': '2020-08-01T00:00:00.000Z',
+            'type': 'EVALUATION',
+            'codeCampagne': 'POLEEMPLOI123',
+            'urlCampagne': 'https://app.pix.fr/campagnes/POLEEMPLOI123',
+            'nomOrganisme': 'Pix',
+            'typeOrganisme': 'externe' },
+          'individu': {
+            'nom': 'Kamado',
+            'prenom': 'Tanjiro',
+            'idPoleEmploi': 'externalUserId' },
+          'test': {
+            'etat': 2,
+            'typeTest': 'DI',
+            'referenceExterne': 123456,
+            'dateDebut': '2020-09-01T00:00:00.000Z',
+            'elementsEvalues': [] } } }]);
+    });
+
+    it('should return 403 HTTP status code if user is not allowed to access', async () => {
+      // given
+      options = {
+        method: 'GET',
+        url: '/api/pole-emploi/envois',
+        headers: { authorization: generateValidRequestAuthorizationHeaderForApplication(POLE_EMPLOI_CLIENT_ID, POLE_EMPLOI_SOURCE) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('should return 401 HTTP status code if user is not authenticated', async () => {
+      // given
+
+      options = {
+        method: 'GET',
+        url: '/api/pole-emploi/envois',
+        headers: { authorization: generateValidRequestAuthorizationHeader() },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(401);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const { expect, databaseBuilder, knex, domainBuilder } = require('../../../test-helper');
 const poleEmploiSendingRepository = require('../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
+const settings = require('../../../../lib/config');
 
 describe('Integration | Repository | PoleEmploiSending', () => {
 
@@ -23,6 +24,78 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       const poleEmploiSendings = await knex('pole-emploi-sendings').select();
       expect(poleEmploiSendings).to.have.lengthOf(1);
       expect(_.omit(poleEmploiSendings[0], ['id', 'createdAt'])).to.deep.equal(poleEmploiSending);
+    });
+  });
+
+  describe('#get', () => {
+    let originalEnvPoleEmploiSendingsLimit;
+    let sending1;
+    let sending2;
+    let sending4;
+
+    beforeEach(async () => {
+      originalEnvPoleEmploiSendingsLimit = settings.poleEmploi.poleEmploiSendingsLimit;
+
+      settings.poleEmploi.poleEmploiSendingsLimit = 3;
+      settings.poleEmploi.poleEmploiIdentityProvider = 'POLE_EMPLOI';
+
+      const organizationId = databaseBuilder.factory.buildOrganization({ name: 'Pole emploi' }).id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+
+      const user1Id = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod({ userId: user1Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId1' });
+      const campaignParticipation1Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user1Id, campaignId }).id;
+      sending1 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-05-01'), payload: { individu: {} } });
+
+      const user2Id = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod({ userId: user2Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId2' });
+      const campaignParticipation2Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user2Id, campaignId }).id;
+      sending2 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation2Id, createdAt: new Date('2021-04-01'), payload: { individu: {} } });
+
+      const user3Id = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod({ userId: user3Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId3' });
+      const campaignParticipation3Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user3Id, campaignId }).id;
+      databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation3Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
+
+      const user4Id = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod({ userId: user4Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId4' });
+      const campaignParticipation4Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user4Id, campaignId }).id;
+      sending4 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation4Id, createdAt: new Date('2021-06-01'), payload: { individu: {} } });
+
+      const user5Id = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod({ userId: user5Id, identityProvider: 'PIX', externalIdentifier: 'externalUserId5' });
+      const campaignParticipation5Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user5Id, campaignId }).id;
+      databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation5Id, createdAt: new Date('2021-06-01'), payload: { individu: {} } });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(() => {
+      settings.poleEmploi.poleEmploiSendingsLimit = originalEnvPoleEmploiSendingsLimit;
+    });
+
+    it('should render 3 sendings because of the poleEmploiSendingsLimit variable', async () => {
+      // when
+      const sendings = await poleEmploiSendingRepository.get();
+
+      // then
+      expect(sendings).to.have.lengthOf(3);
+    });
+
+    it('should render sendings order by date', async () => {
+      // when
+      const sendings = await poleEmploiSendingRepository.get();
+
+      // then
+      expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending4.id, sending1.id, sending2.id]);
+    });
+
+    it('should render sendings with idPoleEmploi inside the object', async () => {
+      // when
+      const sendings = await poleEmploiSendingRepository.get();
+
+      // then
+      expect(sendings.map((sending) => sending.resultat.individu.idPoleEmploi)).to.deep.equal(['externalUserId4', 'externalUserId1', 'externalUserId2']);
     });
   });
 });

--- a/api/tests/unit/application/pole-emploi/index_test.js
+++ b/api/tests/unit/application/pole-emploi/index_test.js
@@ -1,0 +1,50 @@
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+  generateValidRequestAuthorizationHeaderForApplication,
+} = require('../../../test-helper');
+const poleEmploiController = require('../../../../lib/application/pole-emplois/pole-emploi-controller');
+const moduleUnderTest = require('../../../../lib/application/pole-emplois');
+
+describe('Unit | Router | pole-emploi-router', () => {
+
+  describe('GET /api/pole-emploi/envois', () => {
+    it('should return 200 if the user is a pole emploi user', async () => {
+      sinon.stub(poleEmploiController, 'getSendings').callsFake((_request, h) => h.response('ok').code(200));
+
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(moduleUnderTest);
+
+      const POLE_EMPLOI_CLIENT_ID = 'poleEmploiClientId';
+      const POLE_EMPLOI_SCOPE = 'pole-emploi-participants-result';
+      const POLE_EMPLOI_SOURCE = 'poleEmploi';
+
+      const method = 'GET';
+      const url = '/api/pole-emploi/envois';
+      const headers = { authorization: generateValidRequestAuthorizationHeaderForApplication(POLE_EMPLOI_CLIENT_ID, POLE_EMPLOI_SOURCE, POLE_EMPLOI_SCOPE) };
+      // when
+      const response = await httpTestServer.request(method, url, null, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 401 if the user is a pole emploi user', async () => {
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'GET';
+      const url = '/api/pole-emploi/envois';
+      const headers = { authorization: generateValidRequestAuthorizationHeaderForApplication('') };
+      // when
+      const response = await httpTestServer.request(method, url, null, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+  });
+
+});

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -1,0 +1,43 @@
+const { expect, sinon, request, hFake } = require('../../../test-helper');
+
+const poleEmploiController = require('../../../../lib/application/pole-emplois/pole-emploi-controller');
+const usecases = require('../../../../lib/domain/usecases');
+
+describe('Unit | Controller | pole-emplois-controller', () => {
+
+  describe('#getSendings', () => {
+
+    it('should return the pole emploi sending', async () => {
+      // given
+      const sending = [{
+        idEnvoi: 456,
+        dateEnvoi: new Date('2021-05-01'),
+        resultat: {
+          campagne: {
+            nom: 'Campagne PE',
+            dateDebut: '2020-08-01T00:00:00.000Z',
+            type: 'EVALUATION',
+            codeCampagne: 'POLEEMPLOI123',
+            urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123',
+            nomOrganisme: 'Pix',
+            typeOrganisme: 'externe' },
+          individu: {
+            nom: 'Kamado',
+            prenom: 'Tanjiro',
+            idPoleEmploi: 'externalUserId' },
+          test: {
+            etat: 2,
+            typeTest: 'DI',
+            referenceExterne: 123456,
+            dateDebut: '2020-09-01T00:00:00.000Z',
+            elementsEvalues: [] } } }];
+      sinon.stub(usecases, 'getPoleEmploiSendings').withArgs().resolves(sending);
+
+      // when
+      await poleEmploiController.getSendings(request, hFake);
+
+      //then
+      expect(usecases.getPoleEmploiSendings).have.been.calledOnce;
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/open-api-doc/pole-emploi/envois-doc_test.js
+++ b/api/tests/unit/infrastructure/open-api-doc/pole-emploi/envois-doc_test.js
@@ -60,7 +60,7 @@ describe('Unit | Infrastructure | Open API Doc | Pole Emploi | Envois Documentat
     };
 
     // when
-    const result = EnvoiDoc.validate([{ idEnvoi: '1', dateEnvoi: '2020-11-31T12:00:38.133Z', resultat }]);
+    const result = EnvoiDoc.validate([{ idEnvoi: 1, dateEnvoi: '2020-11-31T12:00:38.133Z', resultat }]);
 
     // then
     expect(result.error).to.be.undefined;


### PR DESCRIPTION
## :unicorn: Problème
Pour la résilience avec Pole emploi, si l'envoi d'un résultat a échoué on doit pouvoir l'envoyer de nouveau.

## :robot: Solution
Renvoyer les 100 derniers résultats, sans distinction de statut (envoie échoué ou réussi).

## :rainbow: Remarques


## :100: Pour tester
- **cas où l'accès est autorisé**: créer un jeton avec l'identifiant et le secret pole emploi pour simuler à l'api qu'on est pole emploi (cf. channel pole-emploi sur slack) puis récupérer les 100 derniers résultats en allant sur la route `/pole-emploi/envois`.
- **cas où l'accès est refusé** : créer un jeton avec un faux identifiant et/ou un faux secret puis essayer d'accéder à la route.
- **cas où le nombre des envois est modifié**: aller sur Scalingo, modifier la variable d'env pour mettre le nombre que vous souhaitez et vérifier que le nombre de résultats récupérés est bien celui de la variable.
