### PR TITLE
[BUGFIX] Le compteur "Nombre de certifications non terminées" sur la page d'information d'une session est incorrect sur PixAdmin (PIX-2723)

### DIFF
--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -57,4 +57,14 @@ export default class JuryCertificationSummary extends Model {
     const statusWithLabel = find(certificationStatuses, (certificationStatus) => certificationStatus.value === this.status);
     return statusWithLabel?.label;
   }
+
+  @computed('status')
+  get isCertificationStarted() {
+    return this.status === 'started';
+  }
+
+  @computed('status')
+  get isCertificationInError() {
+    return this.status === 'error';
+  }
 }

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -97,9 +97,9 @@ export default class Session extends Model {
   }
 
   @computed('juryCertificationSummaries.@each.status')
-  get countNonValidatedCertifications() {
-    return _getNumberOf(this.juryCertificationSummaries, (juryCertificationSummary) =>
-      juryCertificationSummary.status !== 'validated');
+  get countStartedAndInErrorCertifications() {
+    return _getNumberOf(this.juryCertificationSummaries,
+      (juryCertificationSummary) => juryCertificationSummary.isCertificationStarted || juryCertificationSummary.isCertificationInError);
   }
 
   @computed('resultsSentToPrescriberAt', 'isFinalized')

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -85,8 +85,8 @@
       <div class="col" data-test-id="session-info__number-of-not-checked-end-screen">{{this.sessionModel.countNotCheckedEndScreen}}</div>
     </div>
     <div class="row">
-      <div class="col">Nombre de certifications non terminées :</div>
-      <div class="col" data-test-id="session-info__number-of-not-ended-certifications">{{this.sessionModel.countNonValidatedCertifications}}</div>
+      <div class="col">Nombre de certifications démarrées/en erreur :</div>
+      <div class="col" data-test-id="session-info__number-of-started-or-error-certifications">{{this.sessionModel.countStartedAndInErrorCertifications}}</div>
     </div>
     {{#if this.sessionModel.hasExaminerGlobalComment}}
     <div class="row">

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -100,7 +100,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       // when
       assert.dom('[data-test-id="session-info__number-of-issue-report"]').hasText('1');
       assert.dom('[data-test-id="session-info__number-of-not-checked-end-screen"]').hasText('1');
-      assert.dom('[data-test-id="session-info__number-of-not-ended-certifications"]').hasText('0');
+      assert.dom('[data-test-id="session-info__number-of-started-or-error-certifications"]').hasText('0');
     });
 
     test('it renders the examinerGlobalComment if any', async function(assert) {

--- a/admin/tests/unit/models/jury-certification-summary_test.js
+++ b/admin/tests/unit/models/jury-certification-summary_test.js
@@ -178,4 +178,140 @@ module('Unit | Model | jury-certification-summary', function(hooks) {
       assert.equal(complementaryCertificationsLabel, 'CléA Numérique\nPix+ Droit Expert');
     });
   });
+
+  module('#get isCertificationStarted', function() {
+
+    test('it should return true when the status is "started"', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'started' });
+      });
+
+      // when
+      const isCertificationStarted = juryCertificationSummary.isCertificationStarted;
+
+      // then
+      assert.equal(isCertificationStarted, true);
+    });
+
+    test('it should return false when the status is "validated" (not started)', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'validated' });
+      });
+
+      // when
+      const isCertificationStarted = juryCertificationSummary.isCertificationStarted;
+
+      // then
+      assert.equal(isCertificationStarted, false);
+    });
+
+    test('it should return false when the status is "rejected" (not started)', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'rejected' });
+      });
+
+      // when
+      const isCertificationStarted = juryCertificationSummary.isCertificationStarted;
+
+      // then
+      assert.equal(isCertificationStarted, false);
+    });
+
+    test('it should return false when the status is "error" (not started)', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'error' });
+      });
+
+      // when
+      const isCertificationStarted = juryCertificationSummary.isCertificationStarted;
+
+      // then
+      assert.equal(isCertificationStarted, false);
+    });
+
+    test('it should return false when the status is "cancelled" (not started)', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'cancelled' });
+      });
+
+      // when
+      const isCertificationStarted = juryCertificationSummary.isCertificationStarted;
+
+      // then
+      assert.equal(isCertificationStarted, false);
+    });
+  });
+
+  module('#isCertificationInError', function() {
+
+    test('it should return true when the status is "error"', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'error' });
+      });
+
+      // when
+      const isCertificationInError = juryCertificationSummary.isCertificationInError;
+
+      // then
+      assert.equal(isCertificationInError, true);
+    });
+
+    test('it should return false when the status is "started" (not in error)', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'started' });
+      });
+
+      // when
+      const isCertificationInError = juryCertificationSummary.isCertificationInError;
+
+      // then
+      assert.equal(isCertificationInError, false);
+    });
+
+    test('it should return false when the status is "validated" (not in error)', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'validated' });
+      });
+
+      // when
+      const isCertificationInError = juryCertificationSummary.isCertificationInError;
+
+      // then
+      assert.equal(isCertificationInError, false);
+    });
+
+    test('it should return false when the status is "rejected" (not in error)', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'rejected' });
+      });
+
+      // when
+      const isCertificationInError = juryCertificationSummary.isCertificationInError;
+
+      // then
+      assert.equal(isCertificationInError, false);
+    });
+
+    test('it should return false when the status is "cancelled" (not in error)', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'cancelled' });
+      });
+
+      // when
+      const isCertificationInError = juryCertificationSummary.isCertificationInError;
+
+      // then
+      assert.equal(isCertificationInError, false);
+    });
+  });
 });

