### PR TITLE
[TECH] Contrôler INE et INA dans l'API lors de la récupération SCO.

### DIFF
--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -7,6 +7,9 @@ const { passwordValidationPattern } = require('../../config').account;
 const identifiersType = require('../../domain/types/identifiers-type');
 const featureToggles = require('../preHandlers/feature-toggles');
 
+const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
+const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
+
 const schoolingRegistrationDependentUserController = require('./schooling-registration-dependent-user-controller');
 
 exports.register = async function(server) {
@@ -151,7 +154,10 @@ exports.register = async function(server) {
               attributes: {
                 'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
                 'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-                'ine-ina': Joi.string().required(),
+                'ine-ina': Joi.alternatives().try(
+                  Joi.string().regex(inePattern).required(),
+                  Joi.string().regex(inaPattern).required(),
+                ),
                 birthdate: Joi.date().format('YYYY-MM-DD').required(),
               },
             },


### PR DESCRIPTION
## :unicorn: Problème
Lors de la récupération d'un compte SCO, le format de l'INA/INA est :
- vérifié dans le front 
- non vérifié dans l'API. 

Les pratiques actuelles de développement dans l'équipe sont d'effectuer les vérifications "stateless" (ex: présence d'un champ, format) dans le front et dans le back, même si le scénario "vérification KO côté API" n'est pas un scénario nominal. En effet, l'utilisateur n'est pas sensé appeler l'API hors front. 

Autrement dit, cette pratique de développement ne résoud pas un problème utilisateur identifié, mais simplifie le processus de décision d'implémentation: "Où dois-je effectuer la vérification ?".

## :robot: Solution
Vérfier le format de l'INA/INE dans le back, en utilisant le mot-clef Joi `alternative`

## :rainbow: Remarques
Sans cet ajout, la vérification actuelle renvoit un `404 NOT FOUND`.
Après cet ajout, elle renverra un `400 BAD REQUEST`. Ce scénario ne pouvant pas arriver dans le front, aucune gestion de l'erreur `400 BAD REQUEST` n'est ajouté dans le front.

De plus, la version actuelle permet de récupérer: 
- un compte avec INE/INA invalide 
- si l'appel n'est pas fait depuis le front

Il y a quelques cas (< 1%) d'INE/INA valide en BDD de production (requête ci-dessous). 
Il a été décidé de ne pas permettre leur récupération.

```
-- Invalid INE / INA
SELECT
       t."nationalStudentId",
       t."userId",
       t."createdAt"
FROM "schooling-registrations" t
WHERE 1=1
    AND t."nationalStudentId" IS NOT NULL
    AND NOT (  t."nationalStudentId" ~ '^[0-9]{9}[a-zA-Z]{2}'
           OR  t."nationalStudentId" ~ '^[0-9]{10}[a-zA-Z]{1}')
ORDER BY
         t."createdAt" DESC
;
```


## :100: Pour tester
Exécuter cette commande curl 

``` bash
curl 'https://api-pr3146.review.pix.fr/api/schooling-registration-dependent-users/recover-account' -H 'Content-Type: application/vnd.api+json' --data-raw '{"data":{"attributes":{"ine-ina":"123456789ABC","first-name":"John","last-name":"Doe","birthdate":"1900-01-01"},"type":"student-information"}}'
```

Vérifier qu'elle renvoie `400 BAD REQUEST`sur le champ INE/INA
```
{ "errors": [
  {"status" : "400",
   "title"  : "Bad Request",
   "detail" : "\"data.attributes.ine-ina\" does not match any of the allowed types"}
]}
```