### PR TITLE
[TECH] Supression du resultCompetenceTree service partie 1 (PIX-2971)

### DIFF
--- a/api/lib/domain/usecases/certificate/get-private-certificate.js
+++ b/api/lib/domain/usecases/certificate/get-private-certificate.js
@@ -5,10 +5,7 @@ module.exports = async function getPrivateCertificate({
   userId,
   certificationRepository,
   privateCertificateRepository,
-  assessmentResultRepository,
-  competenceTreeRepository,
   verifyCertificateCodeService,
-  resultCompetenceTreeService,
 }) {
   const hasCode = await certificationRepository.hasVerificationCode(certificationId);
   if (!hasCode) {
@@ -20,13 +17,6 @@ module.exports = async function getPrivateCertificate({
   if (privateCertificate.userId !== userId) {
     throw new NotFoundError();
   }
-
-  const resultCompetenceTree = await resultCompetenceTreeService.computeForCertification({
-    certificationId,
-    assessmentResultRepository,
-    competenceTreeRepository,
-  });
-  privateCertificate.setResultCompetenceTree(resultCompetenceTree);
 
   return privateCertificate;
 };

--- a/api/tests/unit/domain/usecases/find-certification-attestations-for-division_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-attestations-for-division_test.js
@@ -7,9 +7,6 @@ describe('Unit | UseCase | find-certification-attestations-for-division', async 
   const certificationAttestationRepository = {
     findByDivisionForScoIsManagingStudentsOrganization: () => undefined,
   };
-  const resultCompetenceTreeService = {
-    computeForCertification: () => undefined,
-  };
 
   const dependencies = {
     certificationAttestationRepository,
@@ -17,7 +14,6 @@ describe('Unit | UseCase | find-certification-attestations-for-division', async 
 
   beforeEach(() => {
     certificationAttestationRepository.findByDivisionForScoIsManagingStudentsOrganization = sinon.stub();
-    resultCompetenceTreeService.computeForCertification = sinon.stub();
   });
 
   it('should return multiple certification attestations enhanced with result competence tree', async () => {

--- a/api/tests/unit/domain/usecases/get-private-certificate_test.js
+++ b/api/tests/unit/domain/usecases/get-private-certificate_test.js
@@ -14,19 +14,11 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
   const verifyCertificateCodeService = {
     generateCertificateVerificationCode: undefined,
   };
-  const resultCompetenceTreeService = {
-    computeForCertification: undefined,
-  };
-  const assessmentResultRepository = 'assessmentResultRepository';
-  const competenceTreeRepository = 'competenceTreeRepository';
 
   const dependencies = {
     certificationRepository,
     privateCertificateRepository,
-    assessmentResultRepository,
-    competenceTreeRepository,
     verifyCertificateCodeService,
-    resultCompetenceTreeService,
   };
 
   beforeEach(() => {
@@ -34,7 +26,6 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
     verifyCertificateCodeService.generateCertificateVerificationCode = sinon.stub();
     certificationRepository.hasVerificationCode = sinon.stub();
     certificationRepository.saveVerificationCode = sinon.stub();
-    resultCompetenceTreeService.computeForCertification = sinon.stub();
   });
 
   context('when the user is not owner of the certification', async () => {
@@ -69,7 +60,6 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
         privateCertificateRepository.get.withArgs(123).resolves(privateCertificate);
         verifyCertificateCodeService.generateCertificateVerificationCode.resolves('P-SOMECODE');
         certificationRepository.saveVerificationCode.resolves();
-        resultCompetenceTreeService.computeForCertification.resolves();
 
         // when
         await getPrivateCertificate({ certificationId: 123, userId: 456, ...dependencies });
@@ -92,7 +82,6 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
         privateCertificateRepository.get.withArgs(123).resolves(privateCertificate);
         verifyCertificateCodeService.generateCertificateVerificationCode.rejects(new Error('I should not run.'));
         certificationRepository.saveVerificationCode.resolves(new Error('I should not run.'));
-        resultCompetenceTreeService.computeForCertification.resolves();
 
         // when
         await getPrivateCertificate({ certificationId: 123, userId: 456, ...dependencies });
@@ -105,23 +94,17 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
 
     it('should get the private certificate enhanced with the result competence tree', async () => {
       // given
+      const resultCompetenceTree = domainBuilder.buildResultCompetenceTree();
       const privateCertificate = domainBuilder.buildPrivateCertificate({
         id: 123,
         userId: 456,
+        resultCompetenceTree,
       });
-      const resultCompetenceTree = domainBuilder.buildResultCompetenceTree();
       certificationRepository.hasVerificationCode.withArgs(123).resolves(true);
       privateCertificateRepository.get.withArgs(123).resolves(privateCertificate);
       verifyCertificateCodeService.generateCertificateVerificationCode.rejects(new Error('I should not run.'));
       certificationRepository.saveVerificationCode.resolves(new Error('I should not run.'));
       privateCertificateRepository.get.withArgs(123).resolves(privateCertificate);
-      resultCompetenceTreeService.computeForCertification
-        .withArgs({
-          certificationId: 123,
-          assessmentResultRepository,
-          competenceTreeRepository,
-        })
-        .resolves(resultCompetenceTree);
 
       // when
       const actualPrivateCertificate = await getPrivateCertificate({ certificationId: 123, userId: 456, ...dependencies });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, lors de la récupération des certificats des candidats, on construit les certificat sans resultCompetenceTree via une première méthode de repo, puis on les ajoute au certificat dans les usecase via un service qui refait une requète BDD via un deuxième repo qui va chercher les competence marks.

Quand un seul certificat est computé, le procédé est peu coûteux. Cependant, lors de la récupération de X certificats, le coût de la démarche est énormément ainsi que les perfs peuvent être grandement impactées.

Il faut ne plus faire appel à ce service et construire des certificats complets lors du premier appel réseau 

## :robot: Solution
Construire les certificats complets dans le ```private-certificate-repository```

## :rainbow: Remarques
PR 1 / 2
Deuxième partie à suivre suppression du service dans le ```usecase getShareableCertificate```

## :100: Pour tester
Faire de la non-régression sur mon pix:

- Se connecter avec Anne-Sucess
- Afficher la liste de ses certifications et constater qu'elles sont bien présentes
![image](https://user-images.githubusercontent.com/37305474/129030371-5701138f-8aaf-4f27-a468-25756ab93315.png)

- Consulter en détail la certification obtenue et constater qu'elle s'affiche correctement
![image](https://user-images.githubusercontent.com/37305474/129030402-51dc1c86-a4eb-4905-9a4f-91216c87f98f.png)
