### PR TITLE
[BUGFIX] Empêcher l'erreur 500 quand la clé des jetons Pôle-emploi expire (PIX-2990).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -63,6 +63,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AccountRecoveryDemandExpired) {
     return new HttpErrors.UnauthorizedError(error.message);
   }
+  if (error instanceof DomainErrors.AuthenticationKeyForPoleEmploiTokenExpired) {
+    return new HttpErrors.UnauthorizedError(error.message);
+  }
   if (error instanceof DomainErrors.UserHasAlreadyLeftSCO) {
     return new HttpErrors.ForbiddenError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -145,6 +145,11 @@ class NoStagesForCampaign extends DomainError {
   }
 }
 
+class AuthenticationKeyForPoleEmploiTokenExpired extends DomainError {
+  constructor(message = 'This authentication key for pole emploi token has expired.') {
+    super(message);
+  }
+}
 class AccountRecoveryDemandExpired extends DomainError {
   constructor(message = 'This account recovery demand has expired.') {
     super(message);
@@ -903,6 +908,7 @@ module.exports = {
   AssessmentNotCompletedError,
   AssessmentResultNotCreatedError,
   AuthenticationMethodNotFoundError,
+  AuthenticationKeyForPoleEmploiTokenExpired,
   CampaignCodeError,
   CertificateVerificationCodeGenerationTooManyTrials,
   NoCertificationAttestationForDivisionError,

--- a/api/lib/domain/usecases/create-user-from-pole-emploi.js
+++ b/api/lib/domain/usecases/create-user-from-pole-emploi.js
@@ -2,7 +2,7 @@ const moment = require('moment');
 const User = require('../models/User');
 const AuthenticationMethod = require('../models/AuthenticationMethod');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
-const { InvalidExternalAPIResponseError } = require('../errors');
+const { InvalidExternalAPIResponseError, AuthenticationKeyForPoleEmploiTokenExpired } = require('../errors');
 const logger = require('../../infrastructure/logger');
 
 module.exports = async function createUserFromPoleEmploi({
@@ -13,6 +13,9 @@ module.exports = async function createUserFromPoleEmploi({
   authenticationService,
 }) {
   const poleEmploiTokens = await poleEmploiTokensRepository.getByKey(authenticationKey);
+  if (!poleEmploiTokens) {
+    throw new AuthenticationKeyForPoleEmploiTokenExpired();
+  }
   const userInfo = await authenticationService.getPoleEmploiUserInfo(poleEmploiTokens.idToken);
 
   if (!userInfo.firstName || !userInfo.lastName || !userInfo.externalIdentityId) {

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -9,6 +9,7 @@ const {
   AlreadyRegisteredEmailAndUsernameError,
   AlreadyRegisteredEmailError,
   AlreadyRegisteredUsernameError,
+  AuthenticationKeyForPoleEmploiTokenExpired,
   EntityValidationError,
   InvalidExternalAPIResponseError,
   MissingOrInvalidCredentialsError,
@@ -24,6 +25,7 @@ const { handle } = require('../../../lib/application/error-manager');
 describe('Unit | Application | ErrorManager', () => {
 
   describe('#handle', () => {
+
     it('should translate EntityValidationError', async () => {
       // given
       const request = {
@@ -124,7 +126,6 @@ describe('Unit | Application | ErrorManager', () => {
   describe('#_mapToHttpError', () => {
 
     it('should instantiate UnauthorizedError when MissingOrInvalidCredentialsError', async () => {
-
       // given
       const error = new MissingOrInvalidCredentialsError();
       sinon.stub(HttpErrors, 'UnauthorizedError');
@@ -246,6 +247,19 @@ describe('Unit | Application | ErrorManager', () => {
       expect(HttpErrors.UnauthorizedError).to.have.been.calledWithExactly(error.message);
     });
 
+    it('should instantiate UnauthorizedError when AuthenticationKeyForPoleEmploiTokenExpired', async () => {
+      // given
+      const error = new AuthenticationKeyForPoleEmploiTokenExpired();
+      sinon.stub(HttpErrors, 'UnauthorizedError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.UnauthorizedError).to.have.been.calledWithExactly(error.message);
+    });
+
     it('should instantiate UnauthorizedError when UserHasAlreadyLeftSCO', async () => {
       // given
       const error = new UserHasAlreadyLeftSCO();
@@ -258,7 +272,6 @@ describe('Unit | Application | ErrorManager', () => {
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
     });
-
   });
 
 });

--- a/mon-pix/app/controllers/terms-of-service-pe.js
+++ b/mon-pix/app/controllers/terms-of-service-pe.js
@@ -13,6 +13,7 @@ export default class TermsOfServicePeController extends Controller {
   @tracked authenticationKey = null;
   @tracked isTermsOfServiceValidated = false;
   @tracked showErrorTermsOfServiceNotSelected = false;
+  @tracked showErrorTermsOfServiceExpiredAuthenticatedKey = false;
 
   get homeUrl() {
     return this.url.homeUrl;
@@ -22,9 +23,12 @@ export default class TermsOfServicePeController extends Controller {
   async submit() {
     if (this.isTermsOfServiceValidated) {
       this.showErrorTermsOfServiceNotSelected = false;
-
-      await this.session.authenticate('authenticator:oidc', { authenticationKey: this.authenticationKey });
-
+      try {
+        await this.session.authenticate('authenticator:oidc', { authenticationKey: this.authenticationKey });
+      }
+      catch (error) {
+        this.showErrorTermsOfServiceExpiredAuthenticatedKey = true;
+      }
     } else {
       this.showErrorTermsOfServiceNotSelected = true;
     }

--- a/mon-pix/app/templates/terms-of-service-pe.hbs
+++ b/mon-pix/app/templates/terms-of-service-pe.hbs
@@ -30,7 +30,11 @@
 
     <div class="terms-of-service-form__actions">
       <LinkTo @route="logout" class="button button--white">{{t 'common.actions.back'}}</LinkTo>
+      {{#if this.showErrorTermsOfServiceExpiredAuthenticatedKey }}
+        <div class="terms-of-service-form-conditions__validation-error">{{t 'pages.terms-of-service-pe.form.expired-authentication-key'}}</div>
+      {{else}}
       <button type="submit" class="button terms-of-service-form-actions__submit" {{on 'click' this.submit}}>{{t 'pages.terms-of-service-pe.form.button'}}</button>
+      {{/if}}
     </div>
 
   </div>

--- a/mon-pix/tests/unit/controllers/terms-of-service-pe_test.js
+++ b/mon-pix/tests/unit/controllers/terms-of-service-pe_test.js
@@ -12,7 +12,7 @@ describe('Unit | Controller | terms-of-service-pe', function() {
     beforeEach(function() {
       controller = this.owner.lookup('controller:terms-of-service-pe');
       controller.session = {
-        authenticate: sinon.stub().resolves(),
+        authenticate: sinon.stub(),
       };
     });
 
@@ -37,5 +37,19 @@ describe('Unit | Controller | terms-of-service-pe', function() {
       // then
       expect(controller.showErrorTermsOfServiceNotSelected).to.be.true;
     });
+
+    it('it should show an error expired authentication key', async function() {
+      // given
+      controller.session.authenticate.rejects();
+      controller.isTermsOfServiceValidated = true ;
+      controller.showErrorTermsOfServiceExpiredAuthenticatedKey = false;
+
+      // when
+      await controller.send('submit');
+
+      // then
+      expect(controller.showErrorTermsOfServiceExpiredAuthenticatedKey).to.be.true;
+    });
+
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1219,7 +1219,8 @@
       "cgu": "I agree to the '<a href=\"https://pix.org/en-gb/terms-and-conditions\" class=\"link\" target=\"_blank\">'terms and conditions of use of the Pix platform'</a>'",
       "form": {
         "button": "Continue",
-        "error-message": "Please agree to the terms and conditions of use."
+        "error-message": "Please agree to the terms and conditions of use.",
+        "expired-authentication-key": "Votre demande d'authentification a expirée, merci de renouveler votre connexion en cliquant sur le boutton retour"
       },
       "message": ""
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1219,7 +1219,8 @@
       "cgu": "J'accepte les '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'conditions d'utilisation de Pix'</a>'",
       "form": {
         "button": "Je continue",
-        "error-message": "Vous devez accepter les conditions d’utilisation de Pix."
+        "error-message": "Vous devez accepter les conditions d’utilisation de Pix.",
+        "expired-authentication-key": "Votre demande d'authentification a expirée, merci de renouveler votre connexion en cliquant sur le boutton retour"
       },
       "message": "Votre compte Pix est sur le point d’être créé à partir des éléments transmis par Pôle Emploi."
     },


### PR DESCRIPTION
## :unicorn: Problème
Une erreur 500 est déclenchée en production lors d'une connexion avec Pôle Emploi.
Cette erreur survient quand les données d'authentification stockées temporairement, avec une durée de 19 minutes, expirent.

## :robot: Solution
Sécuriser le code en gérant cette expiration avec une erreur 401 renvoyée au front.

## :rainbow: Remarques
Une refacto de la gestion des erreurs est à prévoir dans une autre PR.

## :100: Pour tester
Cliquer sur ce [lien](https://app-pr3327.review.pix.fr/cgu-pole-emploi?authenticationKey=8a985984-2429-4a1b-a249-6743d91dcb2f) et vérifier que l'erreur 500 n'apparait plus et qu'un message est affiché à l'utilisateur lui précisant l'origine du problème et qui l'invite à se reconnecter.