### PR TITLE
[TECH] Ajouter les top level domains .fr et .org aux domaines locaux

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -72,13 +72,19 @@ npm start
 
 ### 6. (Facultatif) Configurer les domaines locaux.
 
-Il est possible d'accéder aux applications Pix avec des domaines `*.pix.local` 
+Il est possible d'accéder aux applications Pix avec des domaines `*.dev.pix.<tld>` 
 plutôt que `localhost:port` :
 
-- http://app.pix.local/
-- http://orga.pix.local/
-- http://admin.pix.local/
-- http://certif.pix.local/
+- Mon Pix
+  - http://app.dev.pix.fr/
+  - http://app.dev.pix.org/
+- Orga
+  - http://orga.dev.pix.fr/
+  - http://orga.dev.pix.org/
+- Admin
+  - http://admin.dev.pix.fr/
+- Certif
+  - http://certif.dev.pix.fr/
 
 Pour configurer les domaines locaux, exécuter le script :
 

--- a/scripts/local-domains/hosts.txt
+++ b/scripts/local-domains/hosts.txt
@@ -1,4 +1,6 @@
 127.0.0.1 app.dev.pix.fr
+127.0.0.1 app.dev.pix.org
 127.0.0.1 orga.dev.pix.fr
+127.0.0.1 orga.dev.pix.org
 127.0.0.1 admin.dev.pix.fr
 127.0.0.1 certif.dev.pix.fr

--- a/scripts/local-domains/hosts.txt
+++ b/scripts/local-domains/hosts.txt
@@ -1,4 +1,4 @@
-127.0.0.1 app.pix.local
-127.0.0.1 orga.pix.local
-127.0.0.1 admin.pix.local
-127.0.0.1 certif.pix.local
+127.0.0.1 app.dev.pix.fr
+127.0.0.1 orga.dev.pix.fr
+127.0.0.1 admin.dev.pix.fr
+127.0.0.1 certif.dev.pix.fr

--- a/scripts/local-domains/nginx.conf
+++ b/scripts/local-domains/nginx.conf
@@ -1,26 +1,26 @@
 server {
-  server_name app.pix.local;
+  server_name app.dev.pix.fr;
   location / {
     proxy_pass http://host.docker.internal:4200;
   }
 }
 
 server {
-  server_name orga.pix.local;
+  server_name orga.dev.pix.fr;
   location / {
     proxy_pass http://host.docker.internal:4201;
   }
 }
 
 server {
-  server_name admin.pix.local;
+  server_name admin.dev.pix.fr;
   location / {
     proxy_pass http://host.docker.internal:4202;
   }
 }
 
 server {
-  server_name certif.pix.local;
+  server_name certif.dev.pix.fr;
   location / {
     proxy_pass http://host.docker.internal:4203;
   }

--- a/scripts/local-domains/nginx.conf
+++ b/scripts/local-domains/nginx.conf
@@ -6,7 +6,21 @@ server {
 }
 
 server {
+  server_name app.dev.pix.org;
+  location / {
+    proxy_pass http://host.docker.internal:4200;
+  }
+}
+
+server {
   server_name orga.dev.pix.fr;
+  location / {
+    proxy_pass http://host.docker.internal:4201;
+  }
+}
+
+server {
+  server_name orga.dev.pix.org;
   location / {
     proxy_pass http://host.docker.internal:4201;
   }


### PR DESCRIPTION
## :unicorn: Problème

On veut pouvoir tester certaines fonctionnalités qui dépendent du top level domain. Par exemple, le bouton de connexion via Pole Emploi n'est disponible que si le tld est `.fr` et pas `.org`.

## :robot: Solution

Distinguer les domaines dans la config des domaines locaux.

## :rainbow: Remarques

Nous en avons profité pour utiliser des domaines qui respectent la convention des autres environnements, par exemple `app.pix.local` est devenu `app.dev.pix.fr` comme il existe `app.integration.pix.fr`, etc.

## :100: Pour tester
Voir [INSTALLATION.md](https://github.com/1024pix/pix/blob/tech-allow-tld-in-local-domains/INSTALLATION.md)
