### PR TITLE
[FEATURE] Ne plus proposer la première ligne du select sur les épreuves à menu déroulant (PIX-2925).

### DIFF
--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -17,6 +17,7 @@
                 aria-label={{block.ariaLabel}}
                 @emptyOptionLabel={{block.placeholder}}
                 @selectedOption={{get @answersValue block.input}}
+                @emptyOptionNotSelectable={{true}}
                 @options={{block.options}}
                 @onChange={{this.setAnswerValue}}/>
       </div>

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -14718,7 +14718,8 @@
     "dayjs": {
       "version": "1.10.6",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
-      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -35703,8 +35704,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#c725e9c7b6c613a48b6a15de8e668e1d23379871",
-      "from": "git://github.com/1024pix/pix-ui.git#v5.2.0",
+      "version": "git://github.com/1024pix/pix-ui.git#2ddadf02a90a438b401683bb5a6ad573e9ebd6ff",
+      "from": "git://github.com/1024pix/pix-ui.git#v5.2.2",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -113,7 +113,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.2.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.2.2",
     "sass": "^1.32.11",
     "showdown": "^1.9.1",
     "stylelint": "^13.13.0",


### PR DESCRIPTION
## :unicorn: Problème
Sur les épreuves de menu déroulant, la première ligne correspond à une indication. Pour faciliter le choix, on désactive la première ligne après avoir choisi.

## :robot: Solution
- Mise à jour de Pix-UI
- Activer la variable `emptyOptionNotSelectable `

## :rainbow: Remarques

## :100: Pour tester
Epreuve `rec2K0jwrN4moB80l`