### PR TITLE
[BUGFIX] Désactiver le bouton "C'est parti" après avoir cliqué dessus durant la récupération compte SCO (PIX-2917).

### DIFF
--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
@@ -48,7 +48,10 @@
         class="confirmation-step__actions--cancel">
           {{t 'pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.cancel'}}
       </PixButton>
-      <PixButton @type="submit">
+      <PixButton
+        @type="submit"
+        @isDisabled={{not this.isSubmitButtonEnabled}}
+      >
         {{t 'pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'}}
       </PixButton>
     </div>

--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.js
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.js
@@ -27,9 +27,14 @@ export default class BackupEmailConfirmationFormComponent extends Component {
 
   @service intl;
 
+  @tracked email = '';
   @tracked emailValidation = new EmailValidation();
 
-  email = '';
+  get isSubmitButtonEnabled() {
+    return isEmailValid(this.email)
+      && !this._hasAPIRejectedCall()
+      && !this.args.isLoading;
+  }
 
   @action validateEmail() {
     this.args.resetErrors();
@@ -57,6 +62,10 @@ export default class BackupEmailConfirmationFormComponent extends Component {
     this.emailValidation.status = STATUS_MAP['successStatus'];
     this.emailValidation.message = null;
     this.args.sendEmail(this.email);
+  }
+
+  _hasAPIRejectedCall() {
+    return this.emailValidation.status === STATUS_MAP['errorStatus'];
   }
 
 }

--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -34,6 +34,8 @@ export default class FindScoRecordController extends Controller {
 
   @tracked studentInformationForAccountRecovery = new StudentInformationForAccountRecovery();
 
+  @tracked isLoading = false;
+
   @action
   async submitStudentInformation(studentInformation) {
     this.studentInformationForAccountRecovery.birthdate = studentInformation.birthdate;
@@ -78,6 +80,7 @@ export default class FindScoRecordController extends Controller {
       email: newEmail,
     });
     try {
+      this.isLoading = true;
       await accountRecoveryDemand.send();
       this.showAlreadyRegisteredEmailError = false;
       this.showBackupEmailConfirmationForm = false;
@@ -85,6 +88,8 @@ export default class FindScoRecordController extends Controller {
       this.templateImg = 'boite';
     } catch (err) {
       this._handleError(err);
+    } finally {
+      this.isLoading = false;
     }
   }
 

--- a/mon-pix/app/templates/account-recovery/find-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/find-sco-record.hbs
@@ -39,6 +39,7 @@
           @existingEmail={{this.studentInformationForAccountRecovery.email}}
           @cancelAccountRecovery={{this.cancelAccountRecovery}}
           @showAlreadyRegisteredEmailError={{this.showAlreadyRegisteredEmailError}}
+          @isLoading={{this.isLoading}}
         />
       {{/if}}
 

--- a/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
@@ -288,9 +288,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function() {
           expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
         });
       });
-
     });
-
   });
 
 });

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import visit from '../../helpers/visit';
-import { currentURL, triggerEvent } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import setupIntl from '../../helpers/setup-intl';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { fillInByLabel } from '../../helpers/fill-in-by-label';
@@ -119,10 +119,9 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await triggerEvent('#password', 'focusout');
         await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        //when
+        // when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
@@ -144,10 +143,9 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
 
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await triggerEvent('#password', 'focusout');
         await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        //when
+        // when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
@@ -171,10 +169,9 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
 
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await triggerEvent('#password', 'focusout');
         await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        //when
+        // when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
@@ -198,10 +195,9 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
 
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await triggerEvent('#password', 'focusout');
         await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        //when
+        // when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
@@ -225,10 +221,9 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
 
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await triggerEvent('#password', 'focusout');
         await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        //when
+        // when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then

--- a/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
@@ -1,15 +1,17 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import Service from '@ember/service';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { contains } from '../../../helpers/contains';
 import { fillInByLabel } from '../../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../../helpers/click-by-label';
+import findByLabel from '../../../helpers/find-by-label';
 
 describe('Integration | Component | account-recovery::backup-email-confirmation-form', function() {
+
   setupIntlRenderingTest();
 
   const firstName = 'Philippe';
@@ -33,8 +35,11 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-reset-message'))).to.exist;
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'))).to.exist;
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.ask-for-new-email-message'))).to.exist;
-    });
 
