### PR TITLE
[FEATURE] Améliorer l'accessibilité des libellés du menu de Pix Certif (PIX-2690)

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -2,16 +2,16 @@
 
   <aside class="app__sidebar sidebar">
     <header class="sidebar__logo">
-        <LinkTo @route="authenticated.sessions.list" type="button">
-          <img class="sidebar__logo-image" src="{{this.rootUrl}}/pix-certif-logo.svg" alt="PixCertif">
+        <LinkTo @route="authenticated" type="button" aria-hidden="true">
+          <img class="sidebar__logo-image" src="{{this.rootUrl}}/pix-certif-logo.svg" alt="Pix Certif">
         </LinkTo>
     </header>
 
     <nav class="sidebar-menu">
       <ul>
         <li>
-          <LinkTo @route="authenticated.sessions.list" class="sidebar-menu__item" type="button">
-            <img src="{{this.rootURL}}/icons/chevron-square-right.svg" alt="Liste des sessions" class="sidebar-menu__item-icon">
+          <LinkTo @route="authenticated.sessions.list" class="sidebar-menu__item" type="button" aria-label="Sessions de certification">
+            <img src="{{this.rootURL}}/icons/chevron-square-right.svg" alt="" role="presentation" class="sidebar-menu__item-icon">
             Sessions
           </LinkTo>
         </li>


### PR DESCRIPTION
## :unicorn: Problème

L'accessibilité de Pix Certif va prochainement faire l'objet d'un audit et nous voulons au préalable effectuer un maximum de corrections faciles.
Pour lire le libellé d'un lien, un lecteur d'écran va lire tout les libellé des éléments enfants. Actuellement, le lien vers la page de session a pour contenu une image avec un libellé "Liste des sessions" et un lien "Sessions". Le lecteur d'écran va donc énoncer "Liste des sessions Sessions".

## :robot: Solution

Ici l'image est juste décorative, il faut donc mettre un attribut alt vide (alt=""), car il est obligatoire mais peut-être vide.
L'important est le libellé du lien, on peut donc ajouter un attribut aria-label="Liste des sessions de certification".
Vérifier aussi le lien Documentation du menu.

## :rainbow: Remarques

Le lien sur le logo a également été masqué pour les lecteurs d'écrans car il renvoie à la même page que le lien "Sessions" juste en-dessous. Hors, avoir deux liens adjacents redondants est une mauvaise pratique en terme d'accessibilité.

> When adjacent links go to the same location (such as a linked product image and an adjacent linked product name that go to the same product page) this results in additional navigation and repetition for keyboard and screen reader users.

## :100: Pour tester

Se connecter à Pix Certif, [activer l'extension Wave](https://wave.webaim.org/extension/) et vérifier que le menu de gauche ne déclenche pas d'erreur ou d'avertissements.