### PR TITLE
[BUGFIX] Gérer le cas de deux QROCM-dep pour une seule compétence (PIX-2793)

### DIFF
--- a/api/lib/domain/models/AnswerCollectionForScoring.js
+++ b/api/lib/domain/models/AnswerCollectionForScoring.js
@@ -65,7 +65,7 @@ module.exports = class AnswerCollectionForScoring {
       }
     });
 
-    return nbOfCorrectAnswers;
+    return _.min([nbOfCorrectAnswers, 3]);
   }
 
   numberOfNeutralizedChallengesForCompetence(competenceId) {

--- a/api/lib/domain/models/CertificationContract.js
+++ b/api/lib/domain/models/CertificationContract.js
@@ -36,6 +36,16 @@ class CertificationContract {
       }
     });
   }
+
+  static assertThatNoChallengeHasMoreThanOneAnswer(answersForCompetence) {
+    const someChallengesHaveMoreThanOneAnswer = _(answersForCompetence)
+      .groupBy((answer) => answer.challengeId)
+      .some((answerGroup) => answerGroup.length > 1);
+
+    if (someChallengesHaveMoreThanOneAnswer) {
+      throw new CertificationComputeError('Plusieurs réponses pour une même épreuve');
+    }
+  }
 }
 
 module.exports = CertificationContract;

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -34,6 +34,7 @@ function _getCompetencesWithCertifiedLevelAndScore(answers, listCompetences, rep
       CertificationContract.assertThatCompetenceHasAtLeastOneChallenge(challengesForCompetence, competence.index);
       CertificationContract.assertThatCompetenceHasAtLeastOneAnswer(answersForCompetence, competence.index);
       CertificationContract.assertThatEveryAnswerHasMatchingChallenge(answersForCompetence, challengesForCompetence);
+      CertificationContract.assertThatNoChallengeHasMoreThanOneAnswer(answersForCompetence, challengesForCompetence);
     }
 
     const certifiedLevel = CertifiedLevel.from({

--- a/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
@@ -395,7 +395,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       expect(numberOfCorrectAnswers).to.equal(3);
     });
 
