### PR TITLE
[FEATURE] Permettre de remplacer tous les étudiants inscrits pour une organisation SUP (PIX-2948).

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -358,6 +358,35 @@ exports.register = async (server) => {
     },
     {
       method: 'POST',
+      path: '/api/organizations/{id}/schooling-registrations/replace-csv',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents,
+          assign: 'isAdminInOrganizationManagingStudents',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
+        payload: {
+          maxBytes: 1048576 * 10, // 10MB
+          parse: 'gunzip',
+          failAction: (request, h) => {
+            return sendJsonApiError(new PayloadTooLargeError('An error occurred, payload is too large', ERRORS.PAYLOAD_TOO_LARGE, { maxSize: '10' }), h);
+          },
+        },
+        handler: organizationController.replaceHigherSchoolingRegistrations,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés et responsables de l\'organisation**\n' +
+          '- Elle désactive les inscriptions existantes et importe de nouvelles inscriptions d\'étudiants, en masse, depuis un fichier au format csv\n' +
+          '- Elle ne retourne aucune valeur de retour',
+        ],
+        tags: ['api', 'schooling-registrations'],
+      },
+    },
+    {
+      method: 'POST',
       path: '/api/organizations/{id}/invitations',
       config: {
         pre: [{

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -167,6 +167,15 @@ module.exports = {
     return h.response(response).code(200);
   },
 
+  async replaceHigherSchoolingRegistrations(request, h) {
+    const organizationId = request.params.id;
+    const buffer = request.payload;
+    const higherSchoolingRegistrationParser = new HigherSchoolingRegistrationParser(buffer, organizationId, request.i18n);
+    const warnings = await usecases.replaceHigherSchoolingRegistrations({ organizationId, higherSchoolingRegistrationParser });
+    const response = higherSchoolingRegistrationWarningSerializer.serialize({ id: organizationId, warnings });
+    return h.response(response).code(200);
+  },
+
   async sendInvitations(request, h) {
     const organizationId = request.params.id;
     const emails = request.payload.data.attributes.email.split(',');

--- a/api/lib/domain/usecases/import-higher-schooling-registrations.js
+++ b/api/lib/domain/usecases/import-higher-schooling-registrations.js
@@ -4,7 +4,7 @@ module.exports = async function importHigherSchoolingRegistration({
 }) {
   const { registrations, warnings } = higherSchoolingRegistrationParser.parse();
 
-  await higherSchoolingRegistrationRepository.upsertStudents(registrations);
+  await higherSchoolingRegistrationRepository.addStudents(registrations);
 
   return warnings;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -288,6 +288,7 @@ module.exports = injectDependencies({
   rememberUserHasSeenChallengeTooltip: require('./remember-user-has-seen-challenge-tooltip'),
   rememberUserHasSeenNewDashboardInfo: require('./remember-user-has-seen-new-dashboard-info'),
   removeAuthenticationMethod: require('./remove-authentication-method'),
+  replaceHigherSchoolingRegistrations: require('./replace-higher-schooling-registrations'),
   resetScorecard: require('./reset-scorecard'),
   retrieveLastOrCreateCertificationCourse: require('./retrieve-last-or-create-certification-course'),
   saveCertificationCenter: require('./save-certification-center'),

--- a/api/lib/domain/usecases/replace-higher-schooling-registrations.js
+++ b/api/lib/domain/usecases/replace-higher-schooling-registrations.js
@@ -1,0 +1,11 @@
+module.exports = async function replaceHigherSchoolingRegistrations({
+  organizationId,
+  higherSchoolingRegistrationRepository,
+  higherSchoolingRegistrationParser,
+}) {
+  const { registrations, warnings } = higherSchoolingRegistrationParser.parse();
+
+  await higherSchoolingRegistrationRepository.replaceStudents(organizationId, registrations);
+
+  return warnings;
+};

--- a/api/tests/acceptance/application/organizations/organization-controller-replace-higher-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-replace-higher-schooling-registrations_test.js
@@ -1,0 +1,85 @@
+const { expect, knex, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const Membership = require('../../../../lib/domain/models/Membership');
+const HigherSchoolingRegistrationColumns = require('../../../../lib/infrastructure/serializers/csv/higher-schooling-registration-columns');
+
+const { getI18n } = require('../../../../tests/tooling/i18n/i18n');
+const createServer = require('../../../../server');
+
+const i18n = getI18n();
+const higherSchoolingRegistrationColumns = new HigherSchoolingRegistrationColumns(i18n).columns.map((column) => column.label).join(';');
+
+let server;
+
+describe('Acceptance | Application | organization-controller-replace-higher-schooling-registrations', () => {
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  afterEach(() => {
+    return knex('schooling-registrations').delete();
+  });
+
+  describe('POST organizations/:id/schooling-registrations/replace-csv', () => {
+    let connectedUser;
+    beforeEach(async () => {
+      connectedUser = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+    });
+
+    context('when the user is an admin for an organization which managing student', () => {
+      it('replaces the schooling-registrations for the given organization', async () => {
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
+        databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: connectedUser.id, organizationRole: Membership.roles.ADMIN });
+        databaseBuilder.factory.buildSchoolingRegistration({ id: 1, organizationId: organization.id, isDisabled: false });
+        await databaseBuilder.commit();
+        const buffer =
+          `${higherSchoolingRegistrationColumns}\n` +
+          'Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1990;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend\n';
+        const options = {
+          method: 'POST',
+          url: `/api/organizations/${organization.id}/schooling-registrations/replace-csv`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(connectedUser.id),
+          },
+          payload: buffer,
+        };
+
+        const response = await server.inject(options);
+        const registrations = await knex('schooling-registrations').where({ organizationId: organization.id });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result).to.deep.equal({
+          data: {
+            id: String(organization.id),
+            type: 'higher-schooling-registration-warnings',
+            attributes: {
+              warnings: [
+                { code: 'unknown', field: 'study-scheme', studentNumber: '12346', value: 'hello darkness my old friend' },
+                { code: 'unknown', field: 'diploma', studentNumber: '12346', value: 'Master' },
+              ],
+            },
+          },
+        });
+        expect(registrations).to.have.lengthOf(2);
+      });
+
+      it('fails when the file payload is too large', async () => {
+        const buffer = Buffer.alloc(1048576 * 11, 'B'); // > 10 Mo buffer
+
+        const options = {
+          method: 'POST',
+          url: '/api/organizations/123/schooling-registrations/replace-csv',
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(connectedUser.id),
+          },
+          payload: buffer,
+        };
+
+        const response = await server.inject(options);
+        expect(response.statusCode).to.equal(413);
+        expect(response.result.errors[0].code).to.equal('PAYLOAD_TOO_LARGE');
+        expect(response.result.errors[0].meta.maxSize).to.equal('10');
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -363,6 +363,53 @@ describe('Unit | Router | organization-router', () => {
     });
   });
 
+  describe('POST /api/organizations/{id}/schooling-registrations/replace-csv', () => {
+
+    context('when the user is an admin for the organization and the organization is SUP and manages student', () => {
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('responds 200', async () => {
+        sinon.stub(organizationController, 'replaceHigherSchoolingRegistrations');
+        sinon.stub(securityPreHandlers, 'checkUserIsAdminInSUPOrganizationManagingStudents');
+        organizationController.replaceHigherSchoolingRegistrations.resolves('ok');
+        securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.resolves(true);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'POST';
+        const url = '/api/organizations/1/schooling-registrations/replace-csv';
+
+        const response = await httpTestServer.request(method, url);
+
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    context('when the user is not admin for the organization', () => {
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('responds 403', async () => {
+        sinon.stub(organizationController, 'replaceHigherSchoolingRegistrations');
+        sinon.stub(securityPreHandlers, 'checkUserIsAdminInSUPOrganizationManagingStudents');
+        organizationController.replaceHigherSchoolingRegistrations.resolves('ok');
+        securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'POST';
+        const url = '/api/organizations/1/schooling-registrations/replace-csv';
+
+        const response = await httpTestServer.request(method, url);
+
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+
   describe('GET /api/organizations/{id}/schooling-registrations/csv-template', () => {
 
     it('should call the organization controller to csv template', async () => {

--- a/api/tests/unit/domain/usecases/replace-higher-schooling-registrations_test.js
+++ b/api/tests/unit/domain/usecases/replace-higher-schooling-registrations_test.js
@@ -1,0 +1,45 @@
+const { expect, sinon } = require('../../../test-helper');
+
+const replaceHigherSchoolingRegistrations = require('../../../../lib/domain/usecases/replace-higher-schooling-registrations');
+
+describe('Unit | UseCase | ImportHigherSchoolingRegistration', () => {
+  it('parses the csv received and replace the HigherSchoolingRegistration', async () => {
+    const organizationId = 1;
+    const registrations = Symbol('registrations');
+    const warnings = Symbol('warnings');
+    const higherSchoolingRegistrationParser = {
+      parse: sinon.stub().returns({ registrations, warnings }),
+    };
+    const higherSchoolingRegistrationRepository = {
+      replaceStudents: sinon.stub(),
+    };
+
+    await replaceHigherSchoolingRegistrations({
+      organizationId,
+      higherSchoolingRegistrationParser,
+      higherSchoolingRegistrationRepository,
+    });
+
+    expect(higherSchoolingRegistrationRepository.replaceStudents).to.have.been.calledWith(organizationId, registrations);
+  });
+
+  it('should return warnings about the import', async () => {
+    const organizationId = 1;
+    const registrations = Symbol('registrations');
+    const expectedWarnings = Symbol('warnings');
+    const higherSchoolingRegistrationParser = {
+      parse: sinon.stub().returns({ registrations, warnings: expectedWarnings }),
+    };
+    const higherSchoolingRegistrationRepository = {
+      replaceStudents: sinon.stub(),
+    };
+
+    const warnings = await replaceHigherSchoolingRegistrations({
+      organizationId,
+      higherSchoolingRegistrationParser,
+      higherSchoolingRegistrationRepository,
+    });
+
+    expect(warnings).to.equal(expectedWarnings);
+  });
+});

--- a/orga/app/components/student/sup/import-cards/add.hbs
+++ b/orga/app/components/student/sup/import-cards/add.hbs
@@ -1,0 +1,7 @@
+<section class="import-students-page__section">
+  <h2 class="import-students-page-section__title">{{t 'pages.students-sup-import.actions.add.title'}}</h2>
+  <p class="import-students-page-section__details">{{t 'pages.students-sup-import.actions.add.details'}}</p>
+  <FileUpload class="import-students-page-section__action" @name="file-upload-add" @for="students-file-upload-add" @accept=".csv" @multiple={{false}} @onfileadd={{@onAddStudents}}>
+    <span class="button button--thin" role="button" tabindex="0">{{t 'pages.students-sup-import.actions.add.label'}}</span>
+  </FileUpload>
+</section>

--- a/orga/app/components/student/sup/import-cards/replace.hbs
+++ b/orga/app/components/student/sup/import-cards/replace.hbs
@@ -1,0 +1,7 @@
+<section class="import-students-page__section">
+  <h2 class="import-students-page-section__title">{{t 'pages.students-sup-import.actions.replace.title'}}</h2>
+  <p class="import-students-page-section__details">{{t 'pages.students-sup-import.actions.replace.details'}}</p>
+  <FileUpload class="import-students-page-section__action" @name="file-upload-replace" @for="students-file-upload-replace" @accept=".csv" @multiple={{false}} @onfileadd={{@onReplaceStudents}}>
+    <span class="button button--thin" role="button" tabindex="0">{{t 'pages.students-sup-import.actions.replace.label'}}</span>
+  </FileUpload>
+</section>

--- a/orga/app/components/student/sup/import.hbs
+++ b/orga/app/components/student/sup/import.hbs
@@ -3,19 +3,21 @@
   <header class="import-students-page__header">
     <img src="{{this.rootURL}}/images/import-participant.svg" alt="" role="none">
     <h1 class="page-title import-students-page-header__title">{{t 'pages.students-sup-import.title'}}</h1>
-    <p class="import-students-page-header__details">{{t 'pages.students-sup-import.supported-formats'}}</p>
+    <p class="import-students-page-header__details">
+      {{t 'pages.students-sup-import.description'}}
+    </p>
+    <p class="import-students-page-header__details import-students-page-header__details--small">
+      {{t 'pages.students-sup-import.supported-formats'}}
+    </p>
   </header>
 
   {{#if @isLoading}}
     <Ui::PixLoader />
   {{else}}
-    <section class="import-students-page__section">
-      <h2 class="import-students-page-section__title">{{t 'pages.students-sup-import.actions.add.title'}}</h2>
-      <p class="import-students-page-section__details">{{t 'pages.students-sup-import.actions.add.details'}}</p>
-      <FileUpload class="import-students-page-section__action" @name="file-upload" @for="students-file-upload" @accept=".csv" @multiple={{false}} @onfileadd={{@onImportStudents}}>
-        <span class="button button--thin" role="button" tabindex="0">{{t 'pages.students-sup-import.actions.add.label'}}</span>
-      </FileUpload>
-    </section>
+    <div class="import-type-list">
+      <Student::Sup::ImportCards::Add @onAddStudents={{@onImportStudents}} />
+      <Student::Sup::ImportCards::Replace @onReplaceStudents={{@onReplaceStudents}} />
+    </div>
   {{/if}}
 
 </article>

--- a/orga/app/controllers/authenticated/sup-students/import.js
+++ b/orga/app/controllers/authenticated/sup-students/import.js
@@ -19,23 +19,34 @@ export default class ImportController extends Controller {
 
   @action
   async importStudents(file) {
+    const url = `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/import-csv`;
+    await this._uploadFile(url, file);
+  }
+
+  @action
+  async replaceStudents(file) {
+    const url = `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/replace-csv`;
+    await this._uploadFile(url, file);
+  }
+
+  async _uploadFile(url, file) {
     this.isLoading = true;
     this.notifications.clearAll();
     const { access_token } = this.session.data.authenticated;
 
     try {
-      const response = await file.uploadBinary(`${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/import-csv`, {
+      const response = await file.uploadBinary(url, {
         headers: {
           Authorization: `Bearer ${access_token}`,
           'Accept-Language': this.currentUser.prescriber.lang,
         },
       });
-      this.isLoading = false;
       this._sendNotifications(response);
       this.transitionToRoute('authenticated.sup-students.list');
     } catch (errorResponse) {
+      this._sendErrorNotifications(errorResponse);
+    } finally {
       this.isLoading = false;
-      return this._sendErrorNotifications(errorResponse);
     }
   }
 

--- a/orga/app/styles/pages/authenticated/students/import.scss
+++ b/orga/app/styles/pages/authenticated/students/import.scss
@@ -14,11 +14,14 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: space-between;
     max-width: 350px;
+    height: 230px;
     border-radius: 8px;
     box-shadow: 0 2px 5px 0 rgba($black, 0.05);
     background-color: $white;
     padding: 16px;
+    margin: 16px 16px 0 16px;
   }
 }
 
@@ -33,6 +36,10 @@
     font-size: 1rem;
     font-weight: 300;
     margin: 8px;
+
+    &--small {
+      font-size: 0.875rem;
+    }
   }
 }
 
@@ -58,4 +65,10 @@
   &__action {
     margin: 8px;
   }
+}
+
+.import-type-list {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }

--- a/orga/app/templates/authenticated/sup-students/import.hbs
+++ b/orga/app/templates/authenticated/sup-students/import.hbs
@@ -4,4 +4,4 @@
   {{t 'common.actions.back'}}
 </PixReturnTo>
 
-<Student::Sup::Import @onImportStudents={{this.importStudents}} @isLoading={{this.isLoading}}/>
+<Student::Sup::Import @onImportStudents={{this.importStudents}} @onReplaceStudents={{this.replaceStudents}} @isLoading={{this.isLoading}}/>

--- a/orga/tests/acceptance/sup-student-import_test.js
+++ b/orga/tests/acceptance/sup-student-import_test.js
@@ -37,7 +37,7 @@ module('Acceptance | Sup Student Import', function(hooks) {
         const file = new Blob(['foo'], { type: 'valid-file' });
 
         // when
-        const input = find('#students-file-upload');
+        const input = find('#students-file-upload-add');
         await triggerEvent(input, 'change', { files: [file] });
 
         // then
@@ -54,7 +54,7 @@ module('Acceptance | Sup Student Import', function(hooks) {
         const file = new Blob(['foo'], { type: 'valid-file-with-warnings' });
 
         // when
-        const input = find('#students-file-upload');
+        const input = find('#students-file-upload-add');
         await triggerEvent(input, 'change', { files: [file] });
 
         // then
@@ -71,7 +71,7 @@ module('Acceptance | Sup Student Import', function(hooks) {
         const file = new Blob(['foo'], { type: 'invalid-file' });
 
         // when
-        const input = find('#students-file-upload');
+        const input = find('#students-file-upload-add');
         await triggerEvent(input, 'change', { files: [file] });
 
         // then

--- a/orga/tests/unit/controllers/authenticated/sup-students/import_test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-students/import_test.js
@@ -84,4 +84,72 @@ module('Unit | Controller | authenticated/sup-students/import', function(hooks) 
       });
     });
   });
+
+  module('#replaceStudents', function() {
+    test('it sends the chosen file to the API for replacing registrations', async function(assert) {
+      const replaceStudentsURL = `${ENV.APP.API_HOST}/api/organizations/${currentUser.organization.id}/schooling-registrations/replace-csv`;
+      const headers = { Authorization: `Bearer ${12345}`, 'Accept-Language': controller.currentUser.prescriber.lang };
+      const file = { uploadBinary: sinon.spy() };
+
+      controller.session = session;
+      controller.currentUser = currentUser;
+      await controller.replaceStudents(file);
+
+      assert.ok(file.uploadBinary.calledWith(replaceStudentsURL, { headers }));
+    });
+
+    module('manage CSV import errors', function(hooks) {
+      let file;
+
+      hooks.beforeEach(function() {
+        controller.session = session;
+        controller.currentUser = currentUser;
+        file = { uploadBinary: sinon.stub() };
+        controller.notifications.sendError = sinon.spy();
+      });
+
+      test('notify a global error message if error not handled when replacing registrations', async function(assert) {
+        file.uploadBinary.rejects({
+          body: { errors: [{ status: '401' }] },
+        });
+
+        // when
+        await controller.replaceStudents(file);
+
+        // then
+        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        assert.equal(notificationMessage, '<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a></div>');
+      });
+
+      test('notify a detailed error message if 412 error when replacing registrations', async function(assert) {
+        file.uploadBinary.rejects({
+          body: { errors: [
+            { status: '412', detail: 'Error message' },
+          ] },
+        });
+
+        // when
+        await controller.replaceStudents(file);
+
+        // then
+        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        assert.equal(notificationMessage, '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>');
+      });
+
+      test('notify a detailed error message if 413 error when replacing registrations when replacing registrations', async function(assert) {
+        file.uploadBinary.rejects({
+          body: { errors: [
+            { status: '413', detail: 'Error message' },
+          ] },
+        });
+
+        // when
+        await controller.replaceStudents(file);
+
+        // then
+        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        assert.equal(notificationMessage, '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>');
+      });
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -670,18 +670,24 @@
     },
     "students-sup-import": {
       "title": "Import students",
+      "description": "What type of import would you like to use?",
       "actions": {
         "add": {
-          "title": "Add/update",
-          "details": "Add a list of students to the one already imported and/or update students information already imported.",
+          "title": "Add / Edit",
+          "details": "Add a list of students to the one already imported and/or edit the information of students already imported.",
           "label": "Add students"
+        },
+        "replace": {
+          "title": "Overwrite",
+          "details": "Import a new list of students in replacement of the existing one.",
+          "label": "Overwrite list"
         }
       },
       "error-wrapper": "<div>Import has failed.<br/><strong>{message}</strong><br/> Please edit your file and try to import it again.</div>",
       "global-error": "<div>Import has failed.<br/>Please try again or contact us through <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">the help form</a></div>",
       "global-success": "The list has been successfully imported.",
       "global-success-with-warnings": "<div>The list has been successfully imported.<br/><br/>However some values were not recognised:<br/>{warnings}<br/><br/>They have been replaced by \"Not recognised\". If you need other values, please contact us at <a href=\"mailto:sup@pix.fr\">sup@pix.fr</a></div>",
-      "supported-formats": "(Supported formats: csv)",
+      "supported-formats": "(Supported format: csv)",
       "warnings": {
         "diploma": "Diplomas unknown: {diplomas}; ",
         "study-scheme": "Study schemes unknown: {studySchemes}; "

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -668,12 +668,18 @@
       }
     },
     "students-sup-import": {
+      "description": "Quel type d'import souhaitez-vous réaliser ?",
       "title": "Importer des étudiants",
       "actions": {
         "add": {
-          "title": "Ajouter/modifier",
+          "title": "Ajouter / modifier",
           "details": "Permet d’ajouter une liste d'étudiants à celle déjà importée et/ou modifier les informations des étudiants déjà importés.",
           "label": "Ajouter des étudiants"
+        },
+        "replace": {
+          "title": "Remplacer",
+          "details": "Permet d’importer une nouvelle liste d'étudiants à la place de l’existante.",
+          "label": "Importer une nouvelle liste"
         }
       },
       "error-wrapper": "<div>Aucun étudiant n’a été importé.<br/><strong>{message}</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>",


### PR DESCRIPTION
## :unicorn: Problème
Les organisation SUP ne peuvent pas bloqué l'accès à leur campagnes pour les élèves ayant quitté l'établissement.
 

## :robot: Solution
Ajouter un nouveaux type d'import qui va donner à accès à tous les élèves présent dans le fichier importé et supprimer l'accès aux campagnes à tous les élèves absent du fichier, mais qui ont une schooling-registration.

## :rainbow: Remarques
Pour faire la désactivation il n'y a pas de logique dans le domaine donc je suis un peu perplexe et je ne sais pas comment sortir l'intelligence du `repository`.

J'ai choisi de faire une seule méthode de `repository` pour pouvoir cacher la notion de transaction dans le repository.

On à un wording général pour l'import SUP, c'est un peu dommage, parce que la fonctionnalité et les vue sont spécifique au SUP.

## :100: Pour tester
- Se connecter à PixOrga en tant que sup.admin@example.net
- Faire un import pour remplacer les élèves.
- Tous les élèves qui ne sont pas dans le fichier importé ne doivent plus apparaître dans la liste des élèves.

