### PR TITLE
[FEATURE] Supprimer le modèle d'import et l'explication des imports pour les orga AGRI SCO (PIX-2952).

### DIFF
--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -4,7 +4,6 @@ const { DEFAULT_PASSWORD } = require('./users-builder');
 const SCO_MIDDLE_SCHOOL_ID = 3;
 const SCO_HIGH_SCHOOL_ID = 6;
 const SCO_AGRI_ID = 7;
-const SCO_AGRI_CFA_ID = 8;
 const SCO_AEFE_ID = 9;
 const SCO_STUDENT_ID = 99;
 const CANADA_INSEE_CODE = '401';
@@ -284,33 +283,6 @@ function organizationsScoBuilder({ databaseBuilder }) {
     organizationRole: Membership.roles.MEMBER,
   });
 
-  /* CFA AGRICULTURE */
-  databaseBuilder.factory.buildOrganization({
-    id: 8,
-    type: 'SCO',
-    name: 'CFA Agricole',
-    isManagingStudents: true,
-    canCollectProfiles: true,
-    email: 'sco4.generic.account@example.net',
-    externalId: '1237457D',
-    provinceCode: '12',
-  });
-
-  databaseBuilder.factory.buildOrganizationTag({ organizationId: SCO_AGRI_CFA_ID, tagId: 1 });
-  databaseBuilder.factory.buildOrganizationTag({ organizationId: SCO_AGRI_CFA_ID, tagId: 5 });
-
-  databaseBuilder.factory.buildMembership({
-    userId: scoUser1.id,
-    organizationId: SCO_AGRI_CFA_ID,
-    organizationRole: Membership.roles.ADMIN,
-  });
-
-  databaseBuilder.factory.buildMembership({
-    userId: scoUser2.id,
-    organizationId: SCO_AGRI_CFA_ID,
-    organizationRole: Membership.roles.MEMBER,
-  });
-
   /* AEFE */
   databaseBuilder.factory.buildOrganization({
     id: SCO_AEFE_ID,
@@ -369,7 +341,6 @@ module.exports = {
   SCO_MIDDLE_SCHOOL_ID,
   SCO_HIGH_SCHOOL_ID,
   SCO_AGRI_ID,
-  SCO_AGRI_CFA_ID,
   SCO_AEFE_ID,
   SCO_STUDENT_ID,
   SCO_FOREIGNER_USER_ID,

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -63,10 +63,6 @@ class Organization {
     return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.AGRICULTURE));
   }
 
-  get isCFA() {
-    return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.CFA));
-  }
-
   get isAEFE() {
     return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.AEFE));
   }

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -15,7 +15,6 @@ module.exports = {
           organization: {
             ...recordWithoutClass.userOrgaSettings.currentOrganization,
             isAgriculture: recordWithoutClass.userOrgaSettings.currentOrganization.isAgriculture,
-            isCFA: recordWithoutClass.userOrgaSettings.currentOrganization.isCFA,
             isAEFE: recordWithoutClass.userOrgaSettings.currentOrganization.isAEFE,
             isMLF: recordWithoutClass.userOrgaSettings.currentOrganization.isMLF,
             isMediationNumerique: recordWithoutClass.userOrgaSettings.currentOrganization.isMediationNumerique,
@@ -43,7 +42,7 @@ module.exports = {
         attributes: ['organization', 'user'],
         organization: {
           ref: 'id',
-          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isCFA', 'isAEFE', 'isMLF', 'isMediationNumerique', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isAEFE', 'isMLF', 'isMediationNumerique', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1364,34 +1364,6 @@ describe('Acceptance | Application | organization-controller', () => {
       });
     });
 
-    context('when it‘s a SCO AGRICULTURE organization', () => {
-      beforeEach(async () => {
-        organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
-        const tag = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag.id });
-        databaseBuilder.factory.buildMembership({
-          userId,
-          organizationId: organization.id,
-          organizationRole: Membership.roles.ADMIN,
-        });
-        await databaseBuilder.commit();
-      });
-
-      it('should return csv file with statusCode 200', async () => {
-        // given
-        const options = {
-          method: 'GET',
-          url: `/api/organizations/${organization.id}/schooling-registrations/csv-template?accessToken=${accessToken}`,
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200, response.payload);
-      });
-    });
-
     context('when it‘s not a valid organization', () => {
       beforeEach(async () => {
         organization = databaseBuilder.factory.buildOrganization({ type: 'PRO' });

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -175,41 +175,6 @@ describe('Unit | Domain | Models | Organization', () => {
     });
   });
 
-  describe('get#isCFA', () => {
-    context('when organization is not SCO', () => {
-      it('should return false when the organization has the "CFA" tag', () => {
-        // given
-        const tag = domainBuilder.buildTag({ name: Tag.CFA });
-        const organization = domainBuilder.buildOrganization({ type: 'SUP', tags: [tag] });
-
-        // when / then
-        expect(organization.isCFA).is.false;
-      });
-    });
-
-    context('when organization is SCO', () => {
-      it('should return true when organization is of type SCO and has the "CFA" tag', () => {
-        // given
-        const tag1 = domainBuilder.buildTag({ name: Tag.CFA });
-        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
-        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
-
-        // when / then
-        expect(organization.isCFA).is.true;
-      });
-
-      it('should return false when when organization is of type SCO and has not the "CFA" tag', () => {
-        // given
-        const tag1 = domainBuilder.buildTag({ name: 'To infinity…and beyond!' });
-        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
-        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
-
-        // when / then
-        expect(organization.isCFA).is.false;
-      });
-    });
-  });
-
   describe('get#isAEFE', () => {
     context('when organization is not SCO', () => {
       it('should return false when the organization has the "AEFE" tag', () => {

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -65,65 +65,6 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
     });
   });
 
-  context('When user is ADMIN in a SCO-AGRICULTURE organization managing students', () => {
-    it('should return headers line', async () => {
-      // given
-      const tag = domainBuilder.buildTag({ name: 'AGRICULTURE' });
-      const organization = domainBuilder.buildOrganization({ id: '1', isManagingStudents: true, type: 'SCO', tags: [tag] });
-      const membership = domainBuilder.buildMembership({ organizationRole: 'ADMIN', organization });
-      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([membership]);
-
-      // when
-      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, membershipRepository, i18n });
-
-      // then
-      const csvExpected = '\uFEFF"Identifiant unique*";' +
-        '"Premier prénom*";' +
-        '"Deuxième prénom";' +
-        '"Troisième prénom";' +
-        '"Nom de famille*";' +
-        '"Nom d\'usage";' +
-        '"Sexe*";' +
-        '"Date de naissance (jj/mm/aaaa)*";' +
-        '"Code commune naissance**";' +
-        '"Libellé commune naissance**";' +
-        '"Code département naissance*";' +
-        '"Code pays naissance*";' +
-        '"Statut*";' +
-        '"Code MEF*";' +
-        '"Division*"\n';
-
-      expect(result).to.deep.equal(csvExpected);
-    });
-  });
-
-  context('When user is ADMIN in a SCO-AGRICULTURE organization not managing students', () => {
-    it('should throw an error', async () => {
-      // given
-      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: false, type: 'SCO' } }]);
-
-      // when
-      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
-
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
-    });
-  });
-
-  context('When user is not ADMIN in a SCO-AGRICULTURE organization', () => {
-    it('should throw an error', async () => {
-      // given
-      process.env['AGRICULTURE_ORGANIZATION_ID'] = '1';
-      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: false, organization: { id: '1', isManagingStudents: true, type: 'SCO' } }]);
-
-      // when
-      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
-
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
-    });
-  });
-
   context('When user is not a member of the organization', () => {
     it('should throw an error', async () => {
       // given
@@ -136,18 +77,4 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
-
-  context('When user is ADMIN in a SCO organization', () => {
-    it('should throw an error', async () => {
-      // given
-      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: true, type: 'SCO' } }]);
-
-      // when
-      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
-
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
-    });
-  });
-
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -320,48 +320,6 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
       });
     });
 
