### PR TITLE
[BUGFIX] Enregistrer la ville fournie lors de l'inscription d'un candidat avec un code postal de lieu de naissance (PIX-2933).

### DIFF
--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -86,10 +86,10 @@ async function getBirthInformationByPostalCode(birthCity, birthPostalCode, count
     return CpfBirthInformationValidation.failure(`Le code postal "${birthPostalCode}" n'est pas valide.`);
   }
 
-  const sanitizedCity = normalizeAndSortChars(birthCity);
-  const doesCityMatchPostalCode = cities.some((city) => normalizeAndSortChars(city.name) === sanitizedCity);
+  const normalizedAndSortedCity = normalizeAndSortChars(birthCity);
+  const matchedCity = cities.find((city) => normalizeAndSortChars(city.name) === normalizedAndSortedCity);
 
-  if (!doesCityMatchPostalCode) {
+  if (!matchedCity) {
     return CpfBirthInformationValidation.failure(`Le code postal "${birthPostalCode}" ne correspond pas à la ville "${birthCity}"`);
   }
 
@@ -97,7 +97,7 @@ async function getBirthInformationByPostalCode(birthCity, birthPostalCode, count
     birthCountry: country.commonName,
     birthINSEECode: null,
     birthPostalCode,
-    birthCity: _getActualCity(cities),
+    birthCity: matchedCity.name,
   });
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'inscription d'un candidat et de la saisie de son lieu de naissance via le couple code postal + ville, nous effectuons un certain nombre de vérifications comme la concordance des deux valeurs puis nous sélectionnons la ville dont le nom actuel correspond au code postal. Cependant, il arrive que plusieurs villes (dont le nom est courant) possèdent le même code postal. La sélection que nous effectuons peut donc conduire à l'enregistrement en base d'une ville différente de celle saisie par le prescripteur. 

## :robot: Solution
- Enregistrer une version normalisée de la ville fournie à l'inscription plutôt que d'utiliser une déduction qui ne fonctionne que s'il n'existe qu'un seul nom courant de ville pour un code postal donné

## :100: Pour tester
- Inscrire un candidat français avec pour code postal `77160` et la ville `Provins` et vérifier que c'est bien cette ville qui est enregistrée.
- Faire la même opération avec le même code postal et la ville `Poigny`.
