### PR TITLE
[FEATURE] Téléchargement des attestations par classe : mise en place du feature toggle (PIX-2842)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -143,6 +143,7 @@ module.exports = (function() {
     featureToggles: {
       isScoAccountRecoveryEnabled: isFeatureEnabled(process.env.IS_SCO_ACCOUNT_RECOVERY_ENABLED),
       isNewCPFDataEnabled: isFeatureEnabled(process.env.FT_IS_NEW_CPF_DATA_ENABLED),
+      isDownloadCertificationAttestationByDivisionEnabled: isFeatureEnabled(process.env.FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED),
     },
 
     infra: {

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,6 +23,7 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
         data: {
           id: '0',
           attributes: {
+            'is-download-certification-attestation-by-division-enabled': false,
             'is-sco-account-recovery-enabled': false,
             'is-new-cpf-data-enabled': false,
           },

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -9,6 +9,7 @@ export default class AuthenticatedCertificationsController extends Controller {
   @service currentUser;
   @service notifications;
   @service intl;
+  @service featureToggles;
 
   @tracked selectedDivision = '';
 
@@ -55,6 +56,10 @@ export default class AuthenticatedCertificationsController extends Controller {
     }
 
     return `${this.model.options[0].label}, ${this.model.options[1].label} …`;
+  }
+
+  get isCertificationAttestationDownloadEnabled() {
+    return this.featureToggles.featureToggles.isDownloadCertificationAttestationByDivisionEnabled;
   }
 }
 

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,4 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
+  @attr('boolean') isDownloadCertificationAttestationByDivisionEnabled;
 }

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -17,9 +17,14 @@
       required={{true}}
       autocomplete="off"
     />
-    <button class="button" type="submit">
+    <button class="button" type="submit" id="download_results">
       {{t 'pages.certifications.download-button'}}
     </button>
+    {{#if this.isCertificationAttestationDownloadEnabled}}
+      <button class="button" type="submit" id="download_attestations">
+        {{t 'pages.certifications.download-attestations-button'}}
+      </button>
+    {{/if}}
   </form>
 
   <PixMessage @withIcon={{true}}>

--- a/orga/tests/acceptance/certifications_test.js
+++ b/orga/tests/acceptance/certifications_test.js
@@ -51,6 +51,30 @@ module('Acceptance | Certifications page', function(hooks) {
       // then
       assert.dom('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]').exists();
     });
+
+    test('should display attestation download button if toggle is enabled', async function(assert)
+    {
+      // given
+      server.create('feature-toggle', { id: 0, isDownloadCertificationAttestationByDivisionEnabled: true });
+
+      // when
+      await visit('/certifications');
+
+      // then
+      assert.dom('button[id="download_attestations"]').exists();
+    });
+
+    test('should not display attestation download button when toggle not enabled', async function(assert)
+    {
+      // given
+      server.create('feature-toggle', { id: 0 });
+
+      // when
+      await visit('/certifications');
+
+      // then
+      assert.dom('button[id="download_attestations"]').doesNotExist();
+    });
   });
 });
 

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
+import { run } from '@ember/runloop';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Unit | Controller | authenticated/certifications', function(hooks) {
@@ -112,6 +113,34 @@ module('Unit | Controller | authenticated/certifications', function(hooks) {
         { autoClear: false },
       );
       assert.ok(true);
+    });
+  });
+
+  module('#isCertificationAttestationDownloadEnabled', function() {
+    test('should return true if toggle is enabled', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const featureToggles = run(() => store.createRecord('feature-toggle', { isDownloadCertificationAttestationByDivisionEnabled: true }));
+      class FeatureTogglesStub extends Service { featureToggles = featureToggles; }
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+
+      const controller = this.owner.lookup('controller:authenticated/certifications');
+
+      // when / then
+      assert.ok(controller.isCertificationAttestationDownloadEnabled);
+    });
+
+    test('should return false if toggle is disabled', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const featureToggles = run(() => store.createRecord('feature-toggle', { isDownloadCertificationAttestationByDivisionEnabled: false }));
+      class FeatureTogglesStub extends Service { featureToggles = featureToggles; }
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+
+      const controller = this.owner.lookup('controller:authenticated/certifications');
+
+      // when / then
+      assert.notOk(controller.isCertificationAttestationDownloadEnabled);
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -412,6 +412,8 @@
       "documentation-link-label": "Interpreting the results.",
       "documentation-link-notice": "Follow this link to find indications on how to interpret the results: ",
       "download-button": "Export the results",
+      "download-attestations-button": "Download attestations",
+
       "errors": {
         "invalid-division": "The class {selectedDivision} does not exist.",
         "no-results": "No certification results for the class {selectedDivision}."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -412,6 +412,7 @@
       "documentation-link-label": "Interprétation des résultats.",
       "documentation-link-notice": "Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats : ",
       "download-button": "Exporter les résultats",
+      "download-attestations-button": "Télécharger les attestations",
       "errors": {
         "invalid-division": "La classe {selectedDivision} n'existe pas.",
         "no-results": "Aucun résultat de certification pour la classe {selectedDivision}."


### PR DESCRIPTION
## :unicorn: Problème
1) Les établissements scolaires qui gèrent une liste d'élèves souhaitent pouvoir télécharger toutes les attestations de certification de ses élèves afin de pouvoir organiser une remise officielle de diplôme. 

2) De plus, nous souhaitons pouvoir développer cet Epix tout en l'intégrant au fil de l'eau avec le code de production.

## :robot: Solution
1) Permettre aux administrateurs Pix Orga, qui peuvent déjà récupérer le fichier csv des résultats par classe depuis l’onglet “Certifications”, de télécharger les attestations de certifications des élèves, par classe également.

2) Mettre en place une prod cachée par feature toggle.

## :rainbow: Remarques
R.A.S.

## :100: Pour tester
- Sans avoir activé le toggle `FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED`, se connecter à Pix Orga à l'aide de l'utilisateur `sco.admin@example.net` : constater l'absence d'un bouton "Téléchargement de attestions" sur l'onglet "Certifications"
- Après avoir activé le toggle `FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED`, se connecter à Pix Orga à l'aide de l'utilisateur `sco.admin@example.net` : constater la présence d'un bouton "Téléchargement de attestions" sur l'onglet "Certifications"
