### PR TITLE
[TECH] Ne pas filtrer le html contenu dans la consigne d'une épreuve lors de son affichage lors du checkpoint.

### DIFF
--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -27,7 +27,7 @@
 
         <div class="rounded-panel comparison-window__instruction">
           <div class="rounded-panel__row ">
-            <MarkdownToHtml @class="challenge-statement__instruction" @markdown={{@answer.challenge.instruction}} />
+            <MarkdownToHtmlUnsafe @class="challenge-statement__instruction" @markdown={{@answer.challenge.instruction}} />
           </div>
 
          {{#if @answer.challenge.illustrationUrl}}


### PR DESCRIPTION
## :unicorn: Problème
Les épreuves contenant de l'html/CSS dans leur consignes utilisaient un composant qui filtrait les class et Id, ce qui cassait le style.

## :robot: Solution
Utilser le composant MarkdownToHtmlUnsafe pour afficher la consigne.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la consigne s'affiche avec le bon style lors du checkpoint : rec1QoQlL8HKkIpfW