### PR TITLE
[FEATURE] Ajout scroll sur la modale d'édition de candidat sur Pix-Admin (PIX-2980)

### DIFF
--- a/admin/app/styles/components/certification/candidate-edit-modal.scss
+++ b/admin/app/styles/components/certification/candidate-edit-modal.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable no-descending-specificity */
 
 .candidate-edit-modal {
+
   &__title {
     font-family: $open-sans;
     padding: 12px 32px;

--- a/admin/app/styles/components/modal.scss
+++ b/admin/app/styles/components/modal.scss
@@ -63,7 +63,13 @@
 .ember-modal-overlay {
   display:flex;
   justify-content: center;
-  align-items: center;
+  overflow: scroll;
+
+  & > div {
+    height: max-content;
+    position: static;
+    margin: 10vh 0;
+  }
 }
 
 .ember-modal-overlay.translucent {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la modale d'édition ne permet pas de cliquer sur le bouton pour enregistrer les modifications lorsqu'elle elle est zoomée - testé sur FF, Chrome et Edge


## :robot: Solution
Ajouter le scroll à la modale


## :100: Pour tester

Sur Chrome, Firefox et Edge:

- Se connecter à Pix-admin
- Zoomer son navigateur
- Se rendre dans la zone d'édition candidat dans la page de détail d'une certification
- Constater qu la modale est désormais scrollable et qu'il est possible d'enregistrer les modifications


![image](https://user-images.githubusercontent.com/37305474/129863259-5fad1eb5-aea0-444c-a72e-3702a671ef2c.png)


