### PR TITLE
[FEATURE] Rendre le délai d'expiration de la demande de récupération SCO paramétrable (PIX-2827).

### DIFF
--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -23,6 +23,7 @@ const schema = Joi.object({
   LOG_LEVEL: Joi.string().optional().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
   AUTH_SECRET: Joi.string().required(),
   IS_SCO_ACCOUNT_RECOVERY_ENABLED: Joi.string().optional().valid('true', 'false'),
+  SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES: Joi.number().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function() {

--- a/api/sample.env
+++ b/api/sample.env
@@ -345,6 +345,7 @@ AUTH_SECRET=Change me!
 
 
 # SCO account recovery - expiration delay (minutes)
+# Mind to update in the following tempale SENDINBLUE_ACCOUNT_RECOVERY_TEMPLATE_ID
 #
 # presence: optional
 # type: integer

--- a/api/sample.env
+++ b/api/sample.env
@@ -344,5 +344,10 @@ AUTH_SECRET=Change me!
 # SAML_SP_CONFIG=
 
 
-# Allow email change in API
-
+# SCO account recovery - expiration delay (minutes)
+#
+# presence: optional
+# type: integer
+# default: 1 440 (1 day)
+# sample: SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES=10
+# SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES=


### PR DESCRIPTION
## :unicorn: Problème
https://github.com/1024pix/pix/pull/3176#discussion_r670187586

## :robot: Solution
Le rendre modifiable à chaud dans une variable d'environnement

## :rainbow: Remarques
Quel est le mot anglais approprié pour délai d'expiration ? Timeout ?
[delay](https://anglais-pratique.fr/index.php/rubriques/faux-amis/66-delai-delay) semble être un faux ami

## :100: Pour tester
Passer le délai d'expiration à 1 minute `SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES=1`
Créer une demande de récupération 
Attendre une minute
Tenter de l'utiliser et vérifier qu'un message d'erreur s'affiche