### PR TITLE
[FEATURE] Demander a l'utilisateur d'attester sur l'honneur d'appartenance du compte (PIX-2787).

### DIFF
--- a/mon-pix/app/components/account-recovery/confirmation-step.hbs
+++ b/mon-pix/app/components/account-recovery/confirmation-step.hbs
@@ -36,8 +36,11 @@
     </li>
   </ul>
 
-  <p class="account-recovery__content--information-text--details">
-    {{t 'pages.account-recovery.find-sco-record.confirmation-step.certify-account' }}
+  <p class="account-recovery__content--information-text--details checkbox-with-label">
+    <Input @type="checkbox" id="pix-certify" @checked={{this.checked}} />
+    <label for="pix-certify">
+      {{t 'pages.account-recovery.find-sco-record.confirmation-step.certify-account' }}
+    </label>
   </p>
 
   <div class="account-recovery__content--actions">
@@ -50,8 +53,10 @@
     </PixButton>
     <PixButton
       @isBorderVisible={{true}}
+      @isDisabled={{not this.isFormValid}}
       @triggerAction={{@continueAccountRecoveryBackupEmailConfirmation}}
-      @backgroundColor="red">
+      @backgroundColor="red"
+    >
       {{t 'pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm' }}
     </PixButton>
   </div>

--- a/mon-pix/app/components/account-recovery/confirmation-step.js
+++ b/mon-pix/app/components/account-recovery/confirmation-step.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class ConfirmationStepComponent extends Component {
+  @tracked checked = false;
+
+  get isFormValid() {
+    return this.checked;
+  }
+}

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -86,6 +86,20 @@
         a {
           color: $communication-dark;
         }
+
+        &.checkbox-with-label {
+          display: flex;
+          align-items: center;
+
+          input[type='checkbox'] {
+            margin-right: 16px;
+            cursor: pointer;
+          }
+
+          label {
+            cursor: pointer;
+          }
+        }
       }
     }
 

--- a/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
@@ -184,6 +184,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function() {
           await fillStudentInformationFormAndSubmit(this);
 
           // when
+          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
           await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
 
           // then
@@ -201,6 +202,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function() {
 
           await visit('/recuperer-mon-compte');
           await fillStudentInformationFormAndSubmit(this);
+          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
           await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
 
           // when
@@ -222,6 +224,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function() {
           await visit('/recuperer-mon-compte');
           await fillStudentInformationFormAndSubmit(this);
 
+          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
           await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
 
           // when
@@ -251,6 +254,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function() {
           await visit('/recuperer-mon-compte');
           await fillStudentInformationFormAndSubmit(this);
 
+          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
           await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
 
           // when

--- a/mon-pix/tests/integration/components/account-recovery/confirmation-step-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/confirmation-step-test.js
@@ -6,6 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { contains } from '../../../helpers/contains';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { clickByLabel } from '../../../helpers/click-by-label';
+import findByLabel from '../../../helpers/find-by-label';
 import sinon from 'sinon';
 
 describe('Integration | Component | confirmation-step', function() {
@@ -84,6 +85,31 @@ describe('Integration | Component | confirmation-step', function() {
     sinon.assert.calledOnce(cancelAccountRecovery);
   });
 
+  it('should not be possible to continue the account recovery process when have not checked to certify', async function() {
+    // given
+    const studentInformationForAccountRecovery = EmberObject.create({
+      firstName: 'Philippe',
+      lastName: 'Auguste',
+      username: 'Philippe.auguste2312',
+      email: 'philippe.auguste@example.net',
+      latestOrganizationName: 'Collège George-Besse, Loches',
+    });
+    this.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
+    const continueAccountRecoveryBackupEmailConfirmation = sinon.stub();
+    this.set('continueAccountRecoveryBackupEmailConfirmation', continueAccountRecoveryBackupEmailConfirmation);
+
+    // when
+    await render(hbs`<AccountRecovery::ConfirmationStep
+      @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
+      @continueAccountRecoveryBackupEmailConfirmation={{this.continueAccountRecoveryBackupEmailConfirmation}}
+    />`);
+
+    // then
+    const confirmButton = findByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
+    expect(confirmButton).to.exist;
+    expect(confirmButton.disabled).to.be.true;
+  });
+
   it('should be possible to continue the account recovery process', async function() {
     // given
     const studentInformationForAccountRecovery = EmberObject.create({
@@ -102,6 +128,7 @@ describe('Integration | Component | confirmation-step', function() {
       @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
       @continueAccountRecoveryBackupEmailConfirmation={{this.continueAccountRecoveryBackupEmailConfirmation}}
     />`);
+    await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
     await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
 
     // then

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -977,7 +977,7 @@
             "username": "Votre identifiant",
             "latest-organization-name": "Votre dernier établissement"
           },
-          "certify-account": "En confirmant, j’atteste sur l’honneur que le compte associé à ces données m’appartient et j’accepte que Pix supprime le lien vers tous les établissements auxquels je suis rattaché.",
+          "certify-account": "J’atteste sur l’honneur que le compte associé à ces données m’appartient.",
           "buttons": {
             "cancel":"Annuler",
             "confirm": "Je confirme"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -977,7 +977,7 @@
             "username": "Votre identifiant",
             "latest-organization-name": "Votre dernier établissement"
           },
-          "certify-account": "En confirmant, j’atteste sur l’honneur que le compte associé à ces données m’appartient et j’accepte que Pix supprime le lien vers tous les établissements auxquels je suis rattaché.",
+          "certify-account": "J’atteste sur l’honneur que le compte associé à ces données m’appartient.",
           "buttons": {
             "cancel":"Annuler",
             "confirm": "Je confirme"


### PR DESCRIPTION
## 🦄 Problème
A l'étape de validation des données et du compte retrouvé, l'utilisateur n'a pas moyen d'attester sur l'honneur que le compte lui appartient.

## 🤖 Solution
Ajouter une case à cocher
Ne pas permettre de continuer le parcours si elle n'est pas cochée

## 💯 Pour tester
Aller [sur la page](https://app-pr3285.review.pix.fr/recuperer-mon-compte) de récupération de compte 

Saisir

Ine/Ina : 123456789BB
Prénom : George
Nom : De Cambridge
Date de naissance : 22/07/2013

et retrouver le compte 

Ne pas cocher la case, puis vérifier qu'on ne peut pas continuer
Cocher la case et continuer à la prochaine étape