### PR TITLE
[FEATURE] Ajouter l'étape de confirmation dans la récupération de compte (PIX-2732).

### DIFF
--- a/mon-pix/app/adapters/student-information.js
+++ b/mon-pix/app/adapters/student-information.js
@@ -2,7 +2,23 @@ import ApplicationAdapter from './application';
 
 export default class StudentInformationAdapter extends ApplicationAdapter {
 
-  urlForCreateRecord() {
-    return `${this.host}/${this.namespace}/schooling-registration-dependent-users/recover-account`;
+  buildURL(
+    modelName,
+    id,
+    snapshot,
+    requestType,
+    query,
+  ) {
+    if (requestType === 'recover-account') {
+      return `${this.host}/${this.namespace}/schooling-registration-dependent-users/`;
+    } else {
+      return super.buildURL(
+        modelName,
+        id,
+        snapshot,
+        requestType,
+        query,
+      );
+    }
   }
 }

--- a/mon-pix/app/components/recover-account-confirmation-step.hbs
+++ b/mon-pix/app/components/recover-account-confirmation-step.hbs
@@ -1,0 +1,40 @@
+<h1>Bonne nouvelle {{@studentInformationForAccountRecovery.firstName}} !</h1>
+<p>Nous avons retrouvé votre compte :</p>
+<p>Si vous constatez une erreur ou si ces données ne sont pas les votres, contactez le support.</p>
+
+<ul>
+  <li>
+    <div>Votre nom</div>
+    <div>{{@studentInformationForAccountRecovery.lastName}}</div>
+  </li>
+
+  <li>
+    <div>Votre prénom</div>
+    <div>{{@studentInformationForAccountRecovery.firstName}}</div>
+  </li>
+
+  <li>
+    <div>Votre identifiant</div>
+    <div>{{@studentInformationForAccountRecovery.username}}</div>
+  </li>
+
+  <li>
+    <div>Votre dernier établissement</div>
+    <div>{{@studentInformationForAccountRecovery.latestOrganizationName}}</div>
+  </li>
+
+  <p>En confirmant, j’atteste sur l’honneur que le compte associé à ces données m’appartient et j’accepte que Pix supprime le lien vers tous les établissements auquels je suis rattaché.</p>
+
+  <PixButton
+    @isBorderVisible={{true}}
+    @triggerAction={{@cancelAccountRecovery}}
+    @backgroundColor="transparent-light">
+      Annuler
+  </PixButton>
+  <PixButton
+    @isBorderVisible={{true}}
+    @triggerAction={{@continueAccountRecovery}}
+    @backgroundColor="red">
+      Je confirme
+  </PixButton>
+</ul>

--- a/mon-pix/app/components/recover-account-confirmation-step.hbs
+++ b/mon-pix/app/components/recover-account-confirmation-step.hbs
@@ -1,40 +1,40 @@
-<h1>Bonne nouvelle {{@studentInformationForAccountRecovery.firstName}} !</h1>
-<p>Nous avons retrouvé votre compte :</p>
-<p>Si vous constatez une erreur ou si ces données ne sont pas les votres, contactez le support.</p>
+<h1>{{t 'pages.recover-account-after-leaving-sco.confirmation-step.good-news' firstName=@studentInformationForAccountRecovery.firstName }} </h1>
+<p>{{t 'pages.recover-account-after-leaving-sco.confirmation-step.found-account' }}</p>
+<p> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.contact-support' }}</p>
 
 <ul>
   <li>
-    <div>Votre nom</div>
+    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.last-name' }}</div>
     <div>{{@studentInformationForAccountRecovery.lastName}}</div>
   </li>
 
   <li>
-    <div>Votre prénom</div>
+    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.first-name' }}</div>
     <div>{{@studentInformationForAccountRecovery.firstName}}</div>
   </li>
 
   <li>
-    <div>Votre identifiant</div>
+    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.username' }}</div>
     <div>{{@studentInformationForAccountRecovery.username}}</div>
   </li>
 
   <li>
-    <div>Votre dernier établissement</div>
+    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.latest-organization-name' }}</div>
     <div>{{@studentInformationForAccountRecovery.latestOrganizationName}}</div>
   </li>
 
-  <p>En confirmant, j’atteste sur l’honneur que le compte associé à ces données m’appartient et j’accepte que Pix supprime le lien vers tous les établissements auquels je suis rattaché.</p>
+  <p> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.certify-account' }}</p>
 
   <PixButton
     @isBorderVisible={{true}}
     @triggerAction={{@cancelAccountRecovery}}
     @backgroundColor="transparent-light">
-      Annuler
+    {{t 'pages.recover-account-after-leaving-sco.confirmation-step.buttons.cancel' }}
   </PixButton>
   <PixButton
     @isBorderVisible={{true}}
     @triggerAction={{@continueAccountRecovery}}
     @backgroundColor="red">
-      Je confirme
+    {{t 'pages.recover-account-after-leaving-sco.confirmation-step.buttons.confirm' }}
   </PixButton>
 </ul>

--- a/mon-pix/app/components/recover-account-confirmation-step.hbs
+++ b/mon-pix/app/components/recover-account-confirmation-step.hbs
@@ -4,13 +4,13 @@
 
 <ul>
   <li>
-    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.last-name' }}</div>
-    <div>{{@studentInformationForAccountRecovery.lastName}}</div>
+    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.first-name' }}</div>
+    <div>{{@studentInformationForAccountRecovery.firstName}}</div>
   </li>
 
   <li>
-    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.first-name' }}</div>
-    <div>{{@studentInformationForAccountRecovery.firstName}}</div>
+    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.last-name' }}</div>
+    <div>{{@studentInformationForAccountRecovery.lastName}}</div>
   </li>
 
   <li>

--- a/mon-pix/app/components/recover-account-confirmation-step.hbs
+++ b/mon-pix/app/components/recover-account-confirmation-step.hbs
@@ -13,10 +13,12 @@
     <div>{{@studentInformationForAccountRecovery.lastName}}</div>
   </li>
 
+{{#if @studentInformationForAccountRecovery.username}}
   <li>
     <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.username' }}</div>
     <div>{{@studentInformationForAccountRecovery.username}}</div>
   </li>
+{{/if}}
 
   <li>
     <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.latest-organization-name' }}</div>

--- a/mon-pix/app/controllers/recover-account-after-leaving-sco.js
+++ b/mon-pix/app/controllers/recover-account-after-leaving-sco.js
@@ -24,6 +24,12 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
     }
   }
 
+  @action
+  cancelAccountRecovery() {
+    this.showRecoverAccountConfirmationStep = false;
+    this.showRecoverAccountStudentInformationForm = true;
+  }
+
   _handleError(err) {
     const status = err.errors?.[0]?.status;
 

--- a/mon-pix/app/controllers/recover-account-after-leaving-sco.js
+++ b/mon-pix/app/controllers/recover-account-after-leaving-sco.js
@@ -14,7 +14,7 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
     const studentInformationToSave = this.store.createRecord('student-information', studentInformation);
     this.firstName = studentInformation.firstName;
     try {
-      await studentInformationToSave.save();
+      await studentInformationToSave.submitStudentInformation();
     } catch (err) {
       this._handleError(err);
     }

--- a/mon-pix/app/controllers/recover-account-after-leaving-sco.js
+++ b/mon-pix/app/controllers/recover-account-after-leaving-sco.js
@@ -6,7 +6,9 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
 
   @tracked showRecoverAccountStudentInformationForm = true;
   @tracked showRecoverAccountConflictError = false;
+  @tracked showRecoverAccountConfirmationStep = false;
 
+  studentInformationForAccountRecovery;
   firstName;
 
   @action
@@ -14,7 +16,9 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
     const studentInformationToSave = this.store.createRecord('student-information', studentInformation);
     this.firstName = studentInformation.firstName;
     try {
-      await studentInformationToSave.submitStudentInformation();
+      this.studentInformationForAccountRecovery = await studentInformationToSave.submitStudentInformation();
+      this.showRecoverAccountStudentInformationForm = false;
+      this.showRecoverAccountConfirmationStep = true;
     } catch (err) {
       this._handleError(err);
     }

--- a/mon-pix/app/controllers/recover-account-after-leaving-sco.js
+++ b/mon-pix/app/controllers/recover-account-after-leaving-sco.js
@@ -30,6 +30,8 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
     if (status === '409') {
       this.showRecoverAccountStudentInformationForm = false;
       this.showRecoverAccountConflictError = true;
+    } else {
+      console.log(err);
     }
   }
 }

