### PR TITLE
[FEATURE] Etre plus tolérant sur la vérification des noms / prénoms dans le formulaire d'entrée en certification sur PixApp (PIX-2630)

### DIFF
--- a/api/db/database-builder/factory/build-certification-cpf-country.js
+++ b/api/db/database-builder/factory/build-certification-cpf-country.js
@@ -1,12 +1,12 @@
 const databaseBuffer = require('../database-buffer');
-const { sanitizeAndSortChars } = require('../../../lib/infrastructure/utils/string-utils');
+const { normalizeAndSortChars } = require('../../../lib/infrastructure/utils/string-utils');
 
 module.exports = function buildCertificationCpfCountry({
   id = databaseBuffer.getNextId(),
   code = '99123',
   commonName = 'FILÉKISTANIE',
   originalName = 'RÉPUBLIQUE DE FILÉKISTAN',
-  matcher = sanitizeAndSortChars(originalName),
+  matcher = normalizeAndSortChars(originalName),
   createdAt = new Date(),
 } = {}) {
   const values = {

--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -1,4 +1,4 @@
-const { sanitizeAndSortChars } = require('../../infrastructure/utils/string-utils');
+const { normalizeAndSortChars } = require('../../infrastructure/utils/string-utils');
 const isEmpty = require('lodash/isEmpty');
 
 const CpfValidationStatus = {
@@ -86,8 +86,8 @@ async function getBirthInformationByPostalCode(birthCity, birthPostalCode, count
     return CpfBirthInformationValidation.failure(`Le code postal "${birthPostalCode}" n'est pas valide.`);
   }
 
-  const sanitizedCity = sanitizeAndSortChars(birthCity);
-  const doesCityMatchPostalCode = cities.some((city) => sanitizeAndSortChars(city.name) === sanitizedCity);
+  const sanitizedCity = normalizeAndSortChars(birthCity);
+  const doesCityMatchPostalCode = cities.some((city) => normalizeAndSortChars(city.name) === sanitizedCity);
 
   if (!doesCityMatchPostalCode) {
     return CpfBirthInformationValidation.failure(`Le code postal "${birthPostalCode}" ne correspond pas à la ville "${birthCity}"`);
@@ -113,7 +113,7 @@ async function getBirthInformation({
     return CpfBirthInformationValidation.failure('Le champ pays est obligatoire.');
   }
 
-  const matcher = sanitizeAndSortChars(birthCountry);
+  const matcher = normalizeAndSortChars(birthCountry);
   const country = await certificationCpfCountryRepository.getByMatcher({ matcher });
 
   if (!country) {

--- a/api/lib/infrastructure/utils/string-utils.js
+++ b/api/lib/infrastructure/utils/string-utils.js
@@ -26,7 +26,7 @@ function splitIntoWordsAndRemoveBackspaces(string) {
  * @param {string} str
  * @returns {string}
  */
-function sanitizeAndSortChars(str) {
+function normalizeAndSortChars(str) {
   const normalizedName = str.toUpperCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   return [...normalizedName].filter((char) => Boolean(char.match(/[A-Z]/))).sort().join('');
 }
@@ -35,5 +35,5 @@ module.exports = {
   isNumeric,
   splitIntoWordsAndRemoveBackspaces,
   cleanStringAndParseFloat,
-  sanitizeAndSortChars,
+  normalizeAndSortChars,
 };

--- a/api/lib/infrastructure/utils/string-utils.js
+++ b/api/lib/infrastructure/utils/string-utils.js
@@ -22,13 +22,28 @@ function splitIntoWordsAndRemoveBackspaces(string) {
 }
 
 /**
- * Normalize and uppercase a string, remove non canonical characters and sort the remaining characters alphabetically
+ * Normalize and uppercase a string, remove non canonical characters, zero-width characters and sort the remaining characters alphabetically
  * @param {string} str
  * @returns {string}
  */
 function normalizeAndSortChars(str) {
-  const normalizedName = str.toUpperCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-  return [...normalizedName].filter((char) => Boolean(char.match(/[A-Z]/))).sort().join('');
+  const normalizedName = normalize(str);
+  return [...normalizedName].sort().join('');
+}
+
+/**
+ * Normalize and uppercase a string, remove non canonical characters and zero-width characters
+ * @param {string} str
+ * @returns {string}
+ */
+function normalize(str) {
+  const strCanonical = _removeNonCanonicalChars(str);
+  const strUpper = strCanonical.toUpperCase();
+  return [...strUpper].filter((char) => Boolean(char.match(/[A-Z]/))).join('');
+}
+
+function _removeNonCanonicalChars(str) {
+  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
 
 module.exports = {
@@ -36,4 +51,5 @@ module.exports = {
   splitIntoWordsAndRemoveBackspaces,
   cleanStringAndParseFloat,
   normalizeAndSortChars,
+  normalize,
 };

--- a/api/scripts/import-certification-cpf-countries.js
+++ b/api/scripts/import-certification-cpf-countries.js
@@ -8,7 +8,7 @@
 'use strict';
 const { parseCsv } = require('./helpers/csvHelpers');
 const { knex } = require('../lib/infrastructure/bookshelf');
-const { sanitizeAndSortChars } = require('../lib/infrastructure/utils/string-utils');
+const { normalizeAndSortChars } = require('../lib/infrastructure/utils/string-utils');
 const _ = require('lodash');
 
 const CURRENT_NAME_COLUMN = 'LIBCOG';
@@ -44,14 +44,14 @@ function buildCountries({ csvData }) {
         code,
         commonName: data[CURRENT_NAME_COLUMN],
         originalName: data[CURRENT_NAME_COLUMN],
-        matcher: sanitizeAndSortChars(data[CURRENT_NAME_COLUMN]),
+        matcher: normalizeAndSortChars(data[CURRENT_NAME_COLUMN]),
       });
       if (data[ALTERNATIVE_NAME_COLUMN] && data[ALTERNATIVE_NAME_COLUMN] !== data[CURRENT_NAME_COLUMN]) {
         result.push({
           code,
           commonName: data[CURRENT_NAME_COLUMN],
           originalName: data[ALTERNATIVE_NAME_COLUMN],
-          matcher: sanitizeAndSortChars(data[ALTERNATIVE_NAME_COLUMN]),
+          matcher: normalizeAndSortChars(data[ALTERNATIVE_NAME_COLUMN]),
         });
       }
       return result;

--- a/api/tests/tooling/domain-builder/factory/build-country.js
+++ b/api/tests/tooling/domain-builder/factory/build-country.js
@@ -1,10 +1,10 @@
 const { Country } = require('../../../../lib/domain/read-models/Country');
-const { sanitizeAndSortChars } = require('../../../../lib/infrastructure/utils/string-utils');
+const { normalizeAndSortChars } = require('../../../../lib/infrastructure/utils/string-utils');
 
 module.exports = function buildCountry({
   code = '99345',
   name = 'TOGO',
-  matcher = sanitizeAndSortChars(name),
+  matcher = normalizeAndSortChars(name),
 } = {}) {
 
   return new Country({

--- a/api/tests/unit/infrastructure/utils/string-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/string-utils_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('../../../test-helper');
-const { isNumeric, cleanStringAndParseFloat, splitIntoWordsAndRemoveBackspaces, sanitizeAndSortChars } = require('../../../../lib/infrastructure/utils/string-utils');
+const { isNumeric, cleanStringAndParseFloat, splitIntoWordsAndRemoveBackspaces, normalizeAndSortChars } = require('../../../../lib/infrastructure/utils/string-utils');
 
 describe('Unit | Utils | string-utils', () => {
 
@@ -63,14 +63,14 @@ describe('Unit | Utils | string-utils', () => {
     });
   });
 
-  describe('#sanitizeAndSortChars', () => {
+  describe('#normalizeAndSortChars', () => {
 
     it('should sanitize and sort chars of the string "ABCDEFGHI"', () => {
-      expect(sanitizeAndSortChars(('ABCDEFGHI'))).to.equal('ABCDEFGHI');
+      expect(normalizeAndSortChars(('ABCDEFGHI'))).to.equal('ABCDEFGHI');
     });
 
     it('should sanitize and sort chars of the string "Féd \'. àBç - (îHg)"', () => {
-      expect(sanitizeAndSortChars(('Féd \'. àBç - (îHg)'))).to.equal('ABCDEFGHI');
+      expect(normalizeAndSortChars(('Féd \'. àBç - (îHg)'))).to.equal('ABCDEFGHI');
     });
   });
 });

--- a/api/tests/unit/infrastructure/utils/string-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/string-utils_test.js
@@ -1,7 +1,14 @@
 const { expect } = require('../../../test-helper');
-const { isNumeric, cleanStringAndParseFloat, splitIntoWordsAndRemoveBackspaces, normalizeAndSortChars } = require('../../../../lib/infrastructure/utils/string-utils');
+const {
+  isNumeric,
+  cleanStringAndParseFloat,
+  splitIntoWordsAndRemoveBackspaces,
+  normalizeAndSortChars,
+  normalize,
+} = require('../../../../lib/infrastructure/utils/string-utils');
 
 describe('Unit | Utils | string-utils', () => {
+  const zeroWidthSpaceChar = '​';
 
   describe('isNumeric', () => {
     [
@@ -65,12 +72,23 @@ describe('Unit | Utils | string-utils', () => {
 
   describe('#normalizeAndSortChars', () => {
 
-    it('should sanitize and sort chars of the string "ABCDEFGHI"', () => {
+    it('should normalize and sort chars of the string "ABCDEFGHI"', () => {
       expect(normalizeAndSortChars(('ABCDEFGHI'))).to.equal('ABCDEFGHI');
     });
 
-    it('should sanitize and sort chars of the string "Féd \'. àBç - (îHg)"', () => {
-      expect(normalizeAndSortChars(('Féd \'. àBç - (îHg)'))).to.equal('ABCDEFGHI');
+    it(`should normalize and sort chars of a string with non canonical, zero-width and special characters: "Féd '. àBç - (îHg)K${zeroWidthSpaceChar}J"`, () => {
+      expect(normalizeAndSortChars(('Féd \'. àBç - (îHg)K​J'))).to.equal('ABCDEFGHIJK');
+    });
+  });
+
+  describe('#normalize', () => {
+
+    it('should normalize chars of the string "ABCDEFGHI"', () => {
+      expect(normalize(('ABCDEFGHI'))).to.equal('ABCDEFGHI');
+    });
+
+    it(`should normalize chars of a string with non canonical, zero-width and special characters: "Féd '. àBç - (îHg)K${zeroWidthSpaceChar}J"`, () => {
+      expect(normalize(('Féd \'. àBç - (îHg)K​J'))).to.equal('FEDABCIHGKJ');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'à aujourd'hui, contrairement à la réconciliation de prescription, l'entrée en certification se basait et comparait des informations personnelles de façon très stricte (insensible à la casse uniquement).
Cela a posé plusieurs problèmes durant l'année 2021, en particulier sur les prénoms ou les noms avec des caractères un peu spéciaux, comme par exemple : Aïda, Jean-Paul, D'Artigny.

## :robot: Solution
Nous n'allons pas aller jusqu'à faire des comparaisons type Levenshtein comme en prescription, mais nous allons comparer l'input utilisateur avec la BDD en ignorant les caractères spéciaux à savoir :
- les caractères spéciaux
- les espaces au milieu
- les accents
- les caractères `zero-width`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Inscrire un candidat en certification avec des caractères spéciaux.
Entrer en certification avec cette identité sans avoir à saisir ces caractères
