### PR TITLE
[TECH] Ajout du linter de tests qunit sur orga

### DIFF
--- a/orga/.eslintrc.js
+++ b/orga/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     ...(fs.existsSync('../.eslintrc.yaml') ? ['../.eslintrc.yaml'] : []),
     'plugin:ember/recommended',
     'plugin:i18n-json/recommended',
+    'plugin:qunit/recommended',
   ],
   env: {
     browser: true,

--- a/orga/.eslintrc.js
+++ b/orga/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   },
   plugins: [
     'ember',
+    'qunit',
   ],
   extends: [
     ...(fs.existsSync('../.eslintrc.yaml') ? ['../.eslintrc.yaml'] : []),

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -22102,6 +22102,11 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+    },
     "globby": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
@@ -22125,6 +22130,11 @@
           "dev": true
         }
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "good-listener": {
       "version": "1.2.2",
@@ -23247,12 +23257,6 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
-      "dev": true
-    },
-    "js-reporters": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
-      "integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=",
       "dev": true
     },
     "js-string-escape": {
@@ -24761,10 +24765,9 @@
       "dev": true
     },
     "node-watch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.1.tgz",
-      "integrity": "sha512-gwQiR7weFRV8mAtT0x0kXkZ18dfRLB45xH7q0hCOVQMLfLb2f1ZaSvR57q4/b/Vj6B0RwMNJYbvb69e1yM7qEA==",
-      "dev": true
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.1.tgz",
+      "integrity": "sha512-UWblPYuZYrkCQCW5PxAwYSxaELNBLUckrTBBk8xr1/bUgyOkYYTsUcV4e3ytcazFEOyiRyiUrsG37pu6I0I05g=="
     },
     "nomnom": {
       "version": "1.8.1",
@@ -26365,32 +26368,19 @@
       }
     },
     "qunit": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.10.0.tgz",
-      "integrity": "sha512-EP9Q9Kf45z4l/X02ZJtyTQU9DBc82pEWAncSNx7Weo/73BDpX71xqbsdDAQrtEeeilK70cib7CY/lniJV6Cwwg==",
-      "dev": true,
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.16.0.tgz",
+      "integrity": "sha512-88x9t+rRMbB6IrCIUZvYU4pJy7NiBEv7SX8jD4LZAsIj+dV+kwGnFStOmPNvqa6HM96VZMD8CIIFKH2+3qvluA==",
       "requires": {
-        "commander": "2.12.2",
-        "js-reporters": "1.2.1",
-        "minimatch": "3.0.4",
-        "node-watch": "0.6.1",
-        "resolve": "1.9.0"
+        "commander": "7.1.0",
+        "node-watch": "0.7.1",
+        "tiny-glob": "0.2.8"
       },
       "dependencies": {
         "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
-          "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
+          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg=="
         }
       }
     },
@@ -28888,6 +28878,15 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "dev": true
+    },
+    "tiny-glob": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
+      "integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
     },
     "tiny-lr": {
       "version": "2.0.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -20718,14 +20718,31 @@
         }
       }
     },
-    "eslint-plugin-mocha": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
-      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
+    "eslint-plugin-qunit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz",
+      "integrity": "sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^2.1.0",
-        "ramda": "^0.27.1"
+        "eslint-utils": "^3.0.0",
+        "requireindex": "^1.2.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "eslint-scope": {
@@ -26555,12 +26572,6 @@
         }
       }
     },
-    "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-      "dev": true
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -26949,6 +26960,12 @@
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
       "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "requires-port": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -88,7 +88,7 @@
     "eslint": "^7.15.0",
     "eslint-plugin-ember": "^10.0.2",
     "eslint-plugin-i18n-json": "^3.1.0",
-    "eslint-plugin-mocha": "^8.1.0",
+    "eslint-plugin-qunit": "^6.2.0",
     "faker": "^5.5.2",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",

--- a/orga/tests/acceptance/remove-membership_test.js
+++ b/orga/tests/acceptance/remove-membership_test.js
@@ -38,7 +38,7 @@ module('Acceptance | Remove membership', function(hooks) {
     server.create('membership', { userId: user.id, organizationId, organizationRole: 'MEMBER' });
   });
 
