### PR TITLE
[BUGFIX] Corriger le script d'import des villes (PIX-2857).

### DIFF
--- a/api/scripts/import-certification-cpf-cities.js
+++ b/api/scripts/import-certification-cpf-cities.js
@@ -2,12 +2,12 @@
 
 /* eslint-disable no-console */
 // Usage: node import-certification-cpf-cities path/file.csv
-// File downloaded from https://public.opendatasoft.com/explore/dataset/correspondance-code-insee-code-postal/export/?flg=fr
+// File downloaded from https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/
 
 'use strict';
 const { parseCsv } = require('./helpers/csvHelpers');
 const { knex } = require('../lib/infrastructure/bookshelf');
-const { uniqBy } = require('lodash');
+const uniqBy = require('lodash/uniqBy');
 
 const CITY_COLUMN_NAME = 'Nom_commune';
 const POSTAL_CODE_COLUMN_NAME = 'Code_postal';
@@ -34,7 +34,8 @@ function buildCities({ csvData }) {
     }
     return result;
   });
-  return uniqBy(citiesWithAlternates, 'name');
+
+  return uniqBy(citiesWithAlternates, (city) => `${city.INSEECode}${city.postalCode}${city.name}`);
 }
 
 async function main(filePath) {

--- a/api/tests/unit/scripts/import-certification-cpf-cities_test.js
+++ b/api/tests/unit/scripts/import-certification-cpf-cities_test.js
@@ -12,30 +12,31 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', () => {
     describe('#when there are n alternate names', () => {
 
       it('should return n+1 lines for the city', () => {
-      // given
+
         const csvData = [
           {
-            Code_commune_INSEE: '00001',
-            Nom_commune: 'GOTHAM CITY',
-            Code_postal: '09966',
-            Ligne_5: 'GOTHAM',
+            Code_commune_INSEE: '30288',
+            Nom_commune: 'ST NAZAIRE',
+            Code_postal: '30200',
+            Ligne_5: null,
           },
           {
-            Code_commune_INSEE: '00001',
-            Nom_commune: 'GOTHAM CITY',
-            Code_postal: '09966',
-            Ligne_5: 'NEW GOTHAM',
+            Code_commune_INSEE: '44184',
+            Nom_commune: 'ST NAZAIRE',
+            Code_postal: '44600',
+            Ligne_5: 'ST MARC SUR MER',
           },
           {
-            Code_commune_INSEE: '00002',
-            Nom_commune: 'OTHER CITY',
-            Code_postal: '09967',
+            Code_commune_INSEE: '66186',
+            Nom_commune: 'ST NAZAIRE',
+            Code_postal: '66570',
+            Ligne_5: null,
           },
           {
-            Code_commune_INSEE: '00001',
-            Nom_commune: 'GOTHAM CITY',
-            Code_postal: '09966',
-            Ligne_5: 'OLD GOTHAM',
+            Code_commune_INSEE: '44184',
+            Nom_commune: 'ST NAZAIRE',
+            Code_postal: '44600',
+            Ligne_5: null,
           },
         ];
 
@@ -45,34 +46,28 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', () => {
         // then
         expect(cities).to.deep.equal([
           {
-            'INSEECode': '00001',
+            'INSEECode': '30288',
             'isActualName': true,
-            'name': 'GOTHAM CITY',
-            'postalCode': '09966',
+            'name': 'ST NAZAIRE',
+            'postalCode': '30200',
           },
           {
-            'INSEECode': '00001',
-            'isActualName': false,
-            'name': 'GOTHAM',
-            'postalCode': '09966',
-          },
-          {
-            'INSEECode': '00001',
-            'isActualName': false,
-            'name': 'NEW GOTHAM',
-            'postalCode': '09966',
-          },
-          {
-            'INSEECode': '00002',
+            'INSEECode': '44184',
             'isActualName': true,
-            'name': 'OTHER CITY',
-            'postalCode': '09967',
+            'name': 'ST NAZAIRE',
+            'postalCode': '44600',
           },
           {
-            'INSEECode': '00001',
+            'INSEECode': '44184',
             'isActualName': false,
-            'name': 'OLD GOTHAM',
-            'postalCode': '09966',
+            'name': 'ST MARC SUR MER',
+            'postalCode': '44600',
+          },
+          {
+            'INSEECode': '66186',
+            'isActualName': true,
+            'name': 'ST NAZAIRE',
+            'postalCode': '66570',
           },
         ]);
       });


### PR DESCRIPTION
## :unicorn: Problème
Le script applique une condition d'unicité sur le nom des villes. Cependant, il existe des villes différentes (différent code postal et code Insee) portant le même nom  

## :robot: Solution
Corriger la condition.

## :100: Pour tester
Lancer le script d'ajout des villes en BDD avec la commande: 

`scalingo -a pix-api-review-pr3225 --region osc-fr1 run --file ~/Téléchargements/laposte_hexasmal.csv node scripts/import-certification-cpf-cities.js /tmp/uploads/laposte_hexasmal.csv`

- Vérifier en base qu'il y a bien 4 villes avec le nom "ST NAZAIRE":
`pix_api_rev_900=> select * from "certification-cpf-cities" where name = 'ST NAZAIRE';
    id    |    name    | postalCode | INSEECode | isActualName |           createdAt           
----------+------------+------------+-----------+--------------+-------------------------------
 10042940 | ST NAZAIRE | 33220      | 33378     | f            | 2021-07-21 15:29:53.284058+00
 10043807 | ST NAZAIRE | 44600      | 44184     | t            | 2021-07-21 15:29:53.284058+00
 10053118 | ST NAZAIRE | 30200      | 30288     | t            | 2021-07-21 15:29:53.284058+00
 10061429 | ST NAZAIRE | 66570      | 66186     | t            | 2021-07-21 15:29:53.284058+00
`

