### PR TITLE
[FEATURE] Détail des campagnes dans Pix Admin (PIX-2643)

### DIFF
--- a/admin/app/adapters/campaign.js
+++ b/admin/app/adapters/campaign.js
@@ -1,10 +1,11 @@
 import ApplicationAdapter from './application';
 
 export default class Campaigns extends ApplicationAdapter {
+  namespace = 'api/admin';
 
   urlForQuery(query) {
     const baseUrl = this.buildURL();
-    const url = `${baseUrl}/admin/organizations/${query.organizationId}/campaigns`;
+    const url = `${baseUrl}/organizations/${query.organizationId}/campaigns`;
     delete query.organizationId;
 
     return url;

--- a/admin/app/components/campaigns/details.hbs
+++ b/admin/app/components/campaigns/details.hbs
@@ -1,0 +1,26 @@
+<section class="page-section">
+  <h1>{{@campaign.name}}</h1>
+  <p class="campaign__subtitle">
+    Créée le {{moment-format @campaign.createdAt 'DD/MM/YYYY'}} par {{@campaign.creatorFirstName}} {{@campaign.creatorLastName}}
+  </p>
+
+  <ul class="campaign__attributes">
+    <li>Code : {{@campaign.code}}</li>
+    <li>Type : {{if (eq @campaign.type 'ASSESSMENT') "Évaluation" "Collecte de profils"}}</li>
+    <li>Organisation :  
+      <LinkTo @route="authenticated.organizations.get" @model={{@campaign.organizationId}}>
+        {{@campaign.organizationName}}
+      </LinkTo>
+    </li>
+    {{#if @campaign.targetProfileId }}
+      <li>Profil cible :  
+        <LinkTo @route="authenticated.target-profiles.target-profile.details" @model={{@campaign.targetProfileId}}>
+          {{@campaign.targetProfileName}}
+        </LinkTo>
+      </li>
+    {{/if}}
+    {{#if @campaign.archivedAt }}
+      <li>Archivée le {{moment-format @campaign.archivedAt 'DD/MM/YYYY'}}</li>
+    {{/if}}
+  </ul>
+</section>

--- a/admin/app/components/organization-campaigns-section.hbs
+++ b/admin/app/components/organization-campaigns-section.hbs
@@ -21,7 +21,11 @@
           <tbody>
           {{#each @campaigns as |campaign|}}
             <tr aria-label="campagne">
-              <td class="table__column--medium">{{campaign.id}}</td>
+              <td class="table__column--medium">
+                <LinkTo @route="authenticated.campaigns.get" @model={{campaign.id}}>
+                  {{campaign.id}}
+                </LinkTo>
+              </td>
               <td class="table__column--medium">{{campaign.code}}</td>
               <td class="table__column--medium">
                   {{if (eq campaign.type 'ASSESSMENT') "Évaluation" "Collecte de profils"}}

--- a/admin/app/models/campaign.js
+++ b/admin/app/models/campaign.js
@@ -8,4 +8,8 @@ export default class Campaign extends Model {
   @attr('date') createdAt;
   @attr('string') creatorLastName;
   @attr('string') creatorFirstName;
+  @attr('string') organizationId;
+  @attr('string') organizationName;
+  @attr('string') targetProfileId;
+  @attr('string') targetProfileName;
 }

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -38,6 +38,10 @@ Router.map(function() {
       });
     });
 
+    this.route('campaigns', function() {
+      this.route('get', { path: '/:campaign_id' });
+    });
+
     this.route('users', function() {
       this.route('list');
       this.route('get', { path: '/:user_id' });

--- a/admin/app/routes/authenticated/campaigns/get.js
+++ b/admin/app/routes/authenticated/campaigns/get.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class GetRoute extends Route {
+  model(params) {
+    return this.store.findRecord('campaign', params.campaign_id);
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -21,6 +21,7 @@
 /* pages */
 @import 'login';
 @import 'authenticated';
+@import 'authenticated/campaigns/get';
 @import 'authenticated/certifications/index';
 @import 'authenticated/certifications/certification/details';
 @import 'authenticated/certifications/certification/informations';

--- a/admin/app/styles/authenticated/campaigns/get.scss
+++ b/admin/app/styles/authenticated/campaigns/get.scss
@@ -1,0 +1,10 @@
+.campaign__subtitle {
+  font-size: 0.875rem;
+  color: $grey-50;
+}
+
+.campaign__attributes {
+  list-style: none;
+  padding-inline: 0;
+  margin: 0;
+}

--- a/admin/app/styles/misc/global.scss
+++ b/admin/app/styles/misc/global.scss
@@ -17,6 +17,12 @@ h1, h2, h3, h4, h5, h6 {
   font-family: 'Roboto', Arial, sans-serif;
 }
 
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0px;
+}
+
 input:invalid {
   box-shadow: none;
 }

--- a/admin/app/templates/authenticated/campaigns.hbs
+++ b/admin/app/templates/authenticated/campaigns.hbs
@@ -1,0 +1,3 @@
+<div class="page">
+  {{outlet}}
+</div>

--- a/admin/app/templates/authenticated/campaigns/get.hbs
+++ b/admin/app/templates/authenticated/campaigns/get.hbs
@@ -1,0 +1,15 @@
+{{page-title "Campagne " @model.name}}
+
+<header class="page-header">
+  <div class="page-title">
+    <LinkTo @route="authenticated.organizations.list">Toutes les organisations</LinkTo>
+    <span class="wire">&nbsp;>&nbsp;</span>
+    <LinkTo @route="authenticated.organizations.get" @model={{@model.organizationId}}>{{@model.organizationName}}</LinkTo>
+    <span class="wire">&nbsp;>&nbsp;</span>
+    Campagne {{@model.name}}
+  </div>
+</header>
+
+<main class="page-body">
+  <Campaigns::Details @campaign={{@model}} />
+</main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -22,6 +22,10 @@ export default function() {
   this.urlPrefix = 'http://localhost:3000';
   this.namespace = 'api';
 
+  this.get('/admin/campaigns/:id', (schema, request) => {
+    return schema.campaigns.find(request.params.id);
+  });
+
   this.get('/admin/sessions', findPaginatedAndFilteredSessions);
   this.get('/admin/sessions/to-publish', (schema) => {
     const toBePublishedSessions = schema.toBePublishedSessions.all();

--- a/admin/tests/acceptance/authenticated/campaigns/campaign-page_test.js
+++ b/admin/tests/acceptance/authenticated/campaigns/campaign-page_test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Campaign Page', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When user is not logged in', function() {
+    test('it should not be accessible by an unauthenticated user', async function(assert) {
+      // when
+      await visit('/campaigns/1');
+
+      // then
+      assert.equal(currentURL(), '/login');
+    });
+  });
+
+  module('When user is logged in', function(hooks) {
+    hooks.beforeEach(async () => {
+      const user = server.create('user');
+      await createAuthenticateSession({ userId: user.id });
+    });
+
+    test('it should display the campaign detail page', async function(assert) {
+      server.create('campaign', { id: 1, name: 'Campaign name' });
+
+      // when
+      await visit('/campaigns/1');
+
+      // then
+      assert.equal(currentURL(), '/campaigns/1');
+      assert.contains('Campaign name');
+    });
+  });
+});

--- a/admin/tests/integration/components/campaigns/details_test.js
+++ b/admin/tests/integration/components/campaigns/details_test.js
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Campaigns | details', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('should display campaign attributes', async function(assert) {
+    // given
+    this.campaign = {
+      id: 1,
+      name: 'My campaign',
+      type: 'ASSESSMENT',
+      code: 'MYCODE',
+      creatorFirstName: 'Jon',
+      creatorLastName: 'Snow',
+      organizationId: 2,
+      organizationName: 'My organization',
+      targetProfileId: 3,
+      targetProfileName: 'My target profile',
+      createdAt: new Date('2020-02-01'),
+      archivedAt: new Date('2020-03-01'),
+    };
+
+    // when
+    await render(hbs`<Campaigns::Details @campaign={{this.campaign}} />`);
+
+    // expect
+    assert.contains('My campaign');
+    assert.contains('Créée le 01/02/2020 par Jon Snow');
+    assert.contains('Type : Évaluation');
+    assert.contains('Code : MYCODE');
+    assert.contains('My target profile');
+    assert.contains('Archivée le 01/03/2020');
+  });
+
+  test('should display profile collection tag', async function(assert) {
+    // given
+    this.campaign = {
+      id: 1,
+      name: 'My campaign',
+      type: 'COLLECTION_PROFILE',
+    };
+
+    // when
+    await render(hbs`<Campaigns::Details @campaign={{this.campaign}} />`);
+
+    // expect
+    assert.contains('Collecte de profils');
+  });
+});

--- a/api/lib/application/campaigns/campaign-management-controller.js
+++ b/api/lib/application/campaigns/campaign-management-controller.js
@@ -1,0 +1,11 @@
+const usecases = require('../../domain/usecases');
+
+const campaignDetailsManagementSerializer = require('../../infrastructure/serializers/jsonapi/campaign-details-management-serializer');
+
+module.exports = {
+  async getCampaignDetails(request) {
+    const campaignId = request.params.id;
+    const campaign = await usecases.getCampaignDetailsManagement({ campaignId });
+    return campaignDetailsManagementSerializer.serialize(campaign);
+  },
+};

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -1,6 +1,8 @@
 const Joi = require('joi');
 const campaignController = require('./campaign-controller');
+const campaignManagementController = require('./campaign-management-controller');
 const campaignStatsController = require('./campaign-stats-controller');
+const securityPreHandlers = require('../security-pre-handlers');
 const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
@@ -44,6 +46,24 @@ exports.register = async function(server) {
           '- Récupération d\'une campagne par son id',
         ],
         tags: ['api', 'campaign'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/campaigns/{id}',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasRolePixMaster }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignId,
+          }),
+        },
+        handler: campaignManagementController.getCampaignDetails,
+        tags: ['api', 'campaign', 'admin'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de récupérer le détail d\'une campagne.',
+        ],
       },
     },
     {

--- a/api/lib/domain/usecases/get-campaign-details-management.js
+++ b/api/lib/domain/usecases/get-campaign-details-management.js
@@ -1,0 +1,6 @@
+module.exports = async function getCampaignManagement({
+  campaignId,
+  campaignManagementRepository,
+}) {
+  return campaignManagementRepository.get(campaignId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -210,6 +210,7 @@ module.exports = injectDependencies({
   getAttendanceSheet: require('./get-attendance-sheet'),
   getBadgeDetails: require('./get-badge-details'),
   getCampaign: require('./get-campaign'),
+  getCampaignDetailsManagement: require('./get-campaign-details-management'),
   getCampaignByCode: require('./get-campaign-by-code'),
   getCampaignAssessmentParticipation: require('./get-campaign-assessment-participation'),
   getCampaignAssessmentParticipationResult: require('./get-campaign-assessment-participation-result'),

--- a/api/lib/infrastructure/repositories/campaign-management-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-management-repository.js
@@ -4,6 +4,29 @@ const CampaignManagement = require('../../domain/read-models/CampaignManagement'
 const { fetchPage } = require('../utils/knex-utils');
 
 module.exports = {
+  async get(campaignId) {
+    const result = await knex('campaigns')
+      .select({
+        id: 'campaigns.id',
+        code: 'campaigns.code',
+        name: 'campaigns.name',
+        createdAt: 'campaigns.createdAt',
+        archivedAt: 'campaigns.archivedAt',
+        type: 'campaigns.type',
+        creatorLastName: 'users.lastName',
+        creatorFirstName: 'users.firstName',
+        organizationId: 'campaigns.organizationId',
+        organizationName: 'organizations.name',
+        targetProfileId: 'campaigns.targetProfileId',
+        targetProfileName: 'target-profiles.name',
+      })
+      .join('users', 'users.id', 'campaigns.creatorId')
+      .join('organizations', 'organizations.id', 'campaigns.organizationId')
+      .leftJoin('target-profiles', 'target-profiles.id', 'campaigns.targetProfileId')
+      .where('campaigns.id', campaignId)
+      .first();
+    return result;
+  },
 
   async findPaginatedCampaignManagements({ organizationId, page }) {
     const query = knex('campaigns')

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-details-management-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-details-management-serializer.js
@@ -12,6 +12,10 @@ module.exports = {
         'creatorId',
         'creatorLastName',
         'creatorFirstName',
+        'organizationId',
+        'organizationName',
+        'targetProfileId',
+        'targetProfileName',
       ],
       meta,
     }).serialize(campaignManagement);

--- a/api/tests/acceptance/application/campaign-management-controller_test.js
+++ b/api/tests/acceptance/application/campaign-management-controller_test.js
@@ -1,0 +1,47 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const createServer = require('../../../server');
+
+describe('Acceptance | API | Campaign Management Controller', () => {
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('GET /api/admin/campaigns/{id', () => {
+    it('should return the campaign details', async () => {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const user = databaseBuilder.factory.buildUser.withPixRolePixMaster();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/admin/campaigns/${campaign.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.id).to.equal(campaign.id.toString());
+    });
+
+    it('should return HTTP code 403 if user is not Pix Master', async () => {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/admin/campaigns/${campaign.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
@@ -1,8 +1,74 @@
 const { expect, databaseBuilder } = require('../../../test-helper');
 const campaignManagementRepository = require('../../../../lib/infrastructure/repositories/campaign-management-repository');
 const _ = require('lodash');
+const Campaign = require('../../../../lib/domain/models/Campaign');
 
 describe('Integration | Repository | Campaign-Management', () => {
+
+  describe('#get', () => {
+    it('should return campaign details with target profile', async () => {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const organization = databaseBuilder.factory.buildOrganization({});
+      const campaign = databaseBuilder.factory.buildCampaign({
+        creatorId: user.id,
+        targetProfileId: targetProfile.id,
+        organizationId: organization.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignManagementRepository.get(campaign.id);
+
+      // then
+      expect(result).to.deep.equal({
+        id: campaign.id,
+        name: campaign.name,
+        code: campaign.code,
+        type: campaign.type,
+        createdAt: campaign.createdAt,
+        archivedAt: campaign.archivedAt,
+        creatorFirstName: user.firstName,
+        creatorLastName: user.lastName,
+        organizationId: organization.id,
+        organizationName: organization.name,
+        targetProfileId: targetProfile.id,
+        targetProfileName: targetProfile.name,
+      });
+    });
+
+    it('should return campaign details without target profile', async () => {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const organization = databaseBuilder.factory.buildOrganization({});
+      const campaign = databaseBuilder.factory.buildCampaign({
+        type: Campaign.types.PROFILES_COLLECTION,
+        creatorId: user.id,
+        organizationId: organization.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignManagementRepository.get(campaign.id);
+
+      // then
+      expect(result).to.deep.equal({
+        id: campaign.id,
+        name: campaign.name,
+        code: campaign.code,
+        type: campaign.type,
+        createdAt: campaign.createdAt,
+        archivedAt: campaign.archivedAt,
+        creatorFirstName: user.firstName,
+        creatorLastName: user.lastName,
+        organizationId: organization.id,
+        organizationName: organization.name,
+        targetProfileId: null,
+        targetProfileName: null,
+      });
+    });
+  });
 
   describe('#findPaginatedCampaignManagements', () => {
     let page;

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-details-management-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-details-management-serializer_test.js
@@ -1,0 +1,50 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-details-management-serializer');
+
+describe('Unit | Serializer | JSONAPI | campaign-details-management-serializer', function() {
+
+  describe('#serialize()', function() {
+
+    it('should convert a Campaign Detail Management model object into JSON API data', function() {
+      // given
+      const campaignManagement = {
+        id: 'campaign_management_id',
+        name: 'campaign',
+        code: '123',
+        type: 'ASSESSEMENT',
+        archivedAt: new Date('2020-10-10'),
+        createdAt: new Date('2020-10-10'),
+        creatorFirstName: 'Ned',
+        creatorLastName: 'Stark',
+        organizationId: 123,
+        organizationName: 'Orga',
+        targetProfileId: 123,
+        targetProfileName: 'TP',
+      };
+
+      // when
+      const json = serializer.serialize(campaignManagement);
+
+      // then
+      expect(json).to.deep.equal({
+        data: {
+          type: 'campaigns',
+          id: campaignManagement.id.toString(),
+          attributes: {
+            code: campaignManagement.code,
+            name: campaignManagement.name,
+            type: campaignManagement.type,
+            'archived-at': campaignManagement.archivedAt,
+            'created-at': campaignManagement.createdAt,
+            'creator-first-name': campaignManagement.creatorFirstName,
+            'creator-last-name': campaignManagement.creatorLastName,
+            'organization-id': campaignManagement.organizationId,
+            'organization-name': campaignManagement.organizationName,
+            'target-profile-id': campaignManagement.targetProfileId,
+            'target-profile-name': campaignManagement.targetProfileName,
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Il n'y a pas de page dédiée aux campagnes dans Pix Admin, on ne peut pas voir le détail d'une campagne.

## :robot: Solution

Créer une page du détail d'une campagne, dans un premier temps avec les informations de base :
- Nom
- Type
- Code de la campagne
- Date et utilisateur de création
- Nom et lien vers l'organisation
- Nom et lien vers le profil cible (si campagne d'évaluation)
- Date d'archivage (si archivée)

Par la suite cette page pourra afficher des informations plus détaillées et des actions liées à la campagne.

## :rainbow: Remarques

![image](https://user-images.githubusercontent.com/516360/123604749-6bc88a80-d7fb-11eb-9310-7ca8f96049db.png)


## :100: Pour tester
1. Se connecter à Pix Admin
2. Aller sur une organisation
3. Aller sur l'onglet campagne
4. Cliquer sur une campagne
> Le détail de la campagne d'affiche
