### PR TITLE
[FEATURE] Ajouter l'étape de la récupération de l'e-mail dans le parcours de récupération de compte (PIX-2738).

### DIFF
--- a/mon-pix/app/components/recover-account-confirmation-step.hbs
+++ b/mon-pix/app/components/recover-account-confirmation-step.hbs
@@ -35,7 +35,7 @@
   </PixButton>
   <PixButton
     @isBorderVisible={{true}}
-    @triggerAction={{@continueAccountRecovery}}
+    @triggerAction={{@continueAccountRecoveryBackupEmailConfirmation}}
     @backgroundColor="red">
     {{t 'pages.recover-account-after-leaving-sco.confirmation-step.buttons.confirm' }}
   </PixButton>

--- a/mon-pix/app/components/recovery-account/recover-account-backup-email-confirmation-form.hbs
+++ b/mon-pix/app/components/recovery-account/recover-account-backup-email-confirmation-form.hbs
@@ -1,0 +1,39 @@
+<h1>{{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.email-is-needed-message' firstName=@firstName}}</h1>
+
+{{#if @existingEmail}}
+  <p>
+    {{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.email-already-exist-for-account-message'}}<br>
+    {{@existingEmail}}<br>
+    {{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.email-is-valid-message'}}
+    <LinkTo @route="password-reset-demand">
+      {{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.email-reset-message'}}</LinkTo>
+    {{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.ask-for-new-email-message'}}
+  </p>
+{{else}}
+  <p>
+    {{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.email-sent-to-choose-password-message'}}
+  </p>
+{{/if}}
+
+<form onSubmit={{this.submitBackupEmailConfirmationForm}}>
+
+  <FormTextfield @label={{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.form.email'}}
+                 @textfieldName="email"
+                 @inputBindingValue={{this.email}}
+                 @onValidate={{this.validateEmail}}
+                 @validationStatus={{this.emailValidation.status}}
+                 @validationMessage={{this.emailValidation.message}}
+                 @autocomplete="off"
+                 @require={{true}}
+                 @hideRequired={{true}}/>
+
+
+  <PixButton @type="submit">
+    {{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.form.actions.submit'}}
+  </PixButton>
+
+  <PixButton @triggerAction={{@cancelAccountRecovery}}>
+    {{t 'pages.recover-account-after-leaving-sco.backup-email-confirmation.form.actions.cancel'}}
+  </PixButton>
+
+</form>

--- a/mon-pix/app/components/recovery-account/recover-account-backup-email-confirmation-form.js
+++ b/mon-pix/app/components/recovery-account/recover-account-backup-email-confirmation-form.js
@@ -1,0 +1,60 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import isEmpty from 'lodash/isEmpty';
+import isEmailValid from '../../utils/email-validator';
+
+const STATUS_MAP = {
+  defaultStatus: 'default',
+  errorStatus: 'error',
+  successStatus: 'success',
+};
+
+const ERROR_INPUT_MESSAGE_MAP = {
+  emailAlreadyExist: 'pages.recover-account-after-leaving-sco.backup-email-confirmation.form.error.email-already-exist',
+  newEmailAlreadyExist: 'pages.recover-account-after-leaving-sco.backup-email-confirmation.form.error.new-email-already-exist',
+  emptyEmail: 'pages.recover-account-after-leaving-sco.backup-email-confirmation.form.error.empty-email',
+  wrongEmailFormat: 'pages.recover-account-after-leaving-sco.backup-email-confirmation.form.error.wrong-email-format',
+};
+
+class EmailValidation {
+  @tracked status = STATUS_MAP['defaultStatus'];
+  @tracked message = null;
+}
+
+export default class RecoverAccountBackupEmailConfirmationFormComponent extends Component {
+
+  @service intl;
+
+  @tracked emailValidation = new EmailValidation();
+
+  email = '';
+
+  @action validateEmail() {
+    this.email = this.email.trim();
+    if (isEmpty(this.email)) {
+      this.emailValidation.status = STATUS_MAP['errorStatus'];
+      this.emailValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyEmail']);
+      return;
+    }
+
+    const isInvalidInput = !isEmailValid(this.email);
+    if (isInvalidInput) {
+      this.emailValidation.status = STATUS_MAP['errorStatus'];
+      this.emailValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongEmailFormat']);
+      return;
+    }
+
+    this.emailValidation.status = STATUS_MAP['successStatus'];
+    this.emailValidation.message = null;
+  }
+
+  @action
+  async submitBackupEmailConfirmationForm(event) {
+    event.preventDefault();
+    // send email
+
+  }
+
+}

--- a/mon-pix/app/controllers/recover-account-after-leaving-sco.js
+++ b/mon-pix/app/controllers/recover-account-after-leaving-sco.js
@@ -7,6 +7,7 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
   @tracked showRecoverAccountStudentInformationForm = true;
   @tracked showRecoverAccountConflictError = false;
   @tracked showRecoverAccountConfirmationStep = false;
+  @tracked showRecoverAccountBackupEmailConfirmationForm = false;
 
   studentInformationForAccountRecovery;
   firstName;
@@ -22,6 +23,13 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
     } catch (err) {
       this._handleError(err);
     }
+  }
+
+  @action
+  continueAccountRecoveryBackupEmailConfirmation() {
+    this.showRecoverAccountStudentInformationForm = false;
+    this.showRecoverAccountConfirmationStep = false;
+    this.showRecoverAccountBackupEmailConfirmationForm = true;
   }
 
   @action

--- a/mon-pix/app/controllers/recover-account-after-leaving-sco.js
+++ b/mon-pix/app/controllers/recover-account-after-leaving-sco.js
@@ -2,6 +2,15 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+class StudentInformationForAccountRecovery {
+  @tracked firstName = '' ;
+  @tracked lastName = '';
+  @tracked username = '';
+  @tracked email = '';
+  @tracked latestOrganizationName = '';
+
+}
+
 export default class RecoverAccountAfterLeavingScoController extends Controller {
 
   @tracked showRecoverAccountStudentInformationForm = true;
@@ -9,15 +18,21 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
   @tracked showRecoverAccountConfirmationStep = false;
   @tracked showRecoverAccountBackupEmailConfirmationForm = false;
 
-  studentInformationForAccountRecovery;
-  firstName;
+  studentInformationForAccountRecovery = new StudentInformationForAccountRecovery();
+  @tracked firstName;
 
   @action
   async submitStudentInformation(studentInformation) {
     const studentInformationToSave = this.store.createRecord('student-information', studentInformation);
     this.firstName = studentInformation.firstName;
     try {
-      this.studentInformationForAccountRecovery = await studentInformationToSave.submitStudentInformation();
+      const { firstName, lastName, username, email, latestOrganizationName } = await studentInformationToSave.submitStudentInformation();
+      this.studentInformationForAccountRecovery.firstName = firstName;
+      this.studentInformationForAccountRecovery.lastName = lastName;
+      this.studentInformationForAccountRecovery.username = username;
+      this.studentInformationForAccountRecovery.email = email;
+      this.studentInformationForAccountRecovery.latestOrganizationName = latestOrganizationName;
+
       this.showRecoverAccountStudentInformationForm = false;
       this.showRecoverAccountConfirmationStep = true;
     } catch (err) {
@@ -36,6 +51,7 @@ export default class RecoverAccountAfterLeavingScoController extends Controller 
   cancelAccountRecovery() {
     this.showRecoverAccountConfirmationStep = false;
     this.showRecoverAccountStudentInformationForm = true;
+    this.showRecoverAccountBackupEmailConfirmationForm = false;
   }
 
   _handleError(err) {

--- a/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
@@ -15,3 +15,11 @@
     @continueAccountRecoveryBackupEmailConfirmation={{this.continueAccountRecoveryBackupEmailConfirmation}}
   />
 {{/if}}
+
+{{#if this.showRecoverAccountBackupEmailConfirmationForm}}
+<RecoveryAccount::RecoverAccountBackupEmailConfirmationForm
+  @firstName={{this.firstName}}
+  @existingEmail={{this.studentInformationForAccountRecovery.email}}
+  @cancelAccountRecovery={{this.cancelAccountRecovery}}
+/>
+{{/if}}

--- a/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
@@ -12,5 +12,6 @@
   <RecoverAccountConfirmationStep
     @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
     @cancelAccountRecovery={{this.cancelAccountRecovery}}
+    @continueAccountRecoveryBackupEmailConfirmation={{this.continueAccountRecoveryBackupEmailConfirmation}}
   />
 {{/if}}

--- a/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
+++ b/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
@@ -72,7 +72,7 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
         expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.good-news', { firstName }))).to.exist;
       });
 
-      context('click on "Annuler" button', () => {
+      context('click on "Cancel" button', () => {
 
         it('should return to student information form', async function() {
           // given
@@ -185,6 +185,41 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
           // then
           expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-is-needed-message', { firstName }))).to.exist;
           expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.good-news', { firstName }))).to.not.exist;
+        });
+      });
+
+      context('click on "Cancel" button', () => {
+
+        it('should return to student information form', async function() {
+          // given
+          const ineIna = '0123456789A';
+          const lastName = 'Lecol';
+          const firstName = 'Manuela';
+          const dayOfBirth = 20;
+          const monthOfBirth = 5;
+          const yearOfBirth = 2000;
+          const birthdate = '2000-05-20';
+          const username = 'manuela.lecol2005';
+
+          server.create('user', { id: 1, firstName, lastName, username });
+          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
+          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+
+          await visit('/recuperer-mon-compte');
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ineIna);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-day'), dayOfBirth);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-month'), monthOfBirth);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-year'), yearOfBirth);
+          await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
+
+          // when
+          await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.actions.cancel'));
+
+          // then
+          expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-is-needed-message', { firstName }))).to.not.exist;
+          expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.exist;
         });
       });
 

--- a/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
+++ b/mon-pix/tests/acceptance/recover-account-after-leaving-sco_test.js
@@ -150,6 +150,46 @@ describe('Acceptance | RecoverAccountAfterLeavingScoRoute', function() {
         expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.student-information.title'))).to.not.exist;
       });
     });
+
+    context('when confirm student information', () => {
+
+      context('click on "Confirm" button', () => {
+
+        it('should hide recover account confirmation step and show recover account backup email confirmation', async function() {
+          // given
+          const ineIna = '0123456789A';
+          const lastName = 'Lecol';
+          const firstName = 'Manuela';
+          const dayOfBirth = 20;
+          const monthOfBirth = 5;
+          const yearOfBirth = 2000;
+          const birthdate = '2000-05-20';
+          const username = 'manuela.lecol2005';
+
+          server.create('user', { id: 1, firstName, lastName, username });
+          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
+          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+
+          await visit('/recuperer-mon-compte');
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.ine-ina'), ineIna);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.first-name'), firstName);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.last-name'), lastName);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-day'), dayOfBirth);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-month'), monthOfBirth);
+          await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.label.birth-year'), yearOfBirth);
+          await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.student-information.form.submit'));
+
+          // when
+          await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.buttons.confirm'));
+
+          // then
+          expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-is-needed-message', { firstName }))).to.exist;
+          expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.good-news', { firstName }))).to.not.exist;
+        });
+      });
+
+    });
+
   });
 
 });

--- a/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
+++ b/mon-pix/tests/integration/components/recover-account-confirmation-step-test.js
@@ -94,17 +94,17 @@ describe('Integration | Component | recover-account-confirmation-step', function
       latestOrganizationName: 'Collège George-Besse, Loches',
     });
     this.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
-    const continueAccountRecovery = sinon.stub();
-    this.set('continueAccountRecovery', continueAccountRecovery);
+    const continueAccountRecoveryBackupEmailConfirmation = sinon.stub();
+    this.set('continueAccountRecoveryBackupEmailConfirmation', continueAccountRecoveryBackupEmailConfirmation);
 
     // when
     await render(hbs`<RecoverAccountConfirmationStep
       @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
-      @continueAccountRecovery={{this.continueAccountRecovery}}
+      @continueAccountRecoveryBackupEmailConfirmation={{this.continueAccountRecoveryBackupEmailConfirmation}}
     />`);
     await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.confirmation-step.buttons.confirm'));
 
     // then
-    sinon.assert.calledOnce(continueAccountRecovery);
+    sinon.assert.calledOnce(continueAccountRecoveryBackupEmailConfirmation);
   });
 });

--- a/mon-pix/tests/integration/components/recovery-account/recover-account-backup-email-confirmation-form-test.js
+++ b/mon-pix/tests/integration/components/recovery-account/recover-account-backup-email-confirmation-form-test.js
@@ -1,0 +1,105 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { contains } from '../../../helpers/contains';
+import { fillInByLabel } from '../../../helpers/fill-in-by-label';
+import { clickByLabel } from '../../../helpers/click-by-label';
+
+describe('Integration | Component | recovery-account/recover-account-backup-email-confirmation-form', function() {
+  setupIntlRenderingTest();
+
+  const firstName = 'Philippe';
+  const existingEmail = 'philippe@example.net';
+
+  context('when the user already has an email associated with his account', function() {
+
+    it('should render recover account backup email confirmation form with the existing email', async function() {
+      // given
+      this.set('firstName', firstName);
+      this.set('existingEmail', existingEmail);
+
+      // when
+      await render(hbs`<RecoveryAccount::RecoverAccountBackupEmailConfirmationForm @firstName={{this.firstName}} @existingEmail={{this.existingEmail}}/>`);
+
+      // then
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-already-exist-for-account-message'))).to.exist;
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-is-valid-message'))).to.exist;
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-reset-message'))).to.exist;
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.email'))).to.exist;
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.ask-for-new-email-message'))).to.exist;
+
+    });
+
+  });
+
+  context('when the user does not have an email associated with his account', async function() {
+
+    it('should render recover account backup email confirmation form', async function() {
+      // given
+      this.set('firstName', firstName);
+
+      // when
+      await render(hbs`<RecoveryAccount::RecoverAccountBackupEmailConfirmationForm @firstName={{this.firstName}}/>`);
+
+      // then
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-is-needed-message', { firstName }))).to.exist;
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-sent-to-choose-password-message'))).to.exist;
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.email'))).to.exist;
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.email-already-exist-for-account-message'))).to.not.exist;
+
+    });
+
+  });
+
+  context('form validation', () => {
+
+    it('should show an error when email is empty', async function() {
+      // given
+      const email = '';
+
+      await render(hbs`<RecoveryAccount::RecoverAccountBackupEmailConfirmationForm @firstName={{this.firstName}}/>`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.email'), email);
+      await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.actions.submit'));
+
+      // then
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.error.empty-email'))).to.exist;
+
+    });
+
+    it('should show an error when email is not valid', async function() {
+      // given
+      const email = 'Philipe@';
+
+      await render(hbs`<RecoveryAccount::RecoverAccountBackupEmailConfirmationForm @firstName={{this.firstName}}/>`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.email'), email);
+      await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.actions.submit'));
+
+      // then
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.error.wrong-email-format'))).to.exist;
+
+    });
+
+    it('should valid form when email is valid', async function() {
+      // given
+      const email = 'Philipe@example.net';
+      await render(hbs`<RecoveryAccount::RecoverAccountBackupEmailConfirmationForm @firstName={{this.firstName}}/>`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.email'), email);
+      await clickByLabel(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.actions.submit'));
+
+      // then
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.error.wrong-email-format'))).to.not.exist;
+      expect(contains(this.intl.t('pages.recover-account-after-leaving-sco.backup-email-confirmation.form.error.empty-email'))).to.not.exist;
+
+    });
+
+  });
+
+});

--- a/mon-pix/tests/unit/controllers/recover-account-after-leaving-sco-test.js
+++ b/mon-pix/tests/unit/controllers/recover-account-after-leaving-sco-test.js
@@ -68,4 +68,27 @@ describe('Unit | Controller | recover-account-after-leaving-sco', function() {
       });
     });
   });
+
+  context('#continueAccountRecoveryBackupEmailConfirmation', () => {
+
+    context('when confirm recover account student information form', function() {
+
+      it('should show recovery account backup email confirmation', async function() {
+        // given
+        const controller = this.owner.lookup('controller:recover-account-after-leaving-sco');
+        controller.showRecoverAccountStudentInformationForm = true;
+
+        // when
+        await controller.continueAccountRecoveryBackupEmailConfirmation();
+
+        // then
+        expect(controller.showRecoverAccountStudentInformationForm).to.be.false;
+        expect(controller.showRecoverAccountConfirmationStep).to.be.false;
+        expect(controller.showRecoverAccountBackupEmailConfirmationForm).to.be.true;
+
+      });
+
+    });
+  });
+
 });

--- a/mon-pix/tests/unit/controllers/recover-account-after-leaving-sco-test.js
+++ b/mon-pix/tests/unit/controllers/recover-account-after-leaving-sco-test.js
@@ -54,7 +54,8 @@ describe('Unit | Controller | recover-account-after-leaving-sco', function() {
           // given
           const controller = this.owner.lookup('controller:recover-account-after-leaving-sco');
           const studentInformation = { firstName: 'Jules' };
-          const submitStudentInformationStub = sinon.stub().resolves();
+          const submitStudentInformationStub = sinon.stub().resolves({});
+
           const store = { createRecord: sinon.stub().returns({ submitStudentInformation: submitStudentInformationStub }) };
           controller.set('store', store);
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -979,6 +979,32 @@
           "cancel":"Annuler",
           "confirm": "Je confirme"
         }
+      },
+      "backup-email-confirmation": {
+        "email-is-needed-message": "{ firstName } , nous avons besoin de votre adresse e-mail",
+        "email-sent-to-choose-password-message": "Nous vous enverrons un e-mail afin de choisir un mot de passe.",
+        "email-already-exist-for-account-message": "L’adresse e-mail ci-dessous est déjà associée à votre compte :",
+        "email-is-valid-message": "Si elle est valide,",
+        "email-reset-message": "réinitialisez votre mot de passe",
+        "ask-for-new-email-message": "sinon fournissez en une nouvelle",
+        "form": {
+          "email": "Votre adresse e-mail",
+          "actions": {
+            "submit": "C'est partix",
+            "cancel": "Annuler"
+          },
+          "error":  {
+            "empty-email": "le champ email est obligatoire",
+            "wrong-email-format": "Votre adresse e-mail n’est pas valide.",
+            "email-already-exist": {
+              "existing-email": "Vous possédez déjà cette adresse e-mail. Si elle est valide,",
+              "init-password":" réinitialisez votre mot de passe",
+              "new-email": ", sinon saisissez une nouvelle."
+            },
+            "new-backup-email": "Veuillez saisir un e-mail valide pour récupérer votre compte",
+            "new-email-already-exist": "Cette adresse e-mail est déjà utilisée"
+          }
+        }
       }
     },
     "result-item": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -979,6 +979,32 @@
           "cancel":"Annuler",
           "confirm": "Je confirme"
         }
