### PR TITLE
[BUGFIX] Sélectionner la France par défaut lors de l'ajout d'un candidat (PIX-2817)

### DIFF
--- a/api/db/seeds/data/certification/certification-cpf-country-builder.js
+++ b/api/db/seeds/data/certification/certification-cpf-country-builder.js
@@ -1,4 +1,11 @@
 function certificationCpfCountryBuilder({ databaseBuilder }) {
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99401',
+    commonName: 'CANADA',
+    originalName: 'CANADA',
+  });
+
   databaseBuilder.factory.buildCertificationCpfCountry({
     code: '99100',
     commonName: 'FRANCE',
@@ -15,12 +22,6 @@ function certificationCpfCountryBuilder({ databaseBuilder }) {
     code: '99243',
     commonName: 'VIET NAM',
     originalName: 'VIET NAM',
-  });
-
-  databaseBuilder.factory.buildCertificationCpfCountry({
-    code: '99424',
-    commonName: 'VENEZUELA',
-    originalName: 'VENEZUELA',
   });
 
   databaseBuilder.factory.buildCertificationCpfCountry({

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -104,7 +104,7 @@
               class="birth-country-selector"
               @options={{this.countryOptions}}
               @onChange={{this.selectBirthCountry}}
-              @selectedOption="1"
+              @selectedOption={{this.defaultCountryOption}}
               required
             />
           </div>

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -108,6 +108,10 @@ export default class NewCertificationCandidateModal extends Component {
     });
   }
 
+  get defaultCountryOption() {
+    return FRANCE_INSEE_CODE;
+  }
+
   _isFranceSelected() {
     return this.selectedCountryInseeCode === FRANCE_INSEE_CODE;
   }

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -52,7 +52,7 @@ module('Integration | Component | new-certification-candidate-modal', function(h
     assert.dom('#email').exists();
   });
 
-  test('it shows a countries list', async function(assert) {
+  test('it shows a countries list with France selected as default', async function(assert) {
     // given
     const closeModalStub = sinon.stub();
     const updateCandidateStub = sinon.stub();
@@ -67,7 +67,8 @@ module('Integration | Component | new-certification-candidate-modal', function(h
     }]);
     this.set('countries', [
       { id: 1, code: '99123', name: 'Syldavie' },
-      { id: 2, code: '99345', name: 'Botswana' },
+      { id: 2, code: '99100', name: 'France' },
+      { id: 3, code: '99345', name: 'Botswana' },
     ]);
 
     // when
@@ -85,6 +86,7 @@ module('Integration | Component | new-certification-candidate-modal', function(h
     assert.dom('#birth-country').exists();
     assert.dom('#birth-country').includesText('Syldavie');
     assert.dom('#birth-country').includesText('Botswana');
+    assert.dom('#birth-country').hasValue('99100');
   });
 
   module('when close button cross icon is clicked', () => {


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Certif, lors de l'ajout d'un candidat à un session non-SCO, le pays France devrait être sélectionné par défaut, au lieu de quoi c'est le premier pays de la liste qui est sélectionné. Comme dans les seeds de développement, le premier pays est la France, le problème nous a échappé.

## :robot: Solution

- Ajouter un pays avant la France dans les seeds
- Toujours sélectionner la France par défaut, même si ce n'est pas le premier pays de la liste.

## :rainbow: Remarques

*RAS*

## :100: Pour tester

1. Se connecter à Pix Certif avec un compte non-sco (ex: certifsup@example.net)
2. Se rendre dans (si besoin créer) une session de certification, onglet Candidats
3. Cliquer sur Ajouter un candidat
4. Constater que France est sélectionné par défaut malgré le fait qu'il y ait un pays avant dans la liste
