### PR TITLE
[BUGFIX] Connecter l'utilisateur à la fin du processus de récupération compte SCO (PIX-2954).

### DIFF
--- a/mon-pix/app/components/account-recovery/recovery-errors.hbs
+++ b/mon-pix/app/components/account-recovery/recovery-errors.hbs
@@ -21,7 +21,7 @@
     {{t 'pages.account-recovery.support.recover'}}
   </p>
 
-  {{#if @showReturnToHomeButton}}
+  {{#if @showBackToHomeButton}}
     <div class="account-recovery__content--actions">
       <LinkTo @route="login" class="button button--extra-big button--link">
         {{t 'navigation.back-to-homepage'}}

--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -20,7 +20,7 @@ export default class FindScoRecordController extends Controller {
   @tracked accountRecoveryError = {
     message: '',
     title: '',
-    showReturnToHomeButton: false,
+    showBackToHomeButton: false,
   };
 
   @tracked showStudentInformationForm = true;
@@ -131,19 +131,19 @@ export default class FindScoRecordController extends Controller {
       403: {
         message: this.intl.t('pages.account-recovery.errors.key-used'),
         title: this.intl.t('pages.account-recovery.errors.title'),
-        showReturnToHomeButton: true,
+        showBackToHomeButton: true,
       },
       409: {
         message: this.intl.t('pages.account-recovery.find-sco-record.conflict.warning'),
         title: this.intl.t('pages.account-recovery.find-sco-record.conflict.found-you-but', { firstName: this.studentInformationForAccountRecovery.firstName }),
-        showReturnToHomeButton: false,
+        showBackToHomeButton: false,
       },
     };
 
     const internalError = {
       message: this.intl.t('api-error-messages.internal-server-error'),
       title: this.intl.t('pages.account-recovery.errors.title'),
-      showReturnToHomeButton: true,
+      showBackToHomeButton: true,
     };
 
     this.showStudentInformationForm = false;

--- a/mon-pix/app/routes/account-recovery/update-sco-record.js
+++ b/mon-pix/app/routes/account-recovery/update-sco-record.js
@@ -5,8 +5,8 @@ import get from 'lodash/get';
 export default class UpdateScoRecordRoute extends Route {
 
   @service intl;
-  @service store;
   @service featureToggles;
+  @service store;
 
   beforeModel() {
     if (!this.featureToggles.featureToggles.isScoAccountRecoveryEnabled) {
@@ -29,19 +29,19 @@ export default class UpdateScoRecordRoute extends Route {
   _findErrorMessage(statusCode, code) {
     const invalidKey = {
       errorMessage: this.intl.t('pages.account-recovery.errors.key-invalid'),
-      showReturnToHomeButton: true,
+      showBackToHomeButton: true,
     };
 
     const internalError = {
       errorMessage: this.intl.t('api-error-messages.internal-server-error'),
-      showReturnToHomeButton: true,
+      showBackToHomeButton: true,
     };
 
     const httpStatusCodeMessages = {
       400: invalidKey,
       ACCOUNT_WITH_EMAIL_ALREADY_EXISTS: {
         errorMessage: this.intl.t('pages.account-recovery.errors.account-exists'),
-        showReturnToHomeButton: true,
+        showBackToHomeButton: true,
       },
       401: {
         errorMessage: this.intl.t('pages.account-recovery.errors.key-expired'),
@@ -49,7 +49,7 @@ export default class UpdateScoRecordRoute extends Route {
       },
       403: {
         errorMessage: this.intl.t('pages.account-recovery.errors.key-used'),
-        showReturnToHomeButton: true,
+        showBackToHomeButton: true,
       },
       404: invalidKey,
     };

--- a/mon-pix/app/templates/account-recovery/find-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/find-sco-record.hbs
@@ -19,7 +19,7 @@
         <AccountRecovery::RecoveryErrors
           @title={{this.accountRecoveryError.title}}
           @message={{this.accountRecoveryError.message}}
-          @showReturnToHomeButton={{this.accountRecoveryError.showReturnToHomeButton}}
+          @showBackToHomeButton={{this.accountRecoveryError.showBackToHomeButton}}
         />
       {{/if}}
 

--- a/mon-pix/app/templates/account-recovery/update-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/update-sco-record.hbs
@@ -14,7 +14,7 @@
             @title={{t 'pages.account-recovery.errors.title'}}
             @message={{this.errorMessage}}
             @showRenewLink={{this.showRenewLink}}
-            @showReturnToHomeButton={{this.showReturnToHomeButton}}
+            @showBackToHomeButton={{this.showBackToHomeButton}}
           />
         {{else}}
           <AccountRecovery::UpdateScoRecordForm

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
@@ -1,14 +1,16 @@
 import { describe } from 'mocha';
 import { expect } from 'chai';
+
 import { setupApplicationTest } from 'ember-mocha';
-import { setupMirage } from 'ember-cli-mirage/test-support';
-import visit from '../../helpers/visit';
 import { currentURL } from '@ember/test-helpers';
+import { Response } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+import visit from '../../helpers/visit';
 import setupIntl from '../../helpers/setup-intl';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { fillInByLabel } from '../../helpers/fill-in-by-label';
 import { contains } from '../../helpers/contains';
-import { Response } from 'ember-cli-mirage';
 
 describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
 
@@ -132,22 +134,26 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
 
     context('and user chooses a new password and accepts cgu and data protection policy', function() {
 
-      it('should redirect to login page after successful password change', async function() {
+      it('should redirect to homepage after successful password change', async function() {
         // given
         const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        const newPassword = 'Pix1234*';
+
+        const email = 'George@example.net';
+        const password = 'Password123';
+        server.create('user', { id: 2, email, password });
+
         server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
 
         await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
-        await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
+        await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), password);
         await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
         // when
         await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
         // then
-        expect(currentURL()).to.equal('/connexion');
+        expect(currentURL()).to.equal('/accueil');
       });
 
       it('should display an error message when account with email already exists', async function() {

--- a/mon-pix/tests/integration/components/account-recovery/recovery-errors-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/recovery-errors-test.js
@@ -6,6 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { contains } from '../../../helpers/contains';
 
 describe('Integration | Component | recovery-errors', function() {
+
   setupIntlRenderingTest();
 
   it('should render an account recovery error', async function() {
@@ -39,10 +40,10 @@ describe('Integration | Component | recovery-errors', function() {
 
   it('should display back to home link when asked for', async function() {
     // given;
-    this.set('showReturnToHomeButton', true);
+    this.set('showBackToHomeButton', true);
 
     // when
-    await render(hbs`<AccountRecovery::RecoveryErrors @showReturnToHomeButton={{this.showReturnToHomeButton}} />`);
+    await render(hbs`<AccountRecovery::RecoveryErrors @showBackToHomeButton={{this.showBackToHomeButton}} />`);
 
     // then
     expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;

--- a/mon-pix/tests/unit/controllers/account-recovery/update-sco-record-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery/update-sco-record-test.js
@@ -1,0 +1,105 @@
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+import { setupTest } from 'ember-mocha';
+
+import Service from '@ember/service';
+
+describe('Unit | Controller | account-recovery | update-sco-record', function() {
+
+  setupTest();
+
+  describe('#updateRecord', () => {
+
+    context('when user is already authenticated', function() {
+
+      it('should update account-recovery-demand, invalidate the session and authenticate user', async function() {
+        // given
+        const email = 'user@example.net';
+        const password = 'Password123';
+        const scope = 'mon-pix';
+        const temporaryKey = 'temporaryKey';
+
+        const updateDemand = {
+          update: sinon.stub().resolves(),
+        };
+
+        const storeStub = {
+          createRecord: sinon.stub(),
+        };
+        storeStub.createRecord.withArgs(
+          'account-recovery-demand',
+          { temporaryKey, password },
+        ).returns(updateDemand);
+
+        const sessionStub = Service.create({
+          authenticate: sinon.stub(),
+          invalidate: sinon.stub().resolves(),
+          isAuthenticated: true,
+        });
+
+        const controller = this.owner.lookup('controller:account-recovery/update-sco-record');
+        controller.model = { email, temporaryKey };
+        controller.session = sessionStub;
+        controller.store = storeStub;
+
+        // when
+        await controller.updateRecord(password);
+
+        // then
+        sinon.assert.called(updateDemand.update);
+        sinon.assert.called(controller.session.invalidate);
+        sinon.assert.calledWith(controller.session.authenticate, 'authenticator:oauth2', {
+          login: email,
+          password,
+          scope,
+        });
+      });
+    });
+
+    context('when user is not already authenticated', function() {
+
+      it('should update account-recovery-demand and authenticate user', async function() {
+        // given
+        const email = 'user@example.net';
+        const password = 'Password123';
+        const scope = 'mon-pix';
+        const temporaryKey = 'temporaryKey';
+
+        const updateDemand = {
+          update: sinon.stub().resolves(),
+        };
+
+        const storeStub = {
+          createRecord: sinon.stub(),
+        };
+        storeStub.createRecord.withArgs(
+          'account-recovery-demand',
+          { temporaryKey, password },
+        ).returns(updateDemand);
+
+        const sessionStub = Service.create({
+          authenticate: sinon.stub(),
+          invalidate: sinon.stub(),
+          isAuthenticated: false,
+        });
+
+        const controller = this.owner.lookup('controller:account-recovery/update-sco-record');
+        controller.model = { email, temporaryKey };
+        controller.session = sessionStub;
+        controller.store = storeStub;
+
+        // when
+        await controller.updateRecord(password);
+
+        // then
+        sinon.assert.called(updateDemand.update);
+        sinon.assert.notCalled(controller.session.invalidate);
+        sinon.assert.calledWith(controller.session.authenticate, 'authenticator:oauth2', {
+          login: email,
+          password,
+          scope,
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/account-recovery/update-sco-record-test.js
+++ b/mon-pix/tests/unit/routes/account-recovery/update-sco-record-test.js
@@ -1,12 +1,12 @@
-import Service from '@ember/service';
-import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import Service from '@ember/service';
 import { setupTest } from 'ember-mocha';
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
-import sinon from 'sinon';
-
-describe('Unit | Route | account-recovery | update-sco-record', function() {
+describe('Unit | Route | account-recovery | update sco record', function() {
 
   setupTest();
   setupIntl();
@@ -97,7 +97,7 @@ describe('Unit | Route | account-recovery | update-sco-record', function() {
           // then
           return promise.then((result) => {
             expect(result.errorMessage).to.equal(this.intl.t('pages.account-recovery.errors.key-invalid'));
-            expect(result.showReturnToHomeButton).to.be.true;
+            expect(result.showBackToHomeButton).to.be.true;
           });
         });
       });
@@ -132,7 +132,7 @@ describe('Unit | Route | account-recovery | update-sco-record', function() {
         // then
         return promise.then((result) => {
           expect(result.errorMessage).to.equal(this.intl.t('pages.account-recovery.errors.account-exists'));
-          expect(result.showReturnToHomeButton).to.be.true;
+          expect(result.showBackToHomeButton).to.be.true;
         });
       });
 
@@ -149,7 +149,7 @@ describe('Unit | Route | account-recovery | update-sco-record', function() {
         // then
         return promise.then((result) => {
           expect(result.errorMessage).to.equal(this.intl.t('pages.account-recovery.errors.key-used'));
-          expect(result.showReturnToHomeButton).to.be.true;
+          expect(result.showBackToHomeButton).to.be.true;
         });
       });
 
@@ -167,12 +167,10 @@ describe('Unit | Route | account-recovery | update-sco-record', function() {
           // then
           return promise.then((result) => {
             expect(result.errorMessage).to.equal(this.intl.t('api-error-messages.internal-server-error'));
-            expect(result.showReturnToHomeButton).to.be.true;
+            expect(result.showBackToHomeButton).to.be.true;
           });
         });
       });
-
     });
   });
-
 });


### PR DESCRIPTION
## :unicorn: Problème
A la fin du processus de récupération compte SCO, l'utilisateur est redirigé vers la page de login.
Or il devrait être connecté et être sur la page d'accueil.

## :robot: Solution
Connecter l'utilisateur à la fin du processus

## :rainbow: Remarques
Si l'utilisateur est déjà connecté avant de commencer le processus, il sera deconnecté avant l'ultime étape du processus.

## :100: Pour tester
1. Se rendre sur la page de récupération en [RA](https://app-pr3302.review.pix.fr/recuperer-mon-compte)
* Saisir
  * Ine/Ina : `123456789BB`
  * Prénom : `George` 
  * Nom : `De Cambridge`
  * Date de naissance : `22/07/2013`
* Aller jusqu'au bout du processus.
* Vérifiez que vous êtes bien sur la page d'accueil

2. Se rendre sur la page de connexion en [RA](https://app-pr3302.review.pix.fr/connexion)
* Connectez-vous avec par exemple `userpix1@example.net / pix123`
* Sans vous déconnecter refaites l'étape 1
* Vérifiez qu'à la fin du processus vous êtes bien connecté avec le compte de `George`
