### PR TITLE
[FEATURE] Affichage de l'onglet "Activité" pour les campagnes de collecte de profils (PIX-2772).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -30,6 +30,7 @@ const CampaignProfilesCollectionParticipationSummaryRepository = {
           .andOn({ 'campaigns.organizationId': 'schooling-registrations.organizationId' });
       })
       .where('campaign-participations.campaignId', '=', campaignId)
+      .where('campaign-participations.isImproved', '=', false)
       .whereRaw('"campaign-participations"."sharedAt" IS NOT NULL')
       .orderByRaw('?? ASC, ?? ASC', ['lowerLastName', 'lowerFirstName'])
       .modify(_filterQuery, filters);

--- a/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -30,6 +30,7 @@ const CampaignProfilesCollectionParticipationSummaryRepository = {
           .andOn({ 'campaigns.organizationId': 'schooling-registrations.organizationId' });
       })
       .where('campaign-participations.campaignId', '=', campaignId)
+      .whereRaw('"campaign-participations"."sharedAt" IS NOT NULL')
       .orderByRaw('?? ASC, ?? ASC', ['lowerLastName', 'lowerFirstName'])
       .modify(_filterQuery, filters);
 

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -32,8 +32,8 @@ module.exports = {
         'targetProfileImageUrl': 'target-profiles.imageUrl',
       })
       .select(
-        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER (partition by "campaigns"."id") AS "participationsCount"'),
-        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isShared" IS TRUE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'),
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isImproved" IS FALSE) OVER (partition by "campaigns"."id") AS "participationsCount"'),
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isShared" IS TRUE AND "campaign-participations"."isImproved" IS FALSE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'),
       )
       .join('users', 'users.id', 'campaigns.creatorId')
       .leftJoin('target-profiles', 'target-profiles.id', 'campaigns.targetProfileId')

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -56,8 +56,8 @@ module.exports = {
         'users.id AS "creatorId"',
         'users.firstName AS creatorFirstName',
         'users.lastName AS creatorLastName',
-        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER (partition by "campaigns"."id") AS "participationsCount"'),
-        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isShared" IS TRUE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'),
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isImproved" IS FALSE) OVER (partition by "campaigns"."id") AS "participationsCount"'),
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isShared" IS TRUE AND "campaign-participations"."isImproved" IS FALSE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'),
       )
       .join('users', 'users.id', 'campaigns.creatorId')
       .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -33,25 +33,17 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       expect(results.data.length).to.equal(0);
     });
 
