### PR TITLE
[TECH] Rendre Pix Orga un minimum responsive (PIX-2943)

### DIFF
--- a/orga/app/components/campaign-creation-details.hbs
+++ b/orga/app/components/campaign-creation-details.hbs
@@ -1,4 +1,4 @@
-<div class="campaign-details-header-report__created-on">
+<div class="campaign-details-header-report__created-on hide-on-mobile">
   <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.created-on'}}</h4>
   <span class="content-text campaign-details-content__text">
     {{moment-format @creationDate 'DD/MM/YYYY' allow-empty=true}}

--- a/orga/app/components/campaign/copy-paste-button.hbs
+++ b/orga/app/components/campaign/copy-paste-button.hbs
@@ -1,16 +1,18 @@
 {{#if (is-clipboard-supported)}}
-    <PixTooltip
-        @text={{this.tooltipText}}
-        @position='top'
-        @isInline={{true}}
-        class="campaign-details-content__tooltip">
-        <CopyButton
-            aria-label={{t @defaultMessage}}
-            @clipboardText={{@clipBoardtext}}
-            @success={{this.onClipboardSuccess}}
-            {{on 'mouseLeave' this.onClipboardOut}}
-            @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey campaign-details-content__clipboard-button">
-            <FaIcon @icon='copy' @prefix='far'/>
-        </CopyButton>
-    </PixTooltip>
+  <PixTooltip
+    @text={{this.tooltipText}}
+    @position='top'
+    @isInline={{true}}
+    class="campaign-details-content__tooltip">
+    <CopyButton
+      aria-label={{t @defaultMessage}}
+      @clipboardText={{@clipBoardtext}}
+      @success={{this.onClipboardSuccess}}
+      {{on 'mouseLeave' this.onClipboardOut}}
+      class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey campaign-details-content__clipboard-button"
+      ...attributes
+    >
+      <FaIcon @icon='copy' @prefix='far'/>
+    </CopyButton>
+  </PixTooltip>
 {{/if}}

--- a/orga/app/components/campaign/copy-paste-button.hbs
+++ b/orga/app/components/campaign/copy-paste-button.hbs
@@ -3,7 +3,7 @@
     @text={{this.tooltipText}}
     @position='top'
     @isInline={{true}}
-    class="campaign-details-content__tooltip">
+    class="campaign-details-content__tooltip hide-on-mobile">
     <CopyButton
       aria-label={{t @defaultMessage}}
       @clipboardText={{@clipBoardtext}}

--- a/orga/app/components/campaign/filter/participation-filters.hbs
+++ b/orga/app/components/campaign/filter/participation-filters.hbs
@@ -1,7 +1,7 @@
 {{#if this.displayFilters }}
   <PixFilterBanner
     @title={{t 'pages.campaign-results.filters.title'}}
-    class="participant-filter-banner"
+    class="participant-filter-banner hide-on-mobile"
     aria-label={{t 'pages.campaign-results.filters.aria-label'}}
     @details={{t 'pages.campaign-results.filters.participations-count' count=@rowCount}}
     @clearFiltersLabel={{t 'pages.campaign-results.filters.actions.clear'}}

--- a/orga/app/components/campaign/list-actions.hbs
+++ b/orga/app/components/campaign/list-actions.hbs
@@ -1,4 +1,4 @@
-<div class="campaign-list-actions__header">
+<div class="campaign-list-actions__header hide-on-mobile">
   <button
     role="tab"
     type="submit"

--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -7,20 +7,20 @@
             <th class="table__column table__column--wide">
               {{t 'pages.campaigns-list.table.column.campaign'}}
             </th>
-            <th class="table__column">
+            <th class="table__column hide-on-mobile">
               {{t 'pages.campaigns-list.table.column.created-by'}}
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small hide-on-mobile">
               {{t 'pages.campaigns-list.table.column.created-on'}}
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small hide-on-mobile">
               {{t 'pages.campaigns-list.table.column.participants'}}
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small hide-on-mobile">
               {{t 'pages.campaigns-list.table.column.results'}}
             </th>
           </tr>
-          <tr>
+          <tr class="hide-on-mobile">
             <Table::HeaderFilterInput
               @field="name"
               @value={{@nameFilter}}
@@ -50,10 +50,10 @@
                 {{campaign.name}}
               </LinkTo>
             </td>
-            <td class="table__column--truncated">{{campaign.creatorFullName}}</td>
-            <td>{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
-            <td>{{campaign.participationsCount}}</td>
-            <td>{{campaign.sharedParticipationsCount}}</td>
+            <td class="table__column--truncated hide-on-mobile">{{campaign.creatorFullName}}</td>
+            <td class="hide-on-mobile">{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
+            <td class="hide-on-mobile">{{campaign.participationsCount}}</td>
+            <td class="hide-on-mobile">{{campaign.sharedParticipationsCount}}</td>
           </tr>
         {{/each}}
         </tbody>

--- a/orga/app/components/routes/authenticated/campaign/details/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/details/tab.hbs
@@ -42,28 +42,23 @@
       </p>
     </div>
   </div>
-  <div class="campaign-details-row">
-    {{#unless @campaign.isArchived}}
-      <div class="campaign-details-row">
-        <div class="campaign-details-content campaign-details-content--button campaign-details--button">
-          <LinkTo
-            @route="authenticated.campaigns.update"
-            @model={{@campaign.id}}
-            class="button button--grey button--regular button--link campaign-details-content__update-button"
-          >
-            {{t 'pages.campaign-details.actions.edit'}}
-          </LinkTo>
-        </div>
-        <div class="campaign-details-content campaign-details-content--button campaign-details--button campaign-details-content--left">
-          <button
-            type="button"
-            {{on 'click' (fn this.archiveCampaign @campaign.id)}}
-            class="button button--grey button--regular button--link"
-          >
-            {{t 'pages.campaign-details.actions.archive'}}
-          </button>
-        </div>
-      </div>
-    {{/unless}}
-  </div>
+
+  {{#unless @campaign.isArchived}}
+    <div class="campaign-details-buttons">
+      <LinkTo
+        @route="authenticated.campaigns.update"
+        @model={{@campaign.id}}
+        class="button button--grey button--regular button--link"
+      >
+        {{t 'pages.campaign-details.actions.edit'}}
+      </LinkTo>
+      <button
+        type="button"
+        {{on 'click' (fn this.archiveCampaign @campaign.id)}}
+        class="button button--grey button--regular button--link"
+      >
+        {{t 'pages.campaign-details.actions.archive'}}
+      </button>
+    </div>
+  {{/unless}}
 </div>

--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -19,8 +19,8 @@
             {{/if}}
             <th class="table__column--center">{{t 'pages.profiles-list.table.column.sending-date.label'}}</th>
             <th class="table__column--center">{{t 'pages.profiles-list.table.column.pix-score.label'}}</th>
-            <th class="table__column--center">{{t 'pages.profiles-list.table.column.certifiable'}}</th>
-            <th class="table__column--center">{{t 'pages.profiles-list.table.column.competences-certifiables'}}</th>
+            <th class="table__column--center hide-on-mobile">{{t 'pages.profiles-list.table.column.certifiable'}}</th>
+            <th class="table__column--center hide-on-mobile">{{t 'pages.profiles-list.table.column.competences-certifiables'}}</th>
           </tr>
         </thead>
 
@@ -53,12 +53,12 @@
                   </PixTag>
                 {{/if}}
               </td>
-              <td class="table__column--center">
+              <td class="table__column--center hide-on-mobile">
                 {{#if profile.certifiable }}
                   <PixTag @color="green-light">{{t 'pages.profiles-list.table.column.certifiable'}}</PixTag>
                 {{/if}}
               </td>
-              <td class="table__column--center">
+              <td class="table__column--center hide-on-mobile">
                 {{profile.certifiableCompetencesCount}}
               </td>
             </tr>

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -21,7 +21,9 @@
           <Campaign::CopyPasteButton
             @clipBoardtext={{@campaign.code}}
             @successMessage={{t 'pages.campaign.copy.code.success'}}
-            @defaultMessage={{t 'pages.campaign.copy.code.default'}}/>
+            @defaultMessage={{t 'pages.campaign.copy.code.default'}}
+            class="hide-on-mobile"
+          />
         </span>
       </div>
     </div>
@@ -63,13 +65,13 @@
         </LinkTo>
       {{/if}}
 
-      <div class="navbar-item-separator" aria-hidden="true"></div>
+      <div class="navbar-item-separator hide-on-mobile" aria-hidden="true"></div>
       <LinkTo @route="authenticated.campaigns.campaign.details" class="navbar-item" @model={{@campaign}} >
         {{t 'pages.campaign.tab.settings'}}
       </LinkTo>
     </nav>
 
-    <div class="campaign-details-controls__export-button">
+    <div class="campaign-details-controls__export-button hide-on-mobile">
       <a class="button button--link" href="{{this.downloadUrl}}" target="_blank" rel="noopener noreferrer" download>
         {{t 'pages.campaign.actions.export-results'}}
       </a>

--- a/orga/app/components/stage-stars.hbs
+++ b/orga/app/components/stage-stars.hbs
@@ -12,7 +12,9 @@
       @text={{this.tooltipText}}
       @position={{@tooltipPosition}}
       @isWide={{true}}
-      @isLight={{true}}>
+      @isLight={{true}}
+      class="hide-on-mobile"
+    >
       <FaIcon @icon="info-circle" class="stage-stars__info-icon"/>
     </PixTooltip>
   {{/if}}

--- a/orga/app/components/student/sco/header-actions.hbs
+++ b/orga/app/components/student/sco/header-actions.hbs
@@ -1,7 +1,7 @@
 <div class="list-students-page__header">
   <h1 class="page__title page-title">{{t "pages.students-sco.title"}}</h1>
   {{#if this.currentUser.isAdminInOrganization}}
-    <div class="list-students-page__import-students-button">
+    <div class="list-students-page__import-students-button hide-on-mobile">
       {{#if this.displayLearnMoreAndLinkTemplate }}
         <PixTooltip
           @text={{t "pages.students-sco.agri-tooltip" htmlSafe=true}}

--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -6,9 +6,9 @@
         <Table::Header>{{t "pages.students-sco.table.column.first-name"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.date-of-birth"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.login-method"}}</Table::Header>
-        <Table::Header @size="small"/>
+        <Table::Header @size="small" class="hide-on-mobile"/>
       </tr>
-      <tr>
+      <tr class="hide-on-mobile">
         <Table::HeaderFilterInput
           @field="lastName"
           @value={{@lastNameFilter}}
@@ -48,7 +48,7 @@
               <p>{{t authenticationMethod}}</p>
             {{/each}}
           </td>
-          <td class="list-students-page__actions">
+          <td class="list-students-page__actions hide-on-mobile">
             {{#if student.isStudentAssociated}}
               <Dropdown::IconTrigger
                 @icon="ellipsis-v"

--- a/orga/app/components/student/sup/header-actions.hbs
+++ b/orga/app/components/student/sup/header-actions.hbs
@@ -1,7 +1,7 @@
 <div class="list-students-page__header">
   <div class="page__title page-title">{{t "pages.students-sup.title"}}</div>
   {{#if this.currentUser.isAdminInOrganization}}
-    <div class="list-students-page__import-students-button">
+    <div class="list-students-page__import-students-button hide-on-mobile">
       <a class="button button--link button--no-color"
          href="{{this.urlToDownloadCsvTemplate}}" target="_blank" rel="noopener noreferrer" download>
         {{t "pages.students-sup.actions.download-template"}}

--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -6,9 +6,9 @@
         <Table::Header>{{t "pages.students-sup.table.column.last-name"}}</Table::Header>
         <Table::Header>{{t "pages.students-sup.table.column.first-name"}}</Table::Header>
         <Table::Header>{{t "pages.students-sup.table.column.date-of-birth"}}</Table::Header>
-        <Table::Header />
+        <Table::Header class="hide-on-mobile" />
       </tr>
-      <tr>
+      <tr class="hide-on-mobile">
         <Table::HeaderFilterInput
           @field="studentNumber"
           @value={{@studentNumberFilter}}
@@ -43,7 +43,7 @@
           <td>{{student.lastName}}</td>
           <td>{{student.firstName}}</td>
           <td>{{moment-format student.birthdate 'DD/MM/YYYY'}}</td>
-          <td class="list-students-page__actions">
+          <td class="list-students-page__actions hide-on-mobile">
             {{#if this.currentUser.isAdminInOrganization}}
               <Dropdown::IconTrigger
                 @icon="ellipsis-v"

--- a/orga/app/components/team/invitations-list.hbs
+++ b/orga/app/components/team/invitations-list.hbs
@@ -3,14 +3,14 @@
     <thead>
       <tr>
         <th>{{t 'pages.team-invitations.table.column.email-address'}}</th>
-        <th>{{t 'pages.team-invitations.table.column.pending-invitation'}}</th>
+        <th class="hide-on-mobile">{{t 'pages.team-invitations.table.column.pending-invitation'}}</th>
       </tr>
     </thead>
     <tbody>
     {{#each @invitations as |invitation|}}
       <tr aria-label="{{t 'pages.team-invitations.table.row.aria-label'}}">
         <td>{{invitation.email}}</td>
-        <td colspan="3">
+        <td class="hide-on-mobile" colspan="3">
           {{t 'pages.team-invitations.table.row.message'}} {{moment-format invitation.updatedAt 'DD/MM/YYYY [-] HH:mm' locale='fr'}}
         </td>
       </tr>

--- a/orga/app/components/team/members-list-item.hbs
+++ b/orga/app/components/team/members-list-item.hbs
@@ -5,7 +5,7 @@
   {{#unless this.isEditionMode }}
     <td>{{this.displayRole}}</td>
     {{#if (not-eq @membership.user.id this.currentUser.prescriber.id) }}
-      <td class="zone-edit-role">
+      <td class="zone-edit-role hide-on-mobile">
         <Dropdown::IconTrigger
           @icon="ellipsis-v"
           @dropdownButtonClass="zone-edit-role__dropdown-button"
@@ -21,7 +21,7 @@
         </Dropdown::IconTrigger>
       </td>
     {{else}}
-      <td></td>
+      <td class="hide-on-mobile"></td>
     {{/if}}
   {{/unless}}
 

--- a/orga/app/components/team/members-list.hbs
+++ b/orga/app/components/team/members-list.hbs
@@ -6,7 +6,7 @@
           <th>{{t 'pages.team-members.table.column.last-name'}}</th>
           <th>{{t 'pages.team-members.table.column.first-name'}}</th>
           <th>{{t 'pages.team-members.table.column.organization-membership-role'}}</th>
-          <th></th>
+          <th class="hide-on-mobile"></th>
         </tr>
       </thead>
       {{#if @members}}

--- a/orga/app/components/ui/indicator-card.hbs
+++ b/orga/app/components/ui/indicator-card.hbs
@@ -16,7 +16,7 @@
             @text={{@info}}
             @position="top"
             @isWide={{true}}
-            class="indicator-card__tooltip"
+            class="indicator-card__tooltip hide-on-mobile"
           >
             <FaIcon @icon="question-circle" class="indicator-card__tooltip-icon"/>
           </PixTooltip>

--- a/orga/app/components/ui/previous-page-button.hbs
+++ b/orga/app/components/ui/previous-page-button.hbs
@@ -2,7 +2,7 @@
   <PixIconButton
     @icon="arrow-left"
     aria-label={{@backButtonAriaLabel}}
-    class="previous-page-button__return-button"
+    class="previous-page-button__return-button hide-on-mobile"
     @triggerAction={{this.goToPage}}
     @withBackground={{false}}
     @size="small"

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -88,3 +88,9 @@ body > .ember-view {
 input:invalid {
   box-shadow: none;
 }
+
+@include device-is('mobile') {
+  .hide-on-mobile {
+    display: none;
+  }
+}

--- a/orga/app/styles/components/campaign/activity/dashboard.scss
+++ b/orga/app/styles/components/campaign/activity/dashboard.scss
@@ -37,6 +37,7 @@
 
     &__total-participants-card {
       margin-bottom: 16px;
+      margin-right: 0;
     }
 
     &__participations-by-day {

--- a/orga/app/styles/components/sidebar-menu.scss
+++ b/orga/app/styles/components/sidebar-menu.scss
@@ -2,7 +2,6 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  padding-top: 30px;
 
   &__documentation-item {
     flex-grow: 1;

--- a/orga/app/styles/components/user-logged-menu.scss
+++ b/orga/app/styles/components/user-logged-menu.scss
@@ -45,6 +45,7 @@
   right: 0;
   top: 49px;
   width: 400px;
+  max-width: 100%;
 
   &-item {
     color: $grey-60;

--- a/orga/app/styles/components/user-logged-menu.scss
+++ b/orga/app/styles/components/user-logged-menu.scss
@@ -78,3 +78,15 @@
     }
   }
 }
+
+@include device-is('mobile') {
+  .logged-user-summary {
+    &__name {
+      overflow: hidden;
+    }
+  
+    &__organization {
+      overflow: hidden;
+    }
+  }
+}

--- a/orga/app/styles/globals/pages.scss
+++ b/orga/app/styles/globals/pages.scss
@@ -14,8 +14,4 @@
   .page {
     padding: 0;
   }
-
-  .hide-on-mobile {
-    display: none;
-  }
 }

--- a/orga/app/styles/globals/pages.scss
+++ b/orga/app/styles/globals/pages.scss
@@ -9,3 +9,13 @@
 .navigation {
   margin: 24px 0;
 }
+
+@include device-is('mobile') {
+  .page {
+    padding: 0;
+  }
+
+  .hide-on-mobile {
+    display: none;
+  }
+}

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -163,4 +163,33 @@
       background-color: lighten($blue, 32%);
     }
   }
+
+  .panel-header__body {
+    flex-direction: column;
+  }
+  
+  .panel-header__data {
+    flex-direction: column;
+    align-items: flex-start;
+
+    &--highlight {
+      flex-direction: column;
+      align-content: flex-start;
+      padding: 16px;
+      margin-top: 16px;
+    }
+  }
+
+  .panel-header-data {
+    &__content {
+      padding: 0;
+      border-left: none;
+      margin-bottom: 16px;
+    }
+
+
+    &__content:last-child {
+      margin-bottom: 0px;
+    }
+  }
 }

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -146,3 +146,21 @@
       color: $blue;
   }
 }
+
+@include device-is('mobile') {
+  .navbar{
+    width: 100%;
+    height: auto;
+    padding: 0;
+
+    &-item {
+      width: 100%;
+      height: 48px;
+    }
+
+    &-item.active {
+      border-bottom-width: 0px;
+      background-color: lighten($blue, 32%);
+    }
+  }
+}

--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -13,10 +13,19 @@
   }
 }
 
+@include device-is('mobile') {
+  .app {
+    flex-direction: column;
+  
+    &__sidebar {
+      width: 100%;
+    }
+  }
+}
+
 .sidebar {
   display: flex;
   flex-direction: column;
-  height: 100%;
   background: $pix-orga-old-gradient;
 
   &--padding-left {
@@ -38,6 +47,7 @@
 
 .logo {
   padding-top: 20px;
+  padding-bottom: 30px;
 
   &__image {
     height: 60px;

--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -13,16 +13,6 @@
   }
 }
 
-@include device-is('mobile') {
-  .app {
-    flex-direction: column;
-  
-    &__sidebar {
-      width: 100%;
-    }
-  }
-}
-
 .sidebar {
   display: flex;
   flex-direction: column;
@@ -83,5 +73,23 @@
 
   &__organization-credit-info {
     padding: 0 30px;
+  }
+}
+
+
+@include device-is('mobile') {
+  .app {
+    flex-direction: column;
+  
+    &__sidebar {
+      width: 100%;
+    }
+  }
+
+  .topbar {
+    &__user-logged-menu {
+      padding: 0 16px;
+      border-left-width: 0px;
+    }
   }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -105,3 +105,28 @@
     height: inherit;
   }
 }
+
+@include device-is('mobile') {
+  .campaign-details{
+    &__header {
+      flex-direction: column;
+      align-items: initial;
+    }
+  }
+
+  .campaign-details-header {
+    &__headline {
+      margin-bottom: 16px;
+    }
+  
+    &__report {
+      margin-left: 32px;
+    }
+  }
+
+  .campaign-details-controls {
+    &__navbar-tabs {
+      flex-direction: column;
+    }
+  }
+}

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -31,7 +31,6 @@
     align-items: center;
     padding-right: 10px;
     padding-left: 10px;
-    min-width: 345px;
 
     & > *  {
       padding-right: 15px;
@@ -120,7 +119,7 @@
     }
   
     &__report {
-      margin-left: 32px;
+      margin-left: 0;
     }
   }
 

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -71,16 +71,18 @@
   font-weight: 600;
   background: $blue-zodiac;
   display: flex;
-  padding: 13px 13px 13px 32px;
+  padding: 8px 8px 8px 24px;
+  margin-bottom: 24px;
   border-radius: 6px;
   color: $white;
   flex-flow: row nowrap;
   align-items: center;
 
   &__icon {
-    margin-right: 30px;
+    margin-right: 24px;
     font-size: 1.6rem;
   }
+
   &__unarchive-button {
     background: $blue-zodiac;
     border: 2px solid $white;

--- a/orga/app/styles/pages/authenticated/campaigns/details/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/details.scss
@@ -64,3 +64,14 @@
     }
   }
 }
+
+@include device-is('mobile') {
+  .campaign-details-content {
+    width: initial;
+  }
+
+  .campaign-details-row {
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+}

--- a/orga/app/styles/pages/authenticated/campaigns/details/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/details.scss
@@ -16,21 +16,13 @@
 .campaign-details-content {
   display: flex;
   flex-direction: column;
-  padding: 22px 20px 22px 38px;
+  padding: 24px;
   width: 100%;
-
-  &--button {
-    padding-right: 38px;
-  }
 
   &--single {
     &:first-child {
       width: 55%;
     }
-  }
-
-  &--left {
-    margin-right: auto;
   }
 
   &:not(:first-child) {
@@ -62,6 +54,16 @@
     .pix-tooltip__content {
       margin-bottom: 6px;
     }
+  }
+}
+
+.campaign-details-buttons {
+  display: flex;
+  padding: 24px;
+  width: 100%;
+
+  > *:first-child {
+    margin-right: 32px;
   }
 }
 

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -66,3 +66,18 @@ $margin-right: 32px;
     margin-left: 10px;
   }
 }
+
+@include device-is('mobile') {
+  .list-team-page {
+    &__header {
+      flex-direction: column;
+    }
+  }
+
+  .list-team-page-header {
+    &__add-member-button {
+      margin-top: initial;
+      margin-left: initial;
+    }
+  }
+}

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -1,7 +1,7 @@
 <div class="app">
 
   <aside class="app__sidebar sidebar">
-    <header class="sidebar__logo logo sidebar--padding-left">
+    <header class="sidebar__logo logo sidebar--padding-left hide-on-mobile">
       <LinkTo @route="authenticated.campaigns">
         <img class="logo__image" src="{{this.rootUrl}}/pix-orga.svg" alt="" role="none">
       </LinkTo>

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -12,7 +12,7 @@
   <div class="app__main-content main-content">
 
     <div class="main-content__topbar topbar">
-      <div class="topbar__organization-credit-info"><OrganizationCreditInfo /></div>
+      <div class="topbar__organization-credit-info hide-on-mobile"><OrganizationCreditInfo /></div>
       <div class="topbar__user-logged-menu"><UserLoggedMenu /></div>
     </div>
 

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -11,7 +11,7 @@
     <Charts::ParticipantsByStage
       @campaignId={{@model.campaign.id}}
       @onSelectStage={{this.filterByStage}}
-      class="assessment-results__participants-by-stage"
+      class="assessment-results__participants-by-stage hide-on-mobile"
     />
   {{/if}}
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, Pix Orga n'est pas du tout responsive sur mobile et la navigation est impossible.

## :robot: Solution

Corriger le layout des pages et des composants de Pix Orga pour les rendre un minimum responsive sur mobile.

Certaines fonctionnalités ou informations ont été enlevées pour une meilleure navigation et expérience utilisateur sur mobile (même si c'est pas encore toptop).

## :rainbow: Remarques

Ajout d'une classe `hide-on-mobile` permettant de cacher un élément HTML uniquement sur mobile.

Les tableaux n'ont pas encore été rendu responsive.

Fix #3206

## :100: Pour tester

Naviguer sur mobile.
