### PR TITLE
[BUGFIX] Désactiver le bouton "Je me connecte" après avoir cliqué dessus durant la récupération compte SCO (PIX-2950).

### DIFF
--- a/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
@@ -42,14 +42,14 @@
       </label>
       <Input
         @type="checkbox"
-        @checked={{this.cguAndProctectionPoliciesAccepted}}
+        @checked={{this.cguAndProtectionPoliciesAccepted}}
         id="pix-cgu"
       />
     </div>
 
     <PixButton
         @type="submit"
-        @isDisabled={{not this.isFormValid}}
+        @isDisabled={{not this.isSubmitButtonEnabled}}
         class="account-recovery__content--actions update-sco-record-form__submit"
     >
       {{t 'pages.account-recovery.update-sco-record.form.login-button'}}

--- a/mon-pix/app/components/account-recovery/update-sco-record-form.js
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.js
@@ -26,9 +26,9 @@ export default class UpdateScoRecordFormComponent extends Component {
   @service intl;
   @service url;
 
-  @tracked passwordValidation = new PasswordValidation();
+  @tracked cguAndProtectionPoliciesAccepted = false;
   @tracked password = '';
-  @tracked cguAndProctectionPoliciesAccepted = false;
+  @tracked passwordValidation = new PasswordValidation();
 
   get cguUrl() {
     return this.url.cguUrl;
@@ -38,10 +38,11 @@ export default class UpdateScoRecordFormComponent extends Component {
     return this.url.dataProtectionPolicyUrl;
   }
 
-  get isFormValid() {
-    return !isEmpty(this.password)
-      && this.passwordValidation.status !== 'error'
-      && this.cguAndProctectionPoliciesAccepted;
+  get isSubmitButtonEnabled() {
+    return isPasswordValid(this.password)
+      && !this._hasAPIRejectedCall()
+      && this.cguAndProtectionPoliciesAccepted
+      && !this.args.isLoading;
   }
 
   @action validatePassword() {
@@ -68,6 +69,10 @@ export default class UpdateScoRecordFormComponent extends Component {
     this.passwordValidation.status = STATUS_MAP['successStatus'];
     this.passwordValidation.message = null;
     this.args.updateRecord(this.password);
+  }
+
+  _hasAPIRejectedCall() {
+    return this.passwordValidation.status === STATUS_MAP['errorStatus'];
   }
 
 }

--- a/mon-pix/app/controllers/account-recovery/update-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/update-sco-record.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class UpdateScoRecordController extends Controller {
+
   @service store;
   @service intl;
   @service router;
@@ -12,6 +13,8 @@ export default class UpdateScoRecordController extends Controller {
   @tracked showReturnToHomeButton = this.model.showReturnToHomeButton;
   @tracked showRenewLink = this.model.showRenewLink;
 
+  @tracked isLoading = false;
+
   @action
   async updateRecord(password) {
     const updateDemand = this.store.createRecord('account-recovery-demand', {
@@ -19,10 +22,13 @@ export default class UpdateScoRecordController extends Controller {
       password,
     });
     try {
+      this.isLoading = true;
       await updateDemand.update();
       this.router.transitionTo('login');
     } catch (err) {
       this._handleError(err);
+    } finally {
+      this.isLoading = false;
     }
   }
 
@@ -57,6 +63,5 @@ export default class UpdateScoRecordController extends Controller {
     this.errorMessage = errorMessage;
     this.showRenewLink = showRenewLink;
     this.showReturnToHomeButton = showReturnToHomeButton;
-
   }
 }

--- a/mon-pix/app/templates/account-recovery/update-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/update-sco-record.hbs
@@ -21,6 +21,7 @@
             @firstName={{@model.firstName}}
             @email={{@model.email}}
             @updateRecord={{this.updateRecord}}
+            @isLoading={{this.isLoading}}
           />
         {{/if}}
       </div>

--- a/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
@@ -65,6 +65,19 @@ describe('Integration | Component | account-recovery | update-sco-record', funct
       expect(submitButton.disabled).to.be.true;
     });
 
+    it('should disable submission on form when is loading', async function() {
+      // given
+      await render(hbs `<AccountRecovery::UpdateScoRecordForm @isLoading={{true}} />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), 'pix123A*');
+      await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+
+      // then
+      const submitButton = findByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
+      expect(submitButton.disabled).to.be.true;
+    });
+
     it('should enable submission if password is valid and cgu and data protection policy are accepted', async function() {
       // given
       await render(hbs `<AccountRecovery::UpdateScoRecordForm />`);
@@ -95,7 +108,6 @@ describe('Integration | Component | account-recovery | update-sco-record', funct
         // then
         expect(contains(this.intl.t('pages.account-recovery.update-sco-record.form.errors.invalid-password'))).to.not.exist;
       });
-
     });
 
     context('when the user enters an invalid password', function() {

--- a/mon-pix/tests/unit/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/unit/components/account-recovery/update-sco-record-form-test.js
@@ -7,16 +7,16 @@ describe('Unit | Component | account-recovery | update-sco-record-form', functio
 
   setupTest();
 
-  context('#isFormValid', function() {
+  context('#isSubmitButtonEnabled', function() {
 
     it('should return false if password is not valid and cgu are not accepted', function() {
       // given
       const component = createGlimmerComponent('component:account-recovery/update-sco-record-form');
       component.password = 'Pass';
-      component.cguAndProctectionPoliciesAccepted = false;
+      component.cguAndProtectionPoliciesAccepted = false;
 
       // when
-      const result = component.isFormValid;
+      const result = component.isSubmitButtonEnabled;
 
       // then
       expect(result).to.be.false;
@@ -26,10 +26,10 @@ describe('Unit | Component | account-recovery | update-sco-record-form', functio
       // given
       const component = createGlimmerComponent('component:account-recovery/update-sco-record-form');
       component.password = 'Password123';
-      component.cguAndProctectionPoliciesAccepted = false;
+      component.cguAndProtectionPoliciesAccepted = false;
 
       // when
-      const result = component.isFormValid;
+      const result = component.isSubmitButtonEnabled;
 
       // then
       expect(result).to.be.false;
@@ -39,10 +39,10 @@ describe('Unit | Component | account-recovery | update-sco-record-form', functio
       // given
       const component = createGlimmerComponent('component:account-recovery/update-sco-record-form');
       component.password = 'Password123';
-      component.cguAndProctectionPoliciesAccepted = true;
+      component.cguAndProtectionPoliciesAccepted = true;
 
       // when
-      const result = component.isFormValid;
+      const result = component.isSubmitButtonEnabled;
 
       // then
       expect(result).to.be.true;


### PR DESCRIPTION
## :unicorn: Problème
Dans la page de saisie du mot de passe, des clics multiples sur le bouton `Je me connecte` restent possible.

## :robot: Solution
Désactiver le bouton dès qu’on a cliqué dessus (seulement si le mot de passe est valide et que les CGU ont été acceptés).

## :100: Pour tester
Se rendre sur la page de récupération en [RA](https://app-pr3295.review.pix.fr/recuperer-mon-compte)

Saisir
- Ine/Ina : `123456789BB`
- Prénom : `George` 
- Nom : `De Cambridge`
- Date de naissance : `22/07/2013`

Aller jusqu'à la page où un mot de passe est demandé.

- Vérifiez que le bouton "Je me connecte" est désactivé tant qu'un mot de passe valide n'est pas renseignée, et que les CGU ne sont pas acceptés.
- Rentrez un mot de passe valide et acceptez les CGU (le bouton doit devenir actif)
- Avec l'inspecteur de votre navigateur, simulez une connexion lente
- Cliquez sur le bouton une fois
- Le bouton doit être désactivé
