### PR TITLE
[INFRA] Ajouter des helpers de tests getByLabel et queryByLabel

### DIFF
--- a/certif/tests/helpers/extended-ember-test-helpers/click-by-label.js
+++ b/certif/tests/helpers/extended-ember-test-helpers/click-by-label.js
@@ -1,35 +1,8 @@
-import { click, findAll } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import getByLabel from './get-by-label';
 
 export default function clickByLabel(labelText) {
-  const clickableElement = _findClickableElementForLabel(labelText);
-
-  if (!clickableElement) {
-    throw new Error(`Cannot find clickable element labelled "${labelText}".`);
-  }
+  const clickableElement = getByLabel(labelText);
 
   return click(clickableElement);
-}
-
-function _findClickableElementForLabel(labelText) {
-  const clickableSelectors = ['button', 'a[href]', '[role="button"]', 'input[type="radio"]', 'input[type="checkbox"]', 'label[for]'];
-  return findAll(clickableSelectors.join(',')).find(_matchesLabel(labelText));
-}
-
-function _matchesLabel(labelText) {
-  return (element) => _matchesInnerText(element, labelText) ||
-                      _matchesTitle(element, labelText) ||
-                      _matchesAriaLabel(element, labelText);
-}
-
-function _matchesInnerText(element, labelText) {
-  return element.innerText.includes(labelText);
-}
-
-function _matchesTitle(element, labelText) {
-  return element.title && element.title.includes(labelText);
-}
-
-function _matchesAriaLabel(element, labelText) {
-  const ariaLabel = element.getAttribute('aria-label');
-  return ariaLabel && ariaLabel.includes(labelText);
 }

--- a/certif/tests/helpers/extended-ember-test-helpers/fill-in-by-label.js
+++ b/certif/tests/helpers/extended-ember-test-helpers/fill-in-by-label.js
@@ -1,36 +1,8 @@
-import { fillIn, findAll, find } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
+import getByLabel from './get-by-label';
 
 export default function fillInByLabel(labelText, value) {
-  const control = _findControlForLabel(labelText);
+  const control = getByLabel(labelText);
 
   return fillIn(control, value);
-}
-
-function _findControlForLabel(labelText) {
-  const label = _findLabel(labelText);
-  if (label && label.control) return label.control;
-
-  const control = _findControl(labelText);
-  if (control) return control;
-
-  if (label && !label.control) {
-    throw new Error(`Found label "${labelText}" but no associated form control.`);
-  }
-  throw new Error(`Cannot find form control labelled "${labelText}".`);
-}
-
-function _findLabel(labelText) {
-  return findAll('label').find((label) => label.innerText.includes(labelText));
-}
-
-function _findControl(labelText) {
-  const selectors = [];
-
-  for (const tag of ['input', 'textarea', 'select']) {
-    for (const attr of ['aria-label', 'title']) {
-      selectors.push(`${tag}[${attr}="${labelText}"]`);
-    }
-  }
-
-  return find(selectors.join(','));
 }

--- a/certif/tests/helpers/extended-ember-test-helpers/get-by-label.js
+++ b/certif/tests/helpers/extended-ember-test-helpers/get-by-label.js
@@ -1,0 +1,10 @@
+import queryByLabel from './query-by-label';
+
+export default function getByLabel(labelText) {
+  const labelledElement = queryByLabel(labelText);
+  if (!labelledElement) {
+    throw new Error(`Cannot find any element labelled "${labelText}".`);
+  }
+
+  return labelledElement;
+}

