### PR TITLE
[FEATURE] Afficher des tirets sur les champs vides de la modale d'affichage des détails d'un candidat (PIX-2757)

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -16,19 +16,33 @@
         <ul class="certification-candidate-details-modal__list">
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Nom</span>
-            <span class="certification-candidate-details-modal__row__value">{{@candidate.lastName}}</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="last-name-row">
+              {{if @candidate.lastName @candidate.lastName "-"}}
+            </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Prénom</span>
-            <span class="certification-candidate-details-modal__row__value">{{@candidate.firstName}}</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="first-name-row">
+              {{if @candidate.firstName @candidate.firstName "-"}}
+            </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Date de naissance</span>
-            <span class="certification-candidate-details-modal__row__value">{{moment-format @candidate.birthdate "DD/MM/YYYY"}}</span>
+            {{#if @candidate.birthdate}}
+              <span class="certification-candidate-details-modal__row__value" data-test-id="birth-date-row">
+                {{moment-format @candidate.birthdate "DD/MM/YYYY"}}
+              </span>
+            {{else}}
+              <span class="certification-candidate-details-modal__row__value" data-test-id="birth-date-row">
+                {{"-"}}
+              </span>
+            {{/if}}
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Sexe</span>
-            <span class="certification-candidate-details-modal__row__value">{{@candidate.sexLabel}}</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="sex-label-row">
+              {{if @candidate.sexLabel @candidate.sexLabel "-"}}
+            </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Commune de naissance</span>
@@ -50,23 +64,33 @@
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Pays de naissance</span>
-            <span class="certification-candidate-details-modal__row__value">{{@candidate.birthCountry}}</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="birth-country-row">
+              {{if @candidate.birthCountry @candidate.birthCountry "-"}}
+            </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Adresse e-mail du destinataire des résultats</span>
-            <span class="certification-candidate-details-modal__row__value">{{@candidate.resultRecipientEmail}}</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="result-recipient-email-row">
+              {{if @candidate.resultRecipientEmail @candidate.resultRecipientEmail "-"}}
+            </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Adresse e-mail de convocation</span>
-            <span class="certification-candidate-details-modal__row__value">{{@candidate.email}}</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="email-row">
+              {{if @candidate.email @candidate.email "-"}}
+            </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Identifiant externe</span>
-            <span class="certification-candidate-details-modal__row__value">{{@candidate.externalId}}</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="external-id-row">
+              {{if @candidate.externalId @candidate.externalId "-"}}
+            </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Temps majoré (%)</span>
-            <span class="certification-candidate-details-modal__row__value">{{@candidate.extraTimePercentage}}</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="extra-time-row">
+              {{if @candidate.extraTimePercentage @candidate.extraTimePercentage "-"}}
+            </span>
           </li>
         </ul>
 

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -60,15 +60,15 @@ module('Integration | Component | certification-candidate-details-modal', functi
       // given
       const store = this.owner.lookup('service:store');
       const candidate = store.createRecord('certification-candidate', {
-        firstName: 'Jean-Paul',
-        lastName: 'Candidat',
-        birthCountry: 'France',
-        email: 'jeanpauldeu@pix.fr',
-        resultRecipientEmail: 'suric@animal.fr',
-        externalId: '12345',
-        birthdate: '2000-12-25',
-        extraTimePercentage: 10,
-        sex: 'F',
+        firstName: undefined,
+        lastName: undefined,
+        birthCountry: undefined,
+        birthdate: undefined,
+        sex: undefined,
+        email: undefined,
+        resultRecipientEmail: undefined,
+        externalId: undefined,
+        extraTimePercentage: undefined,
       });
 
       const closeModalStub = sinon.stub();
@@ -87,6 +87,15 @@ module('Integration | Component | certification-candidate-details-modal', functi
       assert.dom('[data-test-id="birth-postal-code-row"]').hasText('-');
       assert.dom('[data-test-id="birth-insee-code-row"]').hasText('-');
       assert.dom('[data-test-id="birth-city-row"]').hasText('-');
+      assert.dom('[data-test-id="result-recipient-email-row"]').hasText('-');
+      assert.dom('[data-test-id="email-row"]').hasText('-');
+      assert.dom('[data-test-id="external-id-row"]').hasText('-');
+      assert.dom('[data-test-id="extra-time-row"]').hasText('-');
+      assert.dom('[data-test-id="sex-label-row"]').hasText('-');
+      assert.dom('[data-test-id="birth-date-row"]').hasText('-');
+      assert.dom('[data-test-id="first-name-row"]').hasText('-');
+      assert.dom('[data-test-id="last-name-row"]').hasText('-');
+      assert.dom('[data-test-id="birth-country-row"]').hasText('-');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l’un des champs facultatifs est non renseigné pour un candidat inscrit en certification, certains champs sont remplacés par des tirets et d'autres pas.

## :robot: Solution
Remplacer les champs vides restants par des tirets.


## :100: Pour tester
 - Se rendre sur Pix Certif
 - Se rendre sur une session de certification avec des candidats ou en ajouter
 - Vérifier que les champs vides sont remplacés par des tirets