-    it('should return participant data summary for a not shared campaign participation', async () => {
+    it('should not return participant data summary for a not shared campaign participation', async () => {
       // given
-      const campaignParticipation = { id: 1, campaignId, isShared: false, sharedAt: null, participantExternalId: 'JeBu' };
-      databaseBuilder.factory.buildCampaignParticipationWithUser({ firstName: 'Jérémy', lastName: 'bugietta' }, campaignParticipation, false);
+      const campaignParticipation = { campaignId, isShared: false, sharedAt: null };
+      databaseBuilder.factory.buildCampaignParticipationWithUser({}, campaignParticipation, false);
       await databaseBuilder.commit();
 
       // when
       const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(campaignId);
 
       // then
-      expect(results.data).to.deep.equal([
-        new CampaignProfilesCollectionParticipationSummary({
-          campaignParticipationId: campaignParticipation.id,
-          firstName: 'Jérémy',
-          lastName: 'bugietta',
-          participantExternalId: 'JeBu',
-          sharedAt: null,
-        }),
-      ]);
+      expect(results.data).to.deep.equal([]);
     });
 
     it('should return participants data summary only for the given campaign id', async () => {
@@ -94,9 +86,8 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       beforeEach(async () => {
         const createdAt = new Date('2018-04-06T10:00:00Z');
         const userId = 999;
-
-        campaignParticipation = { id: 1, campaignId, isShared: true, sharedAt };
-        databaseBuilder.factory.buildCampaignParticipationWithUser({ id: userId }, campaignParticipation, false);
+        campaignParticipation = { id: 888, userId, campaignId, isShared: true, sharedAt, participantExternalId: 'JeBu' };
+        databaseBuilder.factory.buildCampaignParticipationWithUser({ id: userId, firstName: 'Jérémy', lastName: 'bugietta' }, campaignParticipation, false);
 
         databaseBuilder.factory.buildKnowledgeElement({
           status: 'validated',
@@ -124,10 +115,18 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(campaignId);
 
         // then
-        expect(results.data[0].sharedAt).to.deep.equal(sharedAt);
-        expect(results.data[0].pixScore).to.equal(46);
-        expect(results.data[0].certifiable).to.equal(false);
-        expect(results.data[0].certifiableCompetencesCount).to.equal(1);
+        expect(results.data).to.deep.equal([
+          new CampaignProfilesCollectionParticipationSummary({
+            campaignParticipationId: campaignParticipation.id,
+            firstName: 'Jérémy',
+            lastName: 'bugietta',
+            participantExternalId: 'JeBu',
+            sharedAt,
+            pixScore: 46,
+            certifiable: false,
+            certifiableCompetencesCount: 1,
+          }),
+        ]);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -130,6 +130,29 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       });
     });
 
+    describe('when a participant has participated twice', () => {
+      let recentCampaignParticipation;
+
+      beforeEach(async () => {
+        const userId = 999;
+        const oldCampaignParticipation = { userId, campaignId, isShared: true, sharedAt, isImproved: true };
+        databaseBuilder.factory.buildCampaignParticipationWithUser({ id: userId }, oldCampaignParticipation, false);
+
+        recentCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ userId, isImproved: false, sharedAt, campaignId, isShared: true });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return only the participationCampaign which is not improved', async () => {
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(campaignId);
+
+        // then
+        expect(results.data).to.have.lengthOf(1);
+        expect(results.data[0].id).to.equal(recentCampaignParticipation.id);
+      });
+    });
+
     describe('when there is a filter on division', () => {
 
       beforeEach(async () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -25,6 +25,34 @@ describe('Integration | Repository | Campaign-Report', () => {
       expect(result).to.deep.include(_.pick(campaign, ['id', 'name', 'code', 'createdAt', 'archivedAt', 'targetProfileId', 'idPixLabel', 'title', 'type', 'customLandingPageText', 'creatorId', 'creatorLastName', 'creatorFirstName', 'targetProfileId', 'targetProfileName', 'targetProfileImageUrl', 'participationsCount', 'sharedParticipationsCount']));
     });
 
+    it('should only count participations not improved', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: true });
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: false });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignReportRepository.get(campaign.id);
+
+      // then
+      expect(result.participationsCount).to.equal(1);
+    });
+
+    it('should only count shared participations not improved', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, sharedAt: new Date(), isShared: true, isImproved: true });
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, sharedAt: null, isShared: false, isImproved: false });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignReportRepository.get(campaign.id);
+
+      // then
+      expect(result.sharedParticipationsCount).to.equal(0);
+    });
+
     it('should throw a NotFoundError if campaign can not be found', async () => {
       // given
       const nonExistentId = 666;

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -162,6 +162,36 @@ describe('Integration | Repository | Campaign-Report', () => {
 
       context('when campaigns have participants', async () => {
 
+        it('should only count participations not improved', async () => {
+          // given
+          const campaign = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId });
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: true });
+          databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: false });
+          await databaseBuilder.commit();
+
+          // when
+          const { models: campaignReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(campaignReports[0].participationsCount).to.equal(1);
+        });
+
+        it('should only count shared participations not improved', async () => {
+          // given
+          const campaign = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId });
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isShared: true, sharedAt: new Date(), isImproved: true });
+          databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: false, isShared: false, sharedAt: null });
+          await databaseBuilder.commit();
+
+          // when
+          const { models: campaignReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(campaignReports[0].sharedParticipationsCount).to.equal(0);
+        });
+
         it('should return correct participations count and shared participations count', async () => {
           // given
           const campaign = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId });

--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -38,8 +38,10 @@ Fonctionnalité: Gestion des Campagnes
     Étant donné que je suis connecté à Pix Orga
     Lorsque je clique sur "Envoi profils Lannister"
     Alors je vois le détail de la campagne "Envoi profils Lannister"
-    Lorsque je clique sur "Participants (2)"
-    Alors je vois 2 profils
+    Lorsque je clique sur "Activité"
+    Alors je vois 2 participants
+    Lorsque je clique sur "Résultats (0)"
+    Alors je vois 0 profils
 
   Scénario: Je créé une campagne d'évaluation
     Étant donné que je suis connecté à Pix Orga
@@ -74,7 +76,7 @@ Fonctionnalité: Gestion des Campagnes
     Et que je clique sur "Campagnes"
     Et que je clique sur "Archivées"
     Alors je vois 0 campagne
