### PR TITLE
[TECH] Ajout d'une méthode pour récupérer toutes les informations nécessaires à la création d'attestations de certification pour une classe SCO (PIX-2904)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const { knex } = require('../../../db/knex-database-connection');
 const CertificationAttestation = require('../../domain/models/CertificationAttestation');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
@@ -30,6 +31,18 @@ module.exports = {
       ...certificationCourseDTO,
       cleaCertificationImagePath,
       pixPlusDroitCertificationImagePath,
+    });
+  },
+
+  async findByDivisionForScoIsManagingStudentsOrganization({ _organizationId, _division } = {}) {
+    const certificationCourseDTOs = await _selectCertificationAttestations()
+      .orderBy('certification-courses.id');
+    return _.map(certificationCourseDTOs, (certificationCourseDTO) => {
+      return new CertificationAttestation({
+        ...certificationCourseDTO,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      });
     });
   },
 };

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -34,7 +34,7 @@ module.exports = {
     });
   },
 
-  async findByDivisionForScoIsManagingStudentsOrganization({ organizationId, _division }) {
+  async findByDivisionForScoIsManagingStudentsOrganization({ organizationId, division }) {
     const certificationCourseDTOs = await _selectCertificationAttestations()
       .select({ schoolingRegistrationId: 'schooling-registrations.id' })
       .innerJoin('certification-candidates', function() {
@@ -44,6 +44,7 @@ module.exports = {
       .innerJoin('schooling-registrations', 'schooling-registrations.id', 'certification-candidates.schoolingRegistrationId')
       .innerJoin('organizations', 'organizations.id', 'schooling-registrations.organizationId')
       .where('schooling-registrations.organizationId', '=', organizationId)
+      .whereRaw('LOWER("schooling-registrations"."division") = ?', division.toLowerCase())
       .whereRaw('"certification-candidates"."userId" = "certification-courses"."userId"')
       .whereRaw('"certification-candidates"."sessionId" = "certification-courses"."sessionId"')
       .modify(_checkOrganizationIsScoIsManagingStudents)

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -29,7 +29,7 @@ module.exports = {
       .from('certification-candidates')
       .join('schooling-registrations', 'schooling-registrations.id', 'certification-candidates.schoolingRegistrationId')
       .where('schooling-registrations.organizationId', '=', organizationId)
-      .whereRaw('LOWER("schooling-registrations"."division") LIKE ?', `${division.toLowerCase()}`)
+      .whereRaw('LOWER("schooling-registrations"."division") = ?', division.toLowerCase())
       .orderBy('certification-candidates.lastName', 'ASC')
       .orderBy('certification-candidates.firstName', 'ASC');
 

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -561,4 +561,361 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       });
     });
   });
+
+  describe('#findByDivisionForScoIsManagingStudentsOrganization', () => {
+
+    it('should return an empty array when there are no certification attestations', async () => {
+      // when
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+
+      // then
+      expect(certificationAttestations).to.be.empty;
+    });
+
+    it('should not return certifications that have no validated assessment-result', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+        certificationCenterId,
+      }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData.id,
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData.date,
+        verificationCode: certificationAttestationData.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+        sessionId,
+        userId,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore,
+        status: 'rejected',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+
+      // then
+      expect(certificationAttestations).to.be.empty;
+    });
+
+    it('should not return cancelled certifications', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+        certificationCenterId,
+      }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData.id,
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: true,
+        createdAt: certificationAttestationData.date,
+        verificationCode: certificationAttestationData.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+        sessionId,
+        userId,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore,
+        status: 'validated',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+
+      // then
+      expect(certificationAttestations).to.be.empty;
+    });
+
+    it('should not return non published certifications', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: false,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+        certificationCenterId,
+      }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData.id,
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData.date,
+        verificationCode: certificationAttestationData.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+        sessionId,
+        userId,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore,
+        status: 'validated',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(certificationAttestationRepository.get)(certificationAttestationData.id);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal('There is no certification course with id "123"');
+    });
+
+    it('should return an array of certification attestations ordered by ID', async () => {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      // Certification ID 456
+      const userId2 = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData2 = {
+        id: 456,
+        firstName: 'James',
+        lastName: 'Marsters',
+        birthdate: '1962-08-20',
+        birthplace: 'Trouville',
+        isPublished: true,
+        userId: userId2,
+        date: new Date('2020-05-01'),
+        verificationCode: 'P-SOMEOTHERCODE',
+        maxReachableLevelOnCertificationDate: 6,
+        deliveredAt: new Date('2021-07-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 23,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const sessionId2 = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData2.deliveredAt,
+        certificationCenter: certificationAttestationData2.certificationCenter,
+        certificationCenterId,
+      }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData2.id,
+        firstName: certificationAttestationData2.firstName,
+        lastName: certificationAttestationData2.lastName,
+        birthdate: certificationAttestationData2.birthdate,
+        birthplace: certificationAttestationData2.birthplace,
+        isPublished: certificationAttestationData2.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData2.date,
+        verificationCode: certificationAttestationData2.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData2.maxReachableLevelOnCertificationDate,
+        sessionId: sessionId2,
+        userId: userId2,
+      }).id;
+      const assessmentId2 = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData2.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: assessmentId2,
+        pixScore: certificationAttestationData2.pixScore,
+        status: 'validated',
+      });
+      // Certification ID 123
+      const userId1 = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData1 = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId: userId1,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const sessionId1 = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData1.deliveredAt,
+        certificationCenter: certificationAttestationData1.certificationCenter,
+        certificationCenterId,
+      }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData1.id,
+        firstName: certificationAttestationData1.firstName,
+        lastName: certificationAttestationData1.lastName,
+        birthdate: certificationAttestationData1.birthdate,
+        birthplace: certificationAttestationData1.birthplace,
+        isPublished: certificationAttestationData1.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData1.date,
+        verificationCode: certificationAttestationData1.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData1.maxReachableLevelOnCertificationDate,
+        sessionId: sessionId1,
+        userId: userId1,
+      }).id;
+      const assessmentId1 = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData1.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: assessmentId1,
+        pixScore: certificationAttestationData1.pixScore,
+        status: 'validated',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+
+      // then
+      const expectedCertificationAttestation1 = domainBuilder.buildCertificationAttestation(certificationAttestationData1);
+      const expectedCertificationAttestation2 = domainBuilder.buildCertificationAttestation(certificationAttestationData2);
+      expect(certificationAttestations).to.have.length(2);
+      expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation1);
+      expect(certificationAttestations[1]).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestations[1]).to.deep.equal(expectedCertificationAttestation2);
+    });
+
+    it('should take into account the latest validated assessment result of a certification', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+        certificationCenterId,
+      }).id;
+      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData.id,
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData.date,
+        verificationCode: certificationAttestationData.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+        sessionId,
+        userId,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore + 20,
+        status: 'validated',
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore,
+        status: 'validated',
+        createdAt: new Date('2020-01-02'),
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: 0,
+        status: 'rejected',
+        createdAt: new Date('2020-01-03'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+
+      // then
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+        id: certificateId,
+        ...certificationAttestationData,
+      });
+      expect(certificationAttestations).to.have.length(1);
+      expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation);
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -298,6 +298,79 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
     });
 
