### PR TITLE
[TECH] Garantir l'unicité de la temporaryKey dans la récupération de compte SCO.

### DIFF
--- a/api/db/migrations/20210716074232_alter_account-recovery-demand_add_unique_temporary_key.js
+++ b/api/db/migrations/20210716074232_alter_account-recovery-demand_add_unique_temporary_key.js
@@ -1,0 +1,8 @@
+
+exports.up = function(knex) {
+  return knex.raw('ALTER TABLE "account-recovery-demands" ADD CONSTRAINT account_recovery_demands_temporary_key_unique UNIQUE("temporaryKey")');
+};
+
+exports.down = function(knex) {
+  return knex.raw('ALTER TABLE "account-recovery-demands" DROP CONSTRAINT account_recovery_demands_temporary_key_unique');
+};

--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -2,7 +2,6 @@ const { knex } = require('../../../db/knex-database-connection');
 const AccountRecoveryDemand = require('../../domain/models/AccountRecoveryDemand');
 const {
   NotFoundError,
-  TooManyRows,
   AccountRecoveryDemandExpired,
 } = require('../../domain/errors');
 const { isEmpty } = require('lodash');
@@ -24,10 +23,6 @@ module.exports = {
 
     if (isEmpty(accountRecoveryDemandDTOs)) {
       throw new NotFoundError('No account recovery demand found');
-    }
-
-    if (accountRecoveryDemandDTOs.length > 1) {
-      throw new TooManyRows('Multiple demands found for the same temporary key');
     }
 
     const accountRecoveryDemand = accountRecoveryDemandDTOs[0];

--- a/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
@@ -2,7 +2,6 @@ const { expect, knex, databaseBuilder, domainBuilder, catchErr } = require('../.
 const accountRecoveryDemandRepository = require('../../../../lib/infrastructure/repositories/account-recovery-demand-repository');
 const {
   NotFoundError,
-  TooManyRows,
   AccountRecoveryDemandExpired,
 } = require('../../../../lib/domain/errors');
 const AccountRecoveryDemand = require('../../../../lib/domain/models/AccountRecoveryDemand');
@@ -72,26 +71,6 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
           // then
           expect(demand).to.deep.equal(expectedAccountRecoveryDemand);
         });
-      });
-
-      context('when multiple demands found for the same temporary key', () => {
-
-        it('should throw too many rows error', async () => {
-          // given
-          const email = 'someMail@example.net';
-          const temporaryKey = 'ERTFFAZSDFR';
-          databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false }).id;
-          databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false });
-          await databaseBuilder.commit();
-
-          // when
-          const error = await catchErr(accountRecoveryDemandRepository.findByTemporaryKey)(temporaryKey);
-
-          // then
-          expect(error).to.be.instanceOf(TooManyRows);
-          expect(error.message).to.be.equal('Multiple demands found for the same temporary key');
-        });
-
       });
 
       context('when demand expired a day ago', () => {


### PR DESCRIPTION
## :unicorn: Problème
https://github.com/1024pix/pix/pull/3176#discussion_r670185703

## :robot: Solution
Ajouter une contrainte d'unicité côté BDD
Supprimer la vérification dans le repository
Modifier le repository pour renvoyer le premier élement.

## :100: Pour tester
Tenter d'insérer un enregistrement en doublon