### PR TITLE
[FEATURE] Affichage d'indicateurs montrant le nombre de participants total et le nombre de résultats reçus dans la page Activité de Pix Orga (Pix-2668).

### DIFF
--- a/orga/app/components/charts/activity.hbs
+++ b/orga/app/components/charts/activity.hbs
@@ -1,0 +1,37 @@
+<div class="activity">
+  <div class="activity__line">
+    <IndicatorCard
+      @title={{t 'charts.participants-count.title'}}
+      @icon="users"
+      @color="blue"
+      @info={{t 'charts.participants-count.information'}}
+      @loading={{this.participantsByStatusLoading}}
+      @loader={{t 'charts.participants-count.loader'}}
+    >
+      {{this.total}}
+    </IndicatorCard>
+    <IndicatorCard
+      @title={{if @isTypeAssessment (t 'charts.submitted-count.title') (t 'charts.submitted-count.title-profiles')}}
+      @icon="share"
+      @color="green"
+      @info={{t 'charts.submitted-count.information'}}
+      @loading={{this.participantsByStatusLoading}}
+      @loader={{t 'charts.submitted-count.loader'}}
+    >
+      {{this.shared}}
+    </IndicatorCard>
+  </div>
+  <div class="activity__line">
+    <Charts::ParticipantsByDay
+      @campaignId={{@campaignId}}
+      @isTypeAssessment={{@isTypeAssessment}}
+      class="activity__participations-by-day"
+    />
+    <Charts::ParticipantsByStatus
+      @loading={{this.participantsByStatusLoading}}
+      @participantCountByStatus={{this.participantCountByStatus}}
+      @isTypeAssessment={{@isTypeAssessment}}
+      class="activity__participations-by-status"
+    />
+  </div>
+</div>

--- a/orga/app/components/charts/activity.js
+++ b/orga/app/components/charts/activity.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import sumBy from 'lodash/sumBy';
+
+export default class Activity extends Component {
+  @service store;
+
+  @tracked participantCountByStatus = [];
+  @tracked total = 0;
+  @tracked shared = 0;
+  @tracked participantsByStatusLoading = true;
+
+  constructor(...args) {
+    super(...args);
+    const { campaignId } = this.args;
+
+    const adapter = this.store.adapterFor('campaign-stats');
+
+    adapter.getParticipationsByStatus(campaignId).then((response) => {
+      const data = response.data.attributes;
+      this.shared = data.shared;
+      this.participantCountByStatus = Object.entries(data);
+      this.total = sumBy(this.participantCountByStatus, ([_, count]) => count);
+      this.participantsByStatusLoading = false;
+    });
+  }
+}

--- a/orga/app/components/charts/participants-by-status.hbs
+++ b/orga/app/components/charts/participants-by-status.hbs
@@ -1,5 +1,5 @@
 <Charts::Card @title={{t 'charts.participants-by-status.title'}} ...attributes>