+    it('should take into account the latest validated assessment result of the certification', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+      };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+        certificationCenterId,
+      }).id;
+      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+        id: certificationAttestationData.id,
+        firstName: certificationAttestationData.firstName,
+        lastName: certificationAttestationData.lastName,
+        birthdate: certificationAttestationData.birthdate,
+        birthplace: certificationAttestationData.birthplace,
+        isPublished: certificationAttestationData.isPublished,
+        isCancelled: false,
+        createdAt: certificationAttestationData.date,
+        verificationCode: certificationAttestationData.verificationCode,
+        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+        sessionId,
+        userId,
+      }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore + 20,
+        status: 'validated',
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: certificationAttestationData.pixScore,
+        status: 'validated',
+        createdAt: new Date('2020-01-02'),
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId,
+        pixScore: 0,
+        status: 'rejected',
+        createdAt: new Date('2020-01-03'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationAttestation = await certificationAttestationRepository.get(certificationAttestationData.id);
+
+      // then
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+        id: certificateId,
+        ...certificationAttestationData,
+      });
+      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+    });
+
     it('should get the clea certification result if taken', async () => {
       // given
       const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -21,7 +21,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should throw a NotFoundError when certification has no assessment-result', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -29,7 +28,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -39,28 +38,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      await databaseBuilder.commit();
+      await _buildIncomplete(certificationAttestationData);
 
       // when
       const error = await catchErr(certificationAttestationRepository.get)(certificationAttestationData.id);
@@ -72,7 +50,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should throw a NotFoundError when certification is cancelled', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -80,7 +57,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -90,33 +67,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: true,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'validated',
-      });
-      await databaseBuilder.commit();
+      await _buildCancelled(certificationAttestationData);
 
       // when
       const error = await catchErr(certificationAttestationRepository.get)(certificationAttestationData.id);
@@ -128,7 +79,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should throw a NotFoundError when certification is not published', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -136,7 +86,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: false,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -146,33 +96,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'validated',
-      });
-      await databaseBuilder.commit();
+      await _buildValidCertificationAttestation(certificationAttestationData);
 
       // when
       const error = await catchErr(certificationAttestationRepository.get)(certificationAttestationData.id);
@@ -184,7 +108,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should throw a NotFoundError when certification is rejected', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -192,7 +115,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -202,32 +125,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'rejected',
-      });
+      await _buildRejected(certificationAttestationData);
       await databaseBuilder.commit();
 
       // when
@@ -240,7 +138,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should return a CertificationAttestation', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -248,7 +145,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -258,49 +155,19 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'validated',
-      });
-      await databaseBuilder.commit();
+      await _buildValidCertificationAttestation(certificationAttestationData);
 
       // when
-      const certificationAttestation = await certificationAttestationRepository.get(certificationAttestationData.id);
+      const certificationAttestation = await certificationAttestationRepository.get(123);
 
       // then
-      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
-        id: certificateId,
-        ...certificationAttestationData,
-      });
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationData);
       expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
     });
 
     it('should take into account the latest validated assessment result of the certification', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -308,7 +175,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -318,62 +185,20 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore + 20,
-        status: 'validated',
-        createdAt: new Date('2020-01-01'),
-      });
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'validated',
-        createdAt: new Date('2020-01-02'),
-      });
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: 0,
-        status: 'rejected',
-        createdAt: new Date('2020-01-03'),
-      });
+      await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
       await databaseBuilder.commit();
 
       // when
-      const certificationAttestation = await certificationAttestationRepository.get(certificationAttestationData.id);
+      const certificationAttestation = await certificationAttestationRepository.get(123);
 
       // then
-      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
-        id: certificateId,
-        ...certificationAttestationData,
-      });
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestation);
       expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
     });
 
     it('should get the clea certification result if taken', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -381,7 +206,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -391,52 +216,23 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: certificationAttestationRepository.macaronCleaPath,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'validated',
-      });
-      databaseBuilder.factory.buildBadge({ key: cleaBadgeKey });
-      databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: cleaBadgeKey, acquired: true });
+      await _buildValidCertificationAttestation(certificationAttestationData);
+      await _buildCleaResult({ certificationCourseId: 123, acquired: true });
       await databaseBuilder.commit();
 
       // when
       const certificationAttestation = await certificationAttestationRepository.get(123);
 
       // then
