### PR TITLE
[TECH] Prévenir les traces incomplètes de récupération de compte SCO (PIX-2973).

### DIFF
--- a/api/db/migrations/20210810084355_alter_table_account-recovery-demands_add_not_null_schoolingRegistrationId.js
+++ b/api/db/migrations/20210810084355_alter_table_account-recovery-demands_add_not_null_schoolingRegistrationId.js
@@ -1,0 +1,8 @@
+
+exports.up = function(knex) {
+  return knex.raw('ALTER TABLE "account-recovery-demands" ALTER COLUMN "schoolingRegistrationId" SET NOT NULL');
+};
+
+exports.down = function(knex) {
+  return knex.raw('ALTER TABLE "account-recovery-demands" ALTER COLUMN "schoolingRegistrationId" DROP NOT NULL');
+};


### PR DESCRIPTION
## :unicorn: Problème
Il existe une contrainte de type FK sur:
- la table account-recovery-demands
- la colonne schoolingRegistrationId

Mais il n'existe pas de contrainte NOT NULL. 

S'il existe un bug  dans le code qui insére un enregistrement à NULL, aucune erreur n'est remontée et l'origine de la demande n'est pas tracée.

## :robot: Solution
Rajouter une contrainte NOT NULL

## :100: Pour tester
Exécuter la requête suivante en RA
```
INSERT INTO "account-recovery-demands"
    ("userId", "oldEmail", "newEmail", "temporaryKey", used, "schoolingRegistrationId")
VALUES
    (100065, NULL, 'philipe@example.net', 'temporary-key', FALSE,  NULL)
;
```

Vérfier que le message suivant est affiché
```
23502] ERROR: null value in column "schoolingRegistrationId" violates not-null constraint Detail: Failing row contains (10000000, 100065, null, philipe@example.net, temporary-key, f, 2021-08-10 08:56:25.530297+00, 2021-08-10 08:56:25.530297+00, null).
```