### PR TITLE
[BUGFIX] Corriger l'affichage de la date d'achèvement d'une certification dans Pix Admin (PIX-147).

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -62,7 +62,7 @@ export default class Certification extends Model {
 
   @computed('completedAt')
   get completionDate() {
-    return (new Date(this.completedAt)).toLocaleString('fr-FR');
+    return this.completedAt ? (new Date(this.completedAt)).toLocaleString('fr-FR') : null;
   }
 
   @computed('status')

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -31,7 +31,7 @@ export default class JuryCertificationSummary extends Model {
 
   @computed('completedAt')
   get completionDate() {
-    return (new Date(this.completedAt)).toLocaleString('fr-FR');
+    return this.completedAt ? (new Date(this.completedAt)).toLocaleString('fr-FR') : null;
   }
 
   get complementaryCertificationsLabel() {

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -259,4 +259,27 @@ module('Unit | Model | certification', function(hooks) {
       assert.false(certification.wasRegisteredBeforeCPF);
     });
   });
+
+  module('#get completionDate', function() {
+
+    test('it should return null if completedAt is null', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('certification', { completedAt: null });
+      });
+
+      // then
+      assert.equal(juryCertificationSummary.completionDate, null);
+    });
+
+    test('it should a formatted date when completedAt is defined', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('certification', { completedAt: '2021-06-30 15:10:45' });
+      });
+
+      // then
+      assert.equal(juryCertificationSummary.completionDate, '30/06/2021, 15:10:45');
+    });
+  });
 });

--- a/admin/tests/unit/models/jury-certification-summary_test.js
+++ b/admin/tests/unit/models/jury-certification-summary_test.js
@@ -314,4 +314,27 @@ module('Unit | Model | jury-certification-summary', function(hooks) {
       assert.false(isCertificationInError);
     });
   });
+
+  module('#get completionDate', function() {
+
+    test('it should return null if completedAt is null', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { completedAt: null });
+      });
+
+      // then
+      assert.equal(juryCertificationSummary.completionDate, null);
+    });
+
+    test('it should a formatted date when completedAt is defined', function(assert) {
+      // given
+      const juryCertificationSummary = run(() => {
+        return store.createRecord('jury-certification-summary', { completedAt: '2021-06-30 15:10:45' });
+      });
+
+      // then
+      assert.equal(juryCertificationSummary.completionDate, '30/06/2021, 15:10:45');
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une certification n'est pas terminée, sa date d'achèvement est `null`. Cependant, dans ce cas, la date `01/01/1970 01:00:00` est affichée dans le tableau listant les certifications d'une session et dans la page de détail d'une certification.

## :robot: Solution
Ne pas afficher la date plutôt qu'une date erronée lorsque cette dernière n'est pas définie.

## :100: Pour tester
- Créer une session de certification dans Pix Certif et démarrer une certification.
- Aller dans Pix Admin et vérifier qu'aucune date de fin n'est affichée dans le tableau listant les certifications d'une session ainsi que dans la page de détail de cette certification.