### PR TITLE
[FEATURE] Voir le commentaire du jury sur une certif dans le fichier des résultats (PIX-996)

### DIFF
--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -40,6 +40,7 @@ function _getRowItemsFromResults(certificationResult) {
     [_headers.EXTERNAL_ID]: certificationResult.externalId,
     [_headers.STATUS]: _formatStatus(certificationResult.status),
     [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
+    [_headers.JURY_COMMENT_FOR_ORGANIZATION]: certificationResult.commentForOrganization,
     [_headers.SESSION_ID]: certificationResult.sessionId,
     [_headers.CERTIFICATION_DATE]: _formatDate(certificationResult.createdAt),
   };
@@ -68,6 +69,7 @@ function _buildFileHeadersWithoutCertificationCenterName() {
     ],
     _competenceIndexes,
     [
+      _headers.JURY_COMMENT_FOR_ORGANIZATION,
       _headers.SESSION_ID,
       _headers.CERTIFICATION_DATE,
     ],

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -109,6 +109,7 @@ function _buildFileHeaders(certificationResults) {
     [ _headers.PIX_SCORE ],
     _competenceIndexes,
     [
+      _headers.JURY_COMMENT_FOR_ORGANIZATION,
       _headers.SESSION_ID,
       _headers.CERTIFICATION_CENTER,
       _headers.CERTIFICATION_DATE,
@@ -129,6 +130,7 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
     [_headers.PIX_PLUS_DROIT_MAITRE_STATUS]: _formatPixPlusDroitMaitreCertificationResult(certificationResult.pixPlusDroitMaitreCertificationResult),
     [_headers.PIX_PLUS_DROIT_EXPERT_STATUS]: _formatPixPlusDroitExpertCertificationResult(certificationResult.pixPlusDroitExpertCertificationResult),
     [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
+    [_headers.JURY_COMMENT_FOR_ORGANIZATION]: certificationResult.commentForOrganization,
     [_headers.SESSION_ID]: session.id,
     [_headers.CERTIFICATION_CENTER]: session.certificationCenter,
     [_headers.CERTIFICATION_DATE]: _formatDate(certificationResult.createdAt),
@@ -241,6 +243,7 @@ const _headers = {
   SESSION_ID: 'Session',
   CERTIFICATION_CENTER: 'Centre de certification',
   CERTIFICATION_DATE: 'Date de passage de la certification',
+  JURY_COMMENT_FOR_ORGANIZATION: 'Commentaire jury pour l’organisation',
 };
 
 module.exports = {

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -24,10 +24,12 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark1,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'rejected',
           competenceMarks: competencesWithMark2,
+          commentForOrganization: null,
         });
 
         const certifResult1 = domainBuilder.buildCertificationResult({
@@ -58,9 +60,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"${certifResult1.commentForOrganization}";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });
@@ -82,10 +84,12 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'rejected',
           competenceMarks: competencesWithMark,
+          commentForOrganization: null,
         });
 
         const certifResult = domainBuilder.buildCertificationResult({
@@ -117,9 +121,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult.id}";"Lili";"${certifResult.lastName}";"${expectedBirthDate}";"${certifResult.birthplace}";"${certifResult.externalId}";"Validée";${certifResult.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${cancelledCertifResult.id}";"Tom";"${cancelledCertifResult.lastName}";"${expectedBirthDate}";"${cancelledCertifResult.birthplace}";"${cancelledCertifResult.externalId}";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult.id}";"Lili";"${certifResult.lastName}";"${expectedBirthDate}";"${certifResult.birthplace}";"${certifResult.externalId}";"Validée";${certifResult.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${cancelledCertifResult.id}";"Tom";"${cancelledCertifResult.lastName}";"${expectedBirthDate}";"${cancelledCertifResult.birthplace}";"${cancelledCertifResult.externalId}";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });
@@ -141,11 +145,13 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'error',
           competenceMarks: [],
           pixScore: '-',
+          commentForOrganization: null,
         });
 
         const certifResult = domainBuilder.buildCertificationResult({
@@ -176,9 +182,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult.id}";"Lili";"${certifResult.lastName}";"${expectedBirthDate}";"${certifResult.birthplace}";"${certifResult.externalId}";"Validée";${certifResult.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${cancelledCertifResult.id}";"Tom";"${cancelledCertifResult.lastName}";"${expectedBirthDate}";"${cancelledCertifResult.birthplace}";"${cancelledCertifResult.externalId}";"En erreur";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult.id}";"Lili";"${certifResult.lastName}";"${expectedBirthDate}";"${certifResult.birthplace}";"${certifResult.externalId}";"Validée";${certifResult.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${cancelledCertifResult.id}";"Tom";"${cancelledCertifResult.lastName}";"${expectedBirthDate}";"${cancelledCertifResult.birthplace}";"${cancelledCertifResult.externalId}";"En erreur";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });
@@ -202,10 +208,12 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark1,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'rejected',
           competenceMarks: competencesWithMark2,
+          commentForOrganization: null,
         });
 
         const certifResult1 = domainBuilder.buildCertificationResult({
@@ -232,9 +240,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });
@@ -258,10 +266,12 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark1,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'rejected',
           competenceMarks: competencesWithMark2,