-      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
-        ...certificationAttestationData,
-      });
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationData);
       expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
     });
 
     context('acquired certifiable badges', () => {
 
-      it('should get the certified badge images of pixPlusDroitMaitre or pixPlusDroitExpert when those certifications were acquired', async () => {
+      it('should get the certified badge images of pixPlusDroitExpert when acquired', async () => {
         // given
-        const userId = databaseBuilder.factory.buildUser().id;
         const certificationAttestationData = {
           id: 123,
           firstName: 'Sarah Michelle',
@@ -444,7 +240,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           birthdate: '1977-04-14',
           birthplace: 'Saint-Ouen',
           isPublished: true,
-          userId,
+          userId: 456,
           date: new Date('2020-01-01'),
           verificationCode: 'P-SOMECODE',
           maxReachableLevelOnCertificationDate: 5,
@@ -454,52 +250,20 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           cleaCertificationImagePath: null,
           pixPlusDroitCertificationImagePath: certificationAttestationRepository.macaronPixPlusDroitExpertPath,
         };
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-        const sessionId = databaseBuilder.factory.buildSession({
-          publishedAt: certificationAttestationData.deliveredAt,
-          certificationCenter: certificationAttestationData.certificationCenter,
-          certificationCenterId,
-        }).id;
-        databaseBuilder.factory.buildCertificationCourse({
-          id: certificationAttestationData.id,
-          firstName: certificationAttestationData.firstName,
-          lastName: certificationAttestationData.lastName,
-          birthdate: certificationAttestationData.birthdate,
-          birthplace: certificationAttestationData.birthplace,
-          isPublished: certificationAttestationData.isPublished,
-          isCancelled: false,
-          createdAt: certificationAttestationData.date,
-          verificationCode: certificationAttestationData.verificationCode,
-          maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-          sessionId,
-          userId,
-        }).id;
-        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-        databaseBuilder.factory.buildAssessmentResult({
-          assessmentId,
-          pixScore: certificationAttestationData.pixScore,
-          status: 'validated',
-        });
-        databaseBuilder.factory.buildBadge({ key: pixPlusDroitExpertBadgeKey });
-        databaseBuilder.factory.buildBadge({ key: 'should_be_ignored' });
-        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: pixPlusDroitExpertBadgeKey, acquired: true });
-        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: 'should_be_ignored', acquired: true });
-        await databaseBuilder.commit();
+        await _buildValidCertificationAttestation(certificationAttestationData);
+        await _buildPixPlusDroitExpertResult({ certificationCourseId: 123, acquired: true });
 
         // when
         const certificationAttestation = await certificationAttestationRepository.get(123);
 
         // then
-        const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
-          ...certificationAttestationData,
-        });
+        const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationData);
         expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
         expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
       });
 
-      it('should only take into account acquired ones', async () => {
+      it('should get the certified badge images of pixPlusDroitMaitre when acquired', async () => {
         // given
-        const userId = databaseBuilder.factory.buildUser().id;
         const certificationAttestationData = {
           id: 123,
           firstName: 'Sarah Michelle',
@@ -507,7 +271,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           birthdate: '1977-04-14',
           birthplace: 'Saint-Ouen',
           isPublished: true,
-          userId,
+          userId: 456,
           date: new Date('2020-01-01'),
           verificationCode: 'P-SOMECODE',
           maxReachableLevelOnCertificationDate: 5,
@@ -517,45 +281,46 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           cleaCertificationImagePath: null,
           pixPlusDroitCertificationImagePath: certificationAttestationRepository.macaronPixPlusDroitMaitrePath,
         };
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-        const sessionId = databaseBuilder.factory.buildSession({
-          publishedAt: certificationAttestationData.deliveredAt,
-          certificationCenter: certificationAttestationData.certificationCenter,
-          certificationCenterId,
-        }).id;
-        databaseBuilder.factory.buildCertificationCourse({
-          id: certificationAttestationData.id,
-          firstName: certificationAttestationData.firstName,
-          lastName: certificationAttestationData.lastName,
-          birthdate: certificationAttestationData.birthdate,
-          birthplace: certificationAttestationData.birthplace,
-          isPublished: certificationAttestationData.isPublished,
-          isCancelled: false,
-          createdAt: certificationAttestationData.date,
-          verificationCode: certificationAttestationData.verificationCode,
-          maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-          sessionId,
-          userId,
-        }).id;
-        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-        databaseBuilder.factory.buildAssessmentResult({
-          assessmentId,
-          pixScore: certificationAttestationData.pixScore,
-          status: 'validated',
-        });
-        databaseBuilder.factory.buildBadge({ key: pixPlusDroitMaitreBadgeKey });
-        databaseBuilder.factory.buildBadge({ key: cleaBadgeKey });
-        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: pixPlusDroitMaitreBadgeKey, acquired: true });
-        databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationAttestationData.id, partnerKey: cleaBadgeKey, acquired: false });
-        await databaseBuilder.commit();
+        await _buildValidCertificationAttestation(certificationAttestationData);
+        await _buildPixPlusDroitMaitreResult({ certificationCourseId: 123, acquired: true });
 
         // when
         const certificationAttestation = await certificationAttestationRepository.get(123);
 
         // then