--- a/mon-pix/app/models/student-information.js
+++ b/mon-pix/app/models/student-information.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+import { memberAction } from 'ember-api-actions';
 
 export default class StudentInformation extends Model {
 
@@ -7,4 +8,28 @@ export default class StudentInformation extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('date-only') birthdate;
+
+  submitStudentInformation = memberAction({
+    path: 'recover-account',
+    type: 'post',
+    urlType: 'recover-account',
+    before() {
+      const payload = this.serialize();
+      return payload;
+    },
+    after(response) {
+      if (response.data && response.data.attributes) {
+        const deserializeResponse = {
+          firstName: response.data.attributes['first-name'],
+          lastName: response.data.attributes['last-name'],
+          email: response.data.attributes['email'],
+          username: response.data.attributes['username'],
+          latestOrganizationName: response.data.attributes['latest-organization-name'],
+        };
+        return deserializeResponse;
+      } else {
+        return response;
+      }
+    },
+  });
 }

--- a/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
@@ -7,3 +7,7 @@
 {{#if this.showRecoverAccountConflictError}}
   <RecoverAccountConflictError @firstName={{this.firstName}} />
 {{/if}}
+
+{{#if this.showRecoverAccountConfirmationStep}}
+  <RecoverAccountConfirmationStep @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}/>
+{{/if}}

--- a/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
@@ -9,5 +9,8 @@
 {{/if}}
 
 {{#if this.showRecoverAccountConfirmationStep}}
-  <RecoverAccountConfirmationStep @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}/>
+  <RecoverAccountConfirmationStep
+    @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
+    @cancelAccountRecovery={{this.cancelAccountRecovery}}
+  />
 {{/if}}

--- a/mon-pix/mirage/routes/schooling-registration-dependent-users/index.js
+++ b/mon-pix/mirage/routes/schooling-registration-dependent-users/index.js
@@ -74,6 +74,10 @@ export default function index(config) {
             'latest-organization-name': 'Collège FouFouFou',
           },
         } });
+    } else {
+      return new Response(409, {}, {
+        errors: [{ status: '409' }],
+      });
     }
   });
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -15140,6 +15140,16 @@
         }
       }
     },
