### PR TITLE
[BUGFIX] Permettre l'envoi du formulaire d'ajout de candidat sous Firefox (PIX-2818)

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -117,6 +117,7 @@
                 <input
                   type="radio"
                   id="insee-code-choice"
+                  name="birth-geo-code-option"
                   value="insee"
                   checked="checked"
                   {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
@@ -126,6 +127,7 @@
                 <input
                   type="radio"
                   id="postal-code-choice"
+                  name="birth-geo-code-option"
                   value="postal"
                   {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
                 >

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -118,7 +118,7 @@
                   type="radio"
                   id="insee-code-choice"
                   value="insee"
-                  checked={{this.isInseeCodeOptionSelected}}
+                  checked="checked"
                   {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
                   required
                 >
@@ -127,9 +127,7 @@
                   type="radio"
                   id="postal-code-choice"
                   value="postal"
-                  checked={{this.isPostalCodeOptionSelected}}
                   {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
-                  required
                 >
                 <label class="radio-button-label" for="postal-code-choice">Code postal</label>
               </div>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -121,7 +121,6 @@
                   checked={{this.isInseeCodeOptionSelected}}
                   {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
                   required={{this.isBirthGeoCodeRequired}}
-                  disabled={{not this.isBirthGeoCodeRequired}}
                 >
                 <label class="radio-button-label" for="insee-code-choice">Code INSEE</label>
                 <input
@@ -131,7 +130,6 @@
                   checked={{this.isPostalCodeOptionSelected}}
                   {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
                   required={{this.isBirthGeoCodeRequired}}
-                  disabled={{not this.isBirthGeoCodeRequired}}
                 >
                 <label class="radio-button-label" for="postal-code-choice">Code postal</label>
               </div>
@@ -151,7 +149,6 @@
                 @class="input"
                 @value={{@candidateData.birthInseeCode}}
                 required={{this.isBirthInseeCodeRequired}}
-                disabled={{not this.isBirthInseeCodeRequired}}
                 {{on 'input' (fn @updateCandidateData @candidateData 'birthInseeCode')}}
               />
             </div>
@@ -170,7 +167,6 @@
                 @class="input"
                 @value={{@candidateData.birthPostalCode}}
                 required={{this.isBirthPostalCodeRequired}}
-                disabled={{not this.isBirthPostalCodeRequired}}
                 {{on 'input' (fn @updateCandidateData @candidateData 'birthPostalCode')}}
               />
             </div>
@@ -188,7 +184,6 @@
                 @class="input"
                 @value={{@candidateData.birthCity}}
                 required={{this.isBirthCityRequired}}
-                disabled={{not this.isBirthCityRequired}}
                 {{on 'input' (fn @updateCandidateData @candidateData 'birthCity')}}
               />
             </div>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -120,7 +120,7 @@
                   value="insee"
                   checked={{this.isInseeCodeOptionSelected}}
                   {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
-                  required={{this.isBirthGeoCodeRequired}}
+                  required
                 >
                 <label class="radio-button-label" for="insee-code-choice">Code INSEE</label>
                 <input
@@ -129,7 +129,7 @@
                   value="postal"
                   checked={{this.isPostalCodeOptionSelected}}
                   {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
-                  required={{this.isBirthGeoCodeRequired}}
+                  required
                 >
                 <label class="radio-button-label" for="postal-code-choice">Code postal</label>
               </div>
@@ -148,7 +148,7 @@
                 maxlength='5'
                 @class="input"
                 @value={{@candidateData.birthInseeCode}}
-                required={{this.isBirthInseeCodeRequired}}
+                required
                 {{on 'input' (fn @updateCandidateData @candidateData 'birthInseeCode')}}
               />
             </div>
@@ -166,7 +166,7 @@
                 maxlength='5'
                 @class="input"
                 @value={{@candidateData.birthPostalCode}}
-                required={{this.isBirthPostalCodeRequired}}
+                required
                 {{on 'input' (fn @updateCandidateData @candidateData 'birthPostalCode')}}
               />
             </div>
@@ -183,7 +183,7 @@
                 @type="text"
                 @class="input"
                 @value={{@candidateData.birthCity}}
-                required={{this.isBirthCityRequired}}
+                required
                 {{on 'input' (fn @updateCandidateData @candidateData 'birthCity')}}
               />
             </div>

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -228,7 +228,7 @@ module('Integration | Component | new-certification-candidate-modal', function(h
   });
 
   module('when the postal code option is selected', () => {
-    test('it disable insee fields and requires postal code and city', async function(assert) {
+    test('it hides insee fields and requires postal code and city', async function(assert) {
       const closeModalStub = sinon.stub();
       const updateCandidateFromValueStub = sinon.stub();
       const updateCandidateFromEventStub = sinon.stub();

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -158,7 +158,7 @@ module('Integration | Component | new-certification-candidate-modal', function(h
   });
 
   module('when a foreign country is selected', () => {
-    test('it hides insee and postal fields and requires city', async function(assert) {
+    test('it shows city field and hides insee code and postal code fields', async function(assert) {
       const closeModalStub = sinon.stub();
       const updateCandidateFromValueStub = sinon.stub();
       const updateCandidateFromEventStub = sinon.stub();
@@ -193,7 +193,7 @@ module('Integration | Component | new-certification-candidate-modal', function(h
   });
 
   module('when the insee code option is selected', () => {
-    test('it shows insee field and hide postal code and city', async function(assert) {
+    test('it shows insee code field and hides postal code and city fields', async function(assert) {
       const closeModalStub = sinon.stub();
       const updateCandidateFromValueStub = sinon.stub();
       const updateCandidateFromEventStub = sinon.stub();
@@ -228,7 +228,7 @@ module('Integration | Component | new-certification-candidate-modal', function(h
   });
 
   module('when the postal code option is selected', () => {
-    test('it hides insee fields and requires postal code and city', async function(assert) {
+    test('it shows postal code and city fields and hides insee code field', async function(assert) {
       const closeModalStub = sinon.stub();
       const updateCandidateFromValueStub = sinon.stub();
       const updateCandidateFromEventStub = sinon.stub();


### PR DESCRIPTION
## :unicorn: Problème

Problème : sous Firefox, lorsqu'on tente d'envoyer le formulaire, le navigateur bloque avec le message "Veuillez sélectionner l'une de ces options" en face du choix Code INSEE / Code Postal quelque soit le champ sélectionné.

## :robot: Solution

Actuellement, les deux éléments `input` qui composent ce bouton radio possèdent l'attribut `required`. Bien que ce ne soit pas nécessaire, c'est la [recommandation de MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required) :

> In the case of a same named group of radio buttons, if a single radio button in the group has the required attribute, a radio button in that group must be checked, although it doesn't have to be the one with the attribute is applied. So to improve code maintenance, it is recommended to either include the required attribute in every same-named radio button in the group, or else in none.

Malgré cela, il semble que si l'on procède ainsi, Firefox considère le champ comme invalide et refuse l'envoi du formulaire si les deux éléments ne sont pas cochés (ce qui est techniquement impossible et de plus n'est pas le comportement désiré).

La solution est donc de ne mettre l'attribut `required` que sur le premier `input` (comme c'est déjà le cas pour le champ Sexe). 

## :rainbow: Remarques

Cette PR fixe Chrome, Firefox et Edge. Le fixe pour IE 11 arrvie dans le prochain ticket

## :100: Pour tester

**Sous Firefox**

1. Se connecter à Pix Certif avec un compte non-sco (ex: certifsup@example.net)
2. Se rendre dans une session (si besoin la créer) et accéder à l'onglet **Candidats**
3. Tenter d'ajouter un candidat avec un candidat avec code INSEE
4. Constater l'ajout du candidat
3. Tenter d'ajouter un candidat avec un candidat avec code postal
4. Constater l'ajout du candidat

Et : tests de non régression sur l'envoi du formulaire (notamment le caractère obligatoire des champs)