-        const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
-          ...certificationAttestationData,
-        });
+        const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationData);
+        expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
+        expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+      });
+
+      it('should only take into account acquired ones', async () => {
+        // given
+        const certificationAttestationData = {
+          id: 123,
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId: 456,
+          date: new Date('2020-01-01'),
+          verificationCode: 'P-SOMECODE',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: 51,
+          cleaCertificationImagePath: null,
+          pixPlusDroitCertificationImagePath: certificationAttestationRepository.macaronPixPlusDroitMaitrePath,
+        };
+        await _buildValidCertificationAttestation(certificationAttestationData);
+        await _buildCleaResult({ certificationCourseId: 123, acquired: false });
+        await _buildPixPlusDroitMaitreResult({ certificationCourseId: 123, acquired: true });
+
+        // when
+        const certificationAttestation = await certificationAttestationRepository.get(123);
+
+        // then
+        const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationData);
         expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
         expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
       });
@@ -574,7 +339,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should not return certifications that have no validated assessment-result', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -582,7 +346,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -592,33 +356,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'rejected',
-      });
-      await databaseBuilder.commit();
+      await _buildRejected(certificationAttestationData);
 
       // when
       const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
@@ -629,7 +367,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should not return cancelled certifications', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -637,7 +374,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -647,33 +384,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: true,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'validated',
-      });
-      await databaseBuilder.commit();
+      await _buildCancelled(certificationAttestationData);
 
       // when
       const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
@@ -684,7 +395,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should not return non published certifications', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -692,7 +402,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: false,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -702,33 +412,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'validated',
-      });
-      await databaseBuilder.commit();
+      await _buildValidCertificationAttestation(certificationAttestationData);
 
       // when
       const error = await catchErr(certificationAttestationRepository.get)(certificationAttestationData.id);
@@ -740,17 +424,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should return an array of certification attestations ordered by ID', async () => {
       // given
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      // Certification ID 456
-      const userId2 = databaseBuilder.factory.buildUser().id;
-      const certificationAttestationData2 = {
+      const certificationAttestationDataA = {
         id: 456,
         firstName: 'James',
         lastName: 'Marsters',
         birthdate: '1962-08-20',
         birthplace: 'Trouville',
         isPublished: true,
-        userId: userId2,
+        userId: 111,
         date: new Date('2020-05-01'),
         verificationCode: 'P-SOMEOTHERCODE',
         maxReachableLevelOnCertificationDate: 6,
@@ -760,41 +441,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const sessionId2 = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData2.deliveredAt,
-        certificationCenter: certificationAttestationData2.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData2.id,
-        firstName: certificationAttestationData2.firstName,
-        lastName: certificationAttestationData2.lastName,
-        birthdate: certificationAttestationData2.birthdate,
-        birthplace: certificationAttestationData2.birthplace,
-        isPublished: certificationAttestationData2.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData2.date,
-        verificationCode: certificationAttestationData2.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData2.maxReachableLevelOnCertificationDate,
-        sessionId: sessionId2,
-        userId: userId2,
-      }).id;
-      const assessmentId2 = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData2.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessmentId2,
-        pixScore: certificationAttestationData2.pixScore,
-        status: 'validated',
-      });
-      // Certification ID 123
-      const userId1 = databaseBuilder.factory.buildUser().id;
-      const certificationAttestationData1 = {
+      const certificationAttestationDataB = {
         id: 123,
         firstName: 'Sarah Michelle',
         lastName: 'Gellar',
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId: userId1,
+        userId: 222,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -804,49 +458,24 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const sessionId1 = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData1.deliveredAt,
-        certificationCenter: certificationAttestationData1.certificationCenter,
-        certificationCenterId,
-      }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData1.id,
-        firstName: certificationAttestationData1.firstName,
-        lastName: certificationAttestationData1.lastName,
-        birthdate: certificationAttestationData1.birthdate,
-        birthplace: certificationAttestationData1.birthplace,
-        isPublished: certificationAttestationData1.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData1.date,
-        verificationCode: certificationAttestationData1.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData1.maxReachableLevelOnCertificationDate,
-        sessionId: sessionId1,
-        userId: userId1,
-      }).id;
-      const assessmentId1 = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData1.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessmentId1,
-        pixScore: certificationAttestationData1.pixScore,
-        status: 'validated',
-      });
-      await databaseBuilder.commit();
+      await _buildValidCertificationAttestation(certificationAttestationDataA);
+      await _buildValidCertificationAttestation(certificationAttestationDataB);
 
       // when
       const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
 
       // then
-      const expectedCertificationAttestation1 = domainBuilder.buildCertificationAttestation(certificationAttestationData1);
-      const expectedCertificationAttestation2 = domainBuilder.buildCertificationAttestation(certificationAttestationData2);
+      const expectedCertificationAttestationA = domainBuilder.buildCertificationAttestation(certificationAttestationDataA);
+      const expectedCertificationAttestationB = domainBuilder.buildCertificationAttestation(certificationAttestationDataB);
       expect(certificationAttestations).to.have.length(2);
       expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
-      expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation1);
+      expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestationB);
       expect(certificationAttestations[1]).to.be.instanceOf(CertificationAttestation);
-      expect(certificationAttestations[1]).to.deep.equal(expectedCertificationAttestation2);
+      expect(certificationAttestations[1]).to.deep.equal(expectedCertificationAttestationA);
     });
 
     it('should take into account the latest validated assessment result of a certification', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -854,7 +483,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         birthdate: '1977-04-14',
         birthplace: 'Saint-Ouen',
         isPublished: true,
-        userId,
+        userId: 456,
         date: new Date('2020-01-01'),
         verificationCode: 'P-SOMECODE',
         maxReachableLevelOnCertificationDate: 5,
@@ -864,58 +493,204 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
       };
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const sessionId = databaseBuilder.factory.buildSession({
-        publishedAt: certificationAttestationData.deliveredAt,
-        certificationCenter: certificationAttestationData.certificationCenter,
-        certificationCenterId,
-      }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
-        id: certificationAttestationData.id,
-        firstName: certificationAttestationData.firstName,
-        lastName: certificationAttestationData.lastName,
-        birthdate: certificationAttestationData.birthdate,
-        birthplace: certificationAttestationData.birthplace,
-        isPublished: certificationAttestationData.isPublished,
-        isCancelled: false,
-        createdAt: certificationAttestationData.date,
-        verificationCode: certificationAttestationData.verificationCode,
-        maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-        sessionId,
-        userId,
-      }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore + 20,
-        status: 'validated',
-        createdAt: new Date('2020-01-01'),
-      });
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: certificationAttestationData.pixScore,
-        status: 'validated',
-        createdAt: new Date('2020-01-02'),
-      });
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
-        pixScore: 0,
-        status: 'rejected',
-        createdAt: new Date('2020-01-03'),
-      });
-      await databaseBuilder.commit();
+      await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
 
       // when
       const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
 
       // then
