### PR TITLE
[FEATURE] Mettre à jour le libellé du destinataire des résultats dans le tableau des candidats inscrits à une session de certification (PIX-2901).

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -69,7 +69,7 @@
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">E-mail du destinataire des résultats (formateur, enseigant...)</span>
+            <span class="certification-candidate-details-modal__row__label">E-mail du destinataire des résultats (formateur, enseignant...)</span>
             <span class="certification-candidate-details-modal__row__value" data-test-id="result-recipient-email-row">
               {{if @candidate.resultRecipientEmail @candidate.resultRecipientEmail "-"}}
             </span>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -67,7 +67,7 @@
               </th>
             {{/if }}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-              <th class="certification-candidates-table__recipient-email">Adresse e-mail du destinataire des résultats</th>
+              <th class="certification-candidates-table__recipient-email">E-mail du destinataire des résultats (formateur, enseignant...)</th>
             {{/unless}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__external-id">Identifiant externe</th>


### PR DESCRIPTION
## :unicorn: Problème
Les champs "Adresse e-mail du destinataire des résultats" et "Adresse e-mail de convocation" ont été modifiés pour devenir "E-mail du destinataire des résultats (formateur, enseigant...)" et  "E-mail de convocation" dans le fichier ods et la modale d'ajout/détail. Cependant, ces changements n'ont pas été effectués dans tableau des candidats inscrits à une session de certification. 

## :robot: Solution
Mettre à jour le libellé du destinataire des résulatst.

## :100: Pour tester
- Se connecter à Pix Certif
- Créer une session de certification
- Ajouter un candidat
- Vérifier que le libellé du destinataire des résultats est `E-mail du destinataire des résultats (formateur, enseigant...)`
