### PR TITLE
[FEATURE] Ajout de la carte du palier moyen d'une campagne d'évaluation (PIX-2890)

### DIFF
--- a/orga/app/components/campaign/activity/dashboard.hbs
+++ b/orga/app/components/campaign/activity/dashboard.hbs
@@ -1,26 +1,15 @@
 <div class="activity-dashboard" ...attributes>
   <div class="activity-dashboard__row">
-    <Ui::IndicatorCard
-      @title={{t 'charts.participants-count.title'}}
-      @icon="users"
-      @color="blue"
-      @info={{t 'charts.participants-count.information'}}
-      @loading={{this.participantsByStatusLoading}}
-      @loader={{t 'charts.participants-count.loader'}}
+    <Campaign::Cards::ParticipantsCount
+      @value={{this.total}}
+      @isLoading={{this.participantsByStatusLoading}}
       class="activity-dashboard__total-participants-card"
-    >
-      {{this.total}}
-    </Ui::IndicatorCard>
-    <Ui::IndicatorCard
-      @title={{if @campaign.isTypeAssessment (t 'charts.submitted-count.title') (t 'charts.submitted-count.title-profiles')}}
-      @icon="share"
-      @color="green"
-      @info={{t 'charts.submitted-count.information'}}
-      @loading={{this.participantsByStatusLoading}}
-      @loader={{t 'charts.submitted-count.loader'}}
-    >
-      {{this.shared}}
-    </Ui::IndicatorCard>
+    />
+    <Campaign::Cards::SharedCount
+      @value={{this.shared}}
+      @isLoading={{this.participantsByStatusLoading}}
+      @isTypeAssessment={{@campaign.isTypeAssessment}}
+    />
   </div>
   <div class="activity-dashboard__row">
     <Charts::ParticipantsByDay

--- a/orga/app/components/campaign/cards/participants-count.hbs
+++ b/orga/app/components/campaign/cards/participants-count.hbs
@@ -1,0 +1,11 @@
+<Ui::IndicatorCard
+  @title={{t 'cards.participants-count.title'}}
+  @icon="users"
+  @color="blue"
+  @info={{t 'cards.participants-count.information'}}
+  @loader={{t 'cards.participants-count.loader'}}
+  @isLoading={{@isLoading}}
+  ...attributes
+>
+  {{@value}}
+</Ui::IndicatorCard>

--- a/orga/app/components/campaign/cards/result-average.hbs
+++ b/orga/app/components/campaign/cards/result-average.hbs
@@ -1,0 +1,10 @@
+<Ui::IndicatorCard
+  @title={{t 'cards.participants-average-results.title'}}
+  @icon="crown"
+  @color="blue"
+  @info={{t 'cards.participants-average-results.information'}}
+  @isLoading={{@isLoading}}
+  ...attributes
+>
+  {{t 'cards.participants-average-results.result' result=@value}}
+</Ui::IndicatorCard>

--- a/orga/app/components/campaign/cards/shared-count.hbs
+++ b/orga/app/components/campaign/cards/shared-count.hbs
@@ -1,0 +1,11 @@
+<Ui::IndicatorCard
+  @title={{if @isTypeAssessment (t 'cards.submitted-count.title') (t 'cards.submitted-count.title-profiles')}}
+  @icon="share"
+  @color="green"
+  @info={{t 'cards.submitted-count.information'}}
+  @loader={{t 'cards.submitted-count.loader'}}
+  @isLoading={{@isLoading}}
+  ...attributes
+>
+  {{@value}}
+</Ui::IndicatorCard>

--- a/orga/app/components/campaign/cards/stage-average.hbs
+++ b/orga/app/components/campaign/cards/stage-average.hbs
@@ -1,0 +1,14 @@
+<Ui::IndicatorCard
+  @title={{t 'cards.participants-average-stages.title'}}
+  @icon="crown"
+  @color="blue"
+  @info={{t 'cards.participants-average-stages.information'}}
+  @isLoading={{@isLoading}}
+  ...attributes
+>
+  <StageStars
+    @result={{this.valuePercentage}}
+    @stages={{@stages}}
+    @isWide={{true}}
+  />
+</Ui::IndicatorCard>