-      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
-        id: certificateId,
-        ...certificationAttestationData,
-      });
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationData);
       expect(certificationAttestations).to.have.length(1);
       expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation);
     });
   });
 });
+
+async function _buildIncomplete(certificationAttestationData) {
+  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
+  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+  const sessionId = databaseBuilder.factory.buildSession({
+    publishedAt: certificationAttestationData.deliveredAt,
+    certificationCenter: certificationAttestationData.certificationCenter,
+    certificationCenterId,
+  }).id;
+  databaseBuilder.factory.buildCertificationCourse({
+    id: certificationAttestationData.id,
+    firstName: certificationAttestationData.firstName,
+    lastName: certificationAttestationData.lastName,
+    birthdate: certificationAttestationData.birthdate,
+    birthplace: certificationAttestationData.birthplace,
+    isPublished: certificationAttestationData.isPublished,
+    isCancelled: false,
+    createdAt: certificationAttestationData.date,
+    verificationCode: certificationAttestationData.verificationCode,
+    maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+    sessionId,
+    userId: certificationAttestationData.userId,
+  }).id;
+  databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+  await databaseBuilder.commit();
+}
+
+async function _buildRejected(certificationAttestationData) {
+  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
+  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+  const sessionId = databaseBuilder.factory.buildSession({
+    publishedAt: certificationAttestationData.deliveredAt,
+    certificationCenter: certificationAttestationData.certificationCenter,
+    certificationCenterId,
+  }).id;
+  databaseBuilder.factory.buildCertificationCourse({
+    id: certificationAttestationData.id,
+    firstName: certificationAttestationData.firstName,
+    lastName: certificationAttestationData.lastName,
+    birthdate: certificationAttestationData.birthdate,
+    birthplace: certificationAttestationData.birthplace,
+    isPublished: certificationAttestationData.isPublished,
+    isCancelled: false,
+    createdAt: certificationAttestationData.date,
+    verificationCode: certificationAttestationData.verificationCode,
+    maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+    sessionId,
+    userId: certificationAttestationData.userId,
+  }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    pixScore: certificationAttestationData.pixScore,
+    status: 'rejected',
+  });
+  await databaseBuilder.commit();
+}
+
+async function _buildCancelled(certificationAttestationData) {
+  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
+  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+  const sessionId = databaseBuilder.factory.buildSession({
+    publishedAt: certificationAttestationData.deliveredAt,
+    certificationCenter: certificationAttestationData.certificationCenter,
+    certificationCenterId,
+  }).id;
+  databaseBuilder.factory.buildCertificationCourse({
+    id: certificationAttestationData.id,
+    firstName: certificationAttestationData.firstName,
+    lastName: certificationAttestationData.lastName,
+    birthdate: certificationAttestationData.birthdate,
+    birthplace: certificationAttestationData.birthplace,
+    isPublished: certificationAttestationData.isPublished,
+    isCancelled: true,
+    createdAt: certificationAttestationData.date,
+    verificationCode: certificationAttestationData.verificationCode,
+    maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+    sessionId,
+    userId: certificationAttestationData.userId,
+  }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    pixScore: certificationAttestationData.pixScore,
+    status: 'validated',
+  });
+  await databaseBuilder.commit();
+}
+
+async function _buildValidCertificationAttestation(certificationAttestationData) {
+  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
+  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+  const sessionId = databaseBuilder.factory.buildSession({
+    publishedAt: certificationAttestationData.deliveredAt,
+    certificationCenter: certificationAttestationData.certificationCenter,
+    certificationCenterId,
+  }).id;
+  databaseBuilder.factory.buildCertificationCourse({
+    id: certificationAttestationData.id,
+    firstName: certificationAttestationData.firstName,
+    lastName: certificationAttestationData.lastName,
+    birthdate: certificationAttestationData.birthdate,
+    birthplace: certificationAttestationData.birthplace,
+    isPublished: certificationAttestationData.isPublished,
+    isCancelled: false,
+    createdAt: certificationAttestationData.date,
+    verificationCode: certificationAttestationData.verificationCode,
+    maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+    sessionId,
+    userId: certificationAttestationData.userId,
+  }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    pixScore: certificationAttestationData.pixScore,
+    status: 'validated',
+    createdAt: new Date('2020-01-02'),
+  });
+  await databaseBuilder.commit();
+}
+
+async function _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData) {
+  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
+  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+  const sessionId = databaseBuilder.factory.buildSession({
+    publishedAt: certificationAttestationData.deliveredAt,
+    certificationCenter: certificationAttestationData.certificationCenter,
+    certificationCenterId,
+  }).id;
+  databaseBuilder.factory.buildCertificationCourse({
+    id: certificationAttestationData.id,
+    firstName: certificationAttestationData.firstName,
+    lastName: certificationAttestationData.lastName,
+    birthdate: certificationAttestationData.birthdate,
+    birthplace: certificationAttestationData.birthplace,
+    isPublished: certificationAttestationData.isPublished,
+    isCancelled: false,
+    createdAt: certificationAttestationData.date,
+    verificationCode: certificationAttestationData.verificationCode,
+    maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
+    sessionId,
+    userId: certificationAttestationData.userId,
+  }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    pixScore: certificationAttestationData.pixScore,
+    status: 'validated',
+    createdAt: new Date('2020-01-02'),
+  });
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    pixScore: certificationAttestationData.pixScore + 20,
+    status: 'validated',
+    createdAt: new Date('2020-01-01'),
+  });
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    pixScore: 0,
+    status: 'rejected',
+    createdAt: new Date('2020-01-03'),
+  });
+  await databaseBuilder.commit();
+}
+
+async function _buildCleaResult({ certificationCourseId, acquired }) {
+  databaseBuilder.factory.buildBadge({ key: cleaBadgeKey });
+  databaseBuilder.factory.buildBadge({ key: 'some-other-badge-c' });
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: cleaBadgeKey, acquired });
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: 'some-other-badge-c', acquired: true });
+  await databaseBuilder.commit();
+}
+
+async function _buildPixPlusDroitExpertResult({ certificationCourseId, acquired }) {
+  databaseBuilder.factory.buildBadge({ key: pixPlusDroitExpertBadgeKey });
+  databaseBuilder.factory.buildBadge({ key: 'some-other-badge-e' });
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: pixPlusDroitExpertBadgeKey, acquired });
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: 'some-other-badge-e', acquired: true });
+  await databaseBuilder.commit();
+}
+
+async function _buildPixPlusDroitMaitreResult({ certificationCourseId, acquired }) {
+  databaseBuilder.factory.buildBadge({ key: pixPlusDroitMaitreBadgeKey });
+  databaseBuilder.factory.buildBadge({ key: 'some-other-badge-m' });
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: pixPlusDroitMaitreBadgeKey, acquired });
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: 'some-other-badge-m', acquired: true });
+  await databaseBuilder.commit();
+}

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -37,6 +37,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildIncomplete(certificationAttestationData);
 
