### PR TITLE
[FEATURE] Réactiver les schooling registration disabled à l'import SUP (PIX-2856)

### DIFF
--- a/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
@@ -43,6 +43,8 @@ module.exports = {
     const registrationsToInsert = higherSchoolingRegistrations.map((registration) => ({
       ..._.pick(registration, ATTRIBUTES_TO_SAVE),
       status: registration.studyScheme,
+      isDisabled: false,
+      updatedAt: knex.raw('CURRENT_TIMESTAMP'),
     }));
 
     try {

--- a/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
@@ -3,7 +3,6 @@ const { SchoolingRegistrationsCouldNotBeSavedError } = require('../../domain/err
 const { knex } = require('../bookshelf');
 const BookshelfSchoolingRegistration = require('../orm-models/SchoolingRegistration');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
-const DomainTransaction = require('../DomainTransaction');
 
 const ATTRIBUTES_TO_SAVE = [
   'firstName',
@@ -23,21 +22,6 @@ const ATTRIBUTES_TO_SAVE = [
 ];
 
 module.exports = {
-
-  async save(higherSchoolingRegistration, domainTransaction = DomainTransaction.emptyTransaction()) {
-    const attributes = {
-      ..._.pick(higherSchoolingRegistration, ATTRIBUTES_TO_SAVE),
-      status: higherSchoolingRegistration.studyScheme,
-    };
-
-    try {
-      await BookshelfSchoolingRegistration
-        .where({ id: higherSchoolingRegistration.id })
-        .save(attributes, { method: 'update', transacting: domainTransaction.knexTransaction });
-    } catch (error) {
-      throw new SchoolingRegistrationsCouldNotBeSavedError();
-    }
-  },
 
   async upsertStudents(higherSchoolingRegistrations) {
     const registrationsToInsert = higherSchoolingRegistrations.map((registration) => ({

--- a/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
@@ -1,7 +1,6 @@
-const { expect, databaseBuilder, knex, catchErr, domainBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, knex, domainBuilder } = require('../../../test-helper');
 const higherSchoolingRegistrationRepository = require('../../../../lib/infrastructure/repositories/higher-schooling-registration-repository');
 const SchoolingRegistration = require('../../../../lib/domain/models/SchoolingRegistration');
-const { SchoolingRegistrationsCouldNotBeSavedError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Infrastructure | Repository | higher-schooling-registration-repository', () => {
   describe('#findOneByStudentNumber', () => {
@@ -143,68 +142,6 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
       await higherSchoolingRegistrationRepository.updateStudentNumber(id, 54321);
       const [schoolingRegistration] = await knex.select('studentNumber').from('schooling-registrations').where({ id });
       expect(schoolingRegistration.studentNumber).to.equal('54321');
-    });
-  });
-
-  describe('#save', () => {
-    context('when there is a schooling registration for the given id', () => {
-      it('update the schooling-registration ', async () => {
-
-        const organization = databaseBuilder.factory.buildOrganization();
-        const user = databaseBuilder.factory.buildUser();
-        const registrationAttributes = {
-          firstName: 'O-Ren',
-          middleName: 'Unknown',
-          thirdName: 'Unknown',
-          lastName: 'Ishii',
-          preferredLastName: 'Cottonmouth',
-          studentNumber: '4',
-          email: 'ishii@example.net',
-          birthdate: '1990-07-01',
-          diploma: 'DUT',
-          department: 'The Crazy 88',
-          educationalTeam: 'Bill',
-          group: 'Tokyo Crime World',
-          studyScheme: 'I have always no idea what it\'s like.',
-        };
-
-        const higherSchoolingRegistration = domainBuilder.buildHigherSchoolingRegistration({ organization, ...registrationAttributes });
-        const higherSchoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: organization.id,
-          studentNumber: registrationAttributes.studentNumber,
-          userId: user.id,
-        }).id;
-        await databaseBuilder.commit();
-
-        higherSchoolingRegistration.id = higherSchoolingRegistrationId;
-        await higherSchoolingRegistrationRepository.save(higherSchoolingRegistration);
-
-        const [schoolingRegistration] = await knex('schooling-registrations').select('*', 'status AS studyScheme').where({ id: higherSchoolingRegistrationId });
-        expect(schoolingRegistration).to.include({ ...registrationAttributes, userId: user.id });
-      });
-    });
-
-    context('when there is no schooling registrations for the given id', () => {
-      it('throws an error', async () => {
-
-        const organization = databaseBuilder.factory.buildOrganization();
-        const registrationAttributes = {
-          organization,
-          firstName: 'O-Ren',
-          lastName: 'Ishii',
-          studentNumber: '1',
-          birthdate: '2000-01-01',
-        };
-
-        const higherSchoolingRegistration = domainBuilder.buildHigherSchoolingRegistration(registrationAttributes);
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: registrationAttributes.organizationId }).id;
-        databaseBuilder.factory.buildSchoolingRegistration({ studentNumber: registrationAttributes.studentNumber }).id;
-        await databaseBuilder.commit();
-
-        const error = await catchErr(higherSchoolingRegistrationRepository.save)(higherSchoolingRegistration);
-
-        expect(error).to.be.an.instanceOf(SchoolingRegistrationsCouldNotBeSavedError);
-      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Quand une schooling registration est désactivée, celle-ci n'est pas réactivée quand elle est ré-importée dans l'organisation.

## :robot: Solution

Au moment de l'import SUP et de la mise à jour des  schooling registrations mettre le champ `isDisabled` à `false`.

## :rainbow: Remarques

- La méthode `save` a été supprimée du repository `higher-schooling-registration-repository` car elle n'était jamais utilisée dans le reste de l'API

## :100: Pour tester

1. Importer des étudiants (SUP) dans Pix Orga
2. Les marquer comme avec `isDisabled=true` directement en base de données]
3. Rafraichir la page et voir que la liste est vide
4. Importer à nouveau le fichier, les étudiants sont alors visibles à nouveau dans la liste.
5. Rafraichir la page et voir la liste des étudiants avec les étudiants importés