### PR TITLE
[FEATURE] Création d'un curseur et ajout de celui-ci dans la réponse lors des envois des résultats P-E (PIX-2743)

### DIFF
--- a/api/db/seeds/data/pole-emploi-sendings-builder.js
+++ b/api/db/seeds/data/pole-emploi-sendings-builder.js
@@ -7,17 +7,16 @@ module.exports = function poleEmploisSendingsBuilder({ databaseBuilder }) {
     return _.sample(possibleChoices);
   };
 
-  const _generateDate = () => {
-    const mounth = Math.floor(Math.random() * 12) + 1;
-    const day = Math.floor(Math.random() * 29) + 1;
-    return new Date(`2020-${mounth}-${day}`);
+  const _generateDate = (index) => {
+    const date = new Date('2019-12-01');
+    return new Date(date.setDate(date.getDate() + index));
   };
 
   _.times(300, async (index) => {
     const user = await databaseBuilder.factory.buildUser({ firstName: `FirstName-${index}`, lastName: `LastName-${index}` });
     await databaseBuilder.factory.buildAuthenticationMethod({ userId: user.id, identityProvider: 'POLE_EMPLOI', externalIdentifier: `externalUserId${user.id}` });
     const campaignParticipationId = await databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, campaignId: POLE_EMPLOI_CAMPAIGN_ID }).id;
-    await databaseBuilder.factory.buildPoleEmploiSending({ ..._generateStatus(), campaignParticipationId, createdAt: _generateDate(), payload: {
+    await databaseBuilder.factory.buildPoleEmploiSending({ ..._generateStatus(), campaignParticipationId, createdAt: _generateDate(index), payload: {
       campagne: {
         nom: 'Campagne PE',
         dateDebut: '2019-08-01T00:00:00.000Z',

--- a/api/lib/application/pole-emplois/pole-emploi-controller.js
+++ b/api/lib/application/pole-emplois/pole-emploi-controller.js
@@ -16,8 +16,9 @@ module.exports = {
     return h.response(response).code(200);
   },
 
-  async getSendings(_request, h) {
-    const sendings = await usecases.getPoleEmploiSendings();
-    return h.response(sendings).code(200);
+  async getSendings(request, h) {
+    const cursor = request.query.curseur;
+    const { sendings, link } = await usecases.getPoleEmploiSendings({ cursor });
+    return h.response(sendings).header('link', link).code(200);
   },
 };

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -89,6 +89,10 @@ module.exports = (function() {
       tokenForStudentReconciliationLifespan: '1h',
     },
 
+    apiManager: {
+      url: (process.env.APIM_URL || 'https://gateway.pix.fr'),
+    },
+
     jwtConfig: {
       livretScolaire: {
         secret: process.env.LIVRET_SCOLAIRE_AUTH_SECRET,

--- a/api/lib/domain/services/pole-emploi-service.js
+++ b/api/lib/domain/services/pole-emploi-service.js
@@ -1,0 +1,24 @@
+const settings = require('../../config');
+
+function generateLink(sending) {
+  const host = settings.apiManager.url;
+  const { dateEnvoi, idEnvoi } = sending;
+  const cursor = generateCursor({ idEnvoi, dateEnvoi });
+  return `${host}/pole-emploi/envois?curseur=${cursor}`;
+}
+
+function generateCursor(data) {
+  const string = JSON.stringify(data);
+  const buffer = new Buffer.from(string);
+  return buffer.toString('base64');
+}
+
+function decodeCursor(strbase64) {
+  if (!strbase64) return null;
+
+  const buffer = new Buffer.from(strbase64, 'base64');
+  const string = buffer.toString('ascii');
+  return JSON.parse(string);
+}
+
+module.exports = { generateLink, generateCursor, decodeCursor };

--- a/api/lib/domain/usecases/get-pole-emploi-sendings.js
+++ b/api/lib/domain/usecases/get-pole-emploi-sendings.js
@@ -1,3 +1,16 @@
-module.exports = function getPoleEmploiSendings({ poleEmploiSendingRepository }) {
-  return poleEmploiSendingRepository.get();
+const poleEmploiService = require('../services/pole-emploi-service');
+
+module.exports = async function getPoleEmploiSendings({ cursor, poleEmploiSendingRepository }) {
+  const cursorData = await poleEmploiService.decodeCursor(cursor);
+  const sendings = await poleEmploiSendingRepository.get(cursorData);
+  const link = _generateLink(sendings);
+  return { sendings, link };
 };
+
+function _generateLink(sendings) {
+  if (!sendings.length) return null;
+
+  const lastSending = sendings[sendings.length - 1];
+  const link = poleEmploiService.generateLink(lastSending);
+  return link;
+}

--- a/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -7,7 +7,7 @@ module.exports = {
     return new BookshelfPoleEmploiSending(poleEmploiSending).save();
   },
 
-  async get() {
+  async get(sending) {
     const POLE_EMPLOI_SENDINGS_LIMIT = settings.poleEmploi.poleEmploiSendingsLimit;
     const IDENTITY_PROVIDER_POLE_EMPLOI = settings.poleEmploi.poleEmploiIdentityProvider;
 
@@ -16,6 +16,7 @@ module.exports = {
       .join('campaign-participations', 'campaign-participations.id', 'pole-emploi-sendings.campaignParticipationId')
       .join('authentication-methods', 'authentication-methods.userId', 'campaign-participations.userId')
       .where('authentication-methods.identityProvider', IDENTITY_PROVIDER_POLE_EMPLOI)
+      .modify(_olderThan, sending)
       .orderBy([{ column: 'pole-emploi-sendings.createdAt', order: 'desc' }, { column: 'pole-emploi-sendings.id', order: 'desc' }])
       .limit(POLE_EMPLOI_SENDINGS_LIMIT);
 
@@ -28,3 +29,10 @@ module.exports = {
     return sendings;
   },
 };
+
+function _olderThan(qb, sending) {
+  if (sending) {
+    qb.where('pole-emploi-sendings.createdAt', '<', sending.dateEnvoi)
+      .where('pole-emploi-sendings.id', '<', sending.idEnvoi);
+  }
+}

--- a/api/sample.env
+++ b/api/sample.env
@@ -183,6 +183,19 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # default: 'orga.pix'
 # DOMAIN_PIX_ORGA=
 
+# ========
+# API MANAGER
+# ========
+
+
+# API Manager url
+#
+# presence: optional
+# type: String
+# default: 'https://gateway.pix.fr'
+#APIM_URL=
+
+
 # ================
 # LEARNING CONTENT
 # ================

--- a/api/tests/integration/domain/usecases/get-pole-emploi-sendings_test.js
+++ b/api/tests/integration/domain/usecases/get-pole-emploi-sendings_test.js
@@ -1,0 +1,80 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const poleEmploiService = require('../../../../lib/domain/services/pole-emploi-service');
+const poleEmploiSendingRepository = require('../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
+const settings = require('../../../../lib/config');
+
+describe('Integration | UseCase | get-campaign-participations-counts-by-stage', () => {
+  let originalEnv;
+  let sending1;
+  let sending2;
+  let campaignId;
+
+  beforeEach(async() => {
+    originalEnv = settings.apiManager.url;
+    settings.apiManager.url = 'https://fake-url.fr';
+
+    const organizationId = databaseBuilder.factory.buildOrganization({ name: 'Pole emploi' }).id;
+    campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+
+    const user1Id = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildAuthenticationMethod({ userId: user1Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId1' });
+    const campaignParticipation1Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user1Id, campaignId }).id;
+    sending1 = databaseBuilder.factory.buildPoleEmploiSending({ id: 8766, campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
+
+    const user2Id = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildAuthenticationMethod({ userId: user2Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId2' });
+    const campaignParticipation2Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user2Id, campaignId }).id;
+    sending2 = databaseBuilder.factory.buildPoleEmploiSending({ id: 45678, campaignParticipationId: campaignParticipation2Id, createdAt: new Date('2021-04-01'), payload: { individu: {} } });
+
+    await databaseBuilder.commit();
+
+  });
+
+  afterEach(() => {
+    settings.apiManager.url = originalEnv;
+  });
+
+  context('when there is no cursor', function() {
+    it('should return the most recent sendings', async () => {
+      //given
+      const cursor = null;
+
+      //when
+      const expectedLink = poleEmploiService.generateLink({ idEnvoi: sending1.id, dateEnvoi: sending1.createdAt });
+
+      const response = await usecases.getPoleEmploiSendings({ cursor, poleEmploiSendingRepository });
+      //then
+      expect(response.sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending2.id, sending1.id]);
+      expect(response.link).to.equal(expectedLink);
+    });
+  });
+
+  context('when there is a cursor', function() {
+    it('should return a sending with a link', async () => {
+      //given
+      const cursorCorrespondingToSending2 = poleEmploiService.generateCursor({ idEnvoi: sending2.id, dateEnvoi: sending2.createdAt });
+      const expectedLink = poleEmploiService.generateLink({ idEnvoi: sending1.id, dateEnvoi: sending1.createdAt });
+
+      //when
+      const response = await usecases.getPoleEmploiSendings({ cursor: cursorCorrespondingToSending2, poleEmploiSendingRepository });
+      //then
+      expect(response.sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending1.id]);
+      expect(response.link).to.equal(expectedLink);
+    });
+  });
+
+  context('when there is a cursor but there is no more sending', function() {
+    it('should return neither a sending nor a link', async () => {
+      //given
+      const cursorCorrespondingToSending1 = poleEmploiService.generateCursor({ idEnvoi: sending1.id, dateEnvoi: sending1.createdAt });
+
+      //when
+      const response = await usecases.getPoleEmploiSendings({ cursor: cursorCorrespondingToSending1, poleEmploiSendingRepository });
+
+      //then
+      expect(response.sendings).to.deep.equal([]);
+      expect(response.link).to.equal(null);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -31,6 +31,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
     let originalEnvPoleEmploiSendingsLimit;
     let sending1;
     let sending2;
+    let sending3;
     let sending4;
 
     beforeEach(async () => {
@@ -45,17 +46,17 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       const user1Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user1Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId1' });
       const campaignParticipation1Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user1Id, campaignId }).id;
-      sending1 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-05-01'), payload: { individu: {} } });
+      sending1 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
 
       const user2Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user2Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId2' });
       const campaignParticipation2Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user2Id, campaignId }).id;
-      sending2 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation2Id, createdAt: new Date('2021-04-01'), payload: { individu: {} } });
+      sending2 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation2Id, createdAt: '2021-04-01 00:00:00+00', payload: { individu: {} } });
 
       const user3Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user3Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId3' });
       const campaignParticipation3Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user3Id, campaignId }).id;
-      databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation3Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
+      sending3 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation3Id, createdAt: new Date('2021-05-01'), payload: { individu: {} } });
 
       const user4Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user4Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId4' });
@@ -87,7 +88,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       const sendings = await poleEmploiSendingRepository.get();
 
       // then
-      expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending4.id, sending1.id, sending2.id]);
+      expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending4.id, sending3.id, sending2.id]);
     });
 
     it('should render sendings with idPoleEmploi inside the object', async () => {
@@ -95,7 +96,21 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       const sendings = await poleEmploiSendingRepository.get();
 
       // then
-      expect(sendings.map((sending) => sending.resultat.individu.idPoleEmploi)).to.deep.equal(['externalUserId4', 'externalUserId1', 'externalUserId2']);
+      expect(sendings.map((sending) => sending.resultat.individu.idPoleEmploi)).to.deep.equal(['externalUserId4', 'externalUserId3', 'externalUserId2']);
+    });
+
+    context('when there is an idEnvoi and a dateEnvoi in the cursor', function() {
+      it('should return sendings where the date is before de given date', async() => {
+        //given
+        const idEnvoi = sending2.id;
+        const dateEnvoi = sending2.createdAt;
+
+        //when
+        const sendings = await poleEmploiSendingRepository.get({ idEnvoi, dateEnvoi });
+
+        //then
+        expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending1.id]);
+      });
     });
   });
 });

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -1,4 +1,4 @@
-const { expect, sinon, request, hFake } = require('../../../test-helper');
+const { expect, sinon, hFake } = require('../../../test-helper');
 
 const poleEmploiController = require('../../../../lib/application/pole-emplois/pole-emploi-controller');
 const usecases = require('../../../../lib/domain/usecases');
