### PR TITLE
[FEATURE] Demander à l'utilisateur de valider les CGU pour récupérer compte SCO (PIX-2916).

### DIFF
--- a/mon-pix/app/components/account-recovery/student-information-form.hbs
+++ b/mon-pix/app/components/account-recovery/student-information-form.hbs
@@ -15,8 +15,8 @@
     {{t 'pages.account-recovery.find-sco-record.student-information.mandatory-all-fields'}}
   </p>
 
-  <form {{on 'submit' this.submit}} class="student-information-form">
-    <div class="student-information-form__fields">
+  <form {{on 'submit' this.submit}} class="account-recovery__content--form">
+    <div class="account-recovery__content--form-fields">
       <div class="student-information-form__tooltip">
         <PixTooltip
           @text={{t 'pages.account-recovery.find-sco-record.student-information.form.tooltip' htmlSafe=true}}

--- a/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable no-nested-interactive --}}
 <h1 class="account-recovery__content--title">
   {{t 'pages.account-recovery.update-sco-record.welcome-message' firstName=@firstName}}
 </h1>
@@ -6,8 +7,8 @@
   {{t 'pages.account-recovery.update-sco-record.fill-password'}}
 </p>
 
-<form onSubmit={{this.submitUpdate}} class="student-information-form">
-  <div class="student-information-form__fields">
+<form onSubmit={{this.submitUpdate}} class="account-recovery__content--form">
+  <div class="account-recovery__content--form-fields">
     <FormTextfield
         @label={{t 'pages.account-recovery.update-sco-record.form.email-label'}}
         @textfieldName="email"
@@ -26,6 +27,26 @@
         @require={{true}}
         @hideRequired={{true}}
     />
+
+    <div class="account-recovery__content--information-text--details checkbox-with-label with-links">
+      <label for="pix-cgu">
+        {{t 'pages.sign-up.fields.cgu.accept'}}
+        <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t 'pages.sign-up.fields.cgu.cgu'}}
+        </a>
+        {{t 'pages.sign-up.fields.cgu.and'}}
+        <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t 'pages.sign-up.fields.cgu.data-protection-policy'}}
+        </a>
+        {{t 'pages.sign-up.fields.cgu.pix'}}
+      </label>
+      <Input
+        @type="checkbox"
+        @checked={{this.cguAndProctectionPoliciesAccepted}}
+        id="pix-cgu"
+      />
+    </div>
+
     <PixButton
         @type="submit"
         @isDisabled={{not this.isFormValid}}
@@ -33,5 +54,9 @@
     >
       {{t 'pages.account-recovery.update-sco-record.form.login-button'}}
     </PixButton>
+  </div>
+
+  <div class="update-sco-record-form__legal-details-container">
+    {{t 'pages.sign-up.legal-information' }}
   </div>
 </form>

--- a/mon-pix/app/components/account-recovery/update-sco-record-form.js
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.js
@@ -22,13 +22,26 @@ class PasswordValidation {
 }
 
 export default class UpdateScoRecordFormComponent extends Component {
+
   @service intl;
+  @service url;
 
   @tracked passwordValidation = new PasswordValidation();
   @tracked password = '';
+  @tracked cguAndProctectionPoliciesAccepted = false;
+
+  get cguUrl() {
+    return this.url.cguUrl;
+  }
+
+  get dataProtectionPolicyUrl() {
+    return this.url.dataProtectionPolicyUrl;
+  }
 
   get isFormValid() {
-    return !isEmpty(this.password) && this.passwordValidation.status !== 'error';
+    return !isEmpty(this.password)
+      && this.passwordValidation.status !== 'error'
+      && this.cguAndProctectionPoliciesAccepted;
   }
 
   @action validatePassword() {

--- a/mon-pix/app/styles/components/account-recovery/_student-information-form.scss
+++ b/mon-pix/app/styles/components/account-recovery/_student-information-form.scss
@@ -1,10 +1,4 @@
 .student-information-form {
-  position: relative;
-
-  &__fields {
-    position: relative;
-    max-width: 400px;
-  }
 
   &__tooltip {
     display: block;

--- a/mon-pix/app/styles/components/account-recovery/_update-sco-record-form.scss
+++ b/mon-pix/app/styles/components/account-recovery/_update-sco-record-form.scss
@@ -1,3 +1,11 @@
-.update-sco-record-form__submit {
-  width: 100%;
+.update-sco-record-form {
+
+  &__submit {
+    width: 100%;
+  }
+
+  &__legal-details-container {
+    margin-top: 30px;
+    font-size: 0.75rem;
+  }
 }

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -26,6 +26,15 @@
       }
     }
 
+    &--form {
+      position: relative;
+
+      &-fields {
+        position: relative;
+        max-width: 400px;
+      }
+    }
+
     &--image {
       display: none;
 
@@ -98,6 +107,10 @@
 
           label {
             cursor: pointer;
+          }
+
+          &.with-links {
+            flex-direction: row-reverse;
           }
         }
       }

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
@@ -106,10 +106,9 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
         expect(contains(this.intl.t('pages.account-recovery.errors.key-expired'))).to.exist;
         expect(contains(this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link'))).to.exist;
       });
-
     });
 
-    context('and user chooses a new password', function() {
+    context('and user chooses a new password and accepts cgu and data protection policy', function() {
 
       it('should redirect to login page after successful password change', async function() {
         // given
@@ -117,14 +116,16 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
         const newPassword = 'Pix1234*';
         server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
 
-        //when
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
-        // then
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
         await triggerEvent('#password', 'focusout');
+        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+
+        //when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
+        // then
         expect(currentURL()).to.equal('/connexion');
       });
 
@@ -141,10 +142,12 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
         });
         server.patch('/account-recovery', () => errorsApi);
 
-        //when
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
         await triggerEvent('#password', 'focusout');
+        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+
+        //when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
@@ -166,10 +169,12 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
         });
         server.patch('/account-recovery', () => errorsApi);
 
