### PR TITLE
[BUGFIX] Certains pays sont importés deux fois lors de l'import CPF des pays depuis le fichier INSEE (PIX-2823)

### DIFF
--- a/api/scripts/import-certification-cpf-countries.js
+++ b/api/scripts/import-certification-cpf-countries.js
@@ -23,7 +23,7 @@ const FRENCH_CODE_IN_FILE = 'XXXXX';
 const TYPES = {
   'actuel': '1',
   'perime': '2',
-  'territoire_sans_codee_officiel_geographique': '3',
+  'territoire_sans_code_officiel_geographique': '3',
   'territoire_ayant_code_officiel_geographique': '4',
 };
 

--- a/api/scripts/import-certification-cpf-countries.js
+++ b/api/scripts/import-certification-cpf-countries.js
@@ -46,7 +46,7 @@ function buildCountries({ csvData }) {
         originalName: data[CURRENT_NAME_COLUMN],
         matcher: sanitizeAndSortChars(data[CURRENT_NAME_COLUMN]),
       });
-      if (data[ALTERNATIVE_NAME_COLUMN]) {
+      if (data[ALTERNATIVE_NAME_COLUMN] && data[ALTERNATIVE_NAME_COLUMN] !== data[CURRENT_NAME_COLUMN]) {
         result.push({
           code,
           commonName: data[CURRENT_NAME_COLUMN],

--- a/api/scripts/import-certification-cpf-countries.js
+++ b/api/scripts/import-certification-cpf-countries.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /* eslint-disable no-console */
-// Usage: node import-coutries-data path/file.csv
+// Usage: node import-certification-cpf-countries.js path/file.csv
 // File Millésime 2021 : Liste des pays et territoires étrangers au 01/01/2021
 // downloaded from https://www.data.gouv.fr/fr/datasets/code-officiel-geographique-cog/
 
@@ -90,8 +90,9 @@ async function main(filePath) {
     console.log('Verify data integrity... ');
     checkTransformUnicity(countries);
 
-    console.log('Inserting countries in database... ');
+    console.log('Emptying existing countries in database... ');
     await trx('certification-cpf-countries').del();
+    console.log('Inserting countries in database... ');
     await trx.batchInsert('certification-cpf-countries', countries);
     trx.commit();
     console.log('ok');

--- a/api/tests/unit/scripts/import-certification-cpf-countries_test.js
+++ b/api/tests/unit/scripts/import-certification-cpf-countries_test.js
@@ -114,6 +114,26 @@ describe('Unit | Scripts | import-certification-cpf-countries.js', () => {
       ]);
     });
 
+    it('should return one occurence of a country if its alternative is the same as its common', () => {
+      // given
+      const csvData = [
+        { LIBCOG: 'PAYS-BAS', LIBENR: 'PAYS-BAS', COG: '99135', ACTUAL: '1' },
+      ];
+
+      // when
+      const countries = buildCountries({ csvData });
+
+      // then
+      expect(countries).to.deep.equal([
+        {
+          'code': '99135',
+          'commonName': 'PAYS-BAS',
+          'originalName': 'PAYS-BAS',
+          'matcher': 'AABPSSY',
+        },
+      ]);
+    });
+
   });
 
   describe('#checkTransformUnicity', () => {


### PR DESCRIPTION
## :unicorn: Problème
Certains pays semblent être importés deux fois.

## :robot: Solution
Dans le fichier, un pays présente un nom commun et un nom alternatif (respectivement les colonnes LIBCOG et LIBENR). Prenons le cas de la Norvège :
![norvege](https://user-images.githubusercontent.com/48727874/125901319-40718e9f-4d23-4b94-bcf9-4affec70656e.png)

Dans ce cas, nous avions souhaité ajouter deux fois la Norvège, sous les deux noms existant, afin d'être plus tolérant sur les imports ODS, et donc d'ajouter deux entrées à la BDD : une avec le nom NORVEGE, l'autre avec le nom ROYAUME DE NORVEGE.

Le problème c'est que cela créé des doublons pour les pays dont le nom alternatif est le même que le nom commun, une vérification était manquante, c'était le cas par exemple pour la Roumanie :
![roumanie](https://user-images.githubusercontent.com/48727874/125901329-8871ff27-04cb-43d5-a5a4-ba8b6152aa85.png)

## :rainbow: Remarques
Ne pas oublier de procéder aux réimports sur les différents environnements

## :100: Pour tester
Exécuter la commande pour importer les pays, puis vérifier dans votre BDD qu'il n'existe bien qu'une seule occurrence par nom distinct de pays.
Pour vérifier :
`select "commonName", "originalName", count(*) from "certification-cpf-countries" group by "commonName", "originalName" having count(*) > 1;`
