### PR TITLE
[FEATURE] Générer les codes de verification à la création de certification et ajout d'un script en production pour rétro-générer des codes de vérification (PIX-2918)

### DIFF
--- a/api/lib/domain/usecases/certificate/get-private-certificate.js
+++ b/api/lib/domain/usecases/certificate/get-private-certificate.js
@@ -15,6 +15,7 @@ module.exports = async function getPrivateCertificate({
     const code = await verifyCertificateCodeService.generateCertificateVerificationCode();
     await certificationRepository.saveVerificationCode(certificationId, code);
   }
+
   const privateCertificate = await privateCertificateRepository.get(certificationId);
   if (privateCertificate.userId !== userId) {
     throw new NotFoundError();

--- a/api/scripts/prod/generate-certificate-verification-code.js
+++ b/api/scripts/prod/generate-certificate-verification-code.js
@@ -1,0 +1,133 @@
+#! /usr/bin/env node
+/* eslint no-console: ["off"] */
+'use strict';
+require('dotenv').config();
+const yargs = require('yargs');
+const { knex } = require('../../db/knex-database-connection');
+const bluebird = require('bluebird');
+const certificationRepository = require('../../lib/infrastructure/repositories/certification-repository');
+const verifyCertificateCodeService = require('../../lib/domain/services/verify-certificate-code-service');
+const uniqueConstraintViolationCode = '23505';
+const DEFAULT_COUNT = 20000;
+const DEFAULT_CONCURRENCY = 1;
+
+let progression = 0;
+function _logProgression(totalCount) {
+  ++progression;
+  process.stdout.cursorTo(0);
+  process.stdout.write(`${Math.round(progression * 100 / totalCount, 2)} %`);
+}
+
+async function main() {
+  console.log('DEBUT');
+  try {
+    console.log('Validation des arguments...');
+    const commandLineArgs = yargs
+      .option('count', {
+        description: 'Nombre de certificats pour lesquels on génère un code.',
+        type: 'number',
+        default: DEFAULT_COUNT,
+      })
+      .option('concurrency', {
+        description: 'Concurrence',
+        type: 'number',
+        default: DEFAULT_CONCURRENCY,
+      })
+      .help()
+      .argv;
+    const {
+      count,
+      concurrency,
+    } = _validateAndNormalizeArgs(commandLineArgs);
+    console.log(`OK : Nombre de certificats - ${count} / Concurrence - ${concurrency}`);
+
+    console.log('Génération des codes...');
+    await _do({ count, concurrency });
+    console.log('OK');
+    console.log('FIN');
+  } catch (error) {
+    console.error('\x1b[31mErreur : %s\x1b[0m', error.message);
+    yargs.showHelp();
+    process.exit(1);
+  }
+}
+
+function _validateAndNormalizeArgs({
+  count,
+  concurrency,
+}) {
+  const finalCount = _validateAndNormalizeCount(count);
+  const finalConcurrency = _validateAndNormalizeConcurrency(concurrency);
+
+  return {
+    count: finalCount,
+    concurrency: finalConcurrency,
+  };
+}
+
+function _validateAndNormalizeCount(count) {
+  if (isNaN(count)) {
+    count = DEFAULT_COUNT;
+  }
+  if (count <= 0 || count > 100000) {
+    throw new Error(`Nombre de certifications à traiter ${count} ne peut pas être inférieur à 1 ni supérieur à 50000.`);
+  }
+
+  return count;
+}
+
+function _validateAndNormalizeConcurrency(concurrency) {
+  if (isNaN(concurrency)) {
+    concurrency = DEFAULT_CONCURRENCY;
+  }
+  if (concurrency <= 0 || concurrency > 10) {
+    throw new Error(`La concurrence ${concurrency} ne peut pas être inférieure à 1 ni supérieure à 10.`);
+  }
+
+  return concurrency;
+}
+
+async function _do({ count, concurrency }) {
+  console.log('\tRécupération des certifications éligibles...');
+  const eligibleCertificationIds = await _findEligibleCertifications(count);
+  console.log(`\tOK : ${eligibleCertificationIds.length} certifications récupérées`);
+
+  console.log('\tGénération des codes de vérification des certifications...');
+  let failedGenerations = 0;
+  await bluebird.map(eligibleCertificationIds, async (certificationId) => {
+    try {
+      await _generateVerificationCode(certificationId);
+    } catch (err) {
+      if (err?.code === uniqueConstraintViolationCode) {
+        ++failedGenerations;
+      } else {
+        throw err;
+      }
+    }
+    _logProgression(count);
+  }, { concurrency });
+  console.log(`\n\tOK, ${failedGenerations} générations de codes échouées pour cause de code en doublon`);
+}
+
+function _findEligibleCertifications(count) {
+  return knex
+    .pluck('id')
+    .from('certification-courses')
+    .whereNull('verificationCode')
+    .limit(count);
+}
+
+async function _generateVerificationCode(certificationId) {
+  const verificationCode = await verifyCertificateCodeService.generateCertificateVerificationCode();
+  return certificationRepository.saveVerificationCode(certificationId, verificationCode);
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}

--- a/api/tests/unit/domain/usecases/get-private-certificate_test.js
+++ b/api/tests/unit/domain/usecases/get-private-certificate_test.js
@@ -57,7 +57,6 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
   });
 
   context('when the user is owner of the certification', async () => {
-
     context('certification has no verification code', () => {
 
       it('should generate and save a verification code', async () => {
@@ -115,6 +114,7 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
       privateCertificateRepository.get.withArgs(123).resolves(privateCertificate);
       verifyCertificateCodeService.generateCertificateVerificationCode.rejects(new Error('I should not run.'));
       certificationRepository.saveVerificationCode.resolves(new Error('I should not run.'));
+      privateCertificateRepository.get.withArgs(123).resolves(privateCertificate);
       resultCompetenceTreeService.computeForCertification
         .withArgs({
           certificationId: 123,

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -13,6 +13,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
   const userId = 'userId';
   const sessionId = 'sessionId';
   const accessCode = 'accessCode';
+  const verificationCode = Symbol('verificationCode');
   let foundSession;
   const assessmentRepository = { save: sinon.stub() };
   const competenceRepository = { listPixCompetencesOnly: sinon.stub() };
@@ -28,6 +29,9 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
   const placementProfileService = {
     getPlacementProfile: sinon.stub(),
   };
+  const verifyCertificateCodeService = {
+    generateCertificateVerificationCode: sinon.stub().resolves(verificationCode),
+  };
   const locale = 'fr';
 
   const parameters = {
@@ -42,6 +46,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
     certificationBadgesService,
     certificationChallengesService,
     placementProfileService,
+    verifyCertificateCodeService,
   };
 
   beforeEach(() => {
@@ -71,6 +76,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
+      expect(certificationCourseRepository.save).not.to.have.been.called;
+      expect(verifyCertificateCodeService.generateCertificateVerificationCode).not.to.have.been.called;
     });
   });
 
@@ -93,6 +100,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
         // then
         expect(error).to.be.instanceOf(SessionNotAccessible);
+        expect(certificationCourseRepository.save).not.to.have.been.called;
+        expect(verifyCertificateCodeService.generateCertificateVerificationCode).not.to.have.been.called;
       });
     });
 
@@ -125,6 +134,9 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             created: false,
             certificationCourse: existingCertificationCourse,
           });
