### PR TITLE
[BUGFIX] La liste des pays retournée par l'API était incomplète et côté Front certains pays étaient dans le désordre (PIX-2824)

### DIFF
--- a/api/lib/domain/read-models/Country.js
+++ b/api/lib/domain/read-models/Country.js
@@ -2,9 +2,11 @@ class Country {
   constructor({
     code,
     name,
+    matcher,
   }) {
     this.code = code;
     this.name = name;
+    this.matcher = matcher;
   }
 }
 

--- a/api/lib/infrastructure/repositories/country-repository.js
+++ b/api/lib/infrastructure/repositories/country-repository.js
@@ -5,7 +5,7 @@ module.exports = {
   async findAll() {
     const result = await knex
       .from('certification-cpf-countries')
-      .select('commonName', 'code')
+      .select('commonName', 'code', 'matcher')
       .where('commonName', '=', knex.ref('originalName'))
       .orderBy('commonName', 'asc');
 

--- a/api/lib/infrastructure/serializers/jsonapi/country-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/country-serializer.js
@@ -4,8 +4,10 @@ module.exports = {
 
   serialize(country) {
     return new Serializer('country', {
-      id: 'code',
       attributes: ['code', 'name'],
+      transform(country) {
+        return { ...country, id: `${country.code}_${country.matcher}` };
+      },
     }).serialize(country);
   },
 

--- a/api/tests/integration/infrastructure/repositories/country-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/country-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const countryRepository = require('../../../../lib/infrastructure/repositories/country-repository');
 const { Country } = require('../../../../lib/domain/read-models/Country');
 
@@ -8,27 +8,24 @@ describe('Integration | Repository | country-repository', () => {
 
     describe('when there are countries', () => {
 
-      it('should return all common named countries', async () => {
+      it('should return all common named countries ordered by name', async () => {
         // given
         databaseBuilder.factory.buildCertificationCpfCountry({
           code: '99345',
           commonName: 'TOGO',
           originalName: 'TOGO',
-          id: 3,
         });
 
         databaseBuilder.factory.buildCertificationCpfCountry({
           code: '99345',
           commonName: 'TOGO',
           originalName: 'RÉPUBLIQUE TOGOLAISE',
-          id: 1,
         });
 
         databaseBuilder.factory.buildCertificationCpfCountry({
           code: '99876',
           commonName: 'NABOO',
           originalName: 'NABOO',
-          id: 2,
         });
 
         await databaseBuilder.commit();
@@ -37,18 +34,19 @@ describe('Integration | Repository | country-repository', () => {
         const countries = await countryRepository.findAll();
 
         // then
+        const togoCountry = domainBuilder.buildCountry({
+          code: '99345',
+          name: 'TOGO',
+          matcher: 'GOOT',
+        });
+        const nabooCountry = domainBuilder.buildCountry({
+          code: '99876',
+          name: 'NABOO',
+          matcher: 'ABNOO',
+        });
         expect(countries.length).to.equal(2);
         expect(countries[0]).to.be.instanceOf(Country);
-        expect(countries).to.deep.equal([
-          {
-            code: '99876',
-            name: 'NABOO',
-          },
-          {
-            code: '99345',
-            name: 'TOGO',
-          },
-        ]);
+        expect(countries).to.deep.equal([nabooCountry, togoCountry]);
       });
     });
 
@@ -62,7 +60,5 @@ describe('Integration | Repository | country-repository', () => {
         expect(countries).to.deep.equal([]);
       });
     });
-
   });
-
 });

--- a/api/tests/tooling/domain-builder/factory/build-country.js
+++ b/api/tests/tooling/domain-builder/factory/build-country.js
@@ -1,12 +1,15 @@
 const { Country } = require('../../../../lib/domain/read-models/Country');
+const { sanitizeAndSortChars } = require('../../../../lib/infrastructure/utils/string-utils');
 
 module.exports = function buildCountry({
   code = '99345',
   name = 'TOGO',
+  matcher = sanitizeAndSortChars(name),
 } = {}) {
 
   return new Country({
     code,
     name,
+    matcher,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/country-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/country-serializer_test.js
@@ -26,7 +26,7 @@ describe('Unit | Serializer | JSONAPI | country-serializer', () => {
       expect(json).to.deep.equal({
         data: [
           {
-            id: '123',
+            id: '123_GOOT',
             type: 'countries',
             attributes: {
               name: 'TOGO',
@@ -34,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | country-serializer', () => {
             },
           },
           {
-            id: '456',
+            id: '456_ABNOO',
             type: 'countries',
             attributes: {
               name: 'NABOO',


### PR DESCRIPTION
## :unicorn: Problème
Dans la liste des pays de la modale d'ajout candidat, on constatait que :
- Certains pays étaient manquants (alors que bien présent dans le payload de retour de l'appel à l'endpoint API pour récupérer les pays) : exemple, Anguila
- Certains pays n'étaient pas positionnés dans l'ordre alphabétique, exemple : Iles vierges britanniques

Ces deux problèmes ont en fait une origine commune.

## :robot: Solution
Ember réclame un ID sur tous les modèles JSON Api qu'il récupère depuis le back. A ce titre, nous avions choisi de mettre comme ID du modèle Country le code INSEE.
Malheureusement, pour bon nombre de pays, ce code n'est pas unique :
![pays_common_code](https://user-images.githubusercontent.com/48727874/125905364-03c3868b-9b4c-4f2b-bb4e-6670924218d5.png)

De fait, lorsque les données sont retournées côté Ember, celui-ci ne va conserver qu'une seule version du code, et il semblerait qu'il conserve la dernière rencontrée.

Il faut donc un ID unique.
La solution proposée est de récupérer également le matcher depuis la table certification-cpf-countries et de créer au niveau du serializer un ID à la volée qui soit unique et qui soit la concaténation du code INSEE et du matcher.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que la liste des pays dans la modale candidat soit complète et ordonnée