### PR TITLE
[FEATURE][A11Y] Permettre la navigation au clavier dans la liste des sessions (PIX-2691)

### DIFF
--- a/certif/app/components/pagination-control.hbs
+++ b/certif/app/components/pagination-control.hbs
@@ -2,7 +2,7 @@
   <div class="page-size">
     <div class="page-size__label">Voir</div>
     <div class="page-size__choice">
-      <select class="content-text content-text--small" {{on "change" this.changePageSize}}>
+      <select aria-label="Nombre d'éléments par page" class="content-text content-text--small" {{on "change" this.changePageSize}}>
         <option value="25" selected="{{if (eq this.pageSize 25) true}}">25</option>
         <option value="50" selected="{{if (eq this.pageSize 50) true}}">50</option>
         <option value="100" selected="{{if (eq this.pageSize 100) true}}">100</option>

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -1,4 +1,4 @@
-<div class="table--with-row-clickable" role="tabpanel">
+<div class="table--with-row-clickable session-summary-list" role="tabpanel">
   <div class="panel">
     <div class="table content-text content-text--small">
       <table>
@@ -36,8 +36,17 @@
 
         <tbody>
         {{#each @sessionSummaries as |sessionSummary|}}
-          <tr aria-label="Session de certification" role="button" {{on 'click' (fn @goToSessionDetails sessionSummary.id)}} class="tr--clickable">
-            <td>{{sessionSummary.id}}</td>
+          <tr aria-label="Session de certification" {{on 'click' (fn @goToSessionDetails sessionSummary.id)}} class="tr--clickable">
+            <td>
+              <LinkTo
+                @route="authenticated.sessions.details"
+                @model={{sessionSummary.id}}
+                class="session-summary-list__link"
+                aria-label="Session {{sessionSummary.id}}"
+              >
+                {{sessionSummary.id}}
+              </LinkTo>
+            </td>
             <td>{{sessionSummary.address}}</td>
             <td>{{sessionSummary.room}}</td>
             <td>{{moment-format sessionSummary.date 'DD/MM/YYYY' allow-empty=true}}</td>

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -38,6 +38,7 @@
 @import "components/session-finalization/reports-informations-step";
 @import "components/session-finalization/formbuilder-link-step";
 @import "components/session-finalization/examiner-global-comment-step";
+@import "components/session-summary-list";
 @import "components/pagination-control.scss";
 @import "components/dropdown";
 @import "components/user-logged-menu";

--- a/certif/app/styles/components/pagination-control.scss
+++ b/certif/app/styles/components/pagination-control.scss
@@ -1,7 +1,7 @@
 .pagination-control {
   display: flex;
   justify-content: space-between;
-  padding: 8px 28px;
+  margin: 16px 0;
   font-weight: 500;
 }
 

--- a/certif/app/styles/components/session-summary-list.scss
+++ b/certif/app/styles/components/session-summary-list.scss
@@ -1,0 +1,6 @@
+.session-summary-list {
+  &__link {
+    color: $grey-80;
+    text-decoration: none;
+  }
+}

--- a/certif/app/styles/globals/tables.scss
+++ b/certif/app/styles/globals/tables.scss
@@ -41,6 +41,7 @@
 
     tr:hover,
     tr:focus,
+    tr:focus-within,
     tr:active {
       color: $grey-80;
       background-color: $grey-10;

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -19,7 +19,7 @@
 }
 
 .content-text {
-  color: $grey-45;
+  color: $grey-60;
   font-family: $roboto;
   font-size: 1rem;
 

--- a/certif/tests/integration/components/pagination-control_test.js
+++ b/certif/tests/integration/components/pagination-control_test.js
@@ -2,6 +2,9 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import fillInByLabel from 'pix-certif/tests/helpers/extended-ember-test-helpers/fill-in-by-label';
+import sinon from 'sinon';
+import Service from '@ember/service';
 
 function getMetaForPage(pageNumber) {
   const rowCount = 50;
@@ -19,7 +22,7 @@ module('Integration | Component | pagination-control', function(hooks) {
 
   test('it should disable previous button when user is on first page', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(1));
+    this.meta = getMetaForPage(1);
 
     // when
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
@@ -31,7 +34,7 @@ module('Integration | Component | pagination-control', function(hooks) {
 
   test('it should disable next button when user is on last page', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(2));
+    this.meta = getMetaForPage(2);
 
     // when
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
@@ -43,7 +46,7 @@ module('Integration | Component | pagination-control', function(hooks) {
 
   test('it should enable previous button when user is on second page', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(2));
+    this.meta = getMetaForPage(2);
 
     // when
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
@@ -53,4 +56,19 @@ module('Integration | Component | pagination-control', function(hooks) {
     assert.dom('.page-navigation__arrow--previous .icon-button').hasNoClass('disabled');
   });
 
+  test('it should re-route to page with changed page size', async function(assert) {
+    const replaceWithStub = sinon.stub();
+    class RouterStub extends Service {
+      replaceWith = replaceWithStub;
+    }
+    this.owner.register('service:router', RouterStub);
+    this.meta = getMetaForPage(2);
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // when
+    await fillInByLabel('Nombre d\'éléments par page', '25');
+
+    // then
+    assert.ok(replaceWithStub.calledWith({ queryParams: { pageSize: '25', pageNumber: 1 } }));
+  });
 });

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -17,7 +17,7 @@ module('Integration | Component | session-summary-list', function(hooks) {
       // given
       const sessionSummaries = [];
       sessionSummaries.meta = { rowCount: 0 };
-      this.set('sessionSummaries', sessionSummaries);
+      this.sessionSummaries = sessionSummaries;
 
       // when
       await render(hbs`<SessionSummaryList
@@ -44,7 +44,7 @@ module('Integration | Component | session-summary-list', function(hooks) {
       sessionSummaries.meta = {
         rowCount: 2,
       };
-      this.set('sessionSummaries', sessionSummaries);
+      this.sessionSummaries = sessionSummaries;
 
       // when
       await render(hbs`<SessionSummaryList
@@ -74,7 +74,7 @@ module('Integration | Component | session-summary-list', function(hooks) {
       sessionSummaries.meta = {
         rowCount: 1,
       };
-      this.set('sessionSummaries', sessionSummaries);
+      this.sessionSummaries = sessionSummaries;
 
       // when
       await render(hbs`<SessionSummaryList
@@ -104,7 +104,7 @@ module('Integration | Component | session-summary-list', function(hooks) {
       sessionSummaries.meta = {
         rowCount: 1,
       };
-      this.set('sessionSummaries', sessionSummaries);
+      this.sessionSummaries = sessionSummaries;
       await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
@@ -115,6 +115,28 @@ module('Integration | Component | session-summary-list', function(hooks) {
       // then
       sinon.assert.calledWith(this.goToSessionDetailsSpy, '123');
       assert.ok(true);
+    });
+
+    test('it should display a link to access session detail', async function(assert) {
+      // given
+      this.goToSessionDetailsSpy = sinon.stub();
+      const store = this.owner.lookup('service:store');
+      const sessionSummary = run(() => store.createRecord('session-summary', {
+        id: 123,
+      }));
+      const sessionSummaries = [sessionSummary];
+      sessionSummaries.meta = {
+        rowCount: 1,
+      };
+      this.sessionSummaries = sessionSummaries;
+
+      // when
+      await render(hbs`<SessionSummaryList
+                  @sessionSummaries={{this.sessionSummaries}}
+                  @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
+
+      // then
+      assert.dom('a[href="/sessions/123"]').exists();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

L'accessibilité de Pix Certif va prochainement faire l'objet d'un audit et nous voulons au préalable effectuer un maximum de corrections faciles.

Il n'est pas possible de naviguer au clavier dans la liste des sessions. La raison est que les lignes du tableau ont le rôle aria "button", or un élément `<button>` ne peut pas être l'enfant d'un élément 
`<tr>`. Le HTML est invalide et la ligne est complètement ignoré par le lecteur d'écran.

## :robot: Solution

Ajouter un lien sur le numéro de session qui puisse être activé au clavier.

D'autres problèmes d'accessibilité remontés par Wave ont été corrigés sur la page :
- Contraste trop faible du texte du contrôle de la pagination sous le tableau (aligné sur Pix Orga)
- Absence de libellé pour le sélecteur de nombre d'éléments dans le contrôle de la pagination 

## :rainbow: Remarques

Cette pull request s'inspire fortement de la #3130.

## :100: Pour tester

1. Se connecter à Pix Certif (idéalement avec un compte ayant beaucoup de sessions, eg certifsco@example.net)
2. Naviguer dans le tableau de la liste des sessions au clavier (touche tab)
3. Constater que l'identifiant de session peut être sélectionner
4. Non-regression : constater qu'il est toujours possible d'accéder à la session en cliquant n'importe où sur la ligne
5. Ouvrir l'extension [Wave](https://wave.webaim.org/extension/) et constater qu'il n'y a plus d'erreurs ni d'avertissements pour cette page
6. Non-regression sur la pagination (tip: ajouter `?pageSize=5` à l'url de la page pour la déclencher même s'il y a peu de session)
