### PR TITLE
[FEATURE] Récupérer les attestation par organisation et classe (PIX-2904).

### DIFF
--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -1,3 +1,4 @@
+const bluebird = require('bluebird');
 const { knex } = require('../../../db/knex-database-connection');
 const CertificationAttestation = require('../../domain/models/CertificationAttestation');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
@@ -46,12 +47,14 @@ module.exports = {
       throw new NotFoundError(`There is no certification course for organization "${organizationId}" and division "${division}"`);
     }
 
-    // const cleaCertificationImagePath = await _getCleaCertificationImagePath(certificationCourseDTO.id);
-    // const pixPlusDroitCertificationImagePath = await _getPixPlusDroitCertificationImagePath(certificationCourseDTO.id);
-    return new CertificationAttestation({
-      ...certificationCourseDTOs,
-    //  cleaCertificationImagePath,
-    //  pixPlusDroitCertificationImagePath,
+    return bluebird.mapSeries(certificationCourseDTOs, async (certificationCourseDTO) => {
+      const cleaCertificationImagePath = await _getCleaCertificationImagePath(certificationCourseDTO.id);
+      const pixPlusDroitCertificationImagePath = await _getPixPlusDroitCertificationImagePath(certificationCourseDTO.id);
+      return new CertificationAttestation({
+        ...certificationCourseDTO,
+        cleaCertificationImagePath,
+        pixPlusDroitCertificationImagePath,
+      });
     });
   },
 };

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -39,7 +39,14 @@ module.exports = {
     const certificationCourseDTOs = await _selectCertificationAttestations()
       .innerJoin('schooling-registrations', 'schooling-registrations.userId', 'certification-courses.userId')
       .where('schooling-registrations.organizationId', '=', organizationId)
-      .whereRaw('LOWER("schooling-registrations"."division") LIKE ?', `${division.toLowerCase()}`)
+      .whereRaw('LOWER("schooling-registrations"."division") = ?', division.toLowerCase())
+      .whereNotExists(
+        knex.select(1)
+          .from({ 'last-certification-courses': 'certification-courses' })
+          .whereRaw('"last-certification-courses"."userId" = "certification-courses"."userId"')
+          .whereRaw('"last-certification-courses"."isCancelled"= false')
+          .whereRaw('"certification-courses"."createdAt" < "last-certification-courses"."createdAt"'),
+      )
       .orderBy('lastName', 'ASC')
       .orderBy('firstName', 'ASC');
 
@@ -79,13 +86,14 @@ function _selectCertificationAttestations() {
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
     .join('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
-    .leftJoin({ 'newerAssessmentResults': 'assessment-results' }, function() {
-      this.on('newerAssessmentResults.assessmentId', 'assessments.id')
-        .andOn('assessment-results.createdAt', '<', knex.ref('newerAssessmentResults.createdAt'))
-        .andOn('newerAssessmentResults.status', '=', knex.raw('?', [AssessmentResult.status.VALIDATED]));
-    })
+    .whereNotExists(
+      knex.select(1)
+        .from({ 'last-assessment-results': 'assessment-results' })
+        .where('last-assessment-results.status', AssessmentResult.status.VALIDATED)
+        .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
+        .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"'),
+    )
     .join('sessions', 'sessions.id', 'certification-courses.sessionId')
-    .whereNull('newerAssessmentResults.id')
     .where('assessment-results.status', AssessmentResult.status.VALIDATED)
     .where('certification-courses.isPublished', true)
     .where('certification-courses.isCancelled', false);

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -29,7 +29,7 @@ module.exports = {
       .from('certification-candidates')
       .join('schooling-registrations', 'schooling-registrations.id', 'certification-candidates.schoolingRegistrationId')
       .where('schooling-registrations.organizationId', '=', organizationId)
-      .whereRaw('LOWER("schooling-registrations"."division") LIKE ?', `${division.toLowerCase()}`)
+      .whereRaw('LOWER("schooling-registrations"."division") = ?', division.toLowerCase())
       .orderBy('certification-candidates.lastName', 'ASC')
       .orderBy('certification-candidates.firstName', 'ASC');
 

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -502,7 +502,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       expect(error.message).to.equal(`There is no certification course for organization "${organizationId}" and division "${division}"`);
     });
 
-    it('should return a CertificationAttestation', async () => {
+    it('should return a list of CertificationAttestation', async () => {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
@@ -548,18 +548,29 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: certificationAttestationData.pixScore,
         status: 'validated',
       });
+      databaseBuilder.factory.buildOrganization({ id: organizationId });
+      databaseBuilder.factory.buildSchoolingRegistration({
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        division,
+        organizationId,
+        userId,
+      });
       await databaseBuilder.commit();
 
       // when
-      const certificationAttestation = await certificationAttestationRepository.getByOrganizationIdAndDivision(certificationAttestationData.id);
+      const certificationAttestations = await certificationAttestationRepository.getByOrganizationIdAndDivision({
+        organizationId, division,
+      });
 
       // then
       const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
         id: certificateId,
         ...certificationAttestationData,
       });
-      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
-      expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+      expect(certificationAttestations).to.have.length(1);
+      expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation);
     });
 
     it('should return a CertificationAttestation with the last validated assessment-result', async () => {

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -488,4 +488,344 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       });
     });
   });