-  {{#if this.loading}}
+  {{#if @loading}}
     <Charts::ParticipantsByStatusLoader />
   {{else}}
     <Charts::Chart
@@ -9,7 +9,7 @@
       aria-hidden="true"
       class="participants-by-status"
     />
-  
+
     <ul class="participants-by-status__legend" aria-hidden="true">
       {{#each this.datasets as |dataset|}}
         <li class="participants-by-status__legend--{{dataset.key}}">
@@ -20,7 +20,7 @@
         </li>
       {{/each}}
     </ul>
-  
+
     <ul class="sr-only">
       {{#each this.datasets as |dataset|}}
         <li>{{dataset.a11y}}</li>

--- a/orga/app/components/charts/participants-by-status.js
+++ b/orga/app/components/charts/participants-by-status.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import sumBy from 'lodash/sumBy';
 import { TOOLTIP_CONFIG } from './chart';
@@ -8,26 +7,14 @@ export default class ParticipantsByStatus extends Component {
   @service store;
   @service intl;
 
-  @tracked datasets = [];
-  @tracked total = 0;
-  @tracked loading = true;
+  get total() {
+    return sumBy(this.args.participantCountByStatus, ([_, count]) => count);
+  }
 
-  constructor(...args) {
-    super(...args);
-    const { campaignId, isTypeAssessment } = this.args;
-
-    const adapter = this.store.adapterFor('campaign-stats');
-
-    adapter.getParticipationsByStatus(campaignId).then((response) => {
-      const entries = Object.entries(response.data.attributes);
-      this.total = sumBy(entries, ([_, count]) => count);
-
-      this.datasets = entries.map(([key, count]) => {
-        const datasetLabels = this.getDatasetLabels(key, count, isTypeAssessment);
-        return { key, count, ...datasetLabels };
-      });
-
-      this.loading = false;
+  get datasets() {
+    return this.args.participantCountByStatus.map(([key, count]) => {
+      const datasetLabels = this.getDatasetLabels(key, count, this.args.isTypeAssessment);
+      return { key, count, ...datasetLabels };
     });
   }
 

--- a/orga/app/components/indicator-card.hbs
+++ b/orga/app/components/indicator-card.hbs
@@ -1,22 +1,28 @@
 <section class="indicator-card">
-  <div class="indicator-card__icon {{if @color (concat "indicator-card__icon--" @color)}}" aria-hidden="true">
-    <FaIcon @icon={{@icon}}/>
-  </div>
-  <div class="indicator-card__content">
-  <label class="indicator-card__title">
-    {{@title}}
-    {{#if @info}}
-      <PixTooltip
-        role="tooltip"
-        @text={{@info}}
-        @position="top"
-        @isWide={{true}}
-        @isLight={{true}}
-      >
-        <FaIcon @icon="question-circle" class="indicator-card__info"/>
-      </PixTooltip>
-    {{/if}}
-  </label>
-  {{yield}}
-  </div>
+  {{#if @loading}}
+    <p class="sr-only">{{@loader}}</p>
+    <div class="indicator-card__icon" aria-hidden="true"/>
+    <div class="indicator-card__content" aria-hidden="true"/>
+  {{else}}
+    <div class="indicator-card__icon {{if @color (concat "indicator-card__icon--" @color)}}" aria-hidden="true">
+      <FaIcon @icon={{@icon}}/>
+    </div>
+    <div class="indicator-card__content">
+      <label class="indicator-card__title">
+        {{@title}}
+        {{#if @info}}
+          <PixTooltip
+            role="tooltip"
+            @text={{@info}}
+            @position="top"
+            @isWide={{true}}
+            @isLight={{true}}
+          >
+            <FaIcon @icon="question-circle" class="indicator-card__info"/>
+          </PixTooltip>
+        {{/if}}
+      </label>
+      {{yield}}
+    </div>
+  {{/if}}
 </section>

--- a/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
@@ -1,18 +1,33 @@
 .activity {
-  &__stats {
+  display: flex;
+  flex-direction: column;
+
+  &__line {
     display: flex;
-    justify-content: space-between;
+    flex-direction: row;
 
-    &__participations-by-day {
-      box-sizing: border-box;
-      flex: 0 0 auto;
-      width: 73%;
+    & >:not(:last-child) {
+      margin-right: 8px;
+    }
+    & >:not(:first-child) {
+      margin-left: 8px;
     }
 
-    &__participations-by-status {
-      box-sizing: border-box;
-      flex: 0 0 auto;
-      width: 25%;
+    &:not(:last-child) {
+      margin-bottom: 8px;
     }
+    &:not(:first-child) {
+      margin-top: 8px;
+    }
+  }
+
+  &__participations-by-day {
+    box-sizing: border-box;
+    flex: 6 2 auto;
+  }
+
+  &__participations-by-status {
+    box-sizing: border-box;
+    flex: 0 1 auto;
   }
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -1,18 +1,1 @@
-<div class="activity">
-  <div class="activity__line">
-    <IndicatorCard @title={{t 'charts.participants-count.title'}} @icon="users" @color="blue" @info={{t 'charts.participants-count.information'}}>143</IndicatorCard>
-    <IndicatorCard @title={{if @model.isTypeAssessment (t 'charts.submitted-count.title') (t 'charts.submitted-count.title-profiles')}} @icon="share" @color="green" @info={{t 'charts.submitted-count.information'}}>74</IndicatorCard>
-</div>
-  <div class="activity__line">
-    <Charts::ParticipantsByDay
-      @campaignId={{@model.id}}
-      @isTypeAssessment={{@model.isTypeAssessment}}
-      class="activity__stats__participations-by-day"
-    />
-    <Charts::ParticipantsByStatus
-      @campaignId={{@model.id}}
-      @isTypeAssessment={{@model.isTypeAssessment}}
-      class="activity__stats__participations-by-status"
-    />
-  </div>
-</div>
+<Charts::Activity @campaignId={{@model.id}} @isTypeAssessment={{@model.isTypeAssessment}}/>

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -1,8 +1,8 @@
 <div class="activity">
   <div class="activity__line">
-    <IndicatorCard @title="Total de participants" @icon="users" @color="blue" @info='Retrouvez ici le nombre de participations totales à votre campagne. Ce chiffre comprend l’ensemble des participants ayant saisi le code et commencé la campagne.'>143</IndicatorCard>
-    <IndicatorCard @title="Résultats reçus" @icon="share" @color="green" @info='Retrouvez ici les résultats envoyés par vos participants. Ce chiffre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton "J’envoie mes résultats".'>74</IndicatorCard>
-  </div>
+    <IndicatorCard @title={{t 'charts.participants-count.title'}} @icon="users" @color="blue" @info={{t 'charts.participants-count.information'}}>143</IndicatorCard>
+    <IndicatorCard @title={{if @model.isTypeAssessment (t 'charts.submitted-count.title') (t 'charts.submitted-count.title-profiles')}} @icon="share" @color="green" @info={{t 'charts.submitted-count.information'}}>74</IndicatorCard>
+</div>
   <div class="activity__line">
     <Charts::ParticipantsByDay
       @campaignId={{@model.id}}

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -1,12 +1,18 @@
-<div class="activity__stats">
-  <Charts::ParticipantsByDay
-    @campaignId={{@model.id}}
-    @isTypeAssessment={{@model.isTypeAssessment}}
-    class="activity__stats__participations-by-day"
-  />
-  <Charts::ParticipantsByStatus
-    @campaignId={{@model.id}}
-    @isTypeAssessment={{@model.isTypeAssessment}}
-    class="activity__stats__participations-by-status"
-  />
+<div class="activity">
+  <div class="activity__line">
+    <IndicatorCard @title="Total de participants" @icon="users" @color="blue" @info='Retrouvez ici le nombre de participations totales à votre campagne. Ce chiffre comprend l’ensemble des participants ayant saisi le code et commencé la campagne.'>143</IndicatorCard>
+    <IndicatorCard @title="Résultats reçus" @icon="share" @color="green" @info='Retrouvez ici les résultats envoyés par vos participants. Ce chiffre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton "J’envoie mes résultats".'>74</IndicatorCard>
+  </div>
+  <div class="activity__line">
+    <Charts::ParticipantsByDay
+      @campaignId={{@model.id}}
+      @isTypeAssessment={{@model.isTypeAssessment}}
+      class="activity__stats__participations-by-day"
+    />
+    <Charts::ParticipantsByStatus
+      @campaignId={{@model.id}}
+      @isTypeAssessment={{@model.isTypeAssessment}}
+      class="activity__stats__participations-by-status"
+    />
+  </div>
 </div>

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -22,9 +22,11 @@ module.exports = function() {
       'power-off',
       'question-circle',
       'search',
+      'share',
       'share-square',
       'sort',
       'times',
+      'users',
     ],
     'free-regular-svg-icons': [
       'check-circle',

--- a/orga/tests/integration/components/charts/participants-by-status_test.js
+++ b/orga/tests/integration/components/charts/participants-by-status_test.js
@@ -1,37 +1,15 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import sinon from 'sinon';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | Charts::ParticipantsByStatus', function(hooks) {
   setupIntlRenderingTest(hooks);
-  const campaignId = 1;
-  let dataFetcher;
-
-  hooks.beforeEach(async function() {
-    // given
-    this.set('campaignId', campaignId);
-
-    const store = this.owner.lookup('service:store');
-    const adapter = store.adapterFor('campaign-stats');
-    dataFetcher = sinon.stub(adapter, 'getParticipationsByStatus');
-  });
 
   test('it should display status for assessment campaign', async function(assert) {
-    // given
-    dataFetcher.withArgs(campaignId).resolves({
-      data: {
-        attributes: {
-          started: 1,
-          completed: 1,
-          shared: 1,
-        },
-      },
-    });
+    this.participantCountByStatus = [['started', 1], ['completed', 1], ['shared', 1]];
 
-    // when
-    await render(hbs`<Charts::ParticipantsByStatus @campaignId={{campaignId}} @isTypeAssessment={{true}} />`);
+    await render(hbs`<Charts::ParticipantsByStatus @participantCountByStatus={{participantCountByStatus}} @isTypeAssessment={{true}} />`);
 
     assert.contains('En cours (1)');
     assert.contains('En attente d\'envoi (1)');
@@ -39,19 +17,9 @@ module('Integration | Component | Charts::ParticipantsByStatus', function(hooks)
   });
 
   test('it should contains tooltips for assessment campaign', async function(assert) {
-    // given
-    dataFetcher.withArgs(campaignId).resolves({
-      data: {
-        attributes: {
-          started: 1,
-          completed: 1,
-          shared: 1,
-        },
-      },
-    });
+    this.participantCountByStatus = [['started', 1], ['completed', 1], ['shared', 1]];
 
-    // when
-    await render(hbs`<Charts::ParticipantsByStatus @campaignId={{campaignId}} @isTypeAssessment={{true}} />`);
+    await render(hbs`<Charts::ParticipantsByStatus @participantCountByStatus={{participantCountByStatus}} @isTypeAssessment={{true}} />`);
 
     assert.contains('En cours : Ces participants n’ont pas encore terminé leur parcours.');
     assert.contains('En attente d’envoi : Ces participants ont terminé leur parcours mais n’ont pas encore envoyé leurs résultats.');
@@ -59,18 +27,9 @@ module('Integration | Component | Charts::ParticipantsByStatus', function(hooks)
   });
 
   test('it should display status for profile collection campaign', async function(assert) {
-    // given
-    dataFetcher.withArgs(campaignId).resolves({
-      data: {
-        attributes: {
-          completed: 1,
-          shared: 1,
-        },
-      },
-    });
+    this.participantCountByStatus = [['completed', 1], ['shared', 1]];
 
-    // when
-    await render(hbs`<Charts::ParticipantsByStatus @campaignId={{campaignId}} @isTypeAssessment={{false}} />`);
+    await render(hbs`<Charts::ParticipantsByStatus @participantCountByStatus={{participantCountByStatus}} @isTypeAssessment={{false}} />`);
 
     assert.notContains('En cours (1)');
     assert.contains('En attente d\'envoi (1)');
@@ -78,18 +37,9 @@ module('Integration | Component | Charts::ParticipantsByStatus', function(hooks)
   });
 
   test('it should contains tooltips for profile collection campaign', async function(assert) {
-    // given
-    dataFetcher.withArgs(campaignId).resolves({
-      data: {
-        attributes: {
-          completed: 1,
-          shared: 1,
-        },
-      },
-    });
+    this.participantCountByStatus = [['completed', 1], ['shared', 1]];
 
-    // when
-    await render(hbs`<Charts::ParticipantsByStatus @campaignId={{campaignId}} @isTypeAssessment={{false}} />`);
+    await render(hbs`<Charts::ParticipantsByStatus @participantCountByStatus={{participantCountByStatus}} @isTypeAssessment={{false}} />`);
 
     assert.contains('En attente d’envoi : Ces participants n’ont pas encore envoyé leurs profils.');
     assert.contains('Profils reçus : Ces participants ont envoyé leurs profils.');

--- a/orga/tests/unit/components/charts/activity_test.js
+++ b/orga/tests/unit/components/charts/activity_test.js
@@ -1,0 +1,35 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Charts | activity', (hooks) => {
+  setupTest(hooks);
+  let component, dataFetcher;
+
+  hooks.beforeEach(function() {
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('campaign-stats');
+    dataFetcher = sinon.stub(adapter, 'getParticipationsByStatus');
+
+    dataFetcher.resolves({
+      data: {
+        attributes: {
+          started: 1,
+          completed: 1,
+          shared: 1,
+        },
+      },
+    });
+  });
+
+  test('should fill data', async (assert) => {
+    // when
+    component = await createGlimmerComponent('component:charts/activity');
+
+    // then
+    assert.equal(component.total, 3);
+    assert.equal(component.shared, 1);
+    assert.deepEqual(component.participantCountByStatus, [['started', 1], ['completed', 1], ['shared', 1]]);
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -105,10 +105,12 @@
     },
     "participants-count": {
       "information": "Find here the total number of participations in your campaign. This includes all the participants who have entered the code and started their customised test or submitted their profile.",
+      "loader": "Loading total participants",
       "title": "Total participants"
     },
     "submitted-count": {
       "information": "Find here the results submitted by your participants. This includes all the participants who have finished and clicked on the button \"Submit my results\" or \"Submit my profile\".",
+      "loader": "Loading submitted results or profiles",
       "title": "Submitted results",
       "title-profiles": "Submitted profiles"
     }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -102,6 +102,15 @@
       },
       "loader": "Loading participant's activity",
       "title": "Participant's activity"
+    },
+    "participants-count": {
+      "information": "Find here the total number of participations in your campaign. This includes all the participants who have entered the code and started their customised test or submitted their profile.",
+      "title": "Total participants"
+    },
+    "submitted-count": {
+      "information": "Find here the results submitted by your participants. This includes all the participants who have finished and clicked on the button \"Submit my results\" or \"Submit my profile\".",
+      "title": "Submitted results",
+      "title-profiles": "Submitted profiles"
     }
   },
   "common": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -105,10 +105,12 @@
     },
     "participants-count": {
       "information": "Retrouvez ici le nombre de participations totales de votre campagne. Ce chiffre comprend l’ensemble des participants ayant saisis le code et commencé son parcours ou son envoi profil.",
+      "loader": "Chargement du total de participants",
       "title": "Total de participants"
     },
     "submitted-count": {
       "information": "Retrouvez ici les résultats envoyés par vos participants. Ce chiffre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton \"J'envoie mes résultats\" ou \"J'envoie mon profil\".",
+      "loader": "Chargement des résultats ou profils reçus",
       "title": "Résultats reçus",
       "title-profiles": "Profils reçus"
     }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -102,6 +102,15 @@
       },
       "loader": "Chargement de l'activité des participants",
       "title": "Activité des participants"
+    },
+    "participants-count": {
+      "information": "Retrouvez ici le nombre de participations totales de votre campagne. Ce chiffre comprend l’ensemble des participants ayant saisis le code et commencé son parcours ou son envoi profil.",
+      "title": "Total de participants"
+    },
+    "submitted-count": {
+      "information": "Retrouvez ici les résultats envoyés par vos participants. Ce chiffre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton \"J'envoie mes résultats\" ou \"J'envoie mon profil\".",
+      "title": "Résultats reçus",
+      "title-profiles": "Profils reçus"
     }
   },
   "common": {


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs ont besoin de savoir rapidement l'état d'avancement global des participants à une campagne.

## :robot: Solution
Ajouter des indicateurs permettant rapidement de voir cela.

## :rainbow: Remarques
Que du front, tout le back est déjà fait. Cela a donc aucun impact perf supplémentaire.

## :100: Pour tester
Aller sur la page Activité d'une campagne d'évaluation ainsi que d'une campagne de collecte de profils.
Tester aussi quand il n'y a pas encore de participants.