@@ -66,6 +67,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildCancelled(certificationAttestationData);
 
@@ -95,6 +97,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
 
@@ -124,6 +127,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildRejected(certificationAttestationData);
       await databaseBuilder.commit();
@@ -154,6 +158,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
 
@@ -184,6 +189,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
       await databaseBuilder.commit();
@@ -215,6 +221,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: certificationAttestationRepository.macaronCleaPath,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
       await _buildCleaResult({ certificationCourseId: 123, acquired: true });
@@ -249,6 +256,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           pixScore: 51,
           cleaCertificationImagePath: null,
           pixPlusDroitCertificationImagePath: certificationAttestationRepository.macaronPixPlusDroitExpertPath,
+          sessionId: 789,
         };
         await _buildValidCertificationAttestation(certificationAttestationData);
         await _buildPixPlusDroitExpertResult({ certificationCourseId: 123, acquired: true });
@@ -280,6 +288,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           pixScore: 51,
           cleaCertificationImagePath: null,
           pixPlusDroitCertificationImagePath: certificationAttestationRepository.macaronPixPlusDroitMaitrePath,
+          sessionId: 789,
         };
         await _buildValidCertificationAttestation(certificationAttestationData);
         await _buildPixPlusDroitMaitreResult({ certificationCourseId: 123, acquired: true });
@@ -311,6 +320,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           pixScore: 51,
           cleaCertificationImagePath: null,
           pixPlusDroitCertificationImagePath: certificationAttestationRepository.macaronPixPlusDroitMaitrePath,
+          sessionId: 789,
         };
         await _buildValidCertificationAttestation(certificationAttestationData);
         await _buildCleaResult({ certificationCourseId: 123, acquired: false });