+
+  describe('#getByOrganizationIdAndDivision', () => {
+    const organizationId = 10;
+    const division = 'YYYY';
+
+    it('should throw a NotFoundError when there are no results for the given organizationId and division', async () => {
+      // when
+      const error = await catchErr(certificationAttestationRepository.getByOrganizationIdAndDivision)({ organizationId, division });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(`There is no certification course for organization "${organizationId}" and division "${division}"`);
+    });
+
+    it('should return a CertificationAttestation', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+        certificationCenterId,
+      }).id;
+      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData.id,
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData.date,
+        verificationCode: certificationAttestationData.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+        sessionId,
+        userId,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore,
+        status: 'validated',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationAttestation = await certificationAttestationRepository.getByOrganizationIdAndDivision(certificationAttestationData.id);
+
+      // then
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+        id: certificateId,
+        ...certificationAttestationData,
+      });
+      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+    });
+
+    it('should return a CertificationAttestation with the last validated assessment-result', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+        certificationCenterId,
+      }).id;
+      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData.id,
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData.date,
+        verificationCode: certificationAttestationData.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+        sessionId,
+        userId,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: 0,
+        status: 'validated',
+        createdAt: new Date('2020-01-01'),
+      });
+
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore,
+        status: 'validated',
+        createdAt: new Date('2020-01-03'),
+      });
+
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: 0,
+        status: 'error',
+        createdAt: new Date('2020-01-04'),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const certificationAttestation = await certificationAttestationRepository.get(certificationAttestationData.id);
+
+      // then
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+        id: certificateId,
+        ...certificationAttestationData,
+      });
+      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+    });
+
+    it('should get the clea certification result if taken', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: certificationAttestationRepository.macaronCleaPath,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+        certificationCenterId,
+      }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData.id,
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData.date,
+        verificationCode: certificationAttestationData.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+        sessionId,
+        userId,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore,
+        status: 'validated',
+      });
+      databaseBuilder.factory.buildBadge({ key: cleaBadgeKey });
+      databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: cleaBadgeKey, acquired: true });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationAttestation = await certificationAttestationRepository.get(123);
+
+      // then
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+        ...certificationAttestationData,
+      });
+      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+    });
+
+    context('acquired certifiable badges', () => {
+
+      it('should get the certified badge images of pixPlusDroitMaitre or pixPlusDroitExpert when those certifications were acquired', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const certificationAttestationData = {
+          id: 123,
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId,
+          date: new Date('2020-01-01'),
+          verificationCode: 'P-SOMECODE',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: 51,
+          cleaCertificationImagePath: null,
+          pixPlusDroitCertificationImagePath: certificationAttestationRepository.macaronPixPlusDroitExpertPath,
+        };
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const sessionId = databaseBuilder.factory.buildSession({
+          publishedAt: certificationAttestationData.deliveredAt,
+          certificationCenter: certificationAttestationData.certificationCenter,
+          certificationCenterId,
+        }).id;
+        databaseBuilder.factory.buildCertificationCourse({
+          id: certificationAttestationData.id,
+          firstName: certificationAttestationData.firstName,
+          lastName: certificationAttestationData.lastName,
+          birthdate: certificationAttestationData.birthdate,
+          birthplace: certificationAttestationData.birthplace,
+          isPublished: certificationAttestationData.isPublished,
+          isCancelled: false,
+          createdAt: certificationAttestationData.date,
+          verificationCode: certificationAttestationData.verificationCode,
+          maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+          sessionId,
+          userId,
+        }).id;
+        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+        databaseBuilder.factory.buildAssessmentResult({
+          assessmentId,
+          pixScore: certificationAttestationData.pixScore,
+          status: 'validated',
+        });
+        databaseBuilder.factory.buildBadge({ key: pixPlusDroitExpertBadgeKey });
+        databaseBuilder.factory.buildBadge({ key: 'should_be_ignored' });
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: pixPlusDroitExpertBadgeKey, acquired: true });
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: 'should_be_ignored', acquired: true });
+        await databaseBuilder.commit();
+
+        // when
+        const certificationAttestation = await certificationAttestationRepository.get(123);
+
+        // then
+        const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+          ...certificationAttestationData,
+        });
+        expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
+        expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+      });
+
+      it('should only take into account acquired ones', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const certificationAttestationData = {
+          id: 123,
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId,
+          date: new Date('2020-01-01'),
+          verificationCode: 'P-SOMECODE',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: 51,
+          cleaCertificationImagePath: null,
+          pixPlusDroitCertificationImagePath: certificationAttestationRepository.macaronPixPlusDroitMaitrePath,
+        };
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const sessionId = databaseBuilder.factory.buildSession({
+          publishedAt: certificationAttestationData.deliveredAt,
+          certificationCenter: certificationAttestationData.certificationCenter,
+          certificationCenterId,
+        }).id;
+        databaseBuilder.factory.buildCertificationCourse({
+          id: certificationAttestationData.id,
+          firstName: certificationAttestationData.firstName,
+          lastName: certificationAttestationData.lastName,
+          birthdate: certificationAttestationData.birthdate,
+          birthplace: certificationAttestationData.birthplace,
+          isPublished: certificationAttestationData.isPublished,
+          isCancelled: false,
+          createdAt: certificationAttestationData.date,
+          verificationCode: certificationAttestationData.verificationCode,
+          maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+          sessionId,
+          userId,
+        }).id;
+        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+        databaseBuilder.factory.buildAssessmentResult({
+          assessmentId,
+          pixScore: certificationAttestationData.pixScore,
+          status: 'validated',
+        });
+        databaseBuilder.factory.buildBadge({ key: pixPlusDroitMaitreBadgeKey });
+        databaseBuilder.factory.buildBadge({ key: cleaBadgeKey });
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: pixPlusDroitMaitreBadgeKey, acquired: true });
+        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: cleaBadgeKey, acquired: false });
+        await databaseBuilder.commit();
+
+        // when
+        const certificationAttestation = await certificationAttestationRepository.get(123);
+
+        // then
+        const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+          ...certificationAttestationData,
+        });
+        expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
+        expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+      });
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -573,7 +573,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation);
     });
 
