### PR TITLE
[FEATURE] Ne permettre qu'une seule récupération de compte SCO - APP (PIX-2912).

### DIFF
--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -79,7 +79,11 @@ export default class FindScoRecordController extends Controller {
       const status = err.errors?.[0]?.status;
 
       if (status === '400') {
+        this.showUserHasAlreadyLeftSCO = false;
         this.showAlreadyRegisteredEmailError = true;
+      } else if (status === '401') {
+        this.showAlreadyRegisteredEmailError = false;
+        this.showUserHasAlreadyLeftSCO = true;
       } else {
         console.log(err);
       }

--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -19,6 +19,7 @@ export default class FindScoRecordController extends Controller {
   @tracked showConfirmationStep = false;
   @tracked showBackupEmailConfirmationForm = false;
   @tracked showAccountNotFoundError = false;
+  @tracked showUserHasAlreadyLeftSCO = false;
   @tracked showAlreadyRegisteredEmailError = false;
   @tracked showConfirmationEmailSent = false;
   @tracked templateImg = 'illustration';
@@ -105,8 +106,13 @@ export default class FindScoRecordController extends Controller {
     if (status === '409') {
       this.showStudentInformationForm = false;
       this.showAccountNotFoundError = false;
+      this.showUserHasAlreadyLeftSCO = false;
       this.showConflictError = true;
+    } else if (status === '401') {
+      this.showAccountNotFoundError = false;
+      this.showUserHasAlreadyLeftSCO = true;
     } else {
+      this.showUserHasAlreadyLeftSCO = false;
       this.showAccountNotFoundError = true;
     }
   }

--- a/mon-pix/app/templates/account-recovery/find-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/find-sco-record.hbs
@@ -12,7 +12,9 @@
       {{#if this.showStudentInformationForm}}
         <AccountRecovery::StudentInformationForm
           @submitStudentInformation={{this.submitStudentInformation}}
-          @showAccountNotFoundError={{this.showAccountNotFoundError}} />
+          @showAccountNotFoundError={{this.showAccountNotFoundError}}
+          @showUserHasAlreadyLeftSCO={{this.showUserHasAlreadyLeftSCO}}
+        />
       {{/if}}
 
       {{#if this.showConflictError}}

--- a/mon-pix/app/templates/account-recovery/find-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/find-sco-record.hbs
@@ -37,6 +37,7 @@
           @existingEmail={{this.studentInformationForAccountRecovery.email}}
           @cancelAccountRecovery={{this.cancelAccountRecovery}}
           @showAlreadyRegisteredEmailError={{this.showAlreadyRegisteredEmailError}}
+          @showUserHasAlreadyLeftSCO={{this.showUserHasAlreadyLeftSCO}}
         />
       {{/if}}
 

--- a/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
@@ -5,7 +5,9 @@ import { hbs } from 'ember-cli-htmlbars';
 import { contains } from '../../../helpers/contains';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillInByLabel } from '../../../helpers/fill-in-by-label';
-import findByLabel from '../../../helpers/find-by-label';
+import { findByLabel } from '../../../helpers/find-by-label';
+import { clickByLabel } from '../../../helpers/click-by-label';
+import sinon from 'sinon';
 
 describe('Integration | Component | account-recovery/update-sco-record', function() {
   setupIntlRenderingTest();
@@ -97,4 +99,22 @@ describe('Integration | Component | account-recovery/update-sco-record', functio
       });
     });
   });
+
+  it.only('should display an error message when user has already left SCO', async function() {
+    // given
+    const validPassword = 'pix123A*';
+    const submitResetPasswordForm = sinon.stub();
+    this.set('submitResetPasswordForm', submitResetPasswordForm);
+    submitResetPasswordForm.rejects({ errors: [{ status: '401', detail: 'User has already left SCO.' }] });
+
+    await render(hbs `<AccountRecovery::ResetPasswordForm @submitResetPasswordForm={{this.submitResetPasswordForm}} />`);
+
+    // when
+    await fillInByLabel(this.intl.t('pages.account-recovery-after-leaving-sco.reset-password.form.password-label'), validPassword);
+    await clickByLabel(this.intl.t('pages.account-recovery-after-leaving-sco.reset-password.form.login-button'));
+
+    // then
+    expect(contains(this.intl.t('pages.account-recovery-after-leaving-sco.reset-password.form.errors.already-has-left-sco'))).to.exist;
+  });
+
 });

