### PR TITLE
[FEATURE] Afficher les schooling registrations actives dans la liste des élèves (PIX-2859)

### DIFF
--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -384,6 +384,7 @@ module.exports = {
         qb.leftJoin('authentication-methods', function() {
           this.on('users.id', 'authentication-methods.userId').andOnVal('authentication-methods.identityProvider', AuthenticationMethod.identityProviders.GAR);
         });
+        qb.where('schooling-registrations.isDisabled', false);
         qb.modify(_setSchoolingRegistrationFilters, filter);
       })
       .fetchPage({

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1660,6 +1660,21 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       expect(_.map(data, 'id')).to.have.members([schoolingRegistration_1.id, schoolingRegistration_2.id]);
     });
 
+    it('should return the schooling registrations not disabled', async () => {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ isDisabled: false, organizationId: organization.id });
+      databaseBuilder.factory.buildSchoolingRegistration({ isDisabled: true, organizationId: organization.id });
+      await databaseBuilder.commit();
+
+      // when
+      const { data } = await schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations({ organizationId: organization.id });
+
+      // then
+      expect(data).to.have.lengthOf(1);
+      expect(data[0].id).to.equal(schoolingRegistration.id);
+    });
+
     it('should order schoolingRegistrations by lastName and then by firstName with no sensitive case', async () => {
       // given
       const organization = databaseBuilder.factory.buildOrganization();


### PR DESCRIPTION
## :unicorn: Problème

Suite à la PR de désactivation des schooling registrations, les élèves désactivés sont affichés dans la liste de Pix Orga.

## :robot: Solution

Ne pas afficher les élèves ayant une schooling registration avec `isDisabled=true`

## :rainbow: Remarques

Fonctionne pour le SCO et le SUP (même appel API)

## :100: Pour tester

SCO
1. Se connecter à Pix Orga sco (Collège Nightwatch)
2. Aller sur la page des élèves
3. Voir que l'élève "Student disabled" (disabled dans les seeds) n'est pas affiché dans la liste

SUP
1. Se connecter à Pix Orga sup (Université du lion)
2. Aller sur la page des élèves
3. Voir que l'étudiant "Bran Stark" (disabled dans les seeds) n'est pas affiché dans la liste