### PR TITLE
[FEATURE] Enregistrer l'identifiant du Pix Master lors de la création d'une organisation dans Pix Admin (PIX-2725).

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -15,6 +15,7 @@ export default class Organization extends Model {
   @attr() canCollectProfiles;
   @attr() credit;
   @attr() email;
+  @attr() createdBy;
 
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;

--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -13,6 +13,7 @@ const buildOrganization = function buildOrganization({
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
   email = 'contact@example.net',
+  createdBy,
 } = {}) {
 
   const values = {
@@ -26,6 +27,7 @@ const buildOrganization = function buildOrganization({
     credit,
     canCollectProfiles,
     email,
+    createdBy,
     createdAt,
     updatedAt,
   };

--- a/api/db/database-builder/factory/build-user-pix-role.js
+++ b/api/db/database-builder/factory/build-user-pix-role.js
@@ -1,5 +1,4 @@
 const buildPixRole = require('./build-pix-role');
-const buildUser = require('./build-user');
 const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
@@ -9,7 +8,6 @@ const buildUserPixRole = function buildUserPixRole({
   pixRoleId,
 } = {}) {
 
-  userId = _.isUndefined(userId) ? buildUser().id : userId;
   pixRoleId = _.isUndefined(pixRoleId) ? buildPixRole().id : pixRoleId;
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20210810061837_add-column-createdBy-to-organizations.js
+++ b/api/db/migrations/20210810061837_add-column-createdBy-to-organizations.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'createdBy';
+const REFERENCED_COLUMN_NAME = 'users.id';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).unsigned().references(REFERENCED_COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -13,7 +13,7 @@ const userWithSchoolingRegistrationSerializer = require('../../infrastructure/se
 const higherSchoolingRegistrationWarningSerializer = require('../../infrastructure/serializers/jsonapi/higher-schooling-registration-warnings-serializer');
 const HigherSchoolingRegistrationParser = require('../../infrastructure/serializers/csv/higher-schooling-registration-parser');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
-const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+const { extractLocaleFromRequest, extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
 const moment = require('moment');
 const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf');
@@ -37,7 +37,9 @@ module.exports = {
       'logo-url': logoUrl,
     } = request.payload.data.attributes;
 
-    return usecases.createOrganization({ name, type, externalId, provinceCode, logoUrl, email })
+    const pixMasterUserId = extractUserIdFromRequest(request);
+
+    return usecases.createOrganization({ createdBy: pixMasterUserId, name, type, externalId, provinceCode, logoUrl, email })
       .then(organizationSerializer.serialize);
   },
 

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -28,6 +28,7 @@ class Organization {
     students = [],
     organizationInvitations = [],
     tags = [],
+    createdBy,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -43,6 +44,7 @@ class Organization {
     this.students = students;
     this.organizationInvitations = organizationInvitations;
     this.tags = tags;
+    this.createdBy = createdBy;
   }
 
   get isSup() {

--- a/api/lib/domain/usecases/create-organization.js
+++ b/api/lib/domain/usecases/create-organization.js
@@ -2,14 +2,15 @@ const Organization = require('../models/Organization');
 const organizationCreationValidator = require('../validators/organization-creation-validator');
 
 module.exports = async function createOrganization({
+  createdBy,
+  externalId,
+  logoUrl,
   name,
   type,
-  logoUrl,
-  externalId,
   provinceCode,
   organizationRepository,
 }) {
   organizationCreationValidator.validate({ name, type });
-  const organization = new Organization({ name, type, logoUrl, externalId, provinceCode });
+  const organization = new Organization({ createdBy, name, type, logoUrl, externalId, provinceCode });
   return organizationRepository.create(organization);
 };

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -10,7 +10,6 @@ const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_PAGE_NUMBER = 1;
 
 function _toDomain(bookshelfOrganization) {
-
   const rawOrganization = bookshelfOrganization.toJSON();
 
   const organization = new Organization({
@@ -24,10 +23,10 @@ function _toDomain(bookshelfOrganization) {
     credit: rawOrganization.credit,
     canCollectProfiles: Boolean(rawOrganization.canCollectProfiles),
     email: rawOrganization.email,
+    createdBy: rawOrganization.createdBy,
   });
 
   organization.targetProfileShares = rawOrganization.targetProfileShares || [];
-
   organization.tags = rawOrganization.tags || [];
 
   return organization;
@@ -52,8 +51,9 @@ function _setSearchFiltersForQueryBuilder(filter, qb) {
 module.exports = {
 
   create(organization) {
-
-    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'email', 'isManagingStudents', 'canCollectProfiles']);
+    const organizationRawData = _.pick(organization,
+      ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'email', 'isManagingStudents', 'canCollectProfiles', 'createdBy'],
+    );
 
     return new BookshelfOrganization()
       .save(organizationRawData)

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -6,7 +6,7 @@ module.exports = {
 
   serialize(organizations, meta) {
     return new Serializer('organizations', {
-      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'canCollectProfiles', 'email', 'memberships', 'students', 'targetProfiles', 'tags'],
+      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'canCollectProfiles', 'email', 'memberships', 'students', 'targetProfiles', 'tags', 'createdBy'],
       memberships: {
         ref: 'id',
         ignoreRelationshipData: true,
@@ -65,6 +65,7 @@ module.exports = {
       provinceCode: attributes['province-code'],
       isManagingStudents: attributes['is-managing-students'],
       canCollectProfiles: attributes['can-collect-profiles'],
+      createdBy: attributes['created-by'],
       tags,
     });
 

--- a/api/tests/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/integration/domain/usecases/create-organization_test.js
@@ -1,0 +1,43 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+
+const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
+const Organization = require('../../../../lib/domain/models/Organization');
+
+const createOrganization = require('../../../../lib/domain/usecases/create-organization');
+
+describe('Integration | UseCases | create-organization', () => {
+
+  afterEach(async () => {
+    await knex('organizations').delete();
+  });
+
+  it('should create and return an Organization', async () => {
+    // given
+    const pixMasterUserId = databaseBuilder.factory.buildUser().id;
+    await databaseBuilder.commit();
+
+    const externalId = 'externalId';
+    const name = 'ACME';
+    const provinceCode = 'provinceCode';
+    const type = 'PRO';
+
+    // when
+    const result = await createOrganization({
+      createdBy: pixMasterUserId,
+      externalId,
+      name,
+      provinceCode,
+      type,
+      organizationRepository,
+    });
+
+    // then
+    expect(result).to.be.instanceOf(Organization);
+    expect(result.createdBy).to.be.equal(pixMasterUserId);
+    expect(result.externalId).to.be.equal(externalId);
+    expect(result.name).to.be.equal(name);
+    expect(result.provinceCode).to.be.equal(provinceCode);
+    expect(result.type).to.be.equal(type);
+  });
+
+});

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -14,7 +14,7 @@ describe('Integration | Repository | UserOrgaSettings', function() {
     'pixOrgaTermsOfServiceAccepted', 'pixCertifTermsOfServiceAccepted'];
 
   const ORGANIZATION_OMITTED_PROPERTIES = ['memberships', 'organizationInvitations', 'students', 'targetProfileShares', 'email', 'tags',
-    'createdAt', 'updatedAt'];
+    'createdAt', 'updatedAt', 'createdBy'];
 
   let user;
   let organization;

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -15,7 +15,7 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
       // given
       const externalId = '1234567A';
       const organization = databaseBuilder.factory.buildOrganization({ externalId });
-      const expectedOrganization = _.omit(organization, ['createdAt', 'updatedAt', 'email', 'tags']);
+      const expectedOrganization = _.omit(organization, ['createdAt', 'updatedAt', 'email', 'tags', 'createdBy']);
 
       await databaseBuilder.commit();
 
@@ -23,7 +23,7 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
       const result = await getOrganizationByExternalId(externalId);
 
       // then
-      expect(_.omit(result, ['email', 'memberships', 'organizationInvitations', 'students', 'targetProfileShares', 'tags']))
+      expect(_.omit(result, ['email', 'memberships', 'organizationInvitations', 'students', 'targetProfileShares', 'tags', 'createdBy']))
         .to.deep.equal(expectedOrganization);
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -26,8 +26,24 @@ function buildOrganization({
   createdAt = new Date('2018-01-12T01:02:03Z'),
   targetProfileShares = [],
   tags = [],
+  createdBy,
 } = {}) {
-  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, email, canCollectProfiles, createdAt, targetProfileShares, tags });
+  return new Organization({
+    id,
+    name,
+    type,
+    logoUrl,
+    externalId,
+    provinceCode,
+    isManagingStudents,
+    credit,
+    email,
+    canCollectProfiles,
+    createdAt,
+    targetProfileShares,
+    tags,
+    createdBy,
+  });
 }
 
 buildOrganization.withSchoolingRegistrations = function({
@@ -42,9 +58,22 @@ buildOrganization.withSchoolingRegistrations = function({
   canCollectProfiles = false,
   createdAt = new Date('2018-01-12T01:02:03Z'),
   students = [],
-} = {},
-) {
-  const organization = new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, canCollectProfiles, createdAt, students });
+  createdBy,
+} = {}) {
+  const organization = new Organization({
+    id,
+    name,
+    type,
+    logoUrl,
+    externalId,
+    provinceCode,
+    isManagingStudents,
+    credit,
+    canCollectProfiles,
+    createdAt,
+    students,
+    createdBy,
+  });
 
   organization.students = [
     _buildSchoolingRegistration({ id: 1, lastName: 'Doe', firstName: 'John', organization }),

--- a/api/tests/unit/domain/usecases/create-organization_test.js
+++ b/api/tests/unit/domain/usecases/create-organization_test.js
@@ -33,15 +33,24 @@ describe('Unit | UseCase | create-organization', () => {
       expect(organizationCreationValidator.validate).to.have.been.calledWithExactly({ name, type });
     });
 
-    it('should create a new Organization Entity into data repository', async () => {
+    it('should create a new Organization Entity with Pix Master userId', async () => {
       // given
-      const expectedOrganization = new Organization({ name, type, externalId, provinceCode });
+      const pixMasterUserId = 10;
+      const createdBy = pixMasterUserId;
+      const expectedOrganization = new Organization({ createdBy, name, type, externalId, provinceCode });
 
       // when
-      await createOrganization({ name, type, externalId, provinceCode, organizationRepository });
+      await createOrganization({
+        createdBy,
+        externalId,
+        name,
+        provinceCode,
+        type,
+        organizationRepository,
+      });
 
       // then
-      expect(organizationRepository.create).to.have.been.calledWithMatch(expectedOrganization);
+      expect(organizationRepository.create).to.have.been.calledWith(expectedOrganization);
     });
   });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -13,7 +13,7 @@ describe('Unit | Serializer | organization-serializer', () => {
         domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
         domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
       ];
-      const organization = domainBuilder.buildOrganization({ email: 'sco.generic.account@example.net', tags });
+      const organization = domainBuilder.buildOrganization({ email: 'sco.generic.account@example.net', tags, createdBy: 10 });
       const meta = { some: 'meta' };
 
       // when
@@ -34,6 +34,7 @@ describe('Unit | Serializer | organization-serializer', () => {
             'credit': organization.credit,
             'can-collect-profiles': organization.canCollectProfiles,
             'email': organization.email,
+            'created-by': organization.createdBy,
           },
           relationships: {
             memberships: {
@@ -115,6 +116,7 @@ describe('Unit | Serializer | organization-serializer', () => {
         provinceCode: '64',
         isManagingStudents: true,
         canCollectProfiles: true,
+        createdBy: 10,
       };
       const jsonApiOrganization = {
         data: {
@@ -130,6 +132,7 @@ describe('Unit | Serializer | organization-serializer', () => {
             'province-code': organizationAttributes.provinceCode,
             'is-managing-students': organizationAttributes.isManagingStudents,
             'can-collect-profiles': organizationAttributes.canCollectProfiles,
+            'created-by': organizationAttributes.createdBy,
           },
         },
       };
@@ -149,6 +152,7 @@ describe('Unit | Serializer | organization-serializer', () => {
         provinceCode: organizationAttributes.provinceCode,
         isManagingStudents: organizationAttributes.isManagingStudents,
         canCollectProfiles: organizationAttributes.canCollectProfiles,
+        createdBy: organizationAttributes.createdBy,
       });
       expect(organization).to.be.instanceOf(Organization);
       expect(organization).to.deep.equal(expectedOrganization);


### PR DESCRIPTION
## :unicorn: Problème
Pour des raisons de suivi et de besoins CNIL, on désire connaitre l'utilisateur ayant créé une organisation, dans Pix Admin.
Or, pour l'instant cette information n'est pas disponible.

## :robot: Solution
* Ajouter une nouvelle colonne `createdBy` dans la table `organizations`
* Enregistrer le `userId` du Pix Master lors de la création d'une organisation dans Pix Admin

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Se rendre sur la page de création d'une organisation de la [RA](https://admin-pr3312.review.pix.fr/organizations/new)
* Ouvrir l'outil d'inspection du navigateur
* Créer une organisation
* Vérifier dans les données renvoyées par l'API que l'attribut `createdBy` est bien renseigné avec le `user.id` de l'utilisateur connecté.