### PR TITLE
[TECH] Gère la redéfinition de l'extension de knex QueryBuilder pour les tests en mode watch

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -26,9 +26,16 @@ const { environment } = require('../lib/config');
 
 /* QueryBuilder Extension */
 const Knex = require('knex');
-Knex.QueryBuilder.extend('whereInArray', function(column, values) {
-  return this.where(column, knex.raw('any(?)', [ values ]));
-});
+
+try {
+  Knex.QueryBuilder.extend('whereInArray', function(column, values) {
+    return this.where(column, knex.raw('any(?)', [ values ]));
+  });
+} catch (e) {
+  if (e.message !== 'Can\'t extend QueryBuilder with existing method (\'whereInArray\').') {
+    console.error(e);
+  }
+}
 /* -------------------- */
 
 const knexConfig = knexConfigs[environment];


### PR DESCRIPTION
## :unicorn: Problème
Depuis #3109 nous avons une extension knex pour le query builder `whereInArray`. En mode watch, on va recharger le fichier `knex-database-connection`, et tenter de rédéfinir l'extension, qui envoie une erreur car déjà défini.

## :robot: Solution
Attraper l'erreur et l'ignore.

## :rainbow: Remarques
Je n'ai pas réussi a trouver un endroit dans le code de knex pour tester si la méthode était déjà défini. Je me suis résigné a faire un try/catch et a n'ignorer que le message d'erreur spécifique

## :100: Pour tester
1. Lancer les tests en mode watch avec `npm run test:api:watch`
2. Faire une modification dans le code quelconque pour déclencher le mode watch
3. Vérifier que les tests tournent bien
