### PR TITLE
[BUGFIX] Correction de tests flaky et bugs sur la navbar Pix Orga

### DIFF
--- a/orga/app/components/campaign/header/tabs.hbs
+++ b/orga/app/components/campaign/header/tabs.hbs
@@ -1,5 +1,5 @@
 <div class="panel campaign-header-tabs">
-  <nav class="campaign-header-tabs__navbar">
+  <nav class="navbar">
     <LinkTo @route="authenticated.campaigns.campaign.activity" @model={{@campaign}} class="navbar-item">
       {{t 'pages.campaign.tab.activity'}}
     </LinkTo>

--- a/orga/app/components/campaign/header/title.hbs
+++ b/orga/app/components/campaign/header/title.hbs
@@ -32,7 +32,7 @@
         {{t 'pages.campaign.code'}}
       </h4>
       <span class="content-text campaign-header-title__campaign-code">
-        {{@campaign.code}}
+        <span>{{@campaign.code}}</span>
         <Campaign::CopyPasteButton
           @clipBoardtext={{@campaign.code}}
           @successMessage={{t 'pages.campaign.copy.code.success'}}

--- a/orga/app/components/participant/assessment/tabs.hbs
+++ b/orga/app/components/participant/assessment/tabs.hbs
@@ -1,5 +1,5 @@
-<div class='panel campaign-details__controls'>
-  <nav class='navbar campaign-details-controls__navbar-tabs'>
+<div class='panel participant-tabs'>
+  <nav class='navbar'>
     <LinkTo
       @route='authenticated.campaigns.participant-assessment.results'
       @models={{array @campaignId @participationId}}

--- a/orga/app/components/ui/indicator-card.hbs
+++ b/orga/app/components/ui/indicator-card.hbs
@@ -9,7 +9,7 @@
     </div>
     <div class="indicator-card__content">
       <label class="indicator-card__title">
-        {{@title}}
+        <span>{{@title}}</span>
         {{#if @info}}
           <PixTooltip
             role="tooltip"

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -29,6 +29,7 @@
 @import "components/indicator-card";
 @import "components/join-request-form";
 @import "components/pagination-control";
+@import "components/participant/tabs";
 @import "components/previous-page-button";
 @import "components/pix-score-tag";
 @import "components/progress-bar";

--- a/orga/app/styles/components/campaign/header/tabs.scss
+++ b/orga/app/styles/components/campaign/header/tabs.scss
@@ -3,22 +3,9 @@
   justify-content: space-between;
   margin-bottom: 24px;
 
-  &__navbar {
-    display: flex;
-  }
-
   &__export-button {
     display: flex;
     align-items: center;
     padding-right: 10px;
-  }
-}
-
-@include device-is('mobile') {
-  .campaign-header-tabs {
-    &__navbar {
-      flex-direction: column;
-      width: 100%;
-    }
   }
 }

--- a/orga/app/styles/components/participant/tabs.scss
+++ b/orga/app/styles/components/participant/tabs.scss
@@ -1,0 +1,3 @@
+.participant-tabs {
+  margin-bottom: 24px;
+}

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -112,6 +112,7 @@
   height: 60px;
   border: none;
   padding: 0 10px;
+  display: flex;
 
   &-item {
     width: 150px;

--- a/orga/app/templates/authenticated/team/list.hbs
+++ b/orga/app/templates/authenticated/team/list.hbs
@@ -7,7 +7,7 @@
     </div>
   </div>
 
-  <nav class="navbar list-team-page__tabs">
+  <nav class="panel navbar list-team-page__tabs">
     <LinkTo @route="authenticated.team.list.members" class="navbar-item">
       {{t 'pages.team-list.tabs.member' count=@model.memberships.meta.rowCount}}
     </LinkTo>

--- a/orga/tests/helpers/contains.js
+++ b/orga/tests/helpers/contains.js
@@ -1,7 +1,7 @@
 import { getRootElement } from '@ember/test-helpers';
 
 function _isChildrenContainsText(element, text) {
-  if (element.textContent.includes(text)) {
+  if (element.textContent.trim() === text) {
     return true;
   } else if (element.children.length > 0) {
     for (let i = 0; i < element.children.length; i++) {

--- a/orga/tests/integration/components/campaign/cards/result_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/result_average_test.js
@@ -14,6 +14,6 @@ module('Integration | Component | Campaign::Cards::ResultAverage', function(hook
     await render(hbs`<Campaign::Cards::ResultAverage @value={{averageResult}} />`);
 
     assert.contains(t('cards.participants-average-results.title'));
-    assert.contains('9');
+    assert.contains(t('cards.participants-average-results.result', { result: this.averageResult }));
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Un test est flaky sur Pix Orga

## :robot: Solution

Le helper `contains` n'est pas assez restrictif et recherche de manière trop exhaustive les textes inclus.

## :rainbow: Remarques

[Scout Rule] Correction d'un bug sur les Navbar de Pix Orga (page des participants et équipe)

## :100: Pour tester

Exécuter les tests
