### PR TITLE
[FEATURE] Ajouter une modale d'inscription d'un nouveau candidat (PIX-2713)

### DIFF
--- a/api/lib/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/lib/domain/usecases/add-certification-candidate-to-session.js
@@ -2,13 +2,19 @@ const {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
 } = require('../errors');
 
+const { featureToggles } = require('../../config');
+
 module.exports = async function addCertificationCandidateToSession({
   sessionId,
   certificationCandidate,
   certificationCandidateRepository,
 }) {
   certificationCandidate.sessionId = sessionId;
-  certificationCandidate.validate();
+
+  const version = featureToggles.isNewCPFDataEnabled ? '1.5' : '1.4';
+
+  certificationCandidate.validate(version);
+
   const duplicateCandidates = await certificationCandidateRepository.findBySessionIdAndPersonalInfo({
     sessionId,
     firstName: certificationCandidate.firstName,

--- a/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
@@ -42,6 +42,9 @@ module.exports = {
 
     const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
     const deserializedCandidate = await deserializer.deserialize(json);
+    deserializedCandidate.birthINSEECode = deserializedCandidate.birthInseeCode;
+    delete deserializedCandidate.birthInseeCode;
+
     return new CertificationCandidate(deserializedCandidate);
   },
 };

--- a/certif/app/components/certification-candidate-in-staging-item.js
+++ b/certif/app/components/certification-candidate-in-staging-item.js
@@ -83,7 +83,7 @@ export default class CertificationCandidateInStagingItem extends Component {
   @action
   updateCandidateDataBirthdate(_, masked) {
     this.maskedBirthdate = masked;
-    this.args.updateCandidateBirthdate(this.args.candidateData, this._formatDate(masked));
+    this.args.updateCandidateBirthdate(this.args.candidateData, 'birthdate', this._formatDate(masked));
   }
 
   _formatDate(date) {

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -11,12 +11,21 @@
         Ajouter des candidats
       </LinkTo>
     {{else}}
-      <div data-test-id="add-certification-candidate-staging__button" class="panel-header__action" {{on 'click' this.addCertificationCandidateInStaging}} >
-        <div id="add-candidate" class="certification-candidates-add-button__text">
+      {{#if @isNewCpfDataToggleEnabled}}
+        <PixButton
+          id="add-candidate"
+          class="certification-candidates-add-button__text"
+          @triggerAction={{fn this.openNewCertificationCandidateModal}}
+          @size="small"
+        >
           Ajouter un candidat
+        </PixButton>
+      {{else}}
+        <div data-test-id="add-certification-candidate-staging__button" class="panel-header__action" {{on 'click' this.addCertificationCandidateInStaging}} >
+          <div id="add-candidate" class="certification-candidates-add-button__text">Ajouter un candidat</div>
+          <PixIconButton aria-describedby="add-candidate" @icon='plus' @withBackground={{true}} />
         </div>
-        <PixIconButton aria-describedby="add-candidate" @icon='plus' @withBackground={{true}} />
-      </div>
+      {{/if}}
     {{/if}}
   </div>
   <div class="table content-text content-text--small certification-candidates-table">
@@ -67,15 +76,17 @@
           </tr>
           </thead>
           <tbody>
-          {{#each this.candidatesInStaging as |candidateInStaging|}}
-            <CertificationCandidateInStagingItem
-                    @candidateData={{candidateInStaging}}
-                    @onClickSave={{this.addCertificationCandidate}}
-                    @onClickCancel={{this.removeCertificationCandidateFromStaging}}
-                    @updateCandidateBirthdate={{this.updateCertificationCandidateInStagingBirthdate}}
-                    @updateCandidateData={{this.updateCertificationCandidateInStagingField}}
-            />
-          {{/each}}
+          {{#unless @isNewCpfDataToggleEnabled}}
+            {{#each this.candidatesInStaging as |candidateInStaging|}}
+              <CertificationCandidateInStagingItem
+                      @candidateData={{candidateInStaging}}
+                      @onClickSave={{this.addCertificationCandidate}}
+                      @onClickCancel={{this.removeCertificationCandidateFromStaging}}
+                      @updateCandidateBirthdate={{this.updateCertificationCandidateInStagingFieldFromValue}}
+                      @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
+              />
+            {{/each}}
+          {{/unless}}
           {{#each @certificationCandidates as |candidate|}}
             <tr>
               <td data-test-id='panel-candidate__lastName__{{candidate.id}}'>{{candidate.lastName}}</td>
@@ -197,8 +208,8 @@
                   @candidateData={{candidateInStaging}}
                   @onClickSave={{this.addCertificationCandidate}}
                   @onClickCancel={{this.removeCertificationCandidateFromStaging}}
-                  @updateCandidateBirthdate={{this.updateCertificationCandidateInStagingBirthdate}}
-                  @updateCandidateData={{this.updateCertificationCandidateInStagingField}}
+                  @updateCandidateBirthdate={{this.updateCertificationCandidateInStagingFieldFromValue}}
+                  @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
           />
         {{/each}}
         {{#each @certificationCandidates as |candidate|}}
@@ -264,5 +275,16 @@
   <CertificationCandidateDetailsModal
     @closeModal={{this.closeCertificationCandidateDetailsModal}}
     @candidate={{this.certificationCandidateInDetailsModal}}
+  />
+{{/if}}
+
+{{#if this.showNewCertificationCandidateModal}}
+  <NewCertificationCandidateModal
+    @closeModal={{this.closeNewCertificationCandidateModal}}
+    @countries={{@countries}}
+    @saveCandidate={{this.addCertificationCandidate}}
+    @candidateData={{this.newCandidate}}
+    @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
+    @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
   />
 {{/if}}

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -10,8 +10,10 @@ export default class EnrolledCandidates extends Component {
   @service store;
   @service notifications;
   @tracked candidatesInStaging = [];
+  @tracked newCandidate = {};
   @tracked shouldDisplayCertificationCandidateModal = false;
   @tracked certificationCandidateInDetailsModal = null;
+  @tracked showNewCertificationCandidateModal = false;
 
   get isCandidateBeingAdded() {
     return this.candidatesInStaging.length > 0;
@@ -36,12 +38,19 @@ export default class EnrolledCandidates extends Component {
 
   @action
   addCertificationCandidateInStaging() {
-    if (this.args.isNewCpfDataToggleEnabled) return;
+    if (!this.args.isNewCpfDataToggleEnabled) {
+      this.candidatesInStaging.pushObject(EmberObject.create({
+        firstName: '', lastName: '', birthdate: '', birthCity: '',
+        birthProvinceCode: '', birthCountry: '', email: '', externalId: '',
+        extraTimePercentage: '' }));
+    }
 
-    this.candidatesInStaging.pushObject(EmberObject.create({
-      firstName: '', lastName: '', birthdate: '', birthCity: '',
-      birthProvinceCode: '', birthCountry: '', email: '', externalId: '',
-      extraTimePercentage: '' }));
+    if (this.args.isNewCpfDataToggleEnabled) {
+      this.newCandidate = EmberObject.create({
+        firstName: '', lastName: '', birthdate: '', birthCity: '',
+        birthCountry: 'FRANCE', email: '', externalId: '', resultRecipientEmail: '',
+        birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '' });
+    }
   }
 
   @action
@@ -51,6 +60,7 @@ export default class EnrolledCandidates extends Component {
     const success = await this.saveCertificationCandidate(certificationCandidate);
     if (success) {
       this.candidatesInStaging.removeObject(candidate);
+      this.closeNewCertificationCandidateModal();
     }
   }
 
@@ -60,14 +70,19 @@ export default class EnrolledCandidates extends Component {
   }
 
   @action
-  updateCertificationCandidateInStagingBirthdate(candidateInStaging, value) {
-    candidateInStaging.set('birthdate', value);
+  updateCertificationCandidateInStagingFieldFromEvent(candidateInStaging, field, ev) {
+    const { value } = ev.target;
+    candidateInStaging.set(field, value);
   }
 
   @action
-  updateCertificationCandidateInStagingField(candidateInStaging, field, ev) {
-    const { value } = ev.target;
+  updateCertificationCandidateInStagingFieldFromValue(candidateInStaging, field, value) {
     candidateInStaging.set(field, value);
+  }
+
+  @action
+  updateCertificationCandidateInStagingBirthdate(candidateInStaging, value) {
+    candidateInStaging.set('birthdate', value);
   }
 
   @action
@@ -109,14 +124,28 @@ export default class EnrolledCandidates extends Component {
     this.certificationCandidateInDetailsModal = null;
   }
 
+  @action
+  openNewCertificationCandidateModal() {
+    this.addCertificationCandidateInStaging();
+    this.showNewCertificationCandidateModal = true;
+  }
+
+  @action
+  closeNewCertificationCandidateModal() {
+    this.showNewCertificationCandidateModal = false;
+  }
+
   _createCertificationCandidateRecord(certificationCandidateData) {
     return this.store.createRecord('certification-candidate', {
       firstName: this._trimOrUndefinedIfFalsy(certificationCandidateData.firstName),
       lastName: this._trimOrUndefinedIfFalsy(certificationCandidateData.lastName),
+      sex: this._trimOrUndefinedIfFalsy(certificationCandidateData.sex),
       birthdate: certificationCandidateData.birthdate,
+      birthCountry: this._trimOrUndefinedIfFalsy(certificationCandidateData.birthCountry),
+      birthInseeCode: this._trimOrUndefinedIfFalsy(certificationCandidateData.birthInseeCode),
+      birthPostalCode: this._trimOrUndefinedIfFalsy(certificationCandidateData.birthPostalCode),
       birthCity: this._trimOrUndefinedIfFalsy(certificationCandidateData.birthCity),
       birthProvinceCode: this._trimOrUndefinedIfFalsy(certificationCandidateData.birthProvinceCode),
-      birthCountry: this._trimOrUndefinedIfFalsy(certificationCandidateData.birthCountry),
       externalId: this._trimOrUndefinedIfFalsy(certificationCandidateData.externalId),
       email: this._trimOrUndefinedIfFalsy(certificationCandidateData.email),
       resultRecipientEmail: this._trimOrUndefinedIfFalsy(certificationCandidateData.resultRecipientEmail),

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -1,0 +1,259 @@
+<AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
+  <div class="new-certification-candidate-details-modal">
+    <div class="pix-modal__close-button">
+      <button aria-label="Fermer la fenêtre d'ajout d'un candidat" type="button" {{on "click" @closeModal}}>
+        Fermer
+        <img src="/icons/icon-close-modal.svg" alt="" role="presentation" width="24" height="24">
+      </button>
+    </div>
+
+    <div class="pix-modal__container pix-modal__container--white">
+      <div class="new-certification-candidate-details-modal__title">
+        <h1>Ajouter un candidat</h1>
+      </div>
+
+      <div class="new-certification-candidate-details-modal__content">
+
+        <form
+          id="new-certification-candidate-form"
+          class="new-certification-candidate-details-modal__form"
+          {{on "submit" (fn this.onFormSubmit)}}
+        >
+
+          <p class="new-certification-candidate-details-modal__form__required-fields-mention">
+            Les champs marqués de <span class="required-field-indicator">*</span> sont obligatoires.
+          </p>
+
+          <div class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
+            <label for="last-name" class="label">
+              <span class="required-field-indicator">*</span>
+              Nom de famille
+            </label>
+            <Input
+              @id="last-name"
+              @type="text"
+              @class="input"
+              @value={{@candidateData.lastName}}
+              {{on 'input' (fn @updateCandidateData @candidateData 'lastName')}}
+              {{ did-insert this.focus }}
+              required
+            />
+          </div>
+
+          <div class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
+            <label for="first-name" class="label">
+              <span class="required-field-indicator">*</span>
+              Prénom
+            </label>
+            <Input
+              @id="first-name"
+              @type="text"
+              @class="input"
+              @value={{@candidateData.firstName}}
+              {{on 'input' (fn @updateCandidateData @candidateData 'firstName')}}
+              required
+            />
+          </div>
+
+          <div class="new-certification-candidate-details-modal__form__field">
+            <span class="required-field-indicator">*</span> Sexe
+            <div class="radio-button-container">
+              <input
+                type="radio"
+                id="female"
+                value="F"
+                name="sex"
+                required
+                {{on 'click' (fn @updateCandidateData @candidateData 'sex')}}
+                >
+              <label class="radio-button-label" for="female">Femme</label>
+              <input
+                type="radio"
+                id="male"
+                value="M"
+                name="sex"
+                {{on 'click' (fn @updateCandidateData @candidateData 'sex')}}
+                >
+              <label class="radio-button-label" for="male">Homme</label>
+            </div>
+          </div>
+
+          <div class="new-certification-candidate-details-modal__form__field">
+            <label for="birthdate" class="label">
+              <span class="required-field-indicator">*</span>
+              Date de naissance
+            </label>
+            <OneWayDateMask
+              required
+              @placeholder='dd/mm/yyyy'
+              @options={{hash inputFormat='dd/mm/yyyy' outputFormat='dd/mm/yyyy'}}
+              class="input"
+              id="birthdate"
+              @value={{this.maskedBirthdate}}
+              @update={{this.updateBirthdate}}
+            />
+          </div>
+
+          <div class="new-certification-candidate-details-modal__form__field">
+            <label for="birth-country" class="label">
+              <span class="required-field-indicator">*</span>
+              Pays de naissance
+            </label>
+            <PixSelect
+              id="birth-country"
+              class="birth-country-selector"
+              @options={{this.countryOptions}}
+              @onChange={{this.selectBirthCountry}}
+              @selectedOption="1"
+              required
+            />
+          </div>
+
+          {{#if this.isBirthGeoCodeRequired}}
+            <div class="new-certification-candidate-details-modal__form__field">
+              <span class="required-field-indicator">*</span>
+              Code géographique de naissance
+              <div class="radio-button-container">
+                <input
+                  type="radio"
+                  id="insee-code-choice"
+                  value="insee"
+                  checked={{this.isInseeCodeOptionSelected}}
+                  {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
+                  required={{this.isBirthGeoCodeRequired}}
+                  disabled={{not this.isBirthGeoCodeRequired}}
+                >
+                <label class="radio-button-label" for="insee-code-choice">Code INSEE</label>
+                <input
+                  type="radio"
+                  id="postal-code-choice"
+                  value="postal"
+                  checked={{this.isPostalCodeOptionSelected}}
+                  {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
+                  required={{this.isBirthGeoCodeRequired}}
+                  disabled={{not this.isBirthGeoCodeRequired}}
+                >
+                <label class="radio-button-label" for="postal-code-choice">Code postal</label>
+              </div>
+            </div>
+          {{/if}}
+
+          {{#if this.isBirthInseeCodeRequired}}
+            <div class="new-certification-candidate-details-modal__form__field">
+              <label for="birth-insee-code" class="label">
+                <span class="required-field-indicator">*</span>
+                Code INSEE de naissance
+              </label>
+              <Input
+                @id="birth-insee-code"
+                @type="text"
+                maxlength='5'
+                @class="input"
+                @value={{@candidateData.birthInseeCode}}
+                required={{this.isBirthInseeCodeRequired}}
+                disabled={{not this.isBirthInseeCodeRequired}}
+                {{on 'input' (fn @updateCandidateData @candidateData 'birthInseeCode')}}
+              />
+            </div>
+          {{/if}}
+
+          {{#if this.isBirthPostalCodeRequired}}
+            <div class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
+              <label for="birth-postal-code" class="label">
+                <span class="required-field-indicator">*</span>
+                Code postal de naissance
+              </label>
+              <Input
+                @id="birth-postal-code"
+                @type="text"
+                maxlength='5'
+                @class="input"
+                @value={{@candidateData.birthPostalCode}}
+                required={{this.isBirthPostalCodeRequired}}
+                disabled={{not this.isBirthPostalCodeRequired}}
+                {{on 'input' (fn @updateCandidateData @candidateData 'birthPostalCode')}}
+              />
+            </div>
+          {{/if}}
+
+          {{#if this.isBirthCityRequired}}
+            <div class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
+              <label for="birth-city" class="label">
+                <span class="required-field-indicator">*</span>
+                Commune de naissance
+              </label>
+              <Input
+                @id="birth-city"
+                @type="text"
+                @class="input"
+                @value={{@candidateData.birthCity}}
+                required={{this.isBirthCityRequired}}
+                disabled={{not this.isBirthCityRequired}}
+                {{on 'input' (fn @updateCandidateData @candidateData 'birthCity')}}
+              />
+            </div>
+          {{/if}}
+
+          <div class="new-certification-candidate-details-modal__form__field">
+            <label for="external-id" class="label">Identifiant externe</label>
+            <Input
+              @id="external-id"
+              @type="text"
+              @class="input"
+              @value={{@candidateData.externalId}}
+              {{on 'input' (fn @updateCandidateData @candidateData 'externalId')}}
+            />
+          </div>
+
+          <div class="new-certification-candidate-details-modal__form__field">
+            <label for="extra-time-percentage" class="label">Temps majoré (%)</label>
+            <Input
+              @id="extra-time-percentage"
+              @type="number"
+              @class="input {{if this.validation.email.hasError 'input--error'}}"
+              @value={{@candidateData.extraTimePercentage}}
+              {{on 'input' (fn @updateCandidateData @candidateData 'extraTimePercentage')}}
+            />
+          </div>
+
+          <div id="recipient-email-container" class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
+            <label for="result-recipient-email" class="label">E-mail du destinataire des résultats</label>
+            <Input
+              @id="result-recipient-email"
+              @type="email"
+              @class="input {{if this.validation.email.hasError 'input--error'}}"
+              @value={{@candidateData.resultRecipientEmail}}
+              {{on 'input' (fn @updateCandidateData @candidateData 'resultRecipientEmail')}}
+            />
+            {{#if this.validation.email.hasError}}
+              <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.email.message}}</div>
+            {{/if}}
+          </div>
+
+          <div id="email-container" class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
+            <label for="email" class="label">E-mail de convocation</label>
+            <Input
+              @id="email"
+              @type="email"
+              @class="input {{if this.validation.email.hasError 'input--error'}}"
+              @value={{@candidateData.email}}
+              {{on 'input' (fn @updateCandidateData @candidateData 'email')}}
+            />
+            {{#if this.validation.email.hasError}}
+              <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.email.message}}</div>
+            {{/if}}
+          </div>
+
+        </form>
+
+        <div class="new-certification-candidate-details-modal__actions">
+          <PixButton @size="small" @triggerAction={{fn @closeModal}} @backgroundColor="transparent-light">
+            Fermer
+          </PixButton>
+          <PixButton @size="small" form="new-certification-candidate-form" @type="submit">Ajouter le candidat</PixButton>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</AppModal>

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -1,0 +1,124 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+const FRANCE_INSEE_CODE = '99100';
+const INSEE_CODE_OPTION = 'insee';
+const POSTAL_CODE_OPTION = 'postal';
+
+export default class NewCertificationCandidateModal extends Component {
+  @tracked selectedBirthGeoCodeOption = INSEE_CODE_OPTION;
+  @tracked selectedCountryInseeCode = FRANCE_INSEE_CODE;
+  @tracked maskedBirthdate;
+
+  focus(element) {
+    element.focus();
+  }
+
+  @action
+  selectBirthGeoCodeOption(option) {
+    this.selectedBirthGeoCodeOption = option;
+
+    if (this.isInseeCodeOptionSelected) {
+      this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthCity', '');
+      this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthPostalCode', '');
+    } else if (this.isPostalCodeOptionSelected) {
+      this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthInseeCode', '');
+    }
+  }
+
+  @action
+  updateBirthdate(_, masked) {
+    this.maskedBirthdate = masked;
+    this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthdate', this._formatDate(masked));
+  }
+
+  @action
+  selectBirthCountry(event) {
+    this.selectedCountryInseeCode = event.target.value;
+    const countryName = this._getCountryName();
+    this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthCountry', countryName);
+    this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthCity', '');
+    this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthPostalCode', '');
+    if (this._isFranceSelected()) {
+      this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthInseeCode', '');
+    } else {
+      this.selectBirthGeoCodeOption(INSEE_CODE_OPTION);
+      this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthInseeCode', event.target.value);
+    }
+  }
+
+  @action
+  async onFormSubmit(event) {
+    event.preventDefault();
+    await this.args.saveCandidate(this.args.candidateData);
+  }
+
+  get isBirthGeoCodeRequired() {
+    return this._isFranceSelected();
+  }
+
+  get isInseeCodeOptionSelected() {
+    return this.selectedBirthGeoCodeOption === INSEE_CODE_OPTION;
+  }
+
+  get isPostalCodeOptionSelected() {
+    return this.selectedBirthGeoCodeOption === POSTAL_CODE_OPTION;
+  }
+
+  get isBirthInseeCodeRequired() {
+    if (!this._isFranceSelected()) {
+      return false;
+    }
+
+    if (this.isInseeCodeOptionSelected) {
+      return true;
+    }
+
+    return false;
+  }
+
+  get isBirthPostalCodeRequired() {
+    if (!this._isFranceSelected()) {
+      return false;
+    }
+
+    if (this.isPostalCodeOptionSelected) {
+      return true;
+    }
+
+    return false;
+  }
+
+  get isBirthCityRequired() {
+    if (!this._isFranceSelected()) {
+      return true;
+    }
+
+    if (this.isPostalCodeOptionSelected) {
+      return true;
+    }
+
+    return false;
+  }
+
+  get countryOptions() {
+    return this.args.countries.map((country) => {
+      return { label: country.name, value: country.code };
+    });
+  }
+
+  _isFranceSelected() {
+    return this.selectedCountryInseeCode === FRANCE_INSEE_CODE;
+  }
+
+  _formatDate(date) {
+    const [day, month, year] = date.split('/');
+    return `${year}-${month}-${day}` ;
+  }
+
+  _getCountryName() {
+    const country = this.args.countries.find((country) => country.code === this.selectedCountryInseeCode);
+    return country.name;
+  }
+}

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -15,6 +15,7 @@ export default class CertificationCandidatesController extends Controller {
   @alias('model.certificationCandidates') certificationCandidates;
   @alias('model.reloadCertificationCandidate') reloadCertificationCandidate;
   @alias('model.shouldDisplayPrescriptionScoStudentRegistrationFeature') shouldDisplayPrescriptionScoStudentRegistrationFeature;
+  @alias('model.countries') countries;
 
   get pageTitle() {
     return `Candidats | Session ${this.currentSession.id} | Pix Certif`;

--- a/certif/app/models/country.js
+++ b/certif/app/models/country.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Country extends Model {
+  @attr('string') code;
+  @attr('string') name;
+}

--- a/certif/app/routes/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/routes/authenticated/sessions/details/certification-candidates.js
@@ -1,7 +1,13 @@
 import Route from '@ember/routing/route';
 
 export default class CertificationCandidatesRoute extends Route {
-  model() {
-    return this.modelFor('authenticated.sessions.details');
+  async model() {
+    const details = await this.modelFor('authenticated.sessions.details');
+    const countries = await this.store.findAll('country');
+
+    return {
+      ...details,
+      countries,
+    };
   }
 }

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -33,6 +33,7 @@
 @import "components/certification-candidate-details-modal";
 @import "components/login-form";
 @import "components/finalize";
+@import "components/new-certification-candidate-modal";
 @import "components/session-finalization-step-container";
 @import "components/session-finalization-reports-informations-step";
 @import "components/session-finalization-formbuilder-link-step";

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -1,0 +1,103 @@
+/* stylelint-disable no-descending-specificity */
+
+.new-certification-candidate-details-modal {
+  min-width: 576px;
+  max-width: 576px;
+
+  &__title {
+    font-family: $open-sans;
+    padding: 12px 32px;
+
+    h1 {
+      font-size: 1.25rem;
+      color: $grey-80;
+      margin: 0;
+      margin-bottom: 4px;
+    }
+  }
+
+  &__content {
+    font-size: 0.875rem;
+    color: $grey-70;
+    border-top: 1px solid $grey-20;
+    border-bottom: 1px solid $grey-20;
+    background-color: $grey-10;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 8px 32px;
+  }
+
+  &__form {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
+    &__required-fields-mention {
+      width: 100%;
+    }
+
+    .required-field-indicator {
+      color: $pix-red;
+    }
+
+    &__field {
+      width: 100%;
+      margin: 12px 0;
+
+      label {
+        display: block;
+        font-size: 0.875rem;
+
+        &.radio-button-label {
+          display: inline-block;
+          margin: 0px 16px 0px 8px;
+        }
+      }
+
+      input {
+        border: 1.2px $grey-35 solid;
+        box-sizing: border-box;
+        width: 248px;
+        height: 36px;
+      }
+
+      .pix-select {
+        height: 36px;
+        width: 248px;
+      }
+
+      .birth-country-selector {
+        border: 1.2px $grey-35 solid;
+        height: 36px;
+        width: 248px;
+      }
+
+      input[type="radio"] {
+        height: 20px;
+        width: 20px;
+      }
+
+      .radio-button-container {
+        align-items: center;
+        display: flex;
+        margin-top: 12px;
+      }
+
+      &-double {
+        width: 248px;
+      }
+    }
+  }
+
+  &__actions {
+    background-color: $grey-10;
+    padding: 16px 0;
+    display: flex;
+    justify-content: flex-end;
+    border-radius: 0 0 5px 5px;
+
+    .pix-button {
+      margin-left: 16px;
+    }
+  }
+}

--- a/certif/app/styles/globals/colors.scss
+++ b/certif/app/styles/globals/colors.scss
@@ -12,6 +12,7 @@ $pix-purplie: #6B20DC;
 $pix-purple: #8A49FF;
 $pix-certif-banner: #C4E8FF;
 $pix-certif-banner-text: #0069AB;
+$pix-red: #D63F00;
 // gradients
 $pix-green-gradient: linear-gradient(-45deg, #52D987 0%, #1A8C89 100%);
 // light

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -33,18 +33,11 @@
     </div>
 
     {{#if this.showBanner}}
-      <PixBanner class="sco-temporary-banner">
-        <span class="sco-temporary-banner__informations-text">
-          <FaIcon @icon="info-circle" class="sco-temporary-banner-informations-text__triangle-icon" />
-          <p>
-            La certification en collège et lycée est possible jusqu'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ».<br>
-            <a href="https://view.genial.ly/6077017b8b37870d98620200" target="_blank" rel="noopener noreferrer"> En savoir plus <FaIcon @icon="external-link-alt"/></a>
-          </p>
-        </span>
-        <button type="button" class="sco-temporary-banner-button" aria-label="Fermer la bannière d'informations" {{on 'click' this.closeBanner}}>
-          <FaIcon @icon="times" class="sco-temporary-banner-button__times-icon" />
-        </button>
-      </PixBanner>
+        <PixBanner
+        @actionLabel= "En savoir plus"
+        @actionUrl= "https://view.genial.ly/6077017b8b37870d98620200"
+      >La certification en collège et lycée est possible jusqu'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ».</PixBanner>
+    
     {{/if}}
 
     <div class="page">

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -9,7 +9,9 @@
         @isNewCpfDataToggleEnabled={{this.isNewCpfDataToggleEnabled}}
         @sessionId={{this.currentSession.id}}
         @certificationCandidates={{this.certificationCandidates}}
-        @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />
+        @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
+        @countries={{this.countries}}
+  />
   {{/if}}
 {{else}}
   <ImportCandidates
@@ -22,6 +24,7 @@
           @isNewCpfDataToggleEnabled={{this.isNewCpfDataToggleEnabled}}
           @sessionId={{this.currentSession.id}}
           @certificationCandidates={{this.certificationCandidates}}
-          @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />
+          @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
+          @countries={{this.countries}}
+  />
 {{/if}}
-

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -164,4 +164,8 @@ export default function() {
 
     return json;
   });
+
+  this.get('/countries', (schema, _) => {
+    return schema.countries.all();
+  });
 }

--- a/certif/mirage/factories/country.js
+++ b/certif/mirage/factories/country.js
@@ -1,0 +1,13 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+
+export default Factory.extend({
+
+  name() {
+    return faker.random.word();
+  },
+
+  code() {
+    return faker.datatype.number({ min: 99000, max: 99999 });
+  },
+});

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -21457,8 +21457,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#991430600802cab6b6731a43e187d4944a287d7c",
-      "from": "git://github.com/1024pix/pix-ui.git#v3.5.0",
+      "version": "git://github.com/1024pix/pix-ui.git#c725e9c7b6c613a48b6a15de8e668e1d23379871",
+      "from": "git://github.com/1024pix/pix-ui.git#v5.2.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -87,7 +87,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.3.0",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v3.5.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.2.0",
     "qunit-dom": "^1.6.0",
     "sass": "^1.32.8",
     "stylelint": "^13.12.0",

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -56,8 +56,8 @@ module('Acceptance | authenticated', function(hooks) {
       await visit('/sessions/liste');
 
       // then
-      assert.dom('.sco-temporary-banner').includesText('La certification en collège et lycée est possible jusqu\'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ». En savoir plus');
-      assert.dom('[aria-label="Fermer la bannière d\'informations"]').exists();
+      assert.dom('.pix-banner--information').exists();
+      assert.dom('.pix-banner--information').hasText('La certification en collège et lycée est possible jusqu\'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ». En savoir plus');
     });
 
     test('it should not display the banner when User is NOT SCO isManagingStudent', async function(assert) {
@@ -69,7 +69,7 @@ module('Acceptance | authenticated', function(hooks) {
       await visit('/sessions/liste');
 
       // then
-      assert.dom('.sco-temporary-banner').doesNotExist();
+      assert.dom('.pix-banner--information').doesNotExist();
     });
   });
 

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -18,6 +18,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
     server.create('feature-toggle', { id: 0, certifPrescriptionSco: true });
     certificationPointOfContact = createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted('SCO');
     session = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+    server.createList('country', 3);
   });
 
   hooks.afterEach(function() {

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -1,0 +1,314 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
+import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+
+module('Integration | Component | new-certification-candidate-modal', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it shows candidate form', async function(assert) {
+    // given
+    const closeModalStub = sinon.stub();
+    const updateCandidateStub = sinon.stub();
+    const updateCandidateWithEventStub = sinon.stub();
+    this.set('closeModal', closeModalStub);
+    this.set('updateCandidateStub', updateCandidateStub);
+    this.set('updateCandidateWithEventStub', updateCandidateWithEventStub);
+    this.set('countries', []);
+    this.set('candidateData', [{
+      firstName: '', lastName: '', birthdate: '', birthCity: '',
+      birthCountry: '', email: '', externalId: '', resultRecipientEmail: '',
+      birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '',
+    }]);
+
+    // when
+    await render(hbs`
+      <NewCertificationCandidateModal
+        @closeModal={{this.closeModal}}
+        @countries={{this.countries}}
+        @updateCandidateData={{this.updateCandidateStub}}
+        @updateCandidateDataWithEvent={{this.updateCandidateStub}}
+        @candidateData={{this.candidateData}}
+      />
+    `);
+
+    // then
+    assert.dom('#last-name').exists();
+    assert.dom('#last-name').isFocused();
+    assert.dom('#first-name').exists();
+    assert.dom('#male').exists();
+    assert.dom('#female').exists();
+    assert.dom('#birthdate').exists();
+    assert.dom('#birth-country').exists();
+    assert.dom('#insee-code-choice').exists();
+    assert.dom('#postal-code-choice').exists();
+    assert.dom('#birth-insee-code').exists();
+    assert.dom('#external-id').exists();
+    assert.dom('#extra-time-percentage').exists();
+    assert.dom('#result-recipient-email').exists();
+    assert.dom('#email').exists();
+  });
+
+  test('it shows a countries list', async function(assert) {
+    // given
+    const closeModalStub = sinon.stub();
+    const updateCandidateStub = sinon.stub();
+    const updateCandidateWithEventStub = sinon.stub();
+    this.set('closeModal', closeModalStub);
+    this.set('updateCandidateStub', updateCandidateStub);
+    this.set('updateCandidateWithEventStub', updateCandidateWithEventStub);
+    this.set('candidateData', [{
+      firstName: '', lastName: '', birthdate: '', birthCity: '',
+      birthCountry: '', email: '', externalId: '', resultRecipientEmail: '',
+      birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '',
+    }]);
+    this.set('countries', [
+      { id: 1, code: '99123', name: 'Syldavie' },
+      { id: 2, code: '99345', name: 'Botswana' },
+    ]);
+
+    // when
+    await render(hbs`
+      <NewCertificationCandidateModal
+        @closeModal={{this.closeModal}}
+        @countries={{this.countries}}
+        @updateCandidateData={{this.updateCandidateStub}}
+        @updateCandidateDataWithEvent={{this.updateCandidateStub}}
+        @candidateData={{this.candidateData}}
+      />
+    `);
+
+    // then
+    assert.dom('#birth-country').exists();
+    assert.dom('#birth-country').includesText('Syldavie');
+    assert.dom('#birth-country').includesText('Botswana');
+  });
+
+  module('when close button cross icon is clicked', () => {
+    test('it closes candidate details modal', async function(assert) {
+      const closeModalStub = sinon.stub();
+      const updateCandidateStub = sinon.stub();
+      const updateCandidateWithEventStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('updateCandidateStub', updateCandidateStub);
+      this.set('updateCandidateWithEventStub', updateCandidateWithEventStub);
+      this.set('countries', []);
+      this.set('candidateData', {
+        firstName: '', lastName: '', birthdate: '', birthCity: '',
+        birthCountry: '', email: '', externalId: '', resultRecipientEmail: '',
+        birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '',
+      });
+
+      // when
+      await render(hbs`
+        <NewCertificationCandidateModal
+          @closeModal={{this.closeModal}}
+          @countries={{this.countries}}
+          @updateCandidateData={{this.updateCandidateStub}}
+          @updateCandidateDataWithEvent={{this.updateCandidateStub}}
+          @candidateData={{this.candidateData}}
+        />
+      `);
+
+      await clickByLabel('Fermer la fenêtre d\'ajout d\'un candidat');
+
+      // then
+      sinon.assert.calledOnce(closeModalStub);
+      assert.ok(true);
+    });
+  });
+
+  module('when close bottom button is clicked', () => {
+    test('it closes candidate details modal ', async function(assert) {
+      const closeModalStub = sinon.stub();
+      const updateCandidateStub = sinon.stub();
+      const updateCandidateWithEventStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('updateCandidateStub', updateCandidateStub);
+      this.set('updateCandidateWithEventStub', updateCandidateWithEventStub);
+      this.set('countries', []);
+      this.set('candidateData', {
+        firstName: '', lastName: '', birthdate: '', birthCity: '',
+        birthCountry: '', email: '', externalId: '', resultRecipientEmail: '',
+        birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '',
+      });
+
+      // when
+      await render(hbs`
+        <NewCertificationCandidateModal
+          @closeModal={{this.closeModal}}
+          @countries={{this.countries}}
+          @updateCandidateData={{this.updateCandidateStub}}
+          @updateCandidateDataWithEvent={{this.updateCandidateStub}}
+          @candidateData={{this.candidateData}}
+        />
+      `);
+
+      await clickByLabel('Fermer');
+
+      // then
+      sinon.assert.calledOnce(closeModalStub);
+      assert.ok(true);
+    });
+  });
+
+  module('when a foreign country is selected', () => {
+    test('it hides insee and postal fields and requires city', async function(assert) {
+      const closeModalStub = sinon.stub();
+      const updateCandidateFromValueStub = sinon.stub();
+      const updateCandidateFromEventStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('updateCandidateFromValueStub', updateCandidateFromValueStub);
+      this.set('updateCandidateFromEventStub', updateCandidateFromEventStub);
+      this.set('countries', [{ code: '99123', name: 'Borduristan' }]);
+      this.set('candidateData', {
+        firstName: '', lastName: '', birthdate: '', birthCity: '',
+        birthCountry: '', email: '', externalId: '', resultRecipientEmail: '',
+        birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '',
+      });
+
+      // when
+      await render(hbs`
+        <NewCertificationCandidateModal
+          @closeModal={{this.closeModal}}
+          @countries={{this.countries}}
+          @updateCandidateData={{this.updateCandidateFromEventStub}}
+          @updateCandidateDataFromValue={{this.updateCandidateFromValueStub}}
+          @candidateData={{this.candidateData}}
+        />
+      `);
+
+      await fillInByLabel('Pays de naissance', '99123');
+
+      // then
+      assert.dom('#birth-insee-code').isNotVisible();
+      assert.dom('#birth-postal-code').isNotVisible();
+      assert.dom('#birth-city').isVisible();
+    });
+  });
+
+  module('when the insee code option is selected', () => {
+    test('it shows insee field and hide postal code and city', async function(assert) {
+      const closeModalStub = sinon.stub();
+      const updateCandidateFromValueStub = sinon.stub();
+      const updateCandidateFromEventStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('updateCandidateFromValueStub', updateCandidateFromValueStub);
+      this.set('updateCandidateFromEventStub', updateCandidateFromEventStub);
+      this.set('countries', [{ code: '99123', name: 'Borduristan' }]);
+      this.set('candidateData', {
+        firstName: '', lastName: '', birthdate: '', birthCity: '',
+        birthCountry: '', email: '', externalId: '', resultRecipientEmail: '',
+        birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '',
+      });
+
+      // when
+      await render(hbs`
+        <NewCertificationCandidateModal
+          @closeModal={{this.closeModal}}
+          @countries={{this.countries}}
+          @updateCandidateData={{this.updateCandidateFromEventStub}}
+          @updateCandidateDataFromValue={{this.updateCandidateFromValueStub}}
+          @candidateData={{this.candidateData}}
+        />
+      `);
+
+      await clickByLabel('Code INSEE');
+
+      // then
+      assert.dom('#birth-insee-code').isVisible();
+      assert.dom('#birth-postal-code').isNotVisible();
+      assert.dom('#birth-city').isNotVisible();
+    });
+  });
+
+  module('when the postal code option is selected', () => {
+    test('it disable insee fields and requires postal code and city', async function(assert) {
+      const closeModalStub = sinon.stub();
+      const updateCandidateFromValueStub = sinon.stub();
+      const updateCandidateFromEventStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('updateCandidateFromValueStub', updateCandidateFromValueStub);
+      this.set('updateCandidateFromEventStub', updateCandidateFromEventStub);
+      this.set('countries', [{ code: '99123', name: 'Borduristan' }]);
+      this.set('candidateData', {
+        firstName: '', lastName: '', birthdate: '', birthCity: '',
+        birthCountry: '', email: '', externalId: '', resultRecipientEmail: '',
+        birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '',
+      });
+
+      // when
+      await render(hbs`
+        <NewCertificationCandidateModal
+          @closeModal={{this.closeModal}}
+          @countries={{this.countries}}
+          @updateCandidateData={{this.updateCandidateFromEventStub}}
+          @updateCandidateDataFromValue={{this.updateCandidateFromValueStub}}
+          @candidateData={{this.candidateData}}
+        />
+      `);
+
+      await clickByLabel('Code postal');
+
+      // then
+      assert.dom('#birth-insee-code').isNotVisible();
+      assert.dom('#birth-postal-code').isVisible();
+      assert.dom('#birth-city').isVisible();
+    });
+  });
+
+  module('when the form is filled', () => {
+    test('it should submit a student', async function(assert) {
+      const closeModalStub = sinon.stub();
+      const updateCandidateFromValueStub = sinon.stub();
+      const updateCandidateFromEventStub = sinon.stub();
+      const saveCandidateStub = sinon.stub();
+
+      this.set('closeModal', closeModalStub);
+      this.set('updateCandidateFromValueStub', updateCandidateFromValueStub);
+      this.set('updateCandidateFromEventStub', updateCandidateFromEventStub);
+      this.set('countries', [{ code: '99123', name: 'Borduristan' }]);
+      this.set('saveCandidate', saveCandidateStub);
+      this.set('candidateData', {
+        firstName: '', lastName: '', birthdate: '', birthCity: '',
+        birthCountry: '', email: '', externalId: '', resultRecipientEmail: '',
+        birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '',
+      });
+      this.set('countries', [{ code: '99100', name: 'FRANCE' }]);
+
+      // when
+      await render(hbs`
+        <NewCertificationCandidateModal
+          @closeModal={{this.closeModal}}
+          @countries={{this.countries}}
+          @updateCandidateData={{this.updateCandidateFromEventStub}}
+          @updateCandidateDataFromValue={{this.updateCandidateFromValueStub}}
+          @candidateData={{this.candidateData}}
+          @saveCandidate={{this.saveCandidate}}
+          />
+      `);
+
+      await fillInByLabel('Prénom', 'Guybrush');
+      await fillInByLabel('Nom de famille', 'Threepwood');
+      await fillInByLabel('Date de naissance', '28/04/2019');
+      await clickByLabel('Homme');
+      await fillInByLabel('Pays de naissance', 99100);
+      await clickByLabel('Code INSEE');
+      await fillInByLabel('Identifiant externe', '44AA3355');
+      await fillInByLabel('Code INSEE de naissance', '75100');
+      await fillInByLabel('Temps majoré (%)', '20');
+      await fillInByLabel('E-mail du destinataire des résultats', 'guybrush.threepwood@example.net');
+      await fillInByLabel('E-mail de convocation', 'roooooar@example.net');
+
+      await clickByLabel('Ajouter le candidat');
+
+      // then
+      assert.equal(updateCandidateFromValueStub.callCount, 7);
+      assert.equal(updateCandidateFromEventStub.callCount, 8);
+      sinon.assert.calledOnce(saveCandidateStub);
+    });
+  });
+});

--- a/certif/tests/unit/components/enrolled-candidates_test.js
+++ b/certif/tests/unit/components/enrolled-candidates_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import EmberObject from '@ember/object';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 module('Unit | Component | enrolled-candidates', function(hooks) {
@@ -74,17 +75,22 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
 
     module('When FT_IS_NEW_CPF_DATA_ENABLED is enabled', function() {
 
-      test('should not add an empty candidate in staging', async function(assert) {
+      test('should add an empty new candidate', async function(assert) {
       // given
         component.args = {
           isNewCpfDataToggleEnabled: true,
         };
 
+        const newCandidate = EmberObject.create({
+          firstName: '', lastName: '', birthdate: '', birthCity: '',
+          birthCountry: 'FRANCE', email: '', externalId: '', resultRecipientEmail: '',
+          birthPostalCode: '', birthInseeCode: '', sex: '', extraTimePercentage: '' });
+
         // when
         await component.addCertificationCandidateInStaging();
 
         // then
-        assert.equal(component.candidatesInStaging.length, 0);
+        assert.deepEqual(component.newCandidate, newCandidate);
       });
 
     });
@@ -131,7 +137,7 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
     });
   });
 
-  module('#openCertificationCandidateDetailsModal', async function() {
+  module('#openCertificationCandidateDetailsModal', function() {
     test('should open the candidate details modal', async function(assert) {
       // given
       const sessionId = 'sessionId';
@@ -145,12 +151,12 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
       await component.openCertificationCandidateDetailsModal(candidate);
 
       // then
-      assert.equal(component.shouldDisplayCertificationCandidateModal, true);
+      assert.true(component.shouldDisplayCertificationCandidateModal);
       assert.equal(component.certificationCandidateInDetailsModal, candidate);
     });
   });
 
-  module('#closeCertificationCandidateDetailsModal', async function() {
+  module('#closeCertificationCandidateDetailsModal', function() {
     test('should close the candidate details modal', async function(assert) {
       // given
       const sessionId = 'sessionId';
@@ -166,8 +172,44 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
       await component.closeCertificationCandidateDetailsModal();
 
       // then
-      assert.equal(component.shouldDisplayCertificationCandidateModal, false);
+      assert.false(component.shouldDisplayCertificationCandidateModal);
       assert.equal(component.certificationCandidateInDetailsModal, null);
+    });
+  });
+
+  module('#openNewCertificationCandidateModal', function() {
+    test('should open the new certification candidate modal', async function(assert) {
+      // given
+      const sessionId = 'sessionId';
+      component.showNewCertificationCandidateModal = false;
+      component.args = {
+        certificationCandidates: [],
+        sessionId,
+      };
+
+      // when
+      await component.openNewCertificationCandidateModal();
+
+      // then
+      assert.true(component.showNewCertificationCandidateModal);
+    });
+  });
+
+  module('#closeNewCertificationCandidateModal', function() {
+    test('should close the new certification candidate modal', async function(assert) {
+      // given
+      const sessionId = 'sessionId';
+      component.showNewCertificationCandidateModal = true;
+      component.args = {
+        certificationCandidates: [],
+        sessionId,
+      };
+
+      // when
+      await component.closeNewCertificationCandidateModal();
+
+      // then
+      assert.false(component.showNewCertificationCandidateModal);
     });
   });
 

--- a/certif/tests/unit/components/enrolled-candidates_test.js
+++ b/certif/tests/unit/components/enrolled-candidates_test.js
@@ -131,6 +131,46 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
     });
   });
 
+  module('#openCertificationCandidateDetailsModal', async function() {
+    test('should open the candidate details modal', async function(assert) {
+      // given
+      const sessionId = 'sessionId';
+      const candidate = _buildCandidate({}, { destroyRecord: sinon.stub() });
+      component.args = {
+        certificationCandidates: [],
+        sessionId,
+      };
+
+      // when
+      await component.openCertificationCandidateDetailsModal(candidate);
+
+      // then
+      assert.equal(component.shouldDisplayCertificationCandidateModal, true);
+      assert.equal(component.certificationCandidateInDetailsModal, candidate);
+    });
+  });
+
+  module('#closeCertificationCandidateDetailsModal', async function() {
+    test('should close the candidate details modal', async function(assert) {
+      // given
+      const sessionId = 'sessionId';
+      const candidate = _buildCandidate({}, { destroyRecord: sinon.stub() });
+      component.shouldDisplayCertificationCandidateModal = true;
+      component.certificationCandidateInDetailsModal = candidate;
+      component.args = {
+        certificationCandidates: [],
+        sessionId,
+      };
+
+      // when
+      await component.closeCertificationCandidateDetailsModal();
+
+      // then
+      assert.equal(component.shouldDisplayCertificationCandidateModal, false);
+      assert.equal(component.certificationCandidateInDetailsModal, null);
+    });
+  });
+
   function _buildCandidate({
     firstName = 'Georges',
     lastName = 'Brassens',

--- a/certif/tests/unit/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/unit/components/new-certification-candidate-modal_test.js
@@ -1,0 +1,266 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | new-certification-candidate-modal', function(hooks) {
+
+  setupTest(hooks);
+
+  let modal;
+
+  hooks.beforeEach(function() {
+    modal = createGlimmerComponent('component:new-certification-candidate-modal');
+  });
+
+  module('#selectBirthGeoCodeOption', function() {
+    module('when birth geo code option is postal', function(hooks) {
+      hooks.beforeEach(function() {
+        modal.selectedBirthGeoCodeOption = 'postal';
+      });
+
+      test('should set the birth geo code option to insee', async function(assert) {
+        // given
+        modal.args.updateCandidateDataFromValue = sinon.stub();
+
+        // when
+        await modal.selectBirthGeoCodeOption('insee');
+
+        // then
+        assert.equal(modal.selectedBirthGeoCodeOption, 'insee');
+      });
+
+      test('should reset the birth city', async function(assert) {
+        // given
+        modal.args.updateCandidateDataFromValue = sinon.stub();
+        modal.args.candidateData = { birthCity: 'Saint Malo' };
+
+        // when
+        await modal.selectBirthGeoCodeOption('insee');
+
+        // then
+        sinon.assert.calledWith(modal.args.updateCandidateDataFromValue, modal.args.candidateData, 'birthCity', '');
+        assert.ok(true);
+      });
+
+      test('should reset the birth postal code', async function(assert) {
+        // given
+        modal.args.updateCandidateDataFromValue = sinon.stub();
+        modal.args.candidateData = { birthPostalCode: '35400' };
+
+        // when
+        await modal.selectBirthGeoCodeOption('insee');
+
+        // then
+        sinon.assert.calledWith(modal.args.updateCandidateDataFromValue, modal.args.candidateData, 'birthPostalCode', '');
+        assert.ok(true);
+      });
+    });
+
+    module('when birth geo code is insee', function(hooks) {
+      hooks.beforeEach(function() {
+        modal.selectedBirthGeoCodeOption = 'insee';
+      });
+
+      test('should set the birth geo code option to postal', async function(assert) {
+        // given
+        modal.args.updateCandidateDataFromValue = sinon.stub();
+
+        // when
+        await modal.selectBirthGeoCodeOption('postal');
+
+        // then
+        assert.equal(modal.selectedBirthGeoCodeOption, 'postal');
+      });
+
+      test('should reset the birth insee code', async function(assert) {
+        // given
+        modal.args.candidateData = { birthInseeCode: '35288' };
+        modal.args.updateCandidateDataFromValue = sinon.stub();
+
+        // when
+        await modal.selectBirthGeoCodeOption('postal');
+
+        // then
+        sinon.assert.calledWith(modal.args.updateCandidateDataFromValue, modal.args.candidateData, 'birthInseeCode', '');
+        assert.ok(true);
+      });
+    });
+  });
+
+  module('#selectBirthCountry', function() {
+
+    const FRANCE_INSEE_CODE = '99100';
+
+    module('when selected country is France', function(hooks) {
+      hooks.beforeEach(function() {
+        modal.selectedCountryInseeCode = FRANCE_INSEE_CODE;
+      });
+
+      test('should set the birthInseeCode to Italy code', async function(assert) {
+        // given
+        modal.args.countries = [
+          {
+            name: 'Italy',
+            code: '99127',
+          },
+          {
+            name: 'France',
+            code: '99100',
+          },
+        ];
+        modal.args.updateCandidateDataFromValue = sinon.stub();
+
+        // when
+        const event = { target: { value: '99127' } };
+        await modal.selectBirthCountry(event);
+
+        // then
+        sinon.assert.calledWith(modal.args.updateCandidateDataFromValue, modal.args.candidateData, 'birthInseeCode', '99127');
+        assert.ok(true);
+      });
+    });
+  });
+
+  module('#isBirthGeoCodeQuired', function() {
+    module('when selected country is Italy', function() {
+      test('should return false for Italy', async function(assert) {
+        // when
+        modal.selectedCountryInseeCode = '99127';
+
+        // then
+        assert.false(modal.isBirthGeoCodeRequired);
+      });
+    });
+
+    module('when selected country is France', function() {
+      test('should return true for France', function(assert) {
+        // when
+        modal.selectedCountryInseeCode = '99100';
+
+        // then
+        assert.true(modal.isBirthGeoCodeRequired);
+      });
+    });
+  });
+
+  module('#isInseeCodeOptionSelected', function() {
+    test('should return true if selected code option is insee', async function(assert) {
+      // given
+      modal.args.updateCandidateDataFromValue = sinon.stub();
+
+      // when
+      await modal.selectBirthGeoCodeOption('insee');
+
+      // then
+      assert.true(modal.isInseeCodeOptionSelected);
+    });
+  });
+
+  module('#isPostalCodeOptionSelected', function() {
+    test('should return true if selected code option is postal', async function(assert) {
+      // given
+      modal.args.updateCandidateDataFromValue = sinon.stub();
+
+      // when
+      await modal.selectBirthGeoCodeOption('postal');
+
+      // then
+      assert.true(modal.isPostalCodeOptionSelected);
+    });
+  });
+
+  module('#isBirthInseeCodeRequired', function() {
+    module('when selected country is other than France', function() {
+      test('should return false for other than France', async function(assert) {
+        // when
+        modal.selectedCountryInseeCode = '99123';
+
+        // then
+        assert.false(modal.isBirthInseeCodeRequired);
+      });
+    });
+
+    module('when selected country is France', function() {
+      test('should return true for insee code option', async function(assert) {
+        // when
+        modal.selectedCountryInseeCode = '99100';
+        modal.selectedBirthGeoCodeOption = 'insee';
+
+        // then
+        assert.true(modal.isBirthInseeCodeRequired);
+      });
+
+      test('should return false for postal code option', async function(assert) {
+        // when
+        modal.selectedCountryInseeCode = '99100';
+        modal.selectedBirthGeoCodeOption = 'postal';
+
+        // then
+        assert.false(modal.isBirthInseeCodeRequired);
+      });
+    });
+  });
+
+  module('#isBirthPostalCodeRequired', function() {
+    test('should return true for postal code option', async function(assert) {
+      // when
+      modal.selectedBirthGeoCodeOption = 'postal';
+
+      // then
+      assert.true(modal.isBirthPostalCodeRequired);
+    });
+
+    test('should return false for insee code option', async function(assert) {
+      // when
+      modal.selectedBirthGeoCodeOption = 'insee';
+
+      // then
+      assert.false(modal.isBirthPostalCodeRequired);
+    });
+  });
+
+  module('#isBirthCityRequired', function() {
+    test('should return true when country is not France', async function(assert) {
+      // when
+      modal.selectedCountryInseeCode = '99123';
+
+      // then
+      assert.true(modal.isBirthCityRequired);
+    });
+
+    test('should return true if country is France and postal code option is selected', async function(assert) {
+      // when
+      modal.selectedCountryInseeCode = '99100';
+      modal.selectedBirthGeoCodeOption = 'postal';
+
+      // then
+      assert.true(modal.isBirthCityRequired);
+    });
+
+    test('should return false if country is France and insee code option is selected', async function(assert) {
+      // when
+      modal.selectedCountryInseeCode = '99100';
+      modal.selectedBirthGeoCodeOption = 'insee';
+
+      // then
+      assert.false(modal.isBirthCityRequired);
+    });
+  });
+
+  module('#countryOptions', function() {
+    test('should return a list of countries', async function(assert) {
+      // when
+      modal.args.countries = [
+        { name: 'Wakanda', code: '99817' },
+        { name: 'Republic of Gilead', code: '99224' },
+      ];
+
+      // then
+      assert.deepEqual(modal.countryOptions, [
+        { label: 'Wakanda', value: '99817' },
+        { label: 'Republic of Gilead', value: '99224' },
+      ]);
+    });
+  });
+});

--- a/certif/tests/unit/models/country_test.js
+++ b/certif/tests/unit/models/country_test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import pick from 'lodash/pick';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | country', function(hooks) {
+  setupTest(hooks);
+
+  test('it creates a Country', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const data = {
+      code: '99134',
+      name: 'Espagne',
+    };
+
+    // when
+    const model = store.createRecord('country', data);
+
+    // then
+    assert.deepEqual(_pickModelData(data), _pickModelData(model));
+  });
+
+  function _pickModelData(country) {
+    return pick(country, ['code', 'name']);
+  }
+});

--- a/certif/tests/unit/routes/authenticated/sessions/details/certification-candidate_test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/details/certification-candidate_test.js
@@ -11,19 +11,26 @@ module('Unit | Route | authenticated/sessions/details/certification-candidates',
   });
 
   module('#model', function(hooks) {
-    const expectedModel = Symbol('model');
+    const details = { session: Symbol('session') };
+    const countries = Symbol('countries');
+    const expectedModel = {
+      ...details,
+      countries,
+    };
 
     hooks.beforeEach(function() {
-      route.modelFor = sinon.stub().returns(expectedModel);
+      route.modelFor = sinon.stub().returns(details);
+      route.store.findAll = sinon.stub().returns(countries);
     });
 
-    test('it should return the expectedModel', function(assert) {
+    test('it should return the expectedModel', async function(assert) {
       // when
-      const actualModel = route.model();
+      const actualModel = await route.model();
 
       // then
       sinon.assert.calledWith(route.modelFor, 'authenticated.sessions.details');
-      assert.equal(actualModel, expectedModel);
+      sinon.assert.calledWith(route.store.findAll, 'country');
+      assert.deepEqual(actualModel, expectedModel);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l’accrochage Mon Compte Formation, des infos perso des candidats à la certification Pix sont nécessaires. Parmi ces infos que nous ne récupérons pas actuellement : le sexe du candidat et son code postal ou code INSEE de la commune de naissance.
Le formulaire en bas de tableau est difficilement utilisable et pas adapté à la refonte du tableau des candidats.

## :robot: Solution

Ajouter une modale d'inscription d'un candidat à la session de certification (voir [maquette](https://share.goabstract.com/a6f164b0-138d-4667-8916-7d2a2c8520c1?collectionLayerId=a1f9ee3a-e227-445e-8a5c-de90a35e45f4&mode=design)).

### Règles d’activation des champs :

#### Si pays autre que France

- commune obligatoire
- code INSEE = code Pays (99XXXX) et verrouillé
- code postal vide et verrouillé

#### Si France et code INSEE

- code INSEE obligatoire
- code postal vide et verrouillé
- commune vide et verrouillé

#### Si France et code postal

- code INSEE vide et verrouillé
- code postal obligatoire
- commune obligatoire

## :rainbow: Remarques

> « *Car c'est au bout des pires calvaires que l'humanité a érigé 
> les pierres blanches de ses victoires les plus décisives* » 
>
> (Goethe)

## :100: Pour tester

 - Activer le feature toggle FT_IS_NEW_CPF_DATA_ENABLED
 - Se rendre sur Pix Certif avec un compte Non Sco ne gérant pas d'étudiants
 - Aller sur le détail d'une session de certification
 - Cliquer sur le bouton Ajouter un candidat
 - Remplir le formulaire
 - Terminer l'ajout du candidat en appuyant sur Ajouter le candidat
 - Vérifier la présence du nouveau candidat dans la liste