### PR TITLE
[BUGFIX] Corriger certaines régressions suite au développement CPF (PIX-2628).

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -89,7 +89,7 @@
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Temps majoré (%)</span>
             <span class="certification-candidate-details-modal__row__value" data-test-id="extra-time-row">
-              {{if @candidate.extraTimePercentage @candidate.extraTimePercentage "-"}}
+              {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
             </span>
           </li>
         </ul>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -211,7 +211,7 @@
             />
           </div>
 
-          <div id="recipient-email-container" class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
+          <div id="recipient-email-container" class="new-certification-candidate-details-modal__form__field">
             <label for="result-recipient-email" class="label">E-mail du destinataire des résultats (formateur, enseignant...)</label>
             <Input
               @id="result-recipient-email"
@@ -222,7 +222,7 @@
             />
           </div>
 
-          <div id="email-container" class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
+          <div id="email-container" class="new-certification-candidate-details-modal__form__field">
             <label for="email" class="label">E-mail de convocation</label>
             <Input
               @id="email"

--- a/certif/app/routes/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/routes/authenticated/sessions/details/certification-candidates.js
@@ -5,9 +5,7 @@ export default class CertificationCandidatesRoute extends Route {
     const details = await this.modelFor('authenticated.sessions.details');
     const countries = await this.store.findAll('country');
 
-    return {
-      ...details,
-      countries,
-    };
+    details.set('countries', countries);
+    return details;
   }
 }

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -50,7 +50,7 @@
 
         &.radio-button-label {
           display: inline-block;
-          margin: 0px 16px 0px 8px;
+          margin: 0 16px 0 8px;
         }
       }
 

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -427,6 +427,17 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
             // then
             assert.dom('table tbody tr').exists({ count: 1 });
           });
+
+          test('it should display the attendance sheet download button', async function(assert) {
+            // given
+            // when
+            await clickByLabel('Ajouter un candidat');
+            await _fillFormWithCorrectDataForCPF();
+            await clickByLabel('Ajouter le candidat');
+
+            // then
+            assert.contains('Feuille d\'émargement');
+          });
         });
       });
     });

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -21,7 +21,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       resultRecipientEmail: 'suric@animal.fr',
       externalId: '12345',
       birthdate: '2000-12-25',
-      extraTimePercentage: 10,
+      extraTimePercentage: 0.10,
       birthInseeCode: 76255,
       birthPostalCode: 76260,
       sex: 'F',
@@ -52,7 +52,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
     assert.contains('suric@animal.fr');
     assert.contains('12345');
     assert.contains('25/12/2000');
-    assert.contains('10');
+    assert.contains('10 %');
   });
 
   module('when candidate has missing data', () => {

--- a/certif/tests/unit/routes/authenticated/sessions/details/certification-candidate_test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/details/certification-candidate_test.js
@@ -1,5 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import EmberObject from '@ember/object';
+import pick from 'lodash/pick';
 import sinon from 'sinon';
 
 module('Unit | Route | authenticated/sessions/details/certification-candidates', function(hooks) {
@@ -11,12 +13,9 @@ module('Unit | Route | authenticated/sessions/details/certification-candidates',
   });
 
   module('#model', function(hooks) {
-    const details = { session: Symbol('session') };
+    const session = Symbol('session');
     const countries = Symbol('countries');
-    const expectedModel = {
-      ...details,
-      countries,
-    };
+    const details = EmberObject.create({ session });
 
     hooks.beforeEach(function() {
       route.modelFor = sinon.stub().returns(details);
@@ -24,13 +23,16 @@ module('Unit | Route | authenticated/sessions/details/certification-candidates',
     });
 
     test('it should return the expectedModel', async function(assert) {
+      // given
+      const expectedModel = { session, countries };
+
       // when
       const actualModel = await route.model();
 
       // then
       sinon.assert.calledWith(route.modelFor, 'authenticated.sessions.details');
       sinon.assert.calledWith(route.store.findAll, 'country');
-      assert.deepEqual(actualModel, expectedModel);
+      assert.deepEqual(pick(actualModel, ['session', 'countries']), expectedModel);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Certaines régressions ont été constatées suite au différents développements liés au CPF.

## :robot: Solution
- Corriger les régressions suivantes:
   - Le bouton de téléchargement de la feuille d'émargement ne s'affiche plus dés l'ajout du premier candidat.
   - Mauvais affichage du temps majoré sur la modale de détail d'un candidat PixCertif.
   - Correction de l'affichage des inputs d'e-mail suite au changement de label (taille plus grande qui entraîne un décalage vertical). 