-    it('counts QROCMDeps as 1 when partially correctfor given competence', () => {
+    it('counts QROCMDeps as 1 when partially correct for given competence', () => {
       // given
       const aCompetenceId = 'recIdOfACompetence';
       const anotherCompetenceId = 'recIdOfAnotherCompetence';
@@ -419,6 +419,26 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
 
       // then
       expect(numberOfCorrectAnswers).to.equal(2);
+    });
+
+    it('counts 2 QROCMDeps as 3 correct answers when fully correct for given competence', () => {
+      // given
+      const aCompetenceId = 'recIdOfACompetence';
+      const qROCMDepChallenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1', competenceId: aCompetenceId, type: 'QROCM-dep' });
+      const qROCMDepChallenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', competenceId: aCompetenceId, type: 'QROCM-dep' });
+      const qROCMDepAnswer1 = domainBuilder.buildAnswer({ challengeId: qROCMDepChallenge1.challengeId, result: AnswerStatus.OK });
+      const qROCMDepAnswer2 = domainBuilder.buildAnswer({ challengeId: qROCMDepChallenge2.challengeId, result: AnswerStatus.OK });
+
+      const answerCollection = AnswerCollectionForScoring.from({
+        answers: [ qROCMDepAnswer1, qROCMDepAnswer2 ],
+        challenges: [ qROCMDepChallenge1, qROCMDepChallenge2 ],
+      });
+
+      // when
+      const numberOfCorrectAnswers = answerCollection.numberOfCorrectAnswersForCompetence(aCompetenceId);
+
+      // then
+      expect(numberOfCorrectAnswers).to.equal(3);
     });
 
     it('counts QROCMDeps as 2 when fully correctfor given competence', () => {

--- a/api/tests/unit/domain/models/CertificationContract_test.js
+++ b/api/tests/unit/domain/models/CertificationContract_test.js
@@ -1,0 +1,147 @@
+const { expect, domainBuilder, catchErr } = require('../../../test-helper');
+const { CertificationComputeError } = require('../../../../lib/domain/errors');
+const CertificationContract = require('../../../../lib/domain/models/CertificationContract');
+const _ = require('lodash');
+
+describe('Unit | Domain | Models | CertificationContract', () => {
+  describe('#assertThatWeHaveEnoughAnswers', () => {
+    describe('when there is less answers than challenges', () => {
+
+      it('should throw', async () => {
+        // given
+        const answers = _.map([
+          { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_D_for_competence_2', result: 'ok' },
+          { challengeId: 'challenge_E_for_competence_2', result: 'ok' },
+        ], domainBuilder.buildAnswer);
+
+        const challenges = _.map([
+          { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1', type: 'QCM' },
+          { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeC_1', type: 'QCM' },
+          { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeB_1', type: 'QCM' },
+          { challengeId: 'challenge_D_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeD_2', type: 'QCM' },
+          { challengeId: 'challenge_E_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeE_2', type: 'QCM' },
+        ], domainBuilder.buildCertificationChallengeWithType);
+
+        // when
+        const error = await catchErr(CertificationContract.assertThatWeHaveEnoughAnswers)(answers, challenges);
+
+        // then
+        expect(error).to.be.instanceOf(CertificationComputeError);
+        expect(error.message).to.equal('L’utilisateur n’a pas répondu à toutes les questions');
+      });
+    });
+  });
+
+  describe('#assertThatCompetenceHasAtLeastOneChallenge', () => {
+    describe('when there not enough challenges for one competence', () => {
+
+      it('should throw', async () => {
+        // given
+        const competenceIndex = '1.1';
+
+        const competenceChallenges = [];
+
+        // when
+        const error = await catchErr(CertificationContract.assertThatCompetenceHasAtLeastOneChallenge)(competenceChallenges, competenceIndex);
+
+        // then
+        expect(error).to.be.instanceOf(CertificationComputeError);
+        expect(error.message).to.equal('Pas assez de challenges posés pour la compétence 1.1');
+      });
+    });
+  });
+
+  describe('#assertThatCompetenceHasAtLeastOneAnswer', () => {
+    describe('when there is not enough answers for one competence', () => {
+
+      it('should throw', async () => {
+        // given
+        const competenceIndex = '1.1';
+
+        const competenceChallenges = [];
+
+        // when
+        const error = await catchErr(CertificationContract.assertThatCompetenceHasAtLeastOneAnswer)(competenceChallenges, competenceIndex);
+
+        // then
+        expect(error).to.be.instanceOf(CertificationComputeError);
+        expect(error.message).to.equal('Pas assez de réponses pour la compétence 1.1');
+      });
+    });
+  });
+
+  describe('#assertThatScoreIsCoherentWithReproducibilityRate', () => {
+    describe('when score is < 1 and reproductibility rate is > 50%', () => {
+
+      it('should throw', async () => {
+        // given
+        const score = 0;
+
+        const reproducibilityRate = 60;
+
+        // when
+        const error = await catchErr(CertificationContract.assertThatScoreIsCoherentWithReproducibilityRate)(score, reproducibilityRate);
+
+        // then
+        expect(error).to.be.instanceOf(CertificationComputeError);
+        expect(error.message).to.equal('Rejeté avec un taux de reproductibilité supérieur à 50');
+      });
+    });
+  });
+
+  describe('#assertThatEveryAnswerHasMatchingChallenge', () => {
+    describe('when an answer does not match a challenge', () => {
+
+      it('should throw', async () => {
+        // given
+        const answers = _.map([
+          { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_C_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_D_for_competence_2', result: 'ok' },
+          { challengeId: 'challenge_E_for_competence_2', result: 'ok' },
+        ], domainBuilder.buildAnswer);
+
+        const challenges = _.map([
+          { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1', type: 'QCM' },
+          { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeC_1', type: 'QCM' },
+          { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeB_1', type: 'QCM' },
+          { challengeId: 'challenge_D_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeD_2', type: 'QCM' },
+        ], domainBuilder.buildCertificationChallengeWithType);
+
+        // when
+        const error = await catchErr(CertificationContract.assertThatEveryAnswerHasMatchingChallenge)(answers, challenges);
+
+        // then
+        expect(error).to.be.instanceOf(CertificationComputeError);
+        expect(error.message).to.equal('Problème de chargement du challenge challenge_E_for_competence_2');
+      });
+    });
+  });
+
+  describe('#assertThatNoChallengeHasMoreThanOneAnswer', () => {
+    describe('when there are several answers for the same challenge', () => {
+
+      it('should throw', async () => {
+        // given
+        const answers = _.map([
+          { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_C_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_D_for_competence_2', result: 'ok' },
+          { challengeId: 'challenge_E_for_competence_2', result: 'ok' },
+        ], domainBuilder.buildAnswer);
+
+        // when
+        const error = await catchErr(CertificationContract.assertThatNoChallengeHasMoreThanOneAnswer)(answers);
+
+        // then
+        expect(error).to.be.instanceOf(CertificationComputeError);
+        expect(error.message).to.equal('Plusieurs réponses pour une même épreuve');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsque deux QROCM-deps sont séléctionnés pour certifier une compétence et que ceux-ci sont complètement répondus correctement : on compte 4 bonnes réponses sur la bonne compétence. Or aucune règle de scoring ne correspond à 2 épreuves posées et 4 bonnes réponses.

## :robot: Solution
Fixer le nb de bonne réponses possibles par compétences à 3

## :100: Pour tester
Impossible à reproduire fonctionnellement...

S'assurer que les tests passent
