### PR TITLE
[FEATURE] Ne plus afficher l'infobulle si l'utilisateur l'a déjà vue (PIX-2878).

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -61,6 +61,7 @@ const buildUser = function buildUser({
   pixCertifTermsOfServiceAccepted = false,
   hasSeenAssessmentInstructions = false,
   hasSeenNewDashboardInfo = false,
+  hasSeenFocusedChallengeTooltip = false,
   isAnonymous = false,
   createdAt = new Date(),
   updatedAt = new Date(),
@@ -73,7 +74,7 @@ const buildUser = function buildUser({
     cgu, lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
-    hasSeenNewDashboardInfo, isAnonymous,
+    hasSeenNewDashboardInfo, hasSeenFocusedChallengeTooltip, isAnonymous,
     createdAt, updatedAt,
   };
 

--- a/api/db/migrations/20210727092407_add-columns-has-seen-focused-and-other-challenge-tooltips.js
+++ b/api/db/migrations/20210727092407_add-columns-has-seen-focused-and-other-challenge-tooltips.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'hasSeenFocusedChallengeTooltip';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -434,6 +434,30 @@ exports.register = async function(server) {
       },
     },
     {
+      method: 'PATCH',
+      path: '/api/users/{id}/has-seen-challenge-tooltip/{challengeType}',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+          assign: 'requestedUserIsAuthenticatedUser',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+            challengeType: Joi.string(),
+          }),
+        },
+        handler: userController.rememberUserHasSeenChallengeTooltip,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Sauvegarde le fait que l\'utilisateur ait vu la tooltip de type d\'épreuve' +
+          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+          '- Le contenu de la requête n\'est pas pris en compte.',
+        ],
+        tags: ['api', 'user'],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/users/{id}/is-certifiable',
       config: {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -143,6 +143,14 @@ module.exports = {
     return userSerializer.serialize(updatedUser);
   },
 
+  async rememberUserHasSeenChallengeTooltip(request) {
+    const authenticatedUserId = request.auth.credentials.userId;
+    const challengeType = request.params.challengeType;
+
+    const updatedUser = await usecases.rememberUserHasSeenChallengeTooltip({ userId: authenticatedUserId, challengeType });
+    return userSerializer.serialize(updatedUser);
+  },
+
   getMemberships(request) {
     const authenticatedUserId = request.auth.credentials.userId;
 

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -17,6 +17,7 @@ class User {
     lastTermsOfServiceValidatedAt,
     hasSeenAssessmentInstructions,
     hasSeenNewDashboardInfo,
+    hasSeenFocusedChallengeTooltip,
     mustValidateTermsOfService,
     lang,
     isAnonymous,
@@ -41,6 +42,7 @@ class User {
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;
     this.hasSeenAssessmentInstructions = hasSeenAssessmentInstructions;
     this.hasSeenNewDashboardInfo = hasSeenNewDashboardInfo;
+    this.hasSeenFocusedChallengeTooltip = hasSeenFocusedChallengeTooltip;
     this.knowledgeElements = knowledgeElements;
     this.lang = lang;
     this.isAnonymous = isAnonymous;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -285,6 +285,7 @@ module.exports = injectDependencies({
   reconcileSchoolingRegistration: require('./reconcile-schooling-registration'),
   reconcileUserToOrganization: require('./reconcile-user-to-organization'),
   rememberUserHasSeenAssessmentInstructions: require('./remember-user-has-seen-assessment-instructions'),
+  rememberUserHasSeenChallengeTooltip: require('./remember-user-has-seen-challenge-tooltip'),
   rememberUserHasSeenNewDashboardInfo: require('./remember-user-has-seen-new-dashboard-info'),
   removeAuthenticationMethod: require('./remove-authentication-method'),
   resetScorecard: require('./reset-scorecard'),

--- a/api/lib/domain/usecases/remember-user-has-seen-challenge-tooltip.js
+++ b/api/lib/domain/usecases/remember-user-has-seen-challenge-tooltip.js
@@ -1,0 +1,7 @@
+module.exports = function rememberUserHasSeenChallengeTooltip({
+  userId,
+  challengeType,
+  userRepository,
+}) {
+  return userRepository.updateHasSeenChallengeTooltip({ userId, challengeType });
+};

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -280,6 +280,14 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user);
   },
 
+  async updateHasSeenChallengeTooltip({ userId, challengeType }) {
+    const user = await BookshelfUser.where({ id: userId }).fetch({ require: false });
+    if (challengeType === 'focused') {
+      await user.save({ 'hasSeenFocusedChallengeTooltip': true }, { patch: true, method: 'update' });
+    }
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user);
+  },
+
   async acceptPixLastTermsOfService(id) {
     const user = await BookshelfUser.where({ id }).fetch({ require: false });
     await user.save({

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -16,7 +16,7 @@ module.exports = {
         'memberships', 'certificationCenterMemberships',
         'pixScore', 'scorecards', 'profile',
         'campaignParticipations', 'hasSeenAssessmentInstructions', 'isCertifiable',
-        'hasSeenNewDashboardInfo',
+        'hasSeenNewDashboardInfo', 'hasSeenFocusedChallengeTooltip',
       ],
       memberships: {
         ref: 'id',

--- a/api/tests/acceptance/application/users/remember-user-has-seen-challenge-tooltip_test.js
+++ b/api/tests/acceptance/application/users/remember-user-has-seen-challenge-tooltip_test.js
@@ -1,0 +1,61 @@
+const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-has-seen-challenge-tooltip', () => {
+
+  let server;
+  let user;
+  let options;
+
+  beforeEach(async () => {
+    const challengeType = 'focused';
+    server = await createServer();
+
+    user = databaseBuilder.factory.buildUser({ hasSeenFocusedChallengeTooltip: false });
+
+    options = {
+      method: 'PATCH',
+      url: `/api/users/${user.id}/has-seen-challenge-tooltip/${challengeType}`,
+      headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+    };
+
+    return databaseBuilder.commit();
+  });
+
+  describe('Resource access management', () => {
+
+    it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
+      // given
+      options.headers.authorization = 'invalid.access.token';
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('should respond with a 403 - forbidden access - if requested user is not the same as authenticated user', async () => {
+      // given
+      const otherUserId = 9999;
+      options.headers.authorization = generateValidRequestAuthorizationHeader(otherUserId);
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+
+  describe('Success case', () => {
+
+    it('should return the user with has seen challenge tooltips', async () => {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.result.data.attributes['has-seen-focused-challenge-tooltip']).to.be.true;
+    });
+  });
+});

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -49,6 +49,7 @@ describe('Acceptance | Controller | users-controller-get-current-user', () => {
             'pix-certif-terms-of-service-accepted': user.pixCertifTermsOfServiceAccepted,
             'has-seen-assessment-instructions': user.hasSeenAssessmentInstructions,
             'has-seen-new-dashboard-info': user.hasSeenNewDashboardInfo,
+            'has-seen-focused-challenge-tooltip': user.hasSeenFocusedChallengeTooltip,
           },
           relationships: {
             memberships: {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1394,6 +1394,27 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
     });
   });
 
+  describe('#updateHasSeenChallengeTooltip', () => {
+
+    let userId;
+
+    beforeEach(() => {
+      userId = databaseBuilder.factory
+        .buildUser({ hasSeenFocusedChallengeTooltip: false })
+        .id;
+      return databaseBuilder.commit();
+    });
+
+    it('should return the model with hasSeenFocusedChallengeTooltip flag updated to true', async () => {
+      // when
+      const challengeType = 'focused';
+      const actualUser = await userRepository.updateHasSeenChallengeTooltip({ userId, challengeType });
+
+      // then
+      expect(actualUser.hasSeenFocusedChallengeTooltip).to.be.true;
+    });
+  });
+
   describe('#findAnotherUserByEmail', () => {
 
     it('should return a list of a single user if email already used', async () => {

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -370,6 +370,34 @@ describe('Unit | Controller | user-controller', () => {
     });
   });
 
+  describe('#rememberUserHasSeenChallengeTooltip', () => {
+    let request;
+    const userId = 1;
+    const challengeType = 'focused';
+
+    beforeEach(() => {
+      request = {
+        auth: { credentials: { userId } },
+        params: { id: userId, challengeType },
+      };
+
+      sinon.stub(usecases, 'rememberUserHasSeenChallengeTooltip');
+      sinon.stub(userSerializer, 'serialize');
+    });
+
+    it('should remember user has seen focused challenge tooltip', async () => {
+      // given
+      usecases.rememberUserHasSeenChallengeTooltip.withArgs({ userId, challengeType }).resolves({});
+      userSerializer.serialize.withArgs({}).returns('ok');
+
+      // when
+      const response = await userController.rememberUserHasSeenChallengeTooltip(request);
+
+      // then
+      expect(response).to.be.equal('ok');
+    });
+  });
+
   describe('#getCurrentUser', () => {
     let request;
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -49,6 +49,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
               'pix-certif-terms-of-service-accepted': userModelObject.pixCertifTermsOfServiceAccepted,
               'has-seen-assessment-instructions': userModelObject.hasSeenAssessmentInstructions,
               'has-seen-new-dashboard-info': userModelObject.hasSeenNewDashboardInfo,
+              'has-seen-focused-challenge-tooltip': userModelObject.hasSeenFocusedChallengeTooltip,
             },
             relationships: {
               memberships: {

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -56,6 +56,12 @@ export default class User extends ApplicationAdapter {
       return url + '/has-seen-new-dashboard-info';
     }
 
+    if (adapterOptions && adapterOptions.tooltipChallengeType) {
+      const tooltipChallengeType = adapterOptions.tooltipChallengeType;
+      delete adapterOptions.tooltipChallengeType;
+      return url + '/has-seen-challenge-tooltip/' + tooltipChallengeType;
+    }
+
     if (adapterOptions && adapterOptions.updatePassword) {
       delete adapterOptions.updatePassword;
       const temporaryKey = adapterOptions.temporaryKey;

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import isInteger from 'lodash/isInteger';
@@ -6,6 +7,7 @@ import ENV from 'mon-pix/config/environment';
 
 export default class ChallengeItemGeneric extends Component {
 
+  @service currentUser;
   @tracked isValidateButtonEnabled = true;
   @tracked isSkipButtonEnabled = true;
   @tracked hasUserConfirmedWarning = false;
@@ -40,7 +42,7 @@ export default class ChallengeItemGeneric extends Component {
   }
 
   get isAnswerFieldDisabled() {
-    if (this.isFocusedChallenge) {
+    if (this.isFocusedChallenge && this.currentUser.user && !this.currentUser.user.hasSeenFocusedChallengeTooltip) {
       return this.args.answer || !this.isTooltipClosed;
     }
     return this.args.answer;

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -15,7 +15,6 @@ export default class ChallengeStatement extends Component {
 
   @tracked selectedAttachmentUrl;
   @tracked displayAlternativeInstruction = false;
-
   @tracked shouldDisplayTooltip = false;
 
   constructor() {
@@ -73,6 +72,9 @@ export default class ChallengeStatement extends Component {
       this.shouldDisplayTooltip = true;
     }
     else if (this.isFocusedChallenge && this.currentUser.user && this.currentUser.user.hasSeenFocusedChallengeTooltip) {
+      this._notifyChallengeTooltipIsClosed();
+    }
+    else if (this.isFocusedChallenge) {
       this._notifyChallengeTooltipIsClosed();
     }
   }

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -10,17 +10,18 @@ const PREFERRED_ATTACHMENT_FORMATS = ['docx', 'xlsx', 'pptx'];
 
 export default class ChallengeStatement extends Component {
   @service mailGenerator;
+  @service currentUser;
   @service intl;
 
   @tracked selectedAttachmentUrl;
   @tracked displayAlternativeInstruction = false;
 
-  @tracked displayTagHelp = false;
+  @tracked shouldDisplayTooltip = false;
 
   constructor() {
     super(...arguments);
     this._initialiseDefaultAttachment();
-    this.showTagHelp();
+    this._showTooltip();
   }
 
   get isFocusedChallengeToggleEnabled() {
@@ -63,14 +64,21 @@ export default class ChallengeStatement extends Component {
 
   @action
   hideTooltip() {
-    this.displayTagHelp = false;
-    this.args.onTooltipClose();
+    this.shouldDisplayTooltip = false;
+    this._notifyChallengeTooltipIsClosed();
   }
 
-  showTagHelp() {
-    if (this.isFocusedChallenge) {
-      this.displayTagHelp = true;
+  _showTooltip() {
+    if (this.isFocusedChallenge && this.currentUser.user && !this.currentUser.user.hasSeenFocusedChallengeTooltip) {
+      this.shouldDisplayTooltip = true;
     }
+    else if (this.isFocusedChallenge && this.currentUser.user && this.currentUser.user.hasSeenFocusedChallengeTooltip) {
+      this._notifyChallengeTooltipIsClosed();
+    }
+  }
+
+  _notifyChallengeTooltipIsClosed() {
+    this.args.onTooltipClose();
   }
 
   @action

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -16,7 +16,7 @@ export default class ChallengeController extends Controller {
   @tracked competenceLeveled = null;
   @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOut = false;
-  @tracked isTooltipOverlayDisplayed = true;
+  @tracked isTooltipOverlayDisplayed = !(this.currentUser.user && this.currentUser.user.hasSeenFocusedChallengeTooltip)
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;
@@ -42,8 +42,10 @@ export default class ChallengeController extends Controller {
 
   @action
   async removeTooltipOverlay() {
-    this.isTooltipOverlayDisplayed = false;
-    await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'focused' } });
+    if (this.currentUser.user && !this.currentUser.user.hasSeenFocusedChallengeTooltip) {
+      this.isTooltipOverlayDisplayed = false;
+      await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'focused' } });
+    }
   }
 
   @action

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -6,6 +6,7 @@ import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 import { action } from '@ember/object';
 const defaultPageTitle = 'pages.challenge.title';
 const timedOutPageTitle = 'pages.challenge.timed-out-title';
+import ENV from 'mon-pix/config/environment';
 
 export default class ChallengeController extends Controller {
   queryParams = ['newLevel', 'competenceLeveled', 'challengeId'];
@@ -15,7 +16,7 @@ export default class ChallengeController extends Controller {
   @tracked competenceLeveled = null;
   @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOut = false;
-  @tracked isTooltipOverlayIsDisplayed = true;
+  @tracked isTooltipOverlayDisplayed = true;
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;
@@ -33,12 +34,15 @@ export default class ChallengeController extends Controller {
   }
 
   get isFocusedChallengeAndTooltipIsDisplayed() {
-    return this.model.challenge.focused && this.isTooltipOverlayIsDisplayed;
+    if (ENV.APP.FT_FOCUS_CHALLENGE_ENABLED) {
+      return this.model.challenge.focused && this.isTooltipOverlayDisplayed && this.currentUser.user && !this.currentUser.user.hasSeenFocusedChallengeTooltip;
+    }
+    return false;
   }
 
   @action
   async removeTooltipOverlay() {
-    this.isTooltipOverlayIsDisplayed = false;
+    this.isTooltipOverlayDisplayed = false;
     await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'focused' } });
   }
 

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -37,8 +37,9 @@ export default class ChallengeController extends Controller {
   }
 
   @action
-  removeTooltipOverlay() {
+  async removeTooltipOverlay() {
     this.isTooltipOverlayIsDisplayed = false;
+    await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'focused' } });
   }
 
   @action

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -11,6 +11,7 @@ export default class User extends Model {
   @attr('boolean') mustValidateTermsOfService;
   @attr('boolean') hasSeenAssessmentInstructions;
   @attr('boolean') hasSeenNewDashboardInfo;
+  @attr('boolean') hasSeenFocusedChallengeTooltip;
   @attr('string') lang;
   @attr('boolean') isAnonymous;
 

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -6,7 +6,7 @@
 
       {{#if this.isFocusedChallengeToggleEnabled}}
         <div class="challenge-statement-instruction__tag challenge-statement-instruction__tag{{if this.isFocusedChallenge "--focused" "--regular"}}">
-          {{#if this.displayTagHelp}}
+          {{#if this.shouldDisplayTooltip}}
             <div role="tooltip"
                  id="challenge-statement-tag--tooltip"
                  class="challenge-statement__tag-information"

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -58,4 +58,10 @@ export default function index(config) {
     user.update({ hasSeenNewDashboardInfo: true });
     return user;
   });
+
+  config.patch('/users/:id/has-seen-challenge-tooltip/:challengeType', (schema, request) => {
+    const user = schema.users.find(request.params.id);
+    user.update({ tooltipChallengeType: request.params.challengeType });
+    return user;
+  });
 }

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateByEmail } from '../helpers/authentication';
 
 describe('Acceptance | Displaying a QROC challenge', () => {
   setupApplicationTest();
@@ -370,165 +371,146 @@ describe('Acceptance | Displaying a QROC challenge', () => {
   });
 
   describe('when challenge is focused', () => {
-    it('should display an overlay and tooltip', async () => {
-      // given
-      assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-      server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
 
-      // when
-      await visit(`/assessments/${assessment.id}/challenges/0`);
+    describe('when user has not seen the challenge tooltip yet', function() {
+      beforeEach(async () => {
+        const user = server.create('user', 'withEmail', {
+          hasSeenFocusedChallengeTooltip: false,
+        });
+        await authenticateByEmail(user);
+      });
 
-      // then
-      expect(find('.assessment-challenge__focused-overlay')).to.exist;
-      expect(find('#challenge-statement-tag--tooltip')).to.exist;
-    });
-
-    it('should disable input and buttons', async () => {
-      // given
-      assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-      server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
-
-      // when
-      await visit(`/assessments/${assessment.id}/challenges/0`);
-
-      // then
-      expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.exist;
-      expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.exist;
-      expect(find('.challenge-response__proposal').getAttribute('disabled')).to.exist;
-    });
-
-    describe('when user closes tooltip', () => {
-      it('should hide an overlay and tooltip', async () => {
+      it('should display an overlay and tooltip', async () => {
         // given
         assessment = server.create('assessment', 'ofCompetenceEvaluationType');
         server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
 
         // when
         await visit(`/assessments/${assessment.id}/challenges/0`);
-        await click('[data-test="challenge-statement-tag-information__button"]');
 
+        // then
+        expect(find('.assessment-challenge__focused-overlay')).to.exist;
+        expect(find('#challenge-statement-tag--tooltip')).to.exist;
+      });
+
+      it('should disable input and buttons', async () => {
+        // given
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+        server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
+
+        // when
+        await visit(`/assessments/${assessment.id}/challenges/0`);
+
+        // then
+        expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.exist;
+        expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.exist;
+        expect(find('.challenge-response__proposal').getAttribute('disabled')).to.exist;
+      });
+
+      it('should not display an info alert with dashed border and overlay', async function() {
+        // given
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+        server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
+
+        // when
+        await visit(`/assessments/${assessment.id}/challenges/0`);
+        const challengeItem = find('.challenge-item');
+        await triggerEvent(challengeItem, 'mouseleave');
+
+        // then
+        expect(find('.alert--info')).to.not.exist;
+        expect(find('.challenge-item__container--focused')).to.not.exist;
+        expect(find('.assessment-challenge__focused-out-overlay')).to.not.exist;
+      });
+
+      describe('when user closes tooltip', () => {
+        beforeEach(async function() {
+          // given
+          assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+          server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
+
+          // when
+          await visit(`/assessments/${assessment.id}/challenges/0`);
+          await click('[data-test="challenge-statement-tag-information__button"]');
+        });
+
+        it('should hide an overlay and tooltip', async () => {
+          // then
+          expect(find('.assessment-challenge__focused-overlay')).to.not.exist;
+          expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
+        });
+
+        it('should enable input and buttons', async () => {
+          // then
+          expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
+          expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
+          expect(find('.challenge-response__proposal').getAttribute('disabled')).to.not.exist;
+        });
+
+        it('should display a warning alert', async function() {
+          // when
+          await triggerEvent(window, 'blur');
+
+          // then
+          expect(find('.alert--warning')).to.exist;
+        });
+
+        it('should display an info alert with dashed border and overlay', async function() {
+          // when
+          const challengeItem = find('.challenge-item');
+          await triggerEvent(challengeItem, 'mouseleave');
+
+          // then
+          expect(find('.alert--info')).to.exist;
+          expect(find('.challenge-item__container--focused')).to.exist;
+          expect(find('.assessment-challenge__focused-out-overlay')).to.exist;
+        });
+
+        it('should display only the warning alert when it has been triggered', async function() {
+          // when
+          const challengeItem = find('.challenge-item');
+          await triggerEvent(challengeItem, 'mouseleave');
+
+          // then
+          expect(find('.alert--info')).to.exist;
+          expect(find('.challenge-item__container--focused')).to.exist;
+          expect(find('.assessment-challenge__focused-out-overlay')).to.exist;
+
+          // when
+          await triggerEvent(window, 'blur');
+
+          expect(find('.alert--info')).to.not.exist;
+          expect(find('.alert--warning')).to.exist;
+          expect(find('.challenge-item__container--focused')).to.exist;
+          expect(find('.assessment-challenge__focused-out-overlay')).to.exist;
+        });
+      });
+    });
+
+    describe('when user has already seen challenge tooltip', () => {
+      beforeEach(async () => {
+        const user = server.create('user', 'withEmail', {
+          hasSeenFocusedChallengeTooltip: true,
+        });
+        await authenticateByEmail(user);
+
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+        server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
+
+        await visit(`/assessments/${assessment.id}/challenges/0`);
+      });
+
+      it('should hide the overlay and tooltip', async () => {
         // then
         expect(find('.assessment-challenge__focused-overlay')).to.not.exist;
         expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
       });
 
       it('should enable input and buttons', async () => {
-        // given
-        assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-        server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
-
-        // when
-        await visit(`/assessments/${assessment.id}/challenges/0`);
-        await click('[data-test="challenge-statement-tag-information__button"]');
-
         // then
         expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
         expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
         expect(find('.challenge-response__proposal').getAttribute('disabled')).to.not.exist;
-      });
-    });
-
-    describe('when user has focused out of document', function() {
-
-      context('when challenge is set as focused', function() {
-
-        context('and user has not closed tooltip', () => {
-          beforeEach(async function() {
-            // given
-            assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-            server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
-
-            // when
-            await visit(`/assessments/${assessment.id}/challenges/0`);
-          });
-
-          it('should not display an info alert with dashed border and overlay', async function() {
-            // when
-            const challengeItem = find('.challenge-item');
-            await triggerEvent(challengeItem, 'mouseleave');
-
-            // then
-            expect(find('.alert--info')).to.not.exist;
-            expect(find('.challenge-item__container--focused')).to.not.exist;
-            expect(find('.assessment-challenge__focused-out-overlay')).to.not.exist;
-          });
-        });
-
-        context('and user has closed tooltip', () => {
-
-          beforeEach(async function() {
-            // given
-            assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-            server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withFocused');
-
-            // when
-            await visit(`/assessments/${assessment.id}/challenges/0`);
-            await click('[data-test="challenge-statement-tag-information__button"]');
-          });
-
-          it('should display a warning alert', async function() {
-            // when
-            await triggerEvent(window, 'blur');
-
-            // then
-            expect(find('.alert--warning')).to.exist;
-          });
-
-          it('should display an info alert with dashed border and overlay', async function() {
-            // when
-            const challengeItem = find('.challenge-item');
-            await triggerEvent(challengeItem, 'mouseleave');
-
-            // then
-            expect(find('.alert--info')).to.exist;
-            expect(find('.challenge-item__container--focused')).to.exist;
-            expect(find('.assessment-challenge__focused-out-overlay')).to.exist;
-          });
-
-          it('should display only the warning alert when it has been triggered', async function() {
-            // when
-            const challengeItem = find('.challenge-item');
-            await triggerEvent(challengeItem, 'mouseleave');
-
-            // then
-            expect(find('.alert--info')).to.exist;
-            expect(find('.challenge-item__container--focused')).to.exist;
-            expect(find('.assessment-challenge__focused-out-overlay')).to.exist;
-
-            // when
-            await triggerEvent(window, 'blur');
-
-            expect(find('.alert--info')).to.not.exist;
-            expect(find('.alert--warning')).to.exist;
-            expect(find('.challenge-item__container--focused')).to.exist;
-            expect(find('.assessment-challenge__focused-out-overlay')).to.exist;
-          });
-
-        });
-      });
-
-      context('when challenge is not set as focused', function() {
-        beforeEach(async function() {
-          // given
-          assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-          server.create('challenge', 'forCompetenceEvaluation', 'QROC');
-
-          // when
-          await visit(`/assessments/${assessment.id}/challenges/0`);
-        });
-
-        it('should not display instructions', async function() {
-          // then
-          expect(find('.focused-challenge-instructions-action__confirmation-button')).to.not.exist;
-        });
-
-        it('should not display a warning alert', async function() {
-          // when
-          await triggerEvent(window, 'blur');
-
-          // then
-          expect(find('.alert--warning')).to.not.exist;
-        });
       });
     });
   });
@@ -545,6 +527,31 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       // then
       expect(find('.assessment-challenge__focused-overlay')).to.not.exist;
       expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
+    });
+
+    describe('when user has focused out of document', function() {
+      beforeEach(async function() {
+        // given
+        const user = server.create('user', 'withEmail');
+        await authenticateByEmail(user);
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+        server.create('challenge', 'forCompetenceEvaluation', 'QROC');
+
+        // when
+        await visit(`/assessments/${assessment.id}/challenges/0`);
+      });
+
+      it('should not display instructions', async function() {
+        // then
+        expect(find('.focused-challenge-instructions-action__confirmation-button')).to.not.exist;
+      });
+
+      it('should not display a warning alert', async function() {
+        // when
+        await triggerEvent(window, 'blur');
+        // then
+        expect(find('.alert--warning')).to.not.exist;
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/adapters/user_test.js
+++ b/mon-pix/tests/unit/adapters/user_test.js
@@ -63,6 +63,16 @@ describe('Unit | Adapters | user', function() {
       expect(url.endsWith('/users/123/remember-user-has-seen-assessment-instructions')).to.be.true;
     });
 
+    it('should redirect to has-seen-challenge-tooltip', async function() {
+      // when
+      const snapshot = { adapterOptions: { tooltipChallengeType: 'focused' } };
+      const url = await adapter.urlForUpdateRecord(123, 'user', snapshot);
+      console.log(url);
+
+      // then
+      expect(url.endsWith('/users/123/has-seen-challenge-tooltip/focused')).to.be.true;
+    });
+
     it('should include temporaryKey if present in adapterOptions', async function() {
       // when
       const snapshot = { adapterOptions: { updatePassword: true, temporaryKey: 'temp=&key' } };


### PR DESCRIPTION
## :unicorn: Problème
Sur une épreuve focus, une tooltip s'affiche pour indiquer à l'utilisateur ce qu'est une épreuve focus.
Cette tooltip s'affiche actuellement à chaque épreuve focus.
Or l'utilisateur n'a pas besoin de la voir à chaque fois.

## :robot: Solution
Afficher la tooltip seulement la première fois:
quand l'utilisateur clique sur "J'ai compris", on sauvegarde en DB que l'utilisateur a déjà vu la tooltip, elle ne sera donc pas réaffichée la prochaine fois.

## :rainbow: Remarques
On distinguait deux types de tooltips: ceux pour les challenges focus et les autres.
La sauvegarde de l'état de la tooltip (déjà vue ou non) se fait sur le même endpoint, quelque soit le type de challenge.
Nous avons choisi de laisser l'endpoint actuel, même si la prise en charge de la tooltip pour les autres épreuves arriveront plus tard.
Update: La prise en charge de `hasSeenOtherChallengeTooltip` a été reportée et donc supprimée de cette PR.

## :100: Pour tester
Se rendre sur une épreuve focus (ex: rec2dRKsI4aBIsayz):
- une tooltip s'affiche
- les boutons actions et input sont déasactivés
- un overlay s'affiche derrière la tooltip
- cliquer sur "J'ai compris' de la tooltip
- vérifier que la tooltip et l'overlay ont disparu et les input et bouton sont cliquables
- en DB le champ `hasSeenFocusedChallengeTooltip` de l'utilisateur est passé à `true`
- après rafraichissement de la page, la tooltip et l'overlay ne sont plus visibles