### PR TITLE
[FEATURE] Ajout de l'étape de conflit lors de la récupération de compte à la sortie du SCO (PIX-2730).

### DIFF
--- a/mon-pix/app/components/recover-account-conflict-error.hbs
+++ b/mon-pix/app/components/recover-account-conflict-error.hbs
@@ -1,0 +1,10 @@
+<h1>{{t 'pages.recover-account-after-leaving-sco.conflict.found-you-but' firstName=@firstName}}</h1>
+<p>{{t 'pages.recover-account-after-leaving-sco.conflict.precaution'}}</p>
+<p>
+  <a href="{{t 'pages.recover-account-after-leaving-sco.conflict.support.url'}}"
+    target="_blank"
+    rel="noopener noreferrer">
+      {{t 'pages.recover-account-after-leaving-sco.conflict.support.url-text'}}
+  </a>
+  {{t 'pages.recover-account-after-leaving-sco.conflict.support.recover'}}
+</p>

--- a/mon-pix/app/components/recover-account-student-information-form.hbs
+++ b/mon-pix/app/components/recover-account-student-information-form.hbs
@@ -10,7 +10,7 @@
 
 <p>{{t 'common.form.mandatory-all-fields'}}</p>
 
-<form onSubmit={{this.submitStudentInformationForm}}>
+<form {{on 'submit' this.submit}}>
   <PixTooltip @text={{t 'pages.recover-account-after-leaving-sco.student-information.form.tooltip' htmlSafe=true}} @position='top-right'>
     <FaIcon @icon="info-circle" />
   </PixTooltip>
@@ -78,7 +78,7 @@
     </div>
   </div>
 
-  <PixButton @type="submit">
+  <PixButton @type="submit" @isDisabled={{not this.isFormValid}}>
     {{t 'pages.recover-account-after-leaving-sco.student-information.form.submit'}}
   </PixButton>
 </form>

--- a/mon-pix/app/components/recover-account-student-information-form.js
+++ b/mon-pix/app/components/recover-account-student-information-form.js
@@ -55,16 +55,35 @@ export default class RecoverAccountStudentInformationFormComponent extends Compo
   get isFormValid() {
     return !isEmpty(this.lastName) &&
       !isEmpty(this.firstName) &&
-      !isEmpty(this.dayOfBirth) &&
-      !isEmpty(this.monthOfBirth) &&
-      !isEmpty(this.yearOfBirth) &&
-      this.isIneInaValid;
+      this._isDayOfBirthValid &&
+      this._isMonthOfBirthValid &&
+      this._isYearOfBirthValid &&
+      this._isIneInaValid;
   }
 