--- a/certif/tests/helpers/extended-ember-test-helpers/query-by-label.js
+++ b/certif/tests/helpers/extended-ember-test-helpers/query-by-label.js
@@ -1,0 +1,56 @@
+import { findAll } from '@ember/test-helpers';
+
+export default function queryByLabel(labelText) {
+  const labelElement = _findLabelElement(labelText);
+  if (labelElement) {
+    return _getElementControlledByLabel(labelElement, labelText);
+  }
+
+  const labelledElement = _findElementWithLabel(labelText);
+  if (!labelledElement) {
+    return null;
+  }
+
+  return labelledElement;
+}
+
+function _findLabelElement(labelText) {
+  return findAll('label').find((label) => label.innerText.includes(labelText));
+}
+
+function _getElementControlledByLabel(label, labelText) {
+  if (!label.control) {
+    throw new Error(`Found label "${labelText}" but no associated form control.`);
+  }
+
+  return label.control;
+}
+
+function _findElementWithLabel(labelText) {
+  const labellableElementSelectors = ['button', 'a[href]', '[role="button"]', 'input', 'textarea', 'select', 'label[for]', 'img'];
+  return findAll(labellableElementSelectors.join(',')).find(_matchesLabel(labelText));
+}
+
+function _matchesLabel(labelText) {
+  return (element) => _matchesInnerText(element, labelText)
+    || _matchesTitle(element, labelText)
+    || _matchesAriaLabel(element, labelText)
+    || _matchesAltAttribute(element, labelText);
+}
+
+function _matchesInnerText(element, labelText) {
+  return element.innerText.includes(labelText);
+}
+
+function _matchesTitle(element, labelText) {
+  return element.title?.includes(labelText);
+}
+
+function _matchesAltAttribute(element, labelText) {
+  return element.alt?.includes(labelText);
+}
+
+function _matchesAriaLabel(element, labelText) {
+  const ariaLabel = element.getAttribute('aria-label');
+  return ariaLabel?.includes(labelText);
+}

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -5,6 +5,8 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+import getByLabel from '../../../helpers/extended-ember-test-helpers/get-by-label';
+import queryByLabel from '../../../helpers/extended-ember-test-helpers/query-by-label';
 
 module('Integration | Component | new-certification-candidate-modal', function(hooks) {
   setupRenderingTest(hooks);
@@ -36,20 +38,20 @@ module('Integration | Component | new-certification-candidate-modal', function(h
     `);
 
     // then
-    assert.dom('#last-name').exists();
-    assert.dom('#last-name').isFocused();
-    assert.dom('#first-name').exists();
-    assert.dom('#male').exists();
-    assert.dom('#female').exists();
-    assert.dom('#birthdate').exists();
-    assert.dom('#birth-country').exists();
-    assert.dom('#insee-code-choice').exists();
-    assert.dom('#postal-code-choice').exists();
-    assert.dom('#birth-insee-code').exists();
-    assert.dom('#external-id').exists();
-    assert.dom('#extra-time-percentage').exists();
-    assert.dom('#result-recipient-email').exists();
-    assert.dom('#email').exists();
+    assert.dom(getByLabel('Nom de famille')).exists();
+    assert.dom(getByLabel('Nom de famille')).isFocused();
+    assert.dom(getByLabel('Prénom')).exists();
+    assert.dom(getByLabel('Homme')).exists();
+    assert.dom(getByLabel('Femme')).exists();
+    assert.dom(getByLabel('Date de naissance')).exists();
+    assert.dom(getByLabel('Pays de naissance')).exists();
+    assert.dom(getByLabel('Code INSEE')).exists();
+    assert.dom(getByLabel('Code postal')).exists();
+    assert.dom(getByLabel('Code INSEE de naissance')).exists();
+    assert.dom(getByLabel('Identifiant externe')).exists();
+    assert.dom(getByLabel('Temps majoré (%)')).exists();
+    assert.dom(getByLabel('E-mail du destinataire des résultats')).exists();
+    assert.dom(getByLabel('E-mail de convocation')).exists();
   });
 
   test('it shows a countries list with France selected as default', async function(assert) {
@@ -83,10 +85,10 @@ module('Integration | Component | new-certification-candidate-modal', function(h
     `);
 
     // then
-    assert.dom('#birth-country').exists();
-    assert.dom('#birth-country').includesText('Syldavie');
-    assert.dom('#birth-country').includesText('Botswana');
-    assert.dom('#birth-country').hasValue('99100');
+    const birthCountryField = getByLabel('Pays de naissance');
+    assert.dom(birthCountryField).includesText('Syldavie');
+    assert.dom(birthCountryField).includesText('Botswana');
+    assert.dom(birthCountryField).hasValue('99100');
   });
 
   module('when close button cross icon is clicked', () => {
@@ -186,9 +188,9 @@ module('Integration | Component | new-certification-candidate-modal', function(h
       await fillInByLabel('Pays de naissance', '99123');
 
       // then
-      assert.dom('#birth-insee-code').isNotVisible();
-      assert.dom('#birth-postal-code').isNotVisible();
-      assert.dom('#birth-city').isVisible();
+      assert.dom(queryByLabel('Code INSEE de naissance')).isNotVisible();
+      assert.dom(queryByLabel('Code postal de naissance')).isNotVisible();
+      assert.dom(queryByLabel('Commune de naissance')).isVisible();
     });
   });
 
@@ -221,9 +223,9 @@ module('Integration | Component | new-certification-candidate-modal', function(h
       await clickByLabel('Code INSEE');
 
       // then
-      assert.dom('#birth-insee-code').isVisible();
-      assert.dom('#birth-postal-code').isNotVisible();
-      assert.dom('#birth-city').isNotVisible();
+      assert.dom(queryByLabel('Code INSEE de naissance')).isVisible();
+      assert.dom(queryByLabel('Code postal de naissance')).isNotVisible();
+      assert.dom(queryByLabel('Commune de naissance')).isNotVisible();
     });
   });
 
@@ -256,9 +258,9 @@ module('Integration | Component | new-certification-candidate-modal', function(h
       await clickByLabel('Code postal');
 
       // then
-      assert.dom('#birth-insee-code').isNotVisible();
-      assert.dom('#birth-postal-code').isVisible();
-      assert.dom('#birth-city').isVisible();
+      assert.dom(queryByLabel('Code INSEE de naissance')).isNotVisible();
+      assert.dom(queryByLabel('Code postal de naissance')).isVisible();
+      assert.dom(queryByLabel('Commune de naissance')).isVisible();
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Il existe aujourd'hui des helpers de test très pratiques `clickByLabel` ou `fillInByLabel` qui permettent de sélectionner un élément HTML via son label puis de cliquer dessus ou de le remplir (dans le cas d'un champ de formulaire).
Mais on a parfois besoin de sélectionner un élément pour faire une autre opération ou simplement vérifier son existence (ou sa non existence).

## :robot: Solution

Cette PR ajoute deux helpers :
- `queryByLabel(label: string)` qui retourne l'élément correspondant au label ou `null` s'il n'existe pas (utile pour vérifier qu'un élément n'est pas présent)
- `getByLabel(label: string)` qui retourne l'élément correspondant au label ou lève une exception s'il n'existe pas

C'est particulièrement utile pour les champs de formulaire car utiliser `assert.dom(getByLabel('Prénom')).exists()` plutôt que `assert.dom('#first-name').exists()` permet en une assertion de vérifier à la fois :
- que l'élément `input` est présent
- que l'élement `label` est présent
- que les deux sont bien reliés ensemble

## :rainbow: Remarques

- l'API s'inspire de l'excellente [Testing Library](https://testing-library.com/docs/queries/about#types-of-queries) qui n'est malheureusement pas compatible avec Ember
- Un test utilisant les helpers a été ajouté dans Pix Certif à titre d'exemple

## :100: Pour tester

Lancer les tests de Pix Certif
