### PR TITLE
[FEATURE] Ajout du paramètre enErreur pour la récupération des résultats à la campagne Pôle emploi (PIX-2684).

### DIFF
--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -60,7 +60,7 @@ buildAuthenticationMethod.buildWithHashedPassword = function({
 
 buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod = function({
   id = databaseBuffer.getNextId(),
-  externalIdentifier = 'externalId',
+  externalIdentifier,
   accessToken = 'ABC789',
   refreshToken = 'DEF753',
   expiredDate = new Date('2022-01-01'),
@@ -71,6 +71,10 @@ buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod = function({
 
   userId = isUndefined(userId) ? buildUser().id : userId;
 
+  let generatedIdentifier = externalIdentifier;
+  if (!generatedIdentifier) {
+    generatedIdentifier = `externalIdentifier-${id}`;
+  }
   const values = {
     id,
     identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
@@ -79,7 +83,7 @@ buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod = function({
       refreshToken,
       expiredDate,
     }),
-    externalIdentifier,
+    externalIdentifier: generatedIdentifier,
     userId,
     createdAt,
     updatedAt,

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -40,7 +40,6 @@ module.exports = {
   buildOrganizationTag: require('./build-organization-tag'),
   buildMembership: require('./build-membership'),
   buildPixRole: require('./build-pix-role'),
-  buildPoleEmploiSending: require('./build-pole-emploi-sending'),
   buildResetPasswordDemand: require('./build-reset-password-demand'),
   buildSession: require('./build-session'),
   buildSchoolingRegistration: require('./build-schooling-registration'),
@@ -57,4 +56,5 @@ module.exports = {
   buildUserTutorial: require('./build-user-tutorial'),
   campaignParticipationOverviewFactory: require('./campaign-participation-overview-factory'),
   knowledgeElementSnapshotFactory: require('./knowledge-elements-snapshot-factory'),
+  poleEmploiSendingFactory: require('./pole-emploi-sending-factory'),
 };

--- a/api/db/database-builder/factory/pole-emploi-sending-factory.js
+++ b/api/db/database-builder/factory/pole-emploi-sending-factory.js
@@ -1,13 +1,15 @@
 const buildCampaignParticipation = require('./build-campaign-participation');
+const buildUser = require('./build-user');
+const buildAuthencationMethod = require('./build-authentication-method');
 const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
-module.exports = function buildPoleEmploiSending({
+function build({
   id = databaseBuffer.getNextId(),
   isSuccessful = true,
   responseCode = '200',
   type = 'CAMPAIGN_PARTICIPATION_START',
-  payload = {},
+  payload = { individu: {} },
   createdAt = new Date('2020-01-01'),
   campaignParticipationId,
 } = {}) {
@@ -27,4 +29,16 @@ module.exports = function buildPoleEmploiSending({
     tableName: 'pole-emploi-sendings',
     values,
   });
+}
+
+function buildWithUser(sendingAttributes, externalIdentifier) {
+  const { id: userId } = buildUser();
+  buildAuthencationMethod.buildPoleEmploiAuthenticationMethod({ userId, externalIdentifier });
+  const { id: campaignParticipationId } = buildCampaignParticipation({ userId });
+  return build({ ...sendingAttributes, campaignParticipationId });
+}
+
+module.exports = {
+  build,
+  buildWithUser,
 };

--- a/api/db/seeds/data/pole-emploi-sendings-builder.js
+++ b/api/db/seeds/data/pole-emploi-sendings-builder.js
@@ -16,7 +16,7 @@ module.exports = function poleEmploisSendingsBuilder({ databaseBuilder }) {
     const user = await databaseBuilder.factory.buildUser({ firstName: `FirstName-${index}`, lastName: `LastName-${index}` });
     await databaseBuilder.factory.buildAuthenticationMethod({ userId: user.id, identityProvider: 'POLE_EMPLOI', externalIdentifier: `externalUserId${user.id}` });
     const campaignParticipationId = await databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, campaignId: POLE_EMPLOI_CAMPAIGN_ID }).id;
-    await databaseBuilder.factory.buildPoleEmploiSending({ ..._generateStatus(), campaignParticipationId, createdAt: _generateDate(index), payload: {
+    await databaseBuilder.factory.poleEmploiSendingFactory.build({ ..._generateStatus(), campaignParticipationId, createdAt: _generateDate(index), payload: {
       campagne: {
         nom: 'Campagne PE',
         dateDebut: '2019-08-01T00:00:00.000Z',

--- a/api/lib/application/pole-emplois/pole-emploi-controller.js
+++ b/api/lib/application/pole-emplois/pole-emploi-controller.js
@@ -1,5 +1,6 @@
 const usecases = require('../../domain/usecases');
 const tokenService = require('../../domain/services/token-service');
+
 module.exports = {
 
   async createUser(request, h) {
@@ -18,7 +19,16 @@ module.exports = {
 
   async getSendings(request, h) {
     const cursor = request.query.curseur;
-    const { sendings, link } = await usecases.getPoleEmploiSendings({ cursor });
+    const filters = _extractFilters(request);
+    const { sendings, link } = await usecases.getPoleEmploiSendings({ cursor, filters });
     return h.response(sendings).header('link', link).code(200);
   },
 };
+
+function _extractFilters(request) {
+  const filters = {};
+  if (Object.keys(request.query).includes('enErreur')) {
+    filters.isSuccessful = !request.query.enErreur;
+  }
+  return filters;
+}

--- a/api/lib/domain/services/pole-emploi-service.js
+++ b/api/lib/domain/services/pole-emploi-service.js
@@ -1,10 +1,14 @@
 const settings = require('../../config');
 
-function generateLink(sending) {
+function generateLink(sending, filters = {}) {
   const host = settings.apiManager.url;
   const { dateEnvoi, idEnvoi } = sending;
   const cursor = generateCursor({ idEnvoi, dateEnvoi });
-  return `${host}/pole-emploi/envois?curseur=${cursor}`;
+  let link = `${host}/pole-emploi/envois?curseur=${cursor}`;
+  if (Object.keys(filters).includes('isSuccessful')) {
+    link += `&enErreur=${!filters.isSuccessful}`;
+  }
+  return link;
 }
 
 function generateCursor(data) {

--- a/api/lib/domain/usecases/get-pole-emploi-sendings.js
+++ b/api/lib/domain/usecases/get-pole-emploi-sendings.js
@@ -1,16 +1,16 @@
 const poleEmploiService = require('../services/pole-emploi-service');
 
-module.exports = async function getPoleEmploiSendings({ cursor, poleEmploiSendingRepository }) {
+module.exports = async function getPoleEmploiSendings({ cursor, poleEmploiSendingRepository, filters }) {
   const cursorData = await poleEmploiService.decodeCursor(cursor);
-  const sendings = await poleEmploiSendingRepository.find(cursorData);
-  const link = _generateLink(sendings);
+  const sendings = await poleEmploiSendingRepository.find(cursorData, filters);
+  const link = _generateLink(sendings, filters);
   return { sendings, link };
 };
 
-function _generateLink(sendings) {
+function _generateLink(sendings, filters) {
   if (!sendings.length) return null;
 
   const lastSending = sendings[sendings.length - 1];
-  const link = poleEmploiService.generateLink(lastSending);
+  const link = poleEmploiService.generateLink(lastSending, filters);
   return link;
 }

--- a/api/lib/domain/usecases/get-pole-emploi-sendings.js
+++ b/api/lib/domain/usecases/get-pole-emploi-sendings.js
@@ -2,7 +2,7 @@ const poleEmploiService = require('../services/pole-emploi-service');
 
 module.exports = async function getPoleEmploiSendings({ cursor, poleEmploiSendingRepository }) {
   const cursorData = await poleEmploiService.decodeCursor(cursor);
-  const sendings = await poleEmploiSendingRepository.get(cursorData);
+  const sendings = await poleEmploiSendingRepository.find(cursorData);
   const link = _generateLink(sendings);
   return { sendings, link };
 };

--- a/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -7,7 +7,7 @@ module.exports = {
     return new BookshelfPoleEmploiSending(poleEmploiSending).save();
   },
 
-  async find(sending) {
+  async find(sending, filters) {
     const POLE_EMPLOI_SENDINGS_LIMIT = settings.poleEmploi.poleEmploiSendingsLimit;
     const IDENTITY_PROVIDER_POLE_EMPLOI = settings.poleEmploi.poleEmploiIdentityProvider;
 
@@ -17,6 +17,7 @@ module.exports = {
       .join('authentication-methods', 'authentication-methods.userId', 'campaign-participations.userId')
       .where('authentication-methods.identityProvider', IDENTITY_PROVIDER_POLE_EMPLOI)
       .modify(_olderThan, sending)
+      .modify(_filterByStatus, filters)
       .orderBy([{ column: 'pole-emploi-sendings.createdAt', order: 'desc' }, { column: 'pole-emploi-sendings.id', order: 'desc' }])
       .limit(POLE_EMPLOI_SENDINGS_LIMIT);
 
@@ -34,5 +35,11 @@ function _olderThan(qb, sending) {
   if (sending) {
     qb.where('pole-emploi-sendings.createdAt', '<', sending.dateEnvoi)
       .where('pole-emploi-sendings.id', '<', sending.idEnvoi);
+  }
+}
+
+function _filterByStatus(qb, filters = {}) {
+  if (Object.keys(filters).includes('isSuccessful')) {
+    qb.where({ isSuccessful: filters.isSuccessful });
   }
 }

--- a/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -7,7 +7,7 @@ module.exports = {
     return new BookshelfPoleEmploiSending(poleEmploiSending).save();
   },
 
-  async get(sending) {
+  async find(sending) {
     const POLE_EMPLOI_SENDINGS_LIMIT = settings.poleEmploi.poleEmploiSendingsLimit;
     const IDENTITY_PROVIDER_POLE_EMPLOI = settings.poleEmploi.poleEmploiIdentityProvider;
 

--- a/api/tests/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/acceptance/application/pole-emploi-controller_test.js
@@ -1,6 +1,7 @@
 const jsonwebtoken = require('jsonwebtoken');
 
 const { expect, knex, databaseBuilder, generateValidRequestAuthorizationHeaderForApplication, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const poleEmploiSendingFactory = databaseBuilder.factory.poleEmploiSendingFactory;
 
 const PoleEmploiTokens = require('../../../lib/domain/models/PoleEmploiTokens');
 const poleEmploiTokensRepository = require('../../../lib/infrastructure/repositories/pole-emploi-tokens-repository');
@@ -87,7 +88,7 @@ describe('Acceptance | API | Pole Emploi Controller', () => {
         const userId = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildAuthenticationMethod({ userId, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId' });
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId }).id;
-        const sending = databaseBuilder.factory.buildPoleEmploiSending({ id: 76345, campaignParticipationId, createdAt: new Date('2021-05-01'), payload: { campagne: { nom: 'Campagne PE', dateDebut: new Date('2020-08-01'), type: 'EVALUATION', codeCampagne: 'POLEEMPLOI123', urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123', nomOrganisme: 'Pix', typeOrganisme: 'externe' }, individu: { nom: 'Kamado', prenom: 'Tanjiro' }, test: { etat: 2, typeTest: 'DI', referenceExterne: 123456, dateDebut: new Date('2020-09-01'), elementsEvalues: [] } } });
+        const sending = poleEmploiSendingFactory.build({ id: 76345, campaignParticipationId, createdAt: new Date('2021-05-01'), payload: { campagne: { nom: 'Campagne PE', dateDebut: new Date('2020-08-01'), type: 'EVALUATION', codeCampagne: 'POLEEMPLOI123', urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123', nomOrganisme: 'Pix', typeOrganisme: 'externe' }, individu: { nom: 'Kamado', prenom: 'Tanjiro' }, test: { etat: 2, typeTest: 'DI', referenceExterne: 123456, dateDebut: new Date('2020-09-01'), elementsEvalues: [] } } });
         await databaseBuilder.commit();
 
         options = {

--- a/api/tests/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/acceptance/application/pole-emploi-controller_test.js
@@ -82,18 +82,13 @@ describe('Acceptance | API | Pole Emploi Controller', () => {
 
     context('When the request returns 200', function() {
       it('should return the sending and a link', async () => {
-        const organizationId = databaseBuilder.factory.buildOrganization({ name: 'Pole emploi' }).id;
-        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-
-        const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildAuthenticationMethod({ userId, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId' });
-        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId }).id;
-        const sending = poleEmploiSendingFactory.build({ id: 76345, campaignParticipationId, createdAt: new Date('2021-05-01'), payload: { campagne: { nom: 'Campagne PE', dateDebut: new Date('2020-08-01'), type: 'EVALUATION', codeCampagne: 'POLEEMPLOI123', urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123', nomOrganisme: 'Pix', typeOrganisme: 'externe' }, individu: { nom: 'Kamado', prenom: 'Tanjiro' }, test: { etat: 2, typeTest: 'DI', referenceExterne: 123456, dateDebut: new Date('2020-09-01'), elementsEvalues: [] } } });
+        const sending = poleEmploiSendingFactory.buildWithUser({ id: 76345, createdAt: new Date('2021-05-01'), payload: { campagne: { nom: 'Campagne PE', dateDebut: new Date('2020-08-01'), type: 'EVALUATION', codeCampagne: 'POLEEMPLOI123', urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123', nomOrganisme: 'Pix', typeOrganisme: 'externe' }, individu: { nom: 'Kamado', prenom: 'Tanjiro' }, test: { etat: 2, typeTest: 'DI', referenceExterne: 123456, dateDebut: new Date('2020-09-01'), elementsEvalues: [] } }, isSuccessful: true }, 'externalUserId');
+        poleEmploiSendingFactory.buildWithUser({ isSuccessful: false });
         await databaseBuilder.commit();
 
         options = {
           method: 'GET',
-          url: '/api/pole-emploi/envois',
+          url: '/api/pole-emploi/envois?enErreur=false',
           headers: { authorization: generateValidRequestAuthorizationHeaderForApplication(POLE_EMPLOI_CLIENT_ID, POLE_EMPLOI_SOURCE, POLE_EMPLOI_SCOPE) },
         };
 
@@ -102,7 +97,7 @@ describe('Acceptance | API | Pole Emploi Controller', () => {
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.headers.link).to.equal('https://url-externe/pole-emploi/envois?curseur=eyJpZEVudm9pIjo3NjM0NSwiZGF0ZUVudm9pIjoiMjAyMS0wNS0wMVQwMDowMDowMC4wMDBaIn0=');
+        expect(response.headers.link).to.equal('https://url-externe/pole-emploi/envois?curseur=eyJpZEVudm9pIjo3NjM0NSwiZGF0ZUVudm9pIjoiMjAyMS0wNS0wMVQwMDowMDowMC4wMDBaIn0=&enErreur=false');
         expect(response.result).to.deep.equal([{
           'idEnvoi': sending.id,
           'dateEnvoi': new Date('2021-05-01'),

--- a/api/tests/integration/domain/usecases/get-pole-emploi-sendings_test.js
+++ b/api/tests/integration/domain/usecases/get-pole-emploi-sendings_test.js
@@ -3,6 +3,7 @@ const usecases = require('../../../../lib/domain/usecases');
 const poleEmploiService = require('../../../../lib/domain/services/pole-emploi-service');
 const poleEmploiSendingRepository = require('../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
 const settings = require('../../../../lib/config');
+const poleEmploiSendingFactory = databaseBuilder.factory.poleEmploiSendingFactory;
 
 describe('Integration | UseCase | get-campaign-participations-counts-by-stage', () => {
   let originalEnv;
@@ -20,12 +21,12 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
     const user1Id = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildAuthenticationMethod({ userId: user1Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId1' });
     const campaignParticipation1Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user1Id, campaignId }).id;
-    sending1 = databaseBuilder.factory.buildPoleEmploiSending({ id: 8766, campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
+    sending1 = poleEmploiSendingFactory.build({ id: 8766, campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
 
     const user2Id = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildAuthenticationMethod({ userId: user2Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId2' });
     const campaignParticipation2Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user2Id, campaignId }).id;
-    sending2 = databaseBuilder.factory.buildPoleEmploiSending({ id: 45678, campaignParticipationId: campaignParticipation2Id, createdAt: new Date('2021-04-01'), payload: { individu: {} } });
+    sending2 = poleEmploiSendingFactory.build({ id: 45678, campaignParticipationId: campaignParticipation2Id, createdAt: new Date('2021-04-01'), payload: { individu: {} } });
 
     await databaseBuilder.commit();
 

--- a/api/tests/integration/domain/usecases/get-pole-emploi-sendings_test.js
+++ b/api/tests/integration/domain/usecases/get-pole-emploi-sendings_test.js
@@ -9,27 +9,15 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
   let originalEnv;
   let sending1;
   let sending2;
-  let campaignId;
 
   beforeEach(async() => {
     originalEnv = settings.apiManager.url;
     settings.apiManager.url = 'https://fake-url.fr';
 
-    const organizationId = databaseBuilder.factory.buildOrganization({ name: 'Pole emploi' }).id;
-    campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-
-    const user1Id = databaseBuilder.factory.buildUser().id;
-    databaseBuilder.factory.buildAuthenticationMethod({ userId: user1Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId1' });
-    const campaignParticipation1Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user1Id, campaignId }).id;
-    sending1 = poleEmploiSendingFactory.build({ id: 8766, campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
-
-    const user2Id = databaseBuilder.factory.buildUser().id;
-    databaseBuilder.factory.buildAuthenticationMethod({ userId: user2Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId2' });
-    const campaignParticipation2Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user2Id, campaignId }).id;
-    sending2 = poleEmploiSendingFactory.build({ id: 45678, campaignParticipationId: campaignParticipation2Id, createdAt: new Date('2021-04-01'), payload: { individu: {} } });
+    sending1 = poleEmploiSendingFactory.buildWithUser({ createdAt: new Date('2021-03-01'), isSuccessful: true });
+    sending2 = poleEmploiSendingFactory.buildWithUser({ createdAt: new Date('2021-04-01'), isSuccessful: false });
 
     await databaseBuilder.commit();
-
   });
 
   afterEach(() => {
@@ -63,6 +51,19 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
       expect(response.sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending1.id]);
       expect(response.link).to.equal(expectedLink);
     });
+
+    it('should return a sending with a link with filters', async () => {
+      //given
+      const filters = { isSuccessful: true };
+      const cursorCorrespondingToSending2 = poleEmploiService.generateCursor({ idEnvoi: sending2.id, dateEnvoi: sending2.createdAt });
+      const expectedLink = poleEmploiService.generateLink({ idEnvoi: sending1.id, dateEnvoi: sending1.createdAt }, filters);
+
+      //when
+      const response = await usecases.getPoleEmploiSendings({ cursor: cursorCorrespondingToSending2, filters, poleEmploiSendingRepository });
+      //then
+      expect(response.sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending1.id]);
+      expect(response.link).to.equal(expectedLink);
+    });
   });
 
   context('when there is a cursor but there is no more sending', function() {
@@ -77,5 +78,13 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
       expect(response.sendings).to.deep.equal([]);
       expect(response.link).to.equal(null);
     });
+  });
+
+  it('returns sendings which match the filters', async () => {
+    //when
+    const { sendings } = await usecases.getPoleEmploiSendings({ cursor: null, poleEmploiSendingRepository, filters: { isSuccessful: false } });
+
+    //then
+    expect(sendings.map(({ idEnvoi }) => idEnvoi)).to.exactlyContain([sending2.id]);
   });
 });

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -71,7 +71,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
 
       beforeEach(async () => {
         expectedSending = poleEmploiSendingFactory.buildWithUser({ createdAt: '2021-03-01' });
-        sendingInCursor = poleEmploiSendingFactory.buildWithUser({ createdAt: '2021-04-01'});
+        sendingInCursor = poleEmploiSendingFactory.buildWithUser({ createdAt: '2021-04-01' });
 
         await databaseBuilder.commit();
       });
@@ -114,7 +114,31 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       it('should render sendings order by date', async () => {
         const sendings = await poleEmploiSendingRepository.find();
 
-        expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending3.id, sending2.id, sending1.id,]);
+        expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending3.id, sending2.id, sending1.id]);
+      });
+    });
+
+    context('when there is a filter on isSucccessful', function() {
+      let sendingSent;
+      let sendingNotSent;
+
+      beforeEach(async () => {
+        sendingSent = poleEmploiSendingFactory.buildWithUser({ isSuccessful: true });
+        sendingNotSent = poleEmploiSendingFactory.buildWithUser({ isSuccessful: false });
+
+        await databaseBuilder.commit();
+      });
+
+      it('returns the sendings which have been sent correctly', async() => {
+        const sendings = await poleEmploiSendingRepository.find(null, { isSuccessful: true });
+        const sendingIds = sendings.map((sending) => sending.idEnvoi);
+        expect(sendingIds).to.exactlyContain([sendingSent.id]);
+      });
+
+      it('returns the sendings which have been not sent correctly', async() => {
+        const sendings = await poleEmploiSendingRepository.find(null, { isSuccessful: false });
+        const sendingIds = sendings.map((sending) => sending.idEnvoi);
+        expect(sendingIds).to.exactlyContain([sendingNotSent.id]);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const { expect, databaseBuilder, knex, domainBuilder } = require('../../../test-helper');
 const poleEmploiSendingRepository = require('../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
 const settings = require('../../../../lib/config');
-
+const poleEmploiSendingFactory = databaseBuilder.factory.poleEmploiSendingFactory;
 describe('Integration | Repository | PoleEmploiSending', () => {
 
   describe('#create', () => {
@@ -46,27 +46,27 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       const user1Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user1Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId1' });
       const campaignParticipation1Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user1Id, campaignId }).id;
-      sending1 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
+      sending1 = poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
 
       const user2Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user2Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId2' });
       const campaignParticipation2Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user2Id, campaignId }).id;
-      sending2 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation2Id, createdAt: '2021-04-01 00:00:00+00', payload: { individu: {} } });
+      sending2 = poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation2Id, createdAt: '2021-04-01 00:00:00+00', payload: { individu: {} } });
 
       const user3Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user3Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId3' });
       const campaignParticipation3Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user3Id, campaignId }).id;
-      sending3 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation3Id, createdAt: new Date('2021-05-01'), payload: { individu: {} } });
+      sending3 = poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation3Id, createdAt: new Date('2021-05-01'), payload: { individu: {} } });
 
       const user4Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user4Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId4' });
       const campaignParticipation4Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user4Id, campaignId }).id;
-      sending4 = databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation4Id, createdAt: new Date('2021-06-01'), payload: { individu: {} } });
+      sending4 = poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation4Id, createdAt: new Date('2021-06-01'), payload: { individu: {} } });
 
       const user5Id = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod({ userId: user5Id, identityProvider: 'PIX', externalIdentifier: 'externalUserId5' });
       const campaignParticipation5Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user5Id, campaignId }).id;
-      databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId: campaignParticipation5Id, createdAt: new Date('2021-06-01'), payload: { individu: {} } });
+      poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation5Id, createdAt: new Date('2021-06-01'), payload: { individu: {} } });
 
       await databaseBuilder.commit();
     });

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -27,7 +27,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
     });
   });
 
-  describe('#get', () => {
+  describe('#find', () => {
     let originalEnvPoleEmploiSendingsLimit;
     let sending1;
     let sending2;
@@ -77,7 +77,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
 
     it('should render 3 sendings because of the poleEmploiSendingsLimit variable', async () => {
       // when
-      const sendings = await poleEmploiSendingRepository.get();
+      const sendings = await poleEmploiSendingRepository.find();
 
       // then
       expect(sendings).to.have.lengthOf(3);
@@ -85,7 +85,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
 
     it('should render sendings order by date', async () => {
       // when
-      const sendings = await poleEmploiSendingRepository.get();
+      const sendings = await poleEmploiSendingRepository.find();
 
       // then
       expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending4.id, sending3.id, sending2.id]);
@@ -93,7 +93,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
 
     it('should render sendings with idPoleEmploi inside the object', async () => {
       // when
-      const sendings = await poleEmploiSendingRepository.get();
+      const sendings = await poleEmploiSendingRepository.find();
 
       // then
       expect(sendings.map((sending) => sending.resultat.individu.idPoleEmploi)).to.deep.equal(['externalUserId4', 'externalUserId3', 'externalUserId2']);
@@ -106,7 +106,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
         const dateEnvoi = sending2.createdAt;
 
         //when
-        const sendings = await poleEmploiSendingRepository.get({ idEnvoi, dateEnvoi });
+        const sendings = await poleEmploiSendingRepository.find({ idEnvoi, dateEnvoi });
 
         //then
         expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending1.id]);

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -3,6 +3,7 @@ const { expect, databaseBuilder, knex, domainBuilder } = require('../../../test-
 const poleEmploiSendingRepository = require('../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
 const settings = require('../../../../lib/config');
 const poleEmploiSendingFactory = databaseBuilder.factory.poleEmploiSendingFactory;
+
 describe('Integration | Repository | PoleEmploiSending', () => {
 
   describe('#create', () => {
@@ -32,84 +33,88 @@ describe('Integration | Repository | PoleEmploiSending', () => {
     let sending1;
     let sending2;
     let sending3;
-    let sending4;
 
     beforeEach(async () => {
       originalEnvPoleEmploiSendingsLimit = settings.poleEmploi.poleEmploiSendingsLimit;
-
       settings.poleEmploi.poleEmploiSendingsLimit = 3;
-      settings.poleEmploi.poleEmploiIdentityProvider = 'POLE_EMPLOI';
-
-      const organizationId = databaseBuilder.factory.buildOrganization({ name: 'Pole emploi' }).id;
-      const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-
-      const user1Id = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod({ userId: user1Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId1' });
-      const campaignParticipation1Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user1Id, campaignId }).id;
-      sending1 = poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation1Id, createdAt: new Date('2021-03-01'), payload: { individu: {} } });
-
-      const user2Id = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod({ userId: user2Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId2' });
-      const campaignParticipation2Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user2Id, campaignId }).id;
-      sending2 = poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation2Id, createdAt: '2021-04-01 00:00:00+00', payload: { individu: {} } });
-
-      const user3Id = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod({ userId: user3Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId3' });
-      const campaignParticipation3Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user3Id, campaignId }).id;
-      sending3 = poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation3Id, createdAt: new Date('2021-05-01'), payload: { individu: {} } });
-
-      const user4Id = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod({ userId: user4Id, identityProvider: 'POLE_EMPLOI', externalIdentifier: 'externalUserId4' });
-      const campaignParticipation4Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user4Id, campaignId }).id;
-      sending4 = poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation4Id, createdAt: new Date('2021-06-01'), payload: { individu: {} } });
-
-      const user5Id = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod({ userId: user5Id, identityProvider: 'PIX', externalIdentifier: 'externalUserId5' });
-      const campaignParticipation5Id = databaseBuilder.factory.buildCampaignParticipation({ userId: user5Id, campaignId }).id;
-      poleEmploiSendingFactory.build({ campaignParticipationId: campaignParticipation5Id, createdAt: new Date('2021-06-01'), payload: { individu: {} } });
-
-      await databaseBuilder.commit();
     });
 
     afterEach(() => {
       settings.poleEmploi.poleEmploiSendingsLimit = originalEnvPoleEmploiSendingsLimit;
     });
 
-    it('should render 3 sendings because of the poleEmploiSendingsLimit variable', async () => {
-      // when
+    it('should render sendings with idPoleEmploi inside the object', async () => {
+      poleEmploiSendingFactory.buildWithUser({}, 'externalUserId1');
+      await databaseBuilder.commit();
+
+      const [sending] = await poleEmploiSendingRepository.find();
+
+      expect(sending.resultat.individu.idPoleEmploi).to.equal('externalUserId1');
+    });
+
+    it('should render existing sendings using poleEmploiSendingsLimit', async () => {
+      poleEmploiSendingFactory.buildWithUser();
+      poleEmploiSendingFactory.buildWithUser();
+      poleEmploiSendingFactory.buildWithUser();
+      poleEmploiSendingFactory.buildWithUser();
+
+      await databaseBuilder.commit();
+
       const sendings = await poleEmploiSendingRepository.find();
 
-      // then
       expect(sendings).to.have.lengthOf(3);
     });
 
-    it('should render sendings order by date', async () => {
-      // when
-      const sendings = await poleEmploiSendingRepository.find();
+    context('when there is a cursor', () => {
+      let expectedSending;
+      let sendingInCursor;
 
-      // then
-      expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending4.id, sending3.id, sending2.id]);
-    });
+      beforeEach(async () => {
+        expectedSending = poleEmploiSendingFactory.buildWithUser({ createdAt: '2021-03-01' });
+        sendingInCursor = poleEmploiSendingFactory.buildWithUser({ createdAt: '2021-04-01'});
 
-    it('should render sendings with idPoleEmploi inside the object', async () => {
-      // when
-      const sendings = await poleEmploiSendingRepository.find();
+        await databaseBuilder.commit();
+      });
 
-      // then
-      expect(sendings.map((sending) => sending.resultat.individu.idPoleEmploi)).to.deep.equal(['externalUserId4', 'externalUserId3', 'externalUserId2']);
-    });
-
-    context('when there is an idEnvoi and a dateEnvoi in the cursor', function() {
       it('should return sendings where the date is before de given date', async() => {
-        //given
-        const idEnvoi = sending2.id;
-        const dateEnvoi = sending2.createdAt;
+        const { id: idEnvoi, createdAt: dateEnvoi } = sendingInCursor;
 
-        //when
-        const sendings = await poleEmploiSendingRepository.find({ idEnvoi, dateEnvoi });
+        const [sending] = await poleEmploiSendingRepository.find({ idEnvoi, dateEnvoi });
 
-        //then
-        expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending1.id]);
+        expect(sending.idEnvoi).to.equal(expectedSending.id);
+      });
+    });
+
+    context('when the participant has several authentication method', () => {
+      it('should render only one sending', async () => {
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod({ userId, identityProvider: 'PIX' });
+        databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId, externalIdentifier: 'idPoleEmploi' });
+        const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({ userId });
+        poleEmploiSendingFactory.build({ campaignParticipationId });
+
+        await databaseBuilder.commit();
+
+        const sendings = await poleEmploiSendingRepository.find();
+
+        expect(sendings.length).to.be.equal(1);
+        expect(sendings[0].resultat.individu.idPoleEmploi).to.be.equal('idPoleEmploi');
+      });
+    });
+
+    context('order', () => {
+      beforeEach(async () => {
+        sending1 = poleEmploiSendingFactory.buildWithUser({ createdAt: '2021-03-01' });
+        sending2 = poleEmploiSendingFactory.buildWithUser({ createdAt: '2021-04-01' });
+        sending3 = poleEmploiSendingFactory.buildWithUser({ createdAt: '2021-05-01' });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should render sendings order by date', async () => {
+        const sendings = await poleEmploiSendingRepository.find();
+
+        expect(sendings.map((sending) => sending.idEnvoi)).to.deep.equal([sending3.id, sending2.id, sending1.id,]);
       });
     });
   });

--- a/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
+++ b/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
@@ -3,7 +3,7 @@ const { expect, databaseBuilder, domainBuilder, knex, learningContentBuilder, mo
 const computePoleEmploiSendings = require('../../../../scripts/prod/compute-pole-emploi-sendings');
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSending');
-
+const poleEmploiSendingFactory = databaseBuilder.factory.poleEmploiSendingFactory;
 function setLearningContent(learningContent) {
   const learningObjects = learningContentBuilder.buildLearningContent(learningContent);
   mockLearningContent(learningObjects);
@@ -280,8 +280,8 @@ describe('computePoleEmploiSendings', () => {
   context('when only one pole emploi sendings is missing', () => {
     beforeEach(() => {
       campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isShared: true, sharedAt: new Date('2021-10-10') }).id;
-      databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId, type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START });
-      databaseBuilder.factory.buildPoleEmploiSending({ campaignParticipationId, type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION });
+      poleEmploiSendingFactory.build({ campaignParticipationId, type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START });
+      poleEmploiSendingFactory.build({ campaignParticipationId, type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION });
       databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'completed', type: 'CAMPAIGN' });
       databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId, snappedAt: new Date('2021-10-10'), snapshot: JSON.stringify([]) });
       return databaseBuilder.commit();

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -10,35 +10,44 @@ describe('Unit | Controller | pole-emplois-controller', () => {
       it('should return the pole emploi sending', async () => {
         // given
         const request = { query: { curseur: 'azefvbjljhgrEDJNH' } };
-        const sending = [{
-          idEnvoi: 456,
-          dateEnvoi: new Date('2021-05-01'),
-          resultat: {
-            campagne: {
-              nom: 'Campagne PE',
-              dateDebut: '2020-08-01T00:00:00.000Z',
-              type: 'EVALUATION',
-              codeCampagne: 'POLEEMPLOI123',
-              urlCampagne: 'https://app.pix.fr/campagnes/POLEEMPLOI123',
-              nomOrganisme: 'Pix',
-              typeOrganisme: 'externe' },
-            individu: {
-              nom: 'Kamado',
-              prenom: 'Tanjiro',
-              idPoleEmploi: 'externalUserId' },
-            test: {
-              etat: 2,
-              typeTest: 'DI',
-              referenceExterne: 123456,
-              dateDebut: '2020-09-01T00:00:00.000Z',
-              elementsEvalues: [] } } }];
-        sinon.stub(usecases, 'getPoleEmploiSendings').withArgs({ cursor: request.query.curseur }).resolves(sending);
+        const sending = [{ idEnvoi: 456 }];
+        sinon.stub(usecases, 'getPoleEmploiSendings').resolves(sending);
 
         // when
         await poleEmploiController.getSendings(request, hFake);
 
         //then
-        expect(usecases.getPoleEmploiSendings).have.been.calledWith({ cursor: 'azefvbjljhgrEDJNH' });
+        expect(usecases.getPoleEmploiSendings).have.been.calledWith({ cursor: 'azefvbjljhgrEDJNH', filters: {} });
+      });
+    });
+    context('when there are filters', function() {
+      context('when enErreur is \'false\'', function() {
+        it('should return the pole emploi sending', async () => {
+          // given
+          const request = { query: { curseur: 'azefvbjljhgrEDJNH', enErreur: false } };
+          const sending = [{ idEnvoi: 456 }];
+          sinon.stub(usecases, 'getPoleEmploiSendings').resolves(sending);
+
+          // when
+          await poleEmploiController.getSendings(request, hFake);
+
+          //then
+          expect(usecases.getPoleEmploiSendings).have.been.calledWith({ cursor: 'azefvbjljhgrEDJNH', filters: { isSuccessful: true } });
+        });
+      });
+      context('when enErreur is \'true\'', function() {
+        it('should return the pole emploi sending', async () => {
+          // given
+          const request = { query: { curseur: 'azefvbjljhgrEDJNH', enErreur: true } };
+          const sending = [{ idEnvoi: 456 }];
+          sinon.stub(usecases, 'getPoleEmploiSendings').resolves(sending);
+
+          // when
+          await poleEmploiController.getSendings(request, hFake);
+
+          //then
+          expect(usecases.getPoleEmploiSendings).have.been.calledWith({ cursor: 'azefvbjljhgrEDJNH', filters: { isSuccessful: false } });
+        });
       });
     });
   });

--- a/api/tests/unit/domain/services/pole-emploi-service_test.js
+++ b/api/tests/unit/domain/services/pole-emploi-service_test.js
@@ -26,6 +26,45 @@ describe('Unit | Service | Pole Emploi Service', function() {
       // then
       expect(generatedLink).to.equal('https://url-externe/pole-emploi/envois?curseur=eyJpZEVudm9pIjo0NTYsImRhdGVFbnZvaSI6IjIwMjEtMDUtMDFUMDA6MDA6MDAuMDAwWiJ9');
     });
+
+    context('when there is a filter', () => {
+      context('when isSuccessful is true', () => {
+        it('should generate a link with a query params using the filters', function() {
+          const sending = {
+            idEnvoi: 456,
+            dateEnvoi: '2021-05-01T00:00:00.000Z',
+            resultat: { } };
+
+          const filters = {
+            isSuccessful: true,
+          };
+
+          // when
+          const generatedLink = poleEmploiService.generateLink(sending, filters);
+
+          // then
+          expect(generatedLink).to.equal('https://url-externe/pole-emploi/envois?curseur=eyJpZEVudm9pIjo0NTYsImRhdGVFbnZvaSI6IjIwMjEtMDUtMDFUMDA6MDA6MDAuMDAwWiJ9&enErreur=false');
+        });
+      });
+      context('when isSuccessful is false', () => {
+        it('should generate a link with a query params using the filters', function() {
+          const sending = {
+            idEnvoi: 456,
+            dateEnvoi: '2021-05-01T00:00:00.000Z',
+            resultat: { } };
+
+          const filters = {
+            isSuccessful: false,
+          };
+
+          // when
+          const generatedLink = poleEmploiService.generateLink(sending, filters);
+
+          // then
+          expect(generatedLink).to.equal('https://url-externe/pole-emploi/envois?curseur=eyJpZEVudm9pIjo0NTYsImRhdGVFbnZvaSI6IjIwMjEtMDUtMDFUMDA6MDA6MDAuMDAwWiJ9&enErreur=true');
+        });
+      });
+    });
   });
 
   describe('#decodeCursor', function() {


### PR DESCRIPTION
## :unicorn: Problème
Le end point de récupération des résultats à la campagne Pôle emploi ne permet pas de récupérer les résultats des envois qui ont échoué.

## :robot: Solution
Ajouter un paramètre pour sélectionner le statut de l'envoi

## :rainbow: Remarques
Les filtres doivent être inclus dans le lien permettant de récupérer les résultats suivants.

## :100: Pour tester
- création d'un jeton pole-emploi
- avec le jeton pole emploi généré, récupération des 100 premiers résultats en ajoutant le paramètre `enErreur` dans la requête + du lien dans le header 
- avec le lien du header, récupérer les 100 prochains.

