### PR TITLE
[BUGFIX] Isoler la création de données de tests pour que les données n'altèrent pas d'autres tests (PIX-2867).

### DIFF
--- a/api/tests/integration/domain/services/placement-profile-service_test.js
+++ b/api/tests/integration/domain/services/placement-profile-service_test.js
@@ -87,27 +87,30 @@ describe('Integration | Service | Placement Profile Service', function() {
   context('V1 Profile', () => {
     describe('#getPlacementProfile', () => {
 
-      const assessment1 = databaseBuilder.factory.buildAssessment({
-        id: 13,
-        status: 'completed',
-        competenceId: 'competenceRecordIdOne',
-      });
-      const assessment2 = databaseBuilder.factory.buildAssessment({
-        id: 1637,
-        status: 'completed',
-        competenceId: 'competenceRecordIdTwo',
-      });
-      const assessment3 = databaseBuilder.factory.buildAssessment({
-        id: 145,
-        status: 'completed',
-        competenceId: 'competenceRecordIdUnknown',
-      });
-      databaseBuilder.factory.buildAssessmentResult({ level: 1, pixScore: 12, assessmentId: assessment1.id });
-      databaseBuilder.factory.buildAssessmentResult({ level: 2, pixScore: 23, assessmentId: assessment2.id });
-      databaseBuilder.factory.buildAssessmentResult({ level: 0, pixScore: 2, assessmentId: assessment3.id });
+      let assessment1;
+      let assessment2;
+      let assessment3;
+      beforeEach(async () => {
+        assessment1 = databaseBuilder.factory.buildAssessment({
+          id: 13,
+          status: 'completed',
+          competenceId: 'competenceRecordIdOne',
+        });
+        assessment2 = databaseBuilder.factory.buildAssessment({
+          id: 1637,
+          status: 'completed',
+          competenceId: 'competenceRecordIdTwo',
+        });
+        assessment3 = databaseBuilder.factory.buildAssessment({
+          id: 145,
+          status: 'completed',
+          competenceId: 'competenceRecordIdUnknown',
+        });
+        databaseBuilder.factory.buildAssessmentResult({ level: 1, pixScore: 12, assessmentId: assessment1.id });
+        databaseBuilder.factory.buildAssessmentResult({ level: 2, pixScore: 23, assessmentId: assessment2.id });
+        databaseBuilder.factory.buildAssessmentResult({ level: 0, pixScore: 2, assessmentId: assessment3.id });
 
-      beforeEach(() => {
-        databaseBuilder.commit();
+        await databaseBuilder.commit();
       });
 
       it('should load achieved assessments', async () => {


### PR DESCRIPTION
## :unicorn: Problème
L'évaluation du fichier api/tests/integration/domain/services/placement-profile-service_test.js crée des données qui existe lors de exécution des autres tests et change leur contexte d'exécution, ce qui ne respecte pas le principe d'isolation des tests.

## :robot: Solution
Déplacer la création des données du test () dans un `beforeEach` pour que les données ne soit crées que lors de l'exécution du test.

## :rainbow: Remarques
Explorer [cette règle de lint](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md) dans une autre PR pour prévenir l'apparition 

## :100: Pour tester
- Ajouter un only sur le describe de ce fichier `api/tests/integration/domain/usecases/start-campaign-participation_test.js`
- Lancer `npm run test:api:integration`
- Tous les tests doivent passer