### PR TITLE
[TECH] Ajout du linter de tests qunit sur certif

### DIFF
--- a/certif/.eslintrc.js
+++ b/certif/.eslintrc.js
@@ -14,10 +14,12 @@ module.exports = {
   },
   plugins: [
     'ember',
+    'qunit',
   ],
   extends: [
     ...(fs.existsSync('../.eslintrc.yaml') ? ['../.eslintrc.yaml'] : []),
     'plugin:ember/recommended',
+    'plugin:qunit/recommended',
   ],
   env: {
     browser: true,

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -16456,14 +16456,31 @@
         "snake-case": "^3.0.3"
       }
     },
-    "eslint-plugin-mocha": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
-      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
+    "eslint-plugin-qunit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz",
+      "integrity": "sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^2.1.0",
-        "ramda": "^0.27.1"
+        "eslint-utils": "^3.0.0",
+        "requireindex": "^1.2.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "eslint-scope": {
@@ -22359,12 +22376,6 @@
         }
       }
     },
-    "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-      "dev": true
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -22884,6 +22895,12 @@
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
       "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "requires-port": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -82,7 +82,7 @@
     "ember-truth-helpers": "^3.0.0",
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.0.2",
-    "eslint-plugin-mocha": "^8.1.0",
+    "eslint-plugin-qunit": "^6.2.0",
     "faker": "^5.5.2",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -73,7 +73,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
       });
     });
 
-    module('when there are some candidates', function() {
+    module('when there are some candidates', function(hooks) {
 
       let sessionWithCandidates;
       let candidates;
@@ -328,7 +328,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
       });
     });
 
