### PR TITLE
[FEATURE] Ne permettre qu'une seule récupération de compte SCO (PIX-2734).

### DIFF
--- a/api/db/database-builder/factory/build-account-recovery-demand.js
+++ b/api/db/database-builder/factory/build-account-recovery-demand.js
@@ -1,9 +1,12 @@
 const databaseBuffer = require('../database-buffer');
 const buildSchoolingRegistration = require('./build-schooling-registration');
+const buildUser = require('./build-user');
 
 module.exports = function buildAccountRecoveryDemand({
   id = databaseBuffer.getNextId(),
   userId,
+  firstName,
+  lastName,
   schoolingRegistrationId,
   oldEmail,
   newEmail = 'philipe@example.net',
@@ -11,16 +14,30 @@ module.exports = function buildAccountRecoveryDemand({
   used = false,
   createdAt,
 } = {}) {
+
+  let schoolingRegistrationAttributes;
+  let user;
+
+  if (!userId) {
+    user = buildUser();
+    schoolingRegistrationAttributes = { userId: user.id, firstName: user.firstName, lastName: user.lastName, nationalStudentId: '123456789JJ' };
+  } else {
+    schoolingRegistrationAttributes = { userId, firstName, lastName, nationalStudentId: '123456789JJ' };
+  }
+  const actualSchoolingRegistrationId = schoolingRegistrationId || buildSchoolingRegistration(schoolingRegistrationAttributes).id;
+  const actualUserId = userId || user.id;
+
   const values = {
     id,
-    userId,
-    schoolingRegistrationId: schoolingRegistrationId || buildSchoolingRegistration({ userId }).id,
+    userId: actualUserId,
+    schoolingRegistrationId: actualSchoolingRegistrationId,
     oldEmail,
     newEmail,
     temporaryKey,
     used,
     createdAt,
   };
+
   return databaseBuffer.pushInsertable({
     tableName: 'account-recovery-demands',
     values,

--- a/api/db/database-builder/factory/build-account-recovery-demand.js
+++ b/api/db/database-builder/factory/build-account-recovery-demand.js
@@ -12,7 +12,7 @@ module.exports = function buildAccountRecoveryDemand({
   newEmail = 'philipe@example.net',
   temporaryKey = 'OWIxZGViNGQtM2I3ZC00YmFkLTliZGQtMmIwZDdiM2RjYjZk',
   used = false,
-  createdAt,
+  createdAt = new Date(),
 } = {}) {
 
   let schoolingRegistrationAttributes;

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -335,6 +335,33 @@ function organizationsScoBuilder({ databaseBuilder }) {
     organizationId: SCO_AEFE_ID,
     organizationRole: Membership.roles.MEMBER,
   });
+
+  // user who has left SCO
+  const userWhoHasLeftSCO = databaseBuilder.factory.buildUser({
+    firstName: 'John',
+    lastName: 'hasLeftSCO',
+    email: 'john.hasleftsco@example.net',
+    username: null,
+    cgu: true,
+    emailConfirmedAt: new Date(),
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod({
+    identityProvider: AuthenticationMethod.identityProviders.GAR,
+    externalIdentifier: '1234555',
+    userId: userWhoHasLeftSCO.id,
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.buildWithPassword({
+    userId: userWhoHasLeftSCO.id,
+  });
+
+  databaseBuilder.factory.buildAccountRecoveryDemand({
+    userId: userWhoHasLeftSCO.id,
+    firstName: userWhoHasLeftSCO.firstName,
+    lastName: userWhoHasLeftSCO.lastName,
+    used: true,
+  });
 }
 
 module.exports = {

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -63,6 +63,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AccountRecoveryDemandExpired) {
     return new HttpErrors.UnauthorizedError(error.message);
   }
+  if (error instanceof DomainErrors.UserHasAlreadyLeftSCO) {
+    return new HttpErrors.UnauthorizedError(error.message);
+  }
   if (error instanceof DomainErrors.AccountRecoveryUserAlreadyConfirmEmail) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -727,6 +727,12 @@ class UserNotAuthorizedToUpdateEmailError extends DomainError {
   }
 }
 
+class UserHasAlreadyLeftSCO extends DomainError {
+  constructor(message = 'User has already left SCO.') {
+    super(message);
+  }
+}
+
 class UserNotAuthorizedToAccessEntityError extends DomainError {
   constructor(message = 'User is not authorized to access ressource') {
     super(message);
@@ -982,6 +988,7 @@ module.exports = {
   UserAlreadyLinkedToCandidateInSessionError,
   UserCantBeCreatedError,
   UserCouldNotBeReconciledError,
+  UserHasAlreadyLeftSCO,
   UserNotAuthorizedToAccessEntityError,
   UserNotAuthorizedToCertifyError,
   UserNotAuthorizedToCreateCampaignError,

--- a/api/lib/domain/models/AccountRecoveryDemand.js
+++ b/api/lib/domain/models/AccountRecoveryDemand.js
@@ -8,6 +8,7 @@ class AccountRecoveryDemand {
     newEmail,
     temporaryKey,
     used,
+    createdAt,
   } = {}) {
     this.id = id;
     this.schoolingRegistrationId = schoolingRegistrationId;
@@ -16,6 +17,7 @@ class AccountRecoveryDemand {
     this.newEmail = newEmail.toLowerCase();
     this.temporaryKey = temporaryKey;
     this.used = used;
+    this.createdAt = createdAt;
   }
 }
 

--- a/api/lib/domain/services/check-sco-account-recovery-service.js
+++ b/api/lib/domain/services/check-sco-account-recovery-service.js
@@ -1,7 +1,12 @@
-const { MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError, UserNotFoundError } = require('../errors');
+const {
+  MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError,
+  UserNotFoundError,
+  UserHasAlreadyLeftSCO,
+} = require('../errors');
 const _ = require('lodash');
 
 async function retrieveSchoolingRegistration({
+  accountRecoveryDemandRepository,
   studentInformation,
   schoolingRegistrationRepository,
   userRepository,
@@ -18,6 +23,12 @@ async function retrieveSchoolingRegistration({
     latestSchoolingRegistration,
     userReconciliationService,
   });
+
+  const accountRecoveryDemands = await accountRecoveryDemandRepository.findByUserId(userId);
+
+  if (accountRecoveryDemands.some((accountRecoveryDemand) => accountRecoveryDemand.used)) {
+    throw new UserHasAlreadyLeftSCO();
+  }
 
   await _checkIfThereAreMultipleUserForTheSameAccount({ userId, schoolingRegistrationRepository });
 

--- a/api/lib/domain/usecases/account-recovery/get-account-recovery-details.js
+++ b/api/lib/domain/usecases/account-recovery/get-account-recovery-details.js
@@ -1,3 +1,5 @@
+const { UserHasAlreadyLeftSCO } = require('../../errors');
+
 module.exports = async function getAccountRecoveryDetails({
   temporaryKey,
   accountRecoveryDemandRepository,
@@ -5,6 +7,12 @@ module.exports = async function getAccountRecoveryDetails({
 }) {
   const accountRecoveryDemand = await accountRecoveryDemandRepository.findByTemporaryKey(temporaryKey);
   const schoolingRegistration = await schoolingRegistrationRepository.get(accountRecoveryDemand.schoolingRegistrationId);
+
+  const accountRecoveryDemands = await accountRecoveryDemandRepository.findByUserId(schoolingRegistration.userId);
+
+  if (accountRecoveryDemands.some((accountRecoveryDemand) => accountRecoveryDemand.used)) {
+    throw new UserHasAlreadyLeftSCO();
+  }
 
   return {
     id: accountRecoveryDemand.id,

--- a/api/lib/domain/usecases/account-recovery/update-user-account.js
+++ b/api/lib/domain/usecases/account-recovery/update-user-account.js
@@ -1,5 +1,5 @@
 const AuthenticationMethod = require('../../../domain/models/AuthenticationMethod');
-const { AccountRecoveryUserAlreadyConfirmEmail } = require('../../../domain/errors');
+const { UserHasAlreadyLeftSCO } = require('../../../domain/errors');
 
 module.exports = async function updateUserAccount({
   password,
@@ -12,10 +12,11 @@ module.exports = async function updateUserAccount({
 }) {
 
   const { userId, newEmail } = await accountRecoveryDemandRepository.findByTemporaryKey(temporaryKey);
-  const user = await userRepository.get(userId);
 
-  if (user && user.emailConfirmedAt) {
-    throw new AccountRecoveryUserAlreadyConfirmEmail();
+  const accountRecoveryDemands = await accountRecoveryDemandRepository.findByUserId(userId);
+
+  if (accountRecoveryDemands.some((accountRecoveryDemand) => accountRecoveryDemand.used)) {
+    throw new UserHasAlreadyLeftSCO();
   }
 
   const authenticationMethods = await authenticationMethodRepository.findByUserId({ userId });

--- a/api/lib/domain/usecases/check-sco-account-recovery.js
+++ b/api/lib/domain/usecases/check-sco-account-recovery.js
@@ -4,8 +4,9 @@ module.exports = async function checkScoAccountRecovery({
   studentInformation,
   schoolingRegistrationRepository,
   organizationRepository,
-  checkScoAccountRecoveryService,
+  accountRecoveryDemandRepository,
   userRepository,
+  checkScoAccountRecoveryService,
   userReconciliationService,
 }) {
 
@@ -17,6 +18,7 @@ module.exports = async function checkScoAccountRecovery({
     email,
   } = await checkScoAccountRecoveryService.retrieveSchoolingRegistration({
     studentInformation,
+    accountRecoveryDemandRepository,
     schoolingRegistrationRepository,
     userRepository,
     userReconciliationService,

--- a/api/lib/domain/usecases/send-email-for-account-recovery.js
+++ b/api/lib/domain/usecases/send-email-for-account-recovery.js
@@ -16,6 +16,7 @@ module.exports = async function sendEmailForAccountRecovery({
 
   const { firstName, id, userId, email: oldEmail } = await checkScoAccountRecoveryService.retrieveSchoolingRegistration({
     studentInformation,
+    accountRecoveryDemandRepository,
     schoolingRegistrationRepository,
     userRepository,
     userReconciliationService,

--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const { knex } = require('../../../db/knex-database-connection');
 const AccountRecoveryDemand = require('../../domain/models/AccountRecoveryDemand');
 const {
@@ -6,11 +7,15 @@ const {
 } = require('../../domain/errors');
 const DomainTransaction = require('../DomainTransaction');
 
-function _toDomainObject(accountRecoveryDemandDTO) {
+const _toDomain = (accountRecoveryDemandDTO) => {
   return new AccountRecoveryDemand({
     ...accountRecoveryDemandDTO,
   });
-}
+};
+
+const _toDomainArray = (accountRecoveryDemandsDTOs) => {
+  return _.map(accountRecoveryDemandsDTOs, _toDomain);
+};
 
 const demandHasExpired = (demandCreationDate) => {
   const minutesInADay = 60 * 24;
@@ -42,7 +47,16 @@ module.exports = {
       throw new AccountRecoveryDemandExpired();
     }
 
-    return _toDomainObject(accountRecoveryDemandDTO);
+    return _toDomain(accountRecoveryDemandDTO);
+  },
+
+  async findByUserId(userId) {
+    const accountRecoveryDemandsDTOs = await knex
+      .select('id', 'schoolingRegistrationId', 'userId', 'oldEmail', 'newEmail', 'temporaryKey', 'used', 'createdAt')
+      .from('account-recovery-demands')
+      .where({ userId });
+
+    return _toDomainArray(accountRecoveryDemandsDTOs);
   },
 
   async save(accountRecoveryDemand) {
@@ -50,7 +64,7 @@ module.exports = {
       .insert(accountRecoveryDemand)
       .returning('*');
 
-    return _toDomainObject(result[0]);
+    return _toDomain(result[0]);
   },
 
   markAsBeingUsed(temporaryKey, domainTransaction = DomainTransaction.emptyTransaction()) {

--- a/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
@@ -57,12 +57,12 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
           // given
           const email = 'someMail@example.net';
           const temporaryKey = 'someTemporaryKey';
-          const { id: demandId, schoolingRegistrationId } = databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false });
+          const { id: demandId, userId, schoolingRegistrationId } = databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false });
           databaseBuilder.factory.buildAccountRecoveryDemand({ email, used: false });
           await databaseBuilder.commit();
           const expectedAccountRecoveryDemand = {
             id: demandId,
-            userId: null,
+            userId,
             oldEmail: null,
             schoolingRegistrationId,
             newEmail: 'philipe@example.net',

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -15,6 +15,7 @@ const {
   UnexpectedUserAccountError,
   UserShouldChangePasswordError,
   MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError,
+  UserHasAlreadyLeftSCO,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -235,6 +236,19 @@ describe('Unit | Application | ErrorManager', () => {
     it('should instantiate UnauthorizedError when AccountRecoveryDemandExpired', async () => {
       // given
       const error = new AccountRecoveryDemandExpired();
+      sinon.stub(HttpErrors, 'UnauthorizedError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.UnauthorizedError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate UnauthorizedError when UserHasAlreadyLeftSCO', async () => {
+      // given
+      const error = new UserHasAlreadyLeftSCO();
       sinon.stub(HttpErrors, 'UnauthorizedError');
       const params = { request: {}, h: hFake, error };
 

--- a/api/tests/unit/domain/usecases/account-recovery/send-email-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/send-email-for-account-recovery_test.js
@@ -43,6 +43,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
       };
 
       checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+        accountRecoveryDemandRepository,
         studentInformation,
         schoolingRegistrationRepository,
         userRepository,
@@ -86,6 +87,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
       };
 
       checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+        accountRecoveryDemandRepository,
         studentInformation,
         schoolingRegistrationRepository,
         userRepository,
@@ -133,6 +135,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
       };
 
       checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+        accountRecoveryDemandRepository,
         studentInformation,
         schoolingRegistrationRepository,
         userRepository,

--- a/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
@@ -9,6 +9,7 @@ const checkScoAccountRecovery = require('../../../../lib/domain/usecases/check-s
 describe('Unit | UseCase | check-sco-account-recovery', () => {
 
   let schoolingRegistrationRepository;
+  let accountRecoveryDemandRepository;
   let userRepository;
   let organizationRepository;
   let checkScoAccountRecoveryService;
@@ -46,6 +47,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
         const expectedOrganization = domainBuilder.buildOrganization({ id: 7, name: 'Lycée Poudlard' });
 
         checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+          accountRecoveryDemandRepository,
           studentInformation,
           schoolingRegistrationRepository,
           userRepository,

--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
@@ -40,6 +40,12 @@
       </PixMessage>
     {{/if}}
 
+    {{#if @showUserHasAlreadyLeftSCO}}
+      <PixMessage @type='alert' class="account-recovery-after-leaving-sco-content__not-found-error">
+        {{t 'pages.account-recovery-after-leaving-sco.backup-email-confirmation.form.error.already-has-left-sco'}}
+      </PixMessage>
+    {{/if}}
+
     <div class="account-recovery-after-leaving-sco-content__actions">
       <PixButton
         @isBorderVisible={{true}}

--- a/mon-pix/app/components/account-recovery/reset-password-form.hbs
+++ b/mon-pix/app/components/account-recovery/reset-password-form.hbs
@@ -26,6 +26,12 @@
     @hideRequired={{true}}
   />
 
+  {{#if @showUserHasAlreadyLeftSCO}}
+    <PixMessage @type='alert' class="account-recovery-after-leaving-sco-content__not-found-error">
+      {{t 'pages.account-recovery-after-leaving-sco.reset-password.form.errors.already-has-left-sco'}}
+    </PixMessage>
+  {{/if}}
+
   <PixButton @type="submit" @isDisabled={{not this.isFormValid}}>
     {{t 'pages.account-recovery-after-leaving-sco.reset-password.form.login-button'}}
   </PixButton>

--- a/mon-pix/app/components/account-recovery/reset-password-form.js
+++ b/mon-pix/app/components/account-recovery/reset-password-form.js
@@ -28,6 +28,7 @@ export default class ResetPasswordFormComponent extends Component {
   @tracked passwordValidation = new PasswordValidation();
 
   @tracked password = '';
+  @tracked showUserHasAlreadyLeftSCO = false;
 
   get isFormValid() {
     return !isEmpty(this.password) && this.passwordValidation.status !== 'error';
@@ -62,8 +63,14 @@ export default class ResetPasswordFormComponent extends Component {
     });
     try {
       await newPassword.update();
-    } catch (err) {
-      console.log(err);
+      this.showUserHasAlreadyLeftSCO = false;
+    } catch (errors) {
+      debugger;
+      if (errors[0].status === 401) {
+        this.showUserHasAlreadyLeftSCO = true;
+      } else {
+        throw errors;
+      }
     }
   }
 

--- a/mon-pix/app/components/account-recovery/student-information-form.hbs
+++ b/mon-pix/app/components/account-recovery/student-information-form.hbs
@@ -109,6 +109,12 @@
       </PixMessage>
     {{/if}}
 
+    {{#if @showUserHasAlreadyLeftSCO}}
+      <PixMessage @type='alert' class="account-recovery-after-leaving-sco-content__not-found-error">
+        {{t 'pages.account-recovery-after-leaving-sco.student-information.errors.already-has-left-sco'}}
+      </PixMessage>
+    {{/if}}
+
     <div class="account-recovery-after-leaving-sco-content__actions">
       <PixButton @type="submit" @isDisabled={{not this.isFormValid}}>
         {{t 'pages.account-recovery-after-leaving-sco.student-information.form.submit'}}

--- a/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
+++ b/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
@@ -79,7 +79,11 @@ export default class AccountRecoveryAfterLeavingScoController extends Controller
       const status = err.errors?.[0]?.status;
 
       if (status === '400') {
+        this.showUserHasAlreadyLeftSCO = false;
         this.showAlreadyRegisteredEmailError = true;
+      } else if (status === '401') {
+        this.showAlreadyRegisteredEmailError = false;
+        this.showUserHasAlreadyLeftSCO = true;
       } else {
         console.log(err);
       }

--- a/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
+++ b/mon-pix/app/controllers/account-recovery-after-leaving-sco.js
@@ -19,6 +19,7 @@ export default class AccountRecoveryAfterLeavingScoController extends Controller
   @tracked showConfirmationStep = false;
   @tracked showBackupEmailConfirmationForm = false;
   @tracked showAccountNotFoundError = false;
+  @tracked showUserHasAlreadyLeftSCO = false;
   @tracked showAlreadyRegisteredEmailError = false;
   @tracked showConfirmationEmailSent = false;
   @tracked templateImg = 'illustration';
@@ -105,8 +106,13 @@ export default class AccountRecoveryAfterLeavingScoController extends Controller
     if (status === '409') {
       this.showStudentInformationForm = false;
       this.showAccountNotFoundError = false;
+      this.showUserHasAlreadyLeftSCO = false;
       this.showConflictError = true;
+    } else if (status === '401') {
+      this.showAccountNotFoundError = false;
+      this.showUserHasAlreadyLeftSCO = true;
     } else {
+      this.showUserHasAlreadyLeftSCO = false;
       this.showAccountNotFoundError = true;
     }
   }

--- a/mon-pix/app/templates/account-recovery-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/account-recovery-after-leaving-sco.hbs
@@ -12,7 +12,9 @@
       {{#if this.showStudentInformationForm}}
         <AccountRecovery::StudentInformationForm
           @submitStudentInformation={{this.submitStudentInformation}}
-          @showAccountNotFoundError={{this.showAccountNotFoundError}} />
+          @showAccountNotFoundError={{this.showAccountNotFoundError}}
+          @showUserHasAlreadyLeftSCO={{this.showUserHasAlreadyLeftSCO}}
+        />
       {{/if}}
 
       {{#if this.showConflictError}}

--- a/mon-pix/app/templates/account-recovery-after-leaving-sco.hbs
+++ b/mon-pix/app/templates/account-recovery-after-leaving-sco.hbs
@@ -37,6 +37,7 @@
           @existingEmail={{this.studentInformationForAccountRecovery.email}}
           @cancelAccountRecovery={{this.cancelAccountRecovery}}
           @showAlreadyRegisteredEmailError={{this.showAlreadyRegisteredEmailError}}
+          @showUserHasAlreadyLeftSCO={{this.showUserHasAlreadyLeftSCO}}
         />
       {{/if}}
 

--- a/mon-pix/tests/integration/components/account-recovery/reset-password-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/reset-password-form-test.js
@@ -5,7 +5,9 @@ import { hbs } from 'ember-cli-htmlbars';
 import { contains } from '../../../helpers/contains';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillInByLabel } from '../../../helpers/fill-in-by-label';
-import findByLabel from '../../../helpers/find-by-label';
+import { findByLabel } from '../../../helpers/find-by-label';
+import { clickByLabel } from '../../../helpers/click-by-label';
+import sinon from 'sinon';
 
 describe('Integration | Component | account-recovery/reset-password', function() {
   setupIntlRenderingTest();
@@ -97,4 +99,22 @@ describe('Integration | Component | account-recovery/reset-password', function()
       });
     });
   });
+
+  it.only('should display an error message when user has already left SCO', async function() {
+    // given
+    const validPassword = 'pix123A*';
+    const submitResetPasswordForm = sinon.stub();
+    this.set('submitResetPasswordForm', submitResetPasswordForm);
+    submitResetPasswordForm.rejects({ errors: [{ status: '401', detail: 'User has already left SCO.' }] });
+
+    await render(hbs `<AccountRecovery::ResetPasswordForm @submitResetPasswordForm={{this.submitResetPasswordForm}} />`);
+
+    // when
+    await fillInByLabel(this.intl.t('pages.account-recovery-after-leaving-sco.reset-password.form.password-label'), validPassword);
+    await clickByLabel(this.intl.t('pages.account-recovery-after-leaving-sco.reset-password.form.login-button'));
+
+    // then
+    expect(contains(this.intl.t('pages.account-recovery-after-leaving-sco.reset-password.form.errors.already-has-left-sco'))).to.exist;
+  });
+
 });

--- a/mon-pix/tests/unit/controllers/account-recovery-after-leaving-sco-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery-after-leaving-sco-test.js
@@ -112,6 +112,25 @@ describe('Unit | Controller | account-recovery-after-leaving-sco', function() {
 
     context('when user clicks on "C\'est parti!" button', function() {
 
+      context('when user has already left SCO', function() {
+
+        it('should show user not found error message', async function() {
+          // given
+          const errors = { errors: [{ status: '401' }] };
+          const controller = this.owner.lookup('controller:account-recovery-after-leaving-sco');
+          const sendEmailStub = sinon.stub();
+          const createRecord = sinon.stub().returns({ send: sendEmailStub.rejects(errors) });
+          const store = { createRecord };
+          controller.set('store', store);
+          const email = 'new_email@example.net';
+          // when
+          await controller.sendEmail(email);
+
+          // then
+          expect(controller.showUserHasAlreadyLeftSCO).to.be.true;
+        });
+      });
+
       it('should send account recovery email', async function() {
         // given
         const controller = this.owner.lookup('controller:account-recovery-after-leaving-sco');

--- a/mon-pix/tests/unit/controllers/account-recovery-after-leaving-sco-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery-after-leaving-sco-test.js
@@ -28,6 +28,44 @@ describe('Unit | Controller | account-recovery-after-leaving-sco', function() {
         sinon.assert.calledOnce(submitStudentInformationStub);
       });
 
+      context('when user account is not found', function() {
+
+        it('should show user not found error message', async function() {
+          // given
+          const errors = { errors: [{ status: '404' }] };
+          const controller = this.owner.lookup('controller:account-recovery-after-leaving-sco');
+          const studentInformation = { firstName: 'Jules' };
+          const submitStudentInformationStub = sinon.stub().rejects(errors);
+          const store = { createRecord: sinon.stub().returns({ submitStudentInformation: submitStudentInformationStub }) };
+          controller.set('store', store);
+
+          // when
+          await controller.submitStudentInformation(studentInformation);
+
+          // then
+          expect(controller.showAccountNotFoundError).to.be.true;
+        });
+      });
+
+      context('when user has already left SCO', function() {
+
+        it('should show user not found error message', async function() {
+          // given
+          const errors = { errors: [{ status: '401' }] };
+          const controller = this.owner.lookup('controller:account-recovery-after-leaving-sco');
+          const studentInformation = { firstName: 'Jules' };
+          const submitStudentInformationStub = sinon.stub().rejects(errors);
+          const store = { createRecord: sinon.stub().returns({ submitStudentInformation: submitStudentInformationStub }) };
+          controller.set('store', store);
+
+          // when
+          await controller.submitStudentInformation(studentInformation);
+
+          // then
+          expect(controller.showUserHasAlreadyLeftSCO).to.be.true;
+        });
+      });
+
       context('when two students used same account', function() {
 
         it('should hide student information form and show conflict error', async function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1009,7 +1009,8 @@
               "new-email": ", sinon saisissez une nouvelle."
             },
             "new-backup-email": "Veuillez saisir un e-mail valide pour récupérer votre compte",
-            "new-email-already-exist": "Cette adresse e-mail est déjà utilisée"
+            "new-email-already-exist": "Cette adresse e-mail est déjà utilisée.",
+            "already-has-left-sco": "T'est déjà passé par ici, petit malin."
           }
         }
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1030,7 +1030,8 @@
           "login-button": "Je me connecte",
           "errors": {
             "invalid-password": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
-            "empty-password": "Le champ mot de passe est obligatoire."
+            "empty-password": "Le champ mot de passe est obligatoire.",
+            "already-has-left-sco": "T'est déjà passé par ici, petit malin."
           }
         }
       }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -957,7 +957,8 @@
           "empty-ine-ina": "Le champ INE est obligatoire.",
           "empty-last-name": "Le champ nom est obligatoire.",
           "empty-first-name": "Le champ prénom est obligatoire.",
-          "not-found": "Pix ne reconnait pas vos données. Vérifiez qu'elles sont exactes, sinon "
+          "not-found": "Pix ne reconnait pas vos données. Vérifiez qu'elles sont exactes, sinon ",
+          "already-has-left-sco": "T'est déjà passé par ici, petit malin."
         }
       },
       "conflict": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1009,7 +1009,8 @@
               "new-email": ", sinon saisissez une nouvelle."
             },
             "new-backup-email": "Veuillez saisir un e-mail valide pour récupérer votre compte",
-            "new-email-already-exist": "Cette adresse e-mail est déjà utilisée"
+            "new-email-already-exist": "Cette adresse e-mail est déjà utilisée.",
+            "already-has-left-sco": "T'est déjà passé par ici, petit malin."
           }
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1030,7 +1030,8 @@
           "login-button": "Je me connecte",
           "errors": {
             "invalid-password": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
-            "empty-password": "Le champ mot de passe est obligatoire."
+            "empty-password": "Le champ mot de passe est obligatoire.",
+            "already-has-left-sco": "T'est déjà passé par ici, petit malin."
           }
         }
       }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -957,7 +957,8 @@
           "empty-ine-ina": "Le champ INE est obligatoire.",
           "empty-last-name": "Le champ nom est obligatoire.",
           "empty-first-name": "Le champ prénom est obligatoire.",
-          "not-found": "Pix ne reconnait pas vos données. Vérifiez qu'elles sont exactes, sinon "
+          "not-found": "Pix ne reconnait pas vos données. Vérifiez qu'elles sont exactes, sinon ",
+          "already-has-left-sco": "T'est déjà passé par ici, petit malin."
         }
       },
       "conflict": {


### PR DESCRIPTION
## :unicorn: Problème
La récupération de compte à la sortie du SCO est une fonctionnalité sensible du point de vue sécurité.

## :robot: Solution
Ne permettre qu'une seule récupération réussie

## :rainbow: Remarques

L'afffichage du message dans le front lors de la page appelée par le clic sur lien email sera effectuée dans PIX-2851

Création d'un JDD
- utilisateur GAR
- réconcilié
- avec demande récupération utilisée et email confirmé
- avec connexion email

Modification du builder de récuparation de compte pour qu'il construise un JDD cohérent
- utilisateur existant
- inscription scolaire avec INE, réconcilié sur cet utilisateur
- nom et Prénom de l'utilisateur égaux à ceux de l' inscription scolaire
- demande de récupération sur cet utilisateur, et cette inscription

## :100: Pour tester

### back
Aller [sur la page](https://app-pr3249.review.pix.fr/recuperer-mon-compte) de récupération de compte 

Entrer les informations:
- INE: 123456789JJ
- Prénom: John
- Nom: hasLeftSCO
- date de naissance : 05 / 08 / 2005


Vérifier la 401 + le message d'erreur renvoyé par l'API dans les DevTools
> User has already left SCO


Essayer sur autres étapes:
- saisie de l'email
- page appelée par le clic sur lien email
- envoi du formulaire de choix d'un mot de passe


## front

Essayer sur étapes:
- saisie INE/Nom/prénom/DDN
- saisie de l'email
- envoi du formulaire de choix d'un mot de passe

Le message doit être
> T'est déjà passé par ici, petit malin.