-  
+
   Scénario: Je modifie une campagne
     Étant donné que je suis connecté à Pix Orga
     Et je clique sur "Campagne du Mur"

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -19,7 +19,7 @@
             <tr aria-label={{t 'pages.campaign-activity.table.row-title'}} role="button" {{on 'click' (fn @onClickParticipant @campaign.id participation.id)}} class="tr--clickable">
               <td>
                 <LinkTo
-                  @route='authenticated.campaigns.assessment'
+                  @route={{if @campaign.isTypeAssessment 'authenticated.campaigns.assessment' 'authenticated.campaigns.profile'}}
                   @models={{array @campaign.id participation.id}}>
                 {{participation.lastName}}
                 </LinkTo>

--- a/orga/app/components/routes/authenticated/campaign/profile/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/details.hbs
@@ -2,7 +2,7 @@
 <article class="profile">
   <header class="navigation">
    <PreviousPageButton
-     @route="authenticated.campaigns.campaign.profiles"
+     @route="authenticated.campaigns.campaign.activity"
      @routeId={{@campaign.id}}
      @backButtonAriaLabel={{t "common.actions.back"}}
      aria-label={{t "pages.campaign.name"}}

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -55,11 +55,9 @@
 
   <div class="panel campaign-details__controls">
     <nav class="navbar campaign-details-controls__navbar-tabs">
