### PR TITLE
[FEATURE] Ajouter la route pour récupérer les pays et leur code INSEE associé (PIX-2756)

### DIFF
--- a/api/db/database-builder/factory/build-certification-cpf-country.js
+++ b/api/db/database-builder/factory/build-certification-cpf-country.js
@@ -1,0 +1,24 @@
+const databaseBuffer = require('../database-buffer');
+const { sanitizeAndSortChars } = require('../../../lib/infrastructure/utils/string-utils');
+
+module.exports = function buildCertificationCpfCountry({
+  id = databaseBuffer.getNextId(),
+  code = '99123',
+  commonName = 'FILÉKISTANIE',
+  originalName = 'RÉPUBLIQUE DE FILÉKISTAN',
+  matcher = sanitizeAndSortChars(originalName),
+  createdAt = new Date(),
+} = {}) {
+  const values = {
+    id,
+    code,
+    commonName,
+    originalName,
+    matcher,
+    createdAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'certification-cpf-countries',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -25,6 +25,7 @@ module.exports = {
   buildCertificationCourse: require('./build-certification-course'),
   buildCertificationIssueReport: require('./build-certification-issue-report'),
   buildCertificationReport: require('./build-certification-report'),
+  buildCertificationCpfCountry: require('./build-certification-cpf-country'),
   buildCompetenceEvaluation: require('./build-competence-evaluation'),
   buildCompetenceMark: require('./build-competence-mark'),
   buildCorrectAnswersAndKnowledgeElementsForLearningContent: require('./build-correct-answers-and-knowledge-elements-for-learning-content'),

--- a/api/db/seeds/data/certification/certification-cpf-country-builder.js
+++ b/api/db/seeds/data/certification/certification-cpf-country-builder.js
@@ -1,0 +1,33 @@
+function certificationCpfCountryBuilder({ databaseBuilder }) {
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99100',
+    commonName: 'FRANCE',
+    originalName: 'FRANCE',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99345',
+    commonName: 'TOGO',
+    originalName: 'TOGO',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99243',
+    commonName: 'VIET NAM',
+    originalName: 'VIET NAM',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99424',
+    commonName: 'VENEZUELA',
+    originalName: 'VENEZUELA',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99425',
+    commonName: 'TURKS ET CAIQUES (ILES)',
+    originalName: 'TURKS ET CAÏQUES (ÎLES)',
+  });
+}
+
+module.exports = { certificationCpfCountryBuilder };

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -26,6 +26,7 @@ const { targetProfilesBuilder } = require('./data/target-profiles-builder');
 const { usersBuilder } = require('./data/users-builder');
 const usersPixRolesBuilder = require('./data/users_pix_roles-builder');
 const stagesBuilder = require('./data/stages-builder');
+const { certificationCpfCountryBuilder } = require('./data/certification/certification-cpf-country-builder');
 const {
   getEligibleCampaignParticipations,
   generateKnowledgeElementSnapshots,
@@ -63,6 +64,7 @@ exports.seed = async (knex) => {
   certificationScoresBuilder({ databaseBuilder });
   badgeAcquisitionBuilder({ databaseBuilder });
   partnerCertificationBuilder({ databaseBuilder });
+  certificationCpfCountryBuilder({ databaseBuilder });
 
   // Éléments de parcours
   campaignsBuilder({ databaseBuilder });

--- a/api/lib/application/countries/country-controller.js
+++ b/api/lib/application/countries/country-controller.js
@@ -1,0 +1,9 @@
+const usecases = require('../../domain/usecases');
+const countrySerializer = require('../../infrastructure/serializers/jsonapi/country-serializer');
+
+module.exports = {
+  async findCountries() {
+    const countries = await usecases.findCountries();
+    return countrySerializer.serialize(countries);
+  },
+};

--- a/api/lib/application/countries/index.js
+++ b/api/lib/application/countries/index.js
@@ -1,0 +1,21 @@
+const countryController = require('./country-controller');
+
+exports.register = async function(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/countries',
+      config: {
+        handler: countryController.findCountries,
+        tags: ['api'],
+        notes: [
+          'Cette route est utilisée par Pix Certif',
+          'Elle renvoie la liste des noms de pays issus du référentiel INSEE dans le cas de l\'inscription d\'un candidat en certification',
+        ],
+      },
+    },
+
+  ]);
+};
+
+exports.name = 'certification-cpf-countries';

