### PR TITLE
[SCRIPT] Ajouter la colonne "createdBy" dans le script de création des organisations PRO (PIX-3009).

### DIFF
--- a/api/lib/domain/usecases/create-pro-organizations-with-tags.js
+++ b/api/lib/domain/usecases/create-pro-organizations-with-tags.js
@@ -62,7 +62,6 @@ module.exports = async function createProOrganizationsWithTags({
 };
 
 function _checkIfOrganizationsDataAreNotEmptyAndUnique(organizations) {
-
   if (!organizations) {
     throw new ObjectValidationError('Les organisations ne sont pas renseignées.');
   }
@@ -74,7 +73,6 @@ function _checkIfOrganizationsDataAreNotEmptyAndUnique(organizations) {
 }
 
 async function _checkIfOrganizationsAlreadyExistInDatabase(organizations, organizationRepository) {
-
   const organizationIds = await organizationRepository.findByExternalIdsFetchingIdsOnly(map(organizations, 'externalId'));
   if (!isEmpty(organizationIds)) {
     throw new OrganizationAlreadyExistError();

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -61,7 +61,10 @@ module.exports = {
   },
 
   async batchCreateProOrganizations(organizations, domainTransaction = DomainTransaction.emptyTransaction()) {
-    const organizationsRawData = organizations.map((organization) => _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'email', 'isManagingStudents', 'canCollectProfiles', 'credit']));
+    const organizationsRawData = organizations.map((organization) => _.pick(
+      organization,
+      ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'email', 'isManagingStudents', 'canCollectProfiles', 'credit', 'createdBy'],
+    ));
     return Bookshelf.knex.batchInsert('organizations', organizationsRawData).transacting(domainTransaction.knexTransaction).returning(['id', 'externalId', 'email', 'name']);
   },
 

--- a/api/scripts/create-pro-organizations-with-tags.js
+++ b/api/scripts/create-pro-organizations-with-tags.js
@@ -1,11 +1,15 @@
 /* eslint-disable no-console */
+
 // Usage: node create-pro-organizations-with-tags.js path/file.csv
-// To use on file with columns |externalId, name, provinceCode, canCollectProfiles, credit, email, locale, tags|
+// To use on file with columns |externalId, name, provinceCode, canCollectProfiles, credit, email, locale, tags, createdBy|
 
 'use strict';
 require('dotenv').config();
 
-const { parseCsvWithHeader } = require('./helpers/csvHelpers');
+const {
+  checkCsvHeader,
+  parseCsvWithHeaderAndRequiredFields,
+} = require('./helpers/csvHelpers');
 
 const createProOrganizationsWithTags = require('../lib/domain/usecases/create-pro-organizations-with-tags');
 const domainTransaction = require('../lib/infrastructure/DomainTransaction');
@@ -14,14 +18,25 @@ const organizationRepository = require('../lib/infrastructure/repositories/organ
 const organizationTagRepository = require('../lib/infrastructure/repositories/organization-tag-repository');
 const tagRepository = require('../lib/infrastructure/repositories/tag-repository');
 
+const REQUIRED_FIELD_NAMES = ['createdBy'];
+
 async function main() {
   console.log('Starting creating PRO organizations.');
 
   try {
     const filePath = process.argv[2];
 
+    console.log('Reading and checking csv header file... ');
+    await checkCsvHeader({
+      filePath,
+      requiredFieldNames: REQUIRED_FIELD_NAMES,
+    });
+
     console.log('Reading and parsing csv data file... ');
-    const organizations = await parseCsvWithHeader(filePath);
+    const organizations = await parseCsvWithHeaderAndRequiredFields({
+      filePath,
+      requiredFieldNames: REQUIRED_FIELD_NAMES,
+    });
 
     console.log('Creating PRO organizations...');
     const createdOrganizations = await createProOrganizationsWithTags({

--- a/api/tests/integration/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/integration/scripts/helpers/csvHelpers_test.js
@@ -1,0 +1,90 @@
+const { expect, catchErr } = require('../../../test-helper');
+const { FileValidationError, NotFoundError } = require('../../../../lib/domain/errors');
+const {
+  checkCsvHeader,
+  parseCsvWithHeaderAndRequiredFields,
+} = require('../../../../scripts/helpers/csvHelpers');
+
+describe('Integration | Scripts | Helpers | csvHelpers.js', () => {
+
+  const withValidHeaderFilePath = `${__dirname}/files/withValidHeader-test.csv`;
+
+  describe('#checkCsvHeader', () => {
+
+    it('should throw NotFoundError if file does not exist', async () => {
+      // given
+      const nonExistentFile = 'nonExistentFile.csv';
+      const requiredFieldNames = ['createdBy'];
+
+      // when
+      const error = await catchErr(checkCsvHeader)({
+        filePath: nonExistentFile,
+        requiredFieldNames,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+
+    it('should throw FileValidationError if required field names are empty', async () => {
+      // given
+      const requiredFieldNames = [];
+
+      // when
+      const error = await catchErr(checkCsvHeader)({
+        filePath: withValidHeaderFilePath,
+        requiredFieldNames,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(FileValidationError);
+      expect(error.code).to.equal('MISSING_REQUIRED_FIELD_NAMES');
+    });
+
+    it('should throw FileValidationError if required header field names are not present', async () => {
+      // given
+      const requiredFieldNames = ['foo'];
+
+      // when
+      const error = await catchErr(checkCsvHeader)({
+        filePath: withValidHeaderFilePath,
+        requiredFieldNames,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(FileValidationError);
+      expect(error.code).to.equal('MISSING_REQUIRED_FIELD_NAMES');
+      expect(error.meta).to.equal('Header are required: foo');
+    });
+
+    it('should not throw if required header field names are present', async () => {
+      // given
+      const requiredFieldNames = ['name', 'createdBy'];
+
+      // then
+      expect(await checkCsvHeader({
+        filePath: withValidHeaderFilePath,
+        requiredFieldNames,
+      })).to.not.throw;
+    });
+  });
+
+  describe('parseCsvWithHeaderAndRequiredFields', () => {
+
+    it('should throw FileValidationError if required field value is empty', async () => {
+      // given
+      const requiredFieldNames = ['createdBy'];
+
+      // when
+      const error = await catchErr(parseCsvWithHeaderAndRequiredFields)({
+        filePath: withValidHeaderFilePath,
+        requiredFieldNames,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(FileValidationError);
+      expect(error.code).to.equal('MISSING_REQUIRED_FIELD_VALUES');
+      expect(error.meta).to.equal('Field values are required: createdBy');
+    });
+  });
+});

--- a/api/tests/integration/scripts/helpers/files/withNoRequiredfieldValue-test.csv
+++ b/api/tests/integration/scripts/helpers/files/withNoRequiredfieldValue-test.csv
@@ -1,0 +1,3 @@
+createdBy;externalId;name;provinceCode;canCollectProfiles;credit;email;locale;tags
+15;b2066;Nom orga;123;false;0;youness.yahya@pix.fr;fr-fr;PUBLIC_AGRICULTURE
+;b2066;Nom orga;123;false;0;youness.yahya@pix.fr;fr-fr;PUBLIC_AGRICULTURE

--- a/api/tests/integration/scripts/helpers/files/withValidHeader-test.csv
+++ b/api/tests/integration/scripts/helpers/files/withValidHeader-test.csv
@@ -1,0 +1,3 @@
+createdBy;externalId;name;provinceCode;canCollectProfiles;credit;email;locale;tags
+15;b2066;Nom orga;123;false;0;youness.yahya@pix.fr;fr-fr;PUBLIC_AGRICULTURE
+;b2066;Nom orga;123;false;0;youness.yahya@pix.fr;fr-fr;PUBLIC_AGRICULTURE

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -31,14 +31,10 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', () => {
       expect(error.meta).to.deep.equal({ fileExtension: '.html' });
     });
 
-    it('should return true if file is valid', async () => {
-      // when
-      const result = await checkCsvExtensionFile(validFilePath);
-
+    it('should not throw if file is valid', async () => {
       // then
-      expect(result).to.be.true;
+      expect(await checkCsvExtensionFile(validFilePath)).to.not.throw;
     });
-
   });
 
   describe('#parseCsv', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Pour la création des organisations PRO, il faut préciser quel Pix Master a créé le fichier csv.

## :robot: Solution
* Dans le script [Création des organisation PRO (OGA)](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2631630885/2020-04-20+Cr+ation+des+organisation+PRO), ajouter la colonne `createdBy` associant un `userId` à chaque organisation. 
* Rendre cette colonne et les valeurs associées obligatoires.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Réinitialisez les seeds de la RA
```sh
scalingo -region osc-fr1 -a pix-api-review-pr3331 run "npm run db:seed"
```

2. Utilisez le fichier [bad-header-PRO-ORGA.csv](https://github.com/1024pix/pix/files/6991724/bad-header-PRO-ORGA.csv) qui n'a pas la colonne `createdBy`
    * Lancez la commande suivante :  
    ```sh 
    scalingo --region osc-fr1 -a pix-api-review-pr3331 run --file bad-header-PRO-ORGA.csv node scripts/create-pro-organizations-with-tags.js /tmp/uploads/bad-header-PRO-ORGA.csv
    ```
    * Vérifiez que vous obtenez une erreur

3. Utilisez le fichier [bad-value-PRO-ORGA.csv](https://github.com/1024pix/pix/files/6991764/bad-value-PRO-ORGA.csv) qui comporte une ligne avec une valeur `createdBy` non renseignée
    * Lancez à nouveau la commande en **1.**
    * Lancez la commande suivante :  
    ```sh 
    scalingo --region osc-fr1 -a pix-api-review-pr3331 run --file bad-value-PRO-ORGA.csv node scripts/create-pro-organizations-with-tags.js /tmp/uploads/bad-value-PRO-ORGA.csv
    ```
    * Vérifiez que vous obtenez une erreur

4. Utilisez le fichier [good-PRO-ORGA.csv](https://github.com/1024pix/pix/files/6991784/good-PRO-ORGA.csv)
    * Lancez à nouveau la commande en **1.**
    * Lancez la commande suivante :  
    ```sh 
    scalingo --region osc-fr1 -a pix-api-review-pr3331 run --file good-PRO-ORGA.csv node scripts/create-pro-organizations-with-tags.js /tmp/uploads/good-PRO-ORGA.csv
    ```
    * Vérifiez que vous obtenez : 
    ```sh
    Done.
    10000007,LIKE A PRO MARKETING
    10000008,Conseil départemental de la Nièvre - Médiation Numérique
    10000009,Cyan47
    ```
    * Vérifiez en base de données que les champs `organizations.createdBy` sont bien renseignés
