### PR TITLE
[FEATURE] Un utilisateur désactivé ne peut rejoindre une campagne (PIX-2862)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -84,6 +84,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.NoCampaignParticipationForUserAndCampaign) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.SchoolingRegistrationDisabledError) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.ChallengeAlreadyAnsweredError) {
     return new HttpErrors.ConflictError('This challenge has already been answered.');
   }

--- a/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
+++ b/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
@@ -51,14 +51,19 @@ module.exports = {
     return h.response(null).code(204);
   },
 
-  findAssociation(request) {
+  async findAssociation(request) {
     const authenticatedUserId = request.auth.credentials.userId;
     // eslint-disable-next-line no-restricted-syntax
     const requestedUserId = parseInt(request.query.userId);
     const campaignCode = request.query.campaignCode;
 
-    return usecases.findAssociationBetweenUserAndSchoolingRegistration({ authenticatedUserId, requestedUserId, campaignCode })
-      .then(schoolingRegistrationSerializer.serialize);
+    const schoolingRegistration = await usecases.findAssociationBetweenUserAndSchoolingRegistration({
+      authenticatedUserId,
+      requestedUserId,
+      campaignCode,
+    });
+
+    return schoolingRegistrationSerializer.serialize(schoolingRegistration);
   },
 
   async generateUsername(request, h) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -765,6 +765,12 @@ class UserNotAuthorizedToRemoveAuthenticationMethod extends DomainError {
   }
 }
 
+class SchoolingRegistrationDisabledError extends DomainError {
+  constructor(message = 'L\'inscription de l\'élève est désactivée dans l\'organisation.') {
+    super(message);
+  }
+}
+
 class SchoolingRegistrationNotFound extends NotFoundError {
   constructor(message = 'Aucune inscription d‘élève n‘a été trouvée.') {
     super(message);
@@ -970,6 +976,7 @@ module.exports = {
   SameNationalApprenticeIdInOrganizationError,
   SameNationalStudentIdInOrganizationError,
   SchoolingRegistrationAlreadyLinkedToUserError,
+  SchoolingRegistrationDisabledError,
   SchoolingRegistrationNotFound,
   SchoolingRegistrationsCouldNotBeSavedError,
   SendingEmailToResultRecipientError,

--- a/api/lib/domain/usecases/find-association-between-user-and-schooling-registration.js
+++ b/api/lib/domain/usecases/find-association-between-user-and-schooling-registration.js
@@ -1,6 +1,7 @@
 const {
   CampaignCodeError,
   UserNotAuthorizedToAccessEntityError,
+  SchoolingRegistrationDisabledError,
 } = require('../errors');
 
 module.exports = async function findAssociationBetweenUserAndSchoolingRegistration({
@@ -19,5 +20,14 @@ module.exports = async function findAssociationBetweenUserAndSchoolingRegistrati
     throw new CampaignCodeError();
   }
 
-  return schoolingRegistrationRepository.findOneByUserIdAndOrganizationId({ userId: authenticatedUserId, organizationId: campaign.organizationId });
+  const registration = await schoolingRegistrationRepository.findOneByUserIdAndOrganizationId({
+    userId: authenticatedUserId,
+    organizationId: campaign.organizationId,
+  });
+
+  if (registration && registration.isDisabled) {
+    throw new SchoolingRegistrationDisabledError();
+  }
+
+  return registration;
 };

--- a/api/lib/infrastructure/repositories/campaign-to-join-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-to-join-repository.js
@@ -74,17 +74,17 @@ async function _checkCanAccessToCampaign(campaign, userId, domainTransaction) {
 
   }
 
-  if (campaign.isRestricted && await _hasNoSchoolingRegistration(userId, campaign, domainTransaction)) {
+  if (campaign.isRestricted && await _hasNoActiveSchoolingRegistration(userId, campaign, domainTransaction)) {
     throw new ForbiddenAccess('Vous n\'êtes pas autorisé à rejoindre la campagne');
   }
 }
 
-async function _hasNoSchoolingRegistration(userId, campaign, domainTransaction) {
+async function _hasNoActiveSchoolingRegistration(userId, campaign, domainTransaction) {
   const knexConn = domainTransaction.knexTransaction || knex;
   const registrations = await knexConn
     .select('schooling-registrations.id')
     .from('schooling-registrations')
-    .where({ userId, organizationId: campaign.organizationId });
+    .where({ userId, organizationId: campaign.organizationId, isDisabled: false });
 
   return registrations.length === 0;
 }

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -136,6 +136,13 @@ describe('Integration | API | Controller Error', () => {
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
     });
+
+    it('responds Precondition Failed when a SchoolingRegistrationDisabledError occurs', async () => {
+      routeHandler.throws(new DomainErrors.SchoolingRegistrationDisabledError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(PRECONDITION_FAILED);
+    });
   });
 
   context('404 Not Found', () => {

--- a/api/tests/tooling/domain-builder/factory/build-schooling-registration.js
+++ b/api/tests/tooling/domain-builder/factory/build-schooling-registration.js
@@ -20,6 +20,7 @@ function buildSchoolingRegistration({
   nationalStudentId = null,
   division = 'B1',
   userId,
+  isDisabled = false,
   updatedAt = new Date('2020-01-01'),
 } = {}) {
 
@@ -42,6 +43,7 @@ function buildSchoolingRegistration({
     division,
     updatedAt,
     userId,
+    isDisabled,
     organizationId: organization.id,
   });
 }

--- a/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
+++ b/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
@@ -18,6 +18,12 @@ export default function(schema, request) {
 
   const campaign = schema.campaigns.find(campaignId);
 
+  if (campaign.code === 'FORBIDDEN') {
+    return new Response(403, {}, {
+      errors: [{ status: 403 }],
+    });
+  }
+
   if (campaign.type === 'PROFILES_COLLECTION') {
     return schema.campaignParticipations.create({ participantExternalId, campaign });
   }

--- a/mon-pix/mirage/routes/schooling-registration-user-associations/index.js
+++ b/mon-pix/mirage/routes/schooling-registration-user-associations/index.js
@@ -4,6 +4,14 @@ export default function index(config) {
   config.get('/schooling-registration-user-associations', (schema, request) => {
     const campaignCode = request.queryParams.campaignCode;
     const schooolingRegistration = schema.schoolingRegistrationUserAssociations.findBy({ campaignCode });
+    if (campaignCode === 'FORBIDDEN') {
+      return new Response(412, {}, {
+        errors: [{
+          status: '412',
+          title: 'Precondition failed',
+        }],
+      });
+    }
     return schooolingRegistration ? schooolingRegistration : { data: null };
   });
 

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -93,5 +93,21 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
         expect(contains('Area_1_Competence_1_name')).to.exist;
       });
     });
+
+    context('When the campaign is restricted and schooling-registration is disabled', function() {
+      beforeEach(async function() {
+        campaign = server.create('campaign', { code: 'FORBIDDEN', isRestricted: true, type: PROFILES_COLLECTION });
+        server.create('campaign-participation', { campaign });
+        await completeCampaignOfTypeProfilesCollectionByCode(campaign.code);
+      });
+
+      it('should display results page', async function() {
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+
+        // then
+        expect(currentURL()).to.contains('/deja-envoye');
+      });
+    });
   });
 });

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -78,6 +78,22 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         expect(contains(COMPETENCE_MASTERY_PERCENTAGE)).to.exist;
       });
 