--- a/admin/tests/unit/models/session_test.js
+++ b/admin/tests/unit/models/session_test.js
@@ -255,33 +255,109 @@ module('Unit | Model | session', function(hooks) {
 
   });
 
-  module('#countNonValidatedCertifications', function() {
+  module('#countStartedAndInErrorCertifications', function() {
 
-    let sessionWithOneNotValidatedCertif;
-    let sessionWithValidatedCertif;
-
-    hooks.beforeEach(async function() {
-      sessionWithOneNotValidatedCertif = run(() => {
-        const certif = store.createRecord('jury-certification-summary', { status: 'nonValidated' });
-        return store.createRecord('session', { juryCertificationSummaries: [certif] });
+    test('it should take into account started certifications', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'started' });
+      });
+      const session = run(() => {
+        return store.createRecord('session', { juryCertificationSummaries: [juryCertificationSummary] });
       });
 
-      sessionWithValidatedCertif = run(() => {
-        const certif = store.createRecord('jury-certification-summary', { status: 'validated' });
-        return store.createRecord('session', { juryCertificationSummaries: [certif] });
+      // when
+      const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
+
+      // then
+      assert.equal(countStartedAndInErrorCertifications, 1);
+    });
+
+    test('it should take into account in error certifications', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'error' });
       });
+      const session = run(() => {
+        return store.createRecord('session', { juryCertificationSummaries: [juryCertificationSummary] });
+      });
+
+      // when
+      const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
+
+      // then
+      assert.equal(countStartedAndInErrorCertifications, 1);
     });
 
-    test('it should count 1 non validated', function(assert) {
-      const countNonValidated = sessionWithOneNotValidatedCertif.countNonValidatedCertifications;
-      assert.equal(countNonValidated, 1);
+    test('it should ignore validated certifications', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'validated' });
+      });
+      const session = run(() => {
+        return store.createRecord('session', { juryCertificationSummaries: [juryCertificationSummary] });
+      });
+
+      // when
+      const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
+
+      // then
+      assert.equal(countStartedAndInErrorCertifications, 0);
     });
 
-    test('it should count 0 non validated', function(assert) {
-      const countNonValidated = sessionWithValidatedCertif.countNonValidatedCertifications;
-      assert.equal(countNonValidated, 0);
+    test('it should ignore rejected certifications', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'validated' });
+      });
+      const session = run(() => {
+        return store.createRecord('session', { juryCertificationSummaries: [juryCertificationSummary] });
+      });
+
+      // when
+      const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
+
+      // then
+      assert.equal(countStartedAndInErrorCertifications, 0);
     });
 
+    test('it should ignore cancelled certifications', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'validated' });
+      });
+      const session = run(() => {
+        return store.createRecord('session', { juryCertificationSummaries: [juryCertificationSummary] });
+      });
+
+      // when
+      const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
+
+      // then
+      assert.equal(countStartedAndInErrorCertifications, 0);
+    });
+
+    test('it should return a sum of started and in error certifications', function(assert) {
+      // given
+      const juryCertificationSummary1 = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'started' });
+      });
+      const juryCertificationSummary2 = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'error' });
+      });
+      const juryCertificationSummary3 = run(() => {
+        return store.createRecord('jury-certification-summary', { status: 'started' });
+      });
+      const session = run(() => {
+        return store.createRecord('session', { juryCertificationSummaries: [juryCertificationSummary1, juryCertificationSummary2, juryCertificationSummary3] });
+      });
+
+      // when
+      const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
+
+      // then
+      assert.equal(countStartedAndInErrorCertifications, 3);
+    });
   });
 
   module('#areResultsToBeSentToPrescriber', function() {


### PR DESCRIPTION
## :unicorn: Problème
"Nombre de certifications non terminées" ne fait qu'ignorer les certifications validées. De fait, dans son compteur, cela inclut les certification rejetées, qui en soi ne méritent pas d'action jury / ne sont pas un problème.

## :robot: Solution
L'idée de cette page est de mettre en valeur, d'un seul coup d'oeil, les problèmes sur une session.
Le label a donc été renommé en "Nombre de certifications démarrées/en erreur", et ainsi est plus explicite quant aux certifications considérées dans son compteur (donc les started et les errors en somme).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Tester le compteur avec différents statuts de certification.
