### PR TITLE
[TECH] Ameliorer l'affichage d'erreur sur le scoring (PIX-2808)

### DIFF
--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -1,6 +1,7 @@
 const {
   UNCERTIFIED_LEVEL,
 } = require('../constants');
+const { DomainError } = require('../errors');
 
 class CertifiedLevel {
   constructor({ value, status }) {
@@ -382,7 +383,7 @@ const _rules = {
   },
 };
 
-class MissingCertifiedLevelRuleError extends Error {
+class MissingCertifiedLevelRuleError extends DomainError {
   constructor({
     numberOfChallenges,
     numberOfCorrectAnswers,


### PR DESCRIPTION
## :unicorn: Problème
Les erreurs de scoring `MissingCertifiedLevelRuleError` s'affichent incorrectement 

> [Object, Object]

## :robot: Solution
`MissingCertifiedLevelRuleError` doit étendre `DomainError` pour que l'affichage se fasse correctement

## :100: Pour tester
- Générer un test avec 2 qrocM-dep et voir que le message s'affiche correctement en voulait refaire le scoring
ou
- Forcer une erreure pour lever une `MissingCertifiedLevelRuleError` et voir que le message s'affiche correctement