### PR TITLE
[TECH] Permettre de pouvoir visualiser les résultats d'Algolix (PIX-2072). 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,10 @@ api/scripts/extractions
 
 # Visual regression snapshots
 high-level-tests/e2e/cypress/snapshots/actual/**
+
+# Jupyter Notebook
+**/.cache
+**/.config
+**/.ipython
+**/.ipynb_checkpoints
+**/.local

--- a/high-level-tests/test-algo/Dockerfile
+++ b/high-level-tests/test-algo/Dockerfile
@@ -1,0 +1,16 @@
+FROM jupyter/base-notebook
+
+USER $NB_UID
+RUN conda install --quiet --yes \
+      statsmodels \
+      numpy \
+      scipy \
+      ipykernel \
+      matplotlib \
+      seaborn \
+      pydot \
+      graphviz \
+      && \
+    conda clean -tipsy && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER

--- a/high-level-tests/test-algo/README.md
+++ b/high-level-tests/test-algo/README.md
@@ -43,3 +43,8 @@ docker compose up -d
 **2.** Rendez-vous sur l'url [localhost:8888](http://localhost:8888). 
 
 **3.** Choisissez le fichier `data_visualization.ipynb`
+
+## Conseil de versionnement des fichiers `.ipynb`
+
+Pour faciliter la lecture du diff, il est nécessaire de faire sur Jupyter Notebook  
+Cell > All Output > Clear avant de commiter.  

--- a/high-level-tests/test-algo/README.md
+++ b/high-level-tests/test-algo/README.md
@@ -32,3 +32,14 @@ Récupérer le prochain challenge sélectionné par l'algorithme
 npm start -- --competenceId #competenceId# [--locale fr]
 ```
 
+# Utiliser la data visualisation
+
+**1.** Lancer le container permettant d'avoir Jupyter Notebook. 
+
+```
+docker compose up -d
+```
+
+**2.** Rendez-vous sur l'url [localhost:8888](http://localhost:8888). 
+
+**3.** Choisissez le fichier `data_visualization.ipynb`

--- a/high-level-tests/test-algo/data_visualization.ipynb
+++ b/high-level-tests/test-algo/data_visualization.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2a2d9cc3",
+   "metadata": {},
+   "source": [
+    "# Algolix - Data Visualization\n",
+    "\n",
+    "Ce notebook a pour but de visualiser les données produites par Algolix, l'outil de test de notre algorithme adaptatif. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dad8dcd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bb1a323",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"20210806100759-results.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "933c0424",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "df.head"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b44c492a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "groups = df.groupby('id')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "823a417b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for id in groups.groups: \n",
+    "    df_temp = df[df['id'] == id]\n",
+    "    fig, ax = plt.subplots()\n",
+    "    ax.plot(df_temp['nChallenge'], df_temp['estimatedLevel'], label='estimatedLevel') \n",
+    "    ax.plot(df_temp['nChallenge'], df_temp['challengeLevel'], label='challengeLevel') \n",
+    "    ax.set_xlabel('numero challenge') \n",
+    "    ax.set_ylabel('niveau')\n",
+    "    ax.set_title(\"niveau estimé par rapport au niveau de la question\")\n",
+    "    ax.legend()  "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/high-level-tests/test-algo/docker-compose.yaml
+++ b/high-level-tests/test-algo/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  datascience-notebook:
+    build: .
+    volumes:
+      - ./:/home/jovyan
+    ports:
+      - 8888:8888
+    container_name: jupyter_notebook
+    command: "start-notebook.sh --ip='*' --NotebookApp.token='' --NotebookApp.password=''"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement Algolix permet de sortir des fichiers en .csv mais nous n'avons pas encore les moyens de visualiser les résultats obtenus.

## :robot: Solution
Permettre de visualiser les résultats d'Algolix en proposant un notebook dédié à cet effet. 
Pour cela il y a eu l'ajout : 
- Dockerfile a été ajouté permettant d'avoir Jupyter Notebook facilement avec les bonnes librairies de visualisation de données
- docker-compose pour lancer facilement le Dockerfile. 
- Notebook pour la visualisation des données

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Lancer dans un premier temps Algolix pour obtenir un fichier de résultat. 
2. Lancer la commande `docker compose up -d`
3. Se rendre sur [http://localhost:8888](http://localhost:8888)
4. Aller dans le fichier `data_visualization.ipnyb`
5. Remplacer le nom du fichier dans la 2ème cellule dans : `pd.read_csv("")`
6. Lancer toutes les cellules en faisant : Cell > Run All 