-  test('should remove the membership', async (assert) => {
+  test('should remove the membership', async function(assert) {
     // given
     await visit('/equipe');
     await clickByLabel('Gérer');

--- a/orga/tests/acceptance/sco-student-list_test.js
+++ b/orga/tests/acceptance/sco-student-list_test.js
@@ -180,14 +180,14 @@ module('Acceptance | Sco Student List', function(hooks) {
         });
       });
 
-      module('when student is associated', async function(hooks) {
+      module('when student is associated', function(hooks) {
         hooks.beforeEach(async function() {
           organizationId = user.memberships.models.firstObject.organizationId;
 
           server.createList('student', 5, { organizationId });
         });
 
-        module('when student authenticated by username and email', async function(hooks) {
+        module('when student authenticated by username and email', function(hooks) {
 
           const username = 'firstname.lastname0112';
           const email = 'firstname.lastname0112@example.net';
@@ -242,7 +242,7 @@ module('Acceptance | Sco Student List', function(hooks) {
           });
         });
 
-        module('when student authenticated by GAR', async function(hooks) {
+        module('when student authenticated by GAR', function(hooks) {
 
           hooks.beforeEach(function() {
             server.create('student', {
@@ -282,7 +282,7 @@ module('Acceptance | Sco Student List', function(hooks) {
           });
         });
 
-        module('when student authenticated by GAR and username', async function(hooks) {
+        module('when student authenticated by GAR and username', function(hooks) {
 
           hooks.beforeEach(function() {
             server.create('student', {

--- a/orga/tests/acceptance/team-list_test.js
+++ b/orga/tests/acceptance/team-list_test.js
@@ -101,7 +101,7 @@ module('Acceptance | Team List', function(hooks) {
       });
     });
 
-    test('it should land on first page', async (assert) => {
+    test('it should land on first page', async function(assert) {
       // given
       const organizationId = server.db.organizations[0].id;
       times(10, () => {

--- a/orga/tests/integration/components/charts/participants-by-stage_test.js
+++ b/orga/tests/integration/components/charts/participants-by-stage_test.js
@@ -64,8 +64,8 @@ module('Integration | Component | Charts::ParticipantsByStage', function(hooks) 
     sinon.assert.calledWith(onSelectStage, 100498);
   });
 
-  module('when there is tooltip info', async function() {
-    module('when there is title and description', async function() {
+  module('when there is tooltip info', function() {
+    module('when there is title and description', function() {
       test('it should contains tooltip info', async function(assert) {
         // given
         dataFetcher.withArgs(campaignId).resolves({
@@ -91,7 +91,7 @@ module('Integration | Component | Charts::ParticipantsByStage', function(hooks) 
       });
     });
 
-    module('when there is only title', async function() {
+    module('when there is only title', function() {
       test('tooltip should contains title', async function(assert) {
         // given
         dataFetcher.withArgs(campaignId).resolves({
@@ -113,7 +113,7 @@ module('Integration | Component | Charts::ParticipantsByStage', function(hooks) 
       });
     });
 
-    module('when there is only description', async function() {
+    module('when there is only description', function() {
       test('tooltip should contains description', async function(assert) {
         // given
         dataFetcher.withArgs(campaignId).resolves({

--- a/orga/tests/integration/components/dissociate-user-modal_test.js
+++ b/orga/tests/integration/components/dissociate-user-modal_test.js
@@ -44,7 +44,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     });
   });
 
-  module('dissociate button', function() {
+  module('dissociate button', function(hooks) {
     let studentAdapter;
     let notifications;
 

--- a/orga/tests/integration/components/edit-student-number-modal_test.js
+++ b/orga/tests/integration/components/edit-student-number-modal_test.js
@@ -123,9 +123,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
         // then
         assert.contains(`Le numéro étudiant saisi est déjà utilisé par l’étudiant ${this.student.firstName} ${this.student.lastName}`);
       });
-    });
 
-    module('when the update button is clicked with the student number and this student number already exist', function() {
       test('it remove errors when submitting is a success', async function(assert) {
         // given
         const error = {

--- a/orga/tests/integration/components/indicator-card-test.js
+++ b/orga/tests/integration/components/indicator-card-test.js
@@ -24,16 +24,14 @@ module('Integration | Component | indicator-card', function(hooks) {
     assert.contains('Text');
   });
 
-  module('when there is no additional information', async function() {
+  module('when there is no additional information', function() {
     test('it does not display question mark and its tooltip', async function(assert) {
       await render(hbs`<IndicatorCard>Text</IndicatorCard>`);
 
       assert.dom('[data-icon="question-circle"]').doesNotExist();
       assert.dom('[role="tooltip"]').doesNotExist();
     });
-  });
 
-  module('when there is some additional information', async function() {
     test('it display question mark and its tooltip', async function(assert) {
       await render(hbs`<IndicatorCard @info="some additional information">Text</IndicatorCard>`);
 

--- a/orga/tests/integration/components/manage-authentication-method-modal_test.js
+++ b/orga/tests/integration/components/manage-authentication-method-modal_test.js
@@ -122,7 +122,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
       });
     });
 
-    module('When password is generated', function() {
+    module('When password is generated', function(hooks) {
 
       let generatedPassword;
 
@@ -194,7 +194,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
     });
   });
 
-  module('When Student is connected with GAR method', function() {
+  module('When Student is connected with GAR method', function(hooks) {
 
     hooks.beforeEach(function() {
       this.studentGAR = EmberObject.create({

--- a/orga/tests/integration/components/modal/dialog_test.js
+++ b/orga/tests/integration/components/modal/dialog_test.js
@@ -8,7 +8,7 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | modal', function(hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('Component rendering', function() {
+  module('Component rendering', function(hooks) {
     let close;
 
     hooks.beforeEach(function() {

--- a/orga/tests/integration/components/organization-credit-info_test.js
+++ b/orga/tests/integration/components/organization-credit-info_test.js
@@ -98,7 +98,7 @@ module('Integration | Component | organization-credit-info', function(hooks) {
     // then
     assert.notContains('crédit');
     assert.notContains('crédits');
-    assert.equal(currentUserStub.isAdminInOrganization, false);
+    assert.false(currentUserStub.isAdminInOrganization);
   });
 
 });

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab_test.js
@@ -35,7 +35,7 @@ module('Integration | Component | routes/authenticated/campaign/analysis/tab', f
     this.set('campaignTubeRecommendations', [campaignTubeRecommendation_1, campaignTubeRecommendation_2]);
   });
 
-  module('when analysis is displayed', async function(hooks) {
+  module('when analysis is displayed', function(hooks) {
     hooks.beforeEach(async function() {
       await render(hbs`<Routes::Authenticated::Campaign::Analysis::Tab
         @campaignTubeRecommendations={{campaignTubeRecommendations}}

--- a/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
@@ -148,7 +148,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     });
   });
 
-  module('Navigation', function() {
+  module('Navigation', function(hooks) {
 
     hooks.beforeEach(function() {
       this.owner.setupRouter();

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items_test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items_test.js
@@ -83,7 +83,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'lastName');
-      assert.equal(call.args[1], true);
+      assert.true(call.args[1]);
       assert.equal(call.args[2].target.value, 'bob');
     });
 
@@ -101,7 +101,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'firstName');
-      assert.equal(call.args[1], true);
+      assert.true(call.args[1]);
       assert.equal(call.args[2].target.value, 'bob');
     });
 
@@ -120,7 +120,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'connexionType');
-      assert.equal(call.args[1], false);
+      assert.false(call.args[1]);
       assert.equal(call.args[2].target.value, 'email');
     });
   });

--- a/orga/tests/integration/components/routes/authenticated/sup-students/list-items_test.js
+++ b/orga/tests/integration/components/routes/authenticated/sup-students/list-items_test.js
@@ -135,7 +135,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'lastName');
-      assert.equal(call.args[1], true);
+      assert.true(call.args[1]);
       assert.equal(call.args[2].target.value, 'bob');
     });
 
@@ -152,7 +152,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'firstName');
-      assert.equal(call.args[1], true);
+      assert.true(call.args[1]);
       assert.equal(call.args[2].target.value, 'bob');
     });
 
@@ -169,7 +169,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'studentNumber');
-      assert.equal(call.args[1], true);
+      assert.true(call.args[1]);
       assert.equal(call.args[2].target.value, 'LATERREURGIGI123');
     });
   });

--- a/orga/tests/integration/components/routes/authenticated/team/items_test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/items_test.js
@@ -140,20 +140,20 @@ module('Integration | Component | routes/authenticated/team | list-items | items
       await clickByLabel('Supprimer');
     });
 
-    test('should display a confirmation modal', (assert) => {
+    test('should display a confirmation modal', function(assert) {
       // then
       assert.contains('Confirmez-vous la suppression ?');
       assert.contains('Annuler');
       assert.contains('Supprimer');
     });
 
-    test('should display the membership first name and last name in the modal', (assert) => {
+    test('should display the membership first name and last name in the modal', function(assert) {
       // then
       assert.contains(memberMembership.user.firstName);
       assert.contains(memberMembership.user.lastName);
     });
 
-    test('should close the modal by clicking on cancel button', async (assert) => {
+    test('should close the modal by clicking on cancel button', async function(assert) {
       // when
       await clickByLabel('Annuler');
 
@@ -161,7 +161,7 @@ module('Integration | Component | routes/authenticated/team | list-items | items
       assert.notContains('Supprimer de l\'équipe');
     });
 
-    test('should call removeMembership and close modal by clicking on remove button', async (assert) => {
+    test('should call removeMembership and close modal by clicking on remove button', async function(assert) {
       // when
       await click('button[data-test-modal-remove-button]');
 

--- a/orga/tests/integration/components/routes/register-form_test.js
+++ b/orga/tests/integration/components/routes/register-form_test.js
@@ -49,7 +49,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
     assert.dom('.register-form').exists();
   });
 
-  module('successful cases', function() {
+  module('successful cases', function(hooks) {
 
     hooks.beforeEach(function() {
       this.owner.unregister('service:store');

--- a/orga/tests/unit/adapters/division_test.js
+++ b/orga/tests/unit/adapters/division_test.js
@@ -22,7 +22,7 @@ module('Unit | Adapters | division', function(hooks) {
       const url = await adapter.urlForQuery(query);
 
       // then
-      assert.equal(url.endsWith(`/organizations/${organizationId}/divisions`), true);
+      assert.true(url.endsWith(`/organizations/${organizationId}/divisions`));
     });
   });
 });

--- a/orga/tests/unit/adapters/organization-invitation-response_test.js
+++ b/orga/tests/unit/adapters/organization-invitation-response_test.js
@@ -23,7 +23,7 @@ module('Unit | Adapters | organization-invitation-response', function(hooks) {
       const url = await adapter.urlForCreateRecord('organization-invitation-response', options);
 
       // then
-      assert.equal(url.endsWith(`/organization-invitations/${organizationInvitationId}/response`), true);
+      assert.true(url.endsWith(`/organization-invitations/${organizationInvitationId}/response`));
     });
   });
 

--- a/orga/tests/unit/adapters/prescriber_test.js
+++ b/orga/tests/unit/adapters/prescriber_test.js
@@ -32,7 +32,7 @@ module('Unit | Adapters | prescriber', function(hooks) {
       const url = await adapter.urlForUpdateRecord(123, 'prescriber', options);
 
       // then
-      assert.equal(url.endsWith('/users/123/pix-orga-terms-of-service-acceptance'), true);
+      assert.true(url.endsWith('/users/123/pix-orga-terms-of-service-acceptance'));
     });
 
     test('should redirect to lang', async function(assert) {
@@ -41,7 +41,7 @@ module('Unit | Adapters | prescriber', function(hooks) {
       const url = await adapter.urlForUpdateRecord(123, 'prescriber', options);
 
       // then
-      assert.equal(url.endsWith('/users/123/lang/en'), true);
+      assert.true(url.endsWith('/users/123/lang/en'));
     });
   });
 });

--- a/orga/tests/unit/adapters/user-orga-setting_test.js
+++ b/orga/tests/unit/adapters/user-orga-setting_test.js
@@ -23,7 +23,7 @@ module('Unit | Adapters | user-orga-setting', function(hooks) {
       const url = await adapter.urlForUpdateRecord(123, 'user-orga-setting', snapshot);
 
       // then
-      assert.equal(url.endsWith(`/user-orga-settings/${userId}`), true);
+      assert.true(url.endsWith(`/user-orga-settings/${userId}`));
     });
   });
 
@@ -66,7 +66,7 @@ module('Unit | Adapters | user-orga-setting', function(hooks) {
       const url = await adapter.urlForCreateRecord('user-orga-setting', snapshot);
 
       // then
-      assert.equal(url.endsWith('/user-orga-settings/1'), true);
+      assert.true(url.endsWith('/user-orga-settings/1'));
     });
   });
 

--- a/orga/tests/unit/components/charts/activity_test.js
+++ b/orga/tests/unit/components/charts/activity_test.js
@@ -23,7 +23,7 @@ module('Unit | Component | Charts | activity', (hooks) => {
     });
   });
 
-  test('should fill data', async (assert) => {
+  test('should fill data', async function(assert) {
     // when
     component = await createGlimmerComponent('component:charts/activity');
 

--- a/orga/tests/unit/components/routes/login-form_test.js
+++ b/orga/tests/unit/components/routes/login-form_test.js
@@ -16,7 +16,7 @@ module('Unit | Component | Routes | login-form', (hooks) => {
 
   module('#authenticate', () => {
 
-    test('should save email without spaces', (assert) => {
+    test('should save email without spaces', function(assert) {
       // given
       const emailWithSpaces = '    user@example.net  ';
       component.email = emailWithSpaces;

--- a/orga/tests/unit/components/user-logged-menu_test.js
+++ b/orga/tests/unit/components/user-logged-menu_test.js
@@ -15,14 +15,14 @@ module('Unit | Component | user-logged-menu', (hooks) => {
   module('action#toggleUserMenu', () => {
     test('should return false as default value', function(assert) {
       // then
-      assert.equal(component.isMenuOpen, false);
+      assert.false(component.isMenuOpen);
     });
 
     test('should return true, when user details is clicked', async function(assert) {
       // when
       await component.toggleUserMenu();
       // then
-      assert.equal(component.isMenuOpen, true);
+      assert.true(component.isMenuOpen);
     });
 
     test('should return false, when isMenuOpen was previously true', async function(assert) {
@@ -30,13 +30,13 @@ module('Unit | Component | user-logged-menu', (hooks) => {
       await component.toggleUserMenu();
       await component.toggleUserMenu();
       // then
-      assert.equal(component.isMenuOpen, false);
+      assert.false(component.isMenuOpen);
     });
   });
 
   module('organizationNameAndExternalId', () => {
 
-    test('should return the organization name if the externalId is not defined', (assert) => {
+    test('should return the organization name if the externalId is not defined', function(assert) {
       // given
       const expectedOrganizationName = 'expectedOrganizationName';
       const currentUser = { organization: { name: expectedOrganizationName } };
@@ -48,7 +48,7 @@ module('Unit | Component | user-logged-menu', (hooks) => {
       assert.equal(computedOrganizationName, expectedOrganizationName);
     });
 
-    test('should return the organization name and externalId if the externalId is defined', (assert) => {
+    test('should return the organization name and externalId if the externalId is defined', function(assert) {
       // given
       const expectedOrganizationName = 'expectedOrganizationName';
       const expectedExternalId = 'expectedExternalId';

--- a/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
@@ -29,7 +29,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
       const displayNoCampaignPanel = controller.displayNoCampaignPanel;
 
       // then
-      assert.equal(displayNoCampaignPanel, true);
+      assert.true(displayNoCampaignPanel);
     });
 
     test('it should know when it should not display "No campaign panel"', function(assert) {
@@ -44,7 +44,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
       const displayNoCampaignPanel = controller.displayNoCampaignPanel;
 
       // then
-      assert.equal(displayNoCampaignPanel, false);
+      assert.false(displayNoCampaignPanel);
     });
 
     module('when there is a filter on campaigns name that does not match any campaign', function() {
@@ -64,7 +64,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
         const displayNoCampaignPanel = controller.displayNoCampaignPanel;
 
         // then
-        assert.equal(displayNoCampaignPanel, false);
+        assert.false(displayNoCampaignPanel);
       });
     });
   });
@@ -81,7 +81,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
         const isArchived = controller.isArchived;
 
         // then
-        assert.equal(isArchived, true);
+        assert.true(isArchived);
       });
 
       test('it should display page title as archived', async function(assert) {
@@ -109,7 +109,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
         const isArchived = controller.isArchived;
 
         // then
-        assert.equal(isArchived, false);
+        assert.false(isArchived);
       });
 
       test('it should display page title as active', async function(assert) {
@@ -152,8 +152,8 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
       controller.send('goToCampaignPage', 123, event);
 
       // then
-      assert.ok(event.preventDefault.called);
-      assert.equal(controller.transitionToRoute.calledWith('authenticated.campaigns.campaign', 123), true);
+      assert.true(event.preventDefault.called);
+      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.campaign', 123));
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/team/list/members_test.js
+++ b/orga/tests/unit/controllers/authenticated/team/list/members_test.js
@@ -15,7 +15,7 @@ module('Unit | Controller | authenticated/team/list/members', function(hooks) {
 
   module('#removeMembership', () => {
 
-    test('should set current organization to the membership ', async (assert) => {
+    test('should set current organization to the membership ', async function(assert) {
       // given
       const saveStub = sinon.stub();
       const membership = {
@@ -29,7 +29,7 @@ module('Unit | Controller | authenticated/team/list/members', function(hooks) {
       assert.equal(membership.organization, currentUser.organization);
     });
 
-    test('should call disable membership endpoint', async (assert) => {
+    test('should call disable membership endpoint', async function(assert) {
       // given
       const saveStub = sinon.stub();
       const membership = {
@@ -45,7 +45,7 @@ module('Unit | Controller | authenticated/team/list/members', function(hooks) {
       assert.ok(true);
     });
 
-    test('should call route\'s refreshModel action', async (assert) => {
+    test('should call route\'s refreshModel action', async function(assert) {
       // given
       const saveStub = sinon.stub();
       const membership = {

--- a/orga/tests/unit/models/campaign_test.js
+++ b/orga/tests/unit/models/campaign_test.js
@@ -72,7 +72,7 @@ module('Unit | Model | campaign', function(hooks) {
         stages: [stage],
       });
 
-      assert.equal(model.hasStages, true);
+      assert.true(model.hasStages);
     });
 
     test('returns false while campaign does not contain stages', function(assert) {
@@ -81,7 +81,7 @@ module('Unit | Model | campaign', function(hooks) {
         stages: [],
       });
 
-      assert.equal(model.hasStages, false);
+      assert.false(model.hasStages);
     });
   });
 
@@ -93,7 +93,7 @@ module('Unit | Model | campaign', function(hooks) {
         badges: [badge],
       });
 
-      assert.equal(model.hasBadges, true);
+      assert.true(model.hasBadges);
     });
 
     test('returns false while campaign does not contain badges', function(assert) {
@@ -102,7 +102,7 @@ module('Unit | Model | campaign', function(hooks) {
         badges: [],
       });
 
-      assert.equal(model.hasBadges, false);
+      assert.false(model.hasBadges);
     });
   });
 

--- a/orga/tests/unit/models/student_test.js
+++ b/orga/tests/unit/models/student_test.js
@@ -100,25 +100,25 @@ module('Unit | Model | student', function(hooks) {
     test('it returns false when the student has no email, no username or is not authenticated from GAR', function(assert) {
       const student = store.createRecord('student', { email: null, username: null, isAuthenticatedFromGar: false });
 
-      assert.equal(student.isStudentAssociated, false);
+      assert.false(student.isStudentAssociated);
     });
 
     test('it returns true when the student has an email', function(assert) {
       const student = store.createRecord('student', { email: 'martin.riggs@example.net', username: null, isAuthenticatedFromGar: false });
 
-      assert.equal(student.isStudentAssociated, true);
+      assert.true(student.isStudentAssociated);
     });
 
     test('it returns true when the student has an username', function(assert) {
       const student = store.createRecord('student', { email: null, username: 'RogerMurtaugh', isAuthenticatedFromGar: false });
 
-      assert.equal(student.isStudentAssociated, true);
+      assert.true(student.isStudentAssociated);
     });
 
     test('it returns true when the student is authenticated from GAR', function(assert) {
       const student = store.createRecord('student', { email: null, username: null, isAuthenticatedFromGar: true });
 
-      assert.equal(student.isStudentAssociated, true);
+      assert.true(student.isStudentAssociated);
     });
   });
 
@@ -131,13 +131,13 @@ module('Unit | Model | student', function(hooks) {
     test('it returns true if the student is authenticated by email only', function(assert) {
       const student = store.createRecord('student', { email: 'john.harry@example.net', username: null, isAuthenticatedFromGar: false });
 
-      assert.equal(student.displayAddUsernameAuthentication, true);
+      assert.true(student.displayAddUsernameAuthentication);
     });
 
     test('it returns true if the student is authenticated from mediacenter only', function(assert) {
       const student = store.createRecord('student', { email: null, username: null, isAuthenticatedFromGar: true });
 
-      assert.equal(student.displayAddUsernameAuthentication, true);
+      assert.true(student.displayAddUsernameAuthentication);
     });
 
   });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profiles_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profiles_test.js
@@ -78,7 +78,7 @@ module('Unit | Route | authenticated/campaigns/campaign/profiles', function(hook
     module('when the transition comes from "authenticated.campaigns.campaign.profiles"', function() {
       test('if returns false', function(assert) {
         const transition = { from: { name: 'authenticated.campaigns.campaign.profiles' } };
-        assert.equal(route.loading(transition), false);
+        assert.false(route.loading(transition));
       });
     });
 

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign_test.js
@@ -21,6 +21,7 @@ module('Unit | Route | authenticated/campaigns/campaign', function(hooks) {
   });
 
   test('should redirect to not-found page', async function(assert) {
+    assert.expect(1);
     // given
     findRecordStub.rejects({ errors: [{ status: '400' }] });
 

--- a/orga/tests/unit/routes/not-found_test.js
+++ b/orga/tests/unit/routes/not-found_test.js
@@ -5,6 +5,7 @@ module('Unit | Route | not-found', function(hooks) {
   setupTest(hooks);
 
   test('should redirect to application route', function(assert) {
+    assert.expect(1);
     const route = this.owner.lookup('route:not-found');
     const expectedRedirection = 'application';
 

--- a/orga/tests/unit/services/current-user_test.js
+++ b/orga/tests/unit/services/current-user_test.js
@@ -92,7 +92,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isAdminInOrganization, false);
+        assert.false(currentUserService.isAdminInOrganization);
       });
     });
 
@@ -109,7 +109,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isAdminInOrganization, true);
+        assert.true(currentUserService.isAdminInOrganization);
       });
     });
 
@@ -125,7 +125,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isSCOManagingStudents, true);
+        assert.true(currentUserService.isSCOManagingStudents);
       });
 
       test('should set isSUPManagingStudents to false', async function(assert) {
@@ -139,7 +139,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isSUPManagingStudents, false);
+        assert.false(currentUserService.isSUPManagingStudents);
       });
     });
 
@@ -155,7 +155,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isSCOManagingStudents, false);
+        assert.false(currentUserService.isSCOManagingStudents);
       });
 
       test('should set isSUPManagingStudents to true', async function(assert) {
@@ -169,7 +169,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isSUPManagingStudents, true);
+        assert.true(currentUserService.isSUPManagingStudents);
       });
     });
 
@@ -185,7 +185,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isSCOManagingStudents, false);
+        assert.false(currentUserService.isSCOManagingStudents);
       });
 
       test('should set isSUPManagingStudents to false with PRO organization', async function(assert) {
@@ -199,7 +199,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isSUPManagingStudents, false);
+        assert.false(currentUserService.isSUPManagingStudents);
       });
     });
 
@@ -215,7 +215,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isSCOManagingStudents, false);
+        assert.false(currentUserService.isSCOManagingStudents);
       });
 
       test('should set isSUPManagingStudents to false when organization is SUP', async function(assert) {
@@ -229,7 +229,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.isSUPManagingStudents, false);
+        assert.false(currentUserService.isSUPManagingStudents);
       });
     });
 

--- a/orga/tests/unit/services/feature-toggle_test.js
+++ b/orga/tests/unit/services/feature-toggle_test.js
@@ -25,7 +25,7 @@ module('Unit | Service | feature toggles', function(hooks) {
       await featureToggleService.load();
 
       // Then
-      assert.equal(featureToggleService.featureToggles.aFakeFeatureToggle, false);
+      assert.false(featureToggleService.featureToggles.aFakeFeatureToggle);
     });
   });
 });

--- a/orga/tests/unit/services/file-saver_test.js
+++ b/orga/tests/unit/services/file-saver_test.js
@@ -10,7 +10,7 @@ module('Unit | Service | file-saver', function(hooks) {
     fileSaver = this.owner.lookup('service:file-saver');
   });
 
-  module('#save', function() {
+  module('#save', function(hooks) {
     const id = 123456;
     const url = `/attestation/${id}`;
     const token = 'mytoken';

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -17,7 +17,7 @@ module('Unit | Service | url', function(hooks) {
       const domainExtension = service.isFrenchDomainExtension;
 
       // then
-      assert.equal(domainExtension, true);
+      assert.true(domainExtension);
     });
 
     test('should not have frenchDomainExtension when the current domain contains pix.org', function(assert) {
@@ -29,7 +29,7 @@ module('Unit | Service | url', function(hooks) {
       const domainExtension = service.isFrenchDomainExtension;
 
       // then
-      assert.equal(domainExtension, false);
+      assert.false(domainExtension);
     });
   });
 

--- a/orga/tests/unit/utils/email-validator_test.js
+++ b/orga/tests/unit/utils/email-validator_test.js
@@ -18,7 +18,7 @@ module('Unit | Utils | email validator', function(hooks) {
       '@pix',
     ].forEach(function(badEmail) {
       test(`should return false when email is invalid: ${badEmail}`, function(assert) {
-        assert.equal(isEmailValid(badEmail), false);
+        assert.false(isEmailValid(badEmail));
       });
     });
   });
@@ -36,7 +36,7 @@ module('Unit | Utils | email validator', function(hooks) {
       'user+beta@pix.beta.gouv.fr',
     ].forEach(function(validEmail) {
       test(`should return true if provided email is valid: ${validEmail}`, function(assert) {
-        assert.equal(isEmailValid(validEmail), true);
+        assert.true(isEmailValid(validEmail));
       });
     });
   });

--- a/orga/tests/unit/utils/input-validator_test.js
+++ b/orga/tests/unit/utils/input-validator_test.js
@@ -13,7 +13,7 @@ module('Unit | Utils | input validator', function(hooks) {
     validator.validate({ value: false });
 
     // then
-    assert.equal(validator.hasError, true);
+    assert.true(validator.hasError);
   });
 
   test('should reset server message if resetServerMessage is true on validate', function(assert) {

--- a/orga/tests/unit/utils/password-validator_test.js
+++ b/orga/tests/unit/utils/password-validator_test.js
@@ -8,23 +8,23 @@ module('Unit | Utils | password validator', function(hooks) {
   module('Validation rules', function() {
 
     test('should contain at least 8 characters:', function(assert) {
-      assert.equal(isPasswordValid('Ab123456'), true);
-      assert.equal(isPasswordValid('A1'), false);
+      assert.true(isPasswordValid('Ab123456'));
+      assert.false(isPasswordValid('A1'));
     });
 
     test('should contain at least one digit', function(assert) {
-      assert.equal(isPasswordValid('Ab123456'), true);
-      assert.equal(isPasswordValid('ABCDEFGH'), false);
+      assert.true(isPasswordValid('Ab123456'));
+      assert.false(isPasswordValid('ABCDEFGH'));
     });
 
     test('should contain at least one uppercase letter', function(assert) {
-      assert.equal(isPasswordValid('Ab123456'), true);
-      assert.equal(isPasswordValid('a1234567'), false);
+      assert.true(isPasswordValid('Ab123456'));
+      assert.false(isPasswordValid('a1234567'));
     });
 
     test('should contain at least one lowercase letter', function(assert) {
-      assert.equal(isPasswordValid('Ab123456'), true);
-      assert.equal(isPasswordValid('A1234567'), false);
+      assert.true(isPasswordValid('Ab123456'));
+      assert.false(isPasswordValid('A1234567'));
     });
 
   });
@@ -45,7 +45,7 @@ module('Unit | Utils | password validator', function(hooks) {
       '+!@)-=`"#&1a',
     ].forEach(function(badPassword) {
       test(`should return false when password is invalid: ${badPassword}`, function(assert) {
-        assert.equal(isPasswordValid(badPassword), false);
+        assert.false(isPasswordValid(badPassword));
       });
     });
   });
@@ -68,7 +68,7 @@ module('Unit | Utils | password validator', function(hooks) {
       'Aà1      ',
     ].forEach(function(validPassword) {
       test(`should return true if provided password is valid: ${validPassword}`, function(assert) {
-        assert.equal(isPasswordValid(validPassword), true);
+        assert.true(isPasswordValid(validPassword));
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Les fichiers de test de Pix ne sont pas correctement linté, car, a part sur mon-pix, on utilise qunit et pas mocha. Pour une raison cocasse, `eslint-plugin-mocha` était installé mais pas utilisé.

## :robot: Solution
Installer `eslint-plugin-qunit`, le configurer et corriger les erreurs associées sur orga. Autres applis a suivre.

## :rainbow: Remarques
J'ai mis à jour la version de qunit utilisé pour pouvoir utiliser `assert.true` et `assert.false`.

## :100: Pour tester
`npm run lint` ne doit renvoyer aucune erreur.