--- a/orga/app/components/campaign/cards/stage-average.js
+++ b/orga/app/components/campaign/cards/stage-average.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class StageAverage extends Component {
+  get valuePercentage() {
+    return this.args.value * 100;
+  }
+}

--- a/orga/app/components/campaign/results/assessment-cards.hbs
+++ b/orga/app/components/campaign/results/assessment-cards.hbs
@@ -1,8 +1,17 @@
 <div class="assessment-cards" >
-  <Campaign::Cards::ResultAverage
-    @value={{@averageResult}}
-    class="assessment-cards__average-result-card"
-  />
+  {{#if @hasStages}}
+    <Campaign::Cards::StageAverage
+      @value={{@averageResult}}
+      @stages={{@stages}}
+      class="assessment-cards__average-card"
+    />
+  {{else}}
+    <Campaign::Cards::ResultAverage
+      @value={{@averageResult}}
+      class="assessment-cards__average-card"
+    />
+  {{/if}}
+
   <Campaign::Cards::SharedCount
     @value={{@sharedParticipationsCount}}
     @isTypeAssessment={{true}}

--- a/orga/app/components/campaign/results/assessment-cards.hbs
+++ b/orga/app/components/campaign/results/assessment-cards.hbs
@@ -1,23 +1,10 @@
 <div class="assessment-cards" >
-  <Ui::IndicatorCard
-    @title={{t 'charts.participants-average-results.title'}}
-    @icon="crown"
-    @color="blue"
-    @info={{t 'charts.participants-average-results.information'}}
-    @loading={{false}}
+  <Campaign::Cards::ResultAverage
+    @value={{@averageResult}}
     class="assessment-cards__average-result-card"
-  >
-    {{t 'charts.participants-average-results.result' result=@averageResult}}
-
-  </Ui::IndicatorCard>
-
-  <Ui::IndicatorCard
-    @title={{t 'charts.submitted-count.title'}}
-    @icon="share"
-    @color="green"
-    @info={{t 'charts.submitted-count.information'}}
-    @loading={{false}}
-    >
-    {{@sharedParticipationsCount}}
-  </Ui::IndicatorCard>
+  />
+  <Campaign::Cards::SharedCount
+    @value={{@sharedParticipationsCount}}
+    @isTypeAssessment={{true}}
+  />
 </div>

--- a/orga/app/components/routes/authenticated/campaign/details/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/details/tab.hbs
@@ -1,4 +1,4 @@
-<div class="panel panel--strong-shadow campaign-details-container">
+<div class="panel campaign-details-container">
   <div class="campaign-details-row">
     {{#if @campaign.isTypeAssessment}}
       <div class="campaign-details-content">

--- a/orga/app/components/stage-stars.hbs
+++ b/orga/app/components/stage-stars.hbs
@@ -4,7 +4,7 @@
     @total={{this.starsTotal}}
     @alt={{this.altMessage}}
     @color="blue"
-    class="stage-stars"
+    class="stage-stars {{if @isWide 'stage-stars--wide'}}"
   />
   {{#if this.displayTooltip}}
     <PixTooltip

--- a/orga/app/components/ui/indicator-card.hbs
+++ b/orga/app/components/ui/indicator-card.hbs
@@ -1,5 +1,5 @@
 <section class="indicator-card" ...attributes>
-  {{#if @loading}}
+  {{#if @isLoading}}
     <p class="sr-only">{{@loader}}</p>
     <div class="indicator-card__icon" aria-hidden="true"/>
     <div class="indicator-card__content" aria-hidden="true"/>

--- a/orga/app/components/ui/indicator-card.hbs
+++ b/orga/app/components/ui/indicator-card.hbs
@@ -22,7 +22,9 @@
           </PixTooltip>
         {{/if}}
       </label>
-      {{yield}}
+      <div class="indicator-card__value">
+        {{yield}}
+      </div>
     </div>
   {{/if}}
 </section>

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -54,6 +54,7 @@
 @import "pages/authenticated/campaigns/list";
 @import "pages/authenticated/campaigns/details/activity";
 @import "pages/authenticated/campaigns/details/analysis";
+@import "pages/authenticated/campaigns/details/assessment-results";
 @import "pages/authenticated/campaigns/details/details";
 @import "pages/authenticated/campaigns/details/participants";
 @import "pages/authenticated/campaigns/details/participants/participant";

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -12,6 +12,7 @@
 @import "globals/forms";
 @import "globals/icons";
 @import "globals/pages";
+@import "globals/shadows";
 @import "globals/panels";
 @import "globals/pix-loader";
 @import "globals/tables";

--- a/orga/app/styles/components/campaign/activity/dashboard.scss
+++ b/orga/app/styles/components/campaign/activity/dashboard.scss
@@ -7,17 +7,17 @@
   }
 
   &__row:first-child {
-    margin-bottom: 32px;
+    margin-bottom: 24px;
   }
 
   &__total-participants-card {
-    margin-right: 32px;
+    margin-right: 24px;
   }
 
   &__participations-by-day {
     box-sizing: border-box;
-    width: calc(75% - 32px);
-    margin-right: 32px;
+    width: calc(75% - 24px);
+    margin-right: 24px;
   }
 
   &__participations-by-status {

--- a/orga/app/styles/components/campaign/results/assessment-cards.scss
+++ b/orga/app/styles/components/campaign/results/assessment-cards.scss
@@ -3,7 +3,19 @@
   margin-top: 16px;
   margin-bottom: 32px;
 
-  &__average-result-card {
-    margin-right: 32px;
+  &__average-card {
+    margin-right: 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .assessment-cards {
+    flex-direction: column;
+    margin-bottom: 16px;
+
+    &__average-card {
+      margin-right: 0;
+      margin-bottom: 16px;
+    }
   }
 }

--- a/orga/app/styles/components/campaign/results/assessment-cards.scss
+++ b/orga/app/styles/components/campaign/results/assessment-cards.scss
@@ -1,7 +1,6 @@
 .assessment-cards {
   display: flex;
-  margin-top: 16px;
-  margin-bottom: 32px;
+  margin-bottom: 24px;
 
   &__average-card {
     margin-right: 24px;

--- a/orga/app/styles/components/charts/cards.scss
+++ b/orga/app/styles/components/charts/cards.scss
@@ -2,7 +2,7 @@
   position: relative;
   border-radius: 10px;
   border: none;
-  box-shadow: 0 1px 1px 0 rgba($black, 0.1), 0 2px 5px 0 rgba($black, 0.1);
+  box-shadow: $shadow-base;
   background-color: $white;
   padding: 16px 20px;
 

--- a/orga/app/styles/components/indicator-card.scss
+++ b/orga/app/styles/components/indicator-card.scss
@@ -32,9 +32,6 @@
     flex-direction: column;
     justify-content: center;
     color: $grey-60;
-    font-family: $open-sans;
-    font-weight: 600;
-    font-size: 2rem;
     margin: 16px 32px;
   }
 
@@ -44,6 +41,14 @@
     font-family: $roboto;
     font-weight: 500;
     font-size: 0.875rem;
+    margin-bottom: 8px;
+  }
+
+  &__value {
+    font-family: $open-sans;
+    font-weight: 600;
+    font-size: 2rem;
+    line-height: 2rem;
   }
 
   &__tooltip {

--- a/orga/app/styles/components/indicator-card.scss
+++ b/orga/app/styles/components/indicator-card.scss
@@ -8,7 +8,7 @@
   width: 100%;
   background-color: $white;
   border-radius: 8px;
-  box-shadow: 0 2px 5px 0 rgba($black, 0.05);
+  box-shadow: $shadow-base;
   height: 112px;
   padding: 0;
 

--- a/orga/app/styles/components/stage-stars.scss
+++ b/orga/app/styles/components/stage-stars.scss
@@ -4,6 +4,13 @@
     height: 18px;
   }
 
+  &--wide {
+    svg {
+      width: 32px;
+      height: 32px;
+    }
+  }
+
   &__container {
     display: inline-flex;
 

--- a/orga/app/styles/globals/pages.scss
+++ b/orga/app/styles/globals/pages.scss
@@ -7,6 +7,5 @@
 }
 
 .navigation {
-  margin-top: 0;
-  margin-bottom: 24px;
+  margin: 24px 0;
 }

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -26,6 +26,7 @@
     width: 100%;
     padding: 24px;
     box-sizing: border-box;
+    margin-bottom: 24px;
   }
 }
 

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -1,26 +1,8 @@
 .panel {
   border-radius: 4px;
   border: none;
-  box-shadow: 0 1px 1px 0 rgba($black, 0.1), 0 2px 5px 0 rgba($black, 0.1);
+  box-shadow: $shadow-base;
   background-color: $white;
-
-  &--strong-shadow {
-    box-shadow: 0 6px 12px 0 rgba($black, 0.1), 0 2px 5px 0 rgba($black, 0.1);
-  }
-
-  &--link {
-    text-decoration: none;
-    border: solid 2px $white;
-    color: $grey-100;
-    outline: none;
-    cursor: pointer;
-
-    &:hover, &:active, &:focus {
-      border-color: $blue;
-      transition: border-color 1s ease;
-      box-shadow: 0 2px 5px 0 rgba($black, 0.05);
-    }
-  }
 
   &--header {
     width: 100%;

--- a/orga/app/styles/globals/shadows.scss
+++ b/orga/app/styles/globals/shadows.scss
@@ -1,0 +1,1 @@
+$shadow-base: 0 2px 5px 0 rgba($black, 0.05);

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -10,13 +10,13 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin: 1em 0;
+    margin: 24px 0;
   }
 
   &__controls {
     display: flex;
     justify-content: space-between;
-    margin: 1em 0;
+    margin-bottom: 24px;
   }
 }
 

--- a/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
@@ -1,14 +1,13 @@
 .activity__dashboard {
-  margin-top: 16px;
-  margin-bottom: 32px;
+  margin-bottom: 24px;
 }
 
 .activity__participants-list {
-  margin-bottom: 32px;
+  margin-bottom: 24px;
 }
 
 @media (max-width: 768px) {
   .activity__dashboard {
-    margin-bottom: 16px;
+    margin-bottom: 12px;
   }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/assessment-results.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/assessment-results.scss
@@ -1,0 +1,5 @@
+.assessment-results {
+  &__participants-by-stage {
+    margin-bottom: 24px;
+  }
+}

--- a/orga/app/styles/pages/authenticated/campaigns/details/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/details.scss
@@ -1,5 +1,4 @@
 .campaign-details-container {
-  margin: 16px 0;
   display: flex;
   flex-direction: column;
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants/participant/results.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants/participant/results.scss
@@ -7,5 +7,5 @@
 }
 
 .participant-filter-banner {
-  margin: 16px 0;
+  margin-bottom: 12px;
 }

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -15,7 +15,7 @@ $margin-right: 32px;
   &__tabs {
     display: flex;
     border-bottom: 1px solid $grey-20;
-    margin-bottom: 16px;
+    margin-bottom: 24px;
   }
 
   .modal-dialog-width {

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -1,16 +1,18 @@
 {{page-title (t 'pages.campaign-results.title')}}
 {{#if @model.campaign.hasSharedParticipations}}
+  <Campaign::Results::AssessmentCards
+    @hasStages={{@model.campaign.hasStages}}
+    @stages={{@model.campaign.stages}}
+    @sharedParticipationsCount={{@model.campaign.sharedParticipationsCount}}
+    @averageResult={{@model.campaign.campaignCollectiveResult.averageResult}}
+  />
+
   {{#if @model.campaign.hasStages}}
     <Charts::ParticipantsByStage
       @campaignId={{@model.campaign.id}}
       @onSelectStage={{this.filterByStage}}
       class="participant-row__result"
     />
-  {{else}}
-    <Campaign::Results::AssessmentCards
-    @sharedParticipationsCount={{@model.campaign.sharedParticipationsCount}}
-    @averageResult={{@model.campaign.campaignCollectiveResult.averageResult}}
-  />
   {{/if}}
 
   <Campaign::Results::AssessmentList
@@ -24,7 +26,5 @@
     @onResetFilter={{this.resetFiltering}}
   />
 {{else}}
-  <Campaign::EmptyState
-    @campaignCode={{@model.campaign.code}}
-  />
+  <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />
 {{/if}}

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -11,7 +11,7 @@
     <Charts::ParticipantsByStage
       @campaignId={{@model.campaign.id}}
       @onSelectStage={{this.filterByStage}}
-      class="participant-row__result"
+      class="assessment-results__participants-by-stage"
     />
   {{/if}}
 

--- a/orga/tests/integration/components/campaign/cards/participants-count_test.js
+++ b/orga/tests/integration/components/campaign/cards/participants-count_test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupIntl, t } from 'ember-intl/test-support';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::Cards::ParticipantsCount', function(hooks) {
+  setupIntlRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it should display participations count card', async function(assert) {
+    this.participantsCount = 10;
+
+    await render(hbs`<Campaign::Cards::ParticipantsCount @value={{participantsCount}} />`);
+
+    assert.contains(t('cards.participants-count.title'));
+    assert.contains('10');
+  });
+});

--- a/orga/tests/integration/components/campaign/cards/result_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/result_average_test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupIntl, t } from 'ember-intl/test-support';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::Cards::ResultAverage', function(hooks) {
+  setupIntlRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it should display average result card', async function(assert) {
+    this.averageResult = 0.91234;
+
+    await render(hbs`<Campaign::Cards::ResultAverage @value={{averageResult}} />`);
+
+    assert.contains(t('cards.participants-average-results.title'));
+    assert.contains('9');
+  });
+});

--- a/orga/tests/integration/components/campaign/cards/shared-count_test.js
+++ b/orga/tests/integration/components/campaign/cards/shared-count_test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupIntl, t } from 'ember-intl/test-support';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::Cards::SharedCount', function(hooks) {
+  setupIntlRenderingTest(hooks);
+  setupIntl(hooks);
+
+  module('When campaign is type assessment', () => {
+    test('it should display shared participations count card', async function(assert) {
+      this.sharedCount = 10;
+
+      await render(hbs`<Campaign::Cards::SharedCount @value={{sharedCount}} @isTypeAssessment={{true}} />`);
+
+      assert.contains(t('cards.submitted-count.title'));
+      assert.contains('10');
+    });
+  });
+
+  module('When campaign is type profile collection', () => {
+    test('it should display shared profiles count card', async function(assert) {
+      this.sharedCount = 10;
+
+      await render(hbs`<Campaign::Cards::SharedCount @value={{sharedCount}} @isTypeAssessment={{false}} />`);
+
+      assert.contains(t('cards.submitted-count.title-profiles'));
+      assert.contains('10');
+    });
+  });
+});

--- a/orga/tests/integration/components/campaign/cards/stage_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/stage_average_test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupIntl, t } from 'ember-intl/test-support';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::Cards::StageAverage', function(hooks) {
+  setupIntlRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it should display average result card', async function(assert) {
+    this.averageResult = 0.5;
+    this.stages = [{ threshold: 20 }, { threshold: 70 }];
+
+    await render(hbs`<Campaign::Cards::StageAverage @value={{averageResult}} @stages={{stages}} />`);
+
+    assert.contains(t('cards.participants-average-stages.title'));
+    assert.contains(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 }));
+  });
+});