-    test('it should redirect to the default candidates detail view', async (assert) => {
+    test('it should redirect to the default candidates detail view', async function(assert) {
       // given
       server.create('feature-toggle', {});
       const linkToCandidate = '.session-details-controls__navbar-tabs a:nth-of-type(2)';

--- a/certif/tests/acceptance/terms-of-service_test.js
+++ b/certif/tests/acceptance/terms-of-service_test.js
@@ -44,8 +44,8 @@ module('Acceptance | terms-of-service', function(hooks) {
       // then
       certificationPointOfContact.reload();
       const actualPixCertifTermsOfServiceVal = certificationPointOfContact.pixCertifTermsOfServiceAccepted;
-      assert.equal(actualPixCertifTermsOfServiceVal, true);
-      assert.equal(previousPixCertifTermsOfServiceVal, false);
+      assert.true(actualPixCertifTermsOfServiceVal);
+      assert.false(previousPixCertifTermsOfServiceVal);
     });
 
     test('it should redirect to session list after saving terms of service acceptation', async function(assert) {

--- a/certif/tests/integration/components/add-student-list_test.js
+++ b/certif/tests/integration/components/add-student-list_test.js
@@ -89,7 +89,7 @@ module('Integration | Component | add-student-list', function(hooks) {
       await click(firstStudentCheckbox);
 
       // then
-      assert.equal(this.students[0].isSelected, true);
+      assert.true(this.students[0].isSelected);
     });
 
     test('it should be possible to unselect a selected student', async function(assert) {
@@ -107,7 +107,7 @@ module('Integration | Component | add-student-list', function(hooks) {
       await click(firstStudentCheckbox);
 
       // then
-      assert.equal(this.students[0].isSelected, false);
+      assert.false(this.students[0].isSelected);
     });
 
     [
@@ -139,7 +139,7 @@ module('Integration | Component | add-student-list', function(hooks) {
         await click(selectAllCheckbox);
 
         // then
-        assert.equal(this.students.every((s) => s.isSelected), true);
+        assert.true(this.students.every((s) => s.isSelected));
       });
     });
 
@@ -159,7 +159,7 @@ module('Integration | Component | add-student-list', function(hooks) {
       await click(selectAllCheckbox);
 
       // then
-      assert.equal(this.students.every((s) => s.isSelected), false);
+      assert.false(this.students.every((s) => s.isSelected));
     });
 
     module('when students are checked', () => {
@@ -207,7 +207,7 @@ module('Integration | Component | add-student-list', function(hooks) {
         sinon.assert.calledWith(save, { adapterOptions: {
           sessionId: 123,
           studentListToAdd: studentList } });
-        assert.equal(this.candidatesWasSaved, true);
+        assert.true(this.candidatesWasSaved);
       });
     });
 

--- a/certif/tests/integration/components/certification-candidate-in-staging-item_test.js
+++ b/certif/tests/integration/components/certification-candidate-in-staging-item_test.js
@@ -72,7 +72,7 @@ module('Integration | Component | certification-candidate-in-staging-item', func
     await click('[data-test-id="panel-candidate__action__cancel"]');
 
     // then
-    assert.equal(cancelStub.calledWith(candidateInStaging), true);
+    assert.true(cancelStub.calledWith(candidateInStaging));
   });
 
   module('when filling the line with sufficient correct data', function(hooks) {
@@ -99,7 +99,7 @@ module('Integration | Component | certification-candidate-in-staging-item', func
       await click('[data-test-id="panel-candidate__action__save"]');
 
       // then
-      assert.equal(saveStub.calledWith(candidateInStaging), true);
+      assert.true(saveStub.calledWith(candidateInStaging));
     });
 
   });

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -60,7 +60,7 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
     });
   });
 
-  module('When FT_IS_NEW_CPF_DATA_ENABLED is enabled', async function() {
+  module('When FT_IS_NEW_CPF_DATA_ENABLED is enabled', function() {
 
     test('it displays candidates information', async function(assert) {
       // given
@@ -120,7 +120,7 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
     });
   });
 
-  module('when details button should not be displayed', async function() {
+  module('when details button should not be displayed', function() {
     test('it should not display details button', async function(assert) {
       // given
       const candidate = _buildCertificationCandidate({

--- a/certif/tests/integration/components/session-finalization-examiner-global-comment-step_test.js
+++ b/certif/tests/integration/components/session-finalization-examiner-global-comment-step_test.js
@@ -57,6 +57,6 @@ module('Integration | Component | session-finalization-examiner-global-comment-s
     await fillIn('#examiner-global-comment', 'You are no more a wizard Harry!');
 
     // then
-    assert.equal(updateExaminerGlobalCommentStub.called, true);
+    assert.true(updateExaminerGlobalCommentStub.called);
   });
 });

--- a/certif/tests/unit/adapters/certification-candidate_test.js
+++ b/certif/tests/unit/adapters/certification-candidate_test.js
@@ -24,7 +24,7 @@ module('Unit | Adapters | certification-candidate', function(hooks) {
       const url = await adapter.urlForQuery(query);
 
       // then
-      assert.equal(url.endsWith(`/sessions/${sessionId}/certification-candidates`), true);
+      assert.true(url.endsWith(`/sessions/${sessionId}/certification-candidates`));
     });
   });
 
@@ -36,7 +36,7 @@ module('Unit | Adapters | certification-candidate', function(hooks) {
       const url = await adapter.urlForCreateRecord('certification-candidate', options);
 
       // then
-      assert.equal(url.endsWith('/certification-candidates'), true);
+      assert.true(url.endsWith('/certification-candidates'));
     });
 
     test('should build create url when registerToSession is true', async function(assert) {
@@ -45,7 +45,7 @@ module('Unit | Adapters | certification-candidate', function(hooks) {
       const url = await adapter.urlForCreateRecord('certification-candidate', options);
 
       // then
-      assert.equal(url.endsWith(`/sessions/${sessionId}/certification-candidates`), true);
+      assert.true(url.endsWith(`/sessions/${sessionId}/certification-candidates`));
     });
 
   });
@@ -58,7 +58,7 @@ module('Unit | Adapters | certification-candidate', function(hooks) {
       const url = await adapter.urlForDeleteRecord(certificationCandidateId, 'certification-candidate', options);
 
       // then
-      assert.equal(url.endsWith(`/certification-candidates/${certificationCandidateId}`), true);
+      assert.true(url.endsWith(`/certification-candidates/${certificationCandidateId}`));
     });
 
     test('should build delete url when sessionId passed in adapterOptions', async function(assert) {
@@ -67,7 +67,7 @@ module('Unit | Adapters | certification-candidate', function(hooks) {
       const url = await adapter.urlForDeleteRecord(certificationCandidateId, 'certification-candidate', options);
 
       // then
-      assert.equal(url.endsWith(`/sessions/${sessionId}/certification-candidates/${certificationCandidateId}`), true);
+      assert.true(url.endsWith(`/sessions/${sessionId}/certification-candidates/${certificationCandidateId}`));
     });
 
   });

--- a/certif/tests/unit/adapters/certification-point-of-contact_test.js
+++ b/certif/tests/unit/adapters/certification-point-of-contact_test.js
@@ -21,7 +21,7 @@ module('Unit | Adapters | certification-point-of-contact', function(hooks) {
       const url = await adapter.urlForUpdateRecord(123, 'certification-point-of-contact', snapshot);
 
       // then
-      assert.equal(url.endsWith('/users/123/pix-certif-terms-of-service-acceptance'), true);
+      assert.true(url.endsWith('/users/123/pix-certif-terms-of-service-acceptance'));
     });
   });
 });

--- a/certif/tests/unit/adapters/division_test.js
+++ b/certif/tests/unit/adapters/division_test.js
@@ -22,7 +22,7 @@ module('Unit | Adapters | division', function(hooks) {
       const url = await adapter.urlForQuery(query);
 
       // then
-      assert.equal(url.endsWith(`/certification-centers/${certificationCenterId}/divisions`), true);
+      assert.true(url.endsWith(`/certification-centers/${certificationCenterId}/divisions`));
     });
   });
 });

