### PR TITLE
[FEATURE] Permettre accéder à la page "Résultats d'un participant à une campagne d'évaluation" au clavier (PIX-2634)

### DIFF
--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -29,7 +29,13 @@
         <tbody>
         {{#each @participations as |participation|}}
           <tr aria-label={{t 'pages.campaign-results.table.row-title'}} role="button" {{on 'click' (fn @onClickParticipant @campaign.id participation.id)}} class="tr--clickable">
-            <td>{{participation.lastName}}</td>
+           <td>
+             <LinkTo
+                @route={{'authenticated.campaigns.assessment'}}
+                @models={{array @campaign.id participation.id}}>
+                  {{participation.lastName}}
+              </LinkTo>
+           </td>
             <td>{{participation.firstName}}</td>
             {{#if @campaign.idPixLabel}}
               <td>{{participation.participantExternalId}}</td>

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -12,7 +12,8 @@ export default class AssessmentResultsController extends Controller {
   @tracked stages = [];
 
   @action
-  goToAssessmentPage(campaignId, participantId) {
+  goToAssessmentPage(campaignId, participantId, event) {
+    event.stopPropagation();
     this.transitionToRoute('authenticated.campaigns.assessment', campaignId, participantId);
   }
 

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -15,6 +15,30 @@ module('Integration | Component | Campaign::Results::AssessmentList', function(h
     store = this.owner.lookup('service:store');
   });
 
+  test('it should display a link to access to result page', async function(assert) {
+    // given
+    this.owner.setupRouter();
+    const campaign = store.createRecord('campaign', {
+      id: 1,
+    });
+
+    const participations = [{
+      id: 5,
+      lastName: 'Midoriya',
+      firstName: 'Izoku',
+    }];
+
+    this.set('campaign', campaign);
+    this.set('participations', participations);
+    this.set('goToAssessmentPage', () => {});
+
+    // when
+    await render(hbs`<Campaign::Results::AssessmentList @campaign={{campaign}} @participations={{participations}} @onClickParticipant={{goToAssessmentPage}}/>`);
+
+    // then
+    assert.dom('a[href="/campagnes/1/evaluations/5"]').exists();
+  });
+
   module('when a participant has shared his results', function() {
     test('it should display the participant\'s results', async function(assert) {
       // given

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/campaigns/campaign/assessment-results', function(hooks) {
   setupTest(hooks);
@@ -89,6 +90,24 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessment-results'
       controller.filterByStage(123);
       // then
       assert.deepEqual(controller.stages, ['123']);
+    });
+  });
+
+  module('#action goToAssessmentPage', function() {
+    test('it should call transitionToRoute with appropriate arguments', function(assert) {
+      // given
+      const event = {
+        stopPropagation: sinon.stub(),
+      };
+
+      controller.transitionToRoute = sinon.stub();
+
+      // when
+      controller.send('goToAssessmentPage', 123, 345, event);
+
+      // then
+      assert.true(event.stopPropagation.called);
+      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.assessment', 123, 345));
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On ne pouvait pas accéder à la page "Résultats d'un participant à une campagne d'évaluation" au clavier.

## :robot: Solution
Pouvoir y accéder au clavier.

## :rainbow: Remarques

## :100: Pour tester
Aller sur pix orga et sélectionner une campagne d'éval.
