### PR TITLE
[BUGFIX]Changer le wording et la couleurs des tags dans la liste des participants dans la page Activité(PIX-2872)

### DIFF
--- a/orga/app/components/campaign/activity/participation-status.js
+++ b/orga/app/components/campaign/activity/participation-status.js
@@ -18,6 +18,6 @@ export default class ParticipationStatus extends Component {
 
 const COLORS = {
   completed: 'purple-light',
-  started: 'blue-light',
+  started: 'yellow-light',
   shared: 'green-light',
 };

--- a/orga/app/components/charts/participants-by-status.js
+++ b/orga/app/components/charts/participants-by-status.js
@@ -68,9 +68,9 @@ const LABELS_ASSESSMENT = {
     color: '#FFBE00',
   },
   completed: {
-    tooltip: 'charts.participants-by-status.labels-tooltip.completed',
-    legend: 'charts.participants-by-status.labels-legend.completed',
-    legendTooltip: 'charts.participants-by-status.labels-legend.completed-tooltip',
+    tooltip: 'charts.participants-by-status.labels-tooltip.completed-assessment',
+    legend: 'charts.participants-by-status.labels-legend.completed-assessment',
+    legendTooltip: 'charts.participants-by-status.labels-legend.completed-assessment-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.completed',
     color: '#8a49ff',
   },
@@ -92,8 +92,8 @@ const LABELS_PROFILE_COLLECTIONS = {
     color: '#FFBE00',
   },
   completed: {
-    tooltip: 'charts.participants-by-status.labels-tooltip.completed',
-    legend: 'charts.participants-by-status.labels-legend.completed',
+    tooltip: 'charts.participants-by-status.labels-tooltip.completed-profile',
+    legend: 'charts.participants-by-status.labels-legend.completed-profile',
     legendTooltip: 'charts.participants-by-status.labels-legend.completed-profile-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.completed',
     color: '#8a49ff',

--- a/orga/app/components/routes/authenticated/campaign/report.js
+++ b/orga/app/components/routes/authenticated/campaign/report.js
@@ -8,12 +8,6 @@ export default class Report extends Component {
   @service currentUser;
   @service intl;
 
-  get participationsCount() {
-    const participationsCount = this.args.campaign.participationsCount;
-
-    return participationsCount > 0 ? participationsCount : false;
-  }
-
   get downloadUrl() {
     return this.args.campaign.urlToResult + `&lang=${this.currentUser.prescriber.lang}`;
   }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -64,7 +64,8 @@
     "participants-by-status": {
       "labels-tooltip": {
         "started": "In progress: {percentage, number, ::percent .0}",
-        "completed": "Pending results: {percentage, number, ::percent .0}",
+        "completed-assessment": "Pending results: {percentage, number, ::percent .0}",
+        "completed-profile": "Pending profiles: {percentage, number, ::percent .0}",
         "shared": "Submitted results: {percentage, number, ::percent .0}",
         "shared-profile": "Submitted profiles: {percentage, number, ::percent .0}"
       },
@@ -77,9 +78,10 @@
       "labels-legend": {
         "started": "In progress ({count})",
         "started-tooltip": "In progress: These participants haven’t finished their customised test yet.",
-        "completed": "Pending results ({count})",
-        "completed-tooltip": "Pending results: These participants have finished their customised test but haven’t submitted their results yet.",
-        "completed-profile-tooltip": "Pending results: These participants haven’t submitted their profiles yet.",
+        "completed-assessment": "Pending results ({count})",
+        "completed-profile": "Pending profiles ({count})",
+        "completed-assessment-tooltip": "Pending results: These participants have finished their customised test but haven’t submitted their results yet.",
+        "completed-profile-tooltip": "Pending profiles: These participants haven’t submitted their profiles yet.",
         "shared": "Submitted results ({count})",
         "shared-tooltip": "Submitted results: These participants have finished their customised test and submitted their results.",
         "shared-profile": "Submitted profiles ({count})",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -225,10 +225,10 @@
       },
       "status": {
         "started-assessment": "In progress ({progression, number, ::percent})",
-        "completed-assessment": "Pending",
-        "shared-assessment": "Submitted",
-        "completed-profile": "Pending",
-        "shared-profile": "Submitted"
+        "completed-assessment": "Pending results",
+        "shared-assessment": "Submitted results",
+        "completed-profile": "Pending profile",
+        "shared-profile": "Submitted profile"
       }
     },
     "campaign-creation": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -64,7 +64,8 @@
     "participants-by-status": {
       "labels-tooltip": {
         "started": "En cours : {percentage, number, ::percent .0}",
-        "completed": "En attente d'envoi : {percentage, number, ::percent .0}",
+        "completed-assessment": "En attente d'envoi : {percentage, number, ::percent .0}",
+        "completed-profile": "En attente d'envoi : {percentage, number, ::percent .0}",
         "shared": "Résultats reçus : {percentage, number, ::percent .0}",
         "shared-profile": "Profils reçus : {percentage, number, ::percent .0}"
       },
@@ -77,8 +78,9 @@
       "labels-legend": {
         "started": "En cours ({count})",
         "started-tooltip": "En cours : Ces participants n’ont pas encore terminé leur parcours.",
-        "completed": "En attente d'envoi ({count})",
-        "completed-tooltip": "En attente d’envoi : Ces participants ont terminé leur parcours mais n’ont pas encore envoyé leurs résultats.",
+        "completed-assessment": "En attente d'envoi ({count})",
+        "completed-profile": "En attente d'envoi ({count})",
+        "completed-assessment-tooltip": "En attente d’envoi : Ces participants ont terminé leur parcours mais n’ont pas encore envoyé leurs résultats.",
         "completed-profile-tooltip": "En attente d’envoi : Ces participants n’ont pas encore envoyé leurs profils.",
         "shared": "Résultats reçus ({count})",
         "shared-tooltip": "Résultats reçus : Ces participants ont terminé leur parcours et envoyé leurs résultats.",


### PR DESCRIPTION
## :unicorn: Problème
Couleur:
La couleur utilisée pour le tag "En cours" n'était pas la même que celle utilisée dans le chart.

Wording:
Dans la version anglaise, on utilisait pas la même formulation pour les résultats envoyés dans le chart et dans le tag.

## :robot: Solution
Homogénéiser les couleurs et le wording.

## :rainbow: Remarques
BSR: supprimer un getter plus utilisé.

## :100: Pour tester
Se connecter a pix orga et aller voir une campagne d'évaluation
