### PR TITLE
[FEATURE] Empêcher l'usurpation d'identité lors de la récupération de compte SCO (PIX-2811).

### DIFF
--- a/api/db/database-builder/factory/build-account-recovery-demand.js
+++ b/api/db/database-builder/factory/build-account-recovery-demand.js
@@ -1,18 +1,20 @@
 const databaseBuffer = require('../database-buffer');
+const buildSchoolingRegistration = require('./build-schooling-registration');
 
 module.exports = function buildAccountRecoveryDemand({
   id = databaseBuffer.getNextId(),
   userId,
+  schoolingRegistrationId,
   oldEmail,
   newEmail = 'philipe@example.net',
   temporaryKey = 'OWIxZGViNGQtM2I3ZC00YmFkLTliZGQtMmIwZDdiM2RjYjZk',
   used = false,
   createdAt,
 } = {}) {
-
   const values = {
     id,
     userId,
+    schoolingRegistrationId: schoolingRegistrationId || buildSchoolingRegistration().id,
     oldEmail,
     newEmail,
     temporaryKey,

--- a/api/db/migrations/20210715153308_add-column-schoolingRegistrationId-to-account-recovery-demands-table.js
+++ b/api/db/migrations/20210715153308_add-column-schoolingRegistrationId-to-account-recovery-demands-table.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'account-recovery-demands';
+const TABLE_COLUMN = 'schoolingRegistrationId';
+const REFERENCED_COLUMN_NAME = 'schooling-registrations.id';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.integer(TABLE_COLUMN).unsigned().references(REFERENCED_COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(TABLE_COLUMN);
+  });
+};

