### PR TITLE
[BUGFIX] Permettre l'envoi du formulaire d'ajout de candidat sous IE (PIX-2834)

### DIFF
--- a/api/db/seeds/data/certification/certification-cpf-city-builder.js
+++ b/api/db/seeds/data/certification/certification-cpf-city-builder.js
@@ -1,0 +1,58 @@
+function certificationCpfCityBuilder({ databaseBuilder }) {
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS 1',
+    postalCode: '75001',
+    INSEECode: '75101',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS 12',
+    postalCode: '75012',
+    INSEECode: '75112',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS 15',
+    postalCode: '75015',
+    INSEECode: '75115',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS 19',
+    postalCode: '75019',
+    INSEECode: '75119',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PERPIGNAN',
+    postalCode: '66000',
+    INSEECode: '66136',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'NANTES',
+    postalCode: '44000',
+    INSEECode: '44109',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'LES-BAUX-DE-BRETEUIL',
+    postalCode: '27160',
+    INSEECode: '27043',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'MARBOIS',
+    postalCode: '27160',
+    INSEECode: '27157',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'MESNILS-SUR-ITON',
+    postalCode: '27160',
+    INSEECode: '27240',
+  });
+}
+
+module.exports = { certificationCpfCityBuilder };

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -27,6 +27,7 @@ const { usersBuilder } = require('./data/users-builder');
 const usersPixRolesBuilder = require('./data/users_pix_roles-builder');
 const stagesBuilder = require('./data/stages-builder');
 const { certificationCpfCountryBuilder } = require('./data/certification/certification-cpf-country-builder');
+const { certificationCpfCityBuilder } = require('./data/certification/certification-cpf-city-builder');
 const {
   getEligibleCampaignParticipations,
   generateKnowledgeElementSnapshots,
@@ -66,6 +67,7 @@ exports.seed = async (knex) => {
   badgeAcquisitionBuilder({ databaseBuilder });
   partnerCertificationBuilder({ databaseBuilder });
   certificationCpfCountryBuilder({ databaseBuilder });
+  certificationCpfCityBuilder({ databaseBuilder });
 
   // Éléments de parcours
   campaignsBuilder({ databaseBuilder });

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -216,13 +216,10 @@
             <Input
               @id="result-recipient-email"
               @type="email"
-              @class="input {{if this.validation.email.hasError 'input--error'}}"
+              @class="input"
               @value={{@candidateData.resultRecipientEmail}}
               {{on 'input' (fn @updateCandidateData @candidateData 'resultRecipientEmail')}}
             />
-            {{#if this.validation.email.hasError}}
-              <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.email.message}}</div>
-            {{/if}}
           </div>
 
           <div id="email-container" class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
@@ -230,13 +227,10 @@
             <Input
               @id="email"
               @type="email"
-              @class="input {{if this.validation.email.hasError 'input--error'}}"
+              @class="input"
               @value={{@candidateData.email}}
               {{on 'input' (fn @updateCandidateData @candidateData 'email')}}
             />
-            {{#if this.validation.email.hasError}}
-              <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.email.message}}</div>
-            {{/if}}
           </div>
 
           <div class="new-certification-candidate-details-modal__actions">

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -239,14 +239,14 @@
             {{/if}}
           </div>
 
-        </form>
+          <div class="new-certification-candidate-details-modal__actions">
+            <PixButton @size="small" @triggerAction={{fn @closeModal}} @backgroundColor="transparent-light">
+              Fermer
+            </PixButton>
+            <PixButton @size="small" @type="submit">Ajouter le candidat</PixButton>
+          </div>
 
-        <div class="new-certification-candidate-details-modal__actions">
-          <PixButton @size="small" @triggerAction={{fn @closeModal}} @backgroundColor="transparent-light">
-            Fermer
-          </PixButton>
-          <PixButton @size="small" form="new-certification-candidate-form" @type="submit">Ajouter le candidat</PixButton>
-        </div>
+        </form>
       </div>
 
     </div>

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -95,6 +95,7 @@
     display: flex;
     justify-content: flex-end;
     border-radius: 0 0 5px 5px;
+    width: 100%;
 
     .pix-button {
       margin-left: 16px;


### PR DESCRIPTION
## :unicorn: Problème

Sur Internet Explorer 11, l'envoi du nouveau formulaire d'ajout de candidat ne fonctionne pas : rien ne se passe quand on clique sur le bouton "Ajouter le candidat".

La raison du problème est que le bouton se trouve en dehors du formulaire. Par défaut, un bouton de type `submit` envoie le `form` parent le plus proche. Si le bouton n'est pas dans un formulaire, on peut indiquer le formulaire à envoyer avec l'attribut `form` : c'est ce qui a été fait ici. Mais cet attribut n'est pas supporté par IE 11 👴🏻.

## :robot: Solution

Retirer l'attribut `form` du bouton d'envoi et le déplacer dans le formulaire.

## :rainbow: Remarques

- [Les villes, codes INSEE et codes postaux ont été ajoutées dans les seeds](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/18907137/Review+app+seeds#Villes%2C-codes-INSEE-et-codes-postaux) pour faciliter les tests fonctionnels
- Du code inutile, ajouté lors du copier-coller initial, a été supprimé de la modale

## :100: Pour tester

**Sur Internet Explorer 11**

1. Se connecter à Pix Certif avec un compte non-sco (ex: certifsup@example.net)
2. Se rendre dans une session (la créer au besoin) puis sur l'onglets Candidat
3. Cliquer sur le bouton **Ajouter un candidat** pour ouvrir la modale
4. Remplir correctement le formulaire et cliquer sur le bouton **Ajouter le candidat**
5. Constater que le candidat a bien été ajouté à la liste