+          commentForOrganization: null,
         });
 
         const certifResult1 = domainBuilder.buildCertificationResult({
@@ -288,9 +298,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });
@@ -314,10 +324,12 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark1,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'rejected',
           competenceMarks: competencesWithMark2,
+          commentForOrganization: null,
         });
 
         const certifResult1 = domainBuilder.buildCertificationResult({
@@ -344,9 +356,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });
@@ -371,14 +383,17 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark1,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'rejected',
           competenceMarks: competencesWithMark2,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult3 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark3,
+          commentForOrganization: null,
         });
 
         const certifResult1 = domainBuilder.buildCertificationResult({
@@ -412,10 +427,10 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";"Non passée";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"Non passée";"Non passée";"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-        `"${certifResult3.id}";"Bob";"${certifResult3.lastName}";"${expectedBirthDate}";"${certifResult3.birthplace}";"${certifResult3.externalId}";"Validée";"Validée";"Non passée";"Non passée";31;"-";"-";"-";"-";"-";"-";"-";"-";3;"-";"-";"-";"-";"-";"-";"-";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";"Non passée";"Validée";"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"Non passée";"Non passée";"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+        `"${certifResult3.id}";"Bob";"${certifResult3.lastName}";"${expectedBirthDate}";"${certifResult3.birthplace}";"${certifResult3.externalId}";"Validée";"Validée";"Non passée";"Non passée";31;"-";"-";"-";"-";"-";"-";"-";"-";3;"-";"-";"-";"-";"-";"-";"-";;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -454,10 +454,12 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark1,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'rejected',
           competenceMarks: competencesWithMark2,
+          commentForOrganization: null,
         });
 
         const certifResult1 = domainBuilder.buildCertificationResult({
@@ -484,9 +486,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Date de passage de la certification"\n' +
-          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"${certifResult1.sessionId}";"${expectedCreatedAt}"\n` +
-          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"${certifResult2.sessionId}";"${expectedCreatedAt}"`;
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";"${certifResult1.sessionId}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;;"${certifResult2.sessionId}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });
@@ -506,10 +508,12 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
           status: 'validated',
           competenceMarks: competencesWithMark,
+          commentForOrganization: 'RAS',
         });
         const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
           status: 'rejected',
           competenceMarks: competencesWithMark,
+          commentForOrganization: null,
         });
 
         const certifResult1 = domainBuilder.buildCertificationResult({
@@ -537,9 +541,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-        '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Date de passage de la certification"\n' +
-        `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"${certifResult1.sessionId}";"${expectedCreatedAt}"\n` +
-        `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"${certifResult2.sessionId}";"${expectedCreatedAt}"`;
+        '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Date de passage de la certification"\n' +
+        `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";"${certifResult1.externalId}";"Validée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"RAS";"${certifResult1.sessionId}";"${expectedCreatedAt}"\n` +
+        `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";"${certifResult2.externalId}";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";;"${certifResult2.sessionId}";"${expectedCreatedAt}"`;
         expect(result).to.equal(expectedResult);
       });
     });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -443,7 +443,7 @@ describe('Unit | Controller | sessionController', () => {
 
       // then
       const expectedHeader = `attachment; filename=${fileName}`;
-      const expectedCsv = '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"';
+      const expectedCsv = '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"';
       expect(response.source.trim()).to.deep.equal(expectedCsv);
       expect(response.headers['Content-Disposition']).to.equal(expectedHeader);
     });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le pôle certif traite une session de certification, il veut parfois pouvoir donner des informations spécifiques concernant une ou plusieurs des certifications de cette session au destinataire des résultats, et donc lui donner des éléments d’interprétation des résultats d'un candidat. Cela peut par exemple être le cas lorsqu’une certification a été annulée (car avec un taux de non proposition trop élevé), ou encore une certification pour laquelle toutes les compétences n’ont pas pu être certifiées (car trop de questions neutralisées).

Il n’est aujourd’hui pas possible pour le pôle certification d’ajouter un commentaire à destination du destinataire des résultats.

## :robot: Solution
Utiliser le champ existant “Commentaire jury pour l’organisation”, éditable depuis la page de détails d’une certification. afin d’afficher ce commentaire dans le fichier csv des résultats pour la certification correspondante : 


- Dans le fichier des résultats, ajouter une colonne “Commentaire jury Pix” avant la colonne “Session”

- SI le champ commentForOrganization est rempli pour une certification, ALORS le commentaire s’affiche dans la colonne “Commentaire jury Pix” pour la certification correspondante

- SINON SI ce champ est vide pour une certification, ALORS la cellule reste vide pour cette certification


## :100: Pour tester
- Se connecter à pix-orga
- Télécharger les résultats de la classe 3A
- Constater la présence d'un commentaire pour organisation dans les résultats de Georges de Cambridge

![image](https://user-images.githubusercontent.com/37305474/129331668-e2c25608-9057-4988-ae4e-b59d3c039842.png)



- Se connecter à pix-admin
- Consulter les résultats de la session 10000000
- Copier le lien de téléchargement
- Télécharger le fichier
- Constater la présence d'un commentaire pour organisation dans les résultats de Georges de Cambridge

![image](https://user-images.githubusercontent.com/37305474/129332031-5d6c1120-8afe-4990-b228-69a82a5f481f.png)
