### PR TITLE
[FEATURE] Ajout du filtre classe sur la page Activité pour les organisations SCO (PIX-2670).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -174,10 +174,14 @@ module.exports = {
 
   async findParticipantsActivity(request) {
     const campaignId = request.params.id;
-    const { page } = queryParamsUtils.extractParameters(request.query);
+
+    const { page, filter: filters } = queryParamsUtils.extractParameters(request.query);
+    if (filters.divisions && !Array.isArray(filters.divisions)) {
+      filters.divisions = [filters.divisions];
+    }
 
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const paginatedParticipations = await usecases.findPaginatedCampaignParticipantsActivities({ userId, campaignId, page });
+    const paginatedParticipations = await usecases.findPaginatedCampaignParticipantsActivities({ userId, campaignId, page, filters });
     return campaignParticipantsActivitySerializer.serialize(paginatedParticipations);
   },
 

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -246,6 +246,7 @@ exports.register = async function(server) {
           query: Joi.object({
             'page[number]': Joi.number().integer().empty(''),
             'page[size]': Joi.number().integer().empty(''),
+            'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
           }),
         },
         handler: campaignController.findParticipantsActivity,

--- a/api/lib/domain/read-models/CampaignParticipantActivity.js
+++ b/api/lib/domain/read-models/CampaignParticipantActivity.js
@@ -16,7 +16,6 @@ class CampaignParticipantActivity {
     sharedAt,
     assessmentState,
     isShared,
-    progression,
   } = {}) {
     this.campaignParticipationId = campaignParticipationId;
     this.userId = userId;
@@ -25,7 +24,6 @@ class CampaignParticipantActivity {
     this.participantExternalId = participantExternalId;
     this.sharedAt = sharedAt;
     this.status = this._getStatus(isShared, assessmentState);
-    this.progression = progression;
   }
 
   _getStatus(isShared, assessmentState) {

--- a/api/lib/domain/usecases/find-paginated-campaign-participants-activities.js
+++ b/api/lib/domain/usecases/find-paginated-campaign-participants-activities.js
@@ -4,13 +4,14 @@ module.exports = async function findPaginatedCampaignParticipantsActivities({
   userId,
   campaignId,
   page,
+  filters,
   campaignRepository,
   campaignParticipantActivityRepository,
 }) {
 
   await _checkUserAccessToCampaign(campaignId, userId, campaignRepository);
 
-  return campaignParticipantActivityRepository.findPaginatedByCampaignId({ page, campaignId });
+  return campaignParticipantActivityRepository.findPaginatedByCampaignId({ page, campaignId, filters });
 };
 
 async function _checkUserAccessToCampaign(campaignId, userId, campaignRepository) {

--- a/api/tests/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
+++ b/api/tests/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
@@ -50,4 +50,32 @@ describe('Integration | UseCase | find-paginated-campaign-participants-activitie
       expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Ashitaka');
     });
   });
