### PR TITLE
[TECH] Supprimer les mixins d'Ember-simple-auth 3.1.0 dans Pix Certif (PIX-2759).

### DIFF
--- a/certif/app/adapters/application.js
+++ b/certif/app/adapters/application.js
@@ -1,11 +1,12 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-// eslint-disable-next-line ember/no-mixins
-import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import { inject as service } from '@ember/service';
 import ENV from 'pix-certif/config/environment';
 
-export default class ApplicationAdapter extends JSONAPIAdapter.extend(DataAdapterMixin) {
+export default class ApplicationAdapter extends JSONAPIAdapter {
+
   @service ajaxQueue;
+  @service session;
+
   host = ENV.APP.API_HOST;
   namespace = 'api';
 

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -1,43 +1,17 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-// eslint-disable-next-line ember/no-mixins
-import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
-export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin) {
+export default class ApplicationRoute extends Route {
 
   @service currentUser;
-  @service url;
   @service featureToggles;
-
-  routeAfterAuthentication = 'authenticated';
 
   async beforeModel() {
     await this.featureToggles.load();
     return this._loadCurrentUser();
   }
 
-  async sessionAuthenticated() {
-    await this._loadCurrentUser();
-    this.transitionTo(this.routeAfterAuthentication);
-  }
-
-  sessionInvalidated() {
-    const redirectionUrl = this._redirectionUrl();
-    this._clearStateAndRedirect(redirectionUrl);
-  }
-
-  _clearStateAndRedirect(url) {
-    return window.location.replace(url);
-  }
-
   _loadCurrentUser() {
     return this.currentUser.load();
-  }
-
-  _redirectionUrl() {
-    const alternativeRootURL = this.session.alternativeRootURL;
-    this.session.alternativeRootURL = null;
-
-    return alternativeRootURL ? alternativeRootURL : this.url.homeUrl;
   }
 }

--- a/certif/app/routes/authenticated.js
+++ b/certif/app/routes/authenticated.js
@@ -1,18 +1,23 @@
 import Route from '@ember/routing/route';
-// eslint-disable-next-line ember/no-mixins
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
+import get from 'lodash/get';
 
-export default class AuthenticatedRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class AuthenticatedRoute extends Route {
+
   @service currentUser;
+  @service router;
+  @service session;
 
   beforeModel(transition) {
-    super.beforeModel(...arguments);
+    this.session.requireAuthentication(transition, 'login');
+
     if (transition.isAborted) {
       return;
     }
-    if (!this.currentUser.certificationPointOfContact.pixCertifTermsOfServiceAccepted) {
-      return this.replaceWith('terms-of-service');
+
+    const pixCertifTermsOfServiceAccepted = get(this.currentUser, 'certificationPointOfContact.pixCertifTermsOfServiceAccepted');
+    if (!pixCertifTermsOfServiceAccepted) {
+      this.router.replaceWith('terms-of-service');
     }
   }
 

--- a/certif/app/routes/authenticated/index.js
+++ b/certif/app/routes/authenticated/index.js
@@ -1,9 +1,12 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route {
 
+  @service router;
+
   beforeModel() {
-    return this.replaceWith('authenticated.sessions.list');
+    return this.router.replaceWith('authenticated.sessions.list');
   }
 
 }

--- a/certif/app/routes/login.js
+++ b/certif/app/routes/login.js
@@ -1,6 +1,11 @@
 import Route from '@ember/routing/route';
-// eslint-disable-next-line ember/no-mixins
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) {
+export default class LoginRoute extends Route {
+
+  @service session;
+
+  beforeModel() {
+    this.session.prohibitAuthentication('authenticated');
+  }
 }

--- a/certif/app/routes/logout.js
+++ b/certif/app/routes/logout.js
@@ -5,7 +5,6 @@ export default class LogoutRoute extends Route {
   @service session;
 
   beforeModel() {
-    super.beforeModel(...arguments);
     if (this.session.isAuthenticated) {
       this.session.invalidate();
     }

--- a/certif/app/routes/terms-of-service.js
+++ b/certif/app/routes/terms-of-service.js
@@ -1,19 +1,23 @@
 import Route from '@ember/routing/route';
-// eslint-disable-next-line ember/no-mixins
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
+import get from 'lodash/get';
 
-export default class TermsOfServiceRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class TermsOfServiceRoute extends Route {
 
   @service currentUser;
+  @service router;
+  @service session;
 
   beforeModel(transition) {
-    super.beforeModel(...arguments);
+    this.session.requireAuthentication(transition, 'login');
+
     if (transition.isAborted) {
       return;
     }
-    if (this.currentUser.certificationPointOfContact.pixCertifTermsOfServiceAccepted) {
-      return this.replaceWith('');
+
+    const pixCertifTermsOfServiceAccepted = get(this.currentUser, 'certificationPointOfContact.pixCertifTermsOfServiceAccepted');
+    if (pixCertifTermsOfServiceAccepted) {
+      this.router.replaceWith('');
     }
   }
 }

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -1,0 +1,28 @@
+import { inject as service } from '@ember/service';
+import SessionService from 'ember-simple-auth/services/session';
+
+export default class CurrentSessionService extends SessionService {
+
+  @service currentUser;
+  @service router;
+  @service url;
+
+  routeAfterAuthentication = 'authenticated';
+
+  async handleAuthentication() {
+    await this.currentUser.load();
+    super.handleAuthentication(this.routeAfterAuthentication);
+  }
+
+  handleInvalidation() {
+    const routeAfterInvalidation = this._getRouteAfterInvalidation();
+    super.handleInvalidation(routeAfterInvalidation);
+  }
+
+  _getRouteAfterInvalidation() {
+    const alternativeRootURL = this.alternativeRootURL;
+    this.alternativeRootURL = null;
+
+    return alternativeRootURL ? alternativeRootURL : this.url.homeUrl;
+  }
+}

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -12,6 +12,7 @@ function parseQueryString(queryString) {
 }
 
 export default function() {
+  this.logging = true;
   this.urlPrefix = 'http://localhost:3000';
   this.namespace = 'api';
   this.timing = 0;
@@ -26,8 +27,8 @@ export default function() {
 
     if (foundUser && params.password === 'secret') {
       return {
-        token_type: '',
-        expires_in: '',
+        expires_in: 3600,
+        token_type: 'Bearer token type',
         access_token: 'aaa.' + btoa(`{"user_id":${foundUser.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
         user_id: foundUser.id,
       };

--- a/certif/tests/acceptance/authentication_test.js
+++ b/certif/tests/acceptance/authentication_test.js
@@ -35,15 +35,13 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When certificationPointOfContact is logging in but has not accepted terms of service yet', function(hooks) {
-
-    hooks.beforeEach(async () => {
-      await invalidateSession();
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceNotAccepted();
-    });
+  module('When certificationPointOfContact is logging in but has not accepted terms of service yet', function() {
 
     test('it should redirect certificationPointOfContact to the terms-of-service page', async function(assert) {
       // given
+      await invalidateSession();
+      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceNotAccepted();
+
       await visit('/connexion');
       await fillIn('#login-email', certificationPointOfContact.email);
       await fillIn('#login-password', 'secret');
@@ -58,6 +56,9 @@ module('Acceptance | authentication', function(hooks) {
 
     test('it should not show menu nor top bar', async function(assert) {
       // given
+      await invalidateSession();
+      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceNotAccepted();
+
       await visit('/connexion');
       await fillIn('#login-email', certificationPointOfContact.email);
       await fillIn('#login-password', 'secret');
@@ -73,15 +74,13 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When certificationPointOfContact is logging in and has accepted terms of service', function(hooks) {
-
-    hooks.beforeEach(async () => {
-      await invalidateSession();
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-    });
+  module('When certificationPointOfContact is logging in and has accepted terms of service', function() {
 
     test('it should redirect certificationPointOfContact to the session list', async function(assert) {
       // given
+      await invalidateSession();
+      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+
       await visit('/connexion');
       await fillIn('#login-email', certificationPointOfContact.email);
       await fillIn('#login-password', 'secret');
@@ -96,6 +95,9 @@ module('Acceptance | authentication', function(hooks) {
 
     test('it should show certificationPointOfContact name', async function(assert) {
       // given
+      await invalidateSession();
+      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+
       await visit('/connexion');
       await fillIn('#login-email', certificationPointOfContact.email);
       await fillIn('#login-password', 'secret');
@@ -105,20 +107,17 @@ module('Acceptance | authentication', function(hooks) {
 
       // then
       assert.ok(currentSession(this.application).get('isAuthenticated'), 'The certificationPointOfContact is authenticated');
-
       assert.dom('.logged-user-summary__name').hasText('Harry Cover');
     });
   });
 
-  module('When certificationPointOfContact is already authenticated and has accepted terms of service', function(hooks) {
-
-    hooks.beforeEach(async () => {
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-
-      await authenticateSession(certificationPointOfContact.id);
-    });
+  module('When certificationPointOfContact is already authenticated and has accepted terms of service', function() {
 
     test('it should let certificationPointOfContact access requested page', async function(assert) {
+      // given
+      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+      await authenticateSession(certificationPointOfContact.id);
+
       // when
       await visit('/sessions/liste');
 
@@ -128,19 +127,27 @@ module('Acceptance | authentication', function(hooks) {
     });
 
     test('it should show the name and externalId of certification center', async function(assert) {
+      // given
+      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+      await authenticateSession(certificationPointOfContact.id);
+
+      // when
       await visit('/sessions/liste');
 
+      // then
       assert.dom('.logged-user-summary__certification-center').hasText('Centre de certification du pix (ABC123)');
     });
 
     test('it should redirect certificationPointOfContact to the session list on root url', async function(assert) {
+      // given
+      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+      await authenticateSession(certificationPointOfContact.id);
+
       // when
       await visit('/');
 
       // then
       assert.equal(currentURL(), '/sessions/liste');
     });
-
   });
-
 });

--- a/certif/tests/unit/adapters/application_test.js
+++ b/certif/tests/unit/adapters/application_test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapters | ApplicationAdapter', function(hooks) {
+module('Unit | Adapters | ApplicationAdapter', function(hooks) {
+
   setupTest(hooks);
 
   test('should specify /api as the root url', function(assert) {
@@ -13,7 +14,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     assert.equal(applicationAdapter.namespace, 'api');
   });
 
-  module('get headers()', function() {
+  module('#get headers()', function() {
 
     test('should add header with authentication token when the session is authenticated', function(assert) {
       // Given
@@ -39,7 +40,8 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     });
   });
 
-  module('ajax()', function() {
+  module('#ajax()', function() {
+
     test('should queue ajax calls', function(assert) {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');

--- a/certif/tests/unit/routes/authenticated/index_test.js
+++ b/certif/tests/unit/routes/authenticated/index_test.js
@@ -1,20 +1,25 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
+
+class RouterStub extends Service {
+  replaceWith = sinon.stub().resolves();
+}
 
 module('Unit | Route | authenticated/sessions', function(hooks) {
+
   setupTest(hooks);
 
   test('it should redirects to authenticated.sessions.list', async function(assert) {
     // given
+    this.owner.register('service:router', RouterStub);
     const route = this.owner.lookup('route:authenticated/index');
-    route.replaceWith = sinon.stub().resolves();
 
     // when
     await route.beforeModel();
 
     // then
-    sinon.assert.calledWith(route.replaceWith, 'authenticated.sessions.list');
-    assert.ok(route);
+    assert.ok(route.router.replaceWith.calledWith('authenticated.sessions.list'));
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
* Les modules Ember-Simple-Auth de nos applications fronts ne sont pas à jour, car ses mixins sont `deprecated`

## :robot: Solution
* Mettre à jour ce module dans Pix Certif

## :100: Pour tester
* Recette globale de Pix Certif, surtout les pages `login`, `logout`, les pages accessibles uniquement si l'utilisateur est authentifié
