### PR TITLE
[DOC] Expliciter la configuration du cache. 

### DIFF
--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -27,6 +27,7 @@ const schema = Joi.object({
   IS_SCO_ACCOUNT_RECOVERY_ENABLED: Joi.string().optional().valid('true', 'false'),
   FT_IS_NEW_CPF_DATA_ENABLED: Joi.string().optional().valid('true', 'false'),
   SCO_ACCOUNT_RECOVERY_TOKEN_LIFETIME_MINUTES: Joi.number().optional(),
+  CACHE_RELOAD_TIME: Joi.string().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function() {

--- a/api/sample.env
+++ b/api/sample.env
@@ -43,6 +43,17 @@ IS_SCO_ACCOUNT_RECOVERY_ENABLED=false
 # default: none
 REDIS_URL=redis://localhost:6379
 
+# Cache reload schedule
+#
+# If not present, the cache reload will crash
+# - when launched in PaaS (refer to background container in Procfile)
+# - when launched manually (refer to npm task scalingo-background-job)
+#
+# presence: optional
+# type: crontab
+# default: none
+# sample: CACHE_RELOAD_TIME=0 */1 * * * (each hour)
+
 # =========
 # DATABASES
 # =========


### PR DESCRIPTION
## :unicorn: Problème
Le paramétrage du cache est lu dans les variables d'environnement mais pas explicité.

## :robot: Solution
Mettre à jour
- sample.env
- validate-environement-variables.js

## :rainbow: Remarques
On peut valider la syntaxe crontab [avec une dépendance Joi](https://github.com/gurisko/joi-cron-expression#readme), WDYT ?

## :100: Pour tester
En local, alimenter à partir de sample.env et lancer le rafraichissement
`node scripts/reload-cache-everyday.js`
