### PR TITLE
[FEATURE] Simplifier la liste des candidats (PIX-2714)

### DIFF
--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -21,58 +21,176 @@
   </div>
   <div class="table content-text content-text--small certification-candidates-table">
     {{#if (or @certificationCandidates this.candidatesInStaging)}}
-      <table>
-        <thead>
-        <tr>
-          <th class="certification-candidates-table__column-last-name">
-            {{#if this.isCandidateBeingAdded}}
-              *
-            {{/if}}
-            Nom de naissance
-          </th>
-          <th class="certification-candidates-table__column-first-name">
-            {{#if this.isCandidateBeingAdded}}
-              *
-            {{/if}}
-            Prénom
-          </th>
-          <th>
-            {{#if this.isCandidateBeingAdded}}
-              *
-            {{/if}}
-            Date de naissance
-          </th>
-          <th>
-            {{#if this.isCandidateBeingAdded}}
-              *
-            {{/if}}
-            Commune de naissance
-          </th>
-          <th>
-            {{#if this.isCandidateBeingAdded}}
-              *
-            {{/if}}
-            Département de naissance
-          </th>
-          <th>
-            {{#if this.isCandidateBeingAdded}}
-              *
-            {{/if}}
-            Pays de naissance
-          </th>
-          {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-            <th>Adresse e-mail du destinataire des résultats</th>
-          {{/unless}}
-          {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-            <th>Adresse e-mail de convocation</th>
-          {{/unless}}
-          {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-            <th>Identifiant externe</th>
-          {{/unless}}
-          <th class="certification-candidates-table__column-time">Temps majoré</th>
-          <th width="185"></th>
-        </tr>
-        </thead>
+      {{#if @isNewCpfDataToggleEnabled}}
+        <table class="certification-candidates-table-cpf-toggle-enabled">
+          <thead>
+          <tr>
+            <th class="certification-candidates-table__column-last-name">
+              {{#if this.isCandidateBeingAdded}}
+                *
+              {{/if}}
+              Nom de naissance
+            </th>
+            <th class="certification-candidates-table__column-first-name">
+              {{#if this.isCandidateBeingAdded}}
+                *
+              {{/if}}
+              Prénom
+            </th>
+            <th class="certification-candidates-table__column-birthdate">
+              {{#if this.isCandidateBeingAdded}}
+                *
+              {{/if}}
+              Date de naissance
+            </th>
+            {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+              <th class="certification-candidates-table__birth-city">
+                {{#if this.isCandidateBeingAdded}}
+                  *
+                {{/if}}
+                Commune de naissance
+              </th>
+              <th>
+                {{#if this.isCandidateBeingAdded}}
+                  *
+                {{/if}}
+                Pays de naissance
+              </th>
+            {{/if }}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+              <th class="certification-candidates-table__recipient-email">Adresse e-mail du destinataire des résultats</th>
+            {{/unless}}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+              <th class="certification-candidates-table__external-id">Identifiant externe</th>
+            {{/unless}}
+            <th class="certification-candidates-table__column-time">Temps majoré</th>
+          </tr>
+          </thead>
+          <tbody>
+          {{#each this.candidatesInStaging as |candidateInStaging|}}
+            <CertificationCandidateInStagingItem
+                    @candidateData={{candidateInStaging}}
+                    @onClickSave={{this.addCertificationCandidate}}
+                    @onClickCancel={{this.removeCertificationCandidateFromStaging}}
+                    @updateCandidateBirthdate={{this.updateCertificationCandidateInStagingBirthdate}}
+                    @updateCandidateData={{this.updateCertificationCandidateInStagingField}}
+            />
+          {{/each}}
+          {{#each @certificationCandidates as |candidate|}}
+            <tr>
+              <td data-test-id='panel-candidate__lastName__{{candidate.id}}'>{{candidate.lastName}}</td>
+              <td data-test-id='panel-candidate__firstName__{{candidate.id}}'>{{candidate.firstName}}</td>
+              <td data-test-id='panel-candidate__birthdate__{{candidate.id}}'>{{moment-format candidate.birthdate 'DD/MM/YYYY'}}</td>
+              {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+                <td data-test-id='panel-candidate__birthCity__{{candidate.id}}'>{{candidate.birthCity}}</td>
+                <td data-test-id='panel-candidate__birthCountry__{{candidate.id}}'>{{candidate.birthCountry}}</td>
+              {{/if}}
+              {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+                <td data-test-id='panel-candidate__result-recipient-email__{{candidate.id}}'>{{candidate.resultRecipientEmail}}</td>
+              {{/unless}}
+              {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+                <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
+              {{/unless}}
+              <td data-test-id='panel-candidate__extraTimePercentage__{{candidate.id}}'>{{format-percentage candidate.extraTimePercentage}}</td>
+              <td>
+                <div class="certification-candidates-actions">
+                  {{#if @isNewCpfDataToggleEnabled}}
+                    {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+                      <div class="certification-candidates-actions__display-details">
+                        <button
+                          type="button"
+                          class="button--showed-as-link"
+                          {{on 'click' (fn this.openCertificationCandidateDetailsModal candidate)}}
+                          aria-label="Voir le détail du candidat {{candidate.firstName}} {{candidate.lastName}}"
+                        >
+                          Voir le détail
+                        </button>
+                      </div>
+                    {{/unless}}
+                  {{/if}}
+                  <div class="certification-candidates-actions__delete">
+                    {{#if candidate.isLinked}}
+                      <PixIconButton
+                        @icon="trash-alt"
+                        class="certification-candidates-actions__delete-button--disabled"
+                        data-test-id="panel-candidate__actions__delete__{{candidate.id}}"
+                        @withBackground={{true}}
+                      />
+                      <div class="certification-candidates-actions__delete-tooltip">
+                        Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.
+                      </div>
+                    {{else}}
+                      <PixIconButton
+                        @icon="trash-alt"
+                        {{on 'click' (fn this.deleteCertificationCandidate candidate)}}
+                        aria-label="Supprimer un élève"
+                        class="certification-candidates-actions__delete-button"
+                        data-test-id="panel-candidate__actions__delete__{{candidate.id}}"
+                        @withBackground={{true}}
+                      />
+                    {{/if}}
+                  </div>
+                </div>
+              </td>
+            </tr>
+          {{/each}}
+          </tbody>
+        </table>
+      {{else}}
+        <table>
+          <thead>
+          <tr>
+            <th class="certification-candidates-table__column-last-name">
+              {{#if this.isCandidateBeingAdded}}
+                *
+              {{/if}}
+              Nom de naissance
+            </th>
+            <th class="certification-candidates-table__column-first-name">
+              {{#if this.isCandidateBeingAdded}}
+                *
+              {{/if}}
+              Prénom
+            </th>
+            <th class="certification-candidates-table__column-birthdate">
+              {{#if this.isCandidateBeingAdded}}
+                *
+              {{/if}}
+              Date de naissance
+            </th>
+            {{#unless @isNewCpfDataToggleEnabled}}
+              <th>
+                {{#if this.isCandidateBeingAdded}}
+                  *
+                {{/if}}
+                Commune de naissance
+              </th>
+              <th>
+                {{#if this.isCandidateBeingAdded}}
+                  *
+                {{/if}}
+                Département de naissance
+              </th>
+              <th>
+                {{#if this.isCandidateBeingAdded}}
+                  *
+                {{/if}}
+                Pays de naissance
+              </th>
+              {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+                <th>Adresse e-mail de convocation</th>
+              {{/unless}}
+            {{/unless}}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+              <th>Adresse e-mail du destinataire des résultats</th>
+            {{/unless}}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+              <th>Identifiant externe</th>
+            {{/unless}}
+            <th class="certification-candidates-table__column-time">Temps majoré</th>
+            <th width="185"></th>
+          </tr>
+          </thead>
         <tbody>
         {{#each this.candidatesInStaging as |candidateInStaging|}}
           <CertificationCandidateInStagingItem
@@ -88,14 +206,16 @@
             <td data-test-id='panel-candidate__lastName__{{candidate.id}}'>{{candidate.lastName}}</td>
             <td data-test-id='panel-candidate__firstName__{{candidate.id}}'>{{candidate.firstName}}</td>
             <td data-test-id='panel-candidate__birthdate__{{candidate.id}}'>{{moment-format candidate.birthdate 'DD/MM/YYYY'}}</td>
-            <td data-test-id='panel-candidate__birthCity__{{candidate.id}}'>{{candidate.birthCity}}</td>
-            <td data-test-id='panel-candidate__birthProvinceCode__{{candidate.id}}'>{{candidate.birthProvinceCode}}</td>
-            <td data-test-id='panel-candidate__birthCountry__{{candidate.id}}'>{{candidate.birthCountry}}</td>
-            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-              <td data-test-id='panel-candidate__result-recipient-email__{{candidate.id}}'>{{candidate.resultRecipientEmail}}</td>
+            {{#unless @isNewCpfDataToggleEnabled}}
+              <td data-test-id='panel-candidate__birthCity__{{candidate.id}}'>{{candidate.birthCity}}</td>
+              <td data-test-id='panel-candidate__birthProvinceCode__{{candidate.id}}'>{{candidate.birthProvinceCode}}</td>
+              <td data-test-id='panel-candidate__birthCountry__{{candidate.id}}'>{{candidate.birthCountry}}</td>
+              {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+                <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
+              {{/unless}}
             {{/unless}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-              <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
+              <td data-test-id='panel-candidate__result-recipient-email__{{candidate.id}}'>{{candidate.resultRecipientEmail}}</td>
             {{/unless}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
@@ -103,18 +223,6 @@
             <td data-test-id='panel-candidate__extraTimePercentage__{{candidate.id}}'>{{format-percentage candidate.extraTimePercentage}}</td>
             <td>
               <div class="certification-candidates-actions">
-                {{#if @shouldDisplayCertificationCandidateDetailsModalButton}}
-                  <div class="certification-candidates-actions__display-details">
-                    <button
-                      type="button"
-                      class="button--showed-as-link"
-                      {{on 'click' (fn this.openCertificationCandidateDetailsModal candidate)}}
-                      aria-label="Voir le détail du candidat {{candidate.firstName}} {{candidate.lastName}}"
-                    >
-                      Voir le détail
-                    </button>
-                  </div>
-                {{/if}}
                 <div class="certification-candidates-actions__delete">
                   {{#if candidate.isLinked}}
                     <PixIconButton
@@ -142,7 +250,8 @@
           </tr>
         {{/each}}
         </tbody>
-      </table>
+        </table>
+      {{/if}}
     {{else}}
       <div class="table__empty content-text">
         <p>En attente de candidats</p>

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -36,6 +36,8 @@ export default class EnrolledCandidates extends Component {
 
   @action
   addCertificationCandidateInStaging() {
+    if (this.args.isNewCpfDataToggleEnabled) return;
+
     this.candidatesInStaging.pushObject(EmberObject.create({
       firstName: '', lastName: '', birthdate: '', birthCity: '',
       birthProvinceCode: '', birthCountry: '', email: '', externalId: '',

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -33,7 +33,7 @@ export default class CertificationCandidatesController extends Controller {
     return certificationCandidatesCount > 0;
   }
 
-  get shouldDisplayCertificationCandidateDetailsModalButton() {
+  get isNewCpfDataToggleEnabled() {
     return this.featureToggles.featureToggles.isNewCpfDataEnabled;
   }
 

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -181,6 +181,10 @@
   width: 130px;
 }
 
+.certification-candidates-table__column-birthdate {
+  width: 130px;
+}
+
 .certification-candidates-table__column-time {
   width: 50px;
 }

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -6,7 +6,7 @@
   {{#if this.hasOneOrMoreCandidates}}
   <EnrolledCandidates
         @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-        @shouldDisplayCertificationCandidateDetailsModalButton={{this.shouldDisplayCertificationCandidateDetailsModalButton}}
+        @isNewCpfDataToggleEnabled={{this.isNewCpfDataToggleEnabled}}
         @sessionId={{this.currentSession.id}}
         @certificationCandidates={{this.certificationCandidates}}
         @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />
@@ -19,7 +19,7 @@
           @importAllowed={{this.importAllowed}}/>
   <EnrolledCandidates
           @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-          @shouldDisplayCertificationCandidateDetailsModalButton={{this.shouldDisplayCertificationCandidateDetailsModalButton}}
+          @isNewCpfDataToggleEnabled={{this.isNewCpfDataToggleEnabled}}
           @sessionId={{this.currentSession.id}}
           @certificationCandidates={{this.certificationCandidates}}
           @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -83,24 +83,29 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
         candidates = server.createList('certification-candidate', 3, { sessionId: sessionWithCandidates.id, isLinked: false, resultRecipientEmail: 'recipient@example.com' });
       });
 
-      test('it should display the list of certification candidates', async function(assert) {
-        // given
-        const aCandidate = candidates[0];
+      module('when the CPF new data feature toggle is off', function() {
 
-        // when
-        await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+        test('it should display the list of certification candidates', async function(assert) {
+          // given
+          const aCandidate = candidates[0];
+          server.create('feature-toggle', { id: 0, isNewCPFDataEnabled: false });
 
-        // then
-        assert.dom('table tbody tr').exists({ count: 3 });
-        assert.contains(`${aCandidate.lastName}`);
-        assert.contains(`${aCandidate.firstName}`);
-        assert.contains(`${moment(aCandidate.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);
-        assert.contains(`${aCandidate.birthCity}`);
-        assert.contains(`${aCandidate.birthProvinceCode}`);
-        assert.contains(`${aCandidate.birthCountry}`);
-        assert.contains(`${aCandidate.email}`);
-        assert.contains(`${aCandidate.resultRecipientEmail}`);
-        assert.contains(`${aCandidate.externalId}`);
+          // when
+          await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+
+          // then
+          assert.dom('table tbody tr').exists({ count: 3 });
+
+          assert.contains(`${aCandidate.lastName}`);
+          assert.contains(`${aCandidate.firstName}`);
+          assert.contains(`${moment(aCandidate.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);
+          assert.contains(`${aCandidate.birthCity}`);
+          assert.contains(`${aCandidate.birthProvinceCode}`);
+          assert.contains(`${aCandidate.birthCountry}`);
+          assert.contains(`${aCandidate.email}`);
+          assert.contains(`${aCandidate.resultRecipientEmail}`);
+          assert.contains(`${aCandidate.externalId}`);
+        });
       });
 
       module('when the CPF new data feature toggle is on', function() {
@@ -113,6 +118,24 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
           // then
           assert.contains('Voir le détail');
+        });
+
+        test('it should display the list of certification candidates ', async function(assert) {
+          // given
+          const aCandidate = candidates[0];
+          server.create('feature-toggle', { id: 0, isNewCPFDataEnabled: true });
+
+          // when
+          await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+
+          // then
+          assert.dom('table tbody tr').exists({ count: 3 });
+          assert.dom('table thead tr th').exists({ count: 6 });
+          assert.contains(`${aCandidate.lastName}`);
+          assert.contains(`${aCandidate.firstName}`);
+          assert.contains(`${moment(aCandidate.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);
+          assert.contains(`${aCandidate.resultRecipientEmail}`);
+          assert.contains(`${aCandidate.externalId}`);
         });
 
         module('when the details button is clicked', function() {

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -23,49 +23,94 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
   const EMAIL_SELECTOR = 'panel-candidate__email__';
   const EXTRA_TIME_SELECTOR = 'panel-candidate__extraTimePercentage__';
 
-  test('it displays candidates information', async function(assert) {
-    // given
-    const candidate = _buildCertificationCandidate({
-      birthdate: new Date('2019-04-28'),
+  module('When FT_IS_NEW_CPF_DATA_ENABLED is not enabled', function() {
+
+    test('it displays all candidates information', async function(assert) {
+      // given
+      const candidate = _buildCertificationCandidate({
+        birthdate: new Date('2019-04-28'),
+      });
+      const isNewCpfDataToggleEnabled = false;
+      const certificationCandidates = [candidate];
+
+      this.set('isNewCpfDataToggleEnabled', isNewCpfDataToggleEnabled);
+      this.set('certificationCandidates', certificationCandidates);
+
+      // when
+      await render(hbs`
+        <EnrolledCandidates 
+          @sessionId="1" 
+          @certificationCandidates={{certificationCandidates}}
+          @isNewCpfDataToggleEnabled={{isNewCpfDataToggleEnabled}}
+          >
+        </EnrolledCandidates>
+      `);
+
+      // then
+      assert.dom(`[data-test-id=${EXTERNAL_ID_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.externalId);
+      assert.dom(`[data-test-id=${BIRTHDATE_COLUMN_SELECTOR}${candidate.id}]`).hasText('28/04/2019');
+      assert.dom(`[data-test-id=${LAST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.lastName);
+      assert.dom(`[data-test-id=${FIRST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.firstName);
+      assert.dom(`[data-test-id=${BIRTH_CITY_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.birthCity);
+      assert.dom(`[data-test-id=${BIRTH_PROVINCE_CODE_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.birthProvinceCode);
+      assert.dom(`[data-test-id=${BIRTH_COUNTRY_SELECTOR}${candidate.id}]`).hasText(candidate.birthCountry);
+      assert.dom(`[data-test-id=${EMAIL_SELECTOR}${candidate.id}]`).hasText(candidate.email);
+      assert.dom(`[data-test-id=${RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.resultRecipientEmail);
+      assert.dom(`[data-test-id=${EXTRA_TIME_SELECTOR}${candidate.id}]`).hasText('3000 %');
     });
-    const certificationCandidates = [candidate];
-
-    this.set('certificationCandidates', certificationCandidates);
-
-    // when
-    await render(hbs`
-      <EnrolledCandidates @sessionId="1" @certificationCandidates={{certificationCandidates}}>
-      </EnrolledCandidates>
-    `);
-
-    // then
-    assert.dom(`[data-test-id=${EXTERNAL_ID_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.externalId);
-    assert.dom(`[data-test-id=${BIRTHDATE_COLUMN_SELECTOR}${candidate.id}]`).hasText('28/04/2019');
-    assert.dom(`[data-test-id=${LAST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.lastName);
-    assert.dom(`[data-test-id=${FIRST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.firstName);
-    assert.dom(`[data-test-id=${BIRTH_CITY_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.birthCity);
-    assert.dom(`[data-test-id=${BIRTH_PROVINCE_CODE_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.birthProvinceCode);
-    assert.dom(`[data-test-id=${BIRTH_COUNTRY_SELECTOR}${candidate.id}]`).hasText(candidate.birthCountry);
-    assert.dom(`[data-test-id=${EMAIL_SELECTOR}${candidate.id}]`).hasText(candidate.email);
-    assert.dom(`[data-test-id=${EXTRA_TIME_SELECTOR}${candidate.id}]`).hasText('3000 %');
   });
 
-  module('when details button should be displayed', async function() {
+  module('When FT_IS_NEW_CPF_DATA_ENABLED is enabled', async function() {
+
+    test('it displays candidates information', async function(assert) {
+      // given
+      const candidate = _buildCertificationCandidate({
+        birthdate: new Date('2019-04-28'),
+      });
+      const isNewCpfDataToggleEnabled = true;
+      const certificationCandidates = [candidate];
+
+      this.set('isNewCpfDataToggleEnabled', isNewCpfDataToggleEnabled);
+      this.set('certificationCandidates', certificationCandidates);
+
+      // when
+      await render(hbs`
+        <EnrolledCandidates 
+          @sessionId="1" 
+          @certificationCandidates={{certificationCandidates}}
+          @isNewCpfDataToggleEnabled={{isNewCpfDataToggleEnabled}}
+          >
+        </EnrolledCandidates>
+      `);
+
+      // then
+      assert.dom(`[data-test-id=${EXTERNAL_ID_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.externalId);
+      assert.dom(`[data-test-id=${BIRTHDATE_COLUMN_SELECTOR}${candidate.id}]`).hasText('28/04/2019');
+      assert.dom(`[data-test-id=${LAST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.lastName);
+      assert.dom(`[data-test-id=${FIRST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.firstName);
+      assert.dom(`[data-test-id=${RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.resultRecipientEmail);
+      assert.dom(`[data-test-id=${EXTRA_TIME_SELECTOR}${candidate.id}]`).hasText('3000 %');
+      assert.dom(`[data-test-id=${BIRTH_CITY_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(`[data-test-id=${BIRTH_PROVINCE_CODE_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(`[data-test-id=${BIRTH_COUNTRY_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(`[data-test-id=${EMAIL_SELECTOR}${candidate.id}]`).doesNotExist();
+    });
+
     test('it should display details button', async function(assert) {
       // given
       const candidate = _buildCertificationCandidate({});
       const certificationCandidates = [candidate];
-      const shouldDisplayCertificationCandidateDetailsModalButton = true;
+      const isNewCpfDataToggleEnabled = true;
 
       this.set('certificationCandidates', certificationCandidates);
-      this.set('shouldDisplayCertificationCandidateDetailsModalButton', shouldDisplayCertificationCandidateDetailsModalButton);
+      this.set('isNewCpfDataToggleEnabled', isNewCpfDataToggleEnabled);
 
       // when
       await render(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
-          @shouldDisplayCertificationCandidateDetailsModalButton={{shouldDisplayCertificationCandidateDetailsModalButton}}
+          @isNewCpfDataToggleEnabled={{isNewCpfDataToggleEnabled}}
         >
         </EnrolledCandidates>
       `);
@@ -85,10 +130,10 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
         extraTimePercentage: 0.1,
       });
       const certificationCandidates = [candidate];
-      const shouldDisplayCertificationCandidateDetailsModalButton = true;
+      const isNewCpfDataToggleEnabled = true;
 
       this.set('certificationCandidates', certificationCandidates);
-      this.set('shouldDisplayCertificationCandidateDetailsModalButton', shouldDisplayCertificationCandidateDetailsModalButton);
+      this.set('isNewCpfDataToggleEnabled', isNewCpfDataToggleEnabled);
 
       // when
       await render(hbs`

--- a/certif/tests/unit/components/enrolled-candidates_test.js
+++ b/certif/tests/unit/components/enrolled-candidates_test.js
@@ -70,6 +70,42 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
       assert.equal(component.args.certificationCandidates.length, 1);
     });
   });
+  module('#addCertificationCandidateInStaging', async function() {
+
+    module('When FT_IS_NEW_CPF_DATA_ENABLED is enabled', async function() {
+
+      test('should not add an empty candidate in staging', async function(assert) {
+      // given
+        component.args = {
+          isNewCpfDataToggleEnabled: true,
+        };
+
+        // when
+        await component.addCertificationCandidateInStaging();
+
+        // then
+        assert.equal(component.candidatesInStaging.length, 0);
+      });
+
+    });
+
+    module('When FT_IS_NEW_CPF_DATA_ENABLED is  not enabled', async function() {
+
+      test('should disable the feature of enrolling a new candidate', async function(assert) {
+      // given
+        component.args = {
+          isNewCpfDataToggleEnabled: false,
+        };
+
+        // when
+        await component.addCertificationCandidateInStaging();
+
+        // then
+        assert.equal(component.candidatesInStaging.length, 1);
+      });
+
+    });
+  });
 
   module('#deleteCertificationCandidate', async function() {
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l’accrochage Mon Compte Formation, des infos perso des candidats à la certification Pix sont nécessaires. Parmi ces infos que nous ne récupérons pas actuellement : le sexe du candidat et son code postal ou code INSEE de la commune de naissance.


Le tableau de la liste des candidats contient déjà beaucoup d'informations, on peut en retirer certaines qui seront toujours accessible dans la modale "détails".

## :robot: Solution
Ne conserver que les champs :

- Nom

- Prénom

- Date de naissance

- Identifiant externe

- Temps majoré

- Adresse des résultats



## :rainbow: Remarques
Cette feature est soumise au toggle FT_IS_NEW_CPF_DATA_ENABLED

## :100: Pour tester

- Activer le toggle FT_IS_NEW_CPF_DATA_ENABLED
- Dans Pix certif, aller sur l'onglet Candidat(s) d'une session ayant déjà des candidats (ou créer une nouvelle session en ajoutant des candidats)
- Constater l'affichage suivant:

![image](https://user-images.githubusercontent.com/37305474/123800485-a3156500-d8e9-11eb-90d3-35ce1761f590.png)



- Désactiver le toggle FT_IS_NEW_CPF_DATA_ENABLED
- Dans Pix certif, aller sur l'onglet Candidat(s) d'une session ayant déjà des candidats (ou créer une nouvelle session en ajoutant des candidats)
- Constater l'affichage suivant:

![image](https://user-images.githubusercontent.com/37305474/123667241-41e28880-d83a-11eb-9ad6-ac7c2d9e2b99.png)