+      const submitButton = findByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
+      expect(submitButton).to.exist;
+      expect(submitButton.disabled).to.be.true;
+    });
   });
 
   context('when the user does not have an email associated with his account', async function() {
@@ -53,7 +58,6 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-sent-to-choose-password-message'))).to.exist;
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'))).to.exist;
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-already-exist-for-account-message'))).to.not.exist;
-
     });
 
     it('should enable submission on backup email confirmation form', async function() {
@@ -73,10 +77,7 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
       sendEmail.resolves();
       this.set('sendEmail', sendEmail);
 
-      await render(hbs`<AccountRecovery::BackupEmailConfirmationForm
-      @sendEmail={{this.sendEmail}}
-      @resetErrors={{this.resetErrors}}
-      />`);
+      await render(hbs `<AccountRecovery::BackupEmailConfirmationForm @sendEmail={{this.sendEmail}} @resetErrors={{this.resetErrors}} />`);
 
       // when
       await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), email);
@@ -86,6 +87,19 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
       sinon.assert.calledWithExactly(sendEmail, email);
     });
 
+    it('should disable submission on backup email confirmation form when is loading', async function() {
+      // given
+      const email = 'Philipe@example.net';
+
+      await render(hbs `<AccountRecovery::BackupEmailConfirmationForm @isLoading={{true}} />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), email);
+
+      // then
+      const submitButton = findByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
+      expect(submitButton.disabled).to.be.true;
+    });
   });
 
   context('form validation', () => {
@@ -100,11 +114,10 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
 
       // when
       await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), email);
-      await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
+      await triggerEvent('#email', 'focusout');
 
       // then
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.empty-email'))).to.exist;
-
     });
 
     it('should show an error when email is not valid', async function() {
@@ -117,11 +130,10 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
 
       // when
       await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), email);
-      await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
+      await triggerEvent('#email', 'focusout');
 
       // then
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.wrong-email-format'))).to.exist;
-
     });
 
     it('should valid form when email is valid', async function() {
@@ -138,9 +150,7 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
       // then
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.wrong-email-format'))).to.not.exist;
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.empty-email'))).to.not.exist;
-
     });
-
   });
 
 });

--- a/mon-pix/tests/unit/components/account-recovery/backup-email-confirmation-form_test.js
+++ b/mon-pix/tests/unit/components/account-recovery/backup-email-confirmation-form_test.js
@@ -1,5 +1,6 @@
-import sinon from 'sinon';
 import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
 import { setupTest } from 'ember-mocha';
 import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
 
@@ -7,7 +8,8 @@ describe('Unit | Component | account-recovery | backup-email-confirmation-form',
 
   setupTest();
 
-  context('#submitBackupEmailConfirmationForm', function() {
+  describe('#submitBackupEmailConfirmationForm', function() {
+
     it('should call sendEmail', function() {
       // given
       const sendEmail = sinon.stub();
@@ -21,6 +23,45 @@ describe('Unit | Component | account-recovery | backup-email-confirmation-form',
 
       // then
       sinon.assert.calledWith(sendEmail, 'john.doe@example.net');
+    });
+  });
+
+  describe('#isSubmitButtonEnabled', function() {
+
+    it('should return false if email is empty', function() {
+      // given
+      const component = createGlimmerComponent('component:account-recovery/backup-email-confirmation-form');
+      component.email = '';
+
+      // when
+      const result = component.isSubmitButtonEnabled;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return false if email is not valid', function() {
+      // given
+      const component = createGlimmerComponent('component:account-recovery/backup-email-confirmation-form');
+      component.email = 'wrongemail';
+
+      // when
+      const result = component.isSubmitButtonEnabled;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return true if email is valid', function() {
+      // given
+      const component = createGlimmerComponent('component:account-recovery/backup-email-confirmation-form');
+      component.email = 'user@example.net';
+
+      // when
+      const result = component.isSubmitButtonEnabled;
+
+      // then
+      expect(result).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans la page de saisie de l'adresse e-mail de récupération, des clics multiples sur le bouton `C'est parti` enverront plusieurs e-mails à l'utilisateur.

## :robot: Solution
Désactiver le bouton dès qu’on a cliqué dessus (seulement si l’adresse e-mail saisi est valide).

## :100: Pour tester
Se rendre sur la page de récupération en [RA](https://app-pr3292.review.pix.fr/recuperer-mon-compte)

Saisir
- Ine/Ina : `123456789BB`
- Prénom : `George` 
- Nom : `De Cambridge`
- Date de naissance : `22/07/2013`

Aller jusqu'à la page où une adresse e-mail est demandée.

- Vérifiez que le bouton "C'est parti" est désactivé tant qu'une adresse e-mail valide n'est pas renseignée.
- Rentrez une adresse e-mail valide (le bouton doit devenir actif)
- Avec l'inspecteur de votre navigateur, simulez une connexion lente
- Cliquez sur le bouton une fois
- Le bouton doit être désactivé
