### PR TITLE
[TECH] Utiliser la version mineure 12.7 de BDD PostgreSQL .

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
   api_build_and_test:
     docker:
       - image: circleci/node:14.17.0
-      - image: postgres:12.5-alpine
+      - image: postgres:12.7-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -229,7 +229,7 @@ jobs:
   e2e_test:
     docker:
       - image: cypress/browsers:node14.17.0-chrome91-ff89
-      - image: postgres:12.5-alpine
+      - image: postgres:12.7-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:12.5-alpine
+    image: postgres:12.7-alpine
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## :unicorn: Problème
La 12.7 de la BDD PostgreSQL est disponible sur Scalingo.
La version utilisée est la 12.5.

## :robot: Solution
Configurer la BDD de CI + locale pour l'utiliser.

## :rainbow: Remarques
Releases notes
- [12.6](https://www.postgresql.org/docs/release/12.6/)
- [12.7](https://www.postgresql.org/docs/release/12.7/)

> However, see the second and third changelog items below, which describe cases in which reindexing indexes after the upgrade may be advisable.

La RA est déjà en 12.7

Monter manuellement la version sur les applications Scalingo Intégration/Recette après le merge [(Wiki)](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1549434939/Mises+jour+hors+npm)

## :100: Pour tester
Vérifier que la suite de test passe en CI et en local