@@ -329,9 +339,64 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
   describe('#findByDivisionForScoIsManagingStudentsOrganization', () => {
 
-    it('should return an empty array when there are no certification attestations', async () => {
+    it('should return an empty array when there are no certification attestations for given organization', async () => {
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
+      databaseBuilder.factory.buildOrganization({ id: 456, type: 'SCO', isManagingStudents: true });
+      await databaseBuilder.commit();
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId: 456,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
+      };
+      await _buildValidCertificationAttestation(certificationAttestationData);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 456 });
+
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+
+      // then
+      expect(certificationAttestations).to.be.empty;
+    });
+
+    it('should return an empty array when the organization is not SCO IS MANAGING STUDENTS', async () => {
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SUP', isManagingStudents: false });
+      await databaseBuilder.commit();
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId: 456,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
+      };
+      await _buildValidCertificationAttestation(certificationAttestationData);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
+
+      // when
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
 
       // then
       expect(certificationAttestations).to.be.empty;
@@ -339,6 +404,8 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should not return certifications that have no validated assessment-result', async () => {
       // given
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
+      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -355,11 +422,13 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildRejected(certificationAttestationData);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
 
       // then
       expect(certificationAttestations).to.be.empty;
@@ -367,6 +436,8 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should not return cancelled certifications', async () => {
       // given
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
+      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -383,11 +454,13 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildCancelled(certificationAttestationData);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
 
       // then
       expect(certificationAttestations).to.be.empty;
@@ -395,6 +468,8 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
     it('should not return non published certifications', async () => {
       // given
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
+      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -411,19 +486,22 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
 
       // when
-      const error = await catchErr(certificationAttestationRepository.get)(certificationAttestationData.id);
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
 
       // then
-      expect(error).to.be.instanceOf(NotFoundError);
-      expect(error.message).to.equal('There is no certification course with id "123"');
+      expect(certificationAttestations).to.be.empty;
     });
 
-    it('should return an array of certification attestations ordered by ID', async () => {
+    it('should return an array of certification attestations ordered by last name, first name', async () => {
       // given
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
+      await databaseBuilder.commit();
       const certificationAttestationDataA = {
         id: 456,
         firstName: 'James',
@@ -440,9 +518,28 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 23,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 777,
       };
       const certificationAttestationDataB = {
         id: 123,
+        firstName: 'Laura',
+        lastName: 'Gellar',
+        birthdate: '1990-01-04',
+        birthplace: 'Torreilles',
+        isPublished: true,
+        userId: 333,
+        date: new Date('2019-01-01'),
+        verificationCode: 'P-YETANOTHERCODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2020-05-05'),
+        certificationCenter: 'Centre Catalan',
+        pixScore: 150,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+        sessionId: 999,
+      };
+      const certificationAttestationDataC = {
+        id: 789,
         firstName: 'Sarah Michelle',
         lastName: 'Gellar',
         birthdate: '1977-04-14',
@@ -457,25 +554,35 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 888,
       };
       await _buildValidCertificationAttestation(certificationAttestationDataA);
       await _buildValidCertificationAttestation(certificationAttestationDataB);
+      await _buildValidCertificationAttestation(certificationAttestationDataC);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataA, organizationId: 123 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataB, organizationId: 123 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataC, organizationId: 123 });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
 
       // then
       const expectedCertificationAttestationA = domainBuilder.buildCertificationAttestation(certificationAttestationDataA);
       const expectedCertificationAttestationB = domainBuilder.buildCertificationAttestation(certificationAttestationDataB);
-      expect(certificationAttestations).to.have.length(2);
+      const expectedCertificationAttestationC = domainBuilder.buildCertificationAttestation(certificationAttestationDataC);
+      expect(certificationAttestations).to.have.length(3);
       expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestationB);
       expect(certificationAttestations[1]).to.be.instanceOf(CertificationAttestation);
-      expect(certificationAttestations[1]).to.deep.equal(expectedCertificationAttestationA);
+      expect(certificationAttestations[1]).to.deep.equal(expectedCertificationAttestationC);
+      expect(certificationAttestations[2]).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestations[2]).to.deep.equal(expectedCertificationAttestationA);
     });
 
     it('should take into account the latest validated assessment result of a certification', async () => {
       // given
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
+      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -492,14 +599,72 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixScore: 51,
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
       };
       await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization();
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
 
       // then
       const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationData);
+      expect(certificationAttestations).to.have.length(1);
+      expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
+      expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation);
+    });
+
+    it('should take into account the latest certification of a schooling registration', async () => {
+      // given
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
+      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: 123 }).id;
+      await databaseBuilder.commit();
+      const certificationAttestationDataOldest = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId: 456,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
+      };
+      const certificationAttestationDataNewest = {
+        id: 456,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId: 789,
+        date: new Date('2021-01-01'),
+        verificationCode: 'P-SOMEOTHERCODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien maigrelettes',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+        sessionId: 999,
+      };
+      await _buildValidCertificationAttestation(certificationAttestationDataOldest);
+      await _buildValidCertificationAttestation(certificationAttestationDataNewest);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataOldest, organizationId: 123, schoolingRegistrationId });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataNewest, organizationId: 123, schoolingRegistrationId });
+
+      // when
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+
+      // then
+      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationDataNewest);
       expect(certificationAttestations).to.have.length(1);
       expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestations[0]).to.deep.equal(expectedCertificationAttestation);
