### PR TITLE
[BUGFIX] Aligner le bouton d'envoi des résultats avec le contenu de la page (PIX-2804)

### DIFF
--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -358,6 +358,7 @@
   &__button {
     letter-spacing: 0.031rem;
     min-width: 100px;
+    margin: 0 auto;
   }
 
   &__legal {


### PR DESCRIPTION
## :unicorn: Problème
Le bouton "envoyer mes résultats n'était plus aligné, le `pix-button` est `flex` . le `text-align:center` n'agit plus sur ce button maintenant.

## :robot: Solution
Ajouter un `margin: 0 auto`

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur mon-pix  avec `jaune.attend@example.net`
J'ai un code : `AZERTY654`

Vérifier que le button est bien centré