-    context('when isCFA is true', () => {
-      it('should serialize prescriber with isCFA', () => {
-        // given
-        const user = domainBuilder.buildUser({
-          pixOrgaTermsOfServiceAccepted: true,
-          memberships: [],
-          certificationCenterMemberships: [],
-        });
-
-        const tags = [domainBuilder.buildTag({ name: 'CFA' })];
-        const organization = domainBuilder.buildOrganization({ tags });
-
-        const membership = domainBuilder.buildMembership({
-          organization,
-          organizationRole: Membership.roles.MEMBER,
-          user,
-        });
-
-        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
-          currentOrganization: organization,
-        });
-        userOrgaSettings.user = null;
-
-        const prescriber = domainBuilder.buildPrescriber({
-          firstName: user.firstName,
-          lastName: user.lastName,
-          areNewYearSchoolingRegistrationsImported: false,
-          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
-          memberships: [membership],
-          userOrgaSettings,
-        });
-
-        const expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField: 'is-cfa', field: 'isCFA' });
-
-        // when
-        const result = serializer.serialize(prescriber);
-
-        // then
-        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
-      });
-    });
-
     context('when isAEFE is true', () => {
       it('should serialize prescriber with isAEFE', () => {
         // given

--- a/orga/app/components/student/sco/header-actions.hbs
+++ b/orga/app/components/student/sco/header-actions.hbs
@@ -2,23 +2,6 @@
   <h1 class="page__title page-title">{{t "pages.students-sco.title"}}</h1>
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="list-students-page__import-students-button hide-on-mobile">
-      {{#if this.displayLearnMoreAndLinkTemplate }}
-        <PixTooltip
-          @text={{t "pages.students-sco.agri-tooltip" htmlSafe=true}}
-          @position='bottom-left'
-          @isLight={{true}}
-          @isWide={{true}}
-          class="list-students-page__tooltip">
-            <span class="list-students-page__tooltip-title">
-              <span>{{t "pages.students-sco.know-more"}}</span>
-              <FaIcon @icon="info-circle" class="info-icon"/>
-            </span>
-        </PixTooltip>
-        <a class="button button--link button--no-color"
-          href="{{this.urlToDownloadCsvTemplate}}" target="_blank" rel="noopener noreferrer" download>
-          {{t "pages.students-sco.actions.download-template"}}
-        </a>
-      {{/if}}
       <FileUpload @name="file-upload" @for="students-file-upload" @accept={{this.acceptedFileType}} @multiple={{false}} @onfileadd={{@onImportStudents}}>
         <span class="button" role="button" tabindex="0">
           {{this.importButtonLabel}}

--- a/orga/app/components/student/sco/header-actions.js
+++ b/orga/app/components/student/sco/header-actions.js
@@ -20,10 +20,6 @@ export default class ScoHeaderActions extends Component {
     return this.intl.t('pages.students-sco.actions.import-file.label', { types });
   }
 
-  get displayLearnMoreAndLinkTemplate() {
-    return this.currentUser.isAgriculture && this.currentUser.isCFA;
-  }
-
   get urlToDownloadCsvTemplate() {
     return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}&lang=${this.currentUser.prescriber.lang}`;
   }

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -8,7 +8,6 @@ export default class Organization extends Model {
   @attr('boolean') isManagingStudents;
   @attr('boolean') canCollectProfiles;
   @attr('boolean') isAgriculture;
-  @attr('boolean') isCFA;
   @attr('boolean') isAEFE;
   @attr('boolean') isMLF;
   @attr('boolean') isMediationNumerique;

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -12,7 +12,6 @@ export default class CurrentUserService extends Service {
   @tracked isSCOManagingStudents;
   @tracked isSUPManagingStudents;
   @tracked isAgriculture;
-  @tracked isCFA;
   @tracked isAEFE;
   @tracked isMLF;
   @tracked isMediationNumerique;
@@ -58,7 +57,6 @@ export default class CurrentUserService extends Service {
     this.isSUPManagingStudents = isSUPManagingStudents;
 
     this.isAgriculture = organization.isAgriculture;
-    this.isCFA = organization.isCFA;
     this.isAEFE = organization.isAEFE;
     this.isMLF = organization.isMLF;
     this.isMediationNumerique = organization.isMediationNumerique;

--- a/orga/tests/integration/components/students/sco/header-actions_test.js
+++ b/orga/tests/integration/components/students/sco/header-actions_test.js
@@ -39,7 +39,6 @@ module('Integration | Component | Student::Sco::HeaderActions', function(hooks) 
           class CurrentUserStub extends Service {
             isAdminInOrganization = true;
             isAgriculture = true;
-            isCFA = true;
             organization = {};
             prescriber = {
               lang: 'fr',

--- a/orga/tests/integration/components/students/sco/header-actions_test.js
+++ b/orga/tests/integration/components/students/sco/header-actions_test.js
@@ -32,40 +32,6 @@ module('Integration | Component | Student::Sco::HeaderActions', function(hooks) 
         test('it should display import XML file button', async function(assert) {
           assert.contains('Importer (.xml ou .zip)');
         });
-
-        test('it should not display download template csv file button for agriculture/cfa organization', async function(assert) {
-          assert.notContains('Télécharger le modèle');
-        });
-
-        test('it should not display the tooltip for agriculture/cfa organization', async function(assert) {
-          assert.notContains('En savoir plus');
-        });
-      });
-
-      module('when organization is SCO and tagged as Agriculture', (hooks) => {
-        hooks.beforeEach(function() {
-          class CurrentUserStub extends Service {
-            isAdminInOrganization = true;
-            isAgriculture = true;
-            organization = {};
-          }
-          this.set('importStudentsSpy', () => {});
-          this.owner.register('service:current-user', CurrentUserStub);
-          return render(hbs`<Student::Sco::HeaderActions @onImportStudents={{importStudentsSpy}} />`);
-        });
-
-        test('it should display import CSV file button', async function(assert) {
-          assert.contains('Importer (.csv)');
-        });
-
-        test('it should not display download template csv button', async function(assert) {
-          // then
-          assert.notContains('Télécharger le modèle');
-        });
-
-        test('it should not display the tooltip', async function(assert) {
-          assert.notContains('En savoir plus');
-        });
       });
 
       module('when organization is SCO and tagged as Agriculture and CFA', (hooks) => {
@@ -87,15 +53,6 @@ module('Integration | Component | Student::Sco::HeaderActions', function(hooks) 
 
         test('it should still display import CSV file button', async function(assert) {
           assert.contains('Importer (.csv)');
-        });
-
-        test('it should display download template csv button', async function(assert) {
-          // then
-          assert.contains('Télécharger le modèle');
-        });
-
-        test('it should display the tooltip', async function(assert) {
-          assert.contains('En savoir plus');
         });
       });
     });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -538,7 +538,6 @@
     "students-sco": {
       "title": "Students",
       "actions": {
-        "download-template": "Download the template",
         "import-file": {
           "file-type-separator": " or ",
           "label": "Import ({types})"
@@ -546,7 +545,6 @@
         "manage-account": "Manage the account",
         "show-actions": "Show actions"
       },
-      "agri-tooltip": "Some information about import:<ul><li>For your students: use the FREGATA export towards Pix and click on the import button.</li><li>For your trainees: Pix imports all trainees at the end of November into your Pix Orga space. From December on, you will be able to add trainees from time to time. To do so, consult the Pix Orga documentation and use the template provided.</li></ul>",
       "connection-types": {
         "email": "Email address",
         "empty": "–",
@@ -559,7 +557,6 @@
         "global-error": "<div>Import has failed.<br/>Please try again or contact us through <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">the help form</a>.</div>",
         "global-success": "The list has been successfully imported."
       },
-      "know-more": "Know more",
       "manage-authentication-method-modal": {
         "title": "Managing the student's Pix account",
         "authentication-methods": "Log in methods",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -537,7 +537,6 @@
     "students-sco": {
       "title": "Élèves",
       "actions": {
-        "download-template": "Télécharger le modèle",
         "import-file": {
           "file-type-separator": " ou ",
           "label": "Importer ({types})"
@@ -545,7 +544,6 @@
         "manage-account": "Gérer le compte",
         "show-actions": "Afficher les actions"
       },
-      "agri-tooltip": "Quelques informations concernant l’import :<ul><li>Pour vos élèves : utiliser l’export FREGATA vers Pix et cliquer sur le bouton importer.</li><li>Pour vos apprentis : Pix importe tous les apprentis fin novembre au sein de votre espace Pix Orga. Les ajouts ponctuels d’apprentis se feront à partir de décembre, pour cela consulter la documentation Pix Orga et utiliser le modèle fourni.</li></ul>",
       "connection-types": {
         "email": "Adresse e-mail",
         "empty": "–",
@@ -558,7 +556,6 @@
         "global-error": "<div>Aucun élève n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">le formulaire du centre d’aide</a>.</div>",
         "global-success": "La liste a été importée avec succès."
       },
-      "know-more": "En savoir plus",
       "manage-authentication-method-modal": {
         "title": "Gestion du compte Pix de l’élève",
         "authentication-methods": "Méthodes de connexion",


### PR DESCRIPTION
## :unicorn: Problème
Le ministère de l'agriculture a décidé de supprimer les INA de leur SI.
Le modèle d'import d'élève et les explications sur cet import ne sont plus utiles.

## :robot: Solution
Supprimer le bouton de téléchargement du modèle et les explications.

## :rainbow: Remarques

## :100: Pour tester
Afficher les pages élèves pour une organisation AGRI et le bouton de téléchargement du modèle et les explications ne doivent pas apparaître.
