### PR TITLE
[FEATURE] Modifier le texte des cgu dans la page d'inscription sur Pix App (PIX-2753).

### DIFF
--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -88,6 +88,7 @@
         <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
           {{t 'pages.sign-up.fields.cgu.data-protection-policy'}}
         </a>
+        {{t 'pages.sign-up.fields.cgu.pix'}}
         {{#if @user.errors.cgu}}
           <div id="validationMessage-cgu" class="sign-form__validation-error" aria-live="polite">
             {{t 'pages.sign-up.fields.cgu.error'}}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1028,6 +1028,7 @@
           "and": "and ",
           "cgu": "Pix terms of use",
           "data-protection-policy": "personal data protection policy",
+          "pix" : "",
           "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
           "label": "Agree Pix terms of use and personal data protection policy"
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1025,9 +1025,10 @@
       "fields": {
         "cgu": {
           "accept": "J'accepte les ",
-          "and": "et ",
-          "cgu": "conditions d'utilisation de Pix",
-          "data-protection-policy": "la politique de confidentialité",
+          "and": "et la ",
+          "cgu": "conditions d'utilisation",
+          "data-protection-policy": "politique de confidentialité",
+          "pix" : " de Pix",
           "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
           "label": "Accepter les conditions d’utilisation de Pix et la politique de confidentialité"
         },


### PR DESCRIPTION
## :unicorn: Problème
Cette PR fait suite à l'ajout du lien de la politique de confidentialité dans la page d'inscription sur pix App => https://github.com/1024pix/pix/pull/3086.

Le "Pix" situé en milieu de phrase (`J'accepte les conditions d'utilisation de Pix et la politique de confidentialité`) est mal placé.

## :robot: Solution
Placer le "Pix" en fin de phrase : `J'accepte les conditions d'utilisation et la politique de confidentialité de Pix`

## :rainbow: Remarques
Pas de modification sur la traduction en anglais.

## :100: Pour tester
Voir la phrase corrigée sur la page d'inscription