+
+  context('when there is a filter on division', () => {
+    beforeEach(async () => {
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+      const participation1 = { participantExternalId: 'Yubaba', campaignId };
+      const participant1 = { id: 456, firstName: 'Chihiro', lastName: 'Ogino' };
+      databaseBuilder.factory.buildAssessmentFromParticipation(participation1, participant1);
+      databaseBuilder.factory.buildSchoolingRegistration({ userId: participant1.id, organizationId, division: '6eme' });
+
+      const participation2 = { participantExternalId: 'Meï', campaignId };
+      const participant2 = { id: 457, firstName: 'Tonari', lastName: 'No Totoro' };
+      databaseBuilder.factory.buildAssessmentFromParticipation(participation2, participant2);
+      databaseBuilder.factory.buildSchoolingRegistration({ userId: participant2.id, organizationId, division: '5eme' });
+
+      await databaseBuilder.commit();
+    });
+
+    it('returns the campaignParticipantsActivities for the participants for the division', async () => {
+      const { campaignParticipantsActivities } = await useCases.findPaginatedCampaignParticipantsActivities({
+        userId,
+        campaignId,
+        filters: { divisions: ['6eme'] },
+      });
+
+      expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Yubaba');
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -253,6 +253,46 @@ describe('Integration | Repository | Campaign Participant activity', () => {
       });
     });
 
+    context('when there is a filter on division', () => {
+      it('returns participants which have the correct division', async () => {
+        campaign = databaseBuilder.factory.buildAssessmentCampaign({});
+
+        const participation1 = {
+          participantExternalId: 'The good',
+          campaignId: campaign.id,
+        };
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 1, division: 'Good Guys Team' });
+
+        const participation2 = {
+          participantExternalId: 'The bad',
+          campaignId: campaign.id,
+        };
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 2, division: 'Bad Guys Team' });
+
+        const participation3 = {
+          participantExternalId: 'The ugly',
+          campaignId: campaign.id,
+        };
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation3, { id: 3 });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 3, division: 'Ugly Guys Team' });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities } = await campaignParticipantActivityRepository.findPaginatedByCampaignId({ campaignId: campaign.id, filters: { divisions: ['Good Guys Team', 'Ugly Guys Team'] } });
+
+        const participantExternalIds = campaignParticipantsActivities.map((result) => result.participantExternalId);
+
+        // then
+        expect(participantExternalIds).to.exactlyContain(['The good', 'The ugly']);
+      });
+    });
+
     context('pagination', () => {
 
       beforeEach(async () => {

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -433,7 +433,7 @@ describe('Unit | Application | Controller | Campaign', () => {
     });
   });
 
-  describe('archiveCampaign', async () => {
+  describe('#archiveCampaign', async () => {
     let updatedCampaign;
     let serializedCampaign;
 
@@ -466,7 +466,7 @@ describe('Unit | Application | Controller | Campaign', () => {
 
   });
 
-  describe('unarchiveCampaign', async () => {
+  describe('#unarchiveCampaign', async () => {
     let updatedCampaign;
     let serializedCampaign;
 

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -692,4 +692,79 @@ describe('Unit | Application | Router | campaign-router ', function() {
       expect(result.statusCode).to.equal(400);
     });
   });
+
+  describe('GET /api/campaigns/{id}/participants-activity', () => {
+
+    it('should return 200', async () => {
+      sinon.stub(campaignController, 'findParticipantsActivity').callsFake((request, h) => h.response('ok').code(200));
+
+      // when
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/participants-activity');
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it('should return 200 with a string array of one element as division filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findParticipantsActivity').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/participants-activity?filter[divisions][]="3EMEB"');
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it('should return 200 with a string array of several elements as division filter', async () => {
+      // given
+      sinon.stub(campaignController, 'findParticipantsActivity').callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/participants-activity?filter[divisions][]="3EMEB"&filter[divisions][]="3EMEA"');
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it('should return 400 with an invalid campaign id', async () => {
+      // when
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      const result = await httpTestServer.request('GET', '/api/campaigns/invalid/participants-activity');
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it('should return 400 with unexpected filters', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/participants-activity?filter[unexpected][]=5');
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it('should return 400 with a division filter which is not an array', async () => {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/participants-activity?filter[divisions]="3EMEA"');
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer_test.js
@@ -1,5 +1,7 @@
 const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer');
+const CampaignParticipantActivity = require('../../../../../lib/domain/read-models/CampaignParticipantActivity');
+const Assessment = require('../../../../../lib/domain/models/Assessment');
 
 describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer', function() {
 
@@ -8,21 +10,24 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
     it('should call serialize method by destructuring passed parameter', function() {
       // given
       const campaignParticipantsActivities = [
-        {
+        new CampaignParticipantActivity({
+          userId: 1,
           campaignParticipationId: '1',
           firstName: 'Karam',
           lastName: 'Habibi',
           participantExternalId: 'Dev',
-          status: 'COMPLETED',
-        },
-        {
+          isShared: true,
+          assessmentState: Assessment.states.COMPLETED,
+        }),
+        new CampaignParticipantActivity({
+          userId: 2,
           campaignParticipationId: '2',
           firstName: 'Dimitri',
           lastName: 'Payet',
           participantExternalId: 'Footballer',
-          progression: 0.6,
-          status: 'ONGOING',
-        },
+          sharedAt: null,
+          assessmentState: Assessment.states.STARTED,
+        }),
       ];
       const pagination = {
         page: {
@@ -42,7 +47,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
               'first-name': 'Karam',
               'last-name': 'Habibi',
               'participant-external-id': 'Dev',
-              status: 'COMPLETED',
+              status: CampaignParticipantActivity.statuses.SHARED,
             },
           },
           {
@@ -52,8 +57,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
               'first-name': 'Dimitri',
               'last-name': 'Payet',
               'participant-external-id': 'Footballer',
-              'progression': 0.6,
-              status: 'ONGOING',
+              status: CampaignParticipantActivity.statuses.STARTED,
             },
           },
         ],

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -31,7 +31,6 @@
               <td>
                 <Campaign::Activity::ParticipationStatus
                   @status={{participation.status}}
-                  @progression={{participation.progression}}
                   @isTypeAssessment={{@campaign.isTypeAssessment}}
                 />
               </td>

--- a/orga/app/components/campaign/activity/participation-status.js
+++ b/orga/app/components/campaign/activity/participation-status.js
@@ -10,9 +10,9 @@ export default class ParticipationStatus extends Component {
   }
 
   get label() {
-    const { status, progression, isTypeAssessment } = this.args;
+    const { status, isTypeAssessment } = this.args;
     const type = isTypeAssessment ? 'assessment' : 'profile';
-    return this.intl.t(`pages.campaign-activity.status.${status}-${type}`, { progression });
+    return this.intl.t(`pages.campaign-activity.status.${status}-${type}`);
   }
 }
 

--- a/orga/app/components/campaign/filter/participation-filters.hbs
+++ b/orga/app/components/campaign/filter/participation-filters.hbs
@@ -5,7 +5,7 @@
     aria-label={{t 'pages.campaign-results.filters.aria-label'}}
     @details={{t 'pages.campaign-results.filters.participations-count' count=@rowCount}}
     @clearFiltersLabel={{t 'pages.campaign-results.filters.actions.clear'}}
-    @onClearFilters={{@resetFiltering}}
+    @onClearFilters={{@onResetFilter}}
     >
     {{#if this.displayDivisionFilter }}
       <PixMultiSelect

--- a/orga/app/components/campaign/filter/participation-filters.js
+++ b/orga/app/components/campaign/filter/participation-filters.js
@@ -11,38 +11,28 @@ export default class ParticipationFilters extends Component {
 
   get displayStagesFilter() {
     const { isTypeAssessment, hasStages } = this.args.campaign;
-    return isTypeAssessment && hasStages;
+    return !this.args.isHiddenStages && isTypeAssessment && hasStages;
+  }
+
+  get displayBadgesFilter() {
+    const { isTypeAssessment, hasBadges } = this.args.campaign;
+    return !this.args.isHiddenBadges && isTypeAssessment && hasBadges;
+  }
+
+  get displayDivisionFilter() {
+    return this.isDivisionsLoaded && this.currentUser.isSCOManagingStudents;
   }
 
   get stageOptions() {
     return this.args.campaign.stages.map(({ id, threshold }) => ({ value: id, threshold }));
   }
 
-  @action
-  onSelectStage(stages) {
-    this.args.triggerFiltering({ stages });
-  }
-
-  get displayBadgesFilter() {
-    const { isTypeAssessment, hasBadges } = this.args.campaign;
-    return isTypeAssessment && hasBadges;
-  }
-
   get badgeOptions() {
     return this.args.campaign.badges.map(({ id, title }) => ({ value: id, label: title }));
   }
 
-  @action
-  onSelectBadge(badges) {
-    this.args.triggerFiltering({ badges });
-  }
-
   get isDivisionsLoaded() {
     return this.args.campaign.divisions.content.length > 0;
-  }
-
-  get displayDivisionFilter() {
-    return this.isDivisionsLoaded && this.currentUser.isSCOManagingStudents;
   }
 
   get divisionOptions() {
@@ -50,7 +40,17 @@ export default class ParticipationFilters extends Component {
   }
 
   @action
+  onSelectStage(stages) {
+    this.args.onFilter({ stages });
+  }
+
+  @action
+  onSelectBadge(badges) {
+    this.args.onFilter({ badges });
+  }
+
+  @action
   onSelectDivision(divisions) {
-    this.args.triggerFiltering({ divisions });
+    this.args.onFilter({ divisions });
   }
 }

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -1,11 +1,12 @@
-<Routes::Authenticated::Campaign::ParticipationFilters
+<Campaign::Filter::ParticipationFilters
   @campaign={{@campaign}}
   @selectedDivisions={{@selectedDivisions}}
   @selectedBadges={{@selectedBadges}}
   @selectedStages={{@selectedStages}}
   @rowCount={{@participations.meta.rowCount}}
-  @resetFiltering={{@onResetFilter}}
-  @triggerFiltering={{@onFilter}}
+  
+  @onResetFilter={{@onResetFilter}}
+  @onFilter={{@onFilter}}
 />
 
 <div class="panel">

--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -1,10 +1,10 @@
-{{#if @campaign.hasParticipations}}
-  <Routes::Authenticated::Campaign::ParticipationFilters
+{{#if @campaign.hasParticipations}}  
+  <Campaign::Filter::ParticipationFilters
     @campaign={{@campaign}}
     @selectedDivisions={{@selectedDivisions}}
-    @triggerFiltering={{@triggerFiltering}}
     @rowCount={{@profiles.meta.rowCount}}
-    @resetFiltering={{@resetFiltering}}
+    @onFilter={{@onFilter}}
+    @onReset={{@onReset}}
   />
 
   <div class="panel">

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -6,6 +6,7 @@ export default class ActivityController extends Controller {
   queryParams = ['pageNumber', 'pageSize'];
   @tracked pageNumber = 1;
   @tracked pageSize = 25;
+  @tracked divisions = [];
 
   @action
   goToParticipantPage(campaignId, participationId) {
@@ -14,5 +15,17 @@ export default class ActivityController extends Controller {
     } else {
       this.transitionToRoute('authenticated.campaigns.profile', campaignId, participationId);
     }
+  }
+
+  @action
+  triggerFiltering(filters) {
+    this.pageNumber = null;
+    this.divisions = filters.divisions;
+  }
+
+  @action
+  resetFiltering() {
+    this.pageNumber = null;
+    this.divisions = [];
   }
 }

--- a/orga/app/models/campaign-participant-activity.js
+++ b/orga/app/models/campaign-participant-activity.js
@@ -5,5 +5,4 @@ export default class CampaignParticipantActivity extends Model {
   @attr('string') lastName;
   @attr('string') participantExternalId;
   @attr('string') status;
-  @attr('number') progression;
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/activity.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
+import { action } from '@ember/object';
 
 export default class ActivityRoute extends Route {
   queryParams = {
@@ -7,6 +8,9 @@ export default class ActivityRoute extends Route {
       refreshModel: true,
     },
     pageSize: {
+      refreshModel: true,
+    },
+    divisions: {
       refreshModel: true,
     },
   }
@@ -26,13 +30,25 @@ export default class ActivityRoute extends Route {
         number: params.pageNumber,
         size: params.pageSize,
       },
+      filter: {
+        divisions: params.divisions,
+      },
     });
+  }
+
+  @action
+  loading(transition) {
+    if (transition.from && transition.from.name === 'authenticated.campaigns.campaign.activity') {
+      return false;
+    }
+    return true;
   }
 
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
       controller.pageSize = 25;
+      controller.divisions = [];
     }
   }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -1,5 +1,6 @@
 @charset "utf-8";
 
+@import "globals/a11y";
 @import "globals/colors";
 @import "ember-modal-dialog/ember-modal-structure";
 @import "ember-modal-dialog/ember-modal-appearance";

--- a/orga/app/styles/globals/a11y.scss
+++ b/orga/app/styles/globals/a11y.scss
@@ -1,0 +1,11 @@
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  display: inline;
+}

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -6,6 +6,18 @@
     class="activity__dashboard"
   />
 
+  <Campaign::Filter::ParticipationFilters
+    @campaign={{@model.campaign}}
+    @selectedDivisions={{this.divisions}}
+    @rowCount={{@model.participations.meta.rowCount}}
+
+    @isHiddenStages={{true}}
+    @isHiddenBadges={{true}}
+
+    @onFilter={{this.triggerFiltering}}
+    @onResetFilter={{this.resetFiltering}}
+  />
+
   <Campaign::Activity::ParticipantsList
     @campaign={{@model.campaign}}
     @participations={{@model.participations}}

--- a/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
@@ -3,7 +3,7 @@
   @campaign={{@model.campaign}}
   @profiles={{@model.profiles}}
   @goToProfilePage={{this.goToProfilePage}}
-  @triggerFiltering={{this.triggerFiltering}}
   @selectedDivisions={{this.divisions}}
-  @resetFiltering={{this.resetFiltering}}
+  @onFilter={{this.triggerFiltering}}
+  @onReset={{this.resetFiltering}}
 />

--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import sinon from 'sinon';
-import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
+import clickByLabel from '../../../../helpers/extended-ember-test-helpers/click-by-label';
 
-module('Integration | Component | routes/authenticated/campaign/participation-filters', function(hooks) {
+module('Integration | Component | Campaign::Filter::ParticipationFilters', function(hooks) {
   setupIntlRenderingTest(hooks);
   let store;
 
@@ -20,7 +20,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       this.set('campaign', campaign);
 
       // when
-      await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+      await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
 
       // then
       assert.notContains('Filtres');
@@ -41,7 +41,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
 
         // then
         assert.notContains('Classes');
@@ -62,7 +62,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
         // then
         assert.contains('Classes');
         assert.contains('d1');
@@ -88,7 +88,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('triggerFiltering', triggerFiltering);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} @triggerFiltering={{triggerFiltering}}/>`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @onFilter={{triggerFiltering}}/>`);
         await click('[for="division-d1"]');
 
         // then
@@ -121,7 +121,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       this.set('campaign', campaign);
 
       // when
-      await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+      await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
 
       // then
       assert.notContains('Classes');
@@ -140,11 +140,29 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}}/>`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}}/>`);
 
         // then
         assert.contains('Thématiques');
         assert.contains('Les bases');
+      });
+
+      test('it should not displays the badge filter when it specified', async function(assert) {
+        // given
+        const badge = store.createRecord('badge', { title: 'Les bases' });
+        const campaign = store.createRecord('campaign', {
+          type: 'ASSESSMENT',
+          badges: [badge],
+        });
+
+        this.set('campaign', campaign);
+
+        // when
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @isHiddenBadges={{true}}/>`);
+
+        // then
+        assert.notContains('Thématiques');
+        assert.notContains('Les bases');
       });
 
       test('it triggers the filter when a badge is selected', async function(assert) {
@@ -160,7 +178,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('triggerFiltering', triggerFiltering);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} @triggerFiltering={{triggerFiltering}} />`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @onFilter={{triggerFiltering}} />`);
         await click('[for="badge-badge1"]');
 
         // then
@@ -179,7 +197,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
 
         // then
         assert.notContains('Thématiques');
@@ -198,7 +216,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
 
         // then
         assert.notContains('Thématiques');
@@ -216,7 +234,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
 
         // then
         assert.notContains('Paliers');
@@ -235,7 +253,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
 
         // then
         assert.notContains('Paliers');
@@ -254,10 +272,27 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}}/>`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}}/>`);
 
         // then
         assert.contains('Paliers');
+      });
+
+      test('it should not display the stage filter when it specified', async function(assert) {
+        // given
+        const stage = store.createRecord('stage', { id: 'stage1', threshold: 40 });
+        const campaign = store.createRecord('campaign', {
+          type: 'ASSESSMENT',
+          stages: [stage],
+        });
+
+        this.set('campaign', campaign);
+
+        // when
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @isHiddenStages={{true}}/>`);
+
+        // then
+        assert.notContains('Paliers');
       });
 
       test('it triggers the filter when a stage is selected', async function(assert) {
@@ -273,7 +308,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('triggerFiltering', triggerFiltering);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} @triggerFiltering={{triggerFiltering}} />`);
+        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @onFilter={{triggerFiltering}} />`);
         await click('[for="stage-stage1"]');
 
         // then
@@ -294,7 +329,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('rowCount', rowCount);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters
+        await render(hbs`<Campaign::Filter::ParticipationFilters
                             @campaign={{campaign}}
                             @rowCount={{rowCount}}
                           />`);
@@ -318,7 +353,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         this.set('details', rowCount);
 
         // when
-        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters
+        await render(hbs`<Campaign::Filter::ParticipationFilters
                             @campaign={{campaign}}
                             @rowCount={{details}}
                           />`);
@@ -340,9 +375,9 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
           this.set('resetFiltering', resetFiltering);
 
           //when
-          await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters
+          await render(hbs`<Campaign::Filter::ParticipationFilters
                             @campaign={{campaign}}
-                            @resetFiltering={{resetFiltering}}
+                            @onResetFilter={{resetFiltering}}
                           />`);
           await clickByLabel('Effacer les filtres');
 

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/list_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/list_test.js
@@ -245,7 +245,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
       this.set('triggerFiltering', triggerFiltering);
 
       // when
-      await render(hbs`<Routes::Authenticated::Campaign::Profile::List @campaign={{campaign}} @profiles={{profiles}} @goToProfilePage={{goToProfilePage}} @triggerFiltering={{triggerFiltering}}/>`);
+      await render(hbs`<Routes::Authenticated::Campaign::Profile::List @campaign={{campaign}} @profiles={{profiles}} @goToProfilePage={{goToProfilePage}} @onFilter={{triggerFiltering}}/>`);
       await click('[for="division-d1"]');
 
       // then

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -226,7 +226,7 @@
         "row-title": "Participant"
       },
       "status": {
-        "started-assessment": "In progress ({progression, number, ::percent})",
+        "started-assessment": "In progress",
         "completed-assessment": "Pending results",
         "shared-assessment": "Submitted results",
         "completed-profile": "Pending profile",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -226,7 +226,7 @@
         "row-title": "Participant"
       },
       "status": {
-        "started-assessment": "En cours ({progression, number, ::percent})",
+        "started-assessment": "En cours",
         "completed-assessment": "En attente d'envoi",
         "shared-assessment": "Résultats reçus",
         "completed-profile": "En attente d'envoi",


### PR DESCRIPTION
## :unicorn: Problème

Les établissements scolaires font participer tous les élèves d'un même niveaux (tous les 3ème par exemple) à une campagne.
Les prescripteurs ne peuvent pas filtrer les participants en fonction de la classe qui les intéresse.

## :robot: Solution

Ajouter un filtre pour trier les participants en fonction de leur classe.

## :rainbow: Remarques

Nous avons identifié un problème de performance pour le calcul du statut des participations et de la progression des participants.

### 1er Problème : La jointure sur les 'assessments'.

Pour connaître le statut d'une participation il faut récupérer le statut de l''assessment' le plus récent de la participation.

La jointure était faite sur toutes les participations pour récupérer le bon 'assessement' et ensuite on appliquait une pagination pour ne pas renvoyer trop de résultats.

Lorsqu'une campagne avait 3000 participants par exemple nous faisions la jointure pour les 3000 participations, mais cette jointure n'était utile que pour les participations que nous voulions afficher.

#### Solution

Nous avons fait les jointures après avoir appliqué le 'LIMIT' et le 'OFFSET' à notre requête SQL pour ne les faire que pour les participations ou c'est nécessaire.

### 2nd Problème : Le calcul de la progression

Pour chaque participant qui n'a pas terminé la campagne on veut afficher la progression du participant :

le nombre d'acquis évalués / nombre d'acquis à évaluer

Pour le faire il faut récupérer le 'knowledge-element' le plus récent pour chaque acquis évalué dans le cadre de la campagne et il faut faire ça pour chaque utilisateur. Ce calcul prend du temps, car il faut filtrer les 'knowledge-elements' par date, par statut et par acquis.

Faire ce calcul pour 25 personnes avec 700 knowledge-elements par participants sur 300 acquis prenait plusieurs secondes.

On ne bénéficie pas de l'utilisation des snapshots, car la progression est calculée avant le partage des résultats et le snapshot est créé au moment du partage.

#### Solution

À court terme: 
Supprimer le calcul de la progression permet de passer à un affichage en ~15ms.

À long terme (suggestion):
Envisager de faire le calcul de la progression au moment on on répond à une question. (usecases/correct-answer-then-update-assessment.js). À ce moment on dispose d'une bonne partie des informations nécessaires à ce calcul et la notion de progression semble appartenir aux 'assessments'.

## :100: Pour tester

Afficher la page activité des campagnes sur PixOrga.
La page doit afficher la liste des participants qu'on peut filtrer par classe.
La page doit s'afficher dans un temps raisonnable.