+    "ember-api-actions": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/ember-api-actions/-/ember-api-actions-0.2.9.tgz",
+      "integrity": "sha512-RDyGOL+CkpzpovOB3W2acawCfoDB/P3cevR+QDA+VqOeFDz9sd9bOkDvx0Vn1qeapGC/1yGx6cTpQkQhmuNLmg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.3",
+        "ember-cli-typescript": "^3.0.0"
+      }
+    },
     "ember-assign-polyfill": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/ember-assign-polyfill/-/ember-assign-polyfill-2.6.0.tgz",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -53,6 +53,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "chai-dom": "^1.9.0",
     "dotenv": "^8.2.0",
+    "ember-api-actions": "^0.2.9",
     "ember-auto-import": "^1.11.3",
     "ember-burger-menu": "^3.3.4",
     "ember-cli": "~3.23.0",

--- a/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
+++ b/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import visit from '../helpers/visit';
-import { currentURL, fillIn } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import setupIntl from '../helpers/setup-intl';
 import { fillInByLabel } from '../helpers/fill-in-by-label';
 import { clickByLabel } from '../helpers/click-by-label';
@@ -62,9 +62,9 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
         await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ineIna);
         await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
         await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
-        await fillIn('#dayOfBirth', dayOfBirth);
-        await fillIn('#monthOfBirth', monthOfBirth);
-        await fillIn('#yearOfBirth', yearOfBirth);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-day'), dayOfBirth);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-month'), monthOfBirth);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-year'), yearOfBirth);
         await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
 
         // then
@@ -105,9 +105,9 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
         await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ineIna);
         await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
         await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
-        await fillIn('#dayOfBirth', dayOfBirth);
-        await fillIn('#monthOfBirth', monthOfBirth);
-        await fillIn('#yearOfBirth', yearOfBirth);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-day'), dayOfBirth);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-month'), monthOfBirth);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-year'), yearOfBirth);
         await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
 
         // then

--- a/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
+++ b/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
@@ -3,9 +3,10 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import visit from '../helpers/visit';
-import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { currentURL, fillIn } from '@ember/test-helpers';
 import setupIntl from '../helpers/setup-intl';
-import { Response } from 'ember-cli-mirage';
+import { fillInByLabel } from '../helpers/fill-in-by-label';
+import { clickByLabel } from '../helpers/click-by-label';
 import { contains } from '../helpers/contains';
 
 describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
@@ -25,9 +26,9 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
     });
   });
 
