### PR TITLE
[TECH] Prévenir les traces incomplètes sur l'utilisateur de récupération de compte SCO  (PIX-2986).

### DIFF
--- a/api/db/migrations/20210811153908_alter_table_account-recovery-demands_add_foreign_key_not_null_userId.js
+++ b/api/db/migrations/20210811153908_alter_table_account-recovery-demands_add_foreign_key_not_null_userId.js
@@ -1,0 +1,9 @@
+exports.up = async function(knex) {
+  await knex.raw('ALTER TABLE "account-recovery-demands" ALTER COLUMN "userId" SET NOT NULL');
+  await knex.raw('ALTER TABLE "account-recovery-demands" ADD CONSTRAINT "account_recovery_demands_userid_foreign" FOREIGN KEY ("userId") REFERENCES "users" (id)');
+};
+
+exports.down = async function(knex) {
+  await knex.raw('ALTER TABLE "account-recovery-demands" ALTER COLUMN "userId" DROP NOT NULL');
+  await knex.raw('ALTER TABLE "account-recovery-demands" DROP CONSTRAINT "account_recovery_demands_userid_foreign"');
+};

--- a/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
@@ -184,10 +184,11 @@ describe('Integration | Infrastructure | Repository | account-recovery-demand-re
 
     it('should persist the account recovery demand', async () => {
       // given
-      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      const user = databaseBuilder.factory.buildUser();
+      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({ userId: user.id }).id;
       await databaseBuilder.commit();
 
-      const userId = 123;
+      const userId = user.id;
       const newEmail = 'dupont@example.net';
       const oldEmail = 'eleve-dupont@example.net';
       const used = false;


### PR DESCRIPTION
## :unicorn: Problème
Il n'existe pas de contraintes sur 
- la table account-recovery-demands
- la colonne userId

S'il existe un bug  dans le code qui insére un enregistrement à NULL ou à une valeur non connue dans users, aucune erreur n'est remontée et l'origine de la demande n'est pas tracée.

## :robot: Solution
Rajouter les contraintes
- FK
- NOT NULL

## :100: Pour tester

Exécuter
``` sql
ix=# INSERT INTO "account-recovery-demands"
    ("userId", "oldEmail", "newEmail", "temporaryKey", used, "schoolingRegistrationId")
VALUES
    (NULL, NULL, 'philipe@example.net', 'temporary-key', FALSE, 1 );
```
Vérifier l'afffichage du message
```
ERROR:  null value in column "userId" violates not-null constraint
DETAIL:  Failing row contains (10000001, null, null, philipe@example.net, temporary-key, f, 2021-08-11 15:52:09.148446+00, 2021-08-11 15:52:09.148446+00, 1).
```

Exécuter
``` sql
INSERT INTO "account-recovery-demands"
    ("userId", "oldEmail", "newEmail", "temporaryKey", used, "schoolingRegistrationId")
VALUES
    (-1, NULL, 'philipe@example.net', 'temporary-key', FALSE, 1 );

```
Vérifier l'afffichage du message
```
ERROR:  insert or update on table "account-recovery-demands" violates foreign key constraint "account_recovery_demands_userid_foreign"
DETAIL:  Key (userId)=(-1) is not present in table "users".
```
