### PR TITLE
[FEATURE] Séparer l'édition des informations candidat du reste sur la page dans PixAdmin (PIX-2837)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -22,6 +22,7 @@ export default class CertificationInformationsController extends Controller {
   // Properties
   @alias('model') certification;
   @tracked editingCandidateResults = false;
+  @tracked editingCandidateInformations = false;
   @service notifications;
   @tracked displayConfirm = false;
   @tracked confirmMessage = '';
@@ -202,6 +203,22 @@ export default class CertificationInformationsController extends Controller {
     }
 
     this.displayConfirm = false;
+  }
+
+  @action
+  onCandidateInformationsEdit() {
+    this.editingCandidateInformations = true;
+  }
+
+  @action
+  onCandidateInformationsCancel() {
+    this.editingCandidateInformations = false;
+  }
+
+  @action
+  onCandidateInformationsSave(event) {
+    event.preventDefault();
+    this.editingCandidateInformations = false;
   }
 
   // Private methods

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -21,12 +21,12 @@ export default class CertificationInformationsController extends Controller {
 
   // Properties
   @alias('model') certification;
-  @tracked edition = false;
+  @tracked editingCandidateResults = false;
   @service notifications;
   @tracked displayConfirm = false;
   @tracked confirmMessage = '';
   @tracked confirmErrorMessage = '';
-  @tracked confirmAction = 'onSave';
+  @tracked confirmAction = 'onCandidateResultsSave';
 
   // private properties
   _competencesCopy = null;
@@ -68,14 +68,14 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
-  onEdit() {
-    this.edition = true;
+  onCandidateResultsEdit() {
+    this.editingCandidateResults = true;
     this._competencesCopy = this._copyCompetences();
   }
 
   @action
-  onCancel() {
-    this.edition = false;
+  onCandidateResultsCancel() {
+    this.editingCandidateResults = false;
     this.certification.rollbackAttributes();
     if (this._competencesCopy) {
       this.certification.competencesWithMark = this._competencesCopy;
@@ -84,24 +84,24 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
-  onSaveConfirm() {
+  onCandidateResultsSaveConfirm() {
     const confirmMessage = 'Souhaitez-vous mettre à jour cette certification ?';
     const errors = this._getCertificationErrorsAfterJuryUpdateIfAny();
     const confirmErrorMessage = this._formatErrorsToHtmlString(errors);
 
     this.confirmMessage = confirmMessage;
     this.confirmErrorMessage = confirmErrorMessage;
-    this.confirmAction = 'onSave';
+    this.confirmAction = 'onCandidateResultsSave';
     this.displayConfirm = true;
   }
 
   @action
-  onCancelConfirm() {
+  onCandidateResultsCancelConfirm() {
     this.displayConfirm = false;
   }
 
   @action
-  async onSave() {
+  async onCandidateResultsSave() {
     const markUpdatedRequired = this.certification.hasDirtyAttributes;
     this.displayConfirm = false;
     try {
@@ -112,7 +112,7 @@ export default class CertificationInformationsController extends Controller {
       }
 
       this.notifications.success('Modifications enregistrées');
-      this.edition = false;
+      this.editingCandidateResults = false;
       this._competencesCopy = null;
 
     } catch (e) {
@@ -173,7 +173,7 @@ export default class CertificationInformationsController extends Controller {
         });
       this.certification.competencesWithMark = A(newCompetences);
       schedule('afterRender', this, () => {
-        this.edition = true;
+        this.editingCandidateResults = true;
       });
     }
   }

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -103,14 +103,9 @@ export default class CertificationInformationsController extends Controller {
 
   @action
   async onCandidateResultsSave() {
-    const markUpdatedRequired = this.certification.hasDirtyAttributes;
     this.displayConfirm = false;
     try {
-      await this.saveWithoutUpdatingCompetenceMarks();
-
-      if (markUpdatedRequired) {
-        await this.saveWithUpdatingCompetenceMarks();
-      }
+      await this.saveAssessementResult();
 
       this.notifications.success('Modifications enregistrées');
       this.editingCandidateResults = false;
@@ -127,11 +122,11 @@ export default class CertificationInformationsController extends Controller {
     }
   }
 
-  saveWithUpdatingCompetenceMarks() {
+  saveAssessementResult() {
     return this.certification.save({ adapterOptions: { updateMarks: true } });
   }
 
-  saveWithoutUpdatingCompetenceMarks() {
+  saveCertificationCourse() {
     return this.certification.save({ adapterOptions: { updateMarks: false } });
   }
 
@@ -220,7 +215,7 @@ export default class CertificationInformationsController extends Controller {
     event.preventDefault();
 
     try {
-      await this.saveWithoutUpdatingCompetenceMarks();
+      await this.saveCertificationCourse();
       this.notifications.success('Les informations du candidat ont bien été enregistrées.');
       this.editingCandidateInformations = false;
     } catch (e) {

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -216,9 +216,22 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
-  onCandidateInformationsSave(event) {
+  async onCandidateInformationsSave(event) {
     event.preventDefault();
-    this.editingCandidateInformations = false;
+
+    try {
+      await this.saveWithoutUpdatingCompetenceMarks();
+      this.notifications.success('Les informations du candidat ont bien été enregistrées.');
+      this.editingCandidateInformations = false;
+    } catch (e) {
+      if (e.errors && e.errors.length > 0) {
+        e.errors.forEach((error) => {
+          this.notifications.error(error.detail);
+        });
+      } else {
+        this.notifications.error(e);
+      }
+    }
   }
 
   // Private methods

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -49,4 +49,19 @@
     content: "🚨";
     margin-right: 8px;
   }
+
+  .certification-informations {
+    &__actions {
+      display: flex;
+      margin-top: 8px;
+      justify-content: center;
+    }
+  }
+
+  .candidate-informations {
+    &__actions {
+      display: flex;
+      margin-top: 8px;
+    }
+  }
 }

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -12,7 +12,7 @@
   </div>
   <div class="row">
     <div class="col">
-      <div class="card">
+      <div class="card {{if this.editingCandidateResults 'border-primary'}}">
         <div class="card-body">
           <h5 class="card-title">
             <Certification::CertificationInfoPublished @record={{this.certification}} @float={{true}} />État
@@ -31,20 +31,50 @@
       </div>
     </div>
     <div class="col">
-      <div class="card {{if this.editingCandidateResults 'border-primary'}}">
-        <div class="card-body">
+      <div class="card {{if this.editingCandidateInformations 'border-primary'}}">
+        <div class="card-body candidate-informations">
           <h5 class="card-title">Candidat</h5>
           <div class="card-text">
-            <Certification::CertificationInfoField @value={{this.certification.firstName}} @edition={{this.editingCandidateResults}} @label="Prénom :" @fieldId="certification-firstName" />
-            <Certification::CertificationInfoField @value={{this.certification.lastName}} @edition={{this.editingCandidateResults}} @label="Nom :" @fieldId="certification-lastName" />
-            <Certification::CertificationInfoField
-                    @isDate={{true}}
-                    @edition={{this.editingCandidateResults}}
-                    @label="Date de naissance :"
-                    @fieldId="certification-birthdate"
-                    @value={{this.certification.birthdate}}
-                    @onUpdateCertificationBirthdate={{this.onUpdateCertificationBirthdate}} />
-            <Certification::CertificationInfoField @value={{this.certification.birthplace}} @edition={{this.editingCandidateResults}} @label="Lieu de naissance :" @fieldId="certification-birthPlace" />
+            <form {{on "submit" this.onCandidateInformationsSave}}>
+              <Certification::CertificationInfoField @value={{this.certification.firstName}} @edition={{this.editingCandidateInformations}} @label="Prénom :" @fieldId="certification-firstName" />
+              <Certification::CertificationInfoField @value={{this.certification.lastName}} @edition={{this.editingCandidateInformations}} @label="Nom :" @fieldId="certification-lastName" />
+              <Certification::CertificationInfoField
+                      @isDate={{true}}
+                      @edition={{this.editingCandidateInformations}}
+                      @label="Date de naissance :"
+                      @fieldId="certification-birthdate"
+                      @value={{this.certification.birthdate}}
+                      @onUpdateCertificationBirthdate={{this.onUpdateCertificationBirthdate}} />
+              <Certification::CertificationInfoField @value={{this.certification.birthplace}} @edition={{this.editingCandidateInformations}} @label="Lieu de naissance :" @fieldId="certification-birthPlace" />
+              <div class="candidate-informations__actions">
+                {{#if this.editingCandidateInformations}}
+                  <PixButton
+                    @size="small"
+                    @backgroundColor="transparent-light"
+                    @triggerAction={{this.onCandidateInformationsCancel}}
+                    aria-label="Annuler la modification des informations du candidat"
+                  >
+                    Annuler
+                  </PixButton>
+                  <PixButton
+                    @size="small"
+                    @type="submit"
+                    aria-label="Enregistrer les informations du candidat"
+                  >
+                    Enregistrer
+                  </PixButton>
+                {{else}}
+                  <PixButton
+                    @size="small"
+                    @triggerAction={{this.onCandidateInformationsEdit}}
+                    @isDisabled={{this.editingCandidateResults}}
+                    aria-label="Modifier les informations du candidat"
+                  >
+                    Modifier
+                  </PixButton>
+                {{/if}}
+              </div>
+            </form>
           </div>
         </div>
       </div>
@@ -156,16 +186,30 @@
     <div class="row">
       <div class="col certification-informations__actions">
         {{#if this.editingCandidateResults}}
-          <button class="btn btn-secondary btn-sm" type="submit" {{on 'click' this.onCandidateResultsCancel}}>
+          <PixButton
+            @size="small"
+            @backgroundColor="transparent-light"
+            @triggerAction={{this.onCandidateResultsCancel}}
+            aria-label="Annuler la modification des résultats du candidat"
+          >
             Annuler
-          </button>
-          <button class="btn btn-primary btn-sm" type="submit" {{on 'click' this.onCandidateResultsSaveConfirm}}>
+          </PixButton>
+          <PixButton
+            @size="small"
+            {{on 'click' this.onCandidateResultsSaveConfirm}}
+            aria-label="Enregistrer les résultats du candidat"
+          >
             Enregistrer
-          </button>
+          </PixButton>
         {{else}}
-          <button class="btn btn-primary btn-sm" type="submit" {{on 'click' this.onCandidateResultsEdit}}>
+          <PixButton
+            @size="small"
+            @triggerAction={{this.onCandidateResultsEdit}}
+            aria-label="Modifier les résultats du candidat"
+            @isDisabled={{this.editingCandidateInformations}}
+          >
             Modifier
-          </button>
+          </PixButton>
         {{/if}}
       </div>
     </div>

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -19,7 +19,7 @@
           </h5>
           <div class="card-text">
             <Certification::CertificationInfoField @value={{this.certification.sessionId}} @edition={{false}} @label="Session :" @linkRoute="authenticated.sessions.session" />
-            <Certification::CertificationStatusSelect @certification={{this.certification}} @edition={{this.edition}} />
+            <Certification::CertificationStatusSelect @certification={{this.certification}} @edition={{this.editingCandidateResults}} />
             <Certification::CertificationInfoField @value={{this.certification.creationDate}} @edition={{false}} @label="Créée le :" />
             <Certification::CertificationInfoField @value={{this.certification.completionDate}} @edition={{false}} @label="Terminée le :" />
             <Certification::CertificationInfoField @value={{this.certification.publishedText}} @edition={{false}} @label="Publiée :" />
@@ -31,20 +31,20 @@
       </div>
     </div>
     <div class="col">
-      <div class="card {{if this.edition 'border-primary'}}">
+      <div class="card {{if this.editingCandidateResults 'border-primary'}}">
         <div class="card-body">
           <h5 class="card-title">Candidat</h5>
           <div class="card-text">
-            <Certification::CertificationInfoField @value={{this.certification.firstName}} @edition={{this.edition}} @label="Prénom :" @fieldId="certification-firstName" />
-            <Certification::CertificationInfoField @value={{this.certification.lastName}} @edition={{this.edition}} @label="Nom :" @fieldId="certification-lastName" />
+            <Certification::CertificationInfoField @value={{this.certification.firstName}} @edition={{this.editingCandidateResults}} @label="Prénom :" @fieldId="certification-firstName" />
+            <Certification::CertificationInfoField @value={{this.certification.lastName}} @edition={{this.editingCandidateResults}} @label="Nom :" @fieldId="certification-lastName" />
             <Certification::CertificationInfoField
                     @isDate={{true}}
-                    @edition={{this.edition}}
+                    @edition={{this.editingCandidateResults}}
                     @label="Date de naissance :"
                     @fieldId="certification-birthdate"
                     @value={{this.certification.birthdate}}
                     @onUpdateCertificationBirthdate={{this.onUpdateCertificationBirthdate}} />
-            <Certification::CertificationInfoField @value={{this.certification.birthplace}} @edition={{this.edition}} @label="Lieu de naissance :" @fieldId="certification-birthPlace" />
+            <Certification::CertificationInfoField @value={{this.certification.birthplace}} @edition={{this.editingCandidateResults}} @label="Lieu de naissance :" @fieldId="certification-birthPlace" />
           </div>
         </div>
       </div>
@@ -54,7 +54,7 @@
   {{#if this.hasIssueReports}}
     <div class="row">
       <div class="col">
-        <div class="card {{if this.edition 'border-primary'}}">
+        <div class="card {{if this.editingCandidateResults 'border-primary'}}">
           <div class="card-body">
             <h5 class="card-title">Signalements</h5>
 
@@ -97,25 +97,25 @@
 
   <div class="row">
     <div class="col">
-      <div class="card {{if this.edition 'border-primary'}}">
+      <div class="card {{if this.editingCandidateResults 'border-primary'}}">
         <div class="card-body">
           <h5 class="card-title">Commentaires jury</h5>
           <div class="card-text">
             <Certification::CertificationInfoField
               @value={{this.certification.commentForCandidate}}
-              @edition={{this.edition}}
+              @edition={{this.editingCandidateResults}}
               @label="Pour le candidat :"
               @fieldId="certification-commentForCandidate"
               @isTextarea={{true}} />
             <Certification::CertificationInfoField
               @value={{this.certification.commentForOrganization}}
-              @edition={{this.edition}}
+              @edition={{this.editingCandidateResults}}
               @label="Pour l'organisation :"
               @fieldId="certification-commentForOrganization"
               @isTextarea={{true}} />
             <Certification::CertificationInfoField
               @value={{this.certification.commentForJury}}
-              @edition={{this.edition}}
+              @edition={{this.editingCandidateResults}}
               @label="Pour le jury :"
               @fieldId="certification-commentForJury"
               @isTextarea={{true}} />
@@ -131,20 +131,20 @@
   </div>
   <div class="row">
     <div class="col">
-      <div class="card {{if this.edition 'border-primary'}}">
+      <div class="card {{if this.editingCandidateResults 'border-primary'}}">
         <div class="card-body">
           <h5 class="card-title">Résultats</h5>
           <div class="card-text">
             <Certification::CertificationInfoField
               @value={{this.certification.pixScore}}
-              @edition={{this.edition}}
+              @edition={{this.editingCandidateResults}}
               @label="Score :"
               @fieldId="certification-pixScore"
               @suffix=" Pix" />
             <p></p>
             <Certification::CertificationCompetenceList
                     @competences={{this.certification.competences}}
-                    @edition={{this.edition}}
+                    @edition={{this.editingCandidateResults}}
                     @onUpdateScore={{this.onUpdateScore}}
                     @onUpdateLevel={{this.onUpdateLevel}} />
           </div>
@@ -155,15 +155,15 @@
   {{#if this.isValid}}
     <div class="row">
       <div class="col certification-informations__actions">
-        {{#if this.edition}}
-          <button class="btn btn-secondary btn-sm" type="submit" {{on 'click' this.onCancel}}>
+        {{#if this.editingCandidateResults}}
+          <button class="btn btn-secondary btn-sm" type="submit" {{on 'click' this.onCandidateResultsCancel}}>
             Annuler
           </button>
-          <button class="btn btn-primary btn-sm" type="submit" {{on 'click' this.onSaveConfirm}}>
+          <button class="btn btn-primary btn-sm" type="submit" {{on 'click' this.onCandidateResultsSaveConfirm}}>
             Enregistrer
           </button>
         {{else}}
-          <button class="btn btn-primary btn-sm" type="submit" {{on 'click' this.onEdit}}>
+          <button class="btn btn-primary btn-sm" type="submit" {{on 'click' this.onCandidateResultsEdit}}>
             Modifier
           </button>
         {{/if}}
@@ -174,6 +174,6 @@
           @message={{this.confirmMessage}}
           @error={{this.confirmErrorMessage}}
           @confirm={{action this.confirmAction}}
-          @cancel={{action this.onCancelConfirm}}
+          @cancel={{action this.onCandidateResultsCancelConfirm}}
           @show={{this.displayConfirm}} />
 </div>

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -25934,8 +25934,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#991430600802cab6b6731a43e187d4944a287d7c",
-      "from": "git://github.com/1024pix/pix-ui.git#v3.5.0",
+      "version": "git://github.com/1024pix/pix-ui.git#10980986c022e5ac6dd6923b7f83d3879614ecd0",
+      "from": "git://github.com/1024pix/pix-ui.git#v5.2.1",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -95,7 +95,7 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.1",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v3.5.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.2.1",
     "popper.js": "^1.16.1",
     "query-string": "^7.0.0",
     "qunit": "^2.14.0",

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -1,0 +1,144 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+import clickByLabel from '../../../../helpers/extended-ember-test-helpers/click-by-label';
+
+module('Acceptance | Route | routes/authenticated/certifications/certification | informations', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let certification;
+
+  hooks.beforeEach(async function() {
+    const user = server.create('user');
+    await createAuthenticateSession({ userId: user.id });
+    certification = this.server.create('certification', {
+      firstName: 'Bora Horza',
+      lastName: 'Gobuchul',
+      birthdate: '1987-07-24',
+      birthplace: 'Sorpen',
+      competencesWithMark: [],
+      listChallengesAndAnswers: [],
+    });
+  });
+
+  test('it displays candidate informations', async function(assert) {
+    // when
+    await visit(`/certifications/${certification.id}`);
+
+    // then
+    assert.contains('Bora Horza');
+    assert.contains('Gobuchul');
+    assert.contains('24/07/1987');
+    assert.contains('Sorpen');
+    assert.dom('[aria-label="Modifier les informations du candidat"]').exists().isEnabled();
+    assert.dom('[aria-label="Modifier les résultats du candidat"]').exists().isEnabled();
+  });
+
+  module('when candidate information edit button is clicked', function() {
+    test('it displays candidate informations form', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les informations du candidat');
+
+      // then
+      assert.dom('#certification-firstName').hasValue('Bora Horza');
+      assert.dom('#certification-lastName').hasValue('Gobuchul');
+      assert.dom('.ember-flatpickr-input').hasValue('1987-07-24');
+      assert.dom('#certification-birthPlace').hasValue('Sorpen');
+      assert.dom('[aria-label="Annuler la modification des informations du candidat"]').exists();
+      assert.dom('[aria-label="Enregistrer les informations du candidat"]').exists();
+    });
+
+    test('it disables candidate results edit button', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les informations du candidat');
+
+      // then
+      assert.dom('[aria-label="Modifier les résultats du candidat"]').isDisabled();
+    });
+  });
+
+  module('when candidate information form cancel button is clicked', function() {
+    test('it hides candidate informations form', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les informations du candidat');
+      await clickByLabel('Annuler la modification des informations du candidat');
+
+      // then
+      assert.dom('#certification-firstName').doesNotExist();
+    });
+
+    test('it re-enables candidate results edit button', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les informations du candidat');
+      await clickByLabel('Annuler la modification des informations du candidat');
+
+      // then
+      assert.dom('[aria-label="Modifier les résultats du candidat"]').exists().isEnabled();
+    });
+  });
+
+  module('when candidate information form is submitted', function() {
+    test('it also hides candidate informations form', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les informations du candidat');
+      await clickByLabel('Enregistrer les informations du candidat');
+
+      // then
+      assert.dom('#certification-firstName').doesNotExist();
+    });
+
+    test('it also re-enables candidate results edit button', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les informations du candidat');
+      await clickByLabel('Annuler la modification des informations du candidat');
+
+      // then
+      assert.dom('[aria-label="Modifier les résultats du candidat"]').exists().isEnabled();
+    });
+  });
+
+  module('when candidate results edit button is clicked', function() {
+    test('it disables candidate informations edit button', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les résultats du candidat');
+
+      // then
+      assert.dom('[aria-label="Modifier les informations du candidat"]').isDisabled();
+    });
+  });
+
+  module('when candidate results form cancel button is clicked', function() {
+    test('it re-enables candidate informations edit button', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les résultats du candidat');
+      await clickByLabel('Annuler la modification des résultats du candidat');
+
+      // then
+      assert.dom('[aria-label="Modifier les informations du candidat"]').exists().isEnabled();
+    });
+  });
+
+  module('when candidate results form is submitted', function() {
+    test('it also re-enables candidate informations edit button', async function(assert) {
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les résultats du candidat');
+      await clickByLabel('Annuler la modification des résultats du candidat');
+
+      // then
+      assert.dom('[aria-label="Modifier les informations du candidat"]').exists().isEnabled();
+    });
+  });
+});

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -38,7 +38,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     assert.dom('[aria-label="Modifier les résultats du candidat"]').exists().isEnabled();
   });
 
-  module('when candidate information edit button is clicked', function() {
+  module('when candidate informations edit button is clicked', function() {
     test('it displays candidate informations form', async function(assert) {
       // when
       await visit(`/certifications/${certification.id}`);
@@ -63,7 +63,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     });
   });
 
-  module('when candidate information form cancel button is clicked', function() {
+  module('when candidate informations form cancel button is clicked', function() {
     test('it hides candidate informations form', async function(assert) {
       // when
       await visit(`/certifications/${certification.id}`);
@@ -85,8 +85,11 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     });
   });
 
-  module('when candidate information form is submitted', function() {
+  module('when candidate informations form is submitted', function() {
     test('it also hides candidate informations form', async function(assert) {
+      // given
+      this.server.patch('/certification-courses/:id', () => ({ data: {} }), 204);
+
       // when
       await visit(`/certifications/${certification.id}`);
       await clickByLabel('Modifier les informations du candidat');
@@ -97,6 +100,9 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     });
 
     test('it also re-enables candidate results edit button', async function(assert) {
+      // given
+      this.server.patch('/certification-courses/:id', () => ({ data: {} }), 204);
+
       // when
       await visit(`/certifications/${certification.id}`);
       await clickByLabel('Modifier les informations du candidat');
@@ -104,6 +110,36 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       // then
       assert.dom('[aria-label="Modifier les résultats du candidat"]').exists().isEnabled();
+    });
+
+    test('it should display a success notification when data is valid', async function(assert) {
+      // given
+      this.server.patch('/certification-courses/:id', () => ({ data: {} }), 204);
+
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les informations du candidat');
+      await clickByLabel('Enregistrer les informations du candidat');
+
+      // then
+      assert.dom('#certification-firstName').doesNotExist();
+      assert.contains('Les informations du candidat ont bien été enregistrées.');
+    });
+
+    test('it should display an error notification when data is invalid', async function(assert) {
+      // given
+      this.server.patch('/certification-courses/:id', () => ({
+        'errors': [{ 'detail': 'Candidate\'s first name must not be blank or empty' }],
+      }), 422);
+
+      // when
+      await visit(`/certifications/${certification.id}`);
+      await clickByLabel('Modifier les informations du candidat');
+      await clickByLabel('Enregistrer les informations du candidat');
+
+      // then
+      assert.dom('#certification-firstName').exists();
+      assert.contains('Candidate\'s first name must not be blank or empty');
     });
   });
 

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -287,7 +287,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
-  module('#onSave', () => {
+  module('#onCandidateResultsSave', () => {
 
     test('it saves competences info when save is sent', async function(assert) {
       // given
@@ -301,7 +301,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       controller.certification = certification;
 
       // when
-      await controller.onSave();
+      await controller.onCandidateResultsSave();
 
       // then
       sinon.assert.calledWith(save, { adapterOptions: { updateMarks: false } });
@@ -320,7 +320,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       controller.certification = certification;
 
       // when
-      await controller.onSave();
+      await controller.onCandidateResultsSave();
 
       // then
       sinon.assert.calledWith(save, { adapterOptions: { updateMarks: false } });
@@ -329,13 +329,13 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
-  module('#onSaveConfirm', () => {
+  module('#onCandidateResultsSaveConfirm', () => {
     module('when there are no error', () => {
       test('should get no error and enable confirm dialog', async function(assert) {
         // when
-        await controller.onSaveConfirm();
+        await controller.onCandidateResultsSaveConfirm();
         // then
-        assert.equal(controller.confirmAction, 'onSave');
+        assert.equal(controller.confirmAction, 'onCandidateResultsSave');
         assert.ok(controller.displayConfirm);
         assert.ok(controller.confirmMessage);
         assert.notOk(controller.confirmErrorMessage);
@@ -361,12 +361,12 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         );
 
         // when
-        await controller.onSaveConfirm();
+        await controller.onCandidateResultsSaveConfirm();
 
         // then
         const levelErrorRegexp = `.*niveau.*${anExistingCompetenceCode}.*${controller.MAX_REACHABLE_LEVEL}`;
         const scoreErrorRegexp = `.*nombre de pix.*${anotherExistingCompetenceCode}.*${controller.MAX_REACHABLE_PIX_BY_COMPETENCE}`;
-        assert.equal(controller.confirmAction, 'onSave');
+        assert.equal(controller.confirmAction, 'onCandidateResultsSave');
         assert.ok(controller.displayConfirm);
         assert.ok(controller.confirmMessage);
         assert.ok(controller.confirmErrorMessage.match(new RegExp(levelErrorRegexp)));
@@ -433,7 +433,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         assert.ok(state.hasPendingTimers);
 
         await settled();
-        assert.ok(controller.edition);
+        assert.ok(controller.editingCandidateResults);
       });
     });
   });
@@ -474,14 +474,14 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     const rollbackAttributes = sinon.stub().resolves();
     controller.certification.rollbackAttributes = rollbackAttributes;
 
-    await controller.onEdit();
+    await controller.onCandidateResultsEdit();
     await controller.onUpdateLevel(anExistingCompetenceCode, '5');
     await controller.onUpdateScore(anExistingCompetenceCode, '50');
     await controller.onUpdateLevel(anotherExistingCompetenceCode, '');
     await controller.onUpdateScore(anotherExistingCompetenceCode, '');
 
     // when
-    await controller.onCancel();
+    await controller.onCandidateResultsCancel() ;
 
     // then
     const competences = controller.certification.competencesWithMark;

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -469,6 +469,45 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
+  module('#onCandidateInformationsEdit', () => {
+    test('it should enter candidate informations edit mode', function(assert) {
+      // given
+      controller.editingCandidateInformations = false;
+
+      // when
+      controller.onCandidateInformationsEdit();
+
+      // then
+      assert.true(controller.editingCandidateInformations);
+    });
+  });
+
+  module('#onCandidateInformationsCancel', () => {
+    test('it should cancel candidate informations edit mode', function(assert) {
+      // given
+      controller.editingCandidateInformations = true;
+
+      // when
+      controller.onCandidateInformationsCancel();
+
+      // then
+      assert.false(controller.editingCandidateInformations);
+    });
+  });
+
+  module('#onCandidateInformationsSave', () => {
+    test('it should exit candidate informations edit mode', function(assert) {
+      // given
+      controller.editingCandidateInformations = true;
+
+      // when
+      controller.onCandidateInformationsSave();
+
+      // then
+      assert.false(controller.editingCandidateInformations);
+    });
+  });
+
   test('it restores competences when cancel is sent', async function(assert) {
     // given
     const rollbackAttributes = sinon.stub().resolves();

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -288,7 +288,6 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#onCandidateResultsSave', () => {
-
     test('it saves competences info when save is sent', async function(assert) {
       // given
       const save = sinon.stub().resolves();
@@ -304,27 +303,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       await controller.onCandidateResultsSave();
 
       // then
-      sinon.assert.calledWith(save, { adapterOptions: { updateMarks: false } });
       sinon.assert.calledWith(save, { adapterOptions: { updateMarks: true } });
-      assert.ok(true);
-    });
-
-    test('marks are not updated when no change has been made and save is sent', async function(assert) {
-      // given
-      const save = sinon.stub().resolves();
-      const store = this.owner.lookup('service:store');
-
-      const certification = store.createRecord('certification');
-      certification.save = save;
-      certification.hasDirtyAttributes = false;
-      controller.certification = certification;
-
-      // when
-      await controller.onCandidateResultsSave();
-
-      // then
-      sinon.assert.calledWith(save, { adapterOptions: { updateMarks: false } });
-      sinon.assert.neverCalledWith(save, { adapterOptions: { updateMarks: true } });
       assert.ok(true);
     });
   });
@@ -334,12 +313,12 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       test('should get no error and enable confirm dialog', async function(assert) {
         // when
         await controller.onCandidateResultsSaveConfirm();
+
         // then
         assert.equal(controller.confirmAction, 'onCandidateResultsSave');
         assert.ok(controller.displayConfirm);
         assert.ok(controller.confirmMessage);
         assert.notOk(controller.confirmErrorMessage);
-
       });
     });
 
@@ -498,7 +477,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   module('#onCandidateInformationsSave', () => {
     test('it exits candidate informations edit mode', async function(assert) {
       // given
-      controller.saveWithoutUpdatingCompetenceMarks = sinon.stub().resolves();
+      controller.saveCertificationCourse = sinon.stub().resolves();
       controller.editingCandidateInformations = true;
       const event = new Event('submit');
 

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -470,7 +470,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#onCandidateInformationsEdit', () => {
-    test('it should enter candidate informations edit mode', function(assert) {
+    test('it enters candidate informations edit mode', function(assert) {
       // given
       controller.editingCandidateInformations = false;
 
@@ -483,7 +483,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#onCandidateInformationsCancel', () => {
-    test('it should cancel candidate informations edit mode', function(assert) {
+    test('it cancels candidate informations edit mode', function(assert) {
       // given
       controller.editingCandidateInformations = true;
 
@@ -496,15 +496,33 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#onCandidateInformationsSave', () => {
-    test('it should exit candidate informations edit mode', function(assert) {
+    test('it exits candidate informations edit mode', async function(assert) {
       // given
+      controller.saveWithoutUpdatingCompetenceMarks = sinon.stub().resolves();
       controller.editingCandidateInformations = true;
+      const event = new Event('submit');
 
       // when
-      controller.onCandidateInformationsSave();
+      await controller.onCandidateInformationsSave(event);
 
       // then
       assert.false(controller.editingCandidateInformations);
+    });
+
+    test('it saves candidates infos', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', { competencesWithMark });
+      certification.save = sinon.stub().resolves();
+      controller.certification = certification;
+      const event = new Event('submit');
+
+      // when
+      await controller.onCandidateInformationsSave(event);
+
+      // then
+      sinon.assert.calledWith(certification.save, { adapterOptions: { updateMarks: false } });
+      assert.ok(true);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’on édite une certification dans la page d’informations sur PixAdmin, aujourd’hui tout un tas d’informations sont éditées en même temps, alors que parfois on souhaite simplement changer le nom du candidat. En fait, c’est parce que l'édition du certification-course (les infos candidats) et l'édition de l’assessment-result (statut + commentaires jury/candidat + résultats) sont faites en même temps.

## :robot: Solution

On propose donc de séparer ces deux éditions, en laissant le bouton modifier tout en bas qui va permettre l'édition de la partie assessment-result, et un bouton d'édition positionner dans la section des informations Candidat qui lui va permettre d'éditer uniquement la section Candidat.Texte du bouton à l’appréciation du développeur, mais proposition : Modifier les infos candidat ?

TODO

- [x] Aligner les boutons de modification des résultats


## :rainbow: Remarques

- Pix UI a été mis à jour pour mettre l'envoi du formulaire avec la touche Entrée

## :100: Pour tester

1. Se rendre dans Pix Admin
2. Se rendre dans une session qui a des certifications
3. Se rendre dans une certification
4. Modifier les informations candidats
5. Rafraichir la page pour constater que les infos ont bien été mises à jour
6. Modifier les résultats du candidat
7. Vérifier que les appels API ont été fait indépendamment et sur les bonnes routes