-  context('when account recovery is enabled', function() {
+  context('when account recovery is enabled', () => {
 
-    it('should access to account recovery page', async function() {
+    it('should access to account recovery page and show student information form', async function() {
       // given
       server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
 
@@ -36,6 +37,41 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
 
       // then
       expect(currentURL()).to.equal('/recuperer-mon-compte');
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.exist;
+    });
+
+    context('when submitting information form with valid data', () => {
+
+      it('should hide student information form and show recover account confirmation step', async function() {
+        // given
+        const ineIna = '0123456789A';
+        const lastName = 'Lecol';
+        const firstName = 'Manuela';
+        const dayOfBirth = 20;
+        const monthOfBirth = 5;
+        const yearOfBirth = 2000;
+        const birthdate = '2000-05-20';
+        const username = 'manuela.lecol2005';
+
+        server.create('user', { id: 1, firstName, lastName, username });
+        server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
+        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+
+        // when
+        await visit('/recuperer-mon-compte');
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ineIna);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
+        await fillIn('#dayOfBirth', dayOfBirth);
+        await fillIn('#monthOfBirth', monthOfBirth);
+        await fillIn('#yearOfBirth', yearOfBirth);
+        await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
+
+        // then
+        expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.not.exist;
+        expect(contains('Nous avons retrouvé votre compte :')).to.exist;
+        expect(contains('Manuela')).to.exist;
+      });
     });
 
     context('when two students used same account', function() {
@@ -73,14 +109,13 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
 
         //when
         await visit('/recuperer-mon-compte');
-
-        await fillIn('#ineIna', ineIna);
-        await fillIn('#firstName', firstName);
-        await fillIn('#lastName', lastName);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ineIna);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
         await fillIn('#dayOfBirth', dayOfBirth);
         await fillIn('#monthOfBirth', monthOfBirth);
         await fillIn('#yearOfBirth', yearOfBirth);
-        await click('button[type=submit]');
+        await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
 
         // then
         expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.conflict.found-you-but', { firstName }))).to.exist;

--- a/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
+++ b/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
@@ -71,6 +71,41 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
         expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.not.exist;
         expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.good-news', { firstName }))).to.exist;
       });
+
+      context('click on "Annuler" button', () => {
+
+        it('should return to student information form', async function() {
+          // given
+          const ineIna = '0123456789A';
+          const lastName = 'Lecol';
+          const firstName = 'Manuela';
+          const dayOfBirth = 20;
+          const monthOfBirth = 5;
+          const yearOfBirth = 2000;
+          const birthdate = '2000-05-20';
+          const username = 'manuela.lecol2005';
+
+          server.create('user', { id: 1, firstName, lastName, username });
+          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
+          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+
+          await visit('/recuperer-mon-compte');
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ineIna);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-day'), dayOfBirth);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-month'), monthOfBirth);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-year'), yearOfBirth);
+          await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
+
+          // when
+          await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.buttons.cancel'));
+
+          // then
+          expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.exist;
+          expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.good-news', { firstName }))).to.not.exist;
+        });
+      });
     });
 
     context('when two students used same account', function() {

--- a/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
+++ b/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
@@ -69,8 +69,7 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
 
         // then
         expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.not.exist;
-        expect(contains('Nous avons retrouvé votre compte :')).to.exist;
-        expect(contains('Manuela')).to.exist;
+        expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.good-news', { firstName }))).to.exist;
       });
     });
 

--- a/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
+++ b/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
@@ -100,12 +100,6 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
           birthdate: '2000-5-20',
         });
 
-        this.server.post('/schooling-registration-dependent-users/recover-account', function() {
-          return new Response(409, {}, {
-            errors: [{ status: '409' }],
-          });
-        });
-
         //when
         await visit('/recuperer-mon-compte');
         await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ineIna);

--- a/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
+++ b/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
@@ -52,8 +52,8 @@ describe('Integration | Component | recover-account-confirmation-step', function
 
       // when
       await render(hbs`<RecoverAccountConfirmationStep
-      @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
-    />`);
+        @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
+      />`);
 
       // then
       expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.fields.username'))).to.not.exist;

--- a/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
+++ b/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
@@ -38,6 +38,28 @@ describe('Integration | Component | recover-account-confirmation-step', function
     expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.certify-account'))).to.exist;
   });
 
+  context('when user does not have a username', function() {
+
+    it('should not display username', async function() {
+      // given
+      const studentInformationForAccountRecovery = EmberObject.create({
+        firstName: 'Philippe',
+        lastName: 'Auguste',
+        email: 'philippe.auguste@example.net',
+        latestOrganizationName: 'Collège George-Besse, Loches',
+      });
+      this.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
+
+      // when
+      await render(hbs`<RecoverAccountConfirmationStep
+      @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
+    />`);
+
+      // then
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.fields.username'))).to.not.exist;
+    });
+  });
+
   it('should be possible to cancel the account recovery process', async function() {
     // given
     const studentInformationForAccountRecovery = EmberObject.create({

--- a/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
+++ b/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
@@ -1,15 +1,15 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { contains } from '../../helpers/contains';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { clickByLabel } from '../../helpers/click-by-label';
 import sinon from 'sinon';
 
 describe('Integration | Component | recover-account-confirmation-step', function() {
-  setupRenderingTest();
+  setupIntlRenderingTest();
 
   it('should render account recovery confirmation step', async function() {
     // given
@@ -28,14 +28,14 @@ describe('Integration | Component | recover-account-confirmation-step', function
     />`);
 
     // then
