### PR TITLE
[TECH] Nommer les conteneurs Docker locaux.

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -10,7 +10,9 @@ Vous devez au préalable avoir correctement installé les logiciels suivants :
 
 > ⚠️ Les versions indiquées sont celles utilisées et préconisées par l'équipe de développement. Il est possible que l'application fonctionne avec des versions différentes.
 
-Assurez-vous aussi de ne pas avoir de process écoutant le port 5432 (PostgreSQL).
+Assurez-vous aussi de ne pas avoir de process:
+- sur le port 5432 (PostgreSQL), ou surchargez la variable `PIX_DATABASE_PORT`;
+- sur le port 6379 (redis), ou surchargez la variable `PIX_CACHE_PORT`.
 
 ## Instructions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   postgres:
     image: postgres:12.7-alpine
+    container_name: pix-api-postgres
     ports:
       - "5432:5432"
     environment:
@@ -10,5 +11,6 @@ services:
 
   redis:
     image: redis:5.0.7-alpine
+    container_name: pix-api-redis
     ports:
       - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:12.7-alpine
     container_name: pix-api-postgres
     ports:
-      - "5432:5432"
+      - "${PIX_DATABASE_PORT:-5432}:5432"
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 
@@ -13,4 +13,4 @@ services:
     image: redis:5.0.7-alpine
     container_name: pix-api-redis
     ports:
-      - "6379:6379"
+      - "${PIX_CACHE_PORT:-6379}:6379"

--- a/high-level-tests/e2e/docker-compose.yml
+++ b/high-level-tests/e2e/docker-compose.yml
@@ -3,14 +3,17 @@ version: '3'
 services:
   postgres:
     image: postgres:12.5-alpine
+    container_name: pix-e2e-postgres
     environment:
       POSTGRES_DB: pix
       POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
+    container_name: pix-e2e-redis
     image: redis:5.0.7-alpine
 
   cypress:
+    container_name: pix-e2e-cypress
     user: node
     build:
       context: .
@@ -24,6 +27,7 @@ services:
       - certif
 
   orga:
+    container_name: pix-e2e-orga
     user: node
     image: node:14.16.0
     command: npx ember serve --proxy http://api:3000
@@ -34,6 +38,7 @@ services:
       - api
 
   certif:
+    container_name: pix-e2e-certif
     user: node
     image: node:14.16.0
     command: npx ember serve --proxy http://api:3000
@@ -44,6 +49,7 @@ services:
       - api
 
   monpix:
+    container_name: pix-e2e-monpix
     user: node
     image: node:14.16.0
     command: npx ember serve --proxy http://api:3000
@@ -54,6 +60,7 @@ services:
       - api
 
   api:
+    container_name: pix-e2e-api
     user: node
     image: node:14.16.0
     env_file: ./env-api

--- a/scripts/tests-e2e
+++ b/scripts/tests-e2e
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 CYPRESS_ARGS="run --browser=chrome"
 DC_CYPRESS_ARGS=""
 if [ "$1" == "open" ]; then
@@ -11,8 +13,8 @@ npm run ci:all
 cd high-level-tests/e2e
 docker-compose stop
 docker-compose up -d postgres redis api monpix certif orga
-docker-compose run --rm api npm run db:prepare
+docker-compose run --name pix-e2e-run-prepare --rm api npm run db:prepare
 docker-compose exec redis redis-cli flushdb
-docker-compose run --rm cypress npx wait-on http://api:3000/api http://monpix:4200 http://orga:4201 http://certif:4203
-docker-compose run --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
+docker-compose run --name pix-e2e-run-wait --rm cypress npx wait-on http://api:3000/api http://monpix:4200 http://orga:4201 http://certif:4203
+docker-compose run --name pix-e2e-run-cypress --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
 docker-compose down


### PR DESCRIPTION
## :unicorn: Problème
Docker nomme automatiquement les images créées (redis/postGres). Le nom va varier en fonction du dossier à partir duquel on lance la commande.

## :robot: Solution
Spécifier le nom du conteneur dans le fichier docker-compose via `container_name`

## :rainbow: Remarques
On pourra ensuite stopper, relancer un conteneur via `docker stop pix-api-postgres` `docker start pix-api-postgres` sans perdre les données.

Ajout de la possibilité de surcharger les valeurs des ports via les var env `PG_PORT` & `REDIS_PORT`

## :100: Pour tester
faire un docker-compose et voir que l'app se connecte aux conteneur sans soucis.
Verifier les noms des conteneurs via un docker ps.
