### PR TITLE
[FEATURE] Adapter les courbes des participations pour qu'elles aillent jusqu'à la date de fin (PIX-2978)

### DIFF
--- a/orga/tests/unit/components/campaign/charts/participants-by-day_test.js
+++ b/orga/tests/unit/components/campaign/charts/participants-by-day_test.js
@@ -1,0 +1,111 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Campaign::Charts::ParticipantsByDay', (hooks) => {
+  setupTest(hooks);
+  let component, dataFetcher;
+
+  hooks.beforeEach(function() {
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('campaign-stats');
+    dataFetcher = sinon.stub(adapter, 'getParticipationsByDay');
+  });
+
+  test('should pass without data', async function(assert) {
+    // given
+    dataFetcher.resolves({
+      data: {
+        attributes: {
+          'started-participations': [],
+          'shared-participations': [],
+        },
+      },
+    });
+
+    // when
+    component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
+
+    // then
+    assert.deepEqual(component.startedDatasets, []);
+    assert.deepEqual(component.sharedDatasets, []);
+  });
+
+  test('should fill the default datasets', async function(assert) {
+    // given
+    dataFetcher.resolves({
+      data: {
+        attributes: {
+          'started-participations': [{ day: '2021-06-01', count: '1' }],
+          'shared-participations': [{ day: '2021-06-01', count: '1' }],
+        },
+      },
+    });
+
+    // when
+    component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
+
+    // then
+    assert.deepEqual(component.startedDatasets, [{ day: '2021-06-01', count: '1' }]);
+    assert.deepEqual(component.sharedDatasets, [{ day: '2021-06-01', count: '1' }]);
+  });
+
+  test('should start shared participations to 0 when there is at least one shared participant', async function(assert) {
+    // given
+    dataFetcher.resolves({
+      data: {
+        attributes: {
+          'started-participations': [{ day: '2021-06-01', count: '1' }],
+          'shared-participations': [{ day: '2021-06-02', count: '1' }],
+        },
+      },
+    });
+
+    // when
+    component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
+
+    // then
+    assert.deepEqual(component.sharedDatasets, [{ day: '2021-06-01', count: '0' }, { day: '2021-06-02', count: '1' }]);
+  });
+
+  module('When last started participation is after the last shared one', () => {
+    test('should add the last started participation to shared participations', async function(assert) {
+      // given
+      dataFetcher.resolves({
+        data: {
+          attributes: {
+            'started-participations': [{ day: '2021-06-01', count: '1' }, { day: '2021-06-03', count: '2' }],
+            'shared-participations': [{ day: '2021-06-01', count: '1' }],
+          },
+        },
+      });
+
+      // when
+      component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
+
+      // then
+      assert.deepEqual(component.sharedDatasets, [{ day: '2021-06-01', count: '1' }, { day: '2021-06-03', count: '1' }]);
+    });
+  });
+
+  module('When last shared participation is after the last started one', () => {
+    test('should add the last shared participation to started participations', async function(assert) {
+      // given
+      dataFetcher.resolves({
+        data: {
+          attributes: {
+            'started-participations': [{ day: '2021-06-01', count: '2' }],
+            'shared-participations': [{ day: '2021-06-01', count: '1' }, { day: '2021-06-03', count: '1' }],
+          },
+        },
+      });
+
+      // when
+      component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
+
+      // then
+      assert.deepEqual(component.startedDatasets, [{ day: '2021-06-01', count: '2' }, { day: '2021-06-03', count: '2' }]);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous avons eu un retour utilisateur nous indiquant que la fin des courbes dans l’onglet activité était bizarre vu qu’elles ne vont pas jusqu’au bout du schémas.

## :robot: Solution

Nous avons décidé de rajouter un Max entre la date de partage ou dernière date de participation. Afin de continuer les courbes jusqu’au bout même si il n’ya pas de données pour l’une ou l’autre des courbe. 

Cela ne doit pas changer les dates de début ou de fin mais plutot continuer les courbe pour quelles aillent les deux jusqu’au bout.

**AVANT:** 
![image](https://user-images.githubusercontent.com/516360/129341004-35b245a7-7d2b-412d-a603-17b700ef2aff.png)

**APRES:** 
![image](https://user-images.githubusercontent.com/516360/129340842-c6a8fa31-e877-47de-bf03-5cee036e24b7.png)

## :rainbow: Remarques

Une borne minimale à zéro a également été ajouté pour les participations partagées pour bien identifé leur début par rapport aux participation démarrées.

**Exemple AVANT borne minimale à zéro:**
![image](https://user-images.githubusercontent.com/516360/129340694-d26350e7-607d-4739-ab80-230afad88728.png)

**Exemple APRES borne minimale à zéro:**
![image](https://user-images.githubusercontent.com/516360/129340538-fcc03fc3-d79d-48d5-816c-4335405b0af1.png)


## :100: Pour tester

Se connecter à Pix Orga (en Pro) et visualiser l'activité des campagnes de collectes et d'évaluation