+
+          expect(certificationCourseRepository.save).not.to.have.been.called;
+          expect(verifyCertificateCodeService.generateCertificateVerificationCode).not.to.have.been.called;
         });
 
       });
@@ -173,6 +185,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             sinon.assert.notCalled(certificationCourseRepository.save);
             sinon.assert.notCalled(assessmentRepository.save);
             sinon.assert.notCalled(certificationChallengeRepository.save);
+            expect(verifyCertificateCodeService.generateCertificateVerificationCode).not.to.have.been.called;
           });
         });
 
@@ -218,6 +231,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
                 created: false,
                 certificationCourse: existingCertificationCourse,
               });
+              expect(certificationCourseRepository.save).not.to.have.been.called;
+              expect(verifyCertificateCodeService.generateCertificateVerificationCode).not.to.have.been.called;
             });
 
             it('should have filled the certification profile with challenges anyway', async () => {
@@ -367,6 +382,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
                   certificationCandidate: foundCertificationCandidate,
                   challenges: expectedChallenges,
                   maxReachableLevelOnCertificationDate: 5,
+                  verificationCode,
                 });
               });
 
@@ -410,6 +426,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
                     certificationCandidate: foundCertificationCandidate,
                     challenges: expectedChallenges,
                     maxReachableLevelOnCertificationDate: 5,
+                    verificationCode,
                   });
                 });
               });
@@ -439,6 +456,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
                   certificationCandidate: foundCertificationCandidate,
                   challenges: expectedChallenges,
                   maxReachableLevelOnCertificationDate: 5,
+                  verificationCode,
                 });
               });
             });


### PR DESCRIPTION
## :unicorn: Problème 
Les codes de vérification sont générés lorsque l'on récupère le certificat "privé". Si on récupère les certificats autrement (PDF par batch, Livret-scolaire), on n'aura pas le code de vérification

## :robot: Solution
Générer ce code à la création de la certification
Ajouter un script pour générer le code rétroactivement sur les certifications existantes n'ayant pas de code de vérification.

## :rainbow: Remarques

## :100: Pour tester
- Démarrer une certification, s'assurer qu'un code a bien été généré (dans la table `certification-courses`, champ `verificationCode`)
- Script : `node scripts/prod/generate-certification-vertification-code.js --count <count> --concurrency <concurrency>`