--- a/orga/tests/integration/components/campaign/results/assessment-cards_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-cards_test.js
@@ -8,9 +8,8 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function(
   setupIntlRenderingTest(hooks);
   setupIntl(hooks);
 
-  module('Average result card', function() {
-
-    test('It should display average result title and score for an ASSESSMENT campaign', async function(assert) {
+  module('When the campaign has no stages', function() {
+    test('It should display average result card', async function(assert) {
       // given
       this.averageResult = 0.9;
 
@@ -18,23 +17,33 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function(
       await render(hbs`<Campaign::Results::AssessmentCards @averageResult={{averageResult}} />`);
 
       //then
-      assert.contains(t('charts.participants-average-results.title'));
-      assert.contains('9');
+      assert.contains(t('cards.participants-average-results.title'));
     });
   });
 
-  module('Shared results card', function() {
-    test('It should display submitted results title and score for an ASSESSMENT campaign', async function(assert) {
+  module('When the campaign has stages', function() {
+    test('It should display average stage card', async function(assert) {
       // given
-      this.sharedParticipationsCount = 10;
+      this.hasStages = true;
+      this.stages = [{ threshold: 20 }, { threshold: 70 }];
+      this.averageResult = 0.5;
 
-      // when
-      await render(hbs`<Campaign::Results::AssessmentCards @sharedParticipationsCount={{sharedParticipationsCount}} />`);
+      //when
+      await render(hbs`<Campaign::Results::AssessmentCards @averageResult={{averageResult}} @hasStages={{hasStages}} @stages={{stages}} />`);
 
       //then
-      assert.contains(t('charts.submitted-count.title'));
-      assert.contains('10');
+      assert.contains(t('cards.participants-average-stages.title'));
     });
   });
 
+  test('It should display shared participation card', async function(assert) {
+    // given
+    this.sharedParticipationsCount = 10;
+
+    // when
+    await render(hbs`<Campaign::Results::AssessmentCards @sharedParticipationsCount={{sharedParticipationsCount}} />`);
+
+    //then
+    assert.contains(t('cards.submitted-count.title'));
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -60,6 +60,10 @@
       "title": "Average result",
       "result": "{result, number, ::percent}"
     },
+    "participants-average-stages": {
+      "information": "Find here the average rating of your campaign. This includes all the participants who have completed their customised test and sent their results.",
+      "title": "Average rating"
+    },
     "participants-count": {
       "information": "Find here the total number of participations in your campaign. This includes all the participants who have entered the code and started their customised test or submitted their profile.",
       "loader": "Loading total participants",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -54,12 +54,25 @@
       "message": "Start of school year: the '<strong>'admin'</strong>' must {linkTo} to start using Pix Orga. Learn more on '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'middle schools {faIcon}'</a>' and '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'high schools {faIcon}'</a>'"
     }
   },
-  "charts": {
+  "cards": {
     "participants-average-results": {
       "information": "Find here the average results of your campaign. This includes all the participants who have completed their customised test and sent their results.",
       "title": "Average result",
       "result": "{result, number, ::percent}"
     },
+    "participants-count": {
+      "information": "Find here the total number of participations in your campaign. This includes all the participants who have entered the code and started their customised test or submitted their profile.",
+      "loader": "Loading total participants",
+      "title": "Total participants"
+    },
+    "submitted-count": {
+      "information": "Find here the results submitted by your participants. This includes all the participants who have finished and clicked on the button \"Submit my results\" or \"Submit my profile\".",
+      "loader": "Loading submitted results or profiles",
+      "title": "Submitted results",
+      "title-profiles": "Submitted profiles"
+    }
+  },
+  "charts": {
     "participants-by-stage": {
       "loader": "Loading and sorting the participants grouped by success rates",
       "participants": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}}",
@@ -109,17 +122,6 @@
       },
       "loader": "Loading participant's activity",
       "title": "Participant's activity"
-    },
-    "participants-count": {
-      "information": "Find here the total number of participations in your campaign. This includes all the participants who have entered the code and started their customised test or submitted their profile.",
-      "loader": "Loading total participants",
-      "title": "Total participants"
-    },
-    "submitted-count": {
-      "information": "Find here the results submitted by your participants. This includes all the participants who have finished and clicked on the button \"Submit my results\" or \"Submit my profile\".",
-      "loader": "Loading submitted results or profiles",
-      "title": "Submitted results",
-      "title-profiles": "Submitted profiles"
     }
   },
   "common": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -60,6 +60,10 @@
       "title": "Résultat moyen",
       "result": "{result, number, ::percent}"
     },
+    "participants-average-stages": {
+      "information": "Retrouvez ici le palier moyen de votre campagne. Ce nombre comprend l'ensemble des participants ayant fini leur parcours et envoyé leur résultat.",
+      "title": "Palier moyen"
+    },
     "participants-count": {
       "information": "Retrouvez ici le nombre de participants total de votre campagne. Ce nombre comprend l'ensemble des participants ayant saisi le code et commencé leur parcours ou leur envoi de profil.",
       "loader": "Chargement du total de participants",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -54,12 +54,25 @@
       "message": "Rentrée 2020 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
     }
   },
-  "charts": {
+  "cards": {
     "participants-average-results": {
       "information": "Retrouvez ici la moyenne des résultats de votre campagne. Ce nombre comprend l'ensemble des participants ayant fini leur parcours et envoyé leur résultat.",
       "title": "Résultat moyen",
       "result": "{result, number, ::percent}"
     },
+    "participants-count": {
+      "information": "Retrouvez ici le nombre de participants total de votre campagne. Ce nombre comprend l'ensemble des participants ayant saisi le code et commencé leur parcours ou leur envoi de profil.",
+      "loader": "Chargement du total de participants",
+      "title": "Total de participants"
+    },
+    "submitted-count": {
+      "information": "Retrouvez ici les résultats envoyés par vos participants. Ce nombre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton \"J'envoie mes résultats\" ou \"J'envoie mon profil\".",
+      "loader": "Chargement des résultats ou profils reçus",
+      "title": "Résultats reçus",
+      "title-profiles": "Profils reçus"
+    }
+  },
+  "charts": {
     "participants-by-stage": {
       "loader": "Chargement de la répartition des participants par paliers",
       "participants": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}}",
@@ -109,17 +122,6 @@
       },
       "loader": "Chargement de l'activité des participants",
       "title": "Activité des participants"
-    },
-    "participants-count": {
-      "information": "Retrouvez ici le nombre de participants total de votre campagne. Ce nombre comprend l'ensemble des participants ayant saisi le code et commencé leur parcours ou leur envoi de profil.",
-      "loader": "Chargement du total de participants",
-      "title": "Total de participants"
-    },
-    "submitted-count": {
-      "information": "Retrouvez ici les résultats envoyés par vos participants. Ce nombre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton \"J'envoie mes résultats\" ou \"J'envoie mon profil\".",
-      "loader": "Chargement des résultats ou profils reçus",
-      "title": "Résultats reçus",
-      "title-profiles": "Profils reçus"
     }
   },
   "common": {


### PR DESCRIPTION
## :unicorn: Problème

L'onglet résultat affiche la carte du résultat moyen quand une campagne n'a pas de palier. Mais quand celle-ci a des paliers de définis, aucune carte n'est affiché.

## :robot: Solution

Afficher une carte du résultat moyen sous forme de palier.

![image](https://user-images.githubusercontent.com/516360/128332643-80452b91-4a59-4775-8f75-6d3f718960f1.png)

## :rainbow: Remarques

Dans cette PR, chaque carte a été isolé dans des composants dédiés.
- Carte du nombre de participations
- Carte du nombre de participations partagées
- Carte du résultat moyen (pourcentage)
- Carte du résultat moyen sous forme de palier

2 commits sont dédiés à l'harmonisation des styles des pages dans Pix Orga
- Harmonisation des marges entre les différentes pages (24px) et mise en cohérence avec la maquette.
- Mise en cohérence des ombres des cartes et panels avec ceux définis dans la maquette

## :100: Pour tester

1. Se connecter avec le compte pro.admin
2. Aller sur une campagne d'évaluation avec palier => voir les cartes dans l'onglet résultat (avec des étoiles)
3. Aller sur une campagne d'évaluation sans palier => voir les cartes dans l'onglet résultat (avec le pourcentage)
