### PR TITLE
[BUGFIX] Ne pas sauvegarder deux fois un même badge pour un même user dans une campagne (PIX-2704).

### DIFF
--- a/api/db/migrations/20210630150224_add_column_updatedAt_to_badge_acquisitions.js
+++ b/api/db/migrations/20210630150224_add_column_updatedAt_to_badge_acquisitions.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'badge-acquisitions';
+const UPDATED_AT_COLUMN = 'updatedAt';
+
+exports.up = async function(knex) {
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(UPDATED_AT_COLUMN).notNullable().defaultTo(knex.fn.now());
+  });
+  return knex(TABLE_NAME).update({
+    'updatedAt': knex.ref('createdAt'),
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(UPDATED_AT_COLUMN);
+  });
+};
+

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -35,7 +35,7 @@ const handleBadgeAcquisition = async function({
     });
 
     if (!_.isEmpty(badgesAcquisitionToCreate)) {
-      await badgeAcquisitionRepository.create(badgesAcquisitionToCreate);
+      await badgeAcquisitionRepository.createOrUpdate(badgesAcquisitionToCreate);
     }
   }
 };

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -6,7 +6,7 @@ const bluebird = require('bluebird');
 
 module.exports = {
 
-  async create(badgeAcquisitionsToCreate = [], domainTransaction = DomainTransaction.emptyTransaction()) {
+  async createOrUpdate(badgeAcquisitionsToCreate = [], domainTransaction = DomainTransaction.emptyTransaction()) {
     const knexConn = domainTransaction.knexTransaction || Bookshelf.knex;
     return bluebird.mapSeries(badgeAcquisitionsToCreate, async (badgeAcquisitionToCreate) => {
       const alreadyCreatedBadgeAcquisition = await knexConn('badge-acquisitions').select('id').where(badgeAcquisitionToCreate);

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -5,7 +5,7 @@ const DomainTransaction = require('../../../../lib/infrastructure/DomainTransact
 
 describe('Integration | Repository | Badge Acquisition', () => {
 
-  describe('#create', () => {
+  describe('#createOrUpdate', () => {
     let badgeAcquisitionToCreate;
 
     beforeEach(async () => {
@@ -28,7 +28,7 @@ describe('Integration | Repository | Badge Acquisition', () => {
     it('should persist the badge acquisition in db', async () => {
       // when
       await DomainTransaction.execute(async (domainTransaction) => {
-        return badgeAcquisitionRepository.create([badgeAcquisitionToCreate], domainTransaction);
+        return badgeAcquisitionRepository.createOrUpdate([badgeAcquisitionToCreate], domainTransaction);
       });
 
       // then
@@ -41,14 +41,14 @@ describe('Integration | Repository | Badge Acquisition', () => {
       expect(result[0].createdAt).to.deep.equal(result[0].updatedAt);
     });
 
-    it('should update the badge acquisition in db if already exist', async () => {
+    it('should update the badge acquisition in the DB if it already exists', async () => {
       // given
       databaseBuilder.factory.buildBadgeAcquisition(badgeAcquisitionToCreate);
       await databaseBuilder.commit();
 
       // when
       await DomainTransaction.execute(async (domainTransaction) => {
-        return badgeAcquisitionRepository.create([badgeAcquisitionToCreate], domainTransaction);
+        return badgeAcquisitionRepository.createOrUpdate([badgeAcquisitionToCreate], domainTransaction);
       });
 
       // then

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -16,7 +16,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
       findUniqByUserId: _.noop,
     };
     const badgeAcquisitionRepository = {
-      create: _.noop,
+      createOrUpdate: _.noop,
     };
 
     const badgeCriteriaService = {
@@ -70,7 +70,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
           knowledgeElementRepository.findUniqByUserId.withArgs({ userId: event.userId }).resolves(knowledgeElements);
           sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
-          sinon.stub(badgeAcquisitionRepository, 'create');
+          sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
         });
 
         it('should create a badge when badge requirements are fulfilled', async () => {
@@ -83,7 +83,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
-          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([{
+          expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([{
             badgeId,
             userId: event.userId,
             campaignParticipationId: event.campaignParticipationId,
@@ -99,7 +99,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
-          expect(badgeAcquisitionRepository.create).to.not.have.been.called;
+          expect(badgeAcquisitionRepository.createOrUpdate).to.not.have.been.called;
         });
       });
 
@@ -130,7 +130,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           knowledgeElementRepository.findUniqByUserId.withArgs({ userId: event.userId }).resolves(knowledgeElements);
 
           sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
-          sinon.stub(badgeAcquisitionRepository, 'create');
+          sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
         });
 
         it('should create one badge when only one badge requirements are fulfilled', async () => {
@@ -146,7 +146,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
-          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([{
+          expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([{
             badgeId: badge1.id,
             userId: event.userId,
             campaignParticipationId: event.campaignParticipationId,
@@ -166,7 +166,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
-          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([
+          expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([
             { badgeId: badge1.id, userId: event.userId, campaignParticipationId: event.campaignParticipationId },
             { badgeId: badge2.id, userId: event.userId, campaignParticipationId: event.campaignParticipationId },
           ]);
@@ -182,13 +182,13 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           sinon.stub(badgeRepository, 'findByCampaignParticipationId');
           badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId).resolves([]);
 
-          sinon.stub(badgeAcquisitionRepository, 'create');
+          sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
 
           // when
           await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
-          expect(badgeAcquisitionRepository.create).to.not.have.been.called;
+          expect(badgeAcquisitionRepository.createOrUpdate).to.not.have.been.called;
 
         });
       });
@@ -197,7 +197,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
     context('when the assessment does not belong to a campaign', () => {
       it('should not create a badge', async () => {
         // given
-        sinon.stub(badgeAcquisitionRepository, 'create');
+        sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
 
         const userId = 42;
         const event = new AssessmentCompleted({ userId });
@@ -206,7 +206,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
         await handleBadgeAcquisition({ event, ...dependencies });
 
         // then
-        expect(badgeAcquisitionRepository.create).to.not.have.been.called;
+        expect(badgeAcquisitionRepository.createOrUpdate).to.not.have.been.called;
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Cas possible : 
- Un utilisateur fini une campagne sans partager ses résultats
- Dans cette campagne, l'utilisateur gagne un badge
- Il remet un zéro/retenter sa campagne
- Il re-fini sa campagne, vu qu'il y a eu de nouvelles questions
- Il re-gagne son badge
- On a 2 lignes en BDD pour le même couple User/Badge/CampaignParticipation, avec uniquement l'id et le "createdAt" qui change. 

Problème : cette double ligne n'a pas de sens fonctionnellement, l'utilisateur a ou n'a pas eu un badge pendant une campagne.

## :robot: Solution
- Lors du deuxième passage, on update la date de gain de ce badge

## :rainbow: Remarques
- Ajout d'une colonne "updatedAt"

## :100: Pour tester
Reproduire le cas ci-dessus.