+      context('When the campaign is restricted and schooling-registration is disabled', function() {
+        beforeEach(function() {
+          campaign = server.create('campaign', { code: 'FORBIDDEN', isRestricted: true, title: 'Parcours restreint' });
+          campaignParticipation = server.create('campaign-participation', { campaign });
+        });
+
+        it('should display results page', async function() {
+          // when
+          await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+          // then
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/resultats`);
+          expect(contains('Parcours restreint')).to.exist;
+        });
+      });
+
       it('should display different competences results when the badge key is PIX_EMPLOI_CLEA', async function() {
         // given
         const BADGE_PARTNER_COMPETENCE_MASTERY_PERCENTAGE = '80%';

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -857,6 +857,20 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
       });
 
+      context('When the campaign access is forbidden', function() {
+        beforeEach(async function() {
+          campaign = server.create('campaign', { code: 'FORBIDDEN' });
+          await visit(`/campagnes/${campaign.code}`);
+          await clickByLabel('Je commence');
+        });
+
+        it('should show an error message', async function() {
+          // then
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          expect(find('.title').textContent).to.contains('Oups, la page demandée n’est pas accessible.');
+        });
+      });
+
       context('When campaign does not exist', function() {
         beforeEach(async function() {
           await visit('/campagnes/codefaux');

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -857,16 +857,15 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
       });
 
-      context('When the campaign access is forbidden', function() {
+      context('When the campaign is restricted and access is forbidden', function() {
         beforeEach(async function() {
-          campaign = server.create('campaign', { code: 'FORBIDDEN' });
+          campaign = server.create('campaign', { code: 'FORBIDDEN', isRestricted: true });
           await visit(`/campagnes/${campaign.code}`);
-          await clickByLabel('Je commence');
         });
 
         it('should show an error message', async function() {
           // then
-          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}`);
           expect(find('.title').textContent).to.contains('Oups, la page demandée n’est pas accessible.');
         });
       });

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -857,16 +857,29 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
       });
 