-      {{#if @campaign.isTypeAssessment}}
-        <LinkTo @route="authenticated.campaigns.campaign.activity" @model={{@campaign}} class="navbar-item">
-          {{t 'pages.campaign.tab.activity'}}
-        </LinkTo>
-      {{/if}}
+      <LinkTo @route="authenticated.campaigns.campaign.activity" @model={{@campaign}} class="navbar-item">
+        {{t 'pages.campaign.tab.activity'}}
+      </LinkTo>
 
       {{#unless @campaign.isTypeAssessment}}
         <LinkTo

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -59,20 +59,15 @@
         {{t 'pages.campaign.tab.activity'}}
       </LinkTo>
 
-      {{#unless @campaign.isTypeAssessment}}
-        <LinkTo
-          @route="authenticated.campaigns.campaign.profiles"
-          @model={{@campaign}}
-          class="navbar-item"
-        >
-          {{t 'pages.campaign.tab.participants' count=@campaign.participationsCount}}
-        </LinkTo>
-      {{/unless}}
+      <LinkTo
+        @route={{if @campaign.isTypeAssessment "authenticated.campaigns.campaign.assessment-results" "authenticated.campaigns.campaign.profiles"}}
+        @model={{@campaign}}
+        class="navbar-item"
+      >
+        {{t 'pages.campaign.tab.results' count=@campaign.sharedParticipationsCount}}
+      </LinkTo>
 
       {{#if @campaign.isTypeAssessment}}
-        <LinkTo @route="authenticated.campaigns.campaign.assessment-results" @model={{@campaign}} class="navbar-item">
-          {{t 'pages.campaign.tab.results' count=@campaign.sharedParticipationsCount}}
-        </LinkTo>
         <LinkTo @route="authenticated.campaigns.campaign.analysis" class="navbar-item" @model={{@campaign}} >
           {{t 'pages.campaign.tab.review'}}
         </LinkTo>

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -9,6 +9,10 @@ export default class ActivityController extends Controller {
 
   @action
   goToParticipantPage(campaignId, participationId) {
-    this.transitionToRoute('authenticated.campaigns.assessment', campaignId, participationId);
+    if (this.model.campaign.isTypeAssessment) {
+      this.transitionToRoute('authenticated.campaigns.assessment', campaignId, participationId);
+    } else {
+      this.transitionToRoute('authenticated.campaigns.profile', campaignId, participationId);
+    }
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign.js
+++ b/orga/app/routes/authenticated/campaigns/campaign.js
@@ -10,14 +10,4 @@ export default class CampaignRoute extends Route {
       this.send('error', error, this.replaceWith('not-found', params.campaign_id));
     }
   }
-
-  redirect(campaign, transition) {
-    if (
-      transition.from
-      && transition.from.name !== 'authenticated.campaigns.new'
-      && campaign.isTypeProfilesCollection
-    ) {
-      this.replaceWith('authenticated.campaigns.campaign.profiles', campaign);
-    }
-  }
 }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -290,7 +290,9 @@ export default function() {
   });
 
   this.get('/campaigns/:campaignId/profiles-collection-participations/:campaignParticipationId', (schema, request) => {
-    return schema.campaignProfiles.findBy({ ...request.params });
+    const campaignId = request.params.campaignId;
+    const id = request.params.campaignParticipationId;
+    return schema.campaignProfiles.findBy({ campaignId, id });
   });
 
   this.get('/campaigns/:campaignId/assessment-participations/:id', (schema, request) => {

--- a/orga/mirage/factories/campaign.js
+++ b/orga/mirage/factories/campaign.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
 import faker from 'faker';
 
 export default Factory.extend({
@@ -14,6 +14,22 @@ export default Factory.extend({
   createdAt() {
     return faker.date.recent();
   },
+
+  ofTypeAssessment: trait({
+    afterCreate(campaign) {
+      campaign.update({
+        type: 'ASSESSMENT',
+      });
+    },
+  }),
+
+  ofTypeProfilesCollection: trait({
+    afterCreate(campaign) {
+      campaign.update({
+        type: 'PROFILES_COLLECTION',
+      });
+    },
+  }),
 
 });
 

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -14,14 +14,15 @@ module('Acceptance | Campaign Activity', function(hooks) {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  let campaignId;
 
   hooks.beforeEach(async () => {
     const user = createUserWithMembershipAndTermsOfServiceAccepted();
     createPrescriberByUser(user);
-
-    server.create('campaign', { id: 1 });
-    const campaignAssessmentParticipationResult = server.create('campaign-assessment-participation-result', 'withCompetenceResults', { id: 1, campaignId: 1 });
-    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult, lastName: 'Bacri' });
+    campaignId = 1;
+    server.create('campaign', 'ofTypeAssessment', { id: campaignId });
+    const campaignAssessmentParticipationResult = server.create('campaign-assessment-participation-result', 'withCompetenceResults', { id: 1, campaignId });
+    server.create('campaign-assessment-participation', { id: 1, campaignId, campaignAssessmentParticipationResult, lastName: 'Bacri' });
     server.create('campaign-participant-activity', { id: 1, lastName: 'Bacri' });
 
     await authenticateSession({
@@ -34,13 +35,33 @@ module('Acceptance | Campaign Activity', function(hooks) {
 
   module('When prescriber arrives on activity page', function() {
 
-    test('it could click on user to go to details', async function(assert) {
-      // when
-      await visit('/campagnes/1');
-      await clickByLabel('Bacri');
+    module('When campaign is of type assessment', function() {
+      test('it could click on user to go to details', async function(assert) {
+        // when
+        await visit('/campagnes/1');
+        await clickByLabel('Bacri');
 
-      // then
-      assert.equal(currentURL(), '/campagnes/1/evaluations/1/resultats');
+        // then
+        assert.equal(currentURL(), '/campagnes/1/evaluations/1/resultats');
+      });
+    });
+
+    module('When campaign is of type profiles collection', function(hooks) {
+      hooks.beforeEach(async () => {
+        campaignId = 2;
+        server.create('campaign', 'ofTypeProfilesCollection', { id: campaignId });
+        server.create('campaign-profile', { id: 1, campaignId, lastName: 'Bacri' });
+        server.create('campaign-participant-activity', { id: 1, lastName: 'Bacri' });
+      });
+
+      test('it could click on profile to go to details', async function(assert) {
+        // when
+        await visit('/campagnes/2');
+        await clickByLabel('Bacri');
+
+        // then
+        assert.equal(currentURL(), '/campagnes/2/profils/1');
+      });
     });
 
     test('it could return on list of participants', async function(assert) {

--- a/orga/tests/acceptance/profile_test.js
+++ b/orga/tests/acceptance/profile_test.js
@@ -27,7 +27,7 @@ module('Acceptance | Campaign Profile', function(hooks) {
     });
   });
 
-  test('it allows user to return to campaign profils page', async function(assert) {
+  test('it allows user to return to campaign activity page', async function(assert) {
     server.create('campaign', { id: 1 });
     server.create('campaignProfile', { campaignId: 1, campaignParticipationId: 1 });
 
@@ -36,7 +36,7 @@ module('Acceptance | Campaign Profile', function(hooks) {
     await clickByLabel('Retour');
 
     // then
-    assert.equal(currentURL(), '/campagnes/1/profils');
+    assert.equal(currentURL(), '/campagnes/1');
   });
 
   test('it display profile information', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
@@ -106,7 +106,6 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       });
 
       test('it should display evaluation results item', async function(assert) {
-
         assert.dom('nav a[href="/campagnes/13/resultats-evaluation"]').hasText('Résultats (10)');
       });
     });
@@ -117,11 +116,16 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
         const campaign = store.createRecord('campaign', {
           id: 13,
           type: 'PROFILES_COLLECTION',
+          sharedParticipationsCount: 6,
         });
 
         this.set('campaign', campaign);
 
         await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
+      });
+
+      test('it should display profile results item', async function(assert) {
+        assert.dom('nav a[href="/campagnes/13/profils"]').hasText('Résultats (6)');
       });
 
       test('it should not display participation item', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report_test.js
@@ -70,20 +70,22 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
 
   module('Navigation', function(hooks) {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(async function() {
       this.owner.setupRouter();
-    });
-
-    test('it should display campaign settings item', async function(assert) {
-
       const campaign = store.createRecord('campaign', {
         id: 12,
       });
 
       this.set('campaign', campaign);
-
       await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
+    });
+
+    test('it should display campaign settings item', async function(assert) {
       assert.dom('nav a[href="/campagnes/12/details"]').hasText('Paramètres');
+    });
+
+    test('it should display activity item', async function(assert) {
+      assert.dom('nav a[href="/campagnes/12"]').hasText('Activité');
     });
 
     module('When campaign type is ASSESSMENT', function(hooks) {
@@ -101,11 +103,6 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
 
       test('it should display campaign analyse item', async function(assert) {
         assert.dom('nav a[href="/campagnes/13/analyse"]').hasText('Analyse');
-      });
-
-      test('it should display activity item', async function(assert) {
-
-        assert.dom('nav a[href="/campagnes/13"]').hasText('Activité');
       });
 
       test('it should display evaluation results item', async function(assert) {
@@ -133,10 +130,6 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
 
       test('it should not display analyse item', async function(assert) {
         assert.dom('nav a[href="/campagnes/13/analyse"]').doesNotExist();
-      });
-
-      test('it should not display activity item', async function(assert) {
-        assert.dom('nav a[href="/campagnes/13/activity"]').doesNotExist();
       });
 
       test('it should not display evaluation results item', async function(assert) {

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/campaigns/campaign/activity', function(hooks) {
+  setupIntlRenderingTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated/campaigns/campaign/activity');
+  });
+
+  module('#action goToParticipantPage', function() {
+
+    test('it should call transitionToRoute with appropriate arguments for profiles collection', function(assert) {
+      // given
+      controller.transitionToRoute = sinon.stub();
+      controller.model = { campaign: { isTypeAssessment: false } };
+
+      // when
+      controller.send('goToParticipantPage', 123, 456);
+
+      // then
+      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.profile', 123, 456));
+    });
+
+    test('it should call transitionToRoute with appropriate arguments for assessment', function(assert) {
+      // given
+      controller.transitionToRoute = sinon.stub();
+      controller.model = { campaign: { isTypeAssessment: true } };
+
+      // when
+      controller.send('goToParticipantPage', 123, 456);
+
+      // then
+      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.assessment', 123, 456));
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -197,7 +197,6 @@
       "tab": {
         "activity": "Activity",
         "results": "Results ({count, number})",
-        "participants": "Participants ({count, number})",
         "review": "Review",
         "settings": "Settings"
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -197,7 +197,6 @@
       "tab": {
         "activity": "Activité",
         "results": "Résultats ({count, number})",
-        "participants": "Participants ({count, number})",
         "review": "Analyse",
         "settings": "Paramètres"
       }


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'alors l'onglet "Activité" n'était disponible que pour les campagnes d'évaluation.

## :robot: Solution
Ouvrir ce dernier pour les campagnes de collecte de profils.

## :rainbow: Remarques
BSR : Prise en compte des participations multiples (récupération de la dernière participation seulement)

## :100: Pour tester
- Se connecter à Pix Orga
- Choisir une campagne de collecte
- Vérifier qu'on arrive sur l'onglet "Activité"
- Cliquer sur l'activité d'un participant
- Vérifier qu'on arrive sur le détail de ce participant

BSR :
- Pour les campagnes à envois multiples, dans la liste des campagnes, le chiffre a changé + dans l'onglet Résultats des 2 types de campagnes