--- a/api/lib/domain/read-models/Country.js
+++ b/api/lib/domain/read-models/Country.js
@@ -1,0 +1,13 @@
+class Country {
+  constructor({
+    code,
+    name,
+  }) {
+    this.code = code;
+    this.name = name;
+  }
+}
+
+module.exports = {
+  Country,
+};

--- a/api/lib/domain/usecases/find-countries.js
+++ b/api/lib/domain/usecases/find-countries.js
@@ -1,0 +1,3 @@
+module.exports = function findCountries({ countryRepository }) {
+  return countryRepository.findAll();
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -35,6 +35,7 @@ const dependencies = {
   certificationChallengeRepository: require('../../infrastructure/repositories/certification-challenge-repository'),
   certificationChallengesService: require('../../domain/services/certification-challenges-service'),
   certificationCourseRepository: require('../../infrastructure/repositories/certification-course-repository'),
+  countryRepository: require('../../infrastructure/repositories/country-repository'),
   certificationIssueReportRepository: require('../../infrastructure/repositories/certification-issue-report-repository'),
   certificationLsRepository: require('../../infrastructure/repositories/certification-livret-scolaire-repository'),
   certificationOfficerRepository: require('../../infrastructure/repositories/certification-officer-repository'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -174,6 +174,7 @@ module.exports = injectDependencies({
   findCampaignParticipationsRelatedToAssessment: require('./find-campaign-participations-related-to-assessment'),
   findCampaignProfilesCollectionParticipationSummaries: require('./find-campaign-profiles-collection-participation-summaries'),
   findCertificationCenterMembershipsByCertificationCenter: require('./find-certification-center-memberships-by-certification-center'),
+  findCountries: require('./find-countries'),
   findCompetenceEvaluationsByAssessment: require('./find-competence-evaluations-by-assessment'),
   findLatestOngoingUserCampaignParticipations: require('./find-latest-ongoing-user-campaign-participations'),
   findDivisionsByCertificationCenter: require('./find-divisions-by-certification-center'),

--- a/api/lib/infrastructure/repositories/country-repository.js
+++ b/api/lib/infrastructure/repositories/country-repository.js
@@ -1,0 +1,21 @@
+const { Country } = require('../../domain/read-models/Country');
+const { knex } = require('../bookshelf');
+
+module.exports = {
+  async findAll() {
+    const result = await knex
+      .from('certification-cpf-countries')
+      .select('commonName', 'code')
+      .where('commonName', '=', knex.ref('originalName'))
+      .orderBy('commonName', 'asc');
+
+    return result.map(_toDomain);
+  },
+};
+
+function _toDomain(row) {
+  return new Country({
+    ...row,
+    name: row.commonName,
+  });
+}

--- a/api/lib/infrastructure/serializers/jsonapi/country-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/country-serializer.js
@@ -1,0 +1,12 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(country) {
+    return new Serializer('country', {
+      id: 'code',
+      attributes: ['code', 'name'],
+    }).serialize(country);
+  },
+
+};

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -11,6 +11,7 @@ module.exports = [
   require('./application/certification-center-memberships'),
   require('./application/certification-centers'),
   require('./application/certification-courses'),
+  require('./application/countries'),
   require('./application/certification-point-of-contacts'),
   require('./application/certification-livret-scolaire'),
   require('./application/certification-reports'),

--- a/api/tests/acceptance/application/countries/countries-controller_test.js
+++ b/api/tests/acceptance/application/countries/countries-controller_test.js
@@ -1,0 +1,31 @@
+const { expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | API | countries-controller', () => {
+
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('GET /api/countries/', () => {
+
+    it('should return 200 HTTP status code', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/countries',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader({ userId: 12345 }),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/country-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/country-repository_test.js
@@ -1,0 +1,68 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const countryRepository = require('../../../../lib/infrastructure/repositories/country-repository');
+const { Country } = require('../../../../lib/domain/read-models/Country');
+
+describe('Integration | Repository | country-repository', () => {
+
+  describe('#findAll', () => {
+
+    describe('when there are countries', () => {
+
+      it('should return all common named countries', async () => {
+        // given
+        databaseBuilder.factory.buildCertificationCpfCountry({
+          code: '99345',
+          commonName: 'TOGO',
+          originalName: 'TOGO',
+          id: 3,
+        });
+
+        databaseBuilder.factory.buildCertificationCpfCountry({
+          code: '99345',
+          commonName: 'TOGO',
+          originalName: 'RÉPUBLIQUE TOGOLAISE',
+          id: 1,
+        });
+
+        databaseBuilder.factory.buildCertificationCpfCountry({
+          code: '99876',
+          commonName: 'NABOO',
+          originalName: 'NABOO',
+          id: 2,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const countries = await countryRepository.findAll();
+
+        // then
+        expect(countries.length).to.equal(2);
+        expect(countries[0]).to.be.instanceOf(Country);
+        expect(countries).to.deep.equal([
+          {
+            code: '99876',
+            name: 'NABOO',
+          },
+          {
+            code: '99345',
+            name: 'TOGO',
+          },
+        ]);
+      });
+    });
+
+    describe('when there are no countries', () => {
+
+      it('should return an empty array', async () => {
+        // given when
+        const countries = await countryRepository.findAll();
+
+        // then
+        expect(countries).to.deep.equal([]);
+      });
+    });
+
+  });
+
+});

--- a/api/tests/tooling/domain-builder/factory/build-country.js
+++ b/api/tests/tooling/domain-builder/factory/build-country.js
@@ -1,0 +1,12 @@
+const { Country } = require('../../../../lib/domain/read-models/Country');
+
+module.exports = function buildCountry({
+  code = '99345',
+  name = 'TOGO',
+} = {}) {
+
+  return new Country({
+    code,
+    name,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -30,6 +30,7 @@ module.exports = {
   buildCertificationChallenge: require('./build-certification-challenge'),
   buildCertificationChallengeWithType: require('./build-certification-challenge-with-type'),
   buildCertificationCourse: require('./build-certification-course'),
+  buildCountry: require('./build-country'),
   buildCertificationDetails: require('./build-certification-details'),
   buildCertificationPointOfContact: require('./build-certification-point-of-contact'),
   buildCertifiableProfileForLearningContent: require('./build-certifiable-profile-for-learning-content'),

--- a/api/tests/unit/application/countries/country-controller_test.js
+++ b/api/tests/unit/application/countries/country-controller_test.js
@@ -1,0 +1,67 @@
+const {
+  expect,
+  hFake,
+  sinon,
+  generateValidRequestAuthorizationHeader,
+  domainBuilder,
+} = require('../../../test-helper');
+
+const usecases = require('../../../../lib/domain/usecases');
+const countrySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/country-serializer');
+
+const countryController = require('../../../../lib/application/countries/country-controller');
+
+describe('Unit | Controller | country-controller', () => {
+
+  describe('#findCountries', () => {
+
+    it('should fetch and return the countries, serialized as JSONAPI', async () => {
+      // given
+      const countries = [
+        domainBuilder.buildCountry({ code: '99345', name: 'Pologne' }),
+        domainBuilder.buildCountry({ code: '99324', name: 'Espagne' }),
+      ];
+
+      const serializedCountries = [
+        {
+          id: '99345',
+          type: 'countries',
+          attributes: {
+            code: '99345',
+            name: 'Pologne',
+          },
+        },
+        {
+          id: '99324',
+          type: 'countries',
+          attributes: {
+            code: '99324',
+            name: 'Espagne',
+          },
+        },
+      ];
+
+      const userId = 42;
+      sinon.stub(countrySerializer, 'serialize');
+      sinon.stub(usecases, 'findCountries');
+
+      usecases.findCountries.resolves(countries);
+      countrySerializer.serialize.withArgs(countries).resolves(serializedCountries);
+
+      const request = {
+        params: { id: 'course_id' },
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        pre: { userId },
+      };
+
+      // when
+      const response = await countryController.findCountries(request, hFake);
+
+      // then
+      expect(usecases.findCountries).to.have.been.called;
+      expect(countrySerializer.serialize).to.have.been.called;
+      expect(countrySerializer.serialize).to.have.been.calledWithExactly(countries);
+      expect(response).to.deep.equal(serializedCountries);
+    });
+  });
+});

--- a/api/tests/unit/application/countries/index_test.js
+++ b/api/tests/unit/application/countries/index_test.js
@@ -1,0 +1,27 @@
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/countries');
+const countryController = require('../../../../lib/application/countries/country-controller');
+
+describe('Unit | Router | country-router', () => {
+
+  describe('GET /api/countries', () => {
+
+    it('should exist', async () => {
+      // given
+      sinon.stub(countryController, 'findCountries').callsFake((request, h) => h.response().code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/countries');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-countries_test.js
+++ b/api/tests/unit/domain/usecases/find-countries_test.js
@@ -1,0 +1,38 @@
+const { expect, domainBuilder, sinon } = require('../../../test-helper');
+const findCountries = require('../../../../lib/domain/usecases/find-countries');
+
+describe('Unit | UseCase | find-country', () => {
+
+  let countryRepository;
+
+  beforeEach(() => {
+
+    countryRepository = {
+      findAll: sinon.stub(),
+    };
+  });
+
+  it('should find the countries', async () => {
+    // given
+    const countries = [
+      domainBuilder.buildCountry({
+        code: '1234',
+        name: 'TOGO',
+      }),
+      domainBuilder.buildCountry({
+        code: '5678',
+        name: 'NABOO',
+      }),
+    ];
+    countryRepository.findAll.resolves(countries);
+
+    // when
+    const result = await findCountries({
+      countryRepository,
+    });
+
+    // then
+    expect(result).to.deep.equal(countries);
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/country-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/country-serializer_test.js
@@ -1,0 +1,48 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/country-serializer');
+const { domainBuilder } = require('../../../../test-helper');
+
+describe('Unit | Serializer | JSONAPI | country-serializer', () => {
+
+  describe('#serialize', () => {
+
+    it('should convert a Certification CPF Country model object into JSON API data', () => {
+      // given
+      const countries = [
+        domainBuilder.buildCountry({
+          code: '123',
+          name: 'TOGO',
+        }),
+        domainBuilder.buildCountry({
+          code: '456',
+          name: 'NABOO',
+        }),
+      ];
+
+      // when
+      const json = serializer.serialize(countries);
+
+      // then
+      expect(json).to.deep.equal({
+        data: [
+          {
+            id: '123',
+            type: 'countries',
+            attributes: {
+              name: 'TOGO',
+              code: '123',
+            },
+          },
+          {
+            id: '456',
+            type: 'countries',
+            attributes: {
+              name: 'NABOO',
+              code: '456',
+            },
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la création de la modale d'inscription de candidat, on souhaite pouvoir sélectionner un pays dans une liste déroulante "cherchable" et renseigner le code INSEE associé à ce pays dans le cas où celui-ci ne serait pas la France.

## :robot: Solution

Créer une route API qui renvoie la liste des pays et leur code INSEE associé. 

## :rainbow: Remarques

*RAS*

## :100: Pour tester

Simuler un appel à l'API et vérifier qu'elle retourne les quatre pays présents dans les seeds.

*Soit* en accédant à [Pix Certif](https://certif-pr3136.review.pix.fr/) avec le navigateur et en copiant-collant dans la console :

```js
fetch("https://certif-pr3136.review.pix.fr/api/countries", {
  "headers": {
    "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxMDAsInNvdXJjZSI6InBpeCIsImlhdCI6MTYyNDg3MDI1MSwiZXhwIjoxNjI1NDc1MDUxfQ.A3A6P2y0y3JhmGzt7-MEQcmVu-S52G26skdOz0qxG0g",
  },
  "method": "GET",
}).then(response => response.json()).then(console.log)
```

*Soit* depuis le terminal en copiant-collant la commande cURL :

```shell
curl 'https://certif-pr3136.review.pix.fr/api/countries' \
  -H 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxMDAsInNvdXJjZSI6InBpeCIsImlhdCI6MTYyNDg3MDI1MSwiZXhwIjoxNjI1NDc1MDUxfQ.A3A6P2y0y3JhmGzt7-MEQcmVu-S52G26skdOz0qxG0g'
```

