### PR TITLE
[FEATURE] Permettre de lancer plusieurs utilisateurs en même temps sur Algolix (PIX-2069).

### DIFF
--- a/high-level-tests/test-algo/AlgoResult.js
+++ b/high-level-tests/test-algo/AlgoResult.js
@@ -1,8 +1,11 @@
 const _ = require('lodash');
 
+let id = 1;
+
 class AlgoResult {
 
   constructor() {
+    this._id = id++;
     this._challenges = [];
     this._estimatedLevels = [];
     this._answerStatuses = [];
@@ -42,6 +45,7 @@ class AlgoResult {
     const challengeIds = this._challenges.map((challenge) => challenge.id);
     this._computeGaps();
     const log = `
+        Result ${this._id} :
         ----- total challenges asked: ${challengeIds.length}
         ----- challenge ids asked: ${challengeIds}
         ----- skill names: ${this._skillNames}

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -160,42 +160,8 @@ function _getChallengeLevel({ assessment, result }) {
   return chosenSkill ? chosenSkill.difficulty : null;
 }
 
-async function launchTest(argv) {
-
-  const { competenceId, targetProfileId, locale, userResult, userKEFile } = argv;
-
-  let allAnswers = [];
-  let knowledgeElements = [];
-
-  const assessment = {
-    id: null,
-    competenceId,
-    userId: 1,
-  };
-
-  const knowledgeElementRepository = {
-    findUniqByUserId: () => [],
-  };
-  const answerRepository = {
-    findByAssessment: () => [],
-  };
-
-  const userKE = _read(userKEFile);
-
+async function proceedAlgo(challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers, userResult, userKE) {
   let isAssessmentOver = false;
-
-  const { challenges, targetSkills } = await _getReferentiel({
-    assessment,
-    targetProfileId,
-    answerRepository,
-    challengeRepository,
-    knowledgeElementRepository,
-    skillRepository,
-    improvementService,
-    targetProfileRepository,
-  });
-
-
   const algoResult = new AlgoResult();
 
   while (!isAssessmentOver) {
@@ -230,6 +196,42 @@ async function launchTest(argv) {
   }
 
   console.log(algoResult.log());
+}
+
+async function launchTest(argv) {
+
+  const { competenceId, targetProfileId, locale, userResult, userKEFile } = argv;
+
+  const allAnswers = [];
+  const knowledgeElements = [];
+
+  const assessment = {
+    id: null,
+    competenceId,
+    userId: 1,
+  };
+
+  const knowledgeElementRepository = {
+    findUniqByUserId: () => [],
+  };
+  const answerRepository = {
+    findByAssessment: () => [],
+  };
+
+  const userKE = _read(userKEFile);
+
+  const { challenges, targetSkills } = await _getReferentiel({
+    assessment,
+    targetProfileId,
+    answerRepository,
+    challengeRepository,
+    knowledgeElementRepository,
+    skillRepository,
+    improvementService,
+    targetProfileRepository,
+  });
+
+  await proceedAlgo(challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers, userResult, userKE);
   process.exit(0);
 }
 

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -24,7 +24,7 @@ function _read(path) {
       return JSON.parse(file);
     }
   }
-  return [];
+  return [[]];
 }
 
 function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId, userResult, userKE }) {
@@ -200,7 +200,7 @@ async function proceedAlgo(challenges, targetSkills, assessment, locale, knowled
 
 async function launchTest(argv) {
 
-  const { competenceId, targetProfileId, locale, userResult, userKEFile } = argv;
+  const { competenceId, targetProfileId, locale, userResult, usersKEFile } = argv;
 
   const allAnswers = [];
   const knowledgeElements = [];
@@ -218,7 +218,7 @@ async function launchTest(argv) {
     findByAssessment: () => [],
   };
 
-  const userKE = _read(userKEFile);
+  const usersKE = _read(usersKEFile);
 
   const { challenges, targetSkills } = await _getReferentiel({
     assessment,
@@ -231,7 +231,12 @@ async function launchTest(argv) {
     targetProfileRepository,
   });
 
-  await proceedAlgo(challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers, userResult, userKE);
+  const proceedUsers = usersKE.map((userKE) => {
+    return proceedAlgo(challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers, userResult, userKE);
+  });
+
+  await Promise.all(proceedUsers);
+
   process.exit(0);
 }
 

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -17,7 +17,7 @@ const AlgoResult = require('./AlgoResult');
 
 const POSSIBLE_ANSWER_STATUSES = [AnswerStatus.OK, AnswerStatus.KO];
 
-function _read(path) {
+function _readUsersKEFile(path) {
   if (path) {
     const file = fs.readFileSync(path, 'utf-8');
     if (file) {
@@ -218,7 +218,7 @@ async function launchTest(argv) {
     findByAssessment: () => [],
   };
 
-  const usersKE = _read(usersKEFile);
+  const usersKE = _readUsersKEFile(usersKEFile);
 
   const { challenges, targetSkills } = await _getReferentiel({
     assessment,

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -2,7 +2,7 @@
 require('dotenv').config();
 const hashInt = require('hash-int');
 const fs = require('fs');
-const { find } = require('lodash');
+const { find, isEmpty } = require('lodash');
 const smartRandom = require('../../api/lib/domain/services/smart-random/smart-random');
 const dataFetcher = require('../../api/lib/domain/services/smart-random/data-fetcher');
 const challengeRepository = require('../../api/lib/infrastructure/repositories/challenge-repository');
@@ -195,6 +195,7 @@ async function launchTest(argv) {
     targetProfileRepository,
   });
 
+
   const algoResult = new AlgoResult();
 
   while (!isAssessmentOver) {
@@ -208,7 +209,6 @@ async function launchTest(argv) {
       allAnswers,
     });
     algoResult.addEstimatedLevels(estimatedLevel);
-
     if (challenge) {
       const { answerStatus, updatedAnswers, updatedKnowledgeElements } = answerTheChallenge({
         challenge,
@@ -216,7 +216,7 @@ async function launchTest(argv) {
         userId: assessment.userId,
         allKnowledgeElements: knowledgeElements,
         targetSkills,
-        userResult,
+        userResult: isEmpty(userKE) ? userResult : 'KE',
         userKE,
       });
       allAnswers = updatedAnswers;

--- a/high-level-tests/test-algo/index.js
+++ b/high-level-tests/test-algo/index.js
@@ -27,9 +27,9 @@ async function index() {
       choices: ['ok', 'ko', 'random', 'firstOKthenKO', 'firstKOthenOK'],
       default: 'ok',
     })
-    .option('userKEFile', {
+    .option('usersKEFile', {
       type: 'string',
-      description: 'Localisation du fichier',
+      description: 'Localisation du fichier .json',
     })
     .check((argv) => {
       return Boolean(argv.competenceId || argv.targetProfileId);


### PR DESCRIPTION
## :unicorn: Problème
Le script de test d'Algolix ne permet pas d'être jouer avec plusieurs utilisateurs. 

## :robot: Solution
Permettre au script d’accepter des fichiers comportant plusieurs utilisateurs.

## :rainbow: Remarques
Le fichier json que l'on donne à lire au script pour jouer les KE des utilisateurs est un tableau de tableau de KE (et plus seulement un tableau de KE).

```json
[
  [ 
    {"source":"inferred","status":"validated","skillId":"","competenceId":""},
    {"source":"direct","status":"validated","skillId":"","competenceId":""},
    {"source":"inferred","status":"validated","skillId":"","competenceId":""}
  ],
  [
    {"source":"inferred","status":"validated","skillId":"","competenceId":""},
    {"source":"direct","status":"validated","skillId":"","competenceId":""},
    {"source":"inferred","status":"validated","skillId":"","competenceId":""}
  ]
]
```

## :100: Pour tester
Jouer le script avec un fichier comportant les KE de plusieurs utilisateur. 