--- a/certif/tests/unit/adapters/session-summary_test.js
+++ b/certif/tests/unit/adapters/session-summary_test.js
@@ -19,7 +19,7 @@ module('Unit | Adapters | session-summary', function(hooks) {
       const url = await adapter.urlForQuery();
 
       // then
-      assert.equal(url.endsWith('/api/certification-centers/123/session-summaries'), true);
+      assert.true(url.endsWith('/api/certification-centers/123/session-summaries'));
     });
   });
 });

--- a/certif/tests/unit/adapters/session_test.js
+++ b/certif/tests/unit/adapters/session_test.js
@@ -34,7 +34,7 @@ module('Unit | Adapter | session', function(hooks) {
 
   module('#updateRecord', () => {
     module('when studentListToAdd adapter option passed', () => {
-      test('should trigger an ajax call with the url, data and method', async (assert) => {
+      test('should trigger an ajax call with the url, data and method', async function(assert) {
         // given
         sinon.stub(adapter, 'ajax').resolves();
         const studentListToAdd = [
@@ -66,7 +66,7 @@ module('Unit | Adapter | session', function(hooks) {
 
     module('when finalization adapter option passed', () => {
 
-      test('should trigger an ajax call with the url, data without former examinerComment', async (assert) => {
+      test('should trigger an ajax call with the url, data without former examinerComment', async function(assert) {
         // given
         sinon.stub(adapter, 'ajax').resolves();
         const expectedMethod = 'PUT';

--- a/certif/tests/unit/adapters/student_test.js
+++ b/certif/tests/unit/adapters/student_test.js
@@ -34,7 +34,7 @@ module('Unit | Adapter | student', function(hooks) {
       const url = await adapter.urlForQuery(query);
 
       // then
-      assert.equal(url.endsWith(`certification-centers/${certificationCenterId}/sessions/${sessionId}/students`), true);
+      assert.true(url.endsWith(`certification-centers/${certificationCenterId}/sessions/${sessionId}/students`));
     });
   });
 });

--- a/certif/tests/unit/components/add-student-list_test.js
+++ b/certif/tests/unit/components/add-student-list_test.js
@@ -32,7 +32,7 @@ module('Unit | Component | add-student-list', function(hooks) {
       const hasCheckedSomething = component.hasCheckedSomething;
 
       // then
-      assert.equal(hasCheckedSomething, false);
+      assert.false(hasCheckedSomething);
     });
 
     test('it should be true if at least one checked student', function(assert) {
@@ -49,7 +49,7 @@ module('Unit | Component | add-student-list', function(hooks) {
       const hasCheckedSomething = component.hasCheckedSomething;
 
       // then
-      assert.equal(hasCheckedSomething, true);
+      assert.true(hasCheckedSomething);
     });
   });
 
@@ -69,7 +69,7 @@ module('Unit | Component | add-student-list', function(hooks) {
       const hasCheckedEverything = component.hasCheckedEverything;
 
       // then
-      assert.equal(hasCheckedEverything, false);
+      assert.false(hasCheckedEverything);
     });
 
     test('it should be true if they are all checked', function(assert) {
@@ -86,7 +86,7 @@ module('Unit | Component | add-student-list', function(hooks) {
       const hasCheckedEverything = component.hasCheckedEverything;
 
       // then
-      assert.equal(hasCheckedEverything, true);
+      assert.true(hasCheckedEverything);
     });
   });
 

--- a/certif/tests/unit/components/app-modal_test.js
+++ b/certif/tests/unit/components/app-modal_test.js
@@ -17,12 +17,12 @@ module('Unit | Component | app-modal', function(hooks) {
   module('#init', function() {
     test('should set the overlay as translucent', function(assert) {
       // then
-      assert.equal(modal.get('translucentOverlay'), true);
+      assert.true(modal.get('translucentOverlay'));
     });
 
     test('should activate keyboard events', function(assert) {
       // then
-      assert.equal(modal.get('keyboardActivated'), true);
+      assert.true(modal.get('keyboardActivated'));
     });
   });
 
@@ -35,7 +35,7 @@ module('Unit | Component | app-modal', function(hooks) {
       modal.trigger(keyUp('Escape'));
 
       // then
-      assert.equal(sendActionStub.calledOnce, true);
+      assert.true(sendActionStub.calledOnce);
     });
   });
 });

--- a/certif/tests/unit/components/enrolled-candidates_test.js
+++ b/certif/tests/unit/components/enrolled-candidates_test.js
@@ -12,7 +12,7 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
     component = createGlimmerComponent('component:enrolled-candidates');
   });
 
-  module('#saveCertificationCandidate', async function() {
+  module('#saveCertificationCandidate', function() {
 
     test('should save certification candidate on saveCertificationCandidate action with appropriate adapter options', async function(assert) {
       // given
@@ -70,9 +70,9 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
       assert.equal(component.args.certificationCandidates.length, 1);
     });
   });
-  module('#addCertificationCandidateInStaging', async function() {
+  module('#addCertificationCandidateInStaging', function() {
 
-    module('When FT_IS_NEW_CPF_DATA_ENABLED is enabled', async function() {
+    module('When FT_IS_NEW_CPF_DATA_ENABLED is enabled', function() {
 
       test('should not add an empty candidate in staging', async function(assert) {
       // given
@@ -89,7 +89,7 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
 
     });
 
-    module('When FT_IS_NEW_CPF_DATA_ENABLED is  not enabled', async function() {
+    module('When FT_IS_NEW_CPF_DATA_ENABLED is  not enabled', function() {
 
       test('should disable the feature of enrolling a new candidate', async function(assert) {
       // given
@@ -107,7 +107,7 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
     });
   });
 
-  module('#deleteCertificationCandidate', async function() {
+  module('#deleteCertificationCandidate', function() {
 
     test('should delete the candidate action with appropriate adapter options', async function(assert) {
       // given

--- a/certif/tests/unit/components/login-form_test.js
+++ b/certif/tests/unit/components/login-form_test.js
@@ -26,7 +26,7 @@ module('Unit | Component | login-form', (hooks) => {
 
   module('#authenticate', () => {
 
-    test('should authenticate user with trimmed email', async (assert) => {
+    test('should authenticate user with trimmed email', async function(assert) {
       // given
       const emailWithSpaces = '  email@example.net  ';
       component.email = emailWithSpaces;

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
@@ -15,7 +15,7 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
       const shouldDisplayStudentList = controller.hasOneOrMoreCandidates;
 
       // then
-      assert.equal(shouldDisplayStudentList, true);
+      assert.true(shouldDisplayStudentList);
     });
 
     test('It should return false when has no candidate', function(assert) {
@@ -28,7 +28,7 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
       const shouldDisplayStudentList = controller.hasOneOrMoreCandidates;
 
       // then
-      assert.equal(shouldDisplayStudentList, false);
+      assert.false(shouldDisplayStudentList);
     });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -83,7 +83,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
 
       // then
-      assert.equal(hasUncheckedHasSeenEndTestScreen, false);
+      assert.false(hasUncheckedHasSeenEndTestScreen);
     });
 
     test('it should be true if at least one unchecked certification reports', function(assert) {
@@ -102,7 +102,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
 
       // then
-      assert.equal(hasUncheckedHasSeenEndTestScreen, true);
+      assert.true(hasUncheckedHasSeenEndTestScreen);
     });
   });
 
@@ -227,6 +227,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       { hasSeenEndTestScreen1: false, hasSeenEndTestScreen2: false, expectedState: true },
     ].forEach(({ hasSeenEndTestScreen1, hasSeenEndTestScreen2, expectedState }) =>
       test('it should toggle the hasSeenEndTestScreen attribute of all certifs in session to false depending on if some were checked', function(assert) {
+        assert.expect(2);
         // given
         const someWereChecked = hasSeenEndTestScreen1 || hasSeenEndTestScreen2;
         const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
@@ -259,7 +260,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       controller.send('openModal');
 
       // then
-      assert.equal(controller.showConfirmModal, true);
+      assert.true(controller.showConfirmModal);
     });
   });
 
@@ -273,7 +274,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       controller.send('closeModal');
 
       // then
-      assert.equal(controller.showConfirmModal, false);
+      assert.false(controller.showConfirmModal);
     });
   });
 });

--- a/certif/tests/unit/models/certification-issue-report_test.js
+++ b/certif/tests/unit/models/certification-issue-report_test.js
@@ -16,6 +16,7 @@ module('Unit | Model | certification issue report', function(hooks) {
   setupTest(hooks);
 
   test('it should return the right label for the category', function(assert) {
+    assert.expect(7);
     // given
     const store = this.owner.lookup('service:store');
 
@@ -30,6 +31,7 @@ module('Unit | Model | certification issue report', function(hooks) {
   });
 
   test('it should return the right label for the subcategory', function(assert) {
+    assert.expect(11);
     // given
     const store = this.owner.lookup('service:store');
 
@@ -44,6 +46,7 @@ module('Unit | Model | certification issue report', function(hooks) {
   });
 
   test('it should return the right code for the category', function(assert) {
+    assert.expect(7);
     // given
     const store = this.owner.lookup('service:store');
 
@@ -58,6 +61,7 @@ module('Unit | Model | certification issue report', function(hooks) {
   });
 
   test('it should return the right code for the subcategory', function(assert) {
+    assert.expect(11);
     // given
     const store = this.owner.lookup('service:store');
 

--- a/certif/tests/unit/models/certification-report_test.js
+++ b/certif/tests/unit/models/certification-report_test.js
@@ -22,7 +22,7 @@ module('Unit | Model | certification report', function(hooks) {
     assert.equal(model.firstName, 'Clément');
     assert.equal(model.lastName, 'Tine');
     assert.equal(model.certificationCourseId, 987);
-    assert.equal(model.hasSeenEndTestScreen, false);
+    assert.false(model.hasSeenEndTestScreen);
     assert.equal(model.firstIssueReportDescription, '');
   });
 

--- a/certif/tests/unit/routes/not-found_test.js
+++ b/certif/tests/unit/routes/not-found_test.js
@@ -5,6 +5,7 @@ module('Unit | Route | not-found', function(hooks) {
   setupTest(hooks);
 
   test('should redirect to application route', function(assert) {
+    assert.expect(1);
     const route = this.owner.lookup('route:not-found');
     const expectedRedirection = 'application';
 

--- a/certif/tests/unit/services/featureToggles_test.js
+++ b/certif/tests/unit/services/featureToggles_test.js
@@ -25,7 +25,7 @@ module('Unit | Service | feature toggles', function(hooks) {
       await featureToggleService.load();
 
       // Then
-      assert.equal(featureToggleService.featureToggles.certifPrescriptionSco, false);
+      assert.false(featureToggleService.featureToggles.certifPrescriptionSco);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
D'une manière similaire et concomitante a #3143 et #3158, on utilise qunit sur pix certif, mais on avait installé mais pas configuré le linter de mocha.

## :robot: Solution
Installer, configurer le linter qunit. Et corriger les erreurs.

## :rainbow: Remarques
RAS cette fois ci.

## :100: Pour tester
`npm run lint` ne doit renvoyer aucune erreur.
