### PR TITLE
[BUGFIX] Sur la page de fin de campagne, afficher uniquement les badges gagnés durant celle-ci (PIX-2705)

### DIFF
--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -25,7 +25,7 @@ async function _getParticipationResults(userId, campaignId) {
 
   const knowledgeElements = await _findTargetedKnowledgeElements(campaignId, userId, sharedAt);
 
-  const acquiredBadgeIds = await _getAcquiredBadgeIds(userId);
+  const acquiredBadgeIds = await _getAcquiredBadgeIds(userId, campaignParticipationId);
 
   return {
     campaignParticipationId,
@@ -62,8 +62,8 @@ async function _findTargetedKnowledgeElements(campaignId, userId, sharedAt) {
   return knowledgeElementsByUser[userId].filter(({ skillId }) => targetedSkillIds.includes(skillId));
 }
 
-async function _getAcquiredBadgeIds(userId) {
-  return knex('badge-acquisitions').select('badgeId').where({ userId });
+async function _getAcquiredBadgeIds(userId, campaignParticipationId) {
+  return knex('badge-acquisitions').select('badgeId').where({ userId, campaignParticipationId });
 }
 
 async function _getTargetProfile(campaignId, locale) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur la page de fin de campagne, les badges affichés sont ceux que l'utilisateur a gagné et qui appartiennent au profil cible testé.
Si l'utilisateur a été testé deux fois sur un profil cible (via deux campagnes), tous les badges gagnés durant ces deux passages seront affichés. Donc s'il a gagné les badges uniquement sur la deuxième campagne, ces badges apparaitront sur la première.

## :robot: Solution
Filtrer les badges par la `campaignParticipationId`

## :rainbow: Remarques
Ce travail a déjà été effectué coté Pix Orga

## :100: Pour tester
- Passer une campagne avec des badges (BADGES123 ou 456...)
- Ne pas les gagner
- Remettre à zéro son compte
- Lancer une nouvelle campagne 
- Gagner les badges
- Les voir sur la page de résultat de la deuxième mais pas sur la première