+      },
+      "backup-email-confirmation": {
+        "email-is-needed-message": "{ firstName } , nous avons besoin de votre adresse e-mail",
+        "email-sent-to-choose-password-message": "Nous vous enverrons un e-mail afin de choisir un mot de passe.",
+        "email-already-exist-for-account-message": "L’adresse e-mail ci-dessous est déjà associée à votre compte :",
+        "email-is-valid-message": "Si elle est valide,",
+        "email-reset-message": "réinitialisez votre mot de passe",
+        "ask-for-new-email-message": "sinon fournissez en une nouvelle",
+        "form": {
+          "email": "Votre adresse e-mail",
+          "actions": {
+            "submit": "C'est partix",
+            "cancel": "Annuler"
+          },
+          "error":  {
+            "empty-email": "le champ email est obligatoire.",
+            "wrong-email-format": "Votre adresse e-mail n’est pas valide.",
+            "email-already-exist": {
+              "existing-email": "Vous possédez déjà cette adresse e-mail. Si elle est valide,",
+              "init-password":" réinitialisez votre mot de passe",
+              "new-email": ", sinon saisissez une nouvelle."
+            },
+            "new-backup-email": "Veuillez saisir un e-mail valide pour récupérer votre compte",
+            "new-email-already-exist": "Cette adresse e-mail est déjà utilisée"
+          }
+        }
       }
     },
     "result-item": {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la sortie SCO, il faut permettre à l'utilisateur de récupérer son compte Pix.

Actuellement le formulaire permettant de fournir les informations nécessaire à la récupération de compte est implémenté (mais soumis à feature toggle, donc désactivé en PROD).

Une fois ce formulaire soumis, il faudrait pouvoir indiquer à l'utilisateur quel compte a été trouvé avec les informations saisies. Quand les informations sont confirmées, ce dernier doit être redirigé vers un formulaire d'envoi de mail afin de récupérer son compte. Ce formulaire n'est pas encore implémentée.

## :robot: Solution
Avoir un formulaire de recovery de mail pour les deux cas figures suivantes:
- Un utilisateur avec un mail déjà existant: Afficher le mail trouvé et l'inciter à réinitialiser son mot de passe si son mail est valide.
- Un utilisateur qui ne dispose pas de mail: Afficher un formulaire qui l'incite seulement à saisir son mail de backup.

## :rainbow: Remarques
Un dossier recovery-account a été crée pour avoir une organisation fonctionnelle par page et avoir un accès rapide aux composants.
Cette partie a besoin de l'implémentation de l'api d'envoi mail qui sera fait dans un prochain ticket.
Cette PR concerne développement du composant du formulaire de backup et de la validation des champs et de son intégration dans le parcours de récupération de compte.

## :100: Pour tester

Lancer l'api avec IS_SCO_ACCOUNT_RECOVERY_ENABLED=true npm start -- --watch .
Lancer mon-pix:

Aller sur [/recuperer-mon-compte](https://app-pr3155.review.pix.fr/recuperer-mon-compte) - RA

##

**Utilisateur sans  adresse e-mail :**

Ine/Ina : 123456789BB
Prénom : George
Nom : De Cambridge
Date de naissance : 22/07/2013

Cliquer sur le bouton
Constater qu'on nous affiche bien une page avec les informations de compte de George et un bouton "Annuler" et "Confirmer"
Cliquer sur confirmer et vérifier qu'on a bien l'écran de récupération de mail de backup.

##

**Utilisateur avec adresse e-mail :** 

Ine/Ina : 123456789DD
Prénom : Lyanna
Nom : Mormont
Date de naissance : 07/01/2002

Vérifier que le lien redirige bien sur la réinitialisation de mot de passe.