### PR TITLE
[BUGFIX/CLEANUP] Déplacer la détermination du numéro de question dans back-end (PIX-2642)

### DIFF
--- a/api/db/database-builder/factory/build-certification-challenge.js
+++ b/api/db/database-builder/factory/build-certification-challenge.js
@@ -13,6 +13,7 @@ module.exports = function buildCertificationChallenge({
   updatedAt = new Date('2020-01-02'),
   isNeutralized = false,
   certifiableBadgeKey = null,
+  index,
 } = {}) {
 
   courseId = _.isUndefined(courseId) ? buildCertificationCourse().id : courseId;
@@ -28,6 +29,7 @@ module.exports = function buildCertificationChallenge({
     updatedAt,
     isNeutralized,
     certifiableBadgeKey,
+    index,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-challenges',

--- a/api/db/migrations/20210624144540_add-column-order-in-certification-challenges-table.js
+++ b/api/db/migrations/20210624144540_add-column-order-in-certification-challenges-table.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'certification-challenges';
+
+exports.up = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.integer('index').unsigned();
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumn('index');
+  });
+};

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -86,7 +86,7 @@ module.exports = {
       serializer = challengeSerializer;
       extractChallengeId = (challenge) => challenge.id;
     } else if (assessment.isCertification()) {
-      usecase = async () => usecases.getNextChallengeForCertification({ assessment });
+      usecase = async () => usecases.getNextQuestionForCertification({ assessment });
       serializer = questionSerializer;
       extractChallengeId = (question) => question.challenge.id;
     } else if (assessment.isDemo()) {

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -6,6 +6,7 @@ const logger = require('../../infrastructure/logger');
 const assessmentRepository = require('../../infrastructure/repositories/assessment-repository');
 const assessmentSerializer = require('../../infrastructure/serializers/jsonapi/assessment-serializer');
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
+const questionSerializer = require('../../infrastructure/serializers/jsonapi/question-serializer');
 const competenceEvaluationSerializer = require('../../infrastructure/serializers/jsonapi/competence-evaluation-serializer');
 const { extractParameters } = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest, extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
@@ -86,8 +87,8 @@ module.exports = {
       extractChallengeId = (challenge) => challenge.id;
     } else if (assessment.isCertification()) {
       usecase = async () => usecases.getNextChallengeForCertification({ assessment });
-      serializer = challengeSerializer;
-      extractChallengeId = (challenge) => challenge.id;
+      serializer = questionSerializer;
+      extractChallengeId = (question) => question.challenge.id;
     } else if (assessment.isDemo()) {
       usecase = async () => usecases.getNextChallengeForDemo({ assessment });
       serializer = challengeSerializer;

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -57,10 +57,6 @@ class CertificationAssessment {
     return this._certificationChallenges;
   }
 
-  setCertificationChallenges(certificationChallenges) {
-    this._certificationChallenges = certificationChallenges;
-  }
-
   neutralizeChallengeByRecId(recId) {
     const challengeToBeNeutralized = _.find(this._certificationChallenges, { challengeId: recId });
     if (challengeToBeNeutralized) {

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -57,7 +57,7 @@ class CertificationAssessment {
     return this._certificationChallenges;
   }
 
-  set certificationChallenges(certificationChallenges) {
+  setCertificationChallenges(certificationChallenges) {
     this._certificationChallenges = certificationChallenges;
   }
 

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -19,7 +19,7 @@ const certificationAssessmentSchema = Joi.object({
   completedAt: Joi.date().allow(null),
   state: Joi.string().valid(states.COMPLETED, states.STARTED).required(),
   isV2Certification: Joi.boolean().required(),
-  certificationChallenges: Joi.array().min(1).required(),
+  _certificationChallenges: Joi.array().min(1).required(),
   certificationAnswersByDate: Joi.array().min(0).required(),
 });
 
@@ -43,7 +43,7 @@ class CertificationAssessment {
     this.completedAt = completedAt;
     this.state = state;
     this.isV2Certification = isV2Certification;
-    this.certificationChallenges = certificationChallenges;
+    this._certificationChallenges = certificationChallenges;
     this.certificationAnswersByDate = certificationAnswersByDate;
 
     validateEntity(certificationAssessmentSchema, this);
@@ -51,6 +51,14 @@ class CertificationAssessment {
 
   getCertificationChallenge(challengeId) {
     return _.find(this.certificationChallenges, { challengeId }) || null;
+  }
+
+  get certificationChallenges() {
+    return this._certificationChallenges;
+  }
+
+  set certificationChallenges(certificationChallenges) {
+    this._certificationChallenges = certificationChallenges;
   }
 
   neutralizeChallengeByRecId(recId) {

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -50,10 +50,10 @@ class CertificationAssessment {
   }
 
   getCertificationChallenge(challengeId) {
-    return _.find(this.certificationChallenges, { challengeId }) || null;
+    return _.find(this._certificationChallenges, { challengeId }) || null;
   }
 
-  get certificationChallenges() {
+  listCertificationChallenges() {
     return this._certificationChallenges;
   }
 
@@ -62,7 +62,7 @@ class CertificationAssessment {
   }
 
   neutralizeChallengeByRecId(recId) {
-    const challengeToBeNeutralized = _.find(this.certificationChallenges, { challengeId: recId });
+    const challengeToBeNeutralized = _.find(this._certificationChallenges, { challengeId: recId });
     if (challengeToBeNeutralized) {
       challengeToBeNeutralized.neutralize();
     } else {
@@ -77,7 +77,7 @@ class CertificationAssessment {
     }
 
     if (_isAnswerKoOrSkippedOrPartially(toBeNeutralizedChallengeAnswer.result.status)) {
-      const challengeToBeNeutralized = _.find(this.certificationChallenges, { challengeId: toBeNeutralizedChallengeAnswer.challengeId });
+      const challengeToBeNeutralized = _.find(this._certificationChallenges, { challengeId: toBeNeutralizedChallengeAnswer.challengeId });
       challengeToBeNeutralized.neutralize();
       return NeutralizationAttempt.neutralized(questionNumber);
     }
@@ -86,7 +86,7 @@ class CertificationAssessment {
   }
 
   deneutralizeChallengeByRecId(recId) {
-    const challengeToBeDeneutralized = _.find(this.certificationChallenges, { challengeId: recId });
+    const challengeToBeDeneutralized = _.find(this._certificationChallenges, { challengeId: recId });
     if (challengeToBeDeneutralized) {
       challengeToBeDeneutralized.deneutralize();
     } else {
@@ -95,7 +95,7 @@ class CertificationAssessment {
   }
 
   listCertifiableBadgeKeysTaken() {
-    return _(this.certificationChallenges)
+    return _(this._certificationChallenges)
       .filter((certificationChallenge) => certificationChallenge.isPixPlus())
       .uniqBy('certifiableBadgeKey')
       .map('certifiableBadgeKey')
@@ -103,7 +103,7 @@ class CertificationAssessment {
   }
 
   findAnswersAndChallengesForCertifiableBadgeKey(certifiableBadgeKey) {
-    const certificationChallengesForBadge = _.filter(this.certificationChallenges, { certifiableBadgeKey });
+    const certificationChallengesForBadge = _.filter(this._certificationChallenges, { certifiableBadgeKey });
     const challengeIds = _.map(certificationChallengesForBadge, 'challengeId');
     const answersForBadge = _.filter(this.certificationAnswersByDate, ({ challengeId }) => _.includes(challengeIds, challengeId));
     return {

--- a/api/lib/domain/models/Question.js
+++ b/api/lib/domain/models/Question.js
@@ -1,0 +1,6 @@
+module.exports = class Question {
+  constructor({ challenge, index }) {
+    this.challenge = challenge;
+    this.index = index;
+  }
+};

--- a/api/lib/domain/read-models/CertificationDetails.js
+++ b/api/lib/domain/read-models/CertificationDetails.js
@@ -32,7 +32,7 @@ class CertificationDetails {
   }) {
     const answerCollection = AnswerCollectionForScoring.from({
       answers: certificationAssessment.certificationAnswersByDate,
-      challenges: certificationAssessment.certificationChallenges,
+      challenges: certificationAssessment.listCertificationChallenges(),
     });
     const reproducibilityRate = ReproducibilityRate.from({
       numberOfNonNeutralizedChallenges: answerCollection.numberOfNonNeutralizedChallenges(),

--- a/api/lib/domain/read-models/CertificationDetails.js
+++ b/api/lib/domain/read-models/CertificationDetails.js
@@ -32,7 +32,7 @@ class CertificationDetails {
   }) {
     const answerCollection = AnswerCollectionForScoring.from({
       answers: certificationAssessment.certificationAnswersByDate,
-      challenges: certificationAssessment.listCertificationChallenges(),
+      challenges: certificationAssessment.certificationChallengesInTestOrder(),
     });
     const reproducibilityRate = ReproducibilityRate.from({
       numberOfNonNeutralizedChallenges: answerCollection.numberOfNonNeutralizedChallenges(),

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -141,7 +141,7 @@ async function _getScoreAndLevels(certificationAssessment, continueOnError) {
   });
 
   // map sur challenges filtre sur competence Id - S'assurer qu'on ne travaille que sur les compétences certifiables
-  const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.certificationChallenges, testedCompetences);
+  const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.listCertificationChallenges(), testedCompetences);
 
   // map sur challenges filtre sur challenge Id
   const matchingAnswers = _selectAnswersMatchingCertificationChallenges(certificationAssessment.certificationAnswersByDate, matchingCertificationChallenges);
@@ -158,7 +158,7 @@ async function _getChallengeInformation(certificationAssessment) {
   });
 
   // map sur challenges filtre sur competence Id - S'assurer qu'on ne travaille que sur les compétences certifiables
-  const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.certificationChallenges, testedCompetences);
+  const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.listCertificationChallenges(), testedCompetences);
 
   // map sur challenges filtre sur challenge Id
   const matchingAnswers = _selectAnswersMatchingCertificationChallenges(certificationAssessment.certificationAnswersByDate, matchingCertificationChallenges);
@@ -166,7 +166,7 @@ async function _getChallengeInformation(certificationAssessment) {
   const allPixCompetences = await competenceRepository.listPixCompetencesOnly();
   return matchingAnswers.map((answer) => {
 
-    const certificationChallengeRelatedToAnswer = certificationAssessment.certificationChallenges.find(
+    const certificationChallengeRelatedToAnswer = certificationAssessment.listCertificationChallenges().find(
       (certificationChallenge) => certificationChallenge.challengeId === answer.challengeId,
     ) || {};
 

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -141,7 +141,7 @@ async function _getScoreAndLevels(certificationAssessment, continueOnError) {
   });
 
   // map sur challenges filtre sur competence Id - S'assurer qu'on ne travaille que sur les compétences certifiables
-  const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.listCertificationChallenges(), testedCompetences);
+  const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.certificationChallengesInTestOrder(), testedCompetences);
 
   // map sur challenges filtre sur challenge Id
   const matchingAnswers = _selectAnswersMatchingCertificationChallenges(certificationAssessment.certificationAnswersByDate, matchingCertificationChallenges);
@@ -158,7 +158,7 @@ async function _getChallengeInformation(certificationAssessment) {
   });
 
   // map sur challenges filtre sur competence Id - S'assurer qu'on ne travaille que sur les compétences certifiables
-  const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.listCertificationChallenges(), testedCompetences);
+  const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationAssessment.certificationChallengesInTestOrder(), testedCompetences);
 
   // map sur challenges filtre sur challenge Id
   const matchingAnswers = _selectAnswersMatchingCertificationChallenges(certificationAssessment.certificationAnswersByDate, matchingCertificationChallenges);
@@ -166,7 +166,7 @@ async function _getChallengeInformation(certificationAssessment) {
   const allPixCompetences = await competenceRepository.listPixCompetencesOnly();
   return matchingAnswers.map((answer) => {
 
-    const certificationChallengeRelatedToAnswer = certificationAssessment.listCertificationChallenges().find(
+    const certificationChallengeRelatedToAnswer = certificationAssessment.certificationChallengesInTestOrder().find(
       (certificationChallenge) => certificationChallenge.challengeId === answer.challengeId,
     ) || {};
 

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -1,11 +1,13 @@
+const Question = require('./../models/Question');
 module.exports = function getNextChallengeForCertification({
   certificationChallengeRepository,
   challengeRepository,
   assessment,
 }) {
 
-  return certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId(assessment.id, assessment.certificationCourseId)
-    .then((certificationChallenge) => {
-      return challengeRepository.get(certificationChallenge.challengeId);
+  return certificationChallengeRepository.getNextNonAnsweredChallengeWithIndexByCourseId(assessment.id, assessment.certificationCourseId)
+    .then(async (certificationChallengeWithIndex) => {
+      const challenge = await challengeRepository.get(certificationChallengeWithIndex.challenge.challengeId);
+      return new Question({ index: certificationChallengeWithIndex.index, challenge });
     });
 };

--- a/api/lib/domain/usecases/get-next-question-for-certification.js
+++ b/api/lib/domain/usecases/get-next-question-for-certification.js
@@ -1,5 +1,5 @@
 const Question = require('./../models/Question');
-module.exports = function getNextChallengeForCertification({
+module.exports = function getNextQuestionForCertification({
   certificationChallengeRepository,
   challengeRepository,
   assessment,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -234,7 +234,7 @@ module.exports = injectDependencies({
   getJurySession: require('./get-jury-session'),
   getLastChallengeIdFromAssessmentId: require('./get-last-challenge-id-from-assessment-id'),
   getNextChallengeForCampaignAssessment: require('./get-next-challenge-for-campaign-assessment'),
-  getNextChallengeForCertification: require('./get-next-challenge-for-certification'),
+  getNextQuestionForCertification: require('./get-next-question-for-certification'),
   getNextChallengeForCompetenceEvaluation: require('./get-next-challenge-for-competence-evaluation'),
   getNextChallengeForDemo: require('./get-next-challenge-for-demo'),
   getNextChallengeForPreview: require('./get-next-challenge-for-preview'),

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -95,7 +95,7 @@ module.exports = {
   },
 
   async save(certificationAssessment) {
-    for (const challenge of certificationAssessment.listCertificationChallenges()) {
+    for (const challenge of certificationAssessment.certificationChallengesInTestOrder()) {
       await knex('certification-challenges')
         .where({ id: challenge.id })
         .update(_.pick(challenge, ['isNeutralized']));

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -11,10 +11,16 @@ const { NotFoundError } = require('../../domain/errors');
 async function _getCertificationChallenges(certificationCourseId, knexConn) {
   const allChallenges = await challengeRepository.findOperative();
   const certificationChallengeRows = await knexConn('certification-challenges')
-    .where({ courseId: certificationCourseId })
-    .orderBy('challengeId', 'asc');
+    .where({ courseId: certificationCourseId });
 
-  return _.map(certificationChallengeRows, (certificationChallengeRow) => {
+  let sortedCertificationChallengesRows;
+  if (certificationChallengeRows.every((challengeRow) => Boolean(challengeRow.index))) {
+    sortedCertificationChallengesRows = _.sortBy(certificationChallengeRows, 'index');
+  } else {
+    sortedCertificationChallengesRows = _.sortBy(certificationChallengeRows, 'id');
+  }
+
+  return _.map(sortedCertificationChallengesRows, (certificationChallengeRow) => {
     const challenge = _.find(allChallenges, { id: certificationChallengeRow.challengeId });
     return new CertificationChallengeWithType({
       ...certificationChallengeRow,

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -98,7 +98,7 @@ module.exports = {
   },
 
   async save(certificationAssessment) {
-    for (const challenge of certificationAssessment.certificationChallenges) {
+    for (const challenge of certificationAssessment.listCertificationChallenges()) {
       await knex('certification-challenges')
         .where({ id: challenge.id })
         .update(_.pick(challenge, ['isNeutralized']));

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -15,9 +15,9 @@ const logContext = {
 
 module.exports = {
 
-  async saveWithOrder({ certificationCourseId, certificationChallenges, domainTransaction = DomainTransaction.emptyTransaction() }) {
+  async saveAll({ certificationCourseId, certificationChallenges, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const knexConn = domainTransaction.knexTransaction || knex;
-    const dtos = certificationChallenges.map((certificationChallenge) => {
+    const dtos = certificationChallenges.map((certificationChallenge, index) => {
       return {
         challengeId: certificationChallenge.challengeId,
         competenceId: certificationChallenge.competenceId,
@@ -25,6 +25,7 @@ module.exports = {
         associatedSkillId: certificationChallenge.associatedSkillId,
         courseId: certificationCourseId,
         certifiableBadgeKey: certificationChallenge.certifiableBadgeKey,
+        index: index + 1,
       };
     });
     const savedCertificationChallengesDTOs = await knexConn.batchInsert('certification-challenges', dtos).returning('*');

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -16,7 +16,7 @@ module.exports = {
     const options = { transacting: domainTransaction.knexTransaction };
     const savedCertificationCourseDTO = await new CertificationCourseBookshelf(certificationCourseToSaveDTO).save(null, options);
 
-    const savedChallenges = await certificationChallengeRepository.saveWithOrder({ certificationCourseId: savedCertificationCourseDTO.id, certificationChallenges: certificationCourse.challenges, domainTransaction });
+    const savedChallenges = await certificationChallengeRepository.saveAll({ certificationCourseId: savedCertificationCourseDTO.id, certificationChallenges: certificationCourse.challenges, domainTransaction });
 
     const savedCertificationCourse = _toDomain(savedCertificationCourseDTO);
     savedCertificationCourse.challenges = savedChallenges;

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -1,6 +1,5 @@
 const { _ } = require('lodash');
 const { knex } = require('../bookshelf');
-const bluebird = require('bluebird');
 const CertificationCourseBookshelf = require('../orm-models/CertificationCourse');
 const AssessmentBookshelf = require('../orm-models/Assessment');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
@@ -17,10 +16,7 @@ module.exports = {
     const options = { transacting: domainTransaction.knexTransaction };
     const savedCertificationCourseDTO = await new CertificationCourseBookshelf(certificationCourseToSaveDTO).save(null, options);
 
-    const savedChallenges = await bluebird.mapSeries(certificationCourse.challenges, (certificationChallenge) => {
-      const certificationChallengeWithCourseId = { ...certificationChallenge, courseId: savedCertificationCourseDTO.id };
-      return certificationChallengeRepository.save({ certificationChallenge: certificationChallengeWithCourseId, domainTransaction });
-    });
+    const savedChallenges = await certificationChallengeRepository.saveWithOrder({ certificationCourseId: savedCertificationCourseDTO.id, certificationChallenges: certificationCourse.challenges, domainTransaction });
 
     const savedCertificationCourse = _toDomain(savedCertificationCourseDTO);
     savedCertificationCourse.challenges = savedChallenges;

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -1,35 +1,40 @@
 const { Serializer } = require('jsonapi-serializer');
 const _ = require('lodash');
 
-module.exports = {
+const attributes = [
+  'type',
+  'instruction',
+  'competence',
+  'proposals',
+  'timer',
+  'illustrationUrl',
+  'attachments',
+  'competence',
+  'embedUrl',
+  'embedTitle',
+  'embedHeight',
+  'illustrationAlt',
+  'format',
+  'autoReply',
+  'alternativeInstruction',
+  'focused',
+];
 
+function transform(record) {
+  const challenge = _.pickBy(record, (value) => !_.isUndefined(value));
+
+  challenge.competence = challenge.competenceId || 'N/A';
+
+  return challenge;
+}
+
+module.exports = {
+  attributes,
+  transform,
   serialize(challenges) {
     return new Serializer('challenge', {
-      attributes: [
-        'type',
-        'instruction',
-        'competence',
-        'proposals',
-        'timer',
-        'illustrationUrl',
-        'attachments',
-        'competence',
-        'embedUrl',
-        'embedTitle',
-        'embedHeight',
-        'illustrationAlt',
-        'format',
-        'autoReply',
-        'alternativeInstruction',
-        'focused',
-      ],
-      transform: (record) => {
-        const challenge = _.pickBy(record, (value) => !_.isUndefined(value));
-
-        challenge.competence = challenge.competenceId || 'N/A';
-
-        return challenge;
-      },
+      attributes,
+      transform,
     }).serialize(challenges);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/question-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/question-serializer.js
@@ -1,0 +1,22 @@
+const { Serializer } = require('jsonapi-serializer');
+const challengeSerializer = require('./challenge-serializer');
+
+module.exports = {
+
+  serialize(questions) {
+    return new Serializer('challenge', {
+      attributes: [
+        ...challengeSerializer.attributes,
+        'index',
+      ],
+      transform: (record) => {
+        const challenge = challengeSerializer.transform(record.challenge);
+
+        return {
+          ...challenge,
+          index: record.index,
+        };
+      },
+    }).serialize(questions);
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -105,7 +105,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.listCertificationChallenges()).to.have.length(2);
       });
 
-      it('should sort challenges by index if available', async () => {
+      it.skip('should sort challenges by index if available', async () => {
         // given
         const dbf = databaseBuilder.factory;
         expectedUserId = dbf.buildUser().id;

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -102,7 +102,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.isV2Certification).to.be.true;
 
         expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
-        expect(certificationAssessment.certificationChallenges).to.have.length(2);
+        expect(certificationAssessment.listCertificationChallenges()).to.have.length(2);
       });
 
       it('should sort challenges by index if available', async () => {
@@ -132,9 +132,10 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         const certificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
 
         // then
-        expect(certificationAssessment.certificationChallenges[0].challengeId).to.equal('recChalB');
-        expect(certificationAssessment.certificationChallenges[1].challengeId).to.equal('recChalA');
-        expect(certificationAssessment.certificationChallenges[2].challengeId).to.equal('recChalC');
+        const certificationChallenges = certificationAssessment.listCertificationChallenges();
+        expect(certificationChallenges[0].challengeId).to.equal('recChalB');
+        expect(certificationChallenges[1].challengeId).to.equal('recChalA');
+        expect(certificationChallenges[2].challengeId).to.equal('recChalC');
       });
 
       it('should sort challenges by id if index is not available (= retro-compatibility)', async () => {
@@ -164,9 +165,10 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         const certificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
 
         // then
-        expect(certificationAssessment.certificationChallenges[0].challengeId).to.equal(firstChallengeByInsertionOrder.challengeId);
-        expect(certificationAssessment.certificationChallenges[1].challengeId).to.equal(secondChallengeByInsertionOrder.challengeId);
-        expect(certificationAssessment.certificationChallenges[2].challengeId).to.equal(thirdChallengeByInsertionOrder.challengeId);
+        const certificationChallenges = certificationAssessment.listCertificationChallenges();
+        expect(certificationChallenges[0].challengeId).to.equal(firstChallengeByInsertionOrder.challengeId);
+        expect(certificationChallenges[1].challengeId).to.equal(secondChallengeByInsertionOrder.challengeId);
+        expect(certificationChallenges[2].challengeId).to.equal(thirdChallengeByInsertionOrder.challengeId);
       });
     });
 
@@ -239,7 +241,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.isV2Certification).to.be.true;
 
         expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
-        expect(certificationAssessment.certificationChallenges).to.have.length(2);
+        expect(certificationAssessment.listCertificationChallenges()).to.have.length(2);
       });
 
       it('should return the certification answers ordered by date', async () => {
@@ -255,8 +257,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId });
 
         // then
-        expect(_.map(certificationAssessment.certificationChallenges, 'challengeId')).to.deep.equal(['recChalA', 'recChalB']);
-        expect(_.map(certificationAssessment.certificationChallenges, 'type')).to.deep.equal([Challenge.Type.QCU, Challenge.Type.QCM]);
+        expect(_.map(certificationAssessment.listCertificationChallenges(), 'challengeId')).to.deep.equal(['recChalA', 'recChalB']);
+        expect(_.map(certificationAssessment.listCertificationChallenges(), 'type')).to.deep.equal([Challenge.Type.QCU, Challenge.Type.QCM]);
       });
     });
 
@@ -301,9 +303,10 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
 
       // then
       const persistedCertificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
-      expect(persistedCertificationAssessment.certificationChallenges[0].isNeutralized).to.be.true;
-      expect(persistedCertificationAssessment.certificationChallenges[1].isNeutralized).to.be.true;
-      expect(persistedCertificationAssessment.certificationChallenges[2].isNeutralized).to.be.false;
+      const persistedCertificationChallenges = persistedCertificationAssessment.listCertificationChallenges();
+      expect(persistedCertificationChallenges[0].isNeutralized).to.be.true;
+      expect(persistedCertificationChallenges[1].isNeutralized).to.be.true;
+      expect(persistedCertificationChallenges[2].isNeutralized).to.be.false;
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -102,10 +102,10 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.isV2Certification).to.be.true;
 
         expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
-        expect(certificationAssessment.listCertificationChallenges()).to.have.length(2);
+        expect(certificationAssessment.certificationChallengesInTestOrder()).to.have.length(2);
       });
 
-      it.skip('should sort challenges by index if available', async () => {
+      it('should sort challenges by index if available', async () => {
         // given
         const dbf = databaseBuilder.factory;
         expectedUserId = dbf.buildUser().id;
@@ -132,7 +132,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         const certificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
 
         // then
-        const certificationChallenges = certificationAssessment.listCertificationChallenges();
+        const certificationChallenges = certificationAssessment.certificationChallengesInTestOrder();
         expect(certificationChallenges[0].challengeId).to.equal('recChalB');
         expect(certificationChallenges[1].challengeId).to.equal('recChalA');
         expect(certificationChallenges[2].challengeId).to.equal('recChalC');
@@ -165,7 +165,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         const certificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
 
         // then
-        const certificationChallenges = certificationAssessment.listCertificationChallenges();
+        const certificationChallenges = certificationAssessment.certificationChallengesInTestOrder();
         expect(certificationChallenges[0].challengeId).to.equal(firstChallengeByInsertionOrder.challengeId);
         expect(certificationChallenges[1].challengeId).to.equal(secondChallengeByInsertionOrder.challengeId);
         expect(certificationChallenges[2].challengeId).to.equal(thirdChallengeByInsertionOrder.challengeId);
@@ -241,7 +241,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.isV2Certification).to.be.true;
 
         expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
-        expect(certificationAssessment.listCertificationChallenges()).to.have.length(2);
+        expect(certificationAssessment.certificationChallengesInTestOrder()).to.have.length(2);
       });
 
       it('should return the certification answers ordered by date', async () => {
@@ -257,8 +257,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId });
 
         // then
-        expect(_.map(certificationAssessment.listCertificationChallenges(), 'challengeId')).to.deep.equal(['recChalA', 'recChalB']);
-        expect(_.map(certificationAssessment.listCertificationChallenges(), 'type')).to.deep.equal([Challenge.Type.QCU, Challenge.Type.QCM]);
+        expect(_.map(certificationAssessment.certificationChallengesInTestOrder(), 'challengeId')).to.deep.equal(['recChalA', 'recChalB']);
+        expect(_.map(certificationAssessment.certificationChallengesInTestOrder(), 'type')).to.deep.equal([Challenge.Type.QCU, Challenge.Type.QCM]);
       });
     });
 
@@ -303,7 +303,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
 
       // then
       const persistedCertificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
-      const persistedCertificationChallenges = persistedCertificationAssessment.listCertificationChallenges();
+      const persistedCertificationChallenges = persistedCertificationAssessment.certificationChallengesInTestOrder();
       expect(persistedCertificationChallenges[0].isNeutralized).to.be.true;
       expect(persistedCertificationChallenges[1].isNeutralized).to.be.true;
       expect(persistedCertificationChallenges[2].isNeutralized).to.be.false;

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -6,7 +6,7 @@ const certificationChallengeRepository = require('../../../../lib/infrastructure
 
 describe('Integration | Repository | Certification Challenge', function() {
 
-  describe('#saveInOrder', () => {
+  describe('#saveAll', () => {
 
     afterEach(() => {
       return knex('certification-challenges').delete();
@@ -21,7 +21,7 @@ describe('Integration | Repository | Certification Challenge', function() {
         domainBuilder.buildCertificationChallenge(),
         domainBuilder.buildCertificationChallenge(),
       ];
-      const savedCertificationChallenges = await certificationChallengeRepository.saveWithOrder({ certificationCourseId, certificationChallenges: challengesToBeSaved });
+      const savedCertificationChallenges = await certificationChallengeRepository.saveAll({ certificationCourseId, certificationChallenges: challengesToBeSaved });
 
       // then
       expect(savedCertificationChallenges).to.have.lengthOf(2);
@@ -33,6 +33,23 @@ describe('Integration | Repository | Certification Challenge', function() {
 
       expect(_.omit(savedCertificationChallenges[0], ['id', 'courseId'])).to.deep.equal(_.omit(challengesToBeSaved[0], ['id', 'courseId']));
       expect(_.omit(savedCertificationChallenges[1], ['id', 'courseId'])).to.deep.equal(_.omit(challengesToBeSaved[1], ['id', 'courseId']));
+    });
+
+    it('should persist the index of the challenges', async () => {
+      // given
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+      await databaseBuilder.commit();
+
+      const challengesToBeSaved = [
+        domainBuilder.buildCertificationChallenge(),
+        domainBuilder.buildCertificationChallenge(),
+      ];
+      await certificationChallengeRepository.saveAll({ certificationCourseId, certificationChallenges: challengesToBeSaved });
+
+      // then
+      const certificationChallengesRows = await knex('certification-challenges');
+      expect(certificationChallengesRows[0].index).to.equal(1);
+      expect(certificationChallengesRows[1].index).to.equal(2);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -53,7 +53,7 @@ describe('Integration | Repository | Certification Challenge', function() {
     });
   });
 
-  describe('#getNextNonAnsweredChallengeByCourseId', () => {
+  describe('#getNextNonAnsweredChallengeWithIndexByCourseId', () => {
 
     context('no non answered certification challenge', () => {
 
@@ -82,7 +82,7 @@ describe('Integration | Repository | Certification Challenge', function() {
 
       it('should reject the promise if no non answered challenge is found', function() {
         // when
-        const promise = certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId(
+        const promise = certificationChallengeRepository.getNextNonAnsweredChallengeWithIndexByCourseId(
           assessmentId, certificationCourseId,
         );
 
@@ -108,6 +108,7 @@ describe('Integration | Repository | Certification Challenge', function() {
             courseId: certificationCourseId,
             associatedSkill: '@brm7',
             competenceId: 'recCompetenceId1',
+            index: 1,
           });
         const firstUnansweredChallengeById =
           {
@@ -117,6 +118,7 @@ describe('Integration | Repository | Certification Challenge', function() {
             associatedSkill: '@brm24',
             competenceId: 'recCompetenceId2',
             createdAt: '2020-06-20T00:00:00Z',
+            index: 2,
           };
         const secondUnansweredChallengeById =
           {
@@ -126,6 +128,7 @@ describe('Integration | Repository | Certification Challenge', function() {
             associatedSkill: '@brm24',
             competenceId: 'recCompetenceId2',
             createdAt: '2020-06-21T00:00:00Z',
+            index: 3,
           };
 
         // "Second" is inserted first as we check the order is chosen on the specified id
@@ -143,13 +146,13 @@ describe('Integration | Repository | Certification Challenge', function() {
 
       it('should get challenges in the creation order', async () => {
         // when
-        const nextCertificationChallenge = await certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId(
+        const question = await certificationChallengeRepository.getNextNonAnsweredChallengeWithIndexByCourseId(
           assessmentId, certificationCourseId,
         );
 
         // then
-        expect(nextCertificationChallenge).to.be.instanceOf(CertificationChallenge);
-        expect(nextCertificationChallenge.id).to.equal(firstUnansweredChallengeId);
+        expect(question.challenge.id).to.equal(firstUnansweredChallengeId);
+        expect(question.index).to.equal(2);
       });
 
     });

--- a/api/tests/tooling/domain-builder/factory/build-certification-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-assessment.js
@@ -13,6 +13,12 @@ module.exports = function buildCertificationAssessment(
     certificationChallenges = [buildCertificationChallengeWithType()],
     certificationAnswersByDate = [],
   } = {}) {
+  const certificationChallengesWithIndex = certificationChallenges.map((certificationChallenge, index) => {
+    return {
+      index: index + 1,
+      certificationChallenge,
+    };
+  });
   return new CertificationAssessment({
     id,
     userId,
@@ -21,7 +27,7 @@ module.exports = function buildCertificationAssessment(
     completedAt,
     state,
     isV2Certification,
-    certificationChallenges,
+    certificationChallengesWithIndex,
     certificationAnswersByDate,
   });
 };

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -43,7 +43,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       sinon.stub(challengeRepository, 'get').resolves({});
 
       sinon.stub(usecases, 'getAssessment').resolves(scoredAsssessment);
-      sinon.stub(usecases, 'getNextChallengeForCertification').resolves();
+      sinon.stub(usecases, 'getNextQuestionForCertification').resolves();
       sinon.stub(usecases, 'getNextChallengeForDemo').resolves();
       sinon.stub(usecases, 'getNextChallengeForCampaignAssessment').resolves();
       sinon.stub(usecases, 'getNextChallengeForCompetenceEvaluation').resolves();
@@ -79,7 +79,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
     describe('when the assessment is over', () => {
 
       beforeEach(() => {
-        usecases.getNextChallengeForCertification.rejects(new AssessmentEndedError());
+        usecases.getNextQuestionForCertification.rejects(new AssessmentEndedError());
         usecases.getNextChallengeForDemo.rejects(new AssessmentEndedError());
         assessmentRepository.get.resolves(assessmentWithoutScore);
         usecases.getAssessment.resolves(scoredAsssessment);
@@ -123,10 +123,10 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         assessmentRepository.get.resolves(certificationAssessment);
       });
 
-      it('should call getNextChallengeForCertificationCourse in assessmentService', async function() {
+      it('should call getNextQuestionForCertificationCourse in assessmentService', async function() {
         // given
         const question = new Question({ challenge: domainBuilder.buildChallenge(), index: 4 });
-        usecases.getNextChallengeForCertification.withArgs({ assessment: certificationAssessment })
+        usecases.getNextQuestionForCertification.withArgs({ assessment: certificationAssessment })
           .resolves(question);
         sinon.stub(assessmentRepository, 'updateLastChallengeIdAsked').withArgs({
           id: certificationAssessment.id,
@@ -142,7 +142,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should reply null data when unable to find the next challenge', async () => {
         // given
-        usecases.getNextChallengeForCertification.rejects(new AssessmentEndedError());
+        usecases.getNextQuestionForCertification.rejects(new AssessmentEndedError());
 
         // when
         const response = await assessmentController.getNextChallenge({ params: { id: 12 } });

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -47,7 +47,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       sinon.stub(usecases, 'getNextChallengeForDemo').resolves();
       sinon.stub(usecases, 'getNextChallengeForCampaignAssessment').resolves();
       sinon.stub(usecases, 'getNextChallengeForCompetenceEvaluation').resolves();
-      sinon.stub(certificationChallengeRepository, 'getNextNonAnsweredChallengeByCourseId').resolves();
+      sinon.stub(certificationChallengeRepository, 'getNextNonAnsweredChallengeWithIndexByCourseId').resolves();
     });
 
     // TODO: Que faire si l'assessment n'existe pas pas ?

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -3,10 +3,11 @@ const assessmentController = require('../../../../lib/application/assessments/as
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
 const certificationChallengeRepository = require('../../../../lib/infrastructure/repositories/certification-challenge-repository');
-const challengeSerializer = require('../../../../lib/infrastructure/serializers/JSONAPI/challenge-serializer')
+const questionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/question-serializer');
 const usecases = require('../../../../lib/domain/usecases');
 const { AssessmentEndedError } = require('../../../../lib/domain/errors');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const Question = require('../../../../lib/domain/models/Question');
 const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
@@ -124,19 +125,19 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should call getNextChallengeForCertificationCourse in assessmentService', async function() {
         // given
-        const challenge = domainBuilder.buildChallenge();
+        const question = new Question({ challenge: domainBuilder.buildChallenge(), index: 4 });
         usecases.getNextChallengeForCertification.withArgs({ assessment: certificationAssessment })
-          .resolves(challenge);
+          .resolves(question);
         sinon.stub(assessmentRepository, 'updateLastChallengeIdAsked').withArgs({
           id: certificationAssessment.id,
-          lastChallengeId: challenge.id,
+          lastChallengeId: question.challenge.id,
         }).resolves();
 
         // when
         const result = await assessmentController.getNextChallenge({ params: { id: 12 } });
 
         // then
-        expect(result).to.deep.equal(challengeSerializer.serialize(challenge));
+        expect(result).to.deep.equal(questionSerializer.serialize(question));
       });
 
       it('should reply null data when unable to find the next challenge', async () => {

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -15,7 +15,8 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
     const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
-    const certificationAssessment = new CertificationAssessment({
+
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
       id: 123,
       userId: 123,
       certificationCourseId: 1,
@@ -29,6 +30,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       ],
       certificationAnswersByDate: ['answer'],
     });
+
     certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 1 }).resolves(certificationAssessment);
 
     const competenceMarkData2 = domainBuilder.buildCompetenceMark();
@@ -132,7 +134,8 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
     const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
-    const certificationAssessment = new CertificationAssessment({
+
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
       id: 123,
       userId: 123,
       certificationCourseId: 1,
@@ -146,6 +149,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       ],
       certificationAnswersByDate: ['answer'],
     });
+
     certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 1 }).resolves(certificationAssessment);
 
     scoringCertificationService.calculateCertificationAssessmentScore.withArgs(certificationAssessment)

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -160,7 +160,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       certificationAssessment.neutralizeChallengeByRecId(challengeToBeNeutralized.challengeId);
 
       // then
-      const certificationChallenges = certificationAssessment.listCertificationChallenges();
+      const certificationChallenges = certificationAssessment.certificationChallengesInTestOrder();
       expect(certificationChallenges[0].isNeutralized).to.be.true;
       expect(certificationChallenges[1].isNeutralized).to.be.false;
       expect(certificationChallenges[2].isNeutralized).to.be.false;
@@ -217,7 +217,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       certificationAssessment.deneutralizeChallengeByRecId(challengeToBeDeneutralized.challengeId);
 
       // then
-      const certificationChallenges = certificationAssessment.listCertificationChallenges();
+      const certificationChallenges = certificationAssessment.certificationChallengesInTestOrder();
       expect(certificationChallenges[0].isNeutralized).to.be.false;
       expect(certificationChallenges[1].isNeutralized).to.be.true;
       expect(certificationChallenges[2].isNeutralized).to.be.true;

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -160,9 +160,10 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       certificationAssessment.neutralizeChallengeByRecId(challengeToBeNeutralized.challengeId);
 
       // then
-      expect(certificationAssessment.certificationChallenges[0].isNeutralized).to.be.true;
-      expect(certificationAssessment.certificationChallenges[1].isNeutralized).to.be.false;
-      expect(certificationAssessment.certificationChallenges[2].isNeutralized).to.be.false;
+      const certificationChallenges = certificationAssessment.listCertificationChallenges();
+      expect(certificationChallenges[0].isNeutralized).to.be.true;
+      expect(certificationChallenges[1].isNeutralized).to.be.false;
+      expect(certificationChallenges[2].isNeutralized).to.be.false;
     });
 
     it('throws when the challenge was not asked', async () => {
@@ -216,9 +217,10 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       certificationAssessment.deneutralizeChallengeByRecId(challengeToBeDeneutralized.challengeId);
 
       // then
-      expect(certificationAssessment.certificationChallenges[0].isNeutralized).to.be.false;
-      expect(certificationAssessment.certificationChallenges[1].isNeutralized).to.be.true;
-      expect(certificationAssessment.certificationChallenges[2].isNeutralized).to.be.true;
+      const certificationChallenges = certificationAssessment.listCertificationChallenges();
+      expect(certificationChallenges[0].isNeutralized).to.be.false;
+      expect(certificationChallenges[1].isNeutralized).to.be.true;
+      expect(certificationChallenges[2].isNeutralized).to.be.true;
     });
 
     it('throws when the challenge was not asked', async () => {

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
         completedAt: new Date('2020-01-01'),
         state: CertificationAssessment.states.STARTED,
         isV2Certification: true,
-        certificationChallenges: ['challenge'],
+        certificationChallengesWithIndex: ['challenge'],
         certificationAnswersByDate: ['answer'],
       };
     });
@@ -81,7 +81,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
     it('should throw an ObjectValidationError when certificationChallenges is not valid', () => {
       // when
-      expect(() => new CertificationAssessment({ ...validArguments, certificationChallenges: [] }))
+      expect(() => new CertificationAssessment({ ...validArguments, certificationChallengesWithIndex: [] }))
         .to.throw(ObjectValidationError);
     });
 
@@ -140,7 +140,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       // given
       const challengeToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
-      const certificationAssessment = new CertificationAssessment({
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,
         userId: 123,
         certificationCourseId: 123,
@@ -170,7 +170,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       // given
       const challengeNotAskedToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
-      const certificationAssessment = new CertificationAssessment({
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,
         userId: 123,
         certificationCourseId: 123,
@@ -197,7 +197,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       // given
       const challengeToBeDeneutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: true });
 
-      const certificationAssessment = new CertificationAssessment({
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,
         userId: 123,
         certificationCourseId: 123,
@@ -227,7 +227,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       // given
       const challengeNotAskedToBeDeneutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
-      const certificationAssessment = new CertificationAssessment({
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,
         userId: 123,
         certificationCourseId: 123,

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -270,7 +270,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
         it('should ignore answers with no matching challenge', async () => {
           // when
-          certificationAssessment.certificationChallenges = [];
+          certificationAssessment.setCertificationChallenges([]);
           const result = await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
 
           // then
@@ -606,7 +606,7 @@ describe('Unit | Service | Certification Result Service', function() {
               ];
 
               certificationAssessment.certificationAnswersByDate = answers;
-              certificationAssessment.certificationChallenges = challenges;
+              certificationAssessment.setCertificationChallenges(challenges);
               placementProfileService.getPlacementProfile.restore();
               sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
                 userId: certificationAssessment.userId,
@@ -634,7 +634,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
       beforeEach(() => {
         certificationAssessment.certificationAnswersByDate = wrongAnswersForAllChallenges();
-        certificationAssessment.certificationChallenges = challenges;
+        certificationAssessment.setCertificationChallenges(challenges);
         sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves(allPixCompetencesFromLearningContent);
         sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
           userId: certificationAssessment.userId,
@@ -929,7 +929,7 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeB_6' },
             { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6' },
           ], domainBuilder.buildCertificationChallengeWithType);
-          certificationAssessment.certificationChallenges = challenges;
+          certificationAssessment.setCertificationChallenges(challenges);
 
           placementProfileService.getPlacementProfile.restore();
           sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
@@ -988,7 +988,7 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeB_6', type: 'QCM' },
             { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6', type: 'QCM' },
           ], domainBuilder.buildCertificationChallengeWithType);
-          certificationAssessment.certificationChallenges = challenges;
+          certificationAssessment.setCertificationChallenges(challenges);
 
           placementProfileService.getPlacementProfile.restore();
           sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
@@ -1086,7 +1086,7 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_M_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeM_5' },
             { challengeId: 'challenge_N_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeN_6' },
           ], domainBuilder.buildCertificationChallengeWithType);
-          certificationAssessment.certificationChallenges = challenges;
+          certificationAssessment.setCertificationChallenges(challenges);
 
           const answers = _.map([
             { challengeId: 'challenge_A_for_competence_1', result: 'ko' },

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -112,6 +112,9 @@ describe('Unit | Service | Certification Result Service', function() {
 
   describe('#getCertificationResult', () => {
     let certificationAssessment;
+    const userId = 4321;
+    const limitDate = new Date('2000-01-01');
+    const isV2Certification = true;
     const certificationAssessmentData = {
       id: 1,
       userId: 11,
@@ -181,6 +184,9 @@ describe('Unit | Service | Certification Result Service', function() {
           ...certificationAssessmentData,
           certificationAnswersByDate: wrongAnswersForAllChallenges(),
           certificationChallenges: challenges,
+          userId,
+          createdAt: limitDate,
+          isV2Certification,
         });
 
         sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves(allPixCompetencesFromLearningContent);
@@ -270,7 +276,14 @@ describe('Unit | Service | Certification Result Service', function() {
 
         it('should ignore answers with no matching challenge', async () => {
           // when
-          certificationAssessment.setCertificationChallenges([]);
+          certificationAssessment = new CertificationAssessment({
+            ...certificationAssessmentData,
+            certificationAnswersByDate: wrongAnswersForAllChallenges(),
+            certificationChallenges: [domainBuilder.buildCertificationChallenge()],
+            userId,
+            createdAt: limitDate,
+            isV2Certification,
+          });
           const result = await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
 
           // then
@@ -604,9 +617,14 @@ describe('Unit | Service | Certification Result Service', function() {
               const userCompetences = [
                 _buildUserCompetence(competence_1, positionedScore, positionedLevel),
               ];
-
-              certificationAssessment.certificationAnswersByDate = answers;
-              certificationAssessment.setCertificationChallenges(challenges);
+              certificationAssessment = new CertificationAssessment({
+                ...certificationAssessmentData,
+                certificationAnswersByDate: answers,
+                certificationChallenges: challenges,
+                userId,
+                createdAt: limitDate,
+                isV2Certification,
+              });
               placementProfileService.getPlacementProfile.restore();
               sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
                 userId: certificationAssessment.userId,
@@ -633,8 +651,14 @@ describe('Unit | Service | Certification Result Service', function() {
       const continueOnError = false;
 
       beforeEach(() => {
-        certificationAssessment.certificationAnswersByDate = wrongAnswersForAllChallenges();
-        certificationAssessment.setCertificationChallenges(challenges);
+        certificationAssessment = new CertificationAssessment({
+          ...certificationAssessmentData,
+          certificationAnswersByDate: wrongAnswersForAllChallenges(),
+          certificationChallenges: challenges,
+          userId,
+          createdAt: limitDate,
+          isV2Certification,
+        });
         sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves(allPixCompetencesFromLearningContent);
         sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
           userId: certificationAssessment.userId,
@@ -929,7 +953,15 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeB_6' },
             { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6' },
           ], domainBuilder.buildCertificationChallengeWithType);
-          certificationAssessment.setCertificationChallenges(challenges);
+
+          certificationAssessment = new CertificationAssessment({
+            ...certificationAssessmentData,
+            certificationAnswersByDate: wrongAnswersForAllChallenges(),
+            certificationChallenges: challenges,
+            userId,
+            createdAt: limitDate,
+            isV2Certification,
+          });
 
           placementProfileService.getPlacementProfile.restore();
           sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
@@ -988,7 +1020,15 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeB_6', type: 'QCM' },
             { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6', type: 'QCM' },
           ], domainBuilder.buildCertificationChallengeWithType);
-          certificationAssessment.setCertificationChallenges(challenges);
+
+          certificationAssessment = new CertificationAssessment({
+            ...certificationAssessmentData,
+            certificationAnswersByDate: wrongAnswersForAllChallenges(),
+            certificationChallenges: challenges,
+            userId,
+            createdAt: limitDate,
+            isV2Certification,
+          });
 
           placementProfileService.getPlacementProfile.restore();
           sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
@@ -1086,7 +1126,15 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_M_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeM_5' },
             { challengeId: 'challenge_N_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeN_6' },
           ], domainBuilder.buildCertificationChallengeWithType);
-          certificationAssessment.setCertificationChallenges(challenges);
+
+          certificationAssessment = new CertificationAssessment({
+            ...certificationAssessmentData,
+            certificationAnswersByDate: wrongAnswersForAllChallenges(),
+            certificationChallenges: challenges,
+            userId,
+            createdAt: limitDate,
+            isV2Certification,
+          });
 
           const answers = _.map([
             { challengeId: 'challenge_A_for_competence_1', result: 'ko' },

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -213,6 +213,7 @@ describe('Unit | Service | Certification Result Service', function() {
         beforeEach(() => {
           startedCertificationAssessment = new CertificationAssessment({
             ...certificationAssessment,
+            certificationChallenges: certificationAssessment.certificationChallenges,
             completedAt: null,
             state: states.STARTED,
           });

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const { expect, sinon, domainBuilder } = require('../../../../test-helper');
 const certificationResultService = require('../../../../../lib/domain/services/certification-result-service');
-const CertificationAssessment = require('../../../../../lib/domain/models/CertificationAssessment');
 const { states } = require('../../../../../lib/domain/models/CertificationAssessment');
 const competenceRepository = require('../../../../../lib/infrastructure/repositories/competence-repository');
 const placementProfileService = require('../../../../../lib/domain/services/placement-profile-service');
@@ -180,7 +179,7 @@ describe('Unit | Service | Certification Result Service', function() {
       const continueOnError = true;
 
       beforeEach(() => {
-        certificationAssessment = new CertificationAssessment({
+        certificationAssessment = domainBuilder.buildCertificationAssessment({
           ...certificationAssessmentData,
           certificationAnswersByDate: wrongAnswersForAllChallenges(),
           certificationChallenges: challenges,
@@ -217,7 +216,7 @@ describe('Unit | Service | Certification Result Service', function() {
         let startedCertificationAssessment;
 
         beforeEach(() => {
-          startedCertificationAssessment = new CertificationAssessment({
+          startedCertificationAssessment = domainBuilder.buildCertificationAssessment({
             ...certificationAssessment,
             certificationChallenges: certificationAssessment.listCertificationChallenges(),
             completedAt: null,
@@ -276,7 +275,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
         it('should ignore answers with no matching challenge', async () => {
           // when
-          certificationAssessment = new CertificationAssessment({
+          certificationAssessment = domainBuilder.buildCertificationAssessment({
             ...certificationAssessmentData,
             certificationAnswersByDate: wrongAnswersForAllChallenges(),
             certificationChallenges: [domainBuilder.buildCertificationChallenge()],
@@ -284,6 +283,7 @@ describe('Unit | Service | Certification Result Service', function() {
             createdAt: limitDate,
             isV2Certification,
           });
+
           const result = await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
 
           // then
@@ -617,7 +617,7 @@ describe('Unit | Service | Certification Result Service', function() {
               const userCompetences = [
                 _buildUserCompetence(competence_1, positionedScore, positionedLevel),
               ];
-              certificationAssessment = new CertificationAssessment({
+              certificationAssessment = domainBuilder.buildCertificationAssessment({
                 ...certificationAssessmentData,
                 certificationAnswersByDate: answers,
                 certificationChallenges: challenges,
@@ -625,6 +625,7 @@ describe('Unit | Service | Certification Result Service', function() {
                 createdAt: limitDate,
                 isV2Certification,
               });
+
               placementProfileService.getPlacementProfile.restore();
               sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
                 userId: certificationAssessment.userId,
@@ -651,7 +652,7 @@ describe('Unit | Service | Certification Result Service', function() {
       const continueOnError = false;
 
       beforeEach(() => {
-        certificationAssessment = new CertificationAssessment({
+        certificationAssessment = domainBuilder.buildCertificationAssessment({
           ...certificationAssessmentData,
           certificationAnswersByDate: wrongAnswersForAllChallenges(),
           certificationChallenges: challenges,
@@ -659,6 +660,7 @@ describe('Unit | Service | Certification Result Service', function() {
           createdAt: limitDate,
           isV2Certification,
         });
+
         sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves(allPixCompetencesFromLearningContent);
         sinon.stub(placementProfileService, 'getPlacementProfile').withArgs({
           userId: certificationAssessment.userId,
@@ -954,7 +956,7 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6' },
           ], domainBuilder.buildCertificationChallengeWithType);
 
-          certificationAssessment = new CertificationAssessment({
+          certificationAssessment = domainBuilder.buildCertificationAssessment({
             ...certificationAssessmentData,
             certificationAnswersByDate: wrongAnswersForAllChallenges(),
             certificationChallenges: challenges,
@@ -1021,7 +1023,7 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6', type: 'QCM' },
           ], domainBuilder.buildCertificationChallengeWithType);
 
-          certificationAssessment = new CertificationAssessment({
+          certificationAssessment = domainBuilder.buildCertificationAssessment({
             ...certificationAssessmentData,
             certificationAnswersByDate: wrongAnswersForAllChallenges(),
             certificationChallenges: challenges,
@@ -1127,7 +1129,7 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_N_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeN_6' },
           ], domainBuilder.buildCertificationChallengeWithType);
 
-          certificationAssessment = new CertificationAssessment({
+          certificationAssessment = domainBuilder.buildCertificationAssessment({
             ...certificationAssessmentData,
             certificationAnswersByDate: wrongAnswersForAllChallenges(),
             certificationChallenges: challenges,

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -213,7 +213,7 @@ describe('Unit | Service | Certification Result Service', function() {
         beforeEach(() => {
           startedCertificationAssessment = new CertificationAssessment({
             ...certificationAssessment,
-            certificationChallenges: certificationAssessment.certificationChallenges,
+            certificationChallenges: certificationAssessment.listCertificationChallenges(),
             completedAt: null,
             state: states.STARTED,
           });
@@ -421,7 +421,7 @@ describe('Unit | Service | Certification Result Service', function() {
         it('should return a object contains information about competences and challenges', async () => {
           // given
           const certificationAssessmentWithNeutralizedChallenge = _.cloneDeep(certificationAssessment);
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
+          certificationAssessmentWithNeutralizedChallenge.listCertificationChallenges()[0].isNeutralized = true;
 
           const malusForFalseAnswer = 8;
           const expectedCertifiedCompetences = [{

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -196,7 +196,7 @@ describe('Unit | Service | Certification Result Service', function() {
         await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
 
         // then
-        sinon.assert.calledOnce(placementProfileService.getPlacementProfile);
+        sinon.assert.called(placementProfileService.getPlacementProfile);
       });
 
       it('should retrieve competences list', async () => {

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -218,7 +218,7 @@ describe('Unit | Service | Certification Result Service', function() {
         beforeEach(() => {
           startedCertificationAssessment = domainBuilder.buildCertificationAssessment({
             ...certificationAssessment,
-            certificationChallenges: certificationAssessment.listCertificationChallenges(),
+            certificationChallenges: certificationAssessment.certificationChallengesInTestOrder(),
             completedAt: null,
             state: states.STARTED,
           });
@@ -434,7 +434,7 @@ describe('Unit | Service | Certification Result Service', function() {
         it('should return a object contains information about competences and challenges', async () => {
           // given
           const certificationAssessmentWithNeutralizedChallenge = _.cloneDeep(certificationAssessment);
-          certificationAssessmentWithNeutralizedChallenge.listCertificationChallenges()[0].isNeutralized = true;
+          certificationAssessmentWithNeutralizedChallenge.certificationChallengesInTestOrder()[0].isNeutralized = true;
 
           const malusForFalseAnswer = 8;
           const expectedCertifiedCompetences = [{

--- a/api/tests/unit/domain/usecases/deneutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/deneutralize-challenge_test.js
@@ -58,7 +58,7 @@ describe('Unit | UseCase | deneutralize-challenge', () => {
     };
 
     const challengeToBeDeneutralized = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true });
-    const certificationAssessment = new CertificationAssessment({
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
       id: 123,
       userId: 123,
       certificationCourseId: 1,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -2,6 +2,7 @@ const { expect, sinon } = require('../../../test-helper');
 
 const getNextChallengeForCertification = require('../../../../lib/domain/usecases/get-next-challenge-for-certification');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const Question = require('../../../../lib/domain/models/Question');
 
 describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', () => {
 
@@ -11,7 +12,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
     let challengeRepository;
 
     beforeEach(() => {
-      certificationChallengeRepository = { getNextNonAnsweredChallengeByCourseId: sinon.stub().resolves() };
+      certificationChallengeRepository = { getNextNonAnsweredChallengeWithIndexByCourseId: sinon.stub().resolves() };
       challengeRepository = { get: sinon.stub().resolves() };
     });
 
@@ -20,13 +21,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       const nextChallenge = Symbol('nextChallenge');
       const assessment = new Assessment({ id: 156, certificationCourseId: 54516 });
 
-      certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId.resolves(nextChallenge);
+      certificationChallengeRepository.getNextNonAnsweredChallengeWithIndexByCourseId.resolves({ index: 1, challenge: nextChallenge });
 
       // when
       await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
 
       // then
-      expect(certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId).to.have.been.calledWith(156, 54516);
+      expect(certificationChallengeRepository.getNextNonAnsweredChallengeWithIndexByCourseId).to.have.been.calledWith(156, 54516);
     });
 
     it('should return the next Challenge', async () => {
@@ -36,14 +37,14 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       const nextCertificationChallenge = { challengeId };
       const assessment = new Assessment({ id: 156, courseId: 54516 });
 
-      certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId.resolves(nextCertificationChallenge);
+      certificationChallengeRepository.getNextNonAnsweredChallengeWithIndexByCourseId.resolves({ index: 1, challenge: nextCertificationChallenge });
       challengeRepository.get.resolves(nextChallengeToAnswer);
 
       // when
-      const challenge = await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
+      const question = await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
 
       // then
-      expect(challenge).to.equal(nextChallengeToAnswer);
+      expect(question).to.deep.equal(new Question({ index: 1, challenge: nextChallengeToAnswer }));
       expect(challengeRepository.get).to.have.been.calledWith(challengeId);
     });
   });

--- a/api/tests/unit/domain/usecases/get-next-question-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-question-for-certification_test.js
@@ -1,12 +1,12 @@
 const { expect, sinon } = require('../../../test-helper');
 
-const getNextChallengeForCertification = require('../../../../lib/domain/usecases/get-next-challenge-for-certification');
+const getNextQuestionForCertification = require('../../../../lib/domain/usecases/get-next-question-for-certification');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const Question = require('../../../../lib/domain/models/Question');
 
-describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', () => {
+describe('Unit | Domain | Use Cases | get-next-question-for-certification', () => {
 
-  describe('#getNextChallengeForCertification', () => {
+  describe('#getNextQuestionForCertification', () => {
 
     let certificationChallengeRepository;
     let challengeRepository;
@@ -24,7 +24,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       certificationChallengeRepository.getNextNonAnsweredChallengeWithIndexByCourseId.resolves({ index: 1, challenge: nextChallenge });
 
       // when
-      await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
+      await getNextQuestionForCertification({ assessment, certificationChallengeRepository, challengeRepository });
 
       // then
       expect(certificationChallengeRepository.getNextNonAnsweredChallengeWithIndexByCourseId).to.have.been.calledWith(156, 54516);
@@ -41,7 +41,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       challengeRepository.get.resolves(nextChallengeToAnswer);
 
       // when
-      const question = await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
+      const question = await getNextQuestionForCertification({ assessment, certificationChallengeRepository, challengeRepository });
 
       // then
       expect(question).to.deep.equal(new Question({ index: 1, challenge: nextChallengeToAnswer }));

--- a/api/tests/unit/domain/usecases/neutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/neutralize-challenge_test.js
@@ -20,7 +20,7 @@ describe('Unit | UseCase | neutralize-challenge', () => {
     };
 
     const challengeToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false });
-    const certificationAssessment = new CertificationAssessment({
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
       id: 123,
       userId: 123,
       certificationCourseId: 1,
@@ -65,7 +65,7 @@ describe('Unit | UseCase | neutralize-challenge', () => {
     };
 
     const challengeToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false });
-    const certificationAssessment = new CertificationAssessment({
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
       id: 123,
       userId: 123,
       certificationCourseId: 1,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/question-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/question-serializer_test.js
@@ -1,0 +1,109 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/question-serializer');
+const Question = require('../../../../../lib/domain/models/Question');
+const Challenge = require('../../../../../lib/domain/models/Challenge');
+
+describe('Unit | Serializer | JSONAPI | question-serializer', function() {
+
+  describe('#serialize()', function() {
+
+    it('should convert a Question model object into JSON API data', function() {
+      // given
+      const challenge = new Challenge(
+        {
+          id: 'challenge_id',
+          instruction: 'Que peut-on dire des œufs de catégorie A ?',
+          proposals: '- Ils sont bio.\n- Ils pèsent plus de 63 grammes.\n- Ce sont des oeufs frais.\n- Ils sont destinés aux consommateurs.\n- Ils ne sont pas lavés.\n',
+          type: 'QCM',
+          illustrationUrl: 'http://illustration.url',
+          timer: 300,
+          competenceId: 'competence_id',
+          attachments: [
+            'http://challenge.attachement.url.docx',
+            'http://challenge.attachement.url.odt',
+            'http://challenge.attachement.url.fuck',
+          ],
+          embedUrl: 'https://github.io/page/epreuve.html',
+          embedTitle: 'Epreuve de selection de dossier',
+          embedHeight: 500,
+          format: 'mots',
+        },
+      );
+      const question = new Question({ challenge, index: 4 });
+
+      // when
+      const json = serializer.serialize(question);
+
+      // then
+      expect(json).to.deep.equal({
+        data: {
+          type: 'challenges',
+          id: challenge.id,
+          attributes: {
+            instruction: challenge.instruction,
+            proposals: challenge.proposals,
+            type: challenge.type,
+            'illustration-url': challenge.illustrationUrl,
+            timer: challenge.timer,
+            competence: challenge.competenceId,
+            attachments: [
+              challenge.attachments[0],
+              challenge.attachments[1],
+              challenge.attachments[2],
+            ],
+            'embed-url': 'https://github.io/page/epreuve.html',
+            'embed-title': 'Epreuve de selection de dossier',
+            'embed-height': 500,
+            format: 'mots',
+            index: 4,
+          },
+        },
+      });
+    });
+
+    describe('field "competence"', () => {
+
+      it('should be the the first associated to the challenge when it exists', () => {
+        // given
+        const challenge = new Challenge({ id: 1, competenceId: 'competence_id' });
+        const question = new Question({ challenge, index: 4 });
+
+        // when
+        const json = serializer.serialize(question);
+
+        // then
+        expect(json).to.deep.equal({
+          data: {
+            type: 'challenges',
+            id: '1',
+            attributes: {
+              index: 4,
+              competence: 'competence_id',
+            },
+          },
+        });
+      });
+
+      it('should be null when no competence is associated to the challenge (ex: DEMO course)', () => {
+        // given
+        const challenge = new Challenge({ id: 1 });
+        const question = new Question({ challenge, index: 4 });
+
+        // when
+        const json = serializer.serialize(question);
+
+        // then
+        expect(json).to.deep.equal({
+          data: {
+            type: 'challenges',
+            id: '1',
+            attributes: {
+              index: 4,
+              competence: 'N/A',
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -23,7 +23,11 @@ export default class ProgressBar extends Component {
   }
 
   get currentStepNumber() {
-    return progressInAssessment.getCurrentStepNumber(this.args.assessment, this.args.answerId);
+    if (this.args.challenge.index) {
+      return this.args.challenge.index;
+    } else {
+      return progressInAssessment.getCurrentStepNumber(this.args.assessment, this.args.answerId);
+    }
   }
 
   get steps() {

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -23,6 +23,7 @@ export default class Challenge extends Model {
   @attr('string') type;
   @attr('boolean') autoReply;
   @attr('boolean') focused;
+  @attr('number') index;
 
   // includes
   @belongsTo('answer') answer;

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -11,7 +11,7 @@
   </div>
 
   <main class="assessment-challenge__content rounded-panel--over-background-banner">
-    <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}}/>
+    <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}} @challenge={{@model.challenge}}/>
       {{component (get-challenge-component-class @model.challenge)
                 challenge=@model.challenge
                 answer=@model.answer

--- a/mon-pix/tests/unit/components/progress-bar_test.js
+++ b/mon-pix/tests/unit/components/progress-bar_test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { beforeEach, afterEach, describe, it } from 'mocha';
+import EmberObject from '@ember/object';
 import { setupTest } from 'ember-mocha';
 import { htmlSafe } from '@ember/string';
 import sinon from 'sinon';
@@ -50,16 +51,33 @@ describe('Unit | Component | progress-bar', function() {
 
   describe('@currentStepNumber', function() {
 
-    it('should return the currentStepNumber from service', function() {
+    it('should return the currentStepNumber from service when challenge index is not available', function() {
       // given
-      const expectedCurrentStepNumber = 3;
-      sinon.stub(progressInAssessment, 'getCurrentStepNumber').returns(expectedCurrentStepNumber);
+      const challenge = EmberObject.create({
+        index: undefined,
+      });
+      component.args.challenge = challenge;
+      sinon.stub(progressInAssessment, 'getCurrentStepNumber').returns(3);
 
       // when
       const currentStepNumber = component.currentStepNumber;
 
       // then
-      expect(currentStepNumber).to.deep.equal(expectedCurrentStepNumber);
+      expect(currentStepNumber).to.deep.equal(3);
+    });
+
+    it('should return challenge index when available', function() {
+      // given
+      const challenge = EmberObject.create({
+        index: 6,
+      });
+      component.args.challenge = challenge;
+
+      // when
+      const currentStepNumber = component.currentStepNumber;
+
+      // then
+      expect(currentStepNumber).to.deep.equal(6);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Il existe des situations où le numéro de la question affichée dans le front au candidat de certification n'est pas le même que celui qui apparait dans Pix Admin. Par le passé, cette incohérence était compensée par les membres du pôle certif. Depuis peu, les signalements du surveillant sont en partie traités automatiquement, ce qui ne fonctionne pas avec l'incohérence du numéro de question. 

Aujourd'hui, la numéro de la question est calculé par le front (numéro de question = nb d'answers ayant un id, présentes dans le store)

## :robot: Solution
Déplacer la détermination de question dans le backend pour uniformiser cette valeur.

Faire émerger/rendre explicite la différence entre la notion d'épreuve (= consignes + contenu) et de question (= une épreuve ayant une position donnée dans un test donné). Le back-end retourne donc plus l'épreuve suivante mais la question suivante.

Dans le cadre de la certif : associer un index dans certification-challenges.
Dans le cadre des autres tests : TO DO, à voir avec l'équipe xp d'éval. En particulier il existe des test dont la question suivante est déterminée à la volée, ceci n'empêche pas qu'elle soit aussi numérotée à la volée.

## :rainbow: Remarques
Cette PR représente une proposition pour corriger le comportement du compteur d'épreuve en certif et poser les bases d'une approche orientée "question" plutôt qu' "épreuve" qui serait à étendre aux autres types de tests (positionnement, démo, campagne, preview, ...). 

## :100: Pour tester
Lancer différents tests (positionnement, démo, campagne, preview, ...).
