### PR TITLE
[FEATURE] Avoir une image par défaut sur les paliers (PIX-2769).

### DIFF
--- a/api/db/database-builder/factory/build-target-profile.js
+++ b/api/db/database-builder/factory/build-target-profile.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 module.exports = function buildTargetProfile({
   id = databaseBuffer.getNextId(),
   name = 'Remplir un tableur',
-  imageUrl = null,
+  imageUrl = 'https://images.pix.fr/profil-cible/Illu_GEN.svg',
   isPublic = true,
   isSimplifiedAccess = false,
   ownerOrganizationId,

--- a/api/db/migrations/20210713145931_set-default-target-profile-image.js
+++ b/api/db/migrations/20210713145931_set-default-target-profile-image.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'target-profiles';
+const DEFAULT_IMAGE_URL = 'https://images.pix.fr/profil-cible/Illu_GEN.svg';
+
+exports.up = async function(knex) {
+  await updateWithDefaultImageUrl(knex);
+};
+
+exports.down = function() {
+};
+
+async function updateWithDefaultImageUrl(knex) {
+  await knex(TABLE_NAME)
+    .whereNull('imageUrl')
+    .update({
+      imageUrl: DEFAULT_IMAGE_URL,
+    });
+}

--- a/api/lib/domain/usecases/create-target-profile.js
+++ b/api/lib/domain/usecases/create-target-profile.js
@@ -1,10 +1,15 @@
 const { TargetProfileInvalidError } = require('../errors');
 const _ = require('lodash');
+const DEFAULT_IMAGE_URL = 'https://images.pix.fr/profil-cible/Illu_GEN.svg';
 
 module.exports = async function createTargetProfile({ targetProfileData, targetProfileRepository, targetProfileWithLearningContentRepository }) {
 
   if (_.isEmpty(targetProfileData.skillsId)) {
     throw new TargetProfileInvalidError('Vous ne pouvez pas créer un profil cible sans acquis ciblés.');
+  }
+
+  if (_.isEmpty(targetProfileData.imageUrl)) {
+    targetProfileData.imageUrl = DEFAULT_IMAGE_URL;
   }
 
   const targetProfileId = await targetProfileRepository.create(targetProfileData);

--- a/api/tests/unit/domain/usecases/create-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/create-target-profile_test.js
@@ -24,25 +24,56 @@ describe('Unit | UseCase | create-target-profile', () => {
 
   });
 
-  it('should create target profile with skills given data', async () => {
-    const skillsId = ['skill1-tube1', 'skill3-tube1'];
-    const targetProfile = Symbol('ok');
-    //given
-    const targetProfileData = {
-      isPublic,
-      name,
-      imageUrl,
-      organizationId,
-      skillsId,
-    };
+  describe('when targetProfile is valid', () => {
 
-    targetProfileRepositoryStub.create.withArgs(targetProfileData).resolves(targetProfileId);
-    targetProfileWithLearningContentRepositoryStub.get.withArgs({ id: targetProfileId }).resolves(targetProfile);
+    it('should create target profile with skills given data', async () => {
+      //given
+      const skillsId = ['skill1-tube1', 'skill3-tube1'];
+      const targetProfile = Symbol('ok');
+      const targetProfileData = {
+        isPublic,
+        name,
+        imageUrl,
+        organizationId,
+        skillsId,
+      };
 
-    //when
-    const result = await createTargetProfile({ targetProfileData, targetProfileRepository: targetProfileRepositoryStub, targetProfileWithLearningContentRepository: targetProfileWithLearningContentRepositoryStub });
+      targetProfileRepositoryStub.create.withArgs(targetProfileData).resolves(targetProfileId);
+      targetProfileWithLearningContentRepositoryStub.get.withArgs({ id: targetProfileId }).resolves(targetProfile);
 
-    expect(result).to.equal(targetProfile);
+      //when
+      const result = await createTargetProfile({ targetProfileData, targetProfileRepository: targetProfileRepositoryStub, targetProfileWithLearningContentRepository: targetProfileWithLearningContentRepositoryStub });
+
+      //then
+      expect(result).to.equal(targetProfile);
+    });
+
+    it('should create target profile with default imageUrl if none is specified', async () => {
+      //given
+      const skillsId = ['skill1-tube1', 'skill3-tube1'];
+      const targetProfile = Symbol('ok');
+      const targetProfileData = {
+        isPublic,
+        name,
+        imageUrl: null,
+        organizationId,
+        skillsId,
+      };
+      targetProfileRepositoryStub.create.resolves(targetProfileId);
+      targetProfileWithLearningContentRepositoryStub.get.withArgs({ id: targetProfileId }).resolves(targetProfile);
+
+      //when
+      await createTargetProfile({ targetProfileData, targetProfileRepository: targetProfileRepositoryStub, targetProfileWithLearningContentRepository: targetProfileWithLearningContentRepositoryStub });
+
+      //then
+      expect(targetProfileRepositoryStub.create).to.have.been.calledWith({
+        isPublic,
+        name,
+        imageUrl: 'https://images.pix.fr/profil-cible/Illu_GEN.svg',
+        organizationId,
+        skillsId,
+      });
+    });
   });
 
   it('should return TargetProfileInvalidError given empty skills', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque les paliers sont affichés en fin de campagne mais qu'aucune image n'est rattachée au profil cible correspondant, alors seules les étoiles du palier s'affichent:

<img width="833" alt="Screenshot 2021-07-13 at 17 28 23" src="https://user-images.githubusercontent.com/11294487/125480359-e7c53a12-8a7f-4fd0-96ba-a105f484e319.png">

Il y a un vide sous les étoiles.

## :robot: Solution
Deux besoins :
- faire une passe sur tous les profils cible et, lorsque le champ "image url" de la table "target profil" est vide alors le remplir avec l'image par défaut (via un script de migration)
- à l'avenir, à la création d'un target profil, avoir le champ "image url" pré rempli avec l'image par défaut (via le usecase de création d'un profil cible)

Si aucune imageUrl n'est renseignée, on a alors par défaut:
<img width="816" alt="Screenshot 2021-07-13 at 17 28 30" src="https://user-images.githubusercontent.com/11294487/125480599-c47f69f1-5f37-42a1-bb6c-e8b22bfec758.png">


## :rainbow: Remarques
Au début, nous voulions mettre un `defaultTo` sur la colonne `imageUrl`. Mais si l'url venait à changer par la suite, cela forcerait à nouveau l'écriture d'un script de migration.
Finalement, nous avons opté pour mettre une valeur par défaut à `imageUrl` depuis le code.

Avant de merger:

- [x] Vérifier que l'url https://images.pix.fr/profil-cible/Illu_GEN.svg fonctionne

## :100: Pour tester
1. Jouer le script de migration.
Constater que les imageUrl de la table `target-profiles` qui étaient vides ne le sont plus
2. Créer un profil cible sur pix-admin sans imageUrl: une valeur par défaut pour `imageUrl` est alors insérée en DB (un exemple de fichier json demandé pour la création d'un profil cible est sur le ticket Jira)