-      context('When the campaign is restricted and access is forbidden', function() {
-        beforeEach(async function() {
+      context('When the campaign is restricted and schooling-registration is disabled', function() {
+        beforeEach(function() {
           campaign = server.create('campaign', { code: 'FORBIDDEN', isRestricted: true });
-          await visit(`/campagnes/${campaign.code}`);
         });
 
-        it('should show an error message', async function() {
+        it('should show an error message when user starts the campaign', async function() {
+          // when
+          await visit(`/campagnes/${campaign.code}`);
+
           // then
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}`);
           expect(find('.title').textContent).to.contains('Oups, la page demandée n’est pas accessible.');
+        });
+
+        it('should resume the campaign when user already has a participation', async function() {
+          // given
+          server.create('campaign-participation', { campaignId: campaign.id, userId: prescritUser.id });
+
+          // when
+          await visit(`/campagnes/${campaign.code}`);
+
+          // then
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
       });
 

--- a/mon-pix/tests/unit/routes/campaigns/restricted/join_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/restricted/join_test.js
@@ -25,10 +25,9 @@ describe('Unit | Route | campaigns/restricted/join', function() {
         user: { id: 'id' },
       }));
       route.replaceWith = sinon.stub();
-      const transition = { to: { queryParams: {} } };
 
       // when
-      await route.afterModel(campaign, transition);
+      await route.afterModel(campaign);
 
       // then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume', campaign.code, { queryParams: { associationDone: true } });

--- a/mon-pix/tests/unit/routes/campaigns/start-or-resume_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/start-or-resume_test.js
@@ -25,6 +25,7 @@ describe('Unit | Route | Start-or-resume', function() {
       const transition = { to: { queryParams: { } } };
       route.modelFor = sinon.stub().returns(campaign);
       route.session = { isAuthenticated: true };
+      route.store = { queryRecord: sinon.stub() };
       route.currentUser = { user: { mustValidateTermsOfService: false } };
       route.replaceWith = sinon.stub();
 


### PR DESCRIPTION
## :unicorn: Problème

Les organisations peuvent désactiver des élèves/étudiants.Si un élève/étudiant est désactivé il est alors interdit pour lui de participer à de NOUVELLES campagnes (car il n'est plus encadré par celle-ci).

## :robot: Solution

- Au moment de la création de la participation à la campagne, vérifier que l'utilisateur est actif dans l'organisation, si ce n'est pas le cas, lever une erreur (Forbidden - 403) et la traiter dans le front (rediriger vers une page d'erreur). C'est uniquement un check côté back
- Au moment de rejoindre une nouvelle campagne, dans l'appel pour vérifier l'existence d'une `schooling-registration-user-association`, renvoi d'une erreur "PreconditionFailed" (412) côté back, et redirection vers une page d'erreur côté front.
- Au moment de reprendre ou voir le résultat d'une campagne, vérification de la participation pour pouvoir y accéder.

## :rainbow: Remarques

Actuellement, dans le `start-or-resume` lors de l'appel API pour la création d'une participation, la gestion d'erreur n'est pas faite correctement. L'appel API est effectué dans le hook `redirect()` de la route et toute erreur levée dans ce hook n'est pas traitée par EmberJS. 
Pour gérer correctement les erreurs, il faut réaliser cet appel dans un de ces hooks : `beforeModel`, `model` ou `afterModel`. (voir [documentation](https://guides.emberjs.com/release/routing/loading-and-error-substates/#toc_error-substates))

Nous avons déplacer l'appel API et quelques checks précédent l'appel dans `afterModel` afin de pouvoir traiter correctement les erreurs remontées.

## :100: Pour tester

1. Se connecter sur une campagne SCO (BADGES123) avec un utilisateur désactivé (student.disabled1234)

> Un page d'erreur apparaît au moment de rejoindre la campagne.

2. Se connecter sur une campagne SCO (BADGES123) avec un utilisateur désactivé (student.disabled1234) qui a déjà commencé cette campagne
> Accède à la campagne

3. Se connecter sur une campagne SCO (BADGES123) avec un utilisateur désactivé (student.disabled1234) qui a terminé une campagne
> Accède aux résultats

4. Refaire tout avec une campagne de collecte de profils (SNAP456) 😃 

NB : changer le `isDisabled` en base à chaque fois