### PR TITLE
[TECH] Supprimer la table "autojury-script-audit" (PIX-2744).

### DIFF
--- a/api/db/migrations/20210722122054_drop-table-autojury-script-audit.js
+++ b/api/db/migrations/20210722122054_drop-table-autojury-script-audit.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'autojury-script-audit';
+
+exports.up = function(knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+exports.down = function(knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments('sessionId').primary();
+    t.text('certificationCenterName');
+    t.dateTime('finalizedAt');
+    t.date('sessionDate');
+    t.time('sessionTime');
+    t.boolean('hasExaminerGlobalComment', 500);
+    t.string('error', 1000);
+    t.enu('status', ['TO DO', 'DOING', 'DONE', 'TO RETRY']);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
La table `autojury-script-audit` a été créée afin de permettre, grâce à un script, d'appliquer le traitement automatique des signalements à d'anciennes sessions de certification. Suite à l'exécution du script, cette table n'est plus nécessaire.

## :robot: Solution
Supprimer la table `autojury-script-audit` 

## :100: Pour tester
- Se connecter à la bdd de la review app: `scalingo -a pix-api-review-pr3232 pgsql-console`.
- Vérifier que la table `autojury-script-audit` n'existe plus.  
