### PR TITLE
[FEATURE] Permettre d'accéder à la page "Résultats d'un participant à une campagne de collecte de profils" au clavier(PIX-2635)

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -28,7 +28,13 @@
           <tbody>
           {{#each @profiles as |profile|}}
             <tr aria-label={{t 'pages.profiles-list.table.row-title'}} role="button" {{on 'click' (fn @goToProfilePage @campaign.id profile.id)}} class="tr--clickable">
-              <td>{{profile.lastName}}</td>
+              <td>
+                <LinkTo
+                  @route={{'authenticated.campaigns.profile'}}
+                  @models={{array @campaign.id profile.id}}>
+                    {{profile.lastName}}
+                </LinkTo>
+              </td>
               <td>{{profile.firstName}}</td>
               {{#if @campaign.idPixLabel}}
                 <td>{{profile.participantExternalId}}</td>

--- a/orga/app/controllers/authenticated/campaigns/campaign/profiles.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profiles.js
@@ -9,7 +9,8 @@ export default class ProfilesController extends Controller {
   @tracked divisions = [];
 
   @action
-  goToProfilePage(campaignId, campaignParticipationId) {
+  goToProfilePage(campaignId, campaignParticipationId, event) {
+    event.stopPropagation();
     this.transitionToRoute('authenticated.campaigns.profile', campaignId, campaignParticipationId);
   }
 

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/list_test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/list_test.js
@@ -130,6 +130,38 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
       assert.contains('Certifiable');
       assert.contains('5');
     });
+
+    test('it should display a link to access participant profile', async function(assert) {
+      // given
+      this.owner.setupRouter();
+
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+        participationsCount: 1,
+      });
+
+      const profiles = [{
+        id: 7,
+        lastName: 'Todori',
+        firstName: 'Shoto',
+      }];
+
+      this.set('campaign', campaign);
+      this.set('profiles', profiles);
+      this.set('goToProfilePage', goToProfilePage);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Profile::List
+      @campaign={{campaign}}
+      @profiles={{profiles}}
+      @goToProfilePage={{goToProfilePage}}
+    />`);
+
+      // then
+      assert.dom('a[href="/campagnes/1/profils/7"]').exists();
+    });
   });
 
   module('when there is no profile', function() {

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profiles_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profiles_test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 module('Unit | Controller | authenticated/campaigns/campaign/profiles', function(hooks) {
   setupTest(hooks);
   let controller;
+
   hooks.beforeEach(function() {
     controller = this.owner.lookup('controller:authenticated/campaigns/campaign/profiles');
   });
@@ -35,6 +36,24 @@ module('Unit | Controller | authenticated/campaigns/campaign/profiles', function
       //then
       assert.deepEqual(controller.divisions, []);
       assert.deepEqual(controller.pageNumber, null);
+    });
+  });
+
+  module('#action goToProfilePage', function() {
+    test('it should call transitionToRoute with appropriate arguments', function(assert) {
+      // given
+      const event = {
+        stopPropagation: sinon.stub(),
+      };
+
+      controller.transitionToRoute = sinon.stub();
+
+      // when
+      controller.send('goToProfilePage', 123, 345, event);
+
+      // then
+      assert.true(event.stopPropagation.called);
+      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.profile', 123, 345));
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On ne pouvait pas accéder à la  page "Résultats d'un participant à une campagne de collecte de profils" au clavier.

## :robot: Solution
Pouvoir y accéder au clavier.

## :rainbow: Remarques


## :100: Pour tester
Aller sur pix orga et sélectionner une campagne de collecte de profils.