-  get isIneInaValid() {
+  get _isIneInaValid() {
     const isValidIne = INE_REGEX.test(this.ineIna);
     const isValidIna = INA_REGEX.test(this.ineIna);
     return (isValidIna || isValidIne) && !isEmpty(this.ineIna);
+  }
+
+  get _isDayOfBirthValid() {
+    return !isEmpty(this.dayOfBirth);
+  }
+
+  get _isMonthOfBirthValid() {
+    return !isEmpty(this.monthOfBirth);
+  }
+
+  get _isYearOfBirthValid() {
+    return !isEmpty(this.yearOfBirth);
+  }
+
+  get _formatBirthdate() {
+    const year = parseInt(this.yearOfBirth);
+    const month = parseInt(this.monthOfBirth) - 1;
+    const day = parseInt(this.dayOfBirth);
+    return moment(new Date(year, month, day)).format('YYYY-MM-DD');
   }
 
   @action validateIneIna() {
@@ -76,7 +95,7 @@ export default class RecoverAccountStudentInformationFormComponent extends Compo
       return;
     }
 
-    if (!this.isIneInaValid) {
+    if (!this._isIneInaValid) {
       this.ineInaValidation.status = STATUS_MAP['errorStatus'];
       this.ineInaValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidIneInaFormat']);
       return;
@@ -115,16 +134,12 @@ export default class RecoverAccountStudentInformationFormComponent extends Compo
     event.preventDefault();
 
     if (this.isFormValid) {
-      const year = parseInt(this.yearOfBirth);
-      const month = parseInt(this.monthOfBirth) - 1;
-      const day = parseInt(this.dayOfBirth);
-      const birthdate = moment(new Date(year, month, day)).format('YYYY-MM-DD');
 
       await this.args.submitStudentInformation({
         ineIna: this.ineIna,
         firstName: this.firstName,
         lastName: this.lastName,
-        birthdate,
+        birthdate: this._formatBirthdate,
       });
     }
   }

--- a/mon-pix/app/controllers/recover-account-after-leaving-sco.js
+++ b/mon-pix/app/controllers/recover-account-after-leaving-sco.js
@@ -1,0 +1,31 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class RecoverAccountAfterLeavingScoController extends Controller {
+
+  @tracked showRecoverAccountStudentInformationForm = true;
+  @tracked showRecoverAccountConflictError = false;
+
+  firstName;
+
+  @action
+  async submitStudentInformation(studentInformation) {
+    const studentInformationToSave = this.store.createRecord('student-information', studentInformation);
+    this.firstName = studentInformation.firstName;
+    try {
+      await studentInformationToSave.save();
+    } catch (err) {
+      this._handleError(err);
+    }
+  }
+
+  _handleError(err) {
+    const status = err.errors?.[0]?.status;
+
+    if (status === '409') {
+      this.showRecoverAccountStudentInformationForm = false;
+      this.showRecoverAccountConflictError = true;
+    }
+  }
+}

--- a/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
@@ -1,2 +1,9 @@
 {{page-title (t 'pages.recover-account-after-leaving-sco.title')}}
-<RecoverAccountStudentInformationForm />
+
+{{#if this.showRecoverAccountStudentInformationForm}}
+  <RecoverAccountStudentInformationForm @submitStudentInformation={{this.submitStudentInformation}} />
+{{/if}}
+
+{{#if this.showRecoverAccountConflictError}}
+  <RecoverAccountConflictError @firstName={{this.firstName}} />
+{{/if}}

--- a/mon-pix/mirage/routes/schooling-registration-dependent-users/index.js
+++ b/mon-pix/mirage/routes/schooling-registration-dependent-users/index.js
@@ -51,4 +51,29 @@ export default function index(config) {
 
     return schema.externalUsers.create({ accessToken: 'aaa.' + btoa(`{"user_id":${user.id},"source":"external","iat":1545321469,"exp":4702193958}`) + '.bbb' });
   });
+
+  config.post('/schooling-registration-dependent-users/recover-account', (schema, request) => {
+    const params = JSON.parse(request.requestBody);
+    const firstName = params.data.attributes['first-name'];
+    const lastName = params.data.attributes['last-name'];
+    const ineIna = params.data.attributes['ine-ina'];
+    const birthdate = params.data.attributes['birthdate'];
+    const foundUser = schema.users.findBy({ firstName, lastName });
+    const foundStudent = schema.studentInformation.findBy({ ineIna, firstName, lastName, birthdate });
+
+    if (foundUser && foundStudent) {
+      return new Response(200, {}, {
+        data: {
+          type: 'student-information',
+          id: 3,
+          attributes: {
+            'first-name': foundUser.firstName,
+            'last-name': foundUser.lastName,
+            username: foundUser.username,
+            email: foundUser.email,
+            'latest-organization-name': 'Collège FouFouFou',
+          },
+        } });
+    }
+  });
 }

--- a/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
+++ b/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
@@ -3,15 +3,20 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import visit from '../helpers/visit';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
+import setupIntl from '../helpers/setup-intl';
+import { Response } from 'ember-cli-mirage';
+import { contains } from '../helpers/contains';
 
 describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
+
   setupApplicationTest();
   setupMirage();
+  setupIntl();
 
-  context('when account recovery is disabled by default', () => {
+  context('when account recovery is disabled by default', function() {
 
-    it('should redirect to login page', async () => {
+    it('should redirect to login page', async function() {
       // given / when
       await visit('/recuperer-mon-compte');
 
@@ -20,9 +25,9 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
     });
   });
 
-  context('when account recovery is enabled', () => {
+  context('when account recovery is enabled', function() {
 
-    it('should access to account recovery page', async () => {
+    it('should access to account recovery page', async function() {
       // given
       server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
 
@@ -31,6 +36,56 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
 
       // then
       expect(currentURL()).to.equal('/recuperer-mon-compte');
+    });
+
+    context('when two students used same account', function() {
+
+      it('should redirect to account recovery conflict page', async function() {
+        // given
+        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+
+        const ineIna = '0123456789A';
+        const lastName = 'Lecol';
+        const firstName = 'Manuela';
+        const dayOfBirth = 20;
+        const monthOfBirth = 5;
+        const yearOfBirth = 2000;
+
+        server.create('user', {
+          id: 1,
+          firstName,
+          lastName,
+        });
+
+        server.create('student-information', {
+          id: 2,
+          ineIna,
+          firstName,
+          lastName,
+          birthdate: '2000-5-20',
+        });
+
+        this.server.post('/schooling-registration-dependent-users/recover-account', function() {
+          return new Response(409, {}, {
+            errors: [{ status: '409' }],
+          });
+        });
+
+        //when
+        await visit('/recuperer-mon-compte');
+
+        await fillIn('#ineIna', ineIna);
+        await fillIn('#firstName', firstName);
+        await fillIn('#lastName', lastName);
+        await fillIn('#dayOfBirth', dayOfBirth);
+        await fillIn('#monthOfBirth', monthOfBirth);
+        await fillIn('#yearOfBirth', yearOfBirth);
+        await click('button[type=submit]');
+
+        // then
+        expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.conflict.found-you-but', { firstName }))).to.exist;
+        expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.not.exist;
+      });
     });
   });
 

--- a/mon-pix/tests/integration/components/recover-account-conflict-error-test.js
+++ b/mon-pix/tests/integration/components/recover-account-conflict-error-test.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { render, find } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { contains } from '../../helpers/contains';
+
+describe('Integration | Component | recover-account-conflict-error', function() {
+  setupIntlRenderingTest();
+
+  it('should render a account recovery conflict error', async function() {
+    // given
+    const firstName = 'Philippe';
+    this.set('firstName', firstName);
+
+    // when
+    await render(hbs`<RecoverAccountConflictError @firstName={{this.firstName}} />`);
+
+    // then
+    const expectedErrorMessage = this.intl.t('pages.recover-account-after-leaving-sco.conflict.found-you-but', { firstName });
+    expect(contains(expectedErrorMessage)).to.exist;
+    expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.conflict.precaution'))).to.exist;
+    expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.conflict.support.url-text'))).to.exist;
+    expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.conflict.support.recover'))).to.exist;
+  });
+
+  it('should redirect to support url on click on link', async function() {
+    // given
+    const firstName = 'Philippe';
+    this.set('firstName', firstName);
+
+    // when
+    await render(hbs`<RecoverAccountConflictError @firstName={{this.firstName}} />`);
+
+    // then
+    expect(find('a').href).to.contains(this.intl.t('pages.recover-account-after-leaving-sco.conflict.support.url'));
+  });
+});

--- a/mon-pix/tests/integration/components/recover-account-student-information-form-test.js
+++ b/mon-pix/tests/integration/components/recover-account-student-information-form-test.js
@@ -1,20 +1,19 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import Service from '@ember/service';
-import { render, fillIn, triggerEvent } from '@ember/test-helpers';
+import { render, fillIn, triggerEvent, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
-import { fillInByLabel } from '../../helpers/fill-in-by-label';
-import { clickByLabel } from '../../helpers/click-by-label';
 import sinon from 'sinon';
 
 describe('Integration | Component | recover-account-student-information-form', function() {
+
   setupIntlRenderingTest();
 
   it('should render a account recovery student information form', async function() {
     // given / when
-    await render(hbs`<RecoverAccountStudentInformationForm />`);
+    await render(hbs `<RecoverAccountStudentInformationForm />`);
 
     // then
     expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.exist;
@@ -26,8 +25,8 @@ describe('Integration | Component | recover-account-student-information-form', f
   it('should enable submission on account recovery form', async function() {
     // given
     const ine = '0123456789A';
-    const lastName = 'Lecol';
     const firstName = 'Manuela';
+    const lastName = 'Lecol';
     const dayOfBirth = 20;
     const monthOfBirth = 5;
     const yearOfBirth = 2000;
@@ -37,33 +36,46 @@ describe('Integration | Component | recover-account-student-information-form', f
       createRecord = createRecordStub;
     }
     this.owner.register('service:store', StoreStubService);
+    const submitStudentInformation = sinon.stub();
+    submitStudentInformation.resolves();
+    this.set('submitStudentInformation', submitStudentInformation);
 
-    await render(hbs`<RecoverAccountStudentInformationForm />`);
+    await render(hbs `
+      <RecoverAccountStudentInformationForm
+        @submitStudentInformation={{this.submitStudentInformation}}
+      />
+    `);
 
     // when
-    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ine);
-    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
-    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
+    await fillIn('#ineIna', ine);
+    await fillIn('#firstName', firstName);
+    await fillIn('#lastName', lastName);
     await fillIn('#dayOfBirth', dayOfBirth);
     await fillIn('#monthOfBirth', monthOfBirth);
     await fillIn('#yearOfBirth', yearOfBirth);
-    await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
+
+    await click('button[type=submit]');
 
     // then
-    sinon.assert.calledWithExactly(createRecordStub, 'student-information', { ineIna: ine, lastName, firstName, birthdate: '2000-5-20' });
+    sinon.assert.calledWithExactly(submitStudentInformation, {
+      ineIna: ine,
+      firstName,
+      lastName,
+      birthdate: '2000-05-20',
+    });
   });
 
   context('ine field', function() {
 
-    context('when the user fill in ine field with valid ina', function() {
+    context('when the user fill in ine field with valid ina or ine', function() {
 
       it('should not display an error message on focus-out', async function() {
         // given
         const validIna = '1234567890A';
-        await render(hbs`<RecoverAccountStudentInformationForm />`);
+        await render(hbs `<RecoverAccountStudentInformationForm />`);
 
         // when
-        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), validIna);
+        await fillIn('#ineIna', validIna);
         await triggerEvent('#ineIna', 'focusout');
 
         // then
@@ -73,10 +85,10 @@ describe('Integration | Component | recover-account-student-information-form', f
       it('should not display an error message on focus-out even if there are leading or trailing spaces', async function() {
         // given
         const validIna = '  1234567890A  ';
-        await render(hbs`<RecoverAccountStudentInformationForm />`);
+        await render(hbs `<RecoverAccountStudentInformationForm />`);
 
         // when
-        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), validIna);
+        await fillIn('#ineIna', validIna);
         await triggerEvent('#ineIna', 'focusout');
 
         // then
@@ -89,10 +101,10 @@ describe('Integration | Component | recover-account-student-information-form', f
       it('should display an invalid format error message on focus-out', async function() {
         // given
         const invalidIneIna = '123ABCDEF';
-        await render(hbs`<RecoverAccountStudentInformationForm />`);
+        await render(hbs `<RecoverAccountStudentInformationForm />`);
 
         // when
-        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), invalidIneIna);
+        await fillIn('#ineIna', invalidIneIna);
         await triggerEvent('#ineIna', 'focusout');
 
         // then
@@ -102,10 +114,10 @@ describe('Integration | Component | recover-account-student-information-form', f
       it('should display a required field error message on focus-out if ine field is empty', async function() {
         // given
         const emptyIneIna = '     ';
-        await render(hbs`<RecoverAccountStudentInformationForm />`);
+        await render(hbs `<RecoverAccountStudentInformationForm />`);
 
         // when
-        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), emptyIneIna);
+        await fillIn('#ineIna', emptyIneIna);
         await triggerEvent('#ineIna', 'focusout');
 
         // then
@@ -119,10 +131,10 @@ describe('Integration | Component | recover-account-student-information-form', f
     it('should display a required field error message on focus-out if last name field is empty', async function() {
       // given
       const emptyLastName = '     ';
-      await render(hbs`<RecoverAccountStudentInformationForm />`);
+      await render(hbs `<RecoverAccountStudentInformationForm />`);
 
       // when
-      await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), emptyLastName);
+      await fillIn('#lastName', emptyLastName);
       await triggerEvent('#lastName', 'focusout');
 
       // then
@@ -135,15 +147,14 @@ describe('Integration | Component | recover-account-student-information-form', f
     it('should display a required field error message on focus-out if first name field is empty', async function() {
       // given
       const emptyFirstName = '     ';
-      await render(hbs`<RecoverAccountStudentInformationForm />`);
+      await render(hbs `<RecoverAccountStudentInformationForm />`);
 
       // when
-      await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), emptyFirstName);
+      await fillIn('#firstName', emptyFirstName);
       await triggerEvent('#firstName', 'focusout');
 
       // then
       expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.errors.empty-first-name'))).to.exist;
     });
   });
-
 });

--- a/mon-pix/tests/unit/components/recover-account-student-information_test.js
+++ b/mon-pix/tests/unit/components/recover-account-student-information_test.js
@@ -1,0 +1,170 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+
+describe('Unit | Component | recover-account-student-information-form', function() {
+
+  setupTest();
+
+  describe('#isIneInaValid', function() {
+
+    describe('when ine or ina is empty', function() {
+
+      it('should return false', function() {
+      // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.ineIna = '';
+
+        // when
+        const result = component.isIneInaValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when ine or ina is invalid', function() {
+
+      it('should return false', function() {
+      // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.ineIna = 'ABCDE';
+
+        // when
+        const result = component.isIneInaValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when ine is valid', function() {
+
+      it('should return true', function() {
+      // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.ineIna = '123456789AA';
+
+        // when
+        const result = component.isIneInaValid;
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    describe('when ina is valid', function() {
+
+      it('should return true', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.ineIna = '1234567890B';
+
+        // when
+        const result = component.isIneInaValid;
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+  });
+
+  describe('#isFormValid', function() {
+
+    describe('when lastName is empty', function() {
+
+      it('should return false', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.lastName = '';
+
+        // when
+        const result = component.isFormValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when firstName is empty', function() {
+
+      it('should return false', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.firstName = '';
+
+        // when
+        const result = component.isFormValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when monthOfBirth is empty', function() {
+
+      it('should return false', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.monthOfBirth = '';
+
+        // when
+        const result = component.isFormValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when dayOfBirth is empty', function() {
+
+      it('should return false', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.dayOfBirth = '';
+
+        // when
+        const result = component.isFormValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when yearOfBirth is empty', function() {
+
+      it('should return false', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.yearOfBirth = '';
+
+        // when
+        const result = component.isFormValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when form is valid', function() {
+
+      it('should return true', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.yearOfBirth = '2000';
+        component.monthOfBirth = '05';
+        component.dayOfBirth = '15';
+        component.lastName = 'Lagaffe';
+        component.firstName = 'Gaston';
+        component.ineIna = '123456789BB';
+
+        // when
+        const result = component.isFormValid;
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/recover-account-student-information_test.js
+++ b/mon-pix/tests/unit/components/recover-account-student-information_test.js
@@ -7,7 +7,7 @@ describe('Unit | Component | recover-account-student-information-form', function
 
   setupTest();
 
-  describe('#isIneInaValid', function() {
+  describe('#_isIneInaValid', function() {
 
     describe('when ine or ina is empty', function() {
 
@@ -17,7 +17,7 @@ describe('Unit | Component | recover-account-student-information-form', function
         component.ineIna = '';
 
         // when
-        const result = component.isIneInaValid;
+        const result = component._isIneInaValid;
 
         // then
         expect(result).to.be.false;
@@ -32,7 +32,7 @@ describe('Unit | Component | recover-account-student-information-form', function
         component.ineIna = 'ABCDE';
 
         // when
-        const result = component.isIneInaValid;
+        const result = component._isIneInaValid;
 
         // then
         expect(result).to.be.false;
@@ -47,7 +47,7 @@ describe('Unit | Component | recover-account-student-information-form', function
         component.ineIna = '123456789AA';
 
         // when
-        const result = component.isIneInaValid;
+        const result = component._isIneInaValid;
 
         // then
         expect(result).to.be.true;
@@ -62,7 +62,7 @@ describe('Unit | Component | recover-account-student-information-form', function
         component.ineIna = '1234567890B';
 
         // when
-        const result = component.isIneInaValid;
+        const result = component._isIneInaValid;
 
         // then
         expect(result).to.be.true;
@@ -166,5 +166,122 @@ describe('Unit | Component | recover-account-student-information-form', function
         expect(result).to.be.true;
       });
     });
+  });
+
+  describe('#_isDayOfBirthValid', function() {
+
+    describe('when dayOfBirth is empty', function() {
+
+      it('should return false', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.dayOfBirth = '';
+
+        // when
+        const result = component._isDayOfBirthValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when dayOfBirth is valid', function() {
+
+      it('should return true', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.dayOfBirth = '5';
+
+        // when
+        const result = component._isDayOfBirthValid;
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+  });
+
+  describe('#_isMonthOfBirthValid', function() {
+
+    describe('when monthOfBirth is empty', function() {
+
+      it('should return false', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.monthOfBirth = '';
+
+        // when
+        const result = component._isMonthOfBirthValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when monthOfBirth is valid', function() {
+
+      it('should return true', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.monthOfBirth = '5';
+
+        // when
+        const result = component._isMonthOfBirthValid;
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+  });
+
+  describe('#_isYearOfBirthValid', function() {
+
+    describe('when yearOfBirth is empty', function() {
+
+      it('should return false', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.yearOfBirth = '';
+
+        // when
+        const result = component._isYearOfBirthValid;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when yearOfBirth is valid', function() {
+
+      it('should return true', function() {
+        // given
+        const component = createGlimmerComponent('component:recover-account-student-information-form');
+        component.yearOfBirth = '2000';
+
+        // when
+        const result = component._isYearOfBirthValid;
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+  });
+
+  describe('#_formatBirthdate', function() {
+
+    it('should return valid birthdate format', function() {
+      // given
+      const component = createGlimmerComponent('component:recover-account-student-information-form');
+      component.dayOfBirth = '2';
+      component.monthOfBirth = '5';
+      component.yearOfBirth = '2004';
+
+      // when
+      const result = component._formatBirthdate;
+
+      // then
+      expect(result).to.equal('2004-05-02');
+    });
+
   });
 });

--- a/mon-pix/tests/unit/controllers/recover-account-after-leaving-sco-test.js
+++ b/mon-pix/tests/unit/controllers/recover-account-after-leaving-sco-test.js
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Controller | recover-account-after-leaving-sco', function() {
+
+  setupTest();
+
+  context('#submitStudentInformation', () => {
+
+    context('when submitting recover account student information form', function() {
+
+      it('should submit student information', async function() {
+      // given
+        const controller = this.owner.lookup('controller:recover-account-after-leaving-sco');
+        const studentInformation = { firstName: 'Jules' };
+        const saveStub = sinon.stub();
+        const createRecord = sinon.stub().returns({ save: saveStub.resolves() });
+        const store = { createRecord };
+        controller.set('store', store);
+
+        // when
+        await controller.submitStudentInformation(studentInformation);
+
+        // then
+        sinon.assert.calledWithExactly(createRecord, 'student-information', studentInformation);
+        sinon.assert.calledOnce(saveStub);
+      });
+
+      context('when two students used same account', function() {
+
+        it('should hide student information form and show conflict error', async function() {
+          // given
+          const errors = { errors: [ { status: '409' }] };
+          const controller = this.owner.lookup('controller:recover-account-after-leaving-sco');
+          const studentInformation = { firstName: 'Jules' };
+          const saveStub = sinon.stub().rejects(errors);
+          const store = { createRecord: sinon.stub().returns({ save: saveStub }) };
+          controller.set('store', store);
+
+          // when
+          await controller.submitStudentInformation(studentInformation);
+
+          // then
+          expect(controller.showRecoverAccountStudentInformationForm).to.be.false;
+          expect(controller.showRecoverAccountConflictError).to.be.true;
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -953,6 +953,16 @@
           "empty-last-name": "Le champ nom est obligatoire.",
           "empty-first-name": "Le champ prénom est obligatoire."
         }
+      },
+      "conflict": {
+        "title": "Conflit",
+        "found-you-but": "{ firstName }, on vous a retrouvé mais ...",
+        "precaution": "Par précaution nous devons vérifier vos données ensemble.",
+        "support": {
+          "url": "https://support.pix.org/fr/support/tickets/new",
+          "url-text": "Contactez le support",
+          "recover": " pour récupérer votre compte Pix."
+        }
       }
     },
     "result-item": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -953,6 +953,16 @@
           "empty-last-name": "Le champ nom est obligatoire.",
           "empty-first-name": "Le champ prénom est obligatoire."
         }
+      },
+      "conflict": {
+        "title": "Conflit",
+        "found-you-but": "{ firstName }, on vous a retrouvé mais ...",
+        "precaution": "Par précaution nous devons vérifier vos données ensemble.",
+        "support": {
+          "url": "https://support.pix.org/fr/support/tickets/new",
+          "url-text": "Contactez le support",
+          "recover": " pour récupérer votre compte Pix."
+        }
       }
     },
     "result-item": {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la sortie SCO, il faut permettre à l'utilisateur de récupérer son compte Pix.
Cependant dans certains cas on ne peut pas leur permettre de le faire seuls et il faut qu'ils puissent contacter le support pour récupérer leur compte.
Par exemple, le cas où on ne permet pas à l'utilisateur de récupérer son compte, c'est lorsqu'on trouve un autre étudiant relié à ce même compte. Ca arrive notamment quand un frère et une soeur utilisent le même compte pour faire leur exercices sur Pix.

## :robot: Solution
Afficher une page d'erreur quand on trouve plusieurs schooling-registration associé au compte que l'utilisateur essaie de récupérer.

## :rainbow: Remarques
- On a pas réussit à passer à une nouvelle route `conflict` un paramètre (firstName en l'occurrence)
En effet, un transitionTo (ou replaceWith) requière un model OU un id en paramètre et rien d'autre.

- On a donc choisit de remplacer la route `conflict` par un component (car il est plus simple de lui filer un paramètre firstName)

- Il n'y aura pas d'ajout de seeds pour tester cette PR car la feature n'est pas prévue d'être souvent modifiée.

## :100: Pour tester

Sur la RA : 
- aller sur `/recuperer-mon-compte` (sur pix app)
- rentrer les infos d'utilisateur qui ont des INE différents :
Ine/Ina : 123456789YY
Prénom : Lyanna
Nom : Mormont
Date de naissance : 07/01/2002

- constater qu'on arrive sur la page d'erreur avec les textes suivants (le CSS sera fait ultérieurement) : 
<img width="293" alt="image" src="https://user-images.githubusercontent.com/38167520/123825110-ea5a2080-d8fe-11eb-8166-e072751c631f.png">

En local : 
Modifier les seeds pour qu'un même user ait 2 schooling registration différents et rejouer le scénario.