-    it('should return a CertificationAttestation with the last validated assessment-result', async () => {
+    it('should return the CertificationAttestation from the last not cancelled certification-course', async () => {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
@@ -613,40 +613,61 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: 0,
-        status: 'validated',
-        createdAt: new Date('2020-01-01'),
-      });
 
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: certificationAttestationData.pixScore,
         status: 'validated',
+        createdAt: new Date('2020-01-01'),
+      });
+
+      const cancelledCertificationId = databaseBuilder.factory.buildCertificationCourse({
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: true,
+        createdAt: new Date('2020-01-02'),
+        sessionId,
+        userId,
+      }).id;
+      const assessmentCancelledId = databaseBuilder.factory.buildAssessment({ certificationCourseId: cancelledCertificationId }).id;
+
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: assessmentCancelledId,
+        pixScore: 0,
+        status: 'validated',
         createdAt: new Date('2020-01-03'),
       });
 
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: 0,
-        status: 'error',
-        createdAt: new Date('2020-01-04'),
+      databaseBuilder.factory.buildOrganization({ id: organizationId });
+      databaseBuilder.factory.buildSchoolingRegistration({
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        division,
+        organizationId,
+        userId,
       });
 
       await databaseBuilder.commit();
 
       // when
-      const certificationAttestation = await certificationAttestationRepository.get(certificationAttestationData.id);
+      const certificationAttestations = await certificationAttestationRepository.getByOrganizationIdAndDivision({
+        organizationId,
+        division,
+      });
 
       // then
       const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
         id: certificateId,
         ...certificationAttestationData,
       });
