### PR TITLE
[FEATURE] Ne pas afficher de conseils/tooltips pour les épreuves hors focus (PIX-2899).

### DIFF
--- a/mon-pix/app/components/challenge/statement/tooltip.hbs
+++ b/mon-pix/app/components/challenge/statement/tooltip.hbs
@@ -1,32 +1,34 @@
-<div class="tooltip__tag tooltip__tag{{if this.isFocusedChallenge "--focused" "--regular"}}">
-  <button type="button"
-          tabindex="0"
-          aria-describedby="tooltip-tag-info"
-          aria-label={{t 'pages.challenge.statement.tooltip.aria-label'}}
-          class="tooltip-tag__icon-button"
-          {{on 'mouseenter' (fn this.displayTooltip true)}}
-          {{on 'mouseleave' (fn this.displayTooltip false)}}
-          {{on 'click' (fn this.displayTooltip true)}}/>
+{{#if this.isChallengeWithTooltip}}
+  <div class="tooltip__tag tooltip__tag{{if this.isFocusedChallenge "--focused" "--regular"}}">
+    <button type="button"
+            tabindex="0"
+            aria-describedby="tooltip-tag-info"
+            aria-label={{t 'pages.challenge.statement.tooltip.aria-label'}}
+            class="tooltip-tag__icon-button"
+            {{on 'mouseenter' (fn this.displayTooltip true)}}
+            {{on 'mouseleave' (fn this.displayTooltip false)}}
+            {{on 'click' (fn this.displayTooltip true)}}/>
 
-  {{#if this.shouldDisplayTooltip}}
-    <div role="tooltip"
-         id="tooltip-tag-info"
-         class="tooltip-tag__information"
-         tabindex="0"
-      {{on-key 'Escape' (fn this.displayTooltip false) event='keyup'}}
-      {{on 'focusout' (fn this.displayTooltip false)}}>
-      {{#if this.isFocusedChallenge}}
-        <p class="tooltip-tag-information__text">
-          {{t 'pages.challenge.statement.tooltip.focused'}}
-        </p>
-      {{/if}}
-      {{#if this.shouldDisplayButton}}
-        <PixButton class="tooltip-tag-information__button"
-                   @size="small"
-                   @triggerAction={{this.confirmInformationIsRead}}>
-          {{t 'pages.challenge.statement.tooltip.close'}}
-        </PixButton>
-      {{/if}}
-    </div>
-  {{/if}}
-</div>
+    {{#if this.shouldDisplayTooltip}}
+      <div role="tooltip"
+           id="tooltip-tag-info"
+           class="tooltip-tag__information"
+           tabindex="0"
+           {{on-key 'Escape' (fn this.displayTooltip false) event='keyup'}}
+           {{on 'focusout' (fn this.displayTooltip false)}}>
+        {{#if this.isFocusedChallenge}}
+          <p class="tooltip-tag-information__text">
+            {{t 'pages.challenge.statement.tooltip.focused'}}
+          </p>
+        {{/if}}
+        {{#if this.shouldDisplayButton}}
+          <PixButton class="tooltip-tag-information__button"
+                     @size="small"
+                     @triggerAction={{this.confirmInformationIsRead}}>
+            {{t 'pages.challenge.statement.tooltip.close'}}
+          </PixButton>
+        {{/if}}
+      </div>
+    {{/if}}
+  </div>
+{{/if}}

--- a/mon-pix/app/components/challenge/statement/tooltip.js
+++ b/mon-pix/app/components/challenge/statement/tooltip.js
@@ -18,6 +18,10 @@ export default class Tooltip extends Component {
     return this.args.challenge.focused;
   }
 
+  get isChallengeWithTooltip() {
+    return this.isFocusedChallenge;
+  }
+
   _showTooltip() {
     if (this._hasCurrentUserNotSeenFocusedChallengeTooltip()) {
       this.shouldDisplayTooltip = true;

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -67,7 +67,23 @@ describe('Integration | Component | ChallengeStatement', function() {
       expect(find('.challenge-statement-instruction__text').textContent.trim()).to.equal('La consigne de mon test');
     });
 
-    it('should render a tag', async function() {
+    it('should render a tag for challenge with tooltip', async function() {
+      // given
+      addAssessmentToContext(this, { id: '267845' });
+      addChallengeToContext(this, {
+        instruction: 'La consigne de mon test',
+        id: 'rec_challenge',
+        focused: true,
+      });
+
+      // when
+      await renderChallengeStatement(this);
+
+      // then
+      expect(find('.tooltip__tag')).to.exist;
+    });
+
+    it('should not render a tag for challenge without tooltip', async function() {
       // given
       addAssessmentToContext(this, { id: '267845' });
       addChallengeToContext(this, {
@@ -79,7 +95,7 @@ describe('Integration | Component | ChallengeStatement', function() {
       await renderChallengeStatement(this);
 
       // then
-      expect(find('.tooltip__tag')).to.exist;
+      expect(find('.tooltip__tag')).to.not.exist;
     });
 
     it('should not render challenge instruction if it does not exist', async function() {
@@ -159,7 +175,7 @@ describe('Integration | Component | ChallengeStatement', function() {
 
       // then
       expect(find('.tooltip__tag--focused')).to.not.exist;
-      expect(find('.tooltip__tag--regular')).to.exist;
+      expect(find('.tooltip__tag--regular')).to.not.exist;
     });
   });
 

--- a/mon-pix/tests/integration/components/challenge/challenge-statement/focused-tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/challenge-statement/focused-tooltip_test.js
@@ -11,6 +11,33 @@ describe('Integration | Component | Tooltip', function() {
 
   const tooltip = '.tooltip-tag__information';
   const confirmationButton = '.tooltip-tag-information__button';
+  describe('when challenge is not focused', function() {
+    beforeEach(async function() {
+      // given
+      class currentUser extends Service {
+        user = {
+          hasSeenFocusedChallengeTooltip: true,
+        }
+      }
+
+      this.owner.unregister('service:currentUser');
+      this.owner.register('service:currentUser', currentUser);
+
+      this.set('challenge', {
+        instruction: 'La consigne de mon test',
+        id: 'rec_challenge',
+        focused: false,
+      });
+      this.set('onTooltipClose', () => {});
+
+      await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipClose}}/>`);
+    });
+
+    it('should not render the tooltip', async function() {
+      // then
+      expect(find(tooltip)).to.not.exist;
+    });
+  });
 
   describe('when user has not seen the tooltip yet', function() {
     beforeEach(async function() {


### PR DESCRIPTION
## :unicorn: Problème
Précédemment, nous devions avoir un tooltip pour les épreuves focus et un autre pour les autres types d'épreuves. En fin de compte, il va falloir avoir plusieurs types de tooltip. Pour éviter tout soucis de compréhension, nous n'affichons pas de conseil pour les épreuves hors focus pour le moment.

## :robot: Solution
N'afficher le component tooltipsque sur les épreuves dont on a déjà un tooltip (actuellement, que le focus)

## :rainbow: Remarques

## :100: Pour tester
Voir les épreuves focus (rec2dRKsI4aBIsayz) et les autres (rec4mYfhm45A222ab)