### PR TITLE
[BUGFIX] Changer le message d'assistance sur la page d'erreur de la sortie SCO (PIX-2935).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1039,7 +1039,7 @@
       "support": {
         "url": "https://support.pix.org/fr/support/tickets/new",
         "url-text": "Contactez le support",
-        "recover": " pour récupérer votre compte Pix."
+        "recover": " pour obtenir une assistance."
       }
     },
     "result-item": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1039,7 +1039,7 @@
       "support": {
         "url": "https://support.pix.org/fr/support/tickets/new",
         "url-text": "Contactez le support",
-        "recover": " pour récupérer votre compte Pix."
+        "recover": " pour obtenir une assistance."
       }
     },
     "result-item": {


### PR DESCRIPTION
## 🦄 Problème
Suite à l'évolution et la précision des erreurs liées au token de l'account recovery demand, le message vers le support ne convient plus et est répétitif dans le cas où le message d'erreur indique que le compte a déjà été récupéré.

## 🤖 Solution
Remplacer `Contacter le support pour récupérer votre compte Pix.` par `Contacter le support pour obtenir une assistance.`

## 💯 Pour tester
Aller [sur la page](https://app-pr3287.review.pix.fr/recuperer-mon-compte/h43h53lj65) de récupération de compte avec une temporary key qui n'existe pas.

Page d'erreur affichée avec nouveau message de support
