### PR TITLE
[CLEANUP] Lancer eslint sur high-level-tests/{test-algo,e2e}

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,10 @@ jobs:
             - ~/.npm
 
       - run:
+          name: Lint
+          command: npm run lint
+
+      - run:
           working_directory: ~/pix/api
           command: cat package*.json > cachekey
       - restore_cache:
@@ -377,6 +381,10 @@ jobs:
           key: v7-test-algo-npm-{{ checksum "~/pix/high-level-tests/test-algo/cachekey" }}
           paths:
             - ~/.npm
+
+      - run:
+          name: Lint
+          command: npm run lint
 
       - run:
           name: Test

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/1024pix/pix"
   },
   "scripts": {
+    "lint": "eslint .",
     "cy:open": "npm run db:initialize && cypress open",
     "cy:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:open",
     "cy:run": "npm run db:initialize && cypress run --browser=chrome && exit",


### PR DESCRIPTION
## :unicorn: Problème
Eslint n'était pas lancé dans les dossiers high-level-tests/test-algo et high-level-tests/e2e.

## :robot: Solution
Lancer le lint pour ces 2 dossiers.


## :100: Pour tester
Vérifier que le build est au vert.