### PR TITLE
[FEATURE] Empêcher un élève de se réconcilier si sa schooling registration a été désactivée (PIX-2863)

### DIFF
--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -278,6 +278,7 @@ module.exports = {
       .query((qb) => {
         qb.where('organizationId', organizationId);
         qb.where('birthdate', birthdate);
+        qb.where('isDisabled', false);
       })
       .fetchAll();
 
@@ -297,7 +298,7 @@ module.exports = {
   async reconcileUserByNationalStudentIdAndOrganizationId({ nationalStudentId, userId, organizationId }) {
     try {
       const schoolingRegistration = await BookshelfSchoolingRegistration
-        .where({ organizationId, nationalStudentId })
+        .where({ organizationId, nationalStudentId, isDisabled: false })
         .save({ userId }, { patch: true });
       return bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration);
     } catch (error) {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la désactivation SCO, on peut maintenant désactiver une schooling-registration pour une orga donnée. Mais il était toujours possible de rattacher un user à une une schooling-registration désactivée.

## :robot: Solution
Empêcher un élève de se réconcilier si sa schooling registration a été désactivée.

## :rainbow: Remarques


## :100: Pour tester
- Aller sur le scalingo de la RA, et enlever le UserId de la schooling-registration de **Blue Ivy Carter** (Ou de Lyanna Mormont) et mettre isDisabled à `true`
- Aller sur mon-pix avec le compte de **Blue Ivy Carter**, rentrer le code de la campagne, entrer les info demandées et voir si on vous empêche de vous reconnecter 