### PR TITLE
[BUGFIX] Réinitialiser le champ ville lorsque l'on veut modifier un candidat dans Pix Admin dont l'inscription a été effectué par code Insee (PIX-2937).

### DIFF
--- a/admin/app/components/certification/candidate-edit-modal.js
+++ b/admin/app/components/certification/candidate-edit-modal.js
@@ -146,9 +146,6 @@ export default class CandidateEditModal extends Component {
   }
 
   _initForm() {
-    this.selectBirthGeoCodeOption(this.args.candidate.birthInseeCode ? INSEE_CODE_OPTION : POSTAL_CODE_OPTION);
-    this.selectedCountryInseeCode = this.args.candidate.birthCountry === 'FRANCE' ? FRANCE_INSEE_CODE : this.args.candidate.birthInseeCode;
-
     this.firstName = this.args.candidate.firstName;
     this.lastName = this.args.candidate.lastName;
     this.birthdate = this.args.candidate.birthdate;
@@ -158,6 +155,9 @@ export default class CandidateEditModal extends Component {
     this.birthInseeCode = this.args.candidate.birthInseeCode;
     this.birthPostalCode = this.args.candidate.birthPostalCode;
     this.birthCountry = this.args.candidate.birthCountry;
+
+    this.selectBirthGeoCodeOption(this.args.candidate.birthInseeCode ? INSEE_CODE_OPTION : POSTAL_CODE_OPTION);
+    this.selectedCountryInseeCode = this.args.candidate.birthCountry === 'FRANCE' ? FRANCE_INSEE_CODE : this.args.candidate.birthInseeCode;
   }
 
   _isFranceSelected() {

--- a/admin/tests/integration/components/certification/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certification/candidate-edit-modal_test.js
@@ -82,7 +82,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
       assert.equal(this.candidate.birthInseeCode, '99101');
       assert.dom('#birth-insee-code').doesNotExist();
       assert.equal(this.candidate.birthplace, 'Copenhague');
-      assert.dom('#birth-city').hasValue('Copenhague');
+      assert.dom('#birth-city').hasValue('');
       assert.equal(this.candidate.birthCountry, 'DANEMARK');
       assert.dom('#birth-country > option[selected]').hasText('DANEMARK');
     });
@@ -186,6 +186,49 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
     assert.dom('#birth-postal-code').hasValue('35400');
     assert.dom('#birth-city').hasValue('Saint-Malo');
     assert.dom('#birth-country > option[selected]').hasText('FRANCE');
+  });
+
+  module('on component creation', function() {
+
+    test('it should select the insee code option if the candidate insee code is defined', async function(assert) {
+      // given
+      this.candidate = EmberObject.create({
+        firstName: 'Quentin',
+        lastName: 'Lebouc',
+        birthdate: '2000-12-15',
+        sex: 'M',
+        birthInseeCode: '35400',
+        birthplace: 'Saint-Malo',
+        birthCountry: 'FRANCE',
+      });
+      this.countries = [];
+
+      // when
+      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{countries}} />`);
+
+      // then
+      assert.dom('#insee-code-choice').isChecked();
+    });
+
+    test('it should select the postal code option if the candidate postal code is defined', async function(assert) {
+      // given
+      this.candidate = EmberObject.create({
+        firstName: 'Quentin',
+        lastName: 'Lebouc',
+        birthdate: '2000-12-15',
+        sex: 'M',
+        birthPostalCode: '35400',
+        birthplace: 'Saint-Malo',
+        birthCountry: 'FRANCE',
+      });
+      this.countries = [];
+
+      // when
+      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{countries}} />`);
+
+      // then
+      assert.dom('#postal-code-choice').isChecked();
+    });
   });
 
   module('when a foreign country is selected', () => {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on inscrit un candidat en session de certification en renseignant un code Insee comme lieu de naissance, nous enregistrons la ville correspondante en base. Lorsque l'on souhaite modifier ce candidat depuis Pix Admin (changer son nom par exemple) une erreur est renvoyée par le service de vérification des informations de naissance car, selon les règles d'inscription, on ne peut pas avoir à la fois un code Insee renseigné et une ville de naissance. 

## :robot: Solution
A l'initialisation des champs de la modal, nettoyer les valeurs qui ne respectent pas les règles du service de vérification des informations de naissance.

## :rainbow: Remarques
Des tests supplémentaires ont été rajoutés afin de consolider les règles d'initialisation de la modal. 

## :100: Pour tester
- Dans Pix Admin, trouver ou modifier un candidat afin que son lieu de naissance soit renseigné par code Insee.
- Modifier une nouvelle fois le candidat afin de lui changer son nom ou prénom et vérifier qu'aucune erreur n'est renvoyée.