@@ -510,7 +675,8 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 async function _buildIncomplete(certificationAttestationData) {
   databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  const sessionId = databaseBuilder.factory.buildSession({
+  databaseBuilder.factory.buildSession({
+    id: certificationAttestationData.sessionId,
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
@@ -526,7 +692,7 @@ async function _buildIncomplete(certificationAttestationData) {
     createdAt: certificationAttestationData.date,
     verificationCode: certificationAttestationData.verificationCode,
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-    sessionId,
+    sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   }).id;
   databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
@@ -536,7 +702,8 @@ async function _buildIncomplete(certificationAttestationData) {
 async function _buildRejected(certificationAttestationData) {
   databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  const sessionId = databaseBuilder.factory.buildSession({
+  databaseBuilder.factory.buildSession({
+    id: certificationAttestationData.sessionId,
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
@@ -552,7 +719,7 @@ async function _buildRejected(certificationAttestationData) {
     createdAt: certificationAttestationData.date,
     verificationCode: certificationAttestationData.verificationCode,
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-    sessionId,
+    sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   }).id;
   const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
@@ -567,7 +734,8 @@ async function _buildRejected(certificationAttestationData) {
 async function _buildCancelled(certificationAttestationData) {
   databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  const sessionId = databaseBuilder.factory.buildSession({
+  databaseBuilder.factory.buildSession({
+    id: certificationAttestationData.sessionId,
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
@@ -583,7 +751,7 @@ async function _buildCancelled(certificationAttestationData) {
     createdAt: certificationAttestationData.date,
     verificationCode: certificationAttestationData.verificationCode,
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-    sessionId,
+    sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   }).id;
   const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
@@ -598,7 +766,8 @@ async function _buildCancelled(certificationAttestationData) {
 async function _buildValidCertificationAttestation(certificationAttestationData) {
   databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  const sessionId = databaseBuilder.factory.buildSession({
+  databaseBuilder.factory.buildSession({
+    id: certificationAttestationData.sessionId,
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
@@ -614,7 +783,7 @@ async function _buildValidCertificationAttestation(certificationAttestationData)
     createdAt: certificationAttestationData.date,
     verificationCode: certificationAttestationData.verificationCode,
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-    sessionId,
+    sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   }).id;
   const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
@@ -630,7 +799,8 @@ async function _buildValidCertificationAttestation(certificationAttestationData)
 async function _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData) {
   databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  const sessionId = databaseBuilder.factory.buildSession({
+  databaseBuilder.factory.buildSession({
+    id: certificationAttestationData.sessionId,
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
@@ -646,7 +816,7 @@ async function _buildValidCertificationAttestationWithSeveralResults(certificati
     createdAt: certificationAttestationData.date,
     verificationCode: certificationAttestationData.verificationCode,
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
-    sessionId,
+    sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   }).id;
   const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
@@ -692,5 +862,18 @@ async function _buildPixPlusDroitMaitreResult({ certificationCourseId, acquired 
   databaseBuilder.factory.buildBadge({ key: 'some-other-badge-m' });
   databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: pixPlusDroitMaitreBadgeKey, acquired });
   databaseBuilder.factory.buildPartnerCertification({ certificationCourseId, partnerKey: 'some-other-badge-m', acquired: true });
+  await databaseBuilder.commit();
+}
+
+async function _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId, schoolingRegistrationId = null }) {
+  const srId = schoolingRegistrationId || databaseBuilder.factory.buildSchoolingRegistration({
+    organizationId,
+    userId: certificationAttestationData.userId,
+  }).id;
+  databaseBuilder.factory.buildCertificationCandidate({
+    userId: certificationAttestationData.userId,
+    sessionId: certificationAttestationData.sessionId,
+    schoolingRegistrationId: srId,
+  });
   await databaseBuilder.commit();
 }

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -362,10 +362,10 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 456 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 456, division: '3emeB' });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
 
       // then
       expect(certificationAttestations).to.be.empty;
@@ -393,10 +393,41 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123, division: '3emeB' });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
+
+      // then
+      expect(certificationAttestations).to.be.empty;
+    });
+
+    it('should return an empty array when the certification does not belong to a schooling registration in the right division', async () => {
+      databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
+      await databaseBuilder.commit();
+      const certificationAttestationData = {
+        id: 123,
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId: 456,
+        date: new Date('2020-01-01'),
+        verificationCode: 'P-SOMECODE',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: 51,
+        cleaCertificationImagePath: null,
+        pixPlusDroitCertificationImagePath: null,
+        sessionId: 789,
+      };
+      await _buildValidCertificationAttestation(certificationAttestationData);
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123, division: '5emeG' });
+
+      // when
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
 
       // then
       expect(certificationAttestations).to.be.empty;
@@ -425,10 +456,10 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         sessionId: 789,
       };
       await _buildRejected(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123, division: '3emeB' });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
 
       // then
       expect(certificationAttestations).to.be.empty;
@@ -457,10 +488,10 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         sessionId: 789,
       };
       await _buildCancelled(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123, division: '3emeB' });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
 
       // then
       expect(certificationAttestations).to.be.empty;
@@ -489,10 +520,10 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123, division: '3emeB' });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
 
       // then
       expect(certificationAttestations).to.be.empty;
@@ -559,12 +590,12 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       await _buildValidCertificationAttestation(certificationAttestationDataA);
       await _buildValidCertificationAttestation(certificationAttestationDataB);
       await _buildValidCertificationAttestation(certificationAttestationDataC);
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataA, organizationId: 123 });
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataB, organizationId: 123 });
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataC, organizationId: 123 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataA, organizationId: 123, division: '3emeB' });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataB, organizationId: 123, division: '3emeB' });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataC, organizationId: 123, division: '3emeB' });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
 
       // then
       const expectedCertificationAttestationA = domainBuilder.buildCertificationAttestation(certificationAttestationDataA);
@@ -602,10 +633,10 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         sessionId: 789,
       };
       await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123 });
+      await _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId: 123, division: '3emeB' });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
 
       // then
       const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationData);
@@ -617,7 +648,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
     it('should take into account the latest certification of a schooling registration', async () => {
       // given
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
-      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: 123 }).id;
+      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: 123, division: '3emeb' }).id;
       await databaseBuilder.commit();
       const certificationAttestationDataOldest = {
         id: 123,
@@ -661,7 +692,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       await _linkCertificationAttestationToOrganization({ certificationAttestationData: certificationAttestationDataNewest, organizationId: 123, schoolingRegistrationId });
 
       // when
-      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123 });
+      const certificationAttestations = await certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization({ organizationId: 123, division: '3emeB' });
 
       // then
       const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestationDataNewest);
@@ -865,10 +896,11 @@ async function _buildPixPlusDroitMaitreResult({ certificationCourseId, acquired 
   await databaseBuilder.commit();
 }
 
-async function _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId, schoolingRegistrationId = null }) {
+async function _linkCertificationAttestationToOrganization({ certificationAttestationData, organizationId, division, schoolingRegistrationId = null }) {
   const srId = schoolingRegistrationId || databaseBuilder.factory.buildSchoolingRegistration({
     organizationId,
     userId: certificationAttestationData.userId,
+    division,
   }).id;
   databaseBuilder.factory.buildCertificationCandidate({
     userId: certificationAttestationData.userId,


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du téléchargement d'un PDF unique contenant toutes les attestations d'une classe pour le SCO, il faut prévoir une méthode de repository qui permette de récupérer l'ensemble des données nécessaires à la génération d'un tel document.

## :robot: Solution
Ajout d'une methode de répo dans le `certification-attestation-repository` permettant, pour une orga SCO IS MANAGING STUDENTS, de récupérer toutes les attestations des élèves d'une classe.

## :rainbow: Remarques
Ajout de tests pour couvrir les cas critiques / chelous.
Je me demande si il ne manque pas une notion d'année ? (de ne récupérer que celles de l'année scolaire courante, voir avec Anne-So)

## :100: Pour tester

