### PR TITLE
[BUGFIX] Changer le wording de la tooltip pour la carte total participant de l'onglet activité (PIX-2850)

### DIFF
--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -104,7 +104,7 @@
       "title": "Activité des participants"
     },
     "participants-count": {
-      "information": "Retrouvez ici le nombre de participations totales de votre campagne. Ce chiffre comprend l’ensemble des participants ayant saisis le code et commencé son parcours ou son envoi profil.",
+      "information": "Retrouvez ici le nombre de participants total de votre campagne. Ce nombre comprend l'ensemble des participants ayant saisi le code et commencé leur parcours ou leur envoi de profil.",
       "loader": "Chargement du total de participants",
       "title": "Total de participants"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -109,7 +109,7 @@
       "title": "Total de participants"
     },
     "submitted-count": {
-      "information": "Retrouvez ici les résultats envoyés par vos participants. Ce chiffre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton \"J'envoie mes résultats\" ou \"J'envoie mon profil\".",
+      "information": "Retrouvez ici les résultats envoyés par vos participants. Ce nombre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton \"J'envoie mes résultats\" ou \"J'envoie mon profil\".",
       "loader": "Chargement des résultats ou profils reçus",
       "title": "Résultats reçus",
       "title-profiles": "Profils reçus"


### PR DESCRIPTION
## :unicorn: Problème
Dans l'onglet Activité, le texte de la tooltip de la carte `total participant` n'était pas le bon.

## :robot: Solution
Changer le texte.

## :rainbow: Remarques


## :100: Pour tester
Aller sur pix Orga, aller sur `/activité`  d'une campagne et regarder le message de la tooltip.
