### PR TITLE
[FEATURE] Modifications du nom de fichier du PDF des attestations de certif (PIX-3003)

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -98,7 +98,9 @@ module.exports = {
 
     const { buffer } = await certificationAttestationPdf.getCertificationAttestationsPdfBuffer({ certificates: attestations });
 
-    const fileName = `attestations-pix-${division}-${moment(attestations[0].deliveredAt).format('YYYYMMDD')}.pdf`;
+    const now = moment();
+    const fileName = `${now.format('YYYYMMDD')}_attestations_${division}.pdf`;
+
     return h.response(buffer)
       .header('Content-Disposition', `attachment; filename=${fileName}`)
       .header('Content-Type', 'application/pdf');

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -866,28 +866,29 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
   describe('#downloadCertificationAttestationsForDivision', () => {
 
-    const certifications = [
-      domainBuilder.buildPrivateCertificateWithCompetenceTree(),
-      domainBuilder.buildPrivateCertificateWithCompetenceTree(),
-    ];
-    const organizationId = domainBuilder.buildOrganization().id;
-    const division = '3b';
-    const attestationsPDF = 'binary string';
-    const fileName = 'attestations-pix-3b-20181003.pdf';
-    const userId = 1;
-
-    const request = {
-      auth: { credentials: { userId } },
-      params: { id: organizationId },
-      query: { division },
-    };
-
-    beforeEach(() => {
-      sinon.stub(usecases, 'findCertificationAttestationsForDivision');
-    });
-
     it('should return binary attestations', async () => {
       // given
+      const certifications = [
+        domainBuilder.buildPrivateCertificateWithCompetenceTree(),
+        domainBuilder.buildPrivateCertificateWithCompetenceTree(),
+      ];
+      const organizationId = domainBuilder.buildOrganization().id;
+      const division = '3b';
+      const attestationsPDF = 'binary string';
+
+      sinon.stub(momentProto, 'format');
+      momentProto.format.withArgs('YYYYMMDD').returns('20210101');
+
+      const fileName = '20210101_attestations_3b.pdf';
+      const userId = 1;
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { id: organizationId },
+        query: { division },
+      };
+
+      sinon.stub(usecases, 'findCertificationAttestationsForDivision');
       sinon.stub(certificationAttestationPdf, 'getCertificationAttestationsPdfBuffer').resolves({ buffer: attestationsPDF, fileName });
       usecases.findCertificationAttestationsForDivision.resolves(certifications);
 
@@ -900,7 +901,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
         organizationId,
       });
       expect(response.source).to.deep.equal(attestationsPDF);
-      expect(response.headers['Content-Disposition']).to.contains('attachment; filename=attestations-pix-3b-20181003.pdf');
+      expect(response.headers['Content-Disposition']).to.contains('attachment; filename=20210101_attestations_3b.pdf');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est possible pour une Admin Pix Orga de télécharger par classe 2 fichiers : le fichier csv des résultats et/ou les attestations de certification. 

Ces 2 fichiers n’ont pas la même nomenclature.

## :robot: Solution
Homogénéiser le nom des 2 fichiers : 

- Modifier le nom du fichier pdf des attestations de certif comme suit : dateDeTelechargement_attestations_nomDeLaClasse (ex : 20210814_attestations_3EME1)

- La date doit être la date de téléchargement du fichier (et non comme actuellement la date de délivrance car il se peut qu’un PDF contienne des attestations avec des dates de délivrance différentes)


## :100: Pour tester
- Activer le toggle FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED
- Dans pix-orga, télécharger les résultats de la classe 3A
- Constater que le nom du fichier correspond à la nouvelle règle 

![image](https://user-images.githubusercontent.com/37305474/129357511-00b7e8e2-2caf-4ee8-b2a2-dbd5206d00cd.png)

