### PR TITLE
[TECH] Améliorer la traduction de "délai d'expiration".

### DIFF
--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -13,11 +13,11 @@ function _toDomainObject(accountRecoveryDemandDTO) {
 
 const demandHasExpired = (demandCreationDate) => {
   const minutesInADay = 60 * 24;
-  const expirationDelayInMinutes = parseInt(process.env.SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES) || minutesInADay;
+  const lifetimeInMinutes = parseInt(process.env.SCO_ACCOUNT_RECOVERY_TOKEN_LIFETIME_MINUTES) || minutesInADay;
   const millisecondsInAMinute = 60 * 1000;
-  const expirationDelayInMilliseconds = expirationDelayInMinutes * millisecondsInAMinute;
+  const lifetimeInMilliseconds = lifetimeInMinutes * millisecondsInAMinute;
 
-  const expirationDate = new Date(demandCreationDate.getTime() + expirationDelayInMilliseconds);
+  const expirationDate = new Date(demandCreationDate.getTime() + lifetimeInMilliseconds);
   const now = new Date();
 
   return expirationDate < now;

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -23,7 +23,7 @@ const schema = Joi.object({
   LOG_LEVEL: Joi.string().optional().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
   AUTH_SECRET: Joi.string().required(),
   IS_SCO_ACCOUNT_RECOVERY_ENABLED: Joi.string().optional().valid('true', 'false'),
-  SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES: Joi.number().optional(),
+  SCO_ACCOUNT_RECOVERY_TOKEN_LIFETIME_MINUTES: Joi.number().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function() {

--- a/api/sample.env
+++ b/api/sample.env
@@ -344,11 +344,11 @@ AUTH_SECRET=Change me!
 # SAML_SP_CONFIG=
 
 
-# SCO account recovery - expiration delay (minutes)
+# SCO account recovery - token lifetime (minutes)
 # Mind to update in the following tempale SENDINBLUE_ACCOUNT_RECOVERY_TEMPLATE_ID
 #
 # presence: optional
 # type: integer
 # default: 1 440 (1 day)
-# sample: SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES=10
-# SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES=
+# sample: SCO_ACCOUNT_RECOVERY_TOKEN_LIFETIME_MINUTES=10
+# SCO_ACCOUNT_RECOVERY_TOKEN_LIFETIME_MINUTES=

--- a/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
@@ -82,7 +82,7 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
           const email = 'someMail@example.net';
           const temporaryKey = 'someTemporaryKey';
 
-          process.env.SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES = undefined;
+          process.env.SCO_ACCOUNT_RECOVERY_TOKEN_LIFETIME_MINUTES = undefined;
 
           const expirationDelayInDays = 1;
           const yesterday = new Date();
@@ -120,7 +120,7 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
           databaseBuilder.factory.buildAccountRecoveryDemand({ email, used: false });
           await databaseBuilder.commit();
 
-          process.env.SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES = 2;
+          process.env.SCO_ACCOUNT_RECOVERY_TOKEN_LIFETIME_MINUTES = 2;
 
           // when
           const error = await catchErr(accountRecoveryDemandRepository.findByTemporaryKey)(temporaryKey);


### PR DESCRIPTION
## :unicorn: Problème
La PR https://github.com/1024pix/pix/pull/3195 introduit une variable d'environnement
`SCO_ACCOUNT_RECOVERY_EXPIRATION_DELAY_MINUTES`

Il s'agit d'une durée d'expiration de token
Or `DELAY` pour traduire délai d'expiration [est un faux ami](https://anglais-pratique.fr/index.php/rubriques/faux-amis/66-delai-delay)

## :robot: Solution
Utiliser le terme associé durée de vie `LIFETIME`