### PR TITLE
[TECH] Supprimer les mixins d'Ember-simple-auth 3.1.0 dans Pix Orga (PIX-2767).

### DIFF
--- a/orga/app/adapters/application.js
+++ b/orga/app/adapters/application.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-mixins
-import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { inject as service } from '@ember/service';
 import ENV from 'pix-orga/config/environment';
@@ -8,10 +6,12 @@ const FRENCH_DOMAIN_EXTENSION = 'fr';
 const FRENCH_LOCALE = 'fr-fr';
 const FRENCHSPOKEN_LOCALE = 'fr';
 
-export default class ApplicationAdapter extends JSONAPIAdapter.extend(DataAdapterMixin) {
-  @service currentDomain;
+export default class ApplicationAdapter extends JSONAPIAdapter {
+
   @service ajaxQueue;
+  @service currentDomain;
   @service intl;
+  @service session;
 
   host = ENV.APP.API_HOST;
   namespace = 'api';

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -1,87 +1,14 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import get from 'lodash/get';
-// eslint-disable-next-line ember/no-mixins
-import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
-const DEFAULT_FRENCH_LOCALE = 'fr';
+export default class ApplicationRoute extends Route {
 
-export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin) {
-
-  routeAfterAuthentication = 'authenticated';
-
-  //@service currentDomain;
-  @service currentUser;
   @service featureToggles;
-  @service intl;
-  @service moment;
-  @service url;
+  @service session;
 
   async beforeModel(transition) {
     await this.featureToggles.load();
     const lang = transition.to.queryParams.lang;
-    return this._getUserAndLocale(lang);
-  }
-
-  async sessionAuthenticated() {
-    await this._getUserAndLocale();
-    this.transitionTo(this.routeAfterAuthentication);
-  }
-
-  sessionInvalidated() {
-    const redirectionUrl = this._redirectionUrl();
-    this._clearStateAndRedirect(redirectionUrl);
-  }
-
-  async _getUserAndLocale(lang = null) {
-    await this._loadCurrentUser();
-    await this._updatePrescriberLanguage(lang);
-    this._setLocale(lang);
-  }
-
-  async _updatePrescriberLanguage(lang) {
-    const prescriber = this.currentUser.prescriber;
-    if (!prescriber || !lang) return;
-    if (prescriber.lang === lang) return;
-
-    try {
-      prescriber.lang = lang;
-      await prescriber.save({ adapterOptions: { lang } });
-    } catch (error) {
-      const status = get(error, 'errors[0].status');
-      if (status === '400') {
-        prescriber.rollbackAttributes();
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  _setLocale(lang) {
-    let locale = DEFAULT_FRENCH_LOCALE;
-
-    if (!this.url.isFrenchDomainExtension) {
-      locale = this.intl.get('locales').includes(lang)
-        ? lang
-        : DEFAULT_FRENCH_LOCALE;
-    }
-
-    this.intl.setLocale([locale, DEFAULT_FRENCH_LOCALE]);
-    this.moment.setLocale(locale);
-  }
-
-  _redirectionUrl() {
-    const alternativeRootURL = this.session.alternativeRootURL;
-    this.session.alternativeRootURL = null;
-
-    return alternativeRootURL ? alternativeRootURL : this.url.homeUrl;
-  }
-
-  _clearStateAndRedirect(url) {
-    return window.location.replace(url);
-  }
-
-  _loadCurrentUser() {
-    return this.currentUser.load();
+    return this.session.handlePrescriberLanguageAndLocale(lang);
   }
 }

--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -1,19 +1,23 @@
-// eslint-disable-next-line ember/no-mixins
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import get from 'lodash/get';
 
-export default class AuthenticatedRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class AuthenticatedRoute extends Route {
 
   @service currentUser;
+  @service router;
+  @service session;
 
   beforeModel(transition) {
-    super.beforeModel(...arguments);
+    this.session.requireAuthentication(transition, 'login');
+
     if (transition.isAborted) {
       return;
     }
-    if (!this.currentUser.prescriber.pixOrgaTermsOfServiceAccepted) {
-      return this.replaceWith('terms-of-service');
+
+    const pixOrgaTermsOfServiceAccepted = get(this.currentUser, 'prescriber.pixOrgaTermsOfServiceAccepted');
+    if (!pixOrgaTermsOfServiceAccepted) {
+      return this.router.replaceWith('terms-of-service');
     }
   }
 }

--- a/orga/app/routes/join-when-authenticated.js
+++ b/orga/app/routes/join-when-authenticated.js
@@ -1,14 +1,12 @@
-// eslint-disable-next-line ember/no-mixins
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default class JoinWhenAuthenticatedRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class JoinWhenAuthenticatedRoute extends Route {
 
   @service session;
 
   beforeModel(transition) {
-    super.beforeModel(...arguments);
+    this.session.requireAuthentication(transition, 'login');
 
     const { queryParams } = transition.to;
     const alternativeRootURL = transition.router.generate('join', { queryParams });
@@ -16,5 +14,4 @@ export default class JoinWhenAuthenticatedRoute extends Route.extend(Authenticat
     this.session.alternativeRootURL = alternativeRootURL;
     this.session.invalidate();
   }
-
 }

--- a/orga/app/routes/join.js
+++ b/orga/app/routes/join.js
@@ -1,10 +1,16 @@
-// eslint-disable-next-line ember/no-mixins
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class JoinRoute extends Route.extend(UnauthenticatedRouteMixin) {
+export default class JoinRoute extends Route {
+
+  @service router;
+  @service session;
 
   routeIfAlreadyAuthenticated = 'join-when-authenticated';
+
+  beforeModel() {
+    this.session.prohibitAuthentication(this.routeIfAlreadyAuthenticated);
+  }
 
   model(params) {
     return this.store.queryRecord('organization-invitation', {
@@ -13,10 +19,10 @@ export default class JoinRoute extends Route.extend(UnauthenticatedRouteMixin) {
     }).catch((errorResponse) => {
       errorResponse.errors.forEach((error) => {
         if (error.status === '412') {
-          this.replaceWith('login', { queryParams: { hasInvitationError: true } });
+          this.router.replaceWith('login', { queryParams: { hasInvitationError: true } });
         }
       });
-      this.replaceWith('login');
+      this.router.replaceWith('login');
     });
   }
 }

--- a/orga/app/routes/login.js
+++ b/orga/app/routes/login.js
@@ -1,8 +1,11 @@
-// eslint-disable-next-line ember/no-mixins
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) {
+export default class LoginRoute extends Route {
 
-  routeIfAlreadyAuthenticated = 'authenticated';
+  @service session;
+
+  beforeModel() {
+    this.session.prohibitAuthentication('authenticated');
+  }
 }

--- a/orga/app/routes/logout.js
+++ b/orga/app/routes/logout.js
@@ -6,7 +6,6 @@ export default class LogoutRoute extends Route {
   @service session;
 
   beforeModel() {
-    super.beforeModel(...arguments);
     if (this.session.isAuthenticated) {
       this.session.invalidate();
     }

--- a/orga/app/routes/not-found.js
+++ b/orga/app/routes/not-found.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class NotFoundRoute extends Route {
 
+  @service router;
+
   afterModel() {
-    this.transitionTo('application');
+    this.router.transitionTo('application');
   }
 }

--- a/orga/app/routes/terms-of-service.js
+++ b/orga/app/routes/terms-of-service.js
@@ -1,20 +1,23 @@
-// eslint-disable-next-line ember/no-mixins
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import get from 'lodash/get';
 
-export default class TermsOfServiceRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class TermsOfServiceRoute extends Route {
 
   @service currentUser;
+  @service router;
+  @service session;
 
   beforeModel(transition) {
-    super.beforeModel(...arguments);
+    this.session.requireAuthentication(transition, 'login');
+
     if (transition.isAborted) {
       return;
     }
-    if (this.currentUser.prescriber.pixOrgaTermsOfServiceAccepted) {
-      return this.replaceWith('');
+
+    const pixOrgaTermsOfServiceAccepted = get(this.currentUser, 'prescriber.pixOrgaTermsOfServiceAccepted');
+    if (pixOrgaTermsOfServiceAccepted) {
+      return this.router.replaceWith('');
     }
   }
-
 }

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -1,0 +1,69 @@
+import { inject as service } from '@ember/service';
+import SessionService from 'ember-simple-auth/services/session';
+import get from 'lodash/get';
+
+const DEFAULT_FRENCH_LOCALE = 'fr';
+
+export default class CurrentSessionService extends SessionService {
+
+  @service currentUser;
+  @service intl;
+  @service moment;
+  @service url;
+
+  routeAfterAuthentication = 'authenticated';
+
+  async handleAuthentication() {
+    await this.handlePrescriberLanguageAndLocale();
+    super.handleAuthentication(this.routeAfterAuthentication);
+  }
+
+  async handleInvalidation() {
+    const routeAfterInvalidation = this._getRouteAfterInvalidation();
+    await super.handleInvalidation(routeAfterInvalidation);
+  }
+
+  async handlePrescriberLanguageAndLocale(lang = null) {
+    await this.currentUser.load();
+    await this._updatePrescriberLanguage(lang);
+    this._setLocale(lang);
+  }
+
+  async _updatePrescriberLanguage(lang) {
+    const prescriber = this.currentUser.prescriber;
+
+    if (!prescriber || !lang || prescriber.lang === lang) return;
+
+    try {
+      prescriber.lang = lang;
+      await prescriber.save({ adapterOptions: { lang } });
+    } catch (error) {
+      const status = get(error, 'errors[0].status');
+      if (status === '400') {
+        prescriber.rollbackAttributes();
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  _setLocale(lang) {
+    let locale = DEFAULT_FRENCH_LOCALE;
+
+    if (!this.url.isFrenchDomainExtension) {
+      locale = this.intl.get('locales').includes(lang)
+        ? lang
+        : DEFAULT_FRENCH_LOCALE;
+    }
+
+    this.intl.setLocale([locale, DEFAULT_FRENCH_LOCALE]);
+    this.moment.setLocale(locale);
+  }
+
+  _getRouteAfterInvalidation() {
+    const alternativeRootURL = this.alternativeRootURL;
+    this.alternativeRootURL = null;
+
+    return alternativeRootURL ? alternativeRootURL : this.url.homeUrl;
+  }
+}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -17,7 +17,7 @@ function parseQueryString(queryString) {
 
 /* eslint ember/no-get: off */
 export default function() {
-
+  this.logging = true;
   this.urlPrefix = 'http://localhost:3000';
   this.namespace = 'api';
   this.timing = 0;
@@ -107,7 +107,6 @@ export default function() {
     if (!organizationInvitationCode) {
       return new Response(400, {}, { errors: [ { status: '400', detail: '' } ] });
     }
-
     const organizationInvitation = schema.organizationInvitations.findBy({ id: organizationInvitationId, code: organizationInvitationCode });
     if (!organizationInvitation) {
       return new Response(404, {}, { errors: [ { status: '404', detail: '' } ] });

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -9605,39 +9605,6 @@
         }
       }
     },
-    "broccoli-concat": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-3.7.5.tgz",
-      "integrity": "sha512-rDs1Mej3Ej0Cy5yIO9oIQq5+BCv0opAwS2NW7M0BeCsAMeFM42Z/zacDUC6jKc5OV5wiHvGTyCPLnZkMe0h6kQ==",
-      "dev": true,
-      "requires": {
-        "broccoli-debug": "^0.6.5",
-        "broccoli-kitchen-sink-helpers": "^0.3.1",
-        "broccoli-plugin": "^1.3.0",
-        "ensure-posix-path": "^1.0.2",
-        "fast-sourcemap-concat": "^1.4.0",
-        "find-index": "^1.1.0",
-        "fs-extra": "^4.0.3",
-        "fs-tree-diff": "^0.5.7",
-        "lodash.merge": "^4.6.2",
-        "lodash.omit": "^4.1.0",
-        "lodash.uniq": "^4.2.0",
-        "walk-sync": "^0.3.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        }
-      }
-    },
     "broccoli-config-loader": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-config-loader/-/broccoli-config-loader-1.0.1.tgz",
@@ -17057,9 +17024,9 @@
       }
     },
     "ember-cookies": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.4.0.tgz",
-      "integrity": "sha512-KXFxmaxEMlSqYQdyAaM/Rs84PxBJCqBQEPkLqhBStC9LwEovUSTEXzhd3FHVbMHch/THI4JzjoYEsj4CrdxVgQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.1.0",
@@ -19111,68 +19078,21 @@
       }
     },
     "ember-simple-auth": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-1.9.2.tgz",
-      "integrity": "sha512-WTG2uGe8+TIfwsy5eaS7uIszEmyQ/pjKLUMjyq6YYkU9d9erSXVRiuO4h46OxTEbVI3c17mjAu/4kTxc+BOFZw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-3.1.0.tgz",
+      "integrity": "sha512-JS8NtYAlSftkoQh36Kxps6iLHTP/InIgKt8w21QBHCTqDx07af4aka59GojaBvc+8GubQuGKldk6vvw3R8bwxA==",
       "dev": true,
       "requires": {
         "base-64": "^0.1.0",
         "broccoli-file-creator": "^2.0.0",
         "broccoli-funnel": "^1.2.0 || ^2.0.0",
         "broccoli-merge-trees": "^2.0.0 || ^3.0.0",
-        "ember-cli-babel": "^6.8.2",
+        "ember-cli-babel": "^7.20.5",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.3.0 || ^0.4.0",
-        "ember-fetch": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0",
+        "ember-cookies": "^0.5.0",
         "silent-error": "^1.0.0"
       },
       "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          }
-        },
         "broccoli-file-creator": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
@@ -19181,272 +19101,6 @@
           "requires": {
             "broccoli-plugin": "^1.1.0",
             "mkdirp": "^0.5.1"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
-            }
-          }
-        },
-        "broccoli-stew": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-2.1.0.tgz",
-          "integrity": "sha512-tgCkuTWYl4uf7k7ib2D79KFEj2hCgnTUNPMnrCoAha0/4bywcNccmaZVWtL9Ex37yX5h5eAbnM/ak2ULoMwSSw==",
-          "dev": true,
-          "requires": {
-            "broccoli-debug": "^0.6.5",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-merge-trees": "^3.0.1",
-            "broccoli-persistent-filter": "^2.1.1",
-            "broccoli-plugin": "^1.3.1",
-            "chalk": "^2.4.1",
-            "debug": "^3.1.0",
-            "ensure-posix-path": "^1.0.1",
-            "fs-extra": "^6.0.1",
-            "minimatch": "^3.0.4",
-            "resolve": "^1.8.1",
-            "rsvp": "^4.8.4",
-            "symlink-or-copy": "^1.2.0",
-            "walk-sync": "^0.3.3"
-          },
-          "dependencies": {
-            "broccoli-merge-trees": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-              "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-              "dev": true,
-              "requires": {
-                "broccoli-plugin": "^1.3.0",
-                "merge-trees": "^2.0.0"
-              }
-            },
-            "broccoli-persistent-filter": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-              "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-              "dev": true,
-              "requires": {
-                "async-disk-cache": "^1.2.1",
-                "async-promise-queue": "^1.0.3",
-                "broccoli-plugin": "^1.0.0",
-                "fs-tree-diff": "^2.0.0",
-                "hash-for-dep": "^1.5.0",
-                "heimdalljs": "^0.2.1",
-                "heimdalljs-logger": "^0.1.7",
-                "mkdirp": "^0.5.1",
-                "promise-map-series": "^0.2.1",
-                "rimraf": "^2.6.1",
-                "rsvp": "^4.7.0",
-                "symlink-or-copy": "^1.0.1",
-                "sync-disk-cache": "^1.3.3",
-                "walk-sync": "^1.0.0"
-              },
-              "dependencies": {
-                "walk-sync": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-                  "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-                  "dev": true,
-                  "requires": {
-                    "@types/minimatch": "^3.0.3",
-                    "ensure-posix-path": "^1.1.0",
-                    "matcher-collection": "^1.1.1"
-                  }
-                }
-              }
-            },
-            "fs-tree-diff": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-              "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-              "dev": true,
-              "requires": {
-                "@types/symlink-or-copy": "^1.2.0",
-                "heimdalljs-logger": "^0.1.7",
-                "object-assign": "^4.1.0",
-                "path-posix": "^1.0.0",
-                "symlink-or-copy": "^1.1.8"
-              }
-            }
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "ember-fetch": {
-          "version": "6.7.2",
-          "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-6.7.2.tgz",
-          "integrity": "sha512-+Dd++MJVkCXoqX2DPtFDjuoDMcLk+7fphLq7D8OoXwJq9KQMTff07sH18qhxWXV5Hqknvz3Uwy214g54vOboag==",
-          "dev": true,
-          "requires": {
-            "abortcontroller-polyfill": "^1.3.0",
-            "broccoli-concat": "^3.2.2",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-merge-trees": "^3.0.0",
-            "broccoli-rollup": "^2.1.1",
-            "broccoli-stew": "^2.1.0",
-            "broccoli-templater": "^2.0.1",
-            "calculate-cache-key-for-tree": "^2.0.0",
-            "caniuse-api": "^3.0.0",
-            "ember-cli-babel": "^6.8.2",
-            "node-fetch": "^2.6.0",
-            "whatwg-fetch": "^3.0.0"
-          },
-          "dependencies": {
-            "broccoli-merge-trees": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-              "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-              "dev": true,
-              "requires": {
-                "broccoli-plugin": "^1.3.0",
-                "merge-trees": "^2.0.0"
-              }
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "merge-trees": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
-          "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
-          "dev": true,
-          "requires": {
-            "fs-updater": "^1.0.4",
-            "heimdalljs": "^0.2.5"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
           }
         }
       }
@@ -22105,7 +21759,8 @@
     "globalyzer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
     },
     "globby": {
       "version": "10.0.0",
@@ -22134,7 +21789,8 @@
     "globrex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "good-listener": {
       "version": "1.2.2",
@@ -24767,7 +24423,8 @@
     "node-watch": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.1.tgz",
-      "integrity": "sha512-UWblPYuZYrkCQCW5PxAwYSxaELNBLUckrTBBk8xr1/bUgyOkYYTsUcV4e3ytcazFEOyiRyiUrsG37pu6I0I05g=="
+      "integrity": "sha512-UWblPYuZYrkCQCW5PxAwYSxaELNBLUckrTBBk8xr1/bUgyOkYYTsUcV4e3ytcazFEOyiRyiUrsG37pu6I0I05g==",
+      "dev": true
     },
     "nomnom": {
       "version": "1.8.1",
@@ -26371,6 +26028,7 @@
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.16.0.tgz",
       "integrity": "sha512-88x9t+rRMbB6IrCIUZvYU4pJy7NiBEv7SX8jD4LZAsIj+dV+kwGnFStOmPNvqa6HM96VZMD8CIIFKH2+3qvluA==",
+      "dev": true,
       "requires": {
         "commander": "7.1.0",
         "node-watch": "0.7.1",
@@ -26380,7 +26038,8 @@
         "commander": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
-          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg=="
+          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==",
+          "dev": true
         }
       }
     },
@@ -28883,6 +28542,7 @@
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
       "integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
+      "dev": true,
       "requires": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
@@ -29793,12 +29453,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -80,7 +80,7 @@
     "ember-page-title": "^6.2.1",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
-    "ember-simple-auth": "^1.9.2",
+    "ember-simple-auth": "^3.1.0",
     "ember-sinon": "^5.0.0",
     "ember-source": "~3.23.1",
     "ember-template-lint": "^2.14.0",

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -20,10 +20,10 @@ module('Acceptance | join', function(hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
-  let loginOrRegisterButton;
+  let loginFormButton;
 
   hooks.beforeEach(function() {
-    loginOrRegisterButton = this.intl.t('pages.login-or-register.login-form.button');
+    loginFormButton = this.intl.t('pages.login-or-register.login-form.button');
   });
 
   module('When prescriber tries to go on join page', function() {
@@ -107,7 +107,7 @@ module('Acceptance | join', function(hooks) {
       test('it should redirect user to the terms-of-service page', async function(assert) {
         // given
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel(loginOrRegisterButton);
+        await clickByLabel(loginFormButton);
         await fillInByLabel(emailInputLabel, user.email);
         await fillInByLabel(passwordInputLabel, 'secret');
 
@@ -124,7 +124,7 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel(loginOrRegisterButton);
+        await clickByLabel(loginFormButton);
         await fillInByLabel(emailInputLabel, user.email);
         await fillInByLabel(passwordInputLabel, 'secret');
 
@@ -162,7 +162,7 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel(loginOrRegisterButton);
+        await clickByLabel(loginFormButton);
         await fillInByLabel(emailInputLabel, user.email);
         await fillInByLabel(passwordInputLabel, 'secret');
 
@@ -179,7 +179,7 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel(loginOrRegisterButton);
+        await clickByLabel(loginFormButton);
         await fillInByLabel(emailInputLabel, user.email);
         await fillInByLabel(passwordInputLabel, 'secret');
 
@@ -195,13 +195,15 @@ module('Acceptance | join', function(hooks) {
 
     module('When prescriber is logging in but his credentials are invalid', function(hooks) {
 
+      const code = 'ABCDEFGH01';
+
       let user;
       let organizationInvitationId;
-      let code;
 
       hooks.beforeEach(() => {
         user = createUserWithMembership();
-        code = 'ABCDEFGH01';
+        server.create('prescriber', { id: user.id });
+
         const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
         organizationInvitationId = server.create('organizationInvitation', {
           organizationId, email: 'random@email.com', status: 'pending', code,
@@ -211,12 +213,13 @@ module('Acceptance | join', function(hooks) {
       test('it should remain on join page', async function(assert) {
         // given
         const expectedErrorMessage = this.intl.t('pages.login-form.errors.status.401');
+
         server.post('/token', {
           errors: [{ status: '401' }],
         }, 401);
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel(loginOrRegisterButton);
+        await clickByLabel(loginFormButton);
         await fillInByLabel(emailInputLabel, user.email);
         await fillInByLabel(passwordInputLabel, 'fakepassword');
 
@@ -226,8 +229,7 @@ module('Acceptance | join', function(hooks) {
         // then
         assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
-        assert.dom('#login-form-error-message')
-          .hasText(expectedErrorMessage);
+        assert.contains(expectedErrorMessage);
       });
     });
 
@@ -258,7 +260,7 @@ module('Acceptance | join', function(hooks) {
           }],
         }, 412);
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel(loginOrRegisterButton);
+        await clickByLabel(loginFormButton);
         await fillInByLabel(emailInputLabel, user.email);
         await fillInByLabel(passwordInputLabel, 'secret');
 

--- a/orga/tests/integration/components/routes/login-form_test.js
+++ b/orga/tests/integration/components/routes/login-form_test.js
@@ -123,7 +123,9 @@ module('Integration | Component | routes/login-form', function(hooks) {
     // given
     const expectedErrorMessages = this.intl.t('pages.login-form.errors.status.401');
     const errorResponse = {
-      errors: [{ status: '401' }],
+      responseJSON: {
+        errors: [{ status: '401' }],
+      },
     };
 
     SessionStub.prototype.authenticate = () => reject(errorResponse);
@@ -144,7 +146,9 @@ module('Integration | Component | routes/login-form', function(hooks) {
     // given
     const expectedErrorMessages = this.intl.t('pages.login-form.errors.status.403');
     const errorResponse = {
-      errors: [{ status: '403' }],
+      responseJSON: {
+        errors: [{ status: '403' }],
+      },
     };
 
     SessionStub.prototype.authenticate = () => reject(errorResponse);

--- a/orga/tests/unit/routes/application_test.js
+++ b/orga/tests/unit/routes/application_test.js
@@ -1,344 +1,52 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import Service from '@ember/service';
 import sinon from 'sinon';
 
 module('Unit | Route | application', function(hooks) {
 
   setupTest(hooks);
 
-  let prescriber;
-  let store;
+  module('beforeModel', function() {
 
-  hooks.beforeEach(function() {
-    store = this.owner.lookup('service:store');
-
-    prescriber = store.createRecord('prescriber', { id: 1, lang: 'en' });
-    prescriber.save = sinon.stub();
-    prescriber.rollbackAttributes = sinon.stub();
-  });
-
-  module('sessionAuthenticated', function() {
-
-    test('should set locale to default french locale if lang parameter is not exist', async function(assert) {
-      // given
-      prescriber.save.resolves();
-      const currentUser = Service.create({
-        load: sinon.stub(),
-        prescriber,
-      });
-      currentUser.load.resolves(prescriber);
-
-      const urlStub = Service.create({
-        isFrenchDomainExtension: false,
-      });
-      const intlStub = Service.create({
-        setLocale: sinon.stub(),
-        get: sinon.stub(),
-      });
-      intlStub.get.withArgs('locales').returns(['en', 'fr']);
-      const momentStub = Service.create({
-        setLocale: sinon.stub(),
-      });
-
-      const route = this.owner.lookup('route:application');
-      route.set('transitionTo', sinon.stub());
-      route.set('currentUser', currentUser);
-      route.set('url', urlStub);
-      route.set('intl', intlStub);
-      route.set('moment', momentStub);
-
-      // when
-      await route.sessionAuthenticated();
-
-      // then
-      assert.ok(route.intl.setLocale.calledWith(['fr', 'fr']));
-      assert.ok(route.moment.setLocale.calledWith('fr'));
-    });
-
-    test('it should load current user', async function(assert) {
-      // given
-      prescriber.save.resolves();
-      const currentUser = Service.create({
-        load: sinon.stub(),
-        prescriber,
-      });
-      currentUser.load.resolves(prescriber);
-
-      const route = this.owner.lookup('route:application');
-      route.set('transitionTo', sinon.stub());
-      route.set('currentUser', currentUser);
-
-      // when
-      await route.sessionAuthenticated();
-
-      // then
-      assert.ok(route.currentUser.load.called);
-    });
-
-    test('it should transition to "routeAfterAuthenticated"', async function(assert) {
-      // given
-      prescriber.save.resolves();
-      const currentUser = Service.create({
-        load: sinon.stub(),
-        prescriber,
-      });
-      currentUser.load.resolves(prescriber);
-
-      const route = this.owner.lookup('route:application');
-      route.set('transitionTo', sinon.stub());
-      route.set('currentUser', currentUser);
-      route.routeAfterAuthentication = 'some route';
-
-      // when
-      await route.sessionAuthenticated();
-
-      // then
-      assert.ok(route.transitionTo.calledWith('some route'));
-    });
-  });
-
-  module('beforeModel', function(hooks) {
-
-    hooks.beforeEach(function() {
-      class FeatureTogglesMock extends Service {
-        load = sinon.stub();
-      }
-      this.owner.register('service:feature-toggles', FeatureTogglesMock);
-    });
-
-    module('Setting prescriber lang', function() {
-
-      module('When lang param exist', function() {
-
-        test('should update prescriber if lang param is different from prescriber lang', async function(assert) {
-          // given
-          const transition = { to: { queryParams: { lang: 'fr' } } };
-
-          prescriber.save.resolves();
-          const currentUser = Service.create({
-            load: sinon.stub(),
-            prescriber,
-          });
-          currentUser.load.resolves(prescriber);
-
-          const route = this.owner.lookup('route:application');
-          route.set('currentUser', currentUser);
-
-          // when
-          await route.beforeModel(transition);
-
-          // then
-          assert.ok(
-            route.currentUser.prescriber.save.calledWith({ adapterOptions: { lang: 'fr' } }),
-          );
-          assert.equal(route.currentUser.prescriber.lang, 'fr');
-        });
-
-        test('should not update prescriber if lang param is the same as the prescriber lang', async function(assert) {
-          // given
-          const transition = { to: { queryParams: { lang: 'en' } } };
-
-          prescriber.save.resolves();
-          const currentUser = Service.create({
-            load: sinon.stub(),
-            prescriber,
-          });
-          currentUser.load.resolves(prescriber);
-
-          const route = this.owner.lookup('route:application');
-          route.set('currentUser', currentUser);
-
-          // when
-          await route.beforeModel(transition);
-
-          // then
-          assert.notOk(route.currentUser.prescriber.save.called);
-          assert.equal(route.currentUser.prescriber.lang, 'en');
-        });
-
-        test('should call rollback prescriber attributes if update return error with http status 400', async function(assert) {
-          // given
-          const transition = { to: { queryParams: { lang: 'wrongLanguage' } } };
-
-          const error = {
-            errors: [{ status: '400' }],
-          };
-          prescriber.save.rejects(error);
-          prescriber.rollbackAttributes.resolves();
-          const currentUser = Service.create({
-            load: sinon.stub(),
-            prescriber,
-          });
-          currentUser.load.resolves(prescriber);
-
-          const route = this.owner.lookup('route:application');
-          route.set('currentUser', currentUser);
-
-          // when
-          await route.beforeModel(transition);
-
-          // then
-          assert.ok(route.currentUser.prescriber.rollbackAttributes.called);
-        });
-      });
-    });
-
-    module('Setting locale', function() {
-
-      test('should set locale to fr if domain extension is fr', async function(assert) {
-        // given
-        const transition = { to: { queryParams: { lang: 'en' } } };
-
-        prescriber.save.resolves();
-        const currentUser = Service.create({
-          load: sinon.stub(),
-          prescriber,
-        });
-        currentUser.load.resolves(prescriber);
-
-        const urlStub = Service.create({
-          isFrenchDomainExtension: true,
-        });
-
-        const intlStub = Service.create({
-          setLocale: sinon.stub(),
-        });
-        const momentStub = Service.create({
-          setLocale: sinon.stub(),
-        });
-
-        const route = this.owner.lookup('route:application');
-        route.set('currentUser', currentUser);
-        route.set('url', urlStub);
-        route.set('intl', intlStub);
-        route.set('moment', momentStub);
-
-        // when
-        await route.beforeModel(transition);
-
-        // then
-        assert.ok(route.intl.setLocale.calledWith(['fr', 'fr']));
-        assert.ok(route.moment.setLocale.calledWith('fr'));
-      });
-
-      test('should set locale to lang parameter if domain extension is not fr and lang is included into intl locales', async function(assert) {
-        // given
-        const transition = { to: { queryParams: { lang: 'en' } } };
-
-        prescriber.lang = undefined;
-        const currentUser = Service.create({
-          load: sinon.stub(),
-          prescriber,
-        });
-        currentUser.load.resolves(prescriber);
-
-        const urlStub = Service.create({
-          isFrenchDomainExtension: false,
-        });
-
-        const intlStub = Service.create({
-          setLocale: sinon.stub(),
-          get: sinon.stub(),
-        });
-        intlStub.get.withArgs('locales').returns(['en', 'fr']);
-        const momentStub = Service.create({
-          setLocale: sinon.stub(),
-        });
-
-        const route = this.owner.lookup('route:application');
-        route.set('currentUser', currentUser);
-        route.set('url', urlStub);
-        route.set('intl', intlStub);
-        route.set('moment', momentStub);
-
-        // when
-        await route.beforeModel(transition);
-
-        // then
-        assert.ok(route.intl.setLocale.calledWith(['en', 'fr']));
-        assert.ok(route.moment.setLocale.calledWith('en'));
-      });
-
-      test('should set locale to fr if domain extension is not fr and lang parameter is not included into intl locales', async function(assert) {
-        // given
-        const transition = { to: { queryParams: { lang: 'en-GB' } } };
-
-        prescriber.lang = undefined;
-        const currentUser = Service.create({
-          load: sinon.stub(),
-          prescriber,
-        });
-        currentUser.load.resolves(prescriber);
-
-        const urlStub = Service.create({
-          isFrenchDomainExtension: false,
-        });
-
-        const intlStub = Service.create({
-          setLocale: sinon.stub(),
-          get: sinon.stub(),
-        });
-        intlStub.get.withArgs('locales').returns(['en', 'fr']);
-        const momentStub = Service.create({
-          setLocale: sinon.stub(),
-        });
-
-        const route = this.owner.lookup('route:application');
-        route.set('currentUser', currentUser);
-        route.set('url', urlStub);
-        route.set('intl', intlStub);
-        route.set('moment', momentStub);
-
-        // when
-        await route.beforeModel(transition);
-
-        // then
-        assert.ok(route.intl.setLocale.calledWith(['fr', 'fr']));
-        assert.ok(route.moment.setLocale.calledWith('fr'));
-      });
-    });
-
-    test('it should load the current user', async function(assert) {
+    test('should load feature toggles', async function(assert) {
       // given
       const transition = { to: { queryParams: {} } };
-
-      const currentUser = Service.create({
-        load: sinon.stub(),
-        prescriber,
-      });
-      currentUser.load.resolves(prescriber);
-
       const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUser);
+
+      sinon.stub(route.featureToggles, 'load');
+      route.featureToggles.load.resolves();
+
+      sinon.stub(route.session, 'handlePrescriberLanguageAndLocale');
+      route.session.handlePrescriberLanguageAndLocale.resolves();
 
       // when
       await route.beforeModel(transition);
 
       // then
-      assert.ok(route.currentUser.load.called);
+      assert.ok(route.featureToggles.load.called);
     });
 
-    test('it should load feature toggles', async function(assert) {
-      // given
-      const transition = { to: { queryParams: {} } };
+    module('When lang parameter exist', function() {
 
-      const currentUser = Service.create({
-        load: sinon.stub(),
-        prescriber,
+      test('should use lang parameter with session service method', async function(assert) {
+        // given
+        const transition = { to: { queryParams: { lang: 'fr' } } };
+        const route = this.owner.lookup('route:application');
+
+        sinon.stub(route.featureToggles, 'load');
+        route.featureToggles.load.resolves();
+
+        sinon.stub(route.session, 'handlePrescriberLanguageAndLocale');
+        route.session.handlePrescriberLanguageAndLocale.resolves();
+
+        // when
+        await route.beforeModel(transition);
+
+        // then
+        assert.ok(
+          route.session.handlePrescriberLanguageAndLocale.calledWith('fr'),
+        );
       });
-      currentUser.load.resolves(prescriber);
-
-      const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUser);
-
-      const featureTogglesService = this.owner.lookup('service:feature-toggles');
-
-      // when
-      await route.beforeModel(transition);
-
-      // then
-      assert.ok(featureTogglesService.load.called);
     });
   });
 });

--- a/orga/tests/unit/routes/not-found_test.js
+++ b/orga/tests/unit/routes/not-found_test.js
@@ -1,22 +1,22 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | not-found', function(hooks) {
   setupTest(hooks);
 
   test('should redirect to application route', function(assert) {
-    assert.expect(1);
-    const route = this.owner.lookup('route:not-found');
+    // given
     const expectedRedirection = 'application';
+    const route = this.owner.lookup('route:not-found');
 
-    route.transitionTo = (redirection) => {
-      assert.equal(
-        redirection,
-        expectedRedirection,
-        `expect transition to ${expectedRedirection}, got ${redirection}`,
-      );
-    };
+    sinon.stub(route.router, 'transitionTo');
+    route.router.transitionTo.resolves();
 
+    // when
     route.afterModel();
+
+    // then
+    assert.ok(route.router.transitionTo.calledWith(expectedRedirection));
   });
 });

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -1,0 +1,126 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | session', function(hooks) {
+
+  setupTest(hooks);
+
+  module('#handlePrescriberLanguageAndLocale', function() {
+
+    module('when there is not prescriber', function() {
+
+      test('should call current user and set fr locale by default', async function(assert) {
+        // given
+        const service = this.owner.lookup('service:session');
+
+        service.currentUser = {
+          load: sinon.stub(),
+        };
+        service.url = {
+          isFrenchDomainExtension: true,
+        };
+        service.intl = {
+          setLocale: sinon.stub(),
+        };
+        service.moment = {
+          setLocale: sinon.stub(),
+        };
+
+        // when
+        await service.handlePrescriberLanguageAndLocale();
+
+        // then
+        assert.ok(service.currentUser.load.called);
+        assert.ok(service.intl.setLocale.calledWith(['fr', 'fr']));
+        assert.ok(service.moment.setLocale.calledWith('fr'));
+      });
+
+      module('when domain extension is not .fr', function() {
+
+        test('should set locale to en when language parameter is en', async function(assert) {
+          // given
+          const service = this.owner.lookup('service:session');
+
+          service.currentUser = {
+            load: sinon.stub(),
+          };
+          service.url = {
+            isFrenchDomainExtension: false,
+          };
+          service.intl = {
+            setLocale: sinon.stub(),
+            get: sinon.stub().withArgs('locales').returns(['fr', 'en']),
+          };
+          service.moment = {
+            setLocale: sinon.stub(),
+          };
+
+          // when
+          await service.handlePrescriberLanguageAndLocale('en');
+
+          // then
+          assert.ok(service.intl.setLocale.calledWith(['en', 'fr']));
+          assert.ok(service.moment.setLocale.calledWith('en'));
+        });
+      });
+    });
+
+    module('when there is a prescriber', function() {
+
+      test('should update prescriber lang when it is different of language parameter', async function(assert) {
+        // given
+        const service = this.owner.lookup('service:session');
+
+        service.currentUser = {
+          load: sinon.stub(),
+          prescriber: {
+            lang: 'fr',
+            save: sinon.stub(),
+          },
+        };
+        service.url = {
+          isFrenchDomainExtension: true,
+        };
+        service.intl = {
+          setLocale: sinon.stub(),
+        };
+        service.moment = {
+          setLocale: sinon.stub(),
+        };
+
+        // when
+        await service.handlePrescriberLanguageAndLocale('en');
+
+        // then
+        assert.ok(service.currentUser.prescriber.save.calledWith({
+          adapterOptions: {
+            lang: 'en',
+          },
+        }));
+      });
+    });
+  });
+
+  module('#handleAuthentication', function() {
+
+    test('should override handleAuthentication method', function(assert) {
+      // when
+      const service = this.owner.lookup('service:session');
+
+      // then
+      assert.ok(service.handleAuthentication instanceof Function);
+    });
+  });
+
+  module('#handleInvalidation', function() {
+
+    test('should override handleInvalidation method', function(assert) {
+      // when
+      const service = this.owner.lookup('service:session');
+
+      // then
+      assert.ok(service.handleInvalidation instanceof Function);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les modules Ember-Simple-Auth de nos applications fronts ne sont pas à jour, car ses mixins sont `deprecated`.

## :robot: Solution
Mettre à jour ce module dans Pix Orga

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Recette globale de Pix Orga, surtout les pages login, logout, les pages accessibles uniquement si l'utilisateur est authentifié.