--- a/api/lib/application/account-recovery/account-recovery-controller.js
+++ b/api/lib/application/account-recovery/account-recovery-controller.js
@@ -1,13 +1,13 @@
 const usecases = require('../../domain/usecases');
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
+const studentInformationForAccountRecoverySerializer = require('../../infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer');
 
 module.exports = {
 
   async sendEmailForAccountRecovery(request, h) {
-    const userId = request.payload.data.attributes['user-id'];
-    const email = request.payload.data.attributes.email;
+    const studentInformation = await studentInformationForAccountRecoverySerializer.deserialize(request.payload);
 
-    await usecases.sendEmailForAccountRecovery({ userId, email });
+    await usecases.sendEmailForAccountRecovery({ studentInformation });
 
     return h.response().code(204);
   },

--- a/api/lib/application/account-recovery/index.js
+++ b/api/lib/application/account-recovery/index.js
@@ -1,6 +1,8 @@
-const Joi = require('joi');
-const identifiersType = require('../../domain/types/identifiers-type');
+const Joi = require('joi').extend(require('@joi/date'));
 const featureToggles = require('../preHandlers/feature-toggles');
+
+const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
+const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
 
 const accountRecoveryController = require('./account-recovery-controller');
 
@@ -22,7 +24,13 @@ exports.register = async function(server) {
           payload: Joi.object({
             data: {
               attributes: {
-                'user-id': identifiersType.userId,
+                'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'ine-ina': Joi.alternatives().try(
+                  Joi.string().regex(inePattern).required(),
+                  Joi.string().regex(inaPattern).required(),
+                ),
+                birthdate: Joi.date().format('YYYY-MM-DD').required(),
                 email: Joi.string().email().required(),
               },
             },

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -96,13 +96,7 @@ module.exports = {
   },
 
   async checkScoAccountRecovery(request) {
-    const payload = request.payload.data.attributes;
-    const studentInformation = {
-      ineIna: payload['ine-ina'],
-      firstName: payload['first-name'],
-      lastName: payload['last-name'],
-      birthdate: payload['birthdate'],
-    };
+    const studentInformation = await studentInformationForAccountRecoverySerializer.deserialize(request.payload);
 
     const studentInformationForAccountRecovery = await usecases.checkScoAccountRecovery({
       studentInformation,

--- a/api/lib/domain/models/AccountRecoveryDemand.js
+++ b/api/lib/domain/models/AccountRecoveryDemand.js
@@ -3,15 +3,17 @@ class AccountRecoveryDemand {
   constructor({
     id,
     userId,
+    schoolingRegistrationId,
     oldEmail,
     newEmail,
     temporaryKey,
     used,
   } = {}) {
     this.id = id;
+    this.schoolingRegistrationId = schoolingRegistrationId;
     this.userId = userId;
     this.oldEmail = oldEmail;
-    this.newEmail = newEmail;
+    this.newEmail = newEmail.toLowerCase();
     this.temporaryKey = temporaryKey;
     this.used = used;
   }

--- a/api/lib/domain/read-models/StudentInformationForAccountRecovery.js
+++ b/api/lib/domain/read-models/StudentInformationForAccountRecovery.js
@@ -1,14 +1,12 @@
 class StudentInformationForAccountRecovery {
   constructor(
     {
-      userId,
       firstName,
       lastName,
       username,
       email,
       latestOrganizationName,
     } = {}) {
-    this.userId = userId;
     this.firstName = firstName;
     this.lastName = lastName;
     this.username = username;

--- a/api/lib/domain/services/check-sco-account-recovery-service.js
+++ b/api/lib/domain/services/check-sco-account-recovery-service.js
@@ -1,0 +1,27 @@
+const { MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError } = require('../errors');
+const _ = require('lodash');
+
+async function retrieveSchoolingRegistration({
+  studentInformation,
+  schoolingRegistrationRepository,
+  userRepository,
+}) {
+
+  const { id, userId, firstName, lastName, organizationId } = await schoolingRegistrationRepository.getSchoolingRegistrationInformation({
+    ...studentInformation,
+    nationalStudentId: studentInformation.ineIna,
+  });
+  const schoolingRegistrations = await schoolingRegistrationRepository.findByUserId({ userId });
+
+  if (_.uniqBy(schoolingRegistrations, 'nationalStudentId').length > 1) {
+    throw new MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError();
+  }
+
+  const { username, email } = await userRepository.get(userId);
+
+  return { id, userId, firstName, lastName, username, organizationId, email };
+}
+
+module.exports = {
+  retrieveSchoolingRegistration,
+};

--- a/api/lib/domain/usecases/check-sco-account-recovery.js
+++ b/api/lib/domain/usecases/check-sco-account-recovery.js
@@ -8,14 +8,14 @@ module.exports = async function checkScoAccountRecovery({
   organizationRepository,
   userRepository,
 }) {
-  const userId = await schoolingRegistrationRepository
-    .getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate({
+  const schoolingRegistrationInformation = await schoolingRegistrationRepository
+    .getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate({
       nationalStudentId: studentInformation.ineIna,
       firstName: studentInformation.firstName,
       lastName: studentInformation.lastName,
       birthdate: studentInformation.birthdate,
     });
-  const schoolingRegistrations = await schoolingRegistrationRepository.findByUserId({ userId });
+  const schoolingRegistrations = await schoolingRegistrationRepository.findByUserId({ userId: schoolingRegistrationInformation.userId });
 
   if (_areThereMultipleStudentForSameAccount(schoolingRegistrations)) {
     throw new MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError();
@@ -23,12 +23,12 @@ module.exports = async function checkScoAccountRecovery({
 
   const latestOrganizationId = _getLatestOrganization(schoolingRegistrations);
   const organization = await organizationRepository.get(latestOrganizationId);
-  const user = await userRepository.get(userId);
+  const user = await userRepository.get(schoolingRegistrationInformation.userId);
 
   return new StudentInformationForAccountRecovery({
-    userId,
-    firstName: user.firstName,
-    lastName: user.lastName,
+    userId: schoolingRegistrationInformation.userId,
+    firstName: schoolingRegistrationInformation.firstName,
+    lastName: schoolingRegistrationInformation.lastName,
     username: user.username,
     email: user.email,
     latestOrganizationName: organization.name,

--- a/api/lib/domain/usecases/check-sco-account-recovery.js
+++ b/api/lib/domain/usecases/check-sco-account-recovery.js
@@ -7,29 +7,25 @@ module.exports = async function checkScoAccountRecovery({
   organizationRepository,
   userRepository,
 }) {
-  const schoolingRegistrationInformation = await schoolingRegistrationRepository
-    .getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate({
-      nationalStudentId: studentInformation.ineIna,
-      firstName: studentInformation.firstName,
-      lastName: studentInformation.lastName,
-      birthdate: studentInformation.birthdate,
-    });
-  const schoolingRegistrations = await schoolingRegistrationRepository.findByUserId({ userId: schoolingRegistrationInformation.userId });
+  const { userId, firstName, lastName, organizationId } = await schoolingRegistrationRepository.getSchoolingRegistrationInformation({
+    ...studentInformation,
+    nationalStudentId: studentInformation.ineIna,
+  });
+  const schoolingRegistrations = await schoolingRegistrationRepository.findByUserId({ userId });
 
   if (_areThereMultipleStudentForSameAccount(schoolingRegistrations)) {
     throw new MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError();
   }
 
-  const organization = await organizationRepository.get(schoolingRegistrationInformation.organizationId);
-  const user = await userRepository.get(schoolingRegistrationInformation.userId);
+  const { name: latestOrganizationName } = await organizationRepository.get(organizationId);
+  const { username, email } = await userRepository.get(userId);
 
   return new StudentInformationForAccountRecovery({
-    userId: schoolingRegistrationInformation.userId,
-    firstName: schoolingRegistrationInformation.firstName,
-    lastName: schoolingRegistrationInformation.lastName,
-    username: user.username,
-    email: user.email,
-    latestOrganizationName: organization.name,
+    firstName,
+    lastName,
+    username,
+    email,
+    latestOrganizationName,
   });
 };
 

--- a/api/lib/domain/usecases/check-sco-account-recovery.js
+++ b/api/lib/domain/usecases/check-sco-account-recovery.js
@@ -1,5 +1,4 @@
 const { MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError } = require('../../domain/errors');
-const _ = require('lodash');
 const StudentInformationForAccountRecovery = require('../read-models/StudentInformationForAccountRecovery');
 
 module.exports = async function checkScoAccountRecovery({
@@ -21,8 +20,7 @@ module.exports = async function checkScoAccountRecovery({
     throw new MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError();
   }
 
-  const latestOrganizationId = _getLatestOrganization(schoolingRegistrations);
-  const organization = await organizationRepository.get(latestOrganizationId);
+  const organization = await organizationRepository.get(schoolingRegistrationInformation.organizationId);
   const user = await userRepository.get(schoolingRegistrationInformation.userId);
 
   return new StudentInformationForAccountRecovery({
@@ -41,12 +39,4 @@ function _areThereMultipleStudentForSameAccount(schoolingRegistrations) {
     .filter((schoolingRegistration) => schoolingRegistration.nationalStudentId !== firstIne);
 
   return anotherStudentForSameAccount.length > 0;
-}
-
-function _getLatestOrganization(schoolingRegistrations) {
-  const latestSchoolingRegistration = _(schoolingRegistrations)
-    .sortBy('updatedAt')
-    .reverse()
-    .first();
-  return latestSchoolingRegistration.organizationId;
 }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -113,6 +113,7 @@ const dependencies = {
   tutorialRepository: require('../../infrastructure/repositories/tutorial-repository'),
   userOrgaSettingsRepository: require('../../infrastructure/repositories/user-orga-settings-repository'),
   userReconciliationService: require('../services/user-reconciliation-service'),
+  checkScoAccountRecoveryService: require('../services/check-sco-account-recovery-service'),
   userRepository: require('../../infrastructure/repositories/user-repository'),
   userService: require('../../domain/services/user-service'),
   userTutorialRepository: require('../../infrastructure/repositories/user-tutorial-repository'),

--- a/api/lib/domain/usecases/send-email-for-account-recovery.js
+++ b/api/lib/domain/usecases/send-email-for-account-recovery.js
@@ -8,13 +8,16 @@ module.exports = async function sendEmailForAccountRecovery({
   userRepository,
   accountRecoveryDemandRepository,
   mailService,
+  checkScoAccountRecoveryService,
 }) {
-  const { email: newEmail, ineIna, ...otherStudentInformation } = studentInformation;
-  const { id, userId, firstName } = await schoolingRegistrationRepository.getSchoolingRegistrationInformation({
-    ...otherStudentInformation,
-    nationalStudentId: ineIna,
+  const { email: newEmail } = studentInformation;
+
+  const { firstName, id, userId, email: oldEmail } = await checkScoAccountRecoveryService.retrieveSchoolingRegistration({
+    studentInformation,
+    schoolingRegistrationRepository,
+    userRepository,
   });
-  const { email: oldEmail } = await userRepository.get(userId);
+
   await userRepository.isEmailAvailable(newEmail);
 
   const accountRecoveryDemand = new AccountRecoveryDemand({

--- a/api/lib/domain/usecases/send-email-for-account-recovery.js
+++ b/api/lib/domain/usecases/send-email-for-account-recovery.js
@@ -2,28 +2,34 @@ const crypto = require('crypto');
 const AccountRecoveryDemand = require('../models/AccountRecoveryDemand');
 
 module.exports = async function sendEmailForAccountRecovery({
-  userId,
-  email,
+  studentInformation,
   temporaryKey = crypto.randomBytes(32).toString('base64'),
+  schoolingRegistrationRepository,
   userRepository,
   accountRecoveryDemandRepository,
   mailService,
 }) {
-  await userRepository.isEmailAvailable(email);
-  const user = await userRepository.get(userId);
+  const { email: newEmail, ineIna, ...otherStudentInformation } = studentInformation;
+  const { id, userId, firstName } = await schoolingRegistrationRepository.getSchoolingRegistrationInformation({
+    ...otherStudentInformation,
+    nationalStudentId: ineIna,
+  });
+  const { email: oldEmail } = await userRepository.get(userId);
+  await userRepository.isEmailAvailable(newEmail);
 
   const accountRecoveryDemand = new AccountRecoveryDemand({
     userId,
-    newEmail: email.toLowerCase(),
-    oldEmail: user.email,
+    schoolingRegistrationId: id,
+    newEmail,
+    oldEmail,
     used: false,
     temporaryKey,
   });
   await accountRecoveryDemandRepository.save(accountRecoveryDemand);
 
   await mailService.sendAccountRecoveryEmail({
-    firstName: user.firstName,
-    email,
+    firstName,
+    email: newEmail,
     temporaryKey,
   });
 };

--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -29,7 +29,7 @@ module.exports = {
 
     const accountRecoveryDemandDTO = await knex
       .where({ temporaryKey, used: false })
-      .select('id', 'userId', 'oldEmail', 'newEmail', 'temporaryKey', 'used', 'createdAt')
+      .select('id', 'schoolingRegistrationId', 'userId', 'oldEmail', 'newEmail', 'temporaryKey', 'used', 'createdAt')
       .from('account-recovery-demands')
       .first();
 

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -333,7 +333,7 @@ module.exports = {
     const schoolingRegistration = await knex
       .where({ nationalStudentId, firstName, lastName, birthdate })
       .whereNotNull('userId')
-      .select('organizationId', 'userId', 'firstName', 'lastName')
+      .select('id', 'organizationId', 'userId', 'firstName', 'lastName')
       .from('schooling-registrations')
       .orderBy('updatedAt', 'desc')
       .first();

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -329,18 +329,19 @@ module.exports = {
       });
   },
 
-  async getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate({ nationalStudentId, firstName, lastName, birthdate }) {
+  async getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate({ nationalStudentId, firstName, lastName, birthdate }) {
     const schoolingRegistration = await knex
-      .from('schooling-registrations')
       .where({ nationalStudentId, firstName, lastName, birthdate })
       .whereNotNull('userId')
+      .select('userId', 'firstName', 'lastName')
+      .from('schooling-registrations')
       .first();
 
     if (!schoolingRegistration) {
       throw new UserNotFoundError();
     }
 
-    return schoolingRegistration.userId;
+    return schoolingRegistration;
   },
 
   async findPaginatedFilteredSchoolingRegistrations({ organizationId, filter, page = {} }) {

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -333,8 +333,9 @@ module.exports = {
     const schoolingRegistration = await knex
       .where({ nationalStudentId, firstName, lastName, birthdate })
       .whereNotNull('userId')
-      .select('userId', 'firstName', 'lastName')
+      .select('organizationId', 'userId', 'firstName', 'lastName')
       .from('schooling-registrations')
+      .orderBy('updatedAt', 'desc')
       .first();
 
     if (!schoolingRegistration) {

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -329,7 +329,7 @@ module.exports = {
       });
   },
 
-  async getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate({ nationalStudentId, firstName, lastName, birthdate }) {
+  async getSchoolingRegistrationInformation({ nationalStudentId, firstName, lastName, birthdate }) {
     const schoolingRegistration = await knex
       .where({ nationalStudentId, firstName, lastName, birthdate })
       .whereNotNull('userId')

--- a/api/lib/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js
@@ -1,11 +1,10 @@
-const { Serializer } = require('jsonapi-serializer');
+const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 module.exports = {
 
   serialize(studentInformationForAccountRecovery) {
     return new Serializer('student-information-for-account-recoveries', {
       attributes: [
-        'userId',
         'firstName',
         'lastName',
         'username',
@@ -13,5 +12,20 @@ module.exports = {
         'latestOrganizationName',
       ],
     }).serialize(studentInformationForAccountRecovery);
+  },
+
+  async deserialize(studentInformationForAccountRecovery) {
+    function transform(record) {
+      return {
+        ineIna: record['ine-ina'],
+        firstName: record['first-name'],
+        lastName: record['last-name'],
+        birthdate: record.birthdate,
+        ...record.email && { email: record.email },
+      };
+    }
+    return new Deserializer({ transform })
+      .deserialize(studentInformationForAccountRecovery)
+      .then((studentInformation) => studentInformation);
   },
 };

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
@@ -29,7 +29,7 @@ describe('Integration | Application | Account-Recovery | Routes', () => {
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.type).to.equal('users');
       expect(response.result.data.id).to.equal(userId.toString());
-      expect(response.result.data.attributes.email).to.equal(newEmail);
+      expect(response.result.data.attributes.email).to.equal(newEmail.toLowerCase());
 
     });
 

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
@@ -413,8 +413,8 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', () => {
         type: 'student-information-for-account-recoveries',
         attributes: {
           'user-id': 8,
-          'first-name': 'Judy',
-          'last-name': 'Howl',
+          'first-name': 'Jude',
+          'last-name': 'Law',
           'username': 'jude.law0601',
           'email': 'jude.law@example.net',
           'latest-organization-name': 'Super Collège Hollywoodien',

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
@@ -368,19 +368,15 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', () => {
       });
       databaseBuilder.factory.buildSchoolingRegistration({
         userId: user.id,
+        ...studentInformation,
         nationalStudentId: studentInformation.ineIna,
-        firstName: studentInformation.firstName,
-        lastName: studentInformation.lastName,
-        birthdate: studentInformation.birthdate,
         organizationId: organization.id,
         updatedAt: new Date('2005-01-01T15:00:00Z'),
       });
       databaseBuilder.factory.buildSchoolingRegistration({
         userId: user.id,
+        ...studentInformation,
         nationalStudentId: studentInformation.ineIna,
-        firstName: studentInformation.firstName,
-        lastName: studentInformation.lastName,
-        birthdate: studentInformation.birthdate,
         organizationId: latestOrganization.id,
         updatedAt: new Date('2010-01-01T15:00:00Z'),
       });
@@ -412,7 +408,6 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', () => {
       expect(response.result.data).to.deep.equal({
         type: 'student-information-for-account-recoveries',
         attributes: {
-          'user-id': 8,
           'first-name': 'Jude',
           'last-name': 'Law',
           'username': 'jude.law0601',

--- a/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
@@ -56,13 +56,14 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
           // given
           const email = 'someMail@example.net';
           const temporaryKey = 'someTemporaryKey';
-          const demandId = databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false }).id;
+          const { id: demandId, schoolingRegistrationId } = databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false });
           databaseBuilder.factory.buildAccountRecoveryDemand({ email, used: false });
           await databaseBuilder.commit();
           const expectedAccountRecoveryDemand = {
             id: demandId,
             userId: null,
             oldEmail: null,
+            schoolingRegistrationId,
             newEmail: 'philipe@example.net',
             temporaryKey: 'someTemporaryKey',
             used: false,
@@ -137,8 +138,11 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
 
   describe('#save', () => {
 
-    it('should insert the account recovery demand in db', async () => {
+    it('should persist the account recovery demand', async () => {
       // given
+      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      await databaseBuilder.commit();
+
       const userId = 123;
       const newEmail = 'dupont@example.net';
       const oldEmail = 'eleve-dupont@example.net';
@@ -146,6 +150,7 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
       const temporaryKey = '123456789AZERTYUIO';
       const accountRecoveryDemandAttributes = {
         userId,
+        schoolingRegistrationId,
         newEmail,
         oldEmail,
         used,

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1436,9 +1436,11 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
 
   describe('#getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate', () => {
 
-    it('should return schooling registration information', async () => {
+    it('should return the latest schooling registration information', async () => {
       // given
       const expectedUserId = databaseBuilder.factory.buildUser().id;
+      const firstOrganizationId = databaseBuilder.factory.buildOrganization({ id: 1 }).id;
+      const secondOrganizationId = databaseBuilder.factory.buildOrganization({ id: 3 }).id;
 
       const studentInformation = {
         nationalStudentId: '123456789AA',
@@ -1447,8 +1449,16 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         birthdate: '2000-12-07',
       };
       databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: firstOrganizationId,
         userId: expectedUserId,
         ...studentInformation,
+        updatedAt: new Date('2013-01-01T15:00:00Z'),
+      });
+      databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: secondOrganizationId,
+        userId: expectedUserId,
+        ...studentInformation,
+        updatedAt: new Date('2000-01-01T15:00:00Z'),
       });
 
       await databaseBuilder.commit();
@@ -1458,6 +1468,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
 
       // then
       expect(SchoolingRegistration).to.deep.equal({
+        organizationId: 1,
         userId: expectedUserId,
         lastName: 'Jédusor',
         firstName: 'Tom',

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1434,66 +1434,103 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     });
   });
 
-  describe('#getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate', () => {
+  describe('#getSchoolingRegistrationInformation', () => {
 
-    it('should return the latest schooling registration information', async () => {
+    it('should return the schooling registration information', async () => {
       // given
       const expectedUserId = databaseBuilder.factory.buildUser().id;
-      const firstOrganizationId = databaseBuilder.factory.buildOrganization({ id: 1 }).id;
-      const secondOrganizationId = databaseBuilder.factory.buildOrganization({ id: 3 }).id;
+      const organizationId = databaseBuilder.factory.buildOrganization({ id: 3 }).id;
 
       const studentInformation = {
-        nationalStudentId: '123456789AA',
+        ineIna: '123456789AA',
         firstName: 'Tom',
         lastName: 'Jédusor',
         birthdate: '2000-12-07',
       };
       databaseBuilder.factory.buildSchoolingRegistration({
-        id: 1,
-        organizationId: firstOrganizationId,
-        userId: expectedUserId,
-        ...studentInformation,
-        updatedAt: new Date('2013-01-01T15:00:00Z'),
-      });
-      databaseBuilder.factory.buildSchoolingRegistration({
         id: 80,
-        organizationId: secondOrganizationId,
+        organizationId: organizationId,
         userId: expectedUserId,
         ...studentInformation,
-        updatedAt: new Date('2000-01-01T15:00:00Z'),
+        nationalStudentId: studentInformation.ineIna,
       });
 
       await databaseBuilder.commit();
 
       // when
-      const SchoolingRegistration = await schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate(studentInformation);
+      const schoolingRegistration = await schoolingRegistrationRepository.getSchoolingRegistrationInformation({
+        ...studentInformation,
+        nationalStudentId: studentInformation.ineIna,
+      });
 
       // then
-      expect(SchoolingRegistration).to.deep.equal({
-        id: 1,
-        organizationId: 1,
+      expect(schoolingRegistration).to.deep.equal({
+        id: 80,
+        organizationId: 3,
         userId: expectedUserId,
         lastName: 'Jédusor',
         firstName: 'Tom',
       });
     });
 
+    it('should return the latest schooling registration', async () => {
+      // given
+      const expectedUserId = databaseBuilder.factory.buildUser().id;
+      const latestOrganizationId = databaseBuilder.factory.buildOrganization({ id: 1 }).id;
+      const oldestOrganizationId = databaseBuilder.factory.buildOrganization({ id: 3 }).id;
+
+      const studentInformation = {
+        ineIna: '123456789AA',
+        firstName: 'Tom',
+        lastName: 'Jédusor',
+        birthdate: '2000-12-07',
+      };
+      databaseBuilder.factory.buildSchoolingRegistration({
+        id: 1,
+        organizationId: latestOrganizationId,
+        userId: expectedUserId,
+        ...studentInformation,
+        nationalStudentId: studentInformation.ineIna,
+        updatedAt: new Date('2013-01-01T15:00:00Z'),
+      });
+      databaseBuilder.factory.buildSchoolingRegistration({
+        id: 80,
+        organizationId: oldestOrganizationId,
+        userId: expectedUserId,
+        ...studentInformation,
+        nationalStudentId: studentInformation.ineIna,
+        updatedAt: new Date('2000-01-01T15:00:00Z'),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const schoolingRegistration = await schoolingRegistrationRepository.getSchoolingRegistrationInformation({
+        ...studentInformation,
+        nationalStudentId: studentInformation.ineIna,
+      });
+
+      // then
+      expect(schoolingRegistration.organizationId).to.equal(1);
+    });
+
     it('should return a UserNotFoundError if INE is invalid', async () => {
       // given
       const studentInformation = {
-        nationalStudentId: '123456789AB',
+        ineIna: '123456789AB',
         firstName: 'Tom',
         lastName: 'Jédusor',
         birthdate: '2000-12-07',
       };
       databaseBuilder.factory.buildSchoolingRegistration({
         ...studentInformation,
+        nationalStudentId: studentInformation.ineIna,
       });
 
       await databaseBuilder.commit();
 
       // when
-      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate)({
+      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformation)({
         nationalStudentId: '222256789AB',
         firstName: 'Tom',
         lastName: 'Jédusor',
@@ -1507,19 +1544,20 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     it('should return a UserNotFoundError if firstName is invalid', async () => {
       // given
       const studentInformation = {
-        nationalStudentId: '123456789AB',
+        ineIna: '123456789AB',
         firstName: 'Tom',
         lastName: 'Jédusor',
         birthdate: '2000-12-07',
       };
       databaseBuilder.factory.buildSchoolingRegistration({
         ...studentInformation,
+        nationalStudentId: studentInformation.ineIna,
       });
 
       await databaseBuilder.commit();
 
       // when
-      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate)({
+      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformation)({
         nationalStudentId: '123456789AB',
         firstName: 'Tim',
         lastName: 'Jédusor',
@@ -1533,20 +1571,21 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     it('should return a UserNotFoundError if userId is null', async () => {
       // given
       const studentInformation = {
-        nationalStudentId: '123456789AB',
+        ineIna: '123456789AB',
         firstName: 'Tom',
         lastName: 'Jédusor',
         birthdate: '2000-12-07',
       };
       databaseBuilder.factory.buildSchoolingRegistration({
         ...studentInformation,
+        nationalStudentId: studentInformation.ineIna,
         userId: null,
       });
 
       await databaseBuilder.commit();
 
       // when
-      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate)({
+      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformation)({
         nationalStudentId: '123456789AB',
         firstName: 'Tom',
         lastName: 'Jédusor',

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1434,9 +1434,9 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     });
   });
 
-  describe('#getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate', () => {
+  describe('#getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate', () => {
 
-    it('should return user id', async () => {
+    it('should return schooling registration information', async () => {
       // given
       const expectedUserId = databaseBuilder.factory.buildUser().id;
 
@@ -1454,10 +1454,14 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       await databaseBuilder.commit();
 
       // when
-      const userId = await schoolingRegistrationRepository.getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate(studentInformation);
+      const SchoolingRegistration = await schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate(studentInformation);
 
       // then
-      expect(userId).to.equal(expectedUserId);
+      expect(SchoolingRegistration).to.deep.equal({
+        userId: expectedUserId,
+        lastName: 'Jédusor',
+        firstName: 'Tom',
+      });
     });
 
     it('should return a UserNotFoundError if INE is invalid', async () => {
@@ -1475,7 +1479,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       await databaseBuilder.commit();
 
       // when
-      const result = await catchErr(schoolingRegistrationRepository.getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate)({
+      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate)({
         nationalStudentId: '222256789AB',
         firstName: 'Tom',
         lastName: 'Jédusor',
@@ -1501,7 +1505,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       await databaseBuilder.commit();
 
       // when
-      const result = await catchErr(schoolingRegistrationRepository.getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate)({
+      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate)({
         nationalStudentId: '123456789AB',
         firstName: 'Tim',
         lastName: 'Jédusor',
@@ -1528,7 +1532,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       await databaseBuilder.commit();
 
       // when
-      const result = await catchErr(schoolingRegistrationRepository.getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate)({
+      const result = await catchErr(schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate)({
         nationalStudentId: '123456789AB',
         firstName: 'Tom',
         lastName: 'Jédusor',

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1449,12 +1449,14 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         birthdate: '2000-12-07',
       };
       databaseBuilder.factory.buildSchoolingRegistration({
+        id: 1,
         organizationId: firstOrganizationId,
         userId: expectedUserId,
         ...studentInformation,
         updatedAt: new Date('2013-01-01T15:00:00Z'),
       });
       databaseBuilder.factory.buildSchoolingRegistration({
+        id: 80,
         organizationId: secondOrganizationId,
         userId: expectedUserId,
         ...studentInformation,
@@ -1468,6 +1470,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
 
       // then
       expect(SchoolingRegistration).to.deep.equal({
+        id: 1,
         organizationId: 1,
         userId: expectedUserId,
         lastName: 'Jédusor',

--- a/api/tests/tooling/domain-builder/factory/build-account-recovery-demand.js
+++ b/api/tests/tooling/domain-builder/factory/build-account-recovery-demand.js
@@ -2,6 +2,7 @@ const AccountRecoveryDemand = require('../../../../lib/domain/models/AccountReco
 
 module.exports = function buildAccountRecoveryDemand({
   userId = 7,
+  schoolingRegistrationId,
   newEmail = 'new-email@example.net',
   oldEmail = 'old-email@example.net',
   used = false,
@@ -9,6 +10,7 @@ module.exports = function buildAccountRecoveryDemand({
 } = {}) {
   return new AccountRecoveryDemand({
     userId,
+    schoolingRegistrationId,
     newEmail,
     oldEmail,
     used,

--- a/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
@@ -2,12 +2,12 @@ const {
   expect,
   sinon,
   hFake,
-  domainBuilder,
 } = require('../../../test-helper');
 
 const accountRecoveryController = require('../../../../lib/application/account-recovery/account-recovery-controller');
 const usecases = require('../../../../lib/domain/usecases');
 const userSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
+const studentInformationForAccountRecoverySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer');
 
 describe('Unit | Controller | account-recovery-controller', () => {
 
@@ -15,27 +15,39 @@ describe('Unit | Controller | account-recovery-controller', () => {
 
     it('should call sendEmailForAccountRecovery usecase and return 204', async () => {
       // given
-      const userId = domainBuilder.buildUser({ id: 1 }).id;
       const newEmail = 'new_email@example.net';
+      const studentInformation = {
+        ineIna: '123456789BB',
+        firstName: 'george',
+        lastName: 'de cambridge',
+        birthdate: '2013-07-22',
+        email: 'new_email@example.net',
+      };
 
       const request = {
         payload: {
           data: {
             attributes: {
-              'user-id': userId,
+              'ine-ina': '123456789BB',
+              'first-name': 'george',
+              'last-name': 'de cambridge',
+              birthdate: '2013-07-22',
               email: newEmail,
             },
           },
         },
       };
 
+      sinon.stub(studentInformationForAccountRecoverySerializer, 'deserialize')
+        .withArgs(request.payload)
+        .resolves(studentInformation);
       sinon.stub(usecases, 'sendEmailForAccountRecovery').resolves();
 
       // when
       const response = await accountRecoveryController.sendEmailForAccountRecovery(request, hFake);
 
       // then
-      expect(usecases.sendEmailForAccountRecovery).calledWith({ userId, email: newEmail });
+      expect(usecases.sendEmailForAccountRecovery).calledWith({ studentInformation });
       expect(response.statusCode).to.equal(204);
     });
 

--- a/api/tests/unit/application/schooling-registration-dependent-user/schooling-registration-dependant-user-controller_test.js
+++ b/api/tests/unit/application/schooling-registration-dependent-user/schooling-registration-dependant-user-controller_test.js
@@ -32,6 +32,9 @@ describe('Unit | Application | Controller | schooling-registration-user-associat
       const studentInformationForAccountRecovery = Symbol();
       const studentInformationForAccountRecoveryJSONAPI = Symbol();
 
+      sinon.stub(studentInformationForAccountRecoverySerializer, 'deserialize')
+        .withArgs(request.payload)
+        .resolves(studentInformation);
       sinon.stub(usecases, 'checkScoAccountRecovery');
       usecases.checkScoAccountRecovery.withArgs({ studentInformation }).resolves(studentInformationForAccountRecovery);
       sinon.stub(studentInformationForAccountRecoverySerializer, 'serialize')

--- a/api/tests/unit/domain/services/check-sco-account-recovery-service_test.js
+++ b/api/tests/unit/domain/services/check-sco-account-recovery-service_test.js
@@ -1,0 +1,219 @@
+const {
+  expect,
+  sinon,
+  domainBuilder,
+  catchErr,
+} = require('../../../test-helper');
+const { retrieveSchoolingRegistration } = require('../../../../lib/domain/services/check-sco-account-recovery-service');
+const { MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError } = require('../../../../lib/domain/errors');
+
+describe('Unit | Service | check-sco-account-recovery-service', () => {
+
+  describe('#retrieveSchoolingRegistration', () => {
+
+    let schoolingRegistrationRepository;
+    let userRepository;
+
+    beforeEach(() => {
+      schoolingRegistrationRepository = {
+        getSchoolingRegistrationInformation: sinon.stub(),
+        findByUserId: sinon.stub(),
+      };
+      userRepository = {
+        get: sinon.stub(),
+      };
+    });
+
+    context('when user is reconciled to several organizations', () => {
+
+      context('when all schooling registrations have the same INE', () => {
+
+        it('should return user account information', async () => {
+          // given
+          const studentInformation = {
+            ineIna: '123456789AA',
+            firstName: 'Nanou',
+            lastName: 'Monchose',
+            birthdate: '2004-05-07',
+          };
+          const expectedUser = domainBuilder.buildUser({
+            id: 9,
+            firstName: studentInformation.firstName,
+            lastName: studentInformation.lastName,
+            birthdate: studentInformation.birthdate,
+            username: 'nanou.monchose0705',
+            email: 'nanou.monchose@example.net',
+          });
+          const firstOrganization = domainBuilder.buildOrganization({ id: 8, name: 'Collège Beauxbâtons' });
+          const secondOrganization = domainBuilder.buildOrganization({ id: 7, name: 'Lycée Poudlard' });
+          const firstSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
+            id: 2,
+            userId: expectedUser.id,
+            organization: firstOrganization,
+            updatedAt: new Date('2000-01-01T15:00:00Z'),
+            ...studentInformation,
+          });
+          const secondSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
+            id: 3,
+            userId: expectedUser.id,
+            organization: secondOrganization,
+            updatedAt: new Date('2005-01-01T15:00:00Z'),
+            ...studentInformation,
+          });
+
+          schoolingRegistrationRepository.getSchoolingRegistrationInformation
+            .withArgs({ ...studentInformation, nationalStudentId: studentInformation.ineIna })
+            .resolves({
+              id: secondSchoolingRegistration.id,
+              organizationId: secondOrganization.id,
+              userId: expectedUser.id,
+              firstName: expectedUser.firstName,
+              lastName: expectedUser.lastName,
+            });
+          schoolingRegistrationRepository.findByUserId
+            .withArgs({ userId: expectedUser.id })
+            .resolves([firstSchoolingRegistration, secondSchoolingRegistration]);
+          userRepository.get.withArgs(expectedUser.id).resolves(expectedUser);
+
+          // when
+          const result = await retrieveSchoolingRegistration({
+            studentInformation,
+            schoolingRegistrationRepository,
+            userRepository,
+          });
+
+          // then
+          const expectedResult = {
+            firstName: 'Nanou',
+            lastName: 'Monchose',
+            username: 'nanou.monchose0705',
+            email: 'nanou.monchose@example.net',
+            id: 3,
+            userId: 9,
+            organizationId: 7,
+          };
+          expect(result).to.deep.equal(expectedResult);
+        });
+      });
+
+      context('when at least one schooling registrations has a different INE', () => {
+
+        it('should throw an error', async () => {
+          // given
+          const studentInformation = {
+            ineIna: '123456789AA',
+            firstName: 'Nanou',
+            lastName: 'Monchose',
+            birthdate: '2004-05-07',
+          };
+          const user = domainBuilder.buildUser({
+            id: 9,
+            firstName: studentInformation.firstName,
+            lastName: studentInformation.lastName,
+            birthdate: studentInformation.birthdate,
+            username: 'nanou.monchose0705',
+            email: 'nanou.monchose@example.net',
+          });
+
+          const firstSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
+            id: 6,
+            userId: user.id,
+            ...studentInformation,
+          });
+          const secondSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
+            id: 9,
+            userId: user.id,
+            nationalStudentId: '111111111AA',
+            firstName: 'Nanou',
+            lastName: 'Monchose',
+            birthdate: '2004-05-07',
+          });
+
+          schoolingRegistrationRepository.getSchoolingRegistrationInformation
+            .withArgs({ ...studentInformation, nationalStudentId: studentInformation.ineIna })
+            .resolves({
+              organizationId: 1,
+              userId: user.id,
+              firstName: user.firstName,
+              lastName: user.lastName,
+            });
+          schoolingRegistrationRepository.findByUserId
+            .withArgs({ userId: user.id })
+            .resolves([firstSchoolingRegistration, secondSchoolingRegistration]);
+
+          // when
+          const result = await catchErr(retrieveSchoolingRegistration)({
+            studentInformation,
+            schoolingRegistrationRepository,
+            userRepository,
+          });
+
+          // then
+          expect(result).to.be.instanceof(MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError);
+        });
+      });
+    });
+
+    context('when user has a single schooling registration', () => {
+      it('should return user account information with schooling registration first name', async () => {
+        // given
+        const studentInformation = {
+          ineIna: '123456789AA',
+          firstName: 'Nanou',
+          lastName: 'Monchose',
+          birthdate: '2004-05-07',
+        };
+        const expectedUser = domainBuilder.buildUser({
+          id: 9,
+          firstName: 'Manuela',
+          lastName: studentInformation.lastName,
+          birthdate: studentInformation.birthdate,
+          username: 'nanou.monchose0705',
+          email: 'nanou.monchose@example.net',
+        });
+        const organization = domainBuilder.buildOrganization({ id: 8, name: 'Collège Beauxbâtons' });
+        const schoolingRegistration = domainBuilder.buildSchoolingRegistration({
+          id: 2,
+          userId: expectedUser.id,
+          organization: organization,
+          updatedAt: new Date('2000-01-01T15:00:00Z'),
+          ...studentInformation,
+          firstName: expectedUser.firstName,
+        });
+
+        schoolingRegistrationRepository.getSchoolingRegistrationInformation
+          .withArgs({ ...studentInformation, nationalStudentId: studentInformation.ineIna })
+          .resolves({
+            id: schoolingRegistration.id,
+            organizationId: organization.id,
+            userId: expectedUser.id,
+            firstName: expectedUser.firstName,
+            lastName: expectedUser.lastName,
+          });
+        schoolingRegistrationRepository.findByUserId
+          .withArgs({ userId: expectedUser.id })
+          .resolves([schoolingRegistration]);
+        userRepository.get.withArgs(expectedUser.id).resolves(expectedUser);
+
+        // when
+        const result = await retrieveSchoolingRegistration({
+          studentInformation,
+          schoolingRegistrationRepository,
+          userRepository,
+        });
+
+        // then
+        const expectedResult = {
+          firstName: 'Manuela',
+          lastName: 'Monchose',
+          username: 'nanou.monchose0705',
+          email: 'nanou.monchose@example.net',
+          id: 2,
+          userId: 9,
+          organizationId: 8,
+        };
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
 
   beforeEach(() => {
     schoolingRegistrationRepository = {
-      getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate: sinon.stub(),
+      getSchoolingRegistrationInformation: sinon.stub(),
       findByUserId: sinon.stub(),
     };
     userRepository = {
@@ -53,17 +53,13 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
           userId: expectedUser.id,
           organization: expectedOrganization,
           nationalStudentId: studentInformation.ineIna,
-          firstName: studentInformation.firstName,
-          lastName: studentInformation.lastName,
-          birthdate: studentInformation.birthdate,
+          ...studentInformation,
         });
 
-        schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate
+        schoolingRegistrationRepository.getSchoolingRegistrationInformation
           .withArgs({
+            ...studentInformation,
             nationalStudentId: studentInformation.ineIna,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
           })
           .resolves({
             organizationId: expectedOrganization.id,
@@ -85,7 +81,6 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
 
         // then
         const expectedResult = {
-          userId: 9,
           firstName: 'Nanou',
           lastName: 'Monchose',
           username: 'nanou.monchose0705',
@@ -125,9 +120,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
             organization: firstOrganization,
             updatedAt: new Date('2000-01-01T15:00:00Z'),
             nationalStudentId: studentInformation.ineIna,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
+            ...studentInformation,
           });
           const secondSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
             id: 3,
@@ -135,17 +128,13 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
             organization: secondOrganization,
             updatedAt: new Date('2005-01-01T15:00:00Z'),
             nationalStudentId: studentInformation.ineIna,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
+            ...studentInformation,
           });
 
-          schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate
+          schoolingRegistrationRepository.getSchoolingRegistrationInformation
             .withArgs({
+              ...studentInformation,
               nationalStudentId: studentInformation.ineIna,
-              firstName: studentInformation.firstName,
-              lastName: studentInformation.lastName,
-              birthdate: studentInformation.birthdate,
             })
             .resolves({
               organizationId: secondOrganization.id,
@@ -169,7 +158,6 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
 
           // then
           const expectedResult = {
-            userId: 9,
             firstName: 'Nanou',
             lastName: 'Monchose',
             username: 'nanou.monchose0705',
@@ -178,7 +166,6 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
           };
           expect(result).to.deep.equal(expectedResult);
         });
-
       });
 
       context('when at least one schooling registrations has a different INE', () => {
@@ -204,9 +191,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
             id: 6,
             userId: user.id,
             nationalStudentId: studentInformation.ineIna,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
+            ...studentInformation,
           });
           const secondSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
             id: 9,
@@ -217,12 +202,10 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
             birthdate: '2004-05-07',
           });
 
-          schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate
+          schoolingRegistrationRepository.getSchoolingRegistrationInformation
             .withArgs({
+              ...studentInformation,
               nationalStudentId: studentInformation.ineIna,
-              firstName: studentInformation.firstName,
-              lastName: studentInformation.lastName,
-              birthdate: studentInformation.birthdate,
             })
             .resolves({
               organizationId: 1,

--- a/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
@@ -66,6 +66,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
             birthdate: studentInformation.birthdate,
           })
           .resolves({
+            organizationId: expectedOrganization.id,
             userId: expectedUser.id,
             firstName: expectedUser.firstName,
             lastName: expectedUser.lastName,
@@ -147,6 +148,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
               birthdate: studentInformation.birthdate,
             })
             .resolves({
+              organizationId: secondOrganization.id,
               userId: expectedUser.id,
               firstName: expectedUser.firstName,
               lastName: expectedUser.lastName,
@@ -177,99 +179,6 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
           expect(result).to.deep.equal(expectedResult);
         });
 
-        it('should return the name of latest organization of this user', async () => {
-          // given
-          const studentInformation = {
-            ineIna: '123456789AA',
-            firstName: 'Nanou',
-            lastName: 'Monchose',
-            birthdate: '2004-05-07',
-          };
-          const expectedUser = domainBuilder.buildUser({
-            id: 9,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
-            username: 'nanou.monchose0705',
-            email: 'nanou.monchose@example.net',
-          });
-
-          const firstOrganization = domainBuilder.buildOrganization({ id: 1, name: 'Lycée Saint Michel' });
-          const secondOrganization = domainBuilder.buildOrganization({ id: 7, name: 'Lycée Saint Paul' });
-          const latestOrganization = domainBuilder.buildOrganization({ id: 3, name: 'Lycée Poudlard' });
-
-          const firstSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
-            id: 88,
-            userId: expectedUser.id,
-            nationalStudentId: studentInformation.ineIna,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
-            organization: firstOrganization,
-            updatedAt: new Date('2000-01-01T15:00:00Z'),
-          });
-          const secondSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
-            id: 99,
-            userId: expectedUser.id,
-            nationalStudentId: studentInformation.ineIna,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
-            organization: secondOrganization,
-            updatedAt: new Date('2015-09-06T15:00:00Z'),
-          });
-          const thirdSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
-            id: 7,
-            userId: expectedUser.id,
-            nationalStudentId: studentInformation.ineIna,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
-            organization: latestOrganization,
-            updatedAt: new Date('2019-09-06T15:00:00Z'),
-          });
-
-          schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate
-            .withArgs({
-              nationalStudentId: studentInformation.ineIna,
-              firstName: studentInformation.firstName,
-              lastName: studentInformation.lastName,
-              birthdate: studentInformation.birthdate,
-            })
-            .resolves({
-              userId: expectedUser.id,
-              firstName: expectedUser.firstName,
-              lastName: expectedUser.lastName,
-            });
-          schoolingRegistrationRepository.findByUserId
-            .withArgs({ userId: expectedUser.id })
-            .resolves([firstSchoolingRegistration, secondSchoolingRegistration, thirdSchoolingRegistration]);
-
-          userRepository.get.withArgs(expectedUser.id).resolves(expectedUser);
-
-          organizationRepository.get.withArgs(firstOrganization.id).resolves(firstOrganization);
-          organizationRepository.get.withArgs(secondOrganization.id).resolves(secondOrganization);
-          organizationRepository.get.withArgs(latestOrganization.id).resolves(latestOrganization);
-
-          // when
-          const result = await checkScoAccountRecovery({
-            studentInformation,
-            schoolingRegistrationRepository,
-            organizationRepository,
-            userRepository,
-          });
-
-          // then
-          const expectedResult = {
-            userId: 9,
-            firstName: 'Nanou',
-            lastName: 'Monchose',
-            username: 'nanou.monchose0705',
-            email: 'nanou.monchose@example.net',
-            latestOrganizationName: 'Lycée Poudlard',
-          };
-          expect(result).to.deep.equal(expectedResult);
-        });
       });
 
       context('when at least one schooling registrations has a different INE', () => {
@@ -316,6 +225,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
               birthdate: studentInformation.birthdate,
             })
             .resolves({
+              organizationId: 1,
               userId: user.id,
               firstName: user.firstName,
               lastName: user.lastName,

--- a/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
@@ -2,9 +2,7 @@ const {
   expect,
   sinon,
   domainBuilder,
-  catchErr,
 } = require('../../../test-helper');
-const { MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError } = require('../../../../lib/domain/errors');
 const StudentInformationForAccountRecovery = require('../../../../lib/domain/read-models/StudentInformationForAccountRecovery');
 const checkScoAccountRecovery = require('../../../../lib/domain/usecases/check-sco-account-recovery');
 
@@ -13,6 +11,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
   let schoolingRegistrationRepository;
   let userRepository;
   let organizationRepository;
+  let checkScoAccountRecoveryService;
 
   beforeEach(() => {
     schoolingRegistrationRepository = {
@@ -24,6 +23,9 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
     };
     organizationRepository = {
       get: sinon.stub(),
+    };
+    checkScoAccountRecoveryService = {
+      retrieveSchoolingRegistration: sinon.stub(),
     };
   });
 
@@ -39,44 +41,29 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
           lastName: 'Monchose',
           birthdate: '2004-05-07',
         };
-        const expectedUser = domainBuilder.buildUser({
-          id: 9,
+
+        const expectedOrganization = domainBuilder.buildOrganization({ id: 7, name: 'Lycée Poudlard' });
+
+        checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+          studentInformation,
+          schoolingRegistrationRepository,
+          userRepository,
+        }).resolves({
           firstName: studentInformation.firstName,
           lastName: studentInformation.lastName,
-          birthdate: studentInformation.birthdate,
           username: 'nanou.monchose0705',
+          organizationId: expectedOrganization.id,
           email: 'nanou.monchose@example.net',
         });
-        const expectedOrganization = domainBuilder.buildOrganization({ id: 7, name: 'Lycée Poudlard' });
-        const expectedSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
-          id: 10,
-          userId: expectedUser.id,
-          organization: expectedOrganization,
-          nationalStudentId: studentInformation.ineIna,
-          ...studentInformation,
-        });
-
-        schoolingRegistrationRepository.getSchoolingRegistrationInformation
-          .withArgs({
-            ...studentInformation,
-            nationalStudentId: studentInformation.ineIna,
-          })
-          .resolves({
-            organizationId: expectedOrganization.id,
-            userId: expectedUser.id,
-            firstName: expectedUser.firstName,
-            lastName: expectedUser.lastName,
-          });
-        schoolingRegistrationRepository.findByUserId.withArgs({ userId: expectedUser.id }).resolves([expectedSchoolingRegistration]);
-        userRepository.get.withArgs(expectedUser.id).resolves(expectedUser);
         organizationRepository.get.withArgs(expectedOrganization.id).resolves(expectedOrganization);
 
         // when
         const result = await checkScoAccountRecovery({
-          studentInformation,
-          schoolingRegistrationRepository,
-          organizationRepository,
           userRepository,
+          schoolingRegistrationRepository,
+          studentInformation,
+          organizationRepository,
+          checkScoAccountRecoveryService,
         });
 
         // then
@@ -89,145 +76,6 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
         };
         expect(result).to.deep.equal(expectedResult);
         expect(result).to.be.instanceof(StudentInformationForAccountRecovery);
-      });
-    });
-
-    context('when user have multiple schooling registrations', () => {
-
-      context('when all schooling registrations have the same INE', () => {
-
-        it('should return user account information', async () => {
-          // given
-          const studentInformation = {
-            ineIna: '123456789AA',
-            firstName: 'Nanou',
-            lastName: 'Monchose',
-            birthdate: '2004-05-07',
-          };
-          const expectedUser = domainBuilder.buildUser({
-            id: 9,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
-            username: 'nanou.monchose0705',
-            email: 'nanou.monchose@example.net',
-          });
-          const firstOrganization = domainBuilder.buildOrganization({ id: 8, name: 'Collège Beauxbâtons' });
-          const secondOrganization = domainBuilder.buildOrganization({ id: 7, name: 'Lycée Poudlard' });
-          const firstSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
-            id: 2,
-            userId: expectedUser.id,
-            organization: firstOrganization,
-            updatedAt: new Date('2000-01-01T15:00:00Z'),
-            nationalStudentId: studentInformation.ineIna,
-            ...studentInformation,
-          });
-          const secondSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
-            id: 3,
-            userId: expectedUser.id,
-            organization: secondOrganization,
-            updatedAt: new Date('2005-01-01T15:00:00Z'),
-            nationalStudentId: studentInformation.ineIna,
-            ...studentInformation,
-          });
-
-          schoolingRegistrationRepository.getSchoolingRegistrationInformation
-            .withArgs({
-              ...studentInformation,
-              nationalStudentId: studentInformation.ineIna,
-            })
-            .resolves({
-              organizationId: secondOrganization.id,
-              userId: expectedUser.id,
-              firstName: expectedUser.firstName,
-              lastName: expectedUser.lastName,
-            });
-          schoolingRegistrationRepository.findByUserId
-            .withArgs({ userId: expectedUser.id })
-            .resolves([firstSchoolingRegistration, secondSchoolingRegistration]);
-          userRepository.get.withArgs(expectedUser.id).resolves(expectedUser);
-          organizationRepository.get.withArgs(secondOrganization.id).resolves(secondOrganization);
-
-          // when
-          const result = await checkScoAccountRecovery({
-            studentInformation,
-            schoolingRegistrationRepository,
-            organizationRepository,
-            userRepository,
-          });
-
-          // then
-          const expectedResult = {
-            firstName: 'Nanou',
-            lastName: 'Monchose',
-            username: 'nanou.monchose0705',
-            email: 'nanou.monchose@example.net',
-            latestOrganizationName: 'Lycée Poudlard',
-          };
-          expect(result).to.deep.equal(expectedResult);
-        });
-      });
-
-      context('when at least one schooling registrations has a different INE', () => {
-
-        it('should throw an error', async () => {
-          // given
-          const studentInformation = {
-            ineIna: '123456789AA',
-            firstName: 'Nanou',
-            lastName: 'Monchose',
-            birthdate: '2004-05-07',
-          };
-          const user = domainBuilder.buildUser({
-            id: 9,
-            firstName: studentInformation.firstName,
-            lastName: studentInformation.lastName,
-            birthdate: studentInformation.birthdate,
-            username: 'nanou.monchose0705',
-            email: 'nanou.monchose@example.net',
-          });
-
-          const firstSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
-            id: 6,
-            userId: user.id,
-            nationalStudentId: studentInformation.ineIna,
-            ...studentInformation,
-          });
-          const secondSchoolingRegistration = domainBuilder.buildSchoolingRegistration({
-            id: 9,
-            userId: user.id,
-            nationalStudentId: '111111111AA',
-            firstName: 'Nanou',
-            lastName: 'Monchose',
-            birthdate: '2004-05-07',
-          });
-
-          schoolingRegistrationRepository.getSchoolingRegistrationInformation
-            .withArgs({
-              ...studentInformation,
-              nationalStudentId: studentInformation.ineIna,
-            })
-            .resolves({
-              organizationId: 1,
-              userId: user.id,
-              firstName: user.firstName,
-              lastName: user.lastName,
-            });
-          schoolingRegistrationRepository.findByUserId
-            .withArgs({ userId: user.id })
-            .resolves([firstSchoolingRegistration, secondSchoolingRegistration]);
-
-          // when
-          const result = await catchErr(checkScoAccountRecovery)({
-            studentInformation,
-            schoolingRegistrationRepository,
-            organizationRepository,
-            userRepository,
-          });
-
-          // then
-          expect(result).to.be.instanceof(MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError);
-        });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
 
   beforeEach(() => {
     schoolingRegistrationRepository = {
-      getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate: sinon.stub(),
+      getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate: sinon.stub(),
       findByUserId: sinon.stub(),
     };
     userRepository = {
@@ -58,14 +58,18 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
           birthdate: studentInformation.birthdate,
         });
 
-        schoolingRegistrationRepository.getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate
+        schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate
           .withArgs({
             nationalStudentId: studentInformation.ineIna,
             firstName: studentInformation.firstName,
             lastName: studentInformation.lastName,
             birthdate: studentInformation.birthdate,
           })
-          .resolves(expectedUser.id);
+          .resolves({
+            userId: expectedUser.id,
+            firstName: expectedUser.firstName,
+            lastName: expectedUser.lastName,
+          });
         schoolingRegistrationRepository.findByUserId.withArgs({ userId: expectedUser.id }).resolves([expectedSchoolingRegistration]);
         userRepository.get.withArgs(expectedUser.id).resolves(expectedUser);
         organizationRepository.get.withArgs(expectedOrganization.id).resolves(expectedOrganization);
@@ -135,14 +139,18 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
             birthdate: studentInformation.birthdate,
           });
 
-          schoolingRegistrationRepository.getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate
+          schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate
             .withArgs({
               nationalStudentId: studentInformation.ineIna,
               firstName: studentInformation.firstName,
               lastName: studentInformation.lastName,
               birthdate: studentInformation.birthdate,
             })
-            .resolves(expectedUser.id);
+            .resolves({
+              userId: expectedUser.id,
+              firstName: expectedUser.firstName,
+              lastName: expectedUser.lastName,
+            });
           schoolingRegistrationRepository.findByUserId
             .withArgs({ userId: expectedUser.id })
             .resolves([firstSchoolingRegistration, secondSchoolingRegistration]);
@@ -221,14 +229,18 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
             updatedAt: new Date('2019-09-06T15:00:00Z'),
           });
 
-          schoolingRegistrationRepository.getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate
+          schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate
             .withArgs({
               nationalStudentId: studentInformation.ineIna,
               firstName: studentInformation.firstName,
               lastName: studentInformation.lastName,
               birthdate: studentInformation.birthdate,
             })
-            .resolves(expectedUser.id);
+            .resolves({
+              userId: expectedUser.id,
+              firstName: expectedUser.firstName,
+              lastName: expectedUser.lastName,
+            });
           schoolingRegistrationRepository.findByUserId
             .withArgs({ userId: expectedUser.id })
             .resolves([firstSchoolingRegistration, secondSchoolingRegistration, thirdSchoolingRegistration]);
@@ -296,14 +308,18 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
             birthdate: '2004-05-07',
           });
 
-          schoolingRegistrationRepository.getUserIdByNationalStudentIdFirstNameLastNameAndBirthdate
+          schoolingRegistrationRepository.getSchoolingRegistrationInformationByNationalStudentIdFirstNameLastNameAndBirthdate
             .withArgs({
               nationalStudentId: studentInformation.ineIna,
               firstName: studentInformation.firstName,
               lastName: studentInformation.lastName,
               birthdate: studentInformation.birthdate,
             })
-            .resolves(user.id);
+            .resolves({
+              userId: user.id,
+              firstName: user.firstName,
+              lastName: user.lastName,
+            });
           schoolingRegistrationRepository.findByUserId
             .withArgs({ userId: user.id })
             .resolves([firstSchoolingRegistration, secondSchoolingRegistration]);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer_test.js
@@ -9,7 +9,6 @@ describe('Unit | Serializer | JSONAPI | student-information-for-account-recovery
     it('should convert a StudentInformationForAccountRecovery model object into JSON API data', function() {
       //given
       const modelStudentInformationForAccountRecovery = new StudentInformationForAccountRecovery({
-        userId: 6,
         firstName: 'Jude',
         lastName: 'Law',
         username: 'jude.law0106',
@@ -25,7 +24,6 @@ describe('Unit | Serializer | JSONAPI | student-information-for-account-recovery
         data: {
           type: 'student-information-for-account-recoveries',
           attributes: {
-            'user-id': modelStudentInformationForAccountRecovery.userId,
             'first-name': modelStudentInformationForAccountRecovery.firstName,
             'last-name': modelStudentInformationForAccountRecovery.lastName,
             'username': modelStudentInformationForAccountRecovery.username,
@@ -33,6 +31,65 @@ describe('Unit | Serializer | JSONAPI | student-information-for-account-recovery
             'latest-organization-name': modelStudentInformationForAccountRecovery.latestOrganizationName,
           },
         },
+      };
+      expect(json).to.deep.equal(expectedJsonApi);
+    });
+  });
+
+  describe('#deserialize()', function() {
+
+    it('should convert the payload json to student information', async function() {
+      //given
+      const payload = {
+        data: {
+          type: 'student-information-for-account-recoveries',
+          attributes: {
+            'ine-ina': '123456789BB',
+            'first-name': 'george',
+            'last-name': 'de cambridge',
+            birthdate: '2013-07-22',
+            email: 'email@example.net',
+          },
+        },
+      };
+
+      // when
+      const json = await serializer.deserialize(payload);
+
+      // then
+      const expectedJsonApi = {
+        firstName: 'george',
+        lastName: 'de cambridge',
+        ineIna: '123456789BB',
+        birthdate: '2013-07-22',
+        email: 'email@example.net',
+      };
+      expect(json).to.deep.equal(expectedJsonApi);
+    });
+
+    it('should not return undefined email when none exist in payload', async function() {
+      //given
+      const payload = {
+        data: {
+          type: 'student-information-for-account-recoveries',
+          attributes: {
+            'ine-ina': '123456789BB',
+            'first-name': 'george',
+            'last-name': 'de cambridge',
+            birthdate: '2013-07-22',
+          },
+        },
+      };
+
+      // when
+      const json = await serializer.deserialize(payload);
+
+      // then
+      const expectedJsonApi = {
+        firstName: 'george',
+        lastName: 'de cambridge',
+        ineIna: '123456789BB',
+        birthdate: '2013-07-22',
       };
       expect(json).to.deep.equal(expectedJsonApi);
     });

--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
@@ -22,18 +22,20 @@
   {{/if}}
 
   <form onSubmit={{this.submitBackupEmailConfirmationForm}}>
-    <FormTextfield @label={{t 'pages.account-recovery-after-leaving-sco.backup-email-confirmation.form.email'}}
-                  @textfieldName="email"
-                  @inputBindingValue={{this.email}}
-                  @onValidate={{this.validateEmail}}
-                  @validationStatus={{this.emailValidation.status}}
-                  @validationMessage={{this.emailValidation.message}}
-                  @autocomplete="off"
-                  @require={{true}}
-                  @hideRequired={{true}}/>
+    <FormTextfield
+      @label={{t 'pages.account-recovery-after-leaving-sco.backup-email-confirmation.form.email'}}
+      @textfieldName="email"
+      @inputBindingValue={{this.email}}
+      @onValidate={{this.validateEmail}}
+      @validationStatus={{this.emailValidation.status}}
+      @validationMessage={{this.emailValidation.message}}
+      @autocomplete="off"
+      @require={{true}}
+      @hideRequired={{true}}
+    />
 
     {{#if @showAlreadyRegisteredEmailError}}
-      <PixMessage @type='alert'>
+      <PixMessage @type='alert' class="account-recovery-after-leaving-sco-content__not-found-error">
         {{t 'pages.account-recovery-after-leaving-sco.backup-email-confirmation.form.error.new-email-already-exist'}}
       </PixMessage>
     {{/if}}

--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.js
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.js
@@ -32,6 +32,7 @@ export default class BackupEmailConfirmationFormComponent extends Component {
   email = '';
 
   @action validateEmail() {
+    this.args.resetErrors();
     this.email = this.email.trim();
     if (isEmpty(this.email)) {
       this.emailValidation.status = STATUS_MAP['errorStatus'];
@@ -53,6 +54,8 @@ export default class BackupEmailConfirmationFormComponent extends Component {
   @action
   async submitBackupEmailConfirmationForm(event) {
     event.preventDefault();
+    this.emailValidation.status = STATUS_MAP['successStatus'];
+    this.emailValidation.message = null;
     this.args.sendEmail(this.email);
   }
 

--- a/mon-pix/app/components/account-recovery/student-information-form.hbs
+++ b/mon-pix/app/components/account-recovery/student-information-form.hbs
@@ -99,7 +99,7 @@
     </div>
 
     {{#if @showAccountNotFoundError}}
-      <PixMessage @type='alert' class="student-information-form__not-found-error">
+      <PixMessage @type='alert' class="account-recovery-after-leaving-sco-content__not-found-error">
         {{t 'pages.account-recovery-after-leaving-sco.student-information.errors.not-found'}}
         <a href="{{t 'pages.account-recovery-after-leaving-sco.contact-support.link-url'}}"
           target="_blank"

--- a/mon-pix/app/components/account-recovery/student-information-form.js
+++ b/mon-pix/app/components/account-recovery/student-information-form.js
@@ -134,7 +134,6 @@ export default class StudentInformationFormComponent extends Component {
     event.preventDefault();
 
     if (this.isFormValid) {
-
       await this.args.submitStudentInformation({
         ineIna: this.ineIna,
         firstName: this.firstName,

--- a/mon-pix/app/components/account-recovery/student-information-form.js
+++ b/mon-pix/app/components/account-recovery/student-information-form.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import isEmpty from 'lodash/isEmpty';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 const INE_REGEX = /^[0-9]{9}[a-zA-Z]{2}$/;
 const INA_REGEX = /^[0-9]{10}[a-zA-Z]{1}$/;
@@ -83,7 +83,7 @@ export default class StudentInformationFormComponent extends Component {
     const year = parseInt(this.yearOfBirth);
     const month = parseInt(this.monthOfBirth) - 1;
     const day = parseInt(this.dayOfBirth);
-    return moment(new Date(year, month, day)).format('YYYY-MM-DD');
+    return dayjs(new Date(year, month, day)).format('YYYY-MM-DD');
   }
 
   @action validateIneIna() {

--- a/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
+++ b/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
@@ -3,10 +3,12 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 class StudentInformationForAccountRecovery {
-  @tracked firstName = '' ;
+  @tracked firstName = '';
+  @tracked ineIna = '';
   @tracked lastName = '';
   @tracked username = '';
   @tracked email = '';
+  @tracked birthdate;
   @tracked latestOrganizationName = '';
 }
 
@@ -21,13 +23,14 @@ export default class AccountRecoveryAfterLeavingScoController extends Controller
   @tracked showConfirmationEmailSent = false;
   @tracked templateImg = 'illustration';
 
-  studentInformationForAccountRecovery = new StudentInformationForAccountRecovery();
-  @tracked firstName;
+  @tracked studentInformationForAccountRecovery = new StudentInformationForAccountRecovery();
 
   @action
   async submitStudentInformation(studentInformation) {
+    this.studentInformationForAccountRecovery.birthdate = studentInformation.birthdate;
+    this.studentInformationForAccountRecovery.ineIna = studentInformation.ineIna;
+    this.studentInformationForAccountRecovery.firstName = studentInformation.firstName;
     const studentInformationToSave = this.store.createRecord('student-information', studentInformation);
-    this.firstName = studentInformation.firstName;
     try {
       const { userId, firstName, lastName, username, email, latestOrganizationName } = await studentInformationToSave.submitStudentInformation();
       this.studentInformationForAccountRecovery.userId = userId;

--- a/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
+++ b/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
@@ -60,8 +60,14 @@ export default class AccountRecoveryAfterLeavingScoController extends Controller
 
   @action
   async sendEmail(newEmail) {
-    const userId = this.studentInformationForAccountRecovery.userId;
-    const accountRecoveryDemand = this.store.createRecord('account-recovery-demand', { userId, email: newEmail });
+    const { firstName, lastName, ineIna, birthdate } = this.studentInformationForAccountRecovery;
+    const accountRecoveryDemand = this.store.createRecord('account-recovery-demand', {
+      firstName,
+      lastName,
+      ineIna,
+      birthdate,
+      email: newEmail,
+    });
     try {
       await accountRecoveryDemand.send();
       this.showAlreadyRegisteredEmailError = false;

--- a/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
+++ b/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
@@ -32,8 +32,13 @@ export default class AccountRecoveryAfterLeavingScoController extends Controller
     this.studentInformationForAccountRecovery.firstName = studentInformation.firstName;
     const studentInformationToSave = this.store.createRecord('student-information', studentInformation);
     try {
-      const { userId, firstName, lastName, username, email, latestOrganizationName } = await studentInformationToSave.submitStudentInformation();
-      this.studentInformationForAccountRecovery.userId = userId;
+      const {
+        firstName,
+        lastName,
+        username,
+        email,
+        latestOrganizationName,
+      } = await studentInformationToSave.submitStudentInformation();
       this.studentInformationForAccountRecovery.firstName = firstName;
       this.studentInformationForAccountRecovery.lastName = lastName;
       this.studentInformationForAccountRecovery.username = username;

--- a/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
+++ b/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
@@ -49,6 +49,11 @@ export default class AccountRecoveryAfterLeavingScoController extends Controller
   }
 
   @action
+  async resetErrors() {
+    this.showAlreadyRegisteredEmailError = false;
+  }
+
+  @action
   async sendEmail(newEmail) {
     const userId = this.studentInformationForAccountRecovery.userId;
     const accountRecoveryDemand = this.store.createRecord('account-recovery-demand', { userId, email: newEmail });

--- a/mon-pix/app/models/account-recovery-demand.js
+++ b/mon-pix/app/models/account-recovery-demand.js
@@ -2,7 +2,10 @@ import Model, { attr } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
 
 export default class AccountRecoveryDemand extends Model {
-  @attr('string') userId;
+  @attr('string') ineIna;
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('date-only') birthdate;
   @attr('string') email;
 
   send = memberAction({

--- a/mon-pix/app/models/student-information.js
+++ b/mon-pix/app/models/student-information.js
@@ -20,7 +20,6 @@ export default class StudentInformation extends Model {
     after(response) {
       if (response.data && response.data.attributes) {
         const deserializeResponse = {
-          userId: response.data.attributes['user-id'],
           firstName: response.data.attributes['first-name'],
           lastName: response.data.attributes['last-name'],
           email: response.data.attributes['email'],

--- a/mon-pix/app/styles/components/account-recovery/_student-information-form.scss
+++ b/mon-pix/app/styles/components/account-recovery/_student-information-form.scss
@@ -46,12 +46,4 @@
       }
     }
   }
-
-  &__not-found-error {
-    margin-top: 20px;
-
-    a {
-      color: $communication-dark;
-    }
-  }
 }

--- a/mon-pix/app/styles/pages/_account-recovery-after-leaving-sco.scss
+++ b/mon-pix/app/styles/pages/_account-recovery-after-leaving-sco.scss
@@ -78,6 +78,14 @@
     }
   }
 
+  &__not-found-error {
+    margin-top: 20px;
+
+    a {
+      color: $communication-dark;
+    }
+  }
+
   &__information-text--details {
     color: $grey-90;
     font-family: $font-roboto;

--- a/mon-pix/app/templates/account-recovery-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/account-recovery-after-leaving-sco.hbs
@@ -30,6 +30,7 @@
       {{#if this.showBackupEmailConfirmationForm}}
         <AccountRecovery::BackupEmailConfirmationForm
           @sendEmail={{this.sendEmail}}
+          @resetErrors={{this.resetErrors}}
           @firstName={{this.studentInformationForAccountRecovery.firstName}}
           @existingEmail={{this.studentInformationForAccountRecovery.email}}
           @cancelAccountRecovery={{this.cancelAccountRecovery}}

--- a/mon-pix/app/templates/account-recovery-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/account-recovery-after-leaving-sco.hbs
@@ -16,7 +16,7 @@
       {{/if}}
 
       {{#if this.showConflictError}}
-        <AccountRecovery::ConflictError @firstName={{this.firstName}} />
+        <AccountRecovery::ConflictError @firstName={{this.studentInformationForAccountRecovery.firstName}} />
       {{/if}}
 
       {{#if this.showConfirmationStep}}
@@ -30,7 +30,7 @@
       {{#if this.showBackupEmailConfirmationForm}}
         <AccountRecovery::BackupEmailConfirmationForm
           @sendEmail={{this.sendEmail}}
-          @firstName={{this.firstName}}
+          @firstName={{this.studentInformationForAccountRecovery.firstName}}
           @existingEmail={{this.studentInformationForAccountRecovery.email}}
           @cancelAccountRecovery={{this.cancelAccountRecovery}}
           @showAlreadyRegisteredEmailError={{this.showAlreadyRegisteredEmailError}}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -14715,6 +14715,11 @@
         "time-zone": "^1.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -52,6 +52,7 @@
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "chai-dom": "^1.9.0",
+    "dayjs": "^1.10.6",
     "dotenv": "^8.2.0",
     "ember-api-actions": "^0.2.9",
     "ember-auto-import": "^1.11.3",

--- a/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
@@ -19,11 +19,13 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
 
     it('should render recover account backup email confirmation form with the existing email', async function() {
       // given
+      const resetErrors = sinon.stub();
+      this.set('resetErrors', resetErrors);
       this.set('firstName', firstName);
       this.set('existingEmail', existingEmail);
 
       // when
-      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}} @existingEmail={{this.existingEmail}}/>`);
+      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}} @existingEmail={{this.existingEmail}} @resetErrors={{this.resetErrors}}/>`);
 
       // then
       expect(contains(this.intl.t('pages.account-recovery-after-leaving-sco.backup-email-confirmation.email-already-exist-for-account-message'))).to.exist;
@@ -31,7 +33,6 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
       expect(contains(this.intl.t('pages.account-recovery-after-leaving-sco.backup-email-confirmation.email-reset-message'))).to.exist;
       expect(contains(this.intl.t('pages.account-recovery-after-leaving-sco.backup-email-confirmation.form.email'))).to.exist;
       expect(contains(this.intl.t('pages.account-recovery-after-leaving-sco.backup-email-confirmation.ask-for-new-email-message'))).to.exist;
-
     });
 
   });
@@ -40,10 +41,12 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
 
     it('should render recover account backup email confirmation form', async function() {
       // given
+      const resetErrors = sinon.stub();
+      this.set('resetErrors', resetErrors);
       this.set('firstName', firstName);
 
       // when
-      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}}/>`);
+      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}} @resetErrors={{this.resetErrors}}/>`);
 
       // then
       expect(contains(this.intl.t('pages.account-recovery-after-leaving-sco.backup-email-confirmation.email-is-needed-message', { firstName }))).to.exist;
@@ -56,11 +59,15 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
     it('should enable submission on backup email confirmation form', async function() {
       // given
       const email = 'Philipe@example.net';
+      const resetErrors = sinon.stub();
+      this.set('resetErrors', resetErrors);
 
       const createRecordStub = sinon.stub();
+
       class StoreStubService extends Service {
         createRecord = createRecordStub;
       }
+
       this.owner.register('service:store', StoreStubService);
       const sendEmail = sinon.stub();
       sendEmail.resolves();
@@ -68,6 +75,7 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
 
       await render(hbs`<AccountRecovery::BackupEmailConfirmationForm
       @sendEmail={{this.sendEmail}}
+      @resetErrors={{this.resetErrors}}
       />`);
 
       // when
@@ -84,9 +92,11 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
 
     it('should show an error when email is empty', async function() {
       // given
+      const resetErrors = sinon.stub();
+      this.set('resetErrors', resetErrors);
       const email = '';
 
-      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}}/>`);
+      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}} @resetErrors={{this.resetErrors}}/>`);
 
       // when
       await fillInByLabel(this.intl.t('pages.account-recovery-after-leaving-sco.backup-email-confirmation.form.email'), email);
@@ -99,9 +109,11 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
 
     it('should show an error when email is not valid', async function() {
       // given
+      const resetErrors = sinon.stub();
+      this.set('resetErrors', resetErrors);
       const email = 'Philipe@';
 
-      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}}/>`);
+      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}} @resetErrors={{this.resetErrors}}/>`);
 
       // when
       await fillInByLabel(this.intl.t('pages.account-recovery-after-leaving-sco.backup-email-confirmation.form.email'), email);
@@ -114,8 +126,10 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
 
     it('should valid form when email is valid', async function() {
       // given
+      const resetErrors = sinon.stub();
+      this.set('resetErrors', resetErrors);
       const email = 'Philipe@example.net';
-      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}}/>`);
+      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}} @resetErrors={{this.resetErrors}}/>`);
 
       // when
       await fillInByLabel(this.intl.t('pages.account-recovery-after-leaving-sco.backup-email-confirmation.form.email'), email);

--- a/mon-pix/tests/unit/controllers/account-recovery-after-leaving-sco-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery-after-leaving-sco-test.js
@@ -77,7 +77,7 @@ describe('Unit | Controller | account-recovery-after-leaving-sco', function() {
       it('should send account recovery email', async function() {
         // given
         const controller = this.owner.lookup('controller:account-recovery-after-leaving-sco');
-        const studentInformationForAccountRecovery = { userId: 1 };
+        const studentInformationForAccountRecovery = { firstName: 'Philippe', lastName: 'Legoff', birthdate: '2012-07-01', ineIna: '123456789CC' };
         controller.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
         const sendEmailStub = sinon.stub();
         const createRecord = sinon.stub().returns({ send: sendEmailStub.resolves() });
@@ -89,7 +89,7 @@ describe('Unit | Controller | account-recovery-after-leaving-sco', function() {
         await controller.sendEmail(email);
 
         // then
-        const expectedAccountRecoveryDemandAttributes = { userId: 1, email };
+        const expectedAccountRecoveryDemandAttributes = { ...studentInformationForAccountRecovery, email };
         sinon.assert.calledWithExactly(createRecord, 'account-recovery-demand', expectedAccountRecoveryDemandAttributes);
         sinon.assert.calledOnce(sendEmailStub);
       });

--- a/mon-pix/tests/unit/models/account-recovery-demand-test.js
+++ b/mon-pix/tests/unit/models/account-recovery-demand-test.js
@@ -18,7 +18,10 @@ describe('Unit | Model | account recovery demand', function() {
       adapter.ajax.resolves();
 
       const accountRecoveryDemand = run(() => store.createRecord('account-recovery-demand', {
-        userId: 3,
+        firstName: 'Jude',
+        lastName: 'Law',
+        ineIna: '123456789BB',
+        birthdate: '2012-07-01',
         email: 'james.potter@example.net',
       }));
 
@@ -31,7 +34,10 @@ describe('Unit | Model | account recovery demand', function() {
         data: {
           data: {
             attributes: {
-              'user-id': '3',
+              'first-name': 'Jude',
+              'last-name': 'Law',
+              'ine-ina': '123456789BB',
+              'birthdate': '2012-07-01',
               'email': 'james.potter@example.net',
             },
             type: 'account-recovery-demands',

--- a/mon-pix/tests/unit/models/student-information-test.js
+++ b/mon-pix/tests/unit/models/student-information-test.js
@@ -19,7 +19,6 @@ describe('Unit | Model | Student-information', function() {
       adapter.ajax.resolves({
         data: {
           attributes: {
-            'user-id': 1,
             'first-name': 'James',
             'last-name': 'Potter',
             'email': 'james.potter@example.net',
@@ -41,7 +40,6 @@ describe('Unit | Model | Student-information', function() {
 
       // then
       const expectedResult = {
-        userId: 1,
         firstName: 'James',
         lastName: 'Potter',
         email: 'james.potter@example.net',


### PR DESCRIPTION
## :unicorn: Problème
L'appel à la route `POST /api/account-recovery` avec un `userId` et un `email` permet de recevoir un email contenant un lien permettant d'ajouter/modifier une connexion par email + mdp. La seule condition est que le `userId` doit être associé à une inscription scolaire. 

Or, l'identifiant est issu d'une séquence, et pas d'un identifiant unique et aléatoire (UUID).

En conséquence, il suffit d'effectuer en masse des appels API avec un identifiant incrémental partant de 0 pour obtenir l'accès à tous les utilisateurs possédant une inscription scolaire.

PI: cette feature n'est pas encore active en production.

## :robot: Solution
Remplacer en entrée de route l'identifiant de l'utilisateur par les informations saisies précédemment, nominatives (Nom / Prénom: Date de naissance / INE) et refaire tous les checks coté serveur pour vérifier que la ressource n'as pas été altéré entre temps coté serveur.

Tracer l'inscription scolaire utilisée dans la table `account-recovery-demands`

## :rainbow: Remarques
Bugfix embarqué: 
- utilisation dans l'email et dans la page de récupération de compte du Nom/Prénom issus de l'inscription scolaire, plutôt que de ceux saisis à la création du compte.
- masquer les anciens messages d’erreur a la validation d'email

## :100: Pour tester
Se rendre sur la page de récupération en [RA](https://app-pr3201.review.pix.fr/recuperer-mon-compte)

Modfier le nom de l'utilisateur
```sql
UPDATE users
    SET "firstName" = 'John', "lastName" = 'Doe'
WHERE id = 100033
```

Ouvrir l'onglet `network` des dev tools.

Saisir
- Ine/Ina : 123456789BB
- Prénom : George
- Nom : De Cambridge
- Date de naissance : 22/07/2013


Vérifier le message "Bonne nouvelle George !"
Cliquer sur "Je confirme", et saisissez une adresse email.

Vérifier le message "Nous venons de vous adresser un mail qui vous permettra de choisir un mot de passe. Vous pouvez consulter dès maintenant votre messagerie."

Exécuter la requête SQL suivante
```sql
SELECT
     'recovery-demand =>'
    ,acd.*
    ,'registration =>'
    ,sr.id
    ,sr."firstName"
    ,sr."lastName"
    ,sr.birthdate
    ,sr."nationalStudentId"
    ,'organization =>'
    ,o.id
    ,o.name
FROM
    "account-recovery-demands" acd
         INNER JOIN "schooling-registrations" sr ON sr.id = acd."schoolingRegistrationId"
         INNER JOIN organizations o              ON sr."organizationId" = o.id
WHERE sr."nationalStudentId" = '123456789BB'
```

Cliquer sur le lien reçu par email,

Vérifier que l'appel `POST /api/account-recovery` ne comporte plus `userId`
```json
{
	"data": {
		"attributes": {
			"birthdate": "2013-07-22",
			"email": "pierre.top@pix.fr",
			"first-name": "George",
			"ine-ina": "123456789BB",
			"last-name": "De Cambridge"
		},
		"type": "account-recovery-demands"
	}
}
```

**Scenario `Conflict`:**

Saisir
- Ine/Ina : 123456789XX
- Prénom : Sansa
- Nom : Stark
- Date de naissance : 28/05/2000

Pour accéder à la page conflit quand un utilisateur a plusieurs schooling avec différents INE-INA