### PR TITLE
[BUGFIX] Le lien "Continuez votre expérience sur Pix" à la fin d'une campagne ne redirige plus vers la page d'accueil  (PIX-2915).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -143,7 +143,8 @@ export default class SkillReview extends Component {
   }
 
   @action
-  async redirectToSignupIfUserIsAnonymous() {
+  async redirectToSignupIfUserIsAnonymous(event) {
+    event.preventDefault();
     if (this.currentUser.user.isAnonymous) {
       await this.session.invalidate();
       this.router.transitionTo('inscription');

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
@@ -450,6 +450,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
 
     it('should redirect to sign up page on click when user is anonymous', async function() {
       // given
+      const event = { preventDefault: () => {} };
       const session = this.owner.lookup('service:session');
       class currentUser extends Service { user = { isAnonymous: true }}
       this.owner.register('service:currentUser', currentUser);
@@ -457,7 +458,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
       session.invalidate = sinon.stub();
 
       // when
-      await component.actions.redirectToSignupIfUserIsAnonymous.call(component);
+      await component.actions.redirectToSignupIfUserIsAnonymous.call(component, event);
 
       // then
       sinon.assert.called(session.invalidate);
@@ -466,14 +467,28 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
 
     it('should redirect to home page when user is not anonymous', async function() {
       // given
+      const event = { preventDefault: () => {} };
       class currentUser extends Service { user = { isAnonymous: false }}
       this.owner.register('service:currentUser', currentUser);
 
       // when
-      await component.actions.redirectToSignupIfUserIsAnonymous.call(component);
+      await component.actions.redirectToSignupIfUserIsAnonymous.call(component, event);
 
       // then
       sinon.assert.calledWith(component.router.transitionTo, 'index');
+    });
+
+    it('prevents default behaviour', async function() {
+      // given
+      const event = { preventDefault: sinon.stub() };
+      class currentUser extends Service { user = { isAnonymous: false }}
+      this.owner.register('service:currentUser', currentUser);
+
+      // when
+      await component.actions.redirectToSignupIfUserIsAnonymous.call(component, event);
+
+      // then
+      sinon.assert.called(event.preventDefault);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le participant d'une campagne partage ses résultats et qu'il clique sur "continuer votre expérience Pix" il n'est pas redirigé vers son profil.

## :robot: Solution
Supprimer le comportement du lien qui fait une redirection sur la page courante au moment du clique.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Participer à une campagne, partager ses résultats et cliquer sur "Continuez votre expérience sur Pix" => Il y a une redirection vers le profil de l'utilisateur.
- Rejoindre une campagne dont on a partagé les résultats et cliquer sur "Continuez votre expérience sur Pix" => Il y a une redirection vers le profil de l'utilisateur.
