### PR TITLE
[FEATURE] Ajouter dans la liste des paliers la présence du titre et de la description du prescripteur (PIX-2831).

### DIFF
--- a/admin/app/components/common/tick-or-cross.hbs
+++ b/admin/app/components/common/tick-or-cross.hbs
@@ -1,0 +1,1 @@
+<FaIcon @icon={{this.icon}} class="tick-or-cross {{this.class}}"/>

--- a/admin/app/components/common/tick-or-cross.js
+++ b/admin/app/components/common/tick-or-cross.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+export default class TickOrCross extends Component {
+
+  get icon() {
+    return this.args.isTrue ? 'check' : 'times';
+  }
+
+  get class() {
+    return this.args.isTrue ? 'tick-or-cross--valid' : 'tick-or-cross--invalid';
+  }
+}

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -15,6 +15,8 @@
               <th class="stages-table__threshold">Seuil</th>
               <th class="stages-table__title">Titre</th>
               <th>Message</th>
+              <th>Titre prescripteur</th>
+              <th>Description prescripteur</th>
               <th class="stages-table__actions">Actions</th>
             </tr>
           </thead>
@@ -68,6 +70,16 @@
                   {{else}}
                     {{stage.message}}
                   {{/if}}
+                </td>
+                <td>
+                  <Common::TickOrCross 
+                    @isTrue={{stage.hasPrescriberTitle}}
+                  />
+                </td>
+                <td>
+                  <Common::TickOrCross 
+                    @isTrue={{stage.hasPrescriberDescription}}
+                  />
                 </td>
                 <td>
                   {{#if stage.isNew}}

--- a/admin/app/models/stage.js
+++ b/admin/app/models/stage.js
@@ -8,4 +8,12 @@ export default class Stage extends Model {
   @attr('string') message;
   @attr('string') prescriberTitle;
   @attr('string') prescriberDescription;
+
+  get hasPrescriberTitle() {
+    return Boolean(this.prescriberTitle);
+  }
+
+  get hasPrescriberDescription() {
+    return Boolean(this.prescriberDescription);
+  }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -35,6 +35,7 @@
 @import 'authenticated/tools';
 
 /* components */
+@import 'components/common/tick-or-cross';
 @import 'components/certification-center-form';
 @import 'components/certification-details-answer';
 @import 'components/certification-details-competence';

--- a/admin/app/styles/components/common/tick-or-cross.scss
+++ b/admin/app/styles/components/common/tick-or-cross.scss
@@ -1,0 +1,9 @@
+.tick-or-cross {
+    &--valid {
+        color: $success;
+    }
+
+    &--invalid {
+        color: $error;
+    }
+}

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -30,6 +30,8 @@ module('Integration | Component | TargetProfiles::Stages', function(hooks) {
     assert.contains('Seuil');
     assert.contains('Titre');
     assert.contains('Message');
+    assert.contains('Titre prescripteur');
+    assert.contains('Description prescripteur');
     assert.contains('Actions');
     assert.dom('tbody tr').exists({ count: 1 });
     assert.equal(find('tbody tr td:first-child').textContent.trim(), '1');
@@ -38,7 +40,7 @@ module('Integration | Component | TargetProfiles::Stages', function(hooks) {
     assert.equal(find('tbody tr td:nth-child(3)').textContent.trim(), '100');
     assert.equal(find('tbody tr td:nth-child(4)').textContent.trim(), 'My title');
     assert.equal(find('tbody tr td:nth-child(5)').textContent.trim(), 'My message');
-    assert.equal(find('tbody tr td:nth-child(6)').textContent.trim(), 'Voir détail');
+    assert.equal(find('tbody tr td:nth-child(8)').textContent.trim(), 'Voir détail');
     assert.notContains('Aucun résultat thématique associé');
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on regarde la liste des paliers d'un profile cible on ne sait quel palier à  un titre et une description de prescripteur.

## :robot: Solution
Ajouter deux colonnes : une pour la description du prescripteur et une pour le titre du prescripteur.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller sur PixAdmin
- Consulter les résultat thématiques d'un profile cible qui à des paliers
- Vérifier qu'il y a bien les colonnes titre du prescripteur et description du prescripteur.