-      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
-      expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+
+      expect(certificationAttestations.length).to.equal(1);
+      expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation);
     });
 
     it('should get the clea certification result if taken', async () => {
@@ -695,12 +716,20 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: certificationAttestationData.pixScore,
         status: 'validated',
       });
+      databaseBuilder.factory.buildOrganization({ id: organizationId });
+      databaseBuilder.factory.buildSchoolingRegistration({
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        division,
+        organizationId,
+        userId,
+      });
       databaseBuilder.factory.buildBadge({ key: cleaBadgeKey });
       databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: cleaBadgeKey, acquired: true });
       await databaseBuilder.commit();
 
       // when
-      const certificationAttestation = await certificationAttestationRepository.get(123);
+      const [certificationAttestation] = await certificationAttestationRepository.getByOrganizationIdAndDivision({ organizationId, division });
 
       // then
       const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
@@ -758,6 +787,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           pixScore: certificationAttestationData.pixScore,
           status: 'validated',
         });
+        databaseBuilder.factory.buildOrganization({ id: organizationId });
+        databaseBuilder.factory.buildSchoolingRegistration({
+          firstName: certificationAttestationData.firstName,
+          lastName: certificationAttestationData.lastName,
+          division,
+          organizationId,
+          userId,
+        });
         databaseBuilder.factory.buildBadge({ key: pixPlusDroitExpertBadgeKey });
         databaseBuilder.factory.buildBadge({ key: 'should_be_ignored' });
         databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: pixPlusDroitExpertBadgeKey, acquired: true });
@@ -765,7 +802,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         await databaseBuilder.commit();
 
         // when
-        const certificationAttestation = await certificationAttestationRepository.get(123);
+        const [certificationAttestation] = await certificationAttestationRepository.getByOrganizationIdAndDivision({ organizationId, division });
 
         // then
         const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({


### PR DESCRIPTION
## :unicorn: Problème
Les attestation ne peux être récupérer que par l'id de la certification, or on souhaite pouvoir les récupérer en groupe pour une classe.

## :robot: Solution
Implementer le repository pour récupérer les données via l'id de l'organisation et le nom de la classe.

## :rainbow: Remarques
Les données seront utilisée dans un pdf [PIX-2893](https://github.com/1024pix/pix/pull/3252)

## :100: Pour tester
Pas d'endpoint, mais avec les seeds, on peut tester de récuperer 2 attestations en mettant à jour les données
`update "schooling-registrations" set "userId" = 104 where id = 100046;`
```
await certificationAttestationRepository.getByOrganizationIdAndDivision({
        organizationId: 3, division: '5D',
      });
```

qui devrait ramener une unique ligne
