### PR TITLE
[BUGFIX] Suppression d'un appel inutile et potentiellement long au back depuis Pix Orga.

### DIFF
--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -23,7 +23,6 @@ export default class AssessmentResultsRoute extends Route {
 
   async model(params) {
     const campaign = this.modelFor('authenticated.campaigns.campaign');
-    await campaign.belongsTo('campaignCollectiveResult').reload();
     return RSVP.hash({
       campaign,
       participations: this.fetchResultMinimalList({ campaignId: campaign.id, ...params }),


### PR DESCRIPTION
## :unicorn: Problème
Un appel à `/api/campaigns/id/collective-results` est réalisé sur l'onglet résultats, alors que les informations récupérées ne sont pas du tout affichées. De plus, cette route agrège des résultats et donc peut mettre un certain temps. Cela n'est pas optimal pour l'expérience utilisateur.

## :robot: Solution
Supprimer cet appel.

## :rainbow: Remarques
Rien à signaler.

## :100: Pour tester
Aller sur l'onglet "Résultats" et vérifier dans l'onglet "Network" de la console que l'appel n'est pas lancé.