-        //when
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
         await triggerEvent('#password', 'focusout');
+        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+
+        //when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
@@ -191,10 +196,12 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
         });
         server.patch('/account-recovery', () => errorsApi);
 
-        //when
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
         await triggerEvent('#password', 'focusout');
+        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+
+        //when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
@@ -216,10 +223,12 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
         });
         server.patch('/account-recovery', () => errorsApi);
 
-        //when
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
         await triggerEvent('#password', 'focusout');
+        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+
+        //when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
@@ -227,9 +236,6 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
         expect(contains(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
         expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
       });
-
     });
-
   });
-
 });

--- a/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
@@ -1,13 +1,15 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { render, triggerEvent } from '@ember/test-helpers';
+import { find, render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { contains } from '../../../helpers/contains';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillInByLabel } from '../../../helpers/fill-in-by-label';
+import { clickByLabel } from '../../../helpers/click-by-label';
 import findByLabel from '../../../helpers/find-by-label';
 
-describe('Integration | Component | account-recovery/update-sco-record', function() {
+describe('Integration | Component | account-recovery | update-sco-record', function() {
+
   setupIntlRenderingTest();
 
   it('should display a reset password form', async function() {
@@ -29,22 +31,55 @@ describe('Integration | Component | account-recovery/update-sco-record', functio
     expect(submitButton).to.exist;
     expect(submitButton.disabled).to.be.true;
     expect(contains('philippe.example.net'));
+
+    expect(find('input[type="checkbox"]')).to.exist;
+    expect(contains(this.intl.t('pages.sign-up.fields.cgu.accept'))).to.exist;
+    expect(contains(this.intl.t('pages.sign-up.fields.cgu.cgu'))).to.exist;
+    expect(contains(this.intl.t('pages.sign-up.fields.cgu.and'))).to.exist;
+    expect(contains(this.intl.t('pages.sign-up.fields.cgu.data-protection-policy'))).to.exist;
   });
 
-  it('should enable submission on reset password form', async function() {
-    // given
-    await render(hbs `<AccountRecovery::UpdateScoRecordForm />`);
+  context('Form submission', function() {
 
-    // when
-    await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), 'pix123A*');
+    it('should disable submission if password is not valid', async function() {
+      // given
+      await render(hbs `<AccountRecovery::UpdateScoRecordForm />`);
 
-    // then
-    const submitButton = findByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
-    expect(submitButton).to.exist;
-    expect(submitButton.disabled).to.be.false;
+      // when
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), 'pass');
+
+      // then
+      const submitButton = findByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
+      expect(submitButton.disabled).to.be.true;
+    });
+
+    it('should disable submission if password is valid and cgu and data protection policy are not accepted', async function() {
+      // given
+      await render(hbs `<AccountRecovery::UpdateScoRecordForm />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), 'pix123A*');
+
+      // then
+      const submitButton = findByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
+      expect(submitButton.disabled).to.be.true;
+    });
+
+    it('should enable submission if password is valid and cgu and data protection policy are accepted', async function() {
+      // given
+      await render(hbs `<AccountRecovery::UpdateScoRecordForm />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), 'pix123A*');
+      await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+
+      // then
+      const submitButton = findByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
+      expect(submitButton.disabled).to.be.false;
+    });
   });
 
-  context('password field', function() {
+  context('Error messages', function() {
 
     context('when the user enters a valid password', function() {
 

--- a/mon-pix/tests/unit/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/unit/components/account-recovery/update-sco-record-form-test.js
@@ -1,0 +1,51 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { setupTest } from 'ember-mocha';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+
+describe('Unit | Component | account-recovery | update-sco-record-form', function() {
+
+  setupTest();
+
+  context('#isFormValid', function() {
+
+    it('should return false if password is not valid and cgu are not accepted', function() {
+      // given
+      const component = createGlimmerComponent('component:account-recovery/update-sco-record-form');
+      component.password = 'Pass';
+      component.cguAndProctectionPoliciesAccepted = false;
+
+      // when
+      const result = component.isFormValid;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return false if password is valid and cgu are not accepted', function() {
+      // given
+      const component = createGlimmerComponent('component:account-recovery/update-sco-record-form');
+      component.password = 'Password123';
+      component.cguAndProctectionPoliciesAccepted = false;
+
+      // when
+      const result = component.isFormValid;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return true if password is valid and cgu are accepted', function() {
+      // given
+      const component = createGlimmerComponent('component:account-recovery/update-sco-record-form');
+      component.password = 'Password123';
+      component.cguAndProctectionPoliciesAccepted = true;
+
+      // when
+      const result = component.isFormValid;
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les élèves ne sont pas soumis aux CGU dans les parcours scolaires.
Or, quand ils quittent le SCO, ils doivent les valider.

## :robot: Solution
* Ajouter une case à cocher et un lien vers les CGU
* Ne pas permettre de finaliser le parcours si elle n'est pas cochée

## :100: Pour tester
Se rendre sur la page de récupération en [RA](https://app-pr3280.review.pix.fr/recuperer-mon-compte)

Saisir
- Ine/Ina : `123456789BB`
- Prénom : `George` 
- Nom : `De Cambridge`
- Date de naissance : `22/07/2013`

Aller au bout du processus, puis :
- ne pas cocher la case, puis vérifier que le formulaire ne peut pas être soumis
- cocher la case et renseigner un mot de passe valide, puis vérifier que le formulaire peut être soumis, et se connecter avec le nouveau mot de passe
