### PR TITLE
[FEATURE] Modifier les valeurs possibles pour la colonne "Code sexe*" de l'import Fregata (PIX-2699).

### DIFF
--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -14,6 +14,11 @@ const ERRORS = {
   INSEE_CODE_INVALID: 'INSEE_CODE_INVALID',
 };
 
+const sexPossibleValues = {
+  M: 'M',
+  F: 'F',
+};
+
 class SchoolingRegistrationSet {
   constructor(hasApprentice) {
     this.registrations = [];
@@ -41,7 +46,7 @@ class SchoolingRegistrationSet {
     }
 
     if (registrationAttributes.sex) {
-      sex = _convertSexCode(registrationAttributes.sex);
+      sex = _convertSexCodeToLabel(registrationAttributes.sex);
     } else {
       sex = null;
     }
@@ -56,9 +61,10 @@ class SchoolingRegistrationSet {
   }
 }
 
-function _convertSexCode(sexCode) {
-  if (sexCode === '1') return 'M';
-  if (sexCode === '2') return 'F';
+function _convertSexCodeToLabel(sexCode) {
+  if (sexCode) {
+    return sexPossibleValues[sexCode.toUpperCase().charAt(0)];
+  }
   return null;
 }
 

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -810,8 +810,8 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
 
         beforeEach(() => {
           const input = `${schoolingRegistrationCsvColumns}
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
-            456F;O-Ren;;;Ishii;Cottonmouth;2;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;f;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+            456F;O-Ren;;;Ishii;Cottonmouth;M;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
             `;
           const buffer = iconv.encode(input, 'UTF-8');
 
@@ -835,6 +835,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const schoolingRegistrations = await knex('schooling-registrations').where({ organizationId });
           expect(schoolingRegistrations).to.have.lengthOf(2);
           expect(_.map(schoolingRegistrations, 'firstName')).to.have.members(['Beatrix', 'O-Ren']);
+          expect(_.map(schoolingRegistrations, 'sex')).to.have.members(['F', 'M']);
         });
       });
 

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -83,7 +83,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
         '"Troisième prénom";' +
         '"Nom de famille*";' +
         '"Nom d\'usage";' +
-        '"Code sexe";' +
+        '"Sexe*";' +
         '"Date de naissance (jj/mm/aaaa)*";' +
         '"Code commune naissance**";' +
         '"Libellé commune naissance**";' +

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -121,7 +121,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
 
         context('when csv does not have \'Sex code\' column', () => {
 
-          const COL_TO_REMOVE = 'Code sexe';
+          const COL_TO_REMOVE = 'Sexe*';
           const schoolingRegistrationCsvColumnsWithoutSexCode = new SchoolingRegistrationColumns(i18n).columns.map((column) => column.label).filter((col) => col !== COL_TO_REMOVE).join(';');
 
           it('returns a schooling registration for each line', () => {

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -73,8 +73,8 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
 
           it('returns schooling registrations for each line using the CSV column', () => {
             const input = `${schoolingRegistrationCsvColumns}
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
-            0123456789F;O-Ren;;;Ishii;Cottonmouth;2;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;M;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
+            0123456789F;O-Ren;;;Ishii;Cottonmouth;f;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
             `;
             const organizationId = 789;
             const encodedInput = iconv.encode(input, 'utf8');

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -73,7 +73,7 @@
       "division": "Class*",
       "first-name": "First name*",
       "last-name": "Last name*",
-      "sex": "Sex code",
+      "sex": "Sex*",
       "mef-code": "MEF code*",
       "middle-name": "Middle name #1",
       "national-identifier": "Unique identifier*",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -73,7 +73,7 @@
       "division": "Division*",
       "first-name": "Premier prénom*",
       "last-name": "Nom de famille*",
-			"sex": "Code sexe",
+			"sex": "Sexe*",
       "mef-code": "Code MEF*",
       "middle-name": "Deuxième prénom",
       "national-identifier": "Identifiant unique*",


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui lors de l'import d'étudiant via le csv fregata la colonne "Code sexe" accepte 1 ou 2 comme valeurs possibles.

Cependant les valeurs remplies dans le csv seront "M" ou "F".


## :robot: Solution
Prendre en compte "M" ou "F" au lieu de 1 ou 2 lors de l'import

:warning:  Gérer la casse


## :100: Pour tester
Depuis orga, pour une orga AGRI (par exemple sco.admin@example.net => Lycée Agricole): 

- Créer un csv selon ce modèle
```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
4581234567F;Léa;;;Corse;Cottonmouth;01/01/1780;2A214;Corse;99;99100;AP;MEF1;Division 2
```
- Le remplir et essayer d'importer des candidats
- Constater que les schooling registrations sont crées

- Ajouter la colonne 'Sexe*' au csv

```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Sexe*;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
4581234567F;Léa;;;Corse;Cottonmouth;F;01/01/1780;2A214;Corse;99;99100;AP;MEF1;Division 2
```

- l'éditer et ajouter M ou F aux élèves
- Constater que les schooling registrations sont correctement crées avec M ou F comme valeur pour le genre