### PR TITLE
[FEATURE] Vérifier la demande de récupération de compte - Sortie SCO (PIX-2774).

### DIFF
--- a/api/db/database-builder/factory/build-account-recovery-demand.js
+++ b/api/db/database-builder/factory/build-account-recovery-demand.js
@@ -7,6 +7,7 @@ module.exports = function buildAccountRecoveryDemand({
   newEmail = 'philipe@example.net',
   temporaryKey = 'OWIxZGViNGQtM2I3ZC00YmFkLTliZGQtMmIwZDdiM2RjYjZk',
   used = false,
+  createdAt,
 } = {}) {
 
   const values = {
@@ -16,6 +17,7 @@ module.exports = function buildAccountRecoveryDemand({
     newEmail,
     temporaryKey,
     used,
+    createdAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'account-recovery-demands',

--- a/api/lib/application/account-recovery/account-recovery-controller.js
+++ b/api/lib/application/account-recovery/account-recovery-controller.js
@@ -1,4 +1,5 @@
 const usecases = require('../../domain/usecases');
+const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 
 module.exports = {
 
@@ -9,6 +10,12 @@ module.exports = {
     await usecases.sendEmailForAccountRecovery({ userId, email });
 
     return h.response().code(204);
+  },
+
+  async checkAccountRecoveryDemand(request) {
+    const temporaryKey = request.params.temporaryKey;
+    const user = await usecases.getUserByAccountRecoveryDemand({ temporaryKey });
+    return userSerializer.serialize(user);
   },
 
 };

--- a/api/lib/application/account-recovery/index.js
+++ b/api/lib/application/account-recovery/index.js
@@ -35,6 +35,24 @@ exports.register = async function(server) {
         tags: ['api', 'account-recovery'],
       },
     },
+
+    {
+      method: 'GET',
+      path: '/api/account-recovery/{temporaryKey}',
+      config: {
+        auth: false,
+        handler: accountRecoveryController.checkAccountRecoveryDemand,
+        pre: [
+          {
+            method: featureToggles.isScoAccountRecoveryEnabled,
+            assign: 'isScoAccountRecoveryEnabled',
+          },
+        ],
+        notes: ['- Permet de vérifier la demande de récupération de son compte Pix.\n' +
+        '- Renvoie l’utilisateur correspondant à la demande pour une réinitialisation de mot de passe.'],
+        tags: ['api', 'account-recovery'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -60,7 +60,9 @@ function _mapToHttpError(error) {
   if (error instanceof HttpErrors.BaseHttpError) {
     return error;
   }
-
+  if (error instanceof DomainErrors.AccountRecoveryDemandExpired) {
+    return new HttpErrors.UnauthorizedError(error.message);
+  }
   if (error instanceof DomainErrors.ImproveCompetenceEvaluationForbiddenError) {
     return new HttpErrors.ImproveCompetenceEvaluationForbiddenError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -139,7 +139,7 @@ class NoStagesForCampaign extends DomainError {
 }
 
 class AccountRecoveryDemandExpired extends DomainError {
-  constructor(message = 'The account recovery demand has expired.') {
+  constructor(message = 'This account recovery demand has expired.') {
     super(message);
   }
 }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -138,6 +138,12 @@ class NoStagesForCampaign extends DomainError {
   }
 }
 
+class AccountRecoveryDemandExpired extends DomainError {
+  constructor(message = 'The account recovery demand has expired.') {
+    super(message);
+  }
+}
+
 class SchoolingRegistrationsCouldNotBeSavedError extends DomainError {
   constructor() {
     super('An error occurred during process');
@@ -857,6 +863,7 @@ class InvalidExternalAPIResponseError extends DomainError {
 
 module.exports = {
   AccountRecoveryDemandNotCreatedError,
+  AccountRecoveryDemandExpired,
   AlreadyExistingEntityError,
   AlreadyExistingCampaignParticipationError,
   AlreadyExistingMembershipError,

--- a/api/lib/domain/usecases/account-recovery/get-user-by-account-recovery-demand.js
+++ b/api/lib/domain/usecases/account-recovery/get-user-by-account-recovery-demand.js
@@ -4,5 +4,7 @@ module.exports = async function getUserByAccountRecoveryDemand({
   userRepository,
 }) {
   const accountRecoveryDemand = await accountRecoveryDemandRepository.findByTemporaryKey(temporaryKey);
-  return userRepository.get(accountRecoveryDemand.userId);
+  const foundUser = await userRepository.get(accountRecoveryDemand.userId);
+  foundUser.email = accountRecoveryDemand.newEmail;
+  return foundUser;
 };

--- a/api/lib/domain/usecases/account-recovery/get-user-by-account-recovery-demand.js
+++ b/api/lib/domain/usecases/account-recovery/get-user-by-account-recovery-demand.js
@@ -1,0 +1,8 @@
+module.exports = async function getUserByAccountRecoveryDemand({
+  temporaryKey,
+  accountRecoveryDemandRepository,
+  userRepository,
+}) {
+  const accountRecoveryDemand = await accountRecoveryDemandRepository.findByTemporaryKey(temporaryKey);
+  return userRepository.get(accountRecoveryDemand.userId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -260,6 +260,7 @@ module.exports = injectDependencies({
   getShareableCertificate: require('./certificate/get-shareable-certificate'),
   getStageDetails: require('./get-stage-details'),
   getTargetProfileDetails: require('./get-target-profile-details'),
+  getUserByAccountRecoveryDemand: require('./account-recovery/get-user-by-account-recovery-demand'),
   getUserByResetPasswordDemand: require('./get-user-by-reset-password-demand'),
   getUserCampaignAssessmentResult: require('./get-user-campaign-assessment-result'),
   getUserCampaignParticipationToCampaign: require('./get-user-campaign-participation-to-campaign'),

--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -7,7 +7,7 @@ const {
 } = require('../../domain/errors');
 const { isEmpty } = require('lodash');
 
-function _toDomain(accountRecoveryDemandDTO) {
+function _toDomainObject(accountRecoveryDemandDTO) {
   return new AccountRecoveryDemand({
     ...accountRecoveryDemandDTO,
   });
@@ -39,7 +39,7 @@ module.exports = {
       throw new AccountRecoveryDemandExpired();
     }
 
-    return _toDomain(accountRecoveryDemand);
+    return _toDomainObject(accountRecoveryDemand);
   },
 
   async save(accountRecoveryDemand) {
@@ -47,7 +47,7 @@ module.exports = {
       .insert(accountRecoveryDemand)
       .returning('*');
 
-    return _toDomain(result[0]);
+    return _toDomainObject(result[0]);
   },
 
 };

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
@@ -1,0 +1,35 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const { featureToggles } = require('../../../../lib/config');
+const createServer = require('../../../../server');
+
+describe('Integration | Application | Account-Recovery | Routes', () => {
+
+  describe('GET /api/account-recovery/{temporaryKey}', () => {
+
+    it('should return 200 http status code when recovery demand found', async () => {
+      // given
+      const temporaryKey = 'DJFKDKJJSHQJ';
+      const userId = 1234;
+      databaseBuilder.factory.buildUser.withRawPassword({ id: userId });
+      databaseBuilder.factory.buildAccountRecoveryDemand({ userId, temporaryKey, used: false });
+      await databaseBuilder.commit();
+      const server = await createServer();
+      featureToggles.isScoAccountRecoveryEnabled = true;
+
+      const options = {
+        method: 'GET',
+        url: '/api/account-recovery/' + temporaryKey,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.type).to.equal('users');
+      expect(response.result.data.id).to.equal(userId.toString());
+
+    });
+
+  });
+});

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
@@ -6,12 +6,13 @@ describe('Integration | Application | Account-Recovery | Routes', () => {
 
   describe('GET /api/account-recovery/{temporaryKey}', () => {
 
-    it('should return 200 http status code when recovery demand found', async () => {
+    it('should return 200 http status code when account recovery demand found', async () => {
       // given
       const temporaryKey = 'DJFKDKJJSHQJ';
       const userId = 1234;
+      const newEmail = 'newEmail@example.net';
       databaseBuilder.factory.buildUser.withRawPassword({ id: userId });
-      databaseBuilder.factory.buildAccountRecoveryDemand({ userId, temporaryKey, used: false });
+      databaseBuilder.factory.buildAccountRecoveryDemand({ userId, temporaryKey, newEmail, used: false });
       await databaseBuilder.commit();
       const server = await createServer();
       featureToggles.isScoAccountRecoveryEnabled = true;
@@ -28,6 +29,7 @@ describe('Integration | Application | Account-Recovery | Routes', () => {
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.type).to.equal('users');
       expect(response.result.data.id).to.equal(userId.toString());
+      expect(response.result.data.attributes.email).to.equal(newEmail);
 
     });
 

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
@@ -31,5 +31,22 @@ describe('Integration | Application | Account-Recovery | Routes', () => {
 
     });
 
+    it('should return 404 http status code when the feature disabled', async () => {
+      // given
+      const temporaryKey = 'DJFKDKJJSHQJ';
+      const server = await createServer();
+
+      const options = {
+        method: 'GET',
+        url: '/api/account-recovery/' + temporaryKey,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+
   });
 });

--- a/api/tests/integration/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/integration/application/account-recovery/account-recovery-controller_test.js
@@ -8,7 +8,6 @@ const { featureToggles } = require('../../../../lib/config');
 const {
   NotFoundError,
   UserNotFoundError,
-  AccountRecoveryDemandExpired,
 } = require('../../../../lib/domain/errors');
 const usecases = require('../../../../lib/domain/usecases');
 
@@ -50,17 +49,6 @@ describe('Integration | Application | Account-Recovery | account-recovery-contro
     });
 
     context('Error cases', () => {
-
-      it('should respond an HTTP response with status code 401 when TemporaryKey has expired', async () => {
-        // given
-        usecases.getUserByAccountRecoveryDemand.rejects(new AccountRecoveryDemandExpired());
-
-        // when
-        const response = await httpTestServer.request(method, url);
-
-        // then
-        expect(response.statusCode).to.equal(401);
-      });
 
       it('should respond an HTTP response with status code 404 when TemporaryKey not found', async () => {
         // given

--- a/api/tests/integration/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/integration/application/account-recovery/account-recovery-controller_test.js
@@ -1,0 +1,90 @@
+const {
+  domainBuilder,
+  expect,
+  sinon,
+  HttpTestServer,
+} = require('../../../test-helper');
+const { featureToggles } = require('../../../../lib/config');
+const {
+  NotFoundError,
+  UserNotFoundError,
+  AccountRecoveryDemandExpired,
+} = require('../../../../lib/domain/errors');
+const usecases = require('../../../../lib/domain/usecases');
+
+const moduleUnderTest = require('../../../../lib/application/account-recovery');
+
+describe('Integration | Application | Account-Recovery | account-recovery-controller', () => {
+
+  let httpTestServer;
+
+  beforeEach(async() => {
+    sinon.stub(usecases, 'getUserByAccountRecoveryDemand');
+
+    httpTestServer = new HttpTestServer();
+    featureToggles.isScoAccountRecoveryEnabled = true;
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('#checkAccountRecoveryDemand', () => {
+
+    const method = 'GET';
+    const url = '/api/account-recovery/ABCDEF123';
+    const userId = 1234;
+    const user = domainBuilder.buildUser({ userId });
+
+    context('Success cases', () => {
+
+      it('should return an HTTP response with status code 200', async () => {
+        // given
+        usecases.getUserByAccountRecoveryDemand.resolves(user);
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.type).to.equal('users');
+        expect(response.result.data.id).to.equal(user.id.toString());
+      });
+    });
+
+    context('Error cases', () => {
+
+      it('should respond an HTTP response with status code 401 when TemporaryKey has expired', async () => {
+        // given
+        usecases.getUserByAccountRecoveryDemand.rejects(new AccountRecoveryDemandExpired());
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+
+      it('should respond an HTTP response with status code 404 when TemporaryKey not found', async () => {
+        // given
+        usecases.getUserByAccountRecoveryDemand.rejects(new NotFoundError());
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+
+      it('should respond an HTTP response with status code 404 when UserNotFoundError', async () => {
+        // given
+        usecases.getUserByAccountRecoveryDemand.rejects(new UserNotFoundError());
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+
+    });
+  });
+
+});

--- a/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
@@ -1,6 +1,10 @@
 const { expect, knex, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
 const accountRecoveryDemandRepository = require('../../../../lib/infrastructure/repositories/account-recovery-demand-repository');
-const { NotFoundError, TooManyRows } = require('../../../../lib/domain/errors');
+const {
+  NotFoundError,
+  TooManyRows,
+  AccountRecoveryDemandExpired,
+} = require('../../../../lib/domain/errors');
 const AccountRecoveryDemand = require('../../../../lib/domain/models/AccountRecoveryDemand');
 
 describe('Integration | Infrastructure | Repository | account-recovery-demand-repository', () => {
@@ -25,16 +29,15 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
     });
 
     context('when demand exists', () => {
-      const temporaryKey = 'someTemporaryKey';
 
       context('when demand has been used already', () => {
 
-        beforeEach(() => {
-          databaseBuilder.factory.buildAccountRecoveryDemand({ temporaryKey, used: true });
-          return databaseBuilder.commit();
-        });
-
         it('should throw a not found recovery demand', async () => {
+          // given
+          const temporaryKey = 'RDFGGHFFDZZ';
+          databaseBuilder.factory.buildAccountRecoveryDemand({ temporaryKey, used: true });
+          await databaseBuilder.commit();
+
           // when
           const error = await catchErr(accountRecoveryDemandRepository.findByTemporaryKey)(temporaryKey);
 
@@ -47,44 +50,63 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
       });
 
       context('when demand is unused yet', () => {
-        const email = 'someMail@example.net';
-        let demandId;
 
-        beforeEach(() => {
-          demandId = databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false }).id;
+        it('should return the account recovery demand when temporary key not expired', async () => {
+          // given
+          const email = 'someMail@example.net';
+          const temporaryKey = 'someTemporaryKey';
+          const demandId = databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false }).id;
           databaseBuilder.factory.buildAccountRecoveryDemand({ email, used: false });
-          return databaseBuilder.commit();
-        });
+          await databaseBuilder.commit();
 
-        it('should return the account recovery demand', async () => {
           // when
           const demand = await accountRecoveryDemandRepository.findByTemporaryKey(temporaryKey);
 
           // then
-          expect(demand.length).to.equal(1);
-          expect(demand[0].id).to.equal(demandId);
-          expect(demand[0].temporaryKey).to.equal(temporaryKey);
-          expect(demand[0].used).to.equal(false);
+          expect(demand.id).to.equal(demandId);
+          expect(demand.temporaryKey).to.equal(temporaryKey);
+          expect(demand.used).to.equal(false);
         });
-
       });
 
       context('when multiple demands found for the same temporary key', () => {
-        const email = 'someMail@example.net';
 
-        beforeEach(() => {
+        it('should throw too many rows error', async () => {
+          // given
+          const email = 'someMail@example.net';
+          const temporaryKey = 'ERTFFAZSDFR';
           databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false }).id;
           databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false });
-          return databaseBuilder.commit();
-        });
+          await databaseBuilder.commit();
 
-        it('should return the account recovery demand', async () => {
           // when
           const error = await catchErr(accountRecoveryDemandRepository.findByTemporaryKey)(temporaryKey);
 
           // then
           expect(error).to.be.instanceOf(TooManyRows);
           expect(error.message).to.be.equal('Multiple demands found for the same temporary key');
+        });
+
+      });
+
+      context('when demand expired a day ago', () => {
+
+        it('should throw Account Recovery Demand Expired ', async () => {
+          // given
+          const email = 'someMail@example.net';
+          const temporaryKey = 'someTemporaryKey';
+          const createdAtExpiredOneDayAgo = new Date();
+          createdAtExpiredOneDayAgo.setDate(createdAtExpiredOneDayAgo.getDate() - 1);
+
+          databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false, createdAt: createdAtExpiredOneDayAgo }).id;
+          databaseBuilder.factory.buildAccountRecoveryDemand({ email, used: false });
+          await databaseBuilder.commit();
+
+          // when
+          const error = await catchErr(accountRecoveryDemandRepository.findByTemporaryKey)(temporaryKey);
+
+          // then
+          expect(error).to.be.instanceOf(AccountRecoveryDemandExpired);
         });
 
       });

--- a/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
@@ -7,6 +7,7 @@ const {
 
 const accountRecoveryController = require('../../../../lib/application/account-recovery/account-recovery-controller');
 const usecases = require('../../../../lib/domain/usecases');
+const userSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
 
 describe('Unit | Controller | account-recovery-controller', () => {
 
@@ -36,6 +37,27 @@ describe('Unit | Controller | account-recovery-controller', () => {
       // then
       expect(usecases.sendEmailForAccountRecovery).calledWith({ userId, email: newEmail });
       expect(response.statusCode).to.equal(204);
+    });
+
+    describe('#checkAccountRecoveryDemand', () => {
+
+      it('should return serialized user', async () => {
+        // given
+        const temporaryKey = 'ABCDEFZEFDD';
+        const request = {
+          params: { temporaryKey },
+        };
+        sinon.stub(usecases, 'getUserByAccountRecoveryDemand');
+        sinon.stub(userSerializer, 'serialize');
+        usecases.getUserByAccountRecoveryDemand.resolves({ userId: 1234 });
+
+        // when
+        await accountRecoveryController.checkAccountRecoveryDemand(request, hFake);
+
+        // then
+        expect(usecases.getUserByAccountRecoveryDemand).to.have.been.calledWith({ temporaryKey });
+        expect(userSerializer.serialize).to.have.been.calledWith({ userId: 1234 });
+      });
     });
 
   });

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -5,6 +5,7 @@ const {
 } = require('../../test-helper');
 
 const {
+  AccountRecoveryDemandExpired,
   AlreadyRegisteredEmailAndUsernameError,
   AlreadyRegisteredEmailError,
   AlreadyRegisteredUsernameError,
@@ -230,6 +231,20 @@ describe('Unit | Application | ErrorManager', () => {
       // then
       expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
     });
+
+    it('should instantiate UnauthorizedError when AccountRecoveryDemandExpired', async () => {
+      // given
+      const error = new AccountRecoveryDemandExpired();
+      sinon.stub(HttpErrors, 'UnauthorizedError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.UnauthorizedError).to.have.been.calledWithExactly(error.message);
+    });
+
   });
 
 });

--- a/api/tests/unit/domain/usecases/account-recovery/get-user-by-account-recovery-demand_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/get-user-by-account-recovery-demand_test.js
@@ -55,7 +55,7 @@ describe('Unit | UseCase | get-user-by-account-recovery-demand', () => {
     expect(error).to.be.an.instanceOf(UserNotFoundError);
   });
 
-  it('should return a user with email updated by recovery demand new email', async () => {
+  it('should return a user with new email from his account recovery demand', async () => {
     // given
     const user = domainBuilder.buildUser();
     const newEmail = 'newemail@example.net';

--- a/api/tests/unit/domain/usecases/account-recovery/get-user-by-account-recovery-demand_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/get-user-by-account-recovery-demand_test.js
@@ -1,0 +1,77 @@
+const { catchErr, domainBuilder, expect, sinon } = require('../../../../test-helper');
+
+const User = require('../../../../../lib/domain/models/User');
+const {
+  NotFoundError,
+  UserNotFoundError,
+} = require('../../../../../lib/domain/errors');
+
+const getUserByAccountRecoveryDemand = require('../../../../../lib/domain/usecases/account-recovery/get-user-by-account-recovery-demand');
+
+describe('Unit | UseCase | get-user-by-account-recovery-demand', () => {
+
+  const temporaryKey = 'ZHABCDEFJSJ';
+  let userRepository;
+  let accountRecoveryDemandRepository;
+
+  beforeEach(() => {
+    accountRecoveryDemandRepository = {
+      findByTemporaryKey: sinon.stub(),
+    };
+    userRepository = {
+      get: sinon.stub(),
+    };
+
+  });
+
+  it('should throw NotFoundError if temporary key does not exist or already used', async () => {
+    // given
+    accountRecoveryDemandRepository.findByTemporaryKey.rejects(new NotFoundError('Temporary key not found or already used'));
+
+    // when
+    const error = await catchErr(getUserByAccountRecoveryDemand)({
+      temporaryKey,
+      accountRecoveryDemandRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(NotFoundError);
+  });
+
+  it('should throw UserNotFoundError if user identifier does not exist', async () => {
+    // given
+    accountRecoveryDemandRepository.findByTemporaryKey.resolves({ userId: 1234 });
+    userRepository.get.throws(new UserNotFoundError());
+
+    // when
+    const error = await catchErr(getUserByAccountRecoveryDemand)({
+      temporaryKey,
+      accountRecoveryDemandRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(UserNotFoundError);
+  });
+
+  it('should return user when the user identifier exist', async () => {
+    // given
+    const user = domainBuilder.buildUser();
+    accountRecoveryDemandRepository.findByTemporaryKey.resolves({ userId: user.id });
+    userRepository.get.resolves(user);
+
+    // when
+    const result = await getUserByAccountRecoveryDemand({
+      temporaryKey,
+      accountRecoveryDemandRepository,
+      userRepository,
+    });
+
+    // then
+    expect(result).to.be.an.instanceOf(User);
+    expect(accountRecoveryDemandRepository.findByTemporaryKey).to.have.been.calledWith(temporaryKey);
+    expect(userRepository.get).to.have.been.calledWith(user.id);
+  });
+
+});

--- a/api/tests/unit/domain/usecases/account-recovery/get-user-by-account-recovery-demand_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/get-user-by-account-recovery-demand_test.js
@@ -55,10 +55,11 @@ describe('Unit | UseCase | get-user-by-account-recovery-demand', () => {
     expect(error).to.be.an.instanceOf(UserNotFoundError);
   });
 
-  it('should return user when the user identifier exist', async () => {
+  it('should return a user with email updated by recovery demand new email', async () => {
     // given
     const user = domainBuilder.buildUser();
-    accountRecoveryDemandRepository.findByTemporaryKey.resolves({ userId: user.id });
+    const newEmail = 'newemail@example.net';
+    accountRecoveryDemandRepository.findByTemporaryKey.resolves({ userId: user.id, newEmail });
     userRepository.get.resolves(user);
 
     // when
@@ -70,6 +71,7 @@ describe('Unit | UseCase | get-user-by-account-recovery-demand', () => {
 
     // then
     expect(result).to.be.an.instanceOf(User);
+    expect(result.email).to.be.equal(newEmail);
     expect(accountRecoveryDemandRepository.findByTemporaryKey).to.have.been.calledWith(temporaryKey);
     expect(userRepository.get).to.have.been.calledWith(user.id);
   });

--- a/api/tests/unit/domain/usecases/account-recovery/send-email-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/send-email-for-account-recovery_test.js
@@ -1,9 +1,9 @@
-const { sinon, expect, catchErr, domainBuilder } = require('../../../test-helper');
-const sendEmailForAccountRecovery = require('../../../../lib/domain/usecases/send-email-for-account-recovery.js');
-const { AlreadyRegisteredEmailError } = require('../../../../lib/domain/errors');
-const AccountRecoveryDemand = require('../../../../lib/domain/models/AccountRecoveryDemand');
+const { sinon, expect, catchErr, domainBuilder } = require('../../../../test-helper');
+const sendEmailForAccountRecovery = require('../../../../../lib/domain/usecases/send-email-for-account-recovery.js');
+const { AlreadyRegisteredEmailError } = require('../../../../../lib/domain/errors');
+const AccountRecoveryDemand = require('../../../../../lib/domain/models/AccountRecoveryDemand');
 
-describe('Unit | UseCase | send-email-for-account-recovery', () => {
+describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', () => {
 
   let userRepository;
   let accountRecoveryDemandRepository;

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -31,6 +31,12 @@ export default class User extends ApplicationAdapter {
       return `${this.host}/${this.namespace}/password-reset-demands/${temporaryKey}`;
     }
 
+    if (query.accountRecoveryDemandTemporaryKey) {
+      const temporaryKey = query.accountRecoveryDemandTemporaryKey;
+      delete query.accountRecoveryDemandTemporaryKey;
+      return `${this.host}/${this.namespace}/account-recovery/${temporaryKey}`;
+    }
+
     return super.urlForQueryRecord(...arguments);
   }
 

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -50,6 +50,7 @@ Router.map(function() {
   this.route('reset-password', { path: '/changer-mot-de-passe/:temporary_key' });
   this.route('password-reset-demand', { path: '/mot-de-passe-oublie' });
   this.route('account-recovery-after-leaving-sco', { path: '/recuperer-mon-compte' });
+  this.route('account-recovery/reset-password', { path: '/recuperer-mon-compte/:temporary_key' });
 
   this.route('update-expired-password', { path: '/mise-a-jour-mot-de-passe-expire' });
   this.route('certifications', function() {
@@ -98,4 +99,5 @@ Router.map(function() {
   this.route('sitemap', { path: '/plan-du-site' });
   // XXX: this route is used for any request that did not match any of the previous routes. SHOULD ALWAYS BE THE LAST ONE
   this.route('not-found', { path: '/*path' });
+
 });

--- a/mon-pix/app/routes/account-recovery/reset-password.js
+++ b/mon-pix/app/routes/account-recovery/reset-password.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import get from 'lodash/get';
+
+export default class AccountRecoveryResetPasswordRoute extends Route {
+
+  errors;
+  @service intl;
+  @service store;
+
+  async model(params) {
+    const accountRecoveryDemandTemporaryKey = params.temporary_key;
+    try {
+      const user = await this.store.queryRecord('user', { accountRecoveryDemandTemporaryKey });
+      return { user, temporaryKey: accountRecoveryDemandTemporaryKey };
+    } catch (error) {
+      const status = get(error, 'errors[0].status', '');
+      if (status === '401' || status === '404' || status === '409') {
+        this.errors = this.intl.t('pages.account-recovery-after-leaving-sco.reset-password.invalid-demand');
+        return { errors: this.errors } ;
+      }
+      else {
+        throw error;
+      }
+    }
+  }
+}
+

--- a/mon-pix/app/templates/account-recovery/reset-password.hbs
+++ b/mon-pix/app/templates/account-recovery/reset-password.hbs
@@ -1,0 +1,5 @@
+{{#if @model.errors}}
+  <h1>{{@model.errors}}</h1>
+{{else}}
+  <h1>{{t 'pages.account-recovery-after-leaving-sco.reset-password.welcome-message' firstName=@model.user.firstName }}</h1>
+{{/if}}

--- a/mon-pix/tests/unit/routes/account-recovery/reset-password-test.js
+++ b/mon-pix/tests/unit/routes/account-recovery/reset-password-test.js
@@ -1,0 +1,90 @@
+import Service from '@ember/service';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Route | recuperer son compte | reset password', function() {
+
+  setupTest();
+
+  describe('Route behavior', function() {
+
+    let storeStub;
+    let queryRecordStub;
+    const params = {
+      temporary_key: 'temporary key',
+    };
+
+    beforeEach(function() {
+      queryRecordStub = sinon.stub();
+      storeStub = Service.create({
+        queryRecord: queryRecordStub,
+      });
+    });
+
+    it('should exists', function() {
+      // when
+      const route = this.owner.lookup('route:account-recovery/reset-password');
+      route.set('store', storeStub);
+
+      // then
+      expect(route).to.be.ok;
+    });
+
+    it('should ask account recovery validity', function() {
+      // given
+      queryRecordStub.resolves();
+      const route = this.owner.lookup('route:account-recovery/reset-password');
+      route.set('store', storeStub);
+
+      // when
+      const promise = route.model(params);
+
+      // then
+      return promise.then(() => {
+        sinon.assert.calledOnce(queryRecordStub);
+        sinon.assert.calledWith(queryRecordStub, 'user', {
+          accountRecoveryDemandTemporaryKey: params.temporary_key,
+        });
+      });
+    });
+
+    describe('when account recovery demand is valid', function() {
+
+      it('should create a new ember user model with fetched data', function() {
+        // given
+        const fetchedOwnerDetails = {
+          data: {
+            id: 1234,
+            attributes: {
+              email: 'philipe@example.net',
+            },
+          },
+        };
+        const expectedUser = {
+          data: {
+            id: 1234,
+            attributes: {
+              email: 'philipe@example.net',
+            },
+          },
+        };
+
+        queryRecordStub.resolves(fetchedOwnerDetails);
+        const route = this.owner.lookup('route:account-recovery/reset-password');
+        route.set('store', storeStub);
+
+        // when
+        const promise = route.model(params);
+
+        // then
+        return promise.then(({ user, temporaryKey }) => {
+          expect(user).to.eql(expectedUser);
+          expect(temporaryKey).to.eql(params.temporary_key);
+        });
+      });
+    });
+
+  });
+});

--- a/mon-pix/tests/unit/routes/account-recovery/reset-password-test.js
+++ b/mon-pix/tests/unit/routes/account-recovery/reset-password-test.js
@@ -4,7 +4,7 @@ import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
-describe('Unit | Route | recuperer son compte | reset password', function() {
+describe('Unit | Route | recuperer-son-compte | reset password', function() {
 
   setupTest();
 
@@ -23,7 +23,7 @@ describe('Unit | Route | recuperer son compte | reset password', function() {
       });
     });
 
-    it('should exists', function() {
+    it('should exist', function() {
       // when
       const route = this.owner.lookup('route:account-recovery/reset-password');
       route.set('store', storeStub);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1017,6 +1017,10 @@
         "send-email": "Nous venons de vous adresser un mail qui vous permettra de choisir un mot de passe. Vous pouvez consulter dès maintenant votre messagerie.",
         "check-spam": "Si vous ne voyez pas cet e-mail, vérifiez vos courriers indésirables.",
         "return": "Retour"
+      },
+      "reset-password": {
+        "welcome-message": "Bon retour parmi nous { firstName } !",
+        "invalid-demand" : "Votre demande de récupération de compte est invalide"
       }
     },
     "result-item": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1017,6 +1017,10 @@
         "send-email": "Nous venons de vous adresser un mail qui vous permettra de choisir un mot de passe. Vous pouvez consulter dès maintenant votre messagerie.",
         "check-spam": "Si vous ne voyez pas cet e-mail, vérifiez vos courriers indésirables.",
         "return": "Retour"
+      },
+      "reset-password": {
+        "welcome-message": "Bon retour parmi nous { firstName } !",
+        "invalid-demand" : "Votre demande de récupération de compte est invalide"
       }
     },
     "result-item": {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la sortie SCO, il faut permettre à l'utilisateur de récupérer son compte Pix.

Actuellement le formulaire permettant de fournir les informations nécessaire à la récupération de compte est implémenté (mais soumis à feature toggle, donc désactivé en PROD).

Lorsque l'utilisateur confirme ses informations, il est invité à ajouter une adresse e-mail. Il reçoit donc un email de confirmation pour récupérer son compte. Le mail contient une référence vers cette demande.
L'étape pour vérifier la demande de récupération de compte n'est pas encore implémentée.

## :robot: Solution
Développer une API qui va permettre de vérifier de la demande de récupération de compte. Une clé temporaire présente dans le lien de redirection de l'émail permet de retrouver la demande en question. 
Dans le cas ou la demande est valide et que l'utilisateur existe, on renvoie l'utilisateur en question afin mettre à jour son mot de passe.
Dans le cas ou la demande n'est pas valide pour les raisons ci-dessous:

- La clé temporaire key n'a pas été trouvée.
- La clé temporaire a déjà été utilisée.
- L'utilisateur n'existe pas 
- La clé temporaire a expirée ( en cours )
L'api renvoie une erreur.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

### Scénario passant

Aller sur un clmient SQL et ajouter une nouvelle entrée dans la table` account-recovery-demand`
Visiter l'url suivante `app-pr3176.review.pix.fr/recuperer-mon-compte/<TEMPORARY_KEY>`

```sql
SELECT 'http://localhost:4200//recuperer-mon-compte/' || acd."temporaryKey" AS url
FROM "account-recovery-demands" acd
```

Constater le message suivant "bon retour parmi nous {{prénom}} ! "

### Scénarios d'erreur

EN RA, une demande de récupération de compte existe  la temporary key `77e576e0-e0c3-11eb-ba80-0242ac130004`

#### Demande expirée
Accéder à l'url [suivante](https://app-pr3176.review.pix.fr/recuperer-mon-compte/77e576e0-e0c3-11eb-ba80-0242ac130004) avec une **temporary key expirée** et constater l'affichage d'un message: votre demande est invalide.

#### Temporary key invalide
Accéder à l'url [suivante ](https://app-pr3176.review.pix.fr/recuperer-mon-compte/invalid-temporary-key) et constater l'affichage d'une demande invalide.

#### Demande dupliquée
Dupliquer une demande et constater l'affichage d'une demande invalide (409).
En effet, l ne peut y avoir plusieurs demandes avec la même temporaryKey.

#### Utilisateur inexistant

Mettre à jour une demande pour obtenir un utilisateur inexistant
```sql
UPDATE    "account-recovery-demands" acd
SET "userId" = -1 * "userId"
WHERE id = <ID>
```

Constater l'affichage d'une demande invalide (404)
