### PR TITLE
[TECH] Autorise les champs t1, t2, t3 status a être des boolean

### DIFF
--- a/api/lib/infrastructure/adapters/solution-adapter.js
+++ b/api/lib/infrastructure/adapters/solution-adapter.js
@@ -1,6 +1,13 @@
 const Solution = require('../../domain/models/Solution');
 const _ = require('../../../lib/infrastructure/utils/lodash-utils');
 
+function statusToBoolean(value) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return value !== 'Désactivé';
+}
+
 module.exports = {
 
   fromDatasourceObject(datasourceObject) {
@@ -8,9 +15,9 @@ module.exports = {
 
     return new Solution({
       id: datasourceObject.id,
-      isT1Enabled: datasourceObject.t1Status !== 'Désactivé',
-      isT2Enabled: datasourceObject.t2Status !== 'Désactivé',
-      isT3Enabled: datasourceObject.t3Status !== 'Désactivé',
+      isT1Enabled: statusToBoolean(datasourceObject.t1Status),
+      isT2Enabled: statusToBoolean(datasourceObject.t2Status),
+      isT3Enabled: statusToBoolean(datasourceObject.t3Status),
       type: datasourceObject.type,
       value: datasourceObject.solution,
       scoring,

--- a/api/tests/integration/infrastructure/repositories/solution-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/solution-repository_test.js
@@ -5,39 +5,79 @@ const solutionRepository = require('../../../../lib/infrastructure/repositories/
 describe('Integration | Repository | solution-repository', () => {
 
   describe('#getByChallengeId', () => {
-    const challenge = {
-      id: 'recChallenge1',
-      t1Status: 'Désactivé',
-      t2Status: 'PasDésactivé',
-      t3Status: 'PasDésactivé',
-      type: 'QROC',
-      solution: 'laSuperSolution',
-      scoring: '@colombe',
-    };
-    const expectedSolution = {
-      id: challenge.id,
-      isT1Enabled: false,
-      isT2Enabled: true,
-      isT3Enabled: true,
-      type: challenge.type,
-      value: challenge.solution,
-      scoring: 'colombe',
-    };
+    context('with t1,t2,t3 as string', () => {
 
-    beforeEach(() => {
-      const learningContent = {
-        challenges: [challenge],
+      const challenge = {
+        id: 'recChallenge1',
+        t1Status: 'Désactivé',
+        t2Status: 'PasDésactivé',
+        t3Status: 'PasDésactivé',
+        type: 'QROC',
+        solution: 'laSuperSolution',
+        scoring: '@colombe',
       };
-      mockLearningContent(learningContent);
+      const expectedSolution = {
+        id: challenge.id,
+        isT1Enabled: false,
+        isT2Enabled: true,
+        isT3Enabled: true,
+        type: challenge.type,
+        value: challenge.solution,
+        scoring: 'colombe',
+      };
+
+      beforeEach(() => {
+        const learningContent = {
+          challenges: [challenge],
+        };
+        mockLearningContent(learningContent);
+      });
+
+      it('should return the solution to the challenge', async () => {
+        // when
+        const solution = await solutionRepository.getByChallengeId('recChallenge1');
+
+        // then
+        expect(solution).to.be.instanceOf(Solution);
+        expect(solution).to.deep.equal(expectedSolution);
+      });
     });
 
-    it('should return the solution to the challenge', async () => {
-      // when
-      const solution = await solutionRepository.getByChallengeId('recChallenge1');
+    context('t1, t2, t3 as boolean', () => {
+      const challenge = {
+        id: 'recChallenge1',
+        t1Status: false,
+        t2Status: true,
+        t3Status: true,
+        type: 'QROC',
+        solution: 'laSuperSolution',
+        scoring: '@colombe',
+      };
+      const expectedSolution = {
+        id: challenge.id,
+        isT1Enabled: false,
+        isT2Enabled: true,
+        isT3Enabled: true,
+        type: challenge.type,
+        value: challenge.solution,
+        scoring: 'colombe',
+      };
 
-      // then
-      expect(solution).to.be.instanceOf(Solution);
-      expect(solution).to.deep.equal(expectedSolution);
+      beforeEach(() => {
+        const learningContent = {
+          challenges: [challenge],
+        };
+        mockLearningContent(learningContent);
+      });
+
+      it('should return the solution to the challenge', async () => {
+        // when
+        const solution = await solutionRepository.getByChallengeId('recChallenge1');
+
+        // then
+        expect(solution).to.be.instanceOf(Solution);
+        expect(solution).to.deep.equal(expectedSolution);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les champs t1, t2, t3 status sont actuellement des chaines de caractères qui ont 2 valeurs possibles: 
- Activé
- Désactivé

Dans un souci de supprimer le francais et de simplifier pix-editor, nous voulons passer a des booléens. Pour permettre une transition sans rien casser, nous voulons permettre d'avoir des chaines de caractères ou des booléens.

## :robot: Solution
Rajouter le support des booléens. 

## :rainbow: Remarques
Une fois que l'API LCMS renverra des booléens, nous pourrons supprimer le code qui gère les chaines de caractères.

## :100: Pour tester
`npm run test`