--- a/mon-pix/tests/unit/controllers/account-recovery/find-sco-record-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery/find-sco-record-test.js
@@ -28,6 +28,44 @@ describe('Unit | Controller | account-recovery | find-sco-record', function() {
         sinon.assert.calledOnce(submitStudentInformationStub);
       });
 
+      context('when user account is not found', function() {
+
+        it('should show user not found error message', async function() {
+          // given
+          const errors = { errors: [{ status: '404' }] };
+          const controller = this.owner.lookup('controller:account-recovery-after-leaving-sco');
+          const studentInformation = { firstName: 'Jules' };
+          const submitStudentInformationStub = sinon.stub().rejects(errors);
+          const store = { createRecord: sinon.stub().returns({ submitStudentInformation: submitStudentInformationStub }) };
+          controller.set('store', store);
+
+          // when
+          await controller.submitStudentInformation(studentInformation);
+
+          // then
+          expect(controller.showAccountNotFoundError).to.be.true;
+        });
+      });
+
+      context('when user has already left SCO', function() {
+
+        it('should show user not found error message', async function() {
+          // given
+          const errors = { errors: [{ status: '401' }] };
+          const controller = this.owner.lookup('controller:account-recovery-after-leaving-sco');
+          const studentInformation = { firstName: 'Jules' };
+          const submitStudentInformationStub = sinon.stub().rejects(errors);
+          const store = { createRecord: sinon.stub().returns({ submitStudentInformation: submitStudentInformationStub }) };
+          controller.set('store', store);
+
+          // when
+          await controller.submitStudentInformation(studentInformation);
+
+          // then
+          expect(controller.showUserHasAlreadyLeftSCO).to.be.true;
+        });
+      });
+
       context('when two students used same account', function() {
 
         it('should hide student information form and show conflict error', async function() {

--- a/mon-pix/tests/unit/controllers/account-recovery/find-sco-record-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery/find-sco-record-test.js
@@ -112,6 +112,25 @@ describe('Unit | Controller | account-recovery | find-sco-record', function() {
 
     context('when user clicks on "C\'est parti!" button', function() {
 
+      context('when user has already left SCO', function() {
+
+        it('should show user not found error message', async function() {
+          // given
+          const errors = { errors: [{ status: '401' }] };
+          const controller = this.owner.lookup('controller:account-recovery-after-leaving-sco');
+          const sendEmailStub = sinon.stub();
+          const createRecord = sinon.stub().returns({ send: sendEmailStub.rejects(errors) });
+          const store = { createRecord };
+          controller.set('store', store);
+          const email = 'new_email@example.net';
+          // when
+          await controller.sendEmail(email);
+
+          // then
+          expect(controller.showUserHasAlreadyLeftSCO).to.be.true;
+        });
+      });
+
       it('should send account recovery email', async function() {
         // given
         const controller = this.owner.lookup('controller:account-recovery/find-sco-record');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1030,7 +1030,8 @@
           "login-button": "Je me connecte",
           "errors": {
             "invalid-password": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
-            "empty-password": "Le champ mot de passe est obligatoire."
+            "empty-password": "Le champ mot de passe est obligatoire.",
+            "already-has-left-sco": "T'est déjà passé par ici, petit malin."
           }
         }
       }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1030,7 +1030,8 @@
           "login-button": "Je me connecte",
           "errors": {
             "invalid-password": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
-            "empty-password": "Le champ mot de passe est obligatoire."
+            "empty-password": "Le champ mot de passe est obligatoire.",
+            "already-has-left-sco": "T'est déjà passé par ici, petit malin."
           }
         }
       }


### PR DESCRIPTION
## :unicorn: Problème
La récupération de compte à la sortie du SCO est une fonctionnalité sensible du point de vue sécurité.

## :robot: Solution
Ne permettre qu'une seule récupération réussie

## :rainbow: Remarques

L'afffichage du message dans le front lors de la page appelée par le clic sur lien email sera effectuée dans PIX-2851

## :100: Pour tester

Aller [sur la page](https://app-pr3249.review.pix.fr/recuperer-mon-compte) de récupération de compte 

Entrer les informations:
- INE: 123456789JJ
- Prénom: John
- Nom: hasLeftSCO
- date de naissance : 05 / 08 / 2005

Le message doit être
> T'est déjà passé par ici, petit malin.


Essayer sur étapes:
- saisie de l'email
- envoi du formulaire de choix d'un mot de passe

