### PR TITLE
[FEATURE] Ne permettre qu'une seule récupération de compte SCO - API (PIX-2911).

### DIFF
--- a/api/db/database-builder/factory/build-account-recovery-demand.js
+++ b/api/db/database-builder/factory/build-account-recovery-demand.js
@@ -1,9 +1,12 @@
 const databaseBuffer = require('../database-buffer');
 const buildSchoolingRegistration = require('./build-schooling-registration');
+const buildUser = require('./build-user');
 
 module.exports = function buildAccountRecoveryDemand({
   id = databaseBuffer.getNextId(),
   userId,
+  firstName,
+  lastName,
   schoolingRegistrationId,
   oldEmail,
   newEmail = 'philipe@example.net',
@@ -11,16 +14,30 @@ module.exports = function buildAccountRecoveryDemand({
   used = false,
   createdAt,
 } = {}) {
+
+  let schoolingRegistrationAttributes;
+  let user;
+
+  if (!userId) {
+    user = buildUser();
+    schoolingRegistrationAttributes = { userId: user.id, firstName: user.firstName, lastName: user.lastName, nationalStudentId: '123456789JJ' };
+  } else {
+    schoolingRegistrationAttributes = { userId, firstName, lastName, nationalStudentId: '123456789JJ' };
+  }
+  const actualSchoolingRegistrationId = schoolingRegistrationId || buildSchoolingRegistration(schoolingRegistrationAttributes).id;
+  const actualUserId = userId || user.id;
+
   const values = {
     id,
-    userId,
-    schoolingRegistrationId: schoolingRegistrationId || buildSchoolingRegistration({ userId }).id,
+    userId: actualUserId,
+    schoolingRegistrationId: actualSchoolingRegistrationId,
     oldEmail,
     newEmail,
     temporaryKey,
     used,
     createdAt,
   };
+
   return databaseBuffer.pushInsertable({
     tableName: 'account-recovery-demands',
     values,

--- a/api/db/database-builder/factory/build-account-recovery-demand.js
+++ b/api/db/database-builder/factory/build-account-recovery-demand.js
@@ -12,7 +12,7 @@ module.exports = function buildAccountRecoveryDemand({
   newEmail = 'philipe@example.net',
   temporaryKey = 'OWIxZGViNGQtM2I3ZC00YmFkLTliZGQtMmIwZDdiM2RjYjZk',
   used = false,
-  createdAt,
+  createdAt = new Date(),
 } = {}) {
 
   let schoolingRegistrationAttributes;

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -335,6 +335,33 @@ function organizationsScoBuilder({ databaseBuilder }) {
     organizationId: SCO_AEFE_ID,
     organizationRole: Membership.roles.MEMBER,
   });
+
+  // user who has left SCO
+  const userWhoHasLeftSCO = databaseBuilder.factory.buildUser({
+    firstName: 'John',
+    lastName: 'hasLeftSCO',
+    email: 'john.hasleftsco@example.net',
+    username: null,
+    cgu: true,
+    emailConfirmedAt: new Date(),
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod({
+    identityProvider: AuthenticationMethod.identityProviders.GAR,
+    externalIdentifier: '1234555',
+    userId: userWhoHasLeftSCO.id,
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.buildWithPassword({
+    userId: userWhoHasLeftSCO.id,
+  });
+
+  databaseBuilder.factory.buildAccountRecoveryDemand({
+    userId: userWhoHasLeftSCO.id,
+    firstName: userWhoHasLeftSCO.firstName,
+    lastName: userWhoHasLeftSCO.lastName,
+    used: true,
+  });
 }
 
 module.exports = {

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -63,6 +63,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AccountRecoveryDemandExpired) {
     return new HttpErrors.UnauthorizedError(error.message);
   }
+  if (error instanceof DomainErrors.UserHasAlreadyLeftSCO) {
+    return new HttpErrors.ForbiddenError(error.message);
+  }
   if (error instanceof DomainErrors.AccountRecoveryUserAlreadyConfirmEmail) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -727,6 +727,12 @@ class UserNotAuthorizedToUpdateEmailError extends DomainError {
   }
 }
 
+class UserHasAlreadyLeftSCO extends DomainError {
+  constructor(message = 'User has already left SCO.') {
+    super(message);
+  }
+}
+
 class UserNotAuthorizedToAccessEntityError extends DomainError {
   constructor(message = 'User is not authorized to access ressource') {
     super(message);
@@ -982,6 +988,7 @@ module.exports = {
   UserAlreadyLinkedToCandidateInSessionError,
   UserCantBeCreatedError,
   UserCouldNotBeReconciledError,
+  UserHasAlreadyLeftSCO,
   UserNotAuthorizedToAccessEntityError,
   UserNotAuthorizedToCertifyError,
   UserNotAuthorizedToCreateCampaignError,

--- a/api/lib/domain/models/AccountRecoveryDemand.js
+++ b/api/lib/domain/models/AccountRecoveryDemand.js
@@ -8,6 +8,7 @@ class AccountRecoveryDemand {
     newEmail,
     temporaryKey,
     used,
+    createdAt,
   } = {}) {
     this.id = id;
     this.schoolingRegistrationId = schoolingRegistrationId;
@@ -16,6 +17,7 @@ class AccountRecoveryDemand {
     this.newEmail = newEmail.toLowerCase();
     this.temporaryKey = temporaryKey;
     this.used = used;
+    this.createdAt = createdAt;
   }
 }
 

--- a/api/lib/domain/services/check-sco-account-recovery-service.js
+++ b/api/lib/domain/services/check-sco-account-recovery-service.js
@@ -1,7 +1,12 @@
-const { MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError, UserNotFoundError } = require('../errors');
+const {
+  MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError,
+  UserNotFoundError,
+  UserHasAlreadyLeftSCO,
+} = require('../errors');
 const _ = require('lodash');
 
 async function retrieveSchoolingRegistration({
+  accountRecoveryDemandRepository,
   studentInformation,
   schoolingRegistrationRepository,
   userRepository,
@@ -18,6 +23,12 @@ async function retrieveSchoolingRegistration({
     latestSchoolingRegistration,
     userReconciliationService,
   });
+
+  const accountRecoveryDemands = await accountRecoveryDemandRepository.findByUserId(userId);
+
+  if (accountRecoveryDemands.some((accountRecoveryDemand) => accountRecoveryDemand.used)) {
+    throw new UserHasAlreadyLeftSCO();
+  }
 
   await _checkIfThereAreMultipleUserForTheSameAccount({ userId, schoolingRegistrationRepository });
 

--- a/api/lib/domain/usecases/account-recovery/get-account-recovery-details.js
+++ b/api/lib/domain/usecases/account-recovery/get-account-recovery-details.js
@@ -1,3 +1,5 @@
+const { UserHasAlreadyLeftSCO } = require('../../errors');
+
 module.exports = async function getAccountRecoveryDetails({
   temporaryKey,
   accountRecoveryDemandRepository,
@@ -5,6 +7,12 @@ module.exports = async function getAccountRecoveryDetails({
 }) {
   const accountRecoveryDemand = await accountRecoveryDemandRepository.findByTemporaryKey(temporaryKey);
   const schoolingRegistration = await schoolingRegistrationRepository.get(accountRecoveryDemand.schoolingRegistrationId);
+
+  const accountRecoveryDemands = await accountRecoveryDemandRepository.findByUserId(schoolingRegistration.userId);
+
+  if (accountRecoveryDemands.some((accountRecoveryDemand) => accountRecoveryDemand.used)) {
+    throw new UserHasAlreadyLeftSCO();
+  }
 
   return {
     id: accountRecoveryDemand.id,

--- a/api/lib/domain/usecases/account-recovery/update-user-account.js
+++ b/api/lib/domain/usecases/account-recovery/update-user-account.js
@@ -1,5 +1,5 @@
 const AuthenticationMethod = require('../../../domain/models/AuthenticationMethod');
-const { AccountRecoveryUserAlreadyConfirmEmail } = require('../../../domain/errors');
+const { UserHasAlreadyLeftSCO } = require('../../../domain/errors');
 
 module.exports = async function updateUserAccount({
   password,
@@ -12,10 +12,11 @@ module.exports = async function updateUserAccount({
 }) {
 
   const { userId, newEmail } = await accountRecoveryDemandRepository.findByTemporaryKey(temporaryKey);
-  const user = await userRepository.get(userId);
 
-  if (user && user.emailConfirmedAt) {
-    throw new AccountRecoveryUserAlreadyConfirmEmail();
+  const accountRecoveryDemands = await accountRecoveryDemandRepository.findByUserId(userId);
+
+  if (accountRecoveryDemands.some((accountRecoveryDemand) => accountRecoveryDemand.used)) {
+    throw new UserHasAlreadyLeftSCO();
   }
 
   const authenticationMethods = await authenticationMethodRepository.findByUserId({ userId });

--- a/api/lib/domain/usecases/check-sco-account-recovery.js
+++ b/api/lib/domain/usecases/check-sco-account-recovery.js
@@ -4,8 +4,9 @@ module.exports = async function checkScoAccountRecovery({
   studentInformation,
   schoolingRegistrationRepository,
   organizationRepository,
-  checkScoAccountRecoveryService,
+  accountRecoveryDemandRepository,
   userRepository,
+  checkScoAccountRecoveryService,
   userReconciliationService,
 }) {
 
@@ -17,6 +18,7 @@ module.exports = async function checkScoAccountRecovery({
     email,
   } = await checkScoAccountRecoveryService.retrieveSchoolingRegistration({
     studentInformation,
+    accountRecoveryDemandRepository,
     schoolingRegistrationRepository,
     userRepository,
     userReconciliationService,

--- a/api/lib/domain/usecases/send-email-for-account-recovery.js
+++ b/api/lib/domain/usecases/send-email-for-account-recovery.js
@@ -16,6 +16,7 @@ module.exports = async function sendEmailForAccountRecovery({
 
   const { firstName, id, userId, email: oldEmail } = await checkScoAccountRecoveryService.retrieveSchoolingRegistration({
     studentInformation,
+    accountRecoveryDemandRepository,
     schoolingRegistrationRepository,
     userRepository,
     userReconciliationService,

--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -34,7 +34,7 @@ module.exports = {
   async findByTemporaryKey(temporaryKey) {
 
     const accountRecoveryDemandDTO = await knex
-      .where({ temporaryKey, used: false })
+      .where({ temporaryKey })
       .select('id', 'schoolingRegistrationId', 'userId', 'oldEmail', 'newEmail', 'temporaryKey', 'used', 'createdAt')
       .from('account-recovery-demands')
       .first();

--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const { knex } = require('../../../db/knex-database-connection');
 const AccountRecoveryDemand = require('../../domain/models/AccountRecoveryDemand');
 const {
@@ -6,11 +7,15 @@ const {
 } = require('../../domain/errors');
 const DomainTransaction = require('../DomainTransaction');
 
-function _toDomainObject(accountRecoveryDemandDTO) {
+const _toDomain = (accountRecoveryDemandDTO) => {
   return new AccountRecoveryDemand({
     ...accountRecoveryDemandDTO,
   });
-}
+};
+
+const _toDomainArray = (accountRecoveryDemandsDTOs) => {
+  return _.map(accountRecoveryDemandsDTOs, _toDomain);
+};
 
 const demandHasExpired = (demandCreationDate) => {
   const minutesInADay = 60 * 24;
@@ -42,7 +47,16 @@ module.exports = {
       throw new AccountRecoveryDemandExpired();
     }
 
-    return _toDomainObject(accountRecoveryDemandDTO);
+    return _toDomain(accountRecoveryDemandDTO);
+  },
+
+  async findByUserId(userId) {
+    const accountRecoveryDemandsDTOs = await knex
+      .select('id', 'schoolingRegistrationId', 'userId', 'oldEmail', 'newEmail', 'temporaryKey', 'used', 'createdAt')
+      .from('account-recovery-demands')
+      .where({ userId });
+
+    return _toDomainArray(accountRecoveryDemandsDTOs);
   },
 
   async save(accountRecoveryDemand) {
@@ -50,7 +64,7 @@ module.exports = {
       .insert(accountRecoveryDemand)
       .returning('*');
 
-    return _toDomainObject(result[0]);
+    return _toDomain(result[0]);
   },
 
   markAsBeingUsed(temporaryKey, domainTransaction = DomainTransaction.emptyTransaction()) {

--- a/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
@@ -57,12 +57,12 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
           // given
           const email = 'someMail@example.net';
           const temporaryKey = 'someTemporaryKey';
-          const { id: demandId, schoolingRegistrationId } = databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false });
+          const { id: demandId, userId, schoolingRegistrationId } = databaseBuilder.factory.buildAccountRecoveryDemand({ email, temporaryKey, used: false });
           databaseBuilder.factory.buildAccountRecoveryDemand({ email, used: false });
           await databaseBuilder.commit();
           const expectedAccountRecoveryDemand = {
             id: demandId,
-            userId: null,
+            userId,
             oldEmail: null,
             schoolingRegistrationId,
             newEmail: 'philipe@example.net',

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -15,6 +15,7 @@ const {
   UnexpectedUserAccountError,
   UserShouldChangePasswordError,
   MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError,
+  UserHasAlreadyLeftSCO,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -243,6 +244,19 @@ describe('Unit | Application | ErrorManager', () => {
 
       // then
       expect(HttpErrors.UnauthorizedError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate UnauthorizedError when UserHasAlreadyLeftSCO', async () => {
+      // given
+      const error = new UserHasAlreadyLeftSCO();
+      sinon.stub(HttpErrors, 'ForbiddenError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
     });
 
   });

--- a/api/tests/unit/domain/usecases/account-recovery/get-account-recovery-details_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/get-account-recovery-details_test.js
@@ -59,9 +59,9 @@ describe('Unit | UseCase | get-account-recovery-details', () => {
     });
   });
 
-  it('should throw NotFoundError if temporary key does not exist or already used', async () => {
+  it('should throw NotFoundError if temporary key does not exist', async () => {
     // given
-    accountRecoveryDemandRepository.findByTemporaryKey.rejects(new NotFoundError('Temporary key not found or already used'));
+    accountRecoveryDemandRepository.findByTemporaryKey.rejects(new NotFoundError('No account recovery demand found'));
 
     // when
     const error = await catchErr(getAccountRecoveryDetails)({

--- a/api/tests/unit/domain/usecases/account-recovery/send-email-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/send-email-for-account-recovery_test.js
@@ -43,6 +43,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
       };
 
       checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+        accountRecoveryDemandRepository,
         studentInformation,
         schoolingRegistrationRepository,
         userRepository,
@@ -86,6 +87,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
       };
 
       checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+        accountRecoveryDemandRepository,
         studentInformation,
         schoolingRegistrationRepository,
         userRepository,
@@ -133,6 +135,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
       };
 
       checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+        accountRecoveryDemandRepository,
         studentInformation,
         schoolingRegistrationRepository,
         userRepository,

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
@@ -41,11 +41,11 @@ describe('Unit | Usecases | update-user-account', () => {
 
   });
 
-  it('should throw an error when temporaryKey is invalid', async () => {
+  it('should throw NotFoundError if temporary key does not exist', async () => {
     // given
     const invalidTemporaryKey = 'temporarykey';
     domainBuilder.buildAccountRecoveryDemand({ temporaryKey: invalidTemporaryKey });
-    accountRecoveryDemandRepository.findByTemporaryKey.rejects(new NotFoundError());
+    accountRecoveryDemandRepository.findByTemporaryKey.rejects(new NotFoundError('No account recovery demand found'));
 
     // when
     const error = await catchErr(updateUserAccount)({

--- a/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/check-sco-account-recovery_test.js
@@ -9,6 +9,7 @@ const checkScoAccountRecovery = require('../../../../lib/domain/usecases/check-s
 describe('Unit | UseCase | check-sco-account-recovery', () => {
 
   let schoolingRegistrationRepository;
+  let accountRecoveryDemandRepository;
   let userRepository;
   let organizationRepository;
   let checkScoAccountRecoveryService;
@@ -46,6 +47,7 @@ describe('Unit | UseCase | check-sco-account-recovery', () => {
         const expectedOrganization = domainBuilder.buildOrganization({ id: 7, name: 'Lycée Poudlard' });
 
         checkScoAccountRecoveryService.retrieveSchoolingRegistration.withArgs({
+          accountRecoveryDemandRepository,
           studentInformation,
           schoolingRegistrationRepository,
           userRepository,


### PR DESCRIPTION
## :unicorn: Problème
La récupération de compte à la sortie du SCO est une fonctionnalité sensible du point de vue sécurité.

## :robot: Solution
Ne permettre qu'une seule récupération réussie: l'API doit renvoyer une 403 s'il existe une demande de récupération utilisée.

## :rainbow: Remarques

L'afffichage du message dans le front sera effectuée dans la PR https://github.com/1024pix/pix/pull/3264

Création d'un JDD
- utilisateur GAR
- réconcilié
- avec demande récupération utilisée et email confirmé
- avec connexion email

Modification du builder de récuparation de compte pour qu'il construise un JDD cohérent
- utilisateur existant
- inscription scolaire avec INE, réconcilié sur cet utilisateur
- nom et Prénom de l'utilisateur égaux à ceux de l' inscription scolaire
- demande de récupération sur cet utilisateur, et cette inscription

## :100: Pour tester

### INE/Saisie Nom/Prénom/DDN

Réinitialiser les seeds
`scalingo -region osc-fr1 -a pix-api-review-pr3263 run "npm run db:seed"`

Aller [sur la page](https://app-pr3263.review.pix.fr/recuperer-mon-compte) de récupération de compte 

Entrer les informations:
- INE: 123456789JJ
- Prénom: John
- Nom: hasLeftSCO
- date de naissance : 05 / 08 / 2005

Vérifier la 403 + le message d'erreur renvoyé par l'API dans les DevTools
> User has already left SCO

### Saisie de l'email

Réinitialiser les seeds
`scalingo -region osc-fr1 -a pix-api-review-pr3263 run "npm run db:seed"`

Supprimer les demandes
`DELETE FROM "account-recovery-demands" WHERE "userId"=100062;`

Aller [sur la page](https://app-pr3263.review.pix.fr/recuperer-mon-compte) de récupération de compte 

Entrer les informations:
- INE: 123456789JJ
- Prénom: John
- Nom: hasLeftSCO
- date de naissance : 05 / 08 / 2005

Cliquer sur Je confirme

Dans une autre fenêtre, répétez l'opération mais sans confirmer

Dans la première fenêtre
- entrer votre email
- cliquer sur "C'est parti"
- cliquer sur le lien 
- entrer un mot de passe et confirmer

Dans la deuxième fenêtre, cliquer sur "Je confirme"

Vérifier la 403 + le message d'erreur renvoyé par l'API dans les DevTools
> User has already left SCO

### Page appelée par le clic sur lien dans l'email

Réinitialiser les seeds
`scalingo -region osc-fr1 -a pix-api-review-pr3263 run "npm run db:seed"`

Supprimer les demandes
`DELETE FROM "account-recovery-demands" WHERE "userId"=100062;`

Aller [sur la page](https://app-pr3263.review.pix.fr/recuperer-mon-compte) de récupération de compte 

Entrer les informations:
- INE: 123456789JJ
- Prénom: John
- Nom: hasLeftSCO
- date de naissance : 05 / 08 / 2005

Cliquer sur Je confirme

Entrer votre email
Cliquer sur "C'est parti"

Répétez l'opération

Ensuite:
- premier lien: cliquez dessus, entrez un mot de passe, et validez, connectez-vous 
- deuxième lien: cliquez dessus

Vérifier la 403 + le message d'erreur renvoyé par l'API dans les DevTools
> User has already left SCO


### Envoi du formulaire de choix d'un mot de passe

Réinitialiser les seeds
`scalingo -region osc-fr1 -a pix-api-review-pr3263 run "npm run db:seed"`

Supprimer les demandes
`DELETE FROM "account-recovery-demands" WHERE "userId"=100062;`

Aller [sur la page](https://app-pr3263.review.pix.fr/recuperer-mon-compte) de récupération de compte 

Entrer les informations:
- INE: 123456789JJ
- Prénom: John
- Nom: hasLeftSCO
- date de naissance : 05 / 08 / 2005

Cliquer sur Je confirme

Entrer votre email
Cliquer sur "C'est parti"

Répétez l'opération

Ensuite:
- premier lien: cliquez dessus
- deuxième lien: cliquez dessus
- fenêtre premier lien: entrez un mot de passe et confirmez, puis connectez-vous
- fenêtre dexuième lien: entrez un mot de passe et confirmez

Vérifier la 403 + le message d'erreur renvoyé par l'API dans les DevTools
> User has already left SCO
- envoi du formulaire de choix d'un mot de passe
