### PR TITLE
[FEATURE] Brancher le bouton de téléchargement des attestations de certification sur Pix Orga (PIX-2941)

### DIFF
--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -50,6 +50,37 @@ export default class AuthenticatedCertificationsController extends Controller {
     }
   }
 
+  @action
+  async downloadAttestation() {
+
+    try {
+      if (_isDivisionInvalid(this.selectedDivision, this.model.options)) {
+        throw new Error(this.intl.t('pages.certifications.errors.invalid-division', { selectedDivision: this.selectedDivision }));
+      }
+
+      const organizationId = this.currentUser.organization.id;
+      const url = `/api/organizations/${organizationId}/certification-attestations?division=${this.selectedDivision}`;
+      const fileName = 'attestations_pix.pdf';
+
+      let token = '';
+
+      if (this.session.isAuthenticated) {
+        token = this.session.data.authenticated.access_token;
+      }
+
+      await this.fileSaver.save({ url, fileName, token });
+    } catch (error) {
+      if (_isErrorNotFound(error)) {
+        this.notifications.info(
+          this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
+          { autoClear: false },
+        );
+      } else {
+        this.notifications.error(error.message, { autoClear: false });
+      }
+    }
+  }
+
   get firstTwoDivisions() {
     if (this.model.options.length < 2) {
       return '';

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -75,6 +75,12 @@ export default class AuthenticatedCertificationsController extends Controller {
           this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
           { autoClear: false },
         );
+      }
+      if (_isErrorNoResults(error)) {
+        this.notifications.info(
+          this.intl.t('pages.certifications.errors.no-certificates', { selectedDivision: this.selectedDivision }),
+          { autoClear: false },
+        );
       } else {
         this.notifications.error(error.message, { autoClear: false });
       }
@@ -102,4 +108,8 @@ function _isDivisionInvalid(selectedDivision, divisions) {
 
 function _isErrorNotFound(error) {
   return error[0] && error[0].status == 404;
+}
+
+function _isErrorNoResults(error) {
+  return error[0] && error[0].status == 400;
 }

--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -45,6 +45,7 @@
       line-height: inherit;
       padding: 8px 20px;
       margin-bottom: 6px;
+      margin-left: 8px;
     }
 
   }

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -21,7 +21,7 @@
       {{t 'pages.certifications.download-button'}}
     </button>
     {{#if this.isCertificationAttestationDownloadEnabled}}
-      <button class="button" type="submit" id="download_attestations">
+      <button class="button" type="button" id="download_attestations" {{on "click" (fn this.downloadAttestation)}}>
         {{t 'pages.certifications.download-attestations-button'}}
       </button>
     {{/if}}

--- a/orga/tests/acceptance/certifications_test.js
+++ b/orga/tests/acceptance/certifications_test.js
@@ -24,7 +24,7 @@ module('Acceptance | Certifications page', function(hooks) {
       await visit('/certifications');
 
       // then
-      assert.dom('.certifications-page__text').containsText('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv. Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.');
+      assert.dom('.certifications-page__text').containsText('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification (.csv) ou télécharger les attestations (.pdf). Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.');
       assert.contains('Exporter les résultats');
       assert.contains('Certifications');
       assert.contains('Classe');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -423,7 +423,7 @@
     },
     "certifications": {
       "title": "Certification results",
-      "description": "Please select the class for which you would like to export the certification results in a csv file.",
+      "description": "Please select the class for which you would like to export the certification results (.csv) or download certificates (.pdf).",
       "documentation-link": "https://cloud.pix.fr/s/cRaeKT4ErrXs4X8",
       "documentation-link-label": "Interpreting the results.",
       "documentation-link-notice": "Follow this link to find indications on how to interpret the results: ",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -432,7 +432,8 @@
 
       "errors": {
         "invalid-division": "The class {selectedDivision} does not exist.",
-        "no-results": "No certification results for the class {selectedDivision}."
+        "no-results": "No certification results for the class {selectedDivision}.",
+        "no-certificates": "No certificates for the class {selectedDivision}."
       },
       "select-label": "Class"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -423,7 +423,7 @@
     },
     "certifications": {
       "title": "Résultats de certification",
-      "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.<br> Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.",
+      "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification (.csv) ou télécharger les attestations (.pdf).<br> Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.",
       "documentation-link": "https://cloud.pix.fr/s/cRaeKT4ErrXs4X8",
       "documentation-link-label": "Interprétation des résultats.",
       "documentation-link-notice": "Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats : ",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -431,7 +431,8 @@
       "download-attestations-button": "Télécharger les attestations",
       "errors": {
         "invalid-division": "La classe {selectedDivision} n'existe pas.",
-        "no-results": "Aucun résultat de certification pour la classe {selectedDivision}."
+        "no-results": "Aucun résultat de certification pour la classe {selectedDivision}.",
+        "no-certificates": "Aucune attestation de certification pour la classe {selectedDivision}."
       },
       "select-label": "Classe"
     },


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix de téléchargement des attestations en masse, on souhaite brancher le bouton de téléchargement des attestations par organisation & classe.

## :robot: Solution
Appeler la route en passant les paramètres nécessaires lors du clic sur Télécharger les attestations

## :100: Pour tester
 - Se connecter à Pix Orga en tant que membre d'une organisation SCO isManagingStudent.
 - Se rendre sur la page de certifications.
 - Sélectionner une classe puis cliquer sur "Télécharger les attestations".