-    expect(contains('Bonne nouvelle Philippe !')).to.exist;
-    expect(contains('Nous avons retrouvé votre compte :')).to.exist;
-    expect(contains('Si vous constatez une erreur ou si ces données ne sont pas les votres, contactez le support.')).to.exist;
+    expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.good-news', { firstName: 'Philippe' }))).to.exist;
+    expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.found-account'))).to.exist;
+    expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.contact-support'))).to.exist;
     expect(contains('Auguste'));
     expect(contains('Philippe'));
     expect(contains('Philippe.auguste2312'));
     expect(contains('Collège George-Besse, Loches'));
-    expect(contains('En confirmant, j’atteste sur l’honneur que le compte associé à ces données m’appartient et j’accepte que Pix supprime le lien vers tous les établissements auquels je suis rattaché.')).to.exist;
+    expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.certify-account'))).to.exist;
   });
 
   it('should be possible to cancel the account recovery process', async function() {
@@ -56,7 +56,7 @@ describe('Integration | Component | recover-account-confirmation-step', function
       @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
       @cancelAccountRecovery={{this.cancelAccountRecovery}}
     />`);
-    await clickByLabel('Annuler');
+    await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.buttons.cancel'));
 
     // then
     sinon.assert.calledOnce(cancelAccountRecovery);
@@ -80,7 +80,7 @@ describe('Integration | Component | recover-account-confirmation-step', function
       @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
       @continueAccountRecovery={{this.continueAccountRecovery}}
     />`);
-    await clickByLabel('Je confirme');
+    await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.buttons.confirm'));
 
     // then
     sinon.assert.calledOnce(continueAccountRecovery);

--- a/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
+++ b/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
@@ -1,0 +1,88 @@
+import EmberObject from '@ember/object';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { contains } from '../../helpers/contains';
+import { clickByLabel } from '../../helpers/click-by-label';
+import sinon from 'sinon';
+
+describe('Integration | Component | recover-account-confirmation-step', function() {
+  setupRenderingTest();
+
+  it('should render account recovery confirmation step', async function() {
+    // given
+    const studentInformationForAccountRecovery = EmberObject.create({
+      firstName: 'Philippe',
+      lastName: 'Auguste',
+      username: 'Philippe.auguste2312',
+      email: 'philippe.auguste@example.net',
+      latestOrganizationName: 'Collège George-Besse, Loches',
+    });
+    this.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
+
+    // when
+    await render(hbs`<RecoverAccountConfirmationStep
+      @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
+    />`);
+
+    // then
+    expect(contains('Bonne nouvelle Philippe !')).to.exist;
+    expect(contains('Nous avons retrouvé votre compte :')).to.exist;
+    expect(contains('Si vous constatez une erreur ou si ces données ne sont pas les votres, contactez le support.')).to.exist;
+    expect(contains('Auguste'));
+    expect(contains('Philippe'));
+    expect(contains('Philippe.auguste2312'));
+    expect(contains('Collège George-Besse, Loches'));
+    expect(contains('En confirmant, j’atteste sur l’honneur que le compte associé à ces données m’appartient et j’accepte que Pix supprime le lien vers tous les établissements auquels je suis rattaché.')).to.exist;
+  });
+
+  it('should be possible to cancel the account recovery process', async function() {
+    // given
+    const studentInformationForAccountRecovery = EmberObject.create({
+      firstName: 'Philippe',
+      lastName: 'Auguste',
+      username: 'Philippe.auguste2312',
+      email: 'philippe.auguste@example.net',
+      latestOrganizationName: 'Collège George-Besse, Loches',
+    });
+    this.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
+    const cancelAccountRecovery = sinon.stub();
+    this.set('cancelAccountRecovery', cancelAccountRecovery);
+
+    // when
+    await render(hbs`<RecoverAccountConfirmationStep
+      @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
+      @cancelAccountRecovery={{this.cancelAccountRecovery}}
+    />`);
+    await clickByLabel('Annuler');
+
+    // then
+    sinon.assert.calledOnce(cancelAccountRecovery);
+  });
+
+  it('should be possible to continue the account recovery process', async function() {
+    // given
+    const studentInformationForAccountRecovery = EmberObject.create({
+      firstName: 'Philippe',
+      lastName: 'Auguste',
+      username: 'Philippe.auguste2312',
+      email: 'philippe.auguste@example.net',
+      latestOrganizationName: 'Collège George-Besse, Loches',
+    });
+    this.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
+    const continueAccountRecovery = sinon.stub();
+    this.set('continueAccountRecovery', continueAccountRecovery);
+
+    // when
+    await render(hbs`<RecoverAccountConfirmationStep
+      @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
+      @continueAccountRecovery={{this.continueAccountRecovery}}
+    />`);
+    await clickByLabel('Je confirme');
+
+    // then
+    sinon.assert.calledOnce(continueAccountRecovery);
+  });
+});

--- a/mon-pix/tests/integration/components/recover-account-student-information-form-test.js
+++ b/mon-pix/tests/integration/components/recover-account-student-information-form-test.js
@@ -1,11 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import Service from '@ember/service';
-import { render, fillIn, triggerEvent, click } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
 import sinon from 'sinon';
+import { fillInByLabel } from '../../helpers/fill-in-by-label';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 describe('Integration | Component | recover-account-student-information-form', function() {
 
@@ -47,14 +49,13 @@ describe('Integration | Component | recover-account-student-information-form', f
     `);
 
     // when
-    await fillIn('#ineIna', ine);
-    await fillIn('#firstName', firstName);
-    await fillIn('#lastName', lastName);
-    await fillIn('#dayOfBirth', dayOfBirth);
-    await fillIn('#monthOfBirth', monthOfBirth);
-    await fillIn('#yearOfBirth', yearOfBirth);
-
-    await click('button[type=submit]');
+    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ine);
+    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
+    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
+    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-day'), dayOfBirth);
+    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-month'), monthOfBirth);
+    await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-year'), yearOfBirth);
+    await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
 
     // then
     sinon.assert.calledWithExactly(submitStudentInformation, {
@@ -75,7 +76,7 @@ describe('Integration | Component | recover-account-student-information-form', f
         await render(hbs `<RecoverAccountStudentInformationForm />`);
 
         // when
-        await fillIn('#ineIna', validIna);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), validIna);
         await triggerEvent('#ineIna', 'focusout');
 
         // then
@@ -88,7 +89,7 @@ describe('Integration | Component | recover-account-student-information-form', f
         await render(hbs `<RecoverAccountStudentInformationForm />`);
 
         // when
-        await fillIn('#ineIna', validIna);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), validIna);
         await triggerEvent('#ineIna', 'focusout');
 
         // then
@@ -104,7 +105,7 @@ describe('Integration | Component | recover-account-student-information-form', f
         await render(hbs `<RecoverAccountStudentInformationForm />`);
 
         // when
-        await fillIn('#ineIna', invalidIneIna);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), invalidIneIna);
         await triggerEvent('#ineIna', 'focusout');
 
         // then
@@ -117,7 +118,7 @@ describe('Integration | Component | recover-account-student-information-form', f
         await render(hbs `<RecoverAccountStudentInformationForm />`);
 
         // when
-        await fillIn('#ineIna', emptyIneIna);
+        await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), emptyIneIna);
         await triggerEvent('#ineIna', 'focusout');
 
         // then
@@ -134,7 +135,7 @@ describe('Integration | Component | recover-account-student-information-form', f
       await render(hbs `<RecoverAccountStudentInformationForm />`);
 
       // when
-      await fillIn('#lastName', emptyLastName);
+      await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), emptyLastName);
       await triggerEvent('#lastName', 'focusout');
 
       // then
@@ -150,7 +151,7 @@ describe('Integration | Component | recover-account-student-information-form', f
       await render(hbs `<RecoverAccountStudentInformationForm />`);
 
       // when
-      await fillIn('#firstName', emptyFirstName);
+      await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), emptyFirstName);
       await triggerEvent('#firstName', 'focusout');
 
       // then

--- a/mon-pix/tests/unit/adapters/student-information-test.js
+++ b/mon-pix/tests/unit/adapters/student-information-test.js
@@ -5,17 +5,15 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Adapter | student information', function() {
   setupTest();
 
-  describe('#urlForCreateRecord', () => {
+  describe('#buildURL', function() {
 
-    it('should call /api/schooling-registration-dependent-users/recover-account', async function() {
-      // given
-      const adapter = this.owner.lookup('adapter:student-information');
-
+    it('should build recover account base URL when called with according requestType', function() {
       // when
-      const url = await adapter.urlForCreateRecord();
+      const adapter = this.owner.lookup('adapter:student-information');
+      const url = adapter.buildURL(123, 'student-information', null, 'recover-account');
 
       // then
-      expect(url.endsWith('/schooling-registration-dependent-users/recover-account')).to.be.true;
+      expect(url.endsWith('/schooling-registration-dependent-users/')).to.be.true;
     });
   });
 });

--- a/mon-pix/tests/unit/controllers/recover-account-after-leaving-sco-test.js
+++ b/mon-pix/tests/unit/controllers/recover-account-after-leaving-sco-test.js
@@ -15,8 +15,8 @@ describe('Unit | Controller | recover-account-after-leaving-sco', function() {
       // given
         const controller = this.owner.lookup('controller:recover-account-after-leaving-sco');
         const studentInformation = { firstName: 'Jules' };
-        const saveStub = sinon.stub();
-        const createRecord = sinon.stub().returns({ save: saveStub.resolves() });
+        const submitStudentInformationStub = sinon.stub();
+        const createRecord = sinon.stub().returns({ submitStudentInformation: submitStudentInformationStub.resolves() });
         const store = { createRecord };
         controller.set('store', store);
 
@@ -25,7 +25,7 @@ describe('Unit | Controller | recover-account-after-leaving-sco', function() {
 
         // then
         sinon.assert.calledWithExactly(createRecord, 'student-information', studentInformation);
-        sinon.assert.calledOnce(saveStub);
+        sinon.assert.calledOnce(submitStudentInformationStub);
       });
 
       context('when two students used same account', function() {
@@ -35,8 +35,8 @@ describe('Unit | Controller | recover-account-after-leaving-sco', function() {
           const errors = { errors: [ { status: '409' }] };
           const controller = this.owner.lookup('controller:recover-account-after-leaving-sco');
           const studentInformation = { firstName: 'Jules' };
-          const saveStub = sinon.stub().rejects(errors);
-          const store = { createRecord: sinon.stub().returns({ save: saveStub }) };
+          const submitStudentInformationStub = sinon.stub().rejects(errors);
+          const store = { createRecord: sinon.stub().returns({ submitStudentInformation: submitStudentInformationStub }) };
           controller.set('store', store);
 
           // when
@@ -45,6 +45,25 @@ describe('Unit | Controller | recover-account-after-leaving-sco', function() {
           // then
           expect(controller.showRecoverAccountStudentInformationForm).to.be.false;
           expect(controller.showRecoverAccountConflictError).to.be.true;
+        });
+      });
+
+      context('when user account is found without any conflict', function() {
+
+        it('should hide student information form and show recover account confirmation step', async function() {
+          // given
+          const controller = this.owner.lookup('controller:recover-account-after-leaving-sco');
+          const studentInformation = { firstName: 'Jules' };
+          const submitStudentInformationStub = sinon.stub().resolves();
+          const store = { createRecord: sinon.stub().returns({ submitStudentInformation: submitStudentInformationStub }) };
+          controller.set('store', store);
+
+          // when
+          await controller.submitStudentInformation(studentInformation);
+
+          // then
+          expect(controller.showRecoverAccountStudentInformationForm).to.be.false;
+          expect(controller.showRecoverAccountConfirmationStep).to.be.true;
         });
       });
     });

--- a/mon-pix/tests/unit/models/student-information-test.js
+++ b/mon-pix/tests/unit/models/student-information-test.js
@@ -1,14 +1,68 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+import ENV from 'mon-pix/config/environment';
+import { run } from '@ember/runloop';
 
 describe('Unit | Model | Student-information', function() {
 
   setupTest();
 
-  it('exists', function() {
-    const store = this.owner.lookup('service:store');
-    const model = store.createRecord('student-information', {});
-    expect(model).to.be.ok;
+  describe('#submitStudentInformation', function() {
+
+    it('submit student information form', async function() {
+      // given
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('student-information');
+      sinon.stub(adapter, 'ajax');
+      adapter.ajax.resolves({
+        data: {
+          attributes: {
+            'first-name': 'James',
+            'last-name': 'Potter',
+            'email': 'james.potter@example.net',
+            'username': 'james.potter0709',
+            'latest-organization-name': 'Collège Louise Michelle',
+          },
+        },
+      });
+
+      const studentInformation = run(() => store.createRecord('student-information', {
+        firstName: 'James',
+        lastName: 'Potter',
+        ineIna: '123456789CC',
+        birthdate: '2010-01-22',
+      }));
+
+      // when
+      const result = await studentInformation.submitStudentInformation();
+
+      // then
+      const expectedResult = {
+        firstName: 'James',
+        lastName: 'Potter',
+        email: 'james.potter@example.net',
+        username: 'james.potter0709',
+        latestOrganizationName: 'Collège Louise Michelle',
+      };
+
+      const url = `${ENV.APP.API_HOST}/api/schooling-registration-dependent-users/recover-account`;
+      const payload = {
+        data: {
+          data: {
+            attributes: {
+              'ine-ina': '123456789CC',
+              'first-name': 'James',
+              'last-name': 'Potter',
+              'birthdate': '2010-01-22',
+            },
+            type: 'student-information',
+          },
+        },
+      };
+      expect(adapter.ajax.calledWith(url, 'POST', payload)).to.be.true;
+      expect(result).to.be.deep.equal(expectedResult);
+    });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -963,6 +963,22 @@
           "url-text": "Contactez le support",
           "recover": " pour récupérer votre compte Pix."
         }
+      },
+      "confirmation-step": {
+        "good-news" : "Bonne nouvelle { firstName } !",
+        "found-account": "Nous avons retrouvé votre compte :",
+        "contact-support": "Si vous constatez une erreur ou si ces données ne sont pas les vôtres, contactez le support.",
+        "fields" : {
+          "last-name": "Votre nom",
+          "first-name": "Votre prénom",
+          "username": "Votre identifiant",
+          "latest-organization-name": "Votre dernier établissement"
+        },
+        "certify-account": "En confirmant, j’atteste sur l’honneur que le compte associé à ces données m’appartient et j’accepte que Pix supprime le lien vers tous les établissements auxquels je suis rattaché.",
+        "buttons": {
+          "cancel":"Annuler",
+          "confirm": "Je confirme"
+        }
       }
     },
     "result-item": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -963,6 +963,22 @@
           "url-text": "Contactez le support",
           "recover": " pour récupérer votre compte Pix."
         }
+      },
+      "confirmation-step": {
+        "good-news" : "Bonne nouvelle { firstName } !",
+        "found-account": "Nous avons retrouvé votre compte :",
+        "contact-support": "Si vous constatez une erreur ou si ces données ne sont pas les votres, contactez le support.",
+        "fields" : {
+          "last-name": "Votre nom",
+          "first-name": "Votre prénom",
+          "username": "Votre identifiant",
+          "latest-organization-name": "Votre dernier établissement"
+        },
+        "certify-account": "En confirmant, j’atteste sur l’honneur que le compte associé à ces données m’appartient et j’accepte que Pix supprime le lien vers tous les établissements auquels je suis rattaché.",
+        "buttons": {
+          "cancel":"Annuler",
+          "confirm": "Je confirme"
+        }
       }
     },
     "result-item": {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la sortie SCO, il faut permettre à l'utilisateur de récupérer son compte Pix.

Actuellement le formulaire permettant de fournir les informations nécessaire à la récupération de compte est implémenté (mais soumis à feature toggle, donc désactivé en PROD).

Une fois ce formulaire soumis, il faudrait pouvoir indiquer à l'utilisateur quel compte a été trouvé avec les informations qu'il a rentré.

## :robot: Solution

Implémenter la page de confirmation de récupération de compte.
Masquer la partie "identifiant" si l'utilisateur n'en dispose pas.

## :rainbow: Remarques
Ajout temporaire d'un `console.log` en attendant l'implem de la gestion d'erreur coté front. (à venir)

Cette PR installe une nouvelle dépendance : https://github.com/mike-north/ember-api-actions 
Les members action permettent de faire des requêtes vers notre API sans avoir besoin d'instancier un model ember dédié.
Dans notre cas nous avons un retour de l'API qui contient 4 attributs : 'first-name', 'last-name', 'email', 'username', 'latest-organization-name'. Informations, qui ne nous servent que pour l'affichage et qui ne seront pas renvoyées à l'API.

## :100: Pour tester
Lancer l'api avec `IS_SCO_ACCOUNT_RECOVERY_ENABLED=true npm start -- --watch `.
Lancer `mon-pix`: 
- Aller sur `/recuperer-mon-compte` - [RA](https://app-pr3152.review.pix.fr/recuperer-mon-compte)

##
Utilisateur **avec identifiant** : 

Ine/Ina : 123456789BB
Prénom : George
Nom : De Cambridge
Date de naissance : 22/07/2013

- Cliquer sur le bouton 
- Constater qu'on nous affiche bien une page avec les informations de compte de George et un bouton "Annuler" et "Confirmer"

##

Utilisateur **sans identifiant** : 

Ine/Ina : 123456789DD
Prénom : Lyanna
Nom : Mormont
Date de naissance : 07/01/2002

- Cliquer sur le bouton 
- Constater que la partie identifiant n'apparaît pas.
