### PR TITLE
[FEATURE] Ajout de la mise en page pour la récupération de compte pour la sortie du SCO (PIX-2773)

### DIFF
--- a/mon-pix/app/components/recover-account-confirmation-step.hbs
+++ b/mon-pix/app/components/recover-account-confirmation-step.hbs
@@ -2,35 +2,38 @@
 <p>{{t 'pages.recover-account-after-leaving-sco.confirmation-step.found-account' }}</p>
 <p> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.contact-support' }}</p>
 
-<ul>
-  <li>
-    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.first-name' }}</div>
+<ul class="recover-account-confirmation-step-account-information">
+  <li class="recover-account-confirmation-step-account-information__field">
+    <div>{{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.first-name' }}</div>
     <div>{{@studentInformationForAccountRecovery.firstName}}</div>
   </li>
 
-  <li>
-    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.last-name' }}</div>
+  <li class="recover-account-confirmation-step-account-information__field">
+    <div>{{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.last-name' }}</div>
     <div>{{@studentInformationForAccountRecovery.lastName}}</div>
   </li>
 
 {{#if @studentInformationForAccountRecovery.username}}
-  <li>
-    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.username' }}</div>
+  <li class="recover-account-confirmation-step-account-information__field">
+    <div>{{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.username' }}</div>
     <div>{{@studentInformationForAccountRecovery.username}}</div>
   </li>
 {{/if}}
 
-  <li>
-    <div> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.latest-organization-name' }}</div>
+  <li class="recover-account-confirmation-step-account-information__field">
+    <div>{{t 'pages.recover-account-after-leaving-sco.confirmation-step.fields.latest-organization-name' }}</div>
     <div>{{@studentInformationForAccountRecovery.latestOrganizationName}}</div>
   </li>
+</ul>
 
-  <p> {{t 'pages.recover-account-after-leaving-sco.confirmation-step.certify-account' }}</p>
+<p>{{t 'pages.recover-account-after-leaving-sco.confirmation-step.certify-account' }}</p>
 
+<div class="recover-account-confirmation-step__actions">
   <PixButton
     @isBorderVisible={{true}}
     @triggerAction={{@cancelAccountRecovery}}
-    @backgroundColor="transparent-light">
+    @backgroundColor="transparent-light"
+    class="recover-account-confirmation-step__actions--cancel">
     {{t 'pages.recover-account-after-leaving-sco.confirmation-step.buttons.cancel' }}
   </PixButton>
   <PixButton
@@ -39,4 +42,4 @@
     @backgroundColor="red">
     {{t 'pages.recover-account-after-leaving-sco.confirmation-step.buttons.confirm' }}
   </PixButton>
-</ul>
+</div>

--- a/mon-pix/app/components/recover-account-conflict-error.hbs
+++ b/mon-pix/app/components/recover-account-conflict-error.hbs
@@ -1,6 +1,6 @@
 <h1>{{t 'pages.recover-account-after-leaving-sco.conflict.found-you-but' firstName=@firstName}}</h1>
-<p>{{t 'pages.recover-account-after-leaving-sco.conflict.precaution'}}</p>
-<p>
+<p class="recover-account-after-leaving-sco-content__information-text">{{t 'pages.recover-account-after-leaving-sco.conflict.precaution'}}</p>
+<p class="recover-account-after-leaving-sco-content__information-text">
   <a href="{{t 'pages.recover-account-after-leaving-sco.conflict.support.url'}}"
     target="_blank"
     rel="noopener noreferrer">

--- a/mon-pix/app/components/recover-account-student-information-form.hbs
+++ b/mon-pix/app/components/recover-account-student-information-form.hbs
@@ -17,7 +17,8 @@
     <PixTooltip
       @text={{t 'pages.recover-account-after-leaving-sco.student-information.form.tooltip' htmlSafe=true}}
       @position='top-left'
-      @isLight={{true}}>
+      @isLight={{true}}
+      aria-label={{t 'pages.recover-account-after-leaving-sco.student-information.form.tooltip' htmlSafe=true}}>
         <FaIcon @icon="info-circle" />
     </PixTooltip>
   </div>
@@ -40,8 +41,7 @@
                  @validationMessage={{this.firstNameValidation.message}}
                  @autocomplete="off"
                  @require={{true}}
-                 @hideRequired="true"
-                 @placeholder="Prénom" />
+                 @hideRequired="true" />
 
   <FormTextfield @label={{t 'pages.recover-account-after-leaving-sco.student-information.form.last-name'}}
                  @textfieldName="lastName"
@@ -51,8 +51,7 @@
                  @validationMessage={{this.lastNameValidation.message}}
                  @autocomplete="off"
                  @require={{true}}
-                 @hideRequired="true"
-                 @placeholder="Nom" />
+                 @hideRequired="true" />
 
   <div>
     <p class="form-textfield__label">

--- a/mon-pix/app/components/recover-account-student-information-form.hbs
+++ b/mon-pix/app/components/recover-account-student-information-form.hbs
@@ -1,19 +1,26 @@
 {{!-- template-lint-disable require-input-label --}}
-<h1>{{t 'pages.recover-account-after-leaving-sco.student-information.title'}}</h1>
+<h1 class="recover-account-after-leaving-sco-content__title">
+  {{t 'pages.recover-account-after-leaving-sco.student-information.title'}}
+</h1>
 
-<p>
+<p class="recover-account-after-leaving-sco-content__information-text">
   {{t 'pages.recover-account-after-leaving-sco.student-information.subtitle.text'}}
   <LinkTo @route="password-reset-demand" >
     {{t 'pages.recover-account-after-leaving-sco.student-information.subtitle.link'}}
   </LinkTo>
 </p>
 
-<p>{{t 'common.form.mandatory-all-fields'}}</p>
+<p class="recover-account-after-leaving-sco-content__information-text">{{t 'common.form.mandatory-all-fields'}}</p>
 
-<form {{on 'submit' this.submit}}>
-  <PixTooltip @text={{t 'pages.recover-account-after-leaving-sco.student-information.form.tooltip' htmlSafe=true}} @position='top-right'>
-    <FaIcon @icon="info-circle" />
-  </PixTooltip>
+<form {{on 'submit' this.submit}} class="recover-account-student-information-form">
+  <div class="recover-account-student-information-form__tooltip">
+    <PixTooltip
+      @text={{t 'pages.recover-account-after-leaving-sco.student-information.form.tooltip' htmlSafe=true}}
+      @position='top-left'
+      @isLight={{true}}>
+        <FaIcon @icon="info-circle" />
+    </PixTooltip>
+  </div>
   <FormTextfield @label={{t 'pages.recover-account-after-leaving-sco.student-information.form.ine-ina'}}
                  @textfieldName="ineIna"
                  @inputBindingValue={{this.ineIna}}
@@ -48,33 +55,41 @@
                  @placeholder="Nom" />
 
   <div>
-    <p>{{t "pages.recover-account-after-leaving-sco.student-information.form.birthdate"}}</p>
-    <div>
-      <Input min="1"
-             max="31"
-             @type="number"
-             @value={{this.dayOfBirth}}
-             placeholder={{t 'pages.recover-account-after-leaving-sco.student-information.form.placeholder.birth-day'}}
-             id="dayOfBirth"
-             {{on "input" this.handleDayInputChange}}
-             aria-label={{t 'pages.recover-account-after-leaving-sco.student-information.form.label.birth-day'}}
-             autocomplete="off" />
-      <Input min="1"
-             max="12"
-             @type="number"
-             @value={{this.monthOfBirth}}
-             placeholder={{t 'pages.recover-account-after-leaving-sco.student-information.form.placeholder.birth-month'}}
-             id="monthOfBirth"
-             {{on "input" this.handleMonthInputChange}}
-             aria-label={{t 'pages.recover-account-after-leaving-sco.student-information.form.label.birth-month'}}
-             autocomplete="off"/>
-      <Input min="1900"
-             @type="number"
-             @value={{this.yearOfBirth}}
-             placeholder={{t 'pages.recover-account-after-leaving-sco.student-information.form.placeholder.birth-year'}}
-             id="yearOfBirth"
-             aria-label={{t 'pages.recover-account-after-leaving-sco.student-information.form.label.birth-year'}}
-             autocomplete="off"/>
+    <p class="form-textfield__label">
+      {{t "pages.recover-account-after-leaving-sco.student-information.form.birthdate"}}
+    </p>
+    <div class="recover-account-student-information-form__birthdate-fields">
+      <div class="form-textfield__input-field-container">
+        <Input min="1"
+              max="31"
+              @type="number"
+              @value={{this.dayOfBirth}}
+              placeholder={{t 'pages.recover-account-after-leaving-sco.student-information.form.placeholder.birth-day'}}
+              id="dayOfBirth"
+              {{on "input" this.handleDayInputChange}}
+              aria-label={{t 'pages.recover-account-after-leaving-sco.student-information.form.label.birth-day'}}
+              autocomplete="off" />
+      </div>
+      <div class="form-textfield__input-field-container">
+        <Input min="1"
+              max="12"
+              @type="number"
+              @value={{this.monthOfBirth}}
+              placeholder={{t 'pages.recover-account-after-leaving-sco.student-information.form.placeholder.birth-month'}}
+              id="monthOfBirth"
+              {{on "input" this.handleMonthInputChange}}
+              aria-label={{t 'pages.recover-account-after-leaving-sco.student-information.form.label.birth-month'}}
+              autocomplete="off"/>
+      </div>
+      <div class="form-textfield__input-field-container">
+        <Input min="1900"
+              @type="number"
+              @value={{this.yearOfBirth}}
+              placeholder={{t 'pages.recover-account-after-leaving-sco.student-information.form.placeholder.birth-year'}}
+              id="yearOfBirth"
+              aria-label={{t 'pages.recover-account-after-leaving-sco.student-information.form.label.birth-year'}}
+              autocomplete="off"/>
+      </div>
     </div>
   </div>
 

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -80,6 +80,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/qrocm-solution-panel';
 @import 'components/reached-stage';
 @import 'components/recover-account-student-information-form';
+@import 'components/recover-account-confirmation-step';
 @import 'components/register-form';
 @import 'components/reset-password-form';
 @import 'components/result-item';

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -79,6 +79,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/qroc-solution-panel';
 @import 'components/qrocm-solution-panel';
 @import 'components/reached-stage';
+@import 'components/recover-account-student-information-form';
 @import 'components/register-form';
 @import 'components/reset-password-form';
 @import 'components/result-item';
@@ -120,6 +121,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'pages/not-connected';
 @import 'pages/profile';
 @import 'pages/profile-already-shared';
+@import 'pages/recover-account-after-leaving-sco';
 @import 'pages/send-profile';
 @import 'pages/sign-form';
 @import 'pages/skill-review';

--- a/mon-pix/app/styles/components/_recover-account-confirmation-step.scss
+++ b/mon-pix/app/styles/components/_recover-account-confirmation-step.scss
@@ -1,0 +1,28 @@
+.recover-account-confirmation-step-account-information {
+  list-style: none;
+  padding: 0;
+}
+
+.recover-account-confirmation-step-account-information__field {
+  background: $grey-10;
+  border-radius: 8px;
+  height: 65px;
+  max-width: 400px;
+  padding: 12px 20px;
+  margin-bottom: 6px;
+
+  & > div:first-of-type {
+    color: $grey-70;
+    font-family: $font-roboto;
+    font-size: 1.167rem;
+    margin-bottom: 4px;
+  }
+}
+
+.recover-account-confirmation-step__actions {
+  display: flex;
+
+  &--cancel {
+    margin-right: 20px;
+  }
+}

--- a/mon-pix/app/styles/components/_recover-account-student-information-form.scss
+++ b/mon-pix/app/styles/components/_recover-account-student-information-form.scss
@@ -1,0 +1,36 @@
+.recover-account-student-information-form {
+  position: relative;
+
+  &__tooltip {
+    position: absolute;
+    right: -120px;
+    z-index: 100;
+    min-width: 300px;
+
+    em {
+      font-weight: bold;
+    }
+  }
+
+  &__birthdate-fields {
+    display: flex;
+
+    p {
+      margin-bottom: 0;
+    }
+
+    .form-textfield__input-field-container {
+      display: block;
+      width: calc(80px + 2 * 2px);
+      margin-right: 8px;
+
+      & > input {
+        width: 80px;
+      }
+    }
+  }
+
+  button[type="submit"] {
+    margin-top: 32px;
+  }
+}

--- a/mon-pix/app/styles/pages/_recover-account-after-leaving-sco.scss
+++ b/mon-pix/app/styles/pages/_recover-account-after-leaving-sco.scss
@@ -1,0 +1,55 @@
+.recover-account-after-leaving-sco {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px;
+
+  @include device-is('desktop') {
+    padding-top: 56px;
+  }
+}
+
+.recover-account-after-leaving-sco-content {
+  margin-top: 12px;
+  max-width: max-content;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &__image {
+    display: none;
+
+    @include device-is('desktop') {
+      display: flex;
+      justify-content: center;
+      width: 400px;
+
+      img {
+        width: 300px;
+      }
+    }
+  }
+
+  &__step {
+    @include device-is('desktop') {
+      max-width: 800px;
+    }
+  }
+}
+
+.recover-account-after-leaving-sco-content__title {
+  color: $grey-90;
+  font-family: $font-open-sans;
+  font-size: 2rem;
+  line-height: 32px;
+  margin-bottom: 32px;
+}
+
+.recover-account-after-leaving-sco-content__information-text {
+  color: $grey-90;
+  font-family: $font-roboto;
+
+  a {
+    color: $communication-dark;
+  }
+}

--- a/mon-pix/app/styles/pages/_recover-account-after-leaving-sco.scss
+++ b/mon-pix/app/styles/pages/_recover-account-after-leaving-sco.scss
@@ -18,6 +18,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  min-height: 80vh;
 
   &__image {
     display: none;

--- a/mon-pix/app/styles/pages/_recover-account-after-leaving-sco.scss
+++ b/mon-pix/app/styles/pages/_recover-account-after-leaving-sco.scss
@@ -1,4 +1,7 @@
 .recover-account-after-leaving-sco {
+  background-color: $white;
+  min-height: max-content;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
@@ -6,7 +6,7 @@
 
     <div class="recover-account-after-leaving-sco-content">
       <div class="recover-account-after-leaving-sco-content__image">
-        <img alt=""
+        <img alt="" role="none"
           src="https://media-exp1.licdn.com/dms/image/C4E03AQGqUyf9FEbMFQ/profile-displayphoto-shrink_200_200/0/1599815293858?e=1629936000&v=beta&t=aYkZM7aqqJJ5tcm__MOF9TZmHt4YMGazq_Sj-OHJtK0">
       </div>
 

--- a/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/recover-account-after-leaving-sco.hbs
@@ -1,16 +1,31 @@
 {{page-title (t 'pages.recover-account-after-leaving-sco.title')}}
 
-{{#if this.showRecoverAccountStudentInformationForm}}
-  <RecoverAccountStudentInformationForm @submitStudentInformation={{this.submitStudentInformation}} />
-{{/if}}
+<div class="recover-account-after-leaving-sco">
+  <div>
+    <PixLogo />
 
-{{#if this.showRecoverAccountConflictError}}
-  <RecoverAccountConflictError @firstName={{this.firstName}} />
-{{/if}}
+    <div class="recover-account-after-leaving-sco-content">
+      <div class="recover-account-after-leaving-sco-content__image">
+        <img alt=""
+          src="https://media-exp1.licdn.com/dms/image/C4E03AQGqUyf9FEbMFQ/profile-displayphoto-shrink_200_200/0/1599815293858?e=1629936000&v=beta&t=aYkZM7aqqJJ5tcm__MOF9TZmHt4YMGazq_Sj-OHJtK0">
+      </div>
 
-{{#if this.showRecoverAccountConfirmationStep}}
-  <RecoverAccountConfirmationStep
-    @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
-    @cancelAccountRecovery={{this.cancelAccountRecovery}}
-  />
-{{/if}}
+      <div class="recover-account-after-leaving-sco-content__step">
+        {{#if this.showRecoverAccountStudentInformationForm}}
+          <RecoverAccountStudentInformationForm @submitStudentInformation={{this.submitStudentInformation}} />
+        {{/if}}
+
+        {{#if this.showRecoverAccountConflictError}}
+          <RecoverAccountConflictError @firstName={{this.firstName}} />
+        {{/if}}
+
+        {{#if this.showRecoverAccountConfirmationStep}}
+          <RecoverAccountConfirmationStep
+            @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
+            @cancelAccountRecovery={{this.cancelAccountRecovery}}
+          />
+        {{/if}}
+      </div>
+    </div>
+  </div>
+</div>

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -930,7 +930,7 @@
           "text": "Si vous possédez un compte avec une adresse e-mail valide, "
         },
         "form": {
-          "tooltip": "Où trouver mon INE ? '<br>' Cet identifiant se trouve souvent sur le bulletin scolaire, sinon votre ancien établissement peut vous le fournir.",
+          "tooltip": "<em>Où trouver mon INE ?</em> '<br>' Cet identifiant se trouve souvent sur le bulletin scolaire, sinon votre ancien établissement peut vous le fournir.",
           "ine-ina": "INE (Identifiant National Élève)",
           "last-name": "Nom",
           "first-name": "Prénom",


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la sortie SCO, il faut permettre à l'utilisateur de récupérer son compte Pix.
En effet, les élèves sortant de leur école on pu utiliser pix sans adresse email, juste en utilisant leur identifiant fournit par l'école / le collège. 

Actuellement nous avons les premières étapes permettant à un étudiant de récupérer son compte : 
- un formulaire pour récupérer ses informations personnelles
- une étape de confirmation
- une étape de conflit si son compte est utilisé par plusieurs personne (ex: un frère et une soeur utilisant le même compte Pix)

Ces étapes n'ont pas été mises en pages pour être développées plus rapidement.

## :robot: Solution
Mettre plus de sexyness sur les étapes de la récupération de compte.
Et rajouter un message d'erreur quand on ne retrouve pas le compte de la personne.

## :rainbow: Remarques
- Il manque encore l'image décorative.
- Maintenant quand on ne trouve pas quelqu'un avec les infos qu'il fournit **on affiche un message d'erreur.**

## :100: Pour tester
Lancer l'API avec le feature toggle actif : 
- `IS_SCO_ACCOUNT_RECOVERY_ENABLED=true npm start -- --watch`
Lancer mon-pix : 
- aller sur `/recuperer-mon-compte`
- constater que la page de formulaire est stylé
- rentrer les infos suivantes : 
```
123456789BB
'De Cambridge'
 'George'
22
07
2013
  ```
- constater que la page de confirmation est stylé
- rentrer en base un nouveau schooling-registration avec les infos suivantes : 
```
userId: 100039	
organizationId: 6
firstName: Lyanna	
lastName: Mormont	
birthdate: 2002-01-07										
nationalStudentId: 123456789DD									
```
- revenir sur la page de formulaire
- remplir avec les infos précédentes (celles de Lyanna)
- constater que la page de conflit est stylé