@@ -6,38 +6,40 @@ const usecases = require('../../../../lib/domain/usecases');
 describe('Unit | Controller | pole-emplois-controller', () => {
 
   describe('#getSendings', () => {
+    context('when there is a cursor in the url', function() {
+      it('should return the pole emploi sending', async () => {
+        // given
+        const request = { query: { curseur: 'azefvbjljhgrEDJNH' } };
+        const sending = [{
+          idEnvoi: 456,
+          dateEnvoi: new Date('2021-05-01'),
+          resultat: {
+            campagne: {
+              nom: 'Campagne PE',
+              dateDebut: '2020-08-01T00:00:00.000Z',
+              type: 'EVALUATION',
+              codeCampagne: 'POLEEMPLOI123',
+              urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123',
+              nomOrganisme: 'Pix',
+              typeOrganisme: 'externe' },
+            individu: {
+              nom: 'Kamado',
+              prenom: 'Tanjiro',
+              idPoleEmploi: 'externalUserId' },
+            test: {
+              etat: 2,
+              typeTest: 'DI',
+              referenceExterne: 123456,
+              dateDebut: '2020-09-01T00:00:00.000Z',
+              elementsEvalues: [] } } }];
+        sinon.stub(usecases, 'getPoleEmploiSendings').withArgs({ cursor: request.query.curseur }).resolves(sending);
 
-    it('should return the pole emploi sending', async () => {
-      // given
-      const sending = [{
-        idEnvoi: 456,
-        dateEnvoi: new Date('2021-05-01'),
-        resultat: {
-          campagne: {
-            nom: 'Campagne PE',
-            dateDebut: '2020-08-01T00:00:00.000Z',
-            type: 'EVALUATION',
-            codeCampagne: 'POLEEMPLOI123',
-            urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123',
-            nomOrganisme: 'Pix',
-            typeOrganisme: 'externe' },
-          individu: {
-            nom: 'Kamado',
-            prenom: 'Tanjiro',
-            idPoleEmploi: 'externalUserId' },
-          test: {
-            etat: 2,
-            typeTest: 'DI',
-            referenceExterne: 123456,
-            dateDebut: '2020-09-01T00:00:00.000Z',
-            elementsEvalues: [] } } }];
-      sinon.stub(usecases, 'getPoleEmploiSendings').withArgs().resolves(sending);
+        // when
+        await poleEmploiController.getSendings(request, hFake);
 
-      // when
-      await poleEmploiController.getSendings(request, hFake);
-
-      //then
-      expect(usecases.getPoleEmploiSendings).have.been.calledOnce;
+        //then
+        expect(usecases.getPoleEmploiSendings).have.been.calledWith({ cursor: 'azefvbjljhgrEDJNH' });
+      });
     });
   });
 });

--- a/api/tests/unit/domain/services/pole-emploi-service_test.js
+++ b/api/tests/unit/domain/services/pole-emploi-service_test.js
@@ -1,0 +1,50 @@
+const { expect } = require('../../../test-helper');
+const poleEmploiService = require('../../../../lib/domain/services/pole-emploi-service');
+const settings = require('../../../../lib/config');
+
+describe('Unit | Service | Pole Emploi Service', function() {
+  describe('#generateLink', function() {
+    const originalEnv = settings.apiManager.url;
+
+    before(() => {
+      settings.apiManager.url = 'https://url-externe';
+    });
+
+    after(() => {
+      settings.apiManager.url = originalEnv;
+    });
+
+    it('should generate a link', function() {
+      const sending = {
+        idEnvoi: 456,
+        dateEnvoi: '2021-05-01T00:00:00.000Z',
+        resultat: { } };
+
+      // when
+      const generatedLink = poleEmploiService.generateLink(sending);
+
+      // then
+      expect(generatedLink).to.equal('https://url-externe/pole-emploi/envois?curseur=eyJpZEVudm9pIjo0NTYsImRhdGVFbnZvaSI6IjIwMjEtMDUtMDFUMDA6MDA6MDAuMDAwWiJ9');
+    });
+  });
+
+  describe('#decodeCursor', function() {
+    context('when there is a cursor', ()=> {
+      it('should decode the cursor', function() {
+        const cursor = poleEmploiService.generateCursor({ idEnvoi: 456, dateEnvoi: '2021-05-01T00:00:00.000Z' });
+        const decodedData = poleEmploiService.decodeCursor(cursor);
+
+        expect(decodedData).to.deep.equal({ idEnvoi: 456, dateEnvoi: '2021-05-01T00:00:00.000Z' });
+      });
+    });
+
+    context('when the parameter is undefined', ()=> {
+      it('should return null', function() {
+        const str = undefined;
+        const decodedData = poleEmploiService.decodeCursor(str);
+
+        expect(decodedData).to.deep.equal(null);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Cette pr fait suite à la [PR#3133](https://github.com/1024pix/pix/pull/3133) qui concerne la résilience pole-emploi. On renvoie les résultats par paquets de 100. Mais on a aucun moyen de savoir à quel est le dernier résultat  envoyé.


## :robot: Solution
Création d'un curseur, qui est composé de l'id et de la date d'envoi du dernier résultat envoyé. Une fois ce curseur généré, on vient créer un lien avec en paramètre le curseur. Ce lien va être envoyé dans le header de la réponse.

Lorsqu'on va vouloir récupérer les 100 prochains résultats, on va utiliser le lien et on va décoder les curseur pour savoir quel était le dernier résultat envoyé et envoyé les 100 prochains.

## :rainbow: Remarques

Ajout de la variable d'environnement `APIM_URL`

## :100: Pour tester
- création d'un jeton pole-emploi
- avec le jeton pole emploi généré, récupération des 100 premiers résultats  + du lien dans le header
- avec le lien du header, récupérer les 100 prochains.
