### PR TITLE
[TECH] Mettre en cohérence l'URL du support 

### DIFF
--- a/mon-pix/app/components/footer.js
+++ b/mon-pix/app/components/footer.js
@@ -27,7 +27,7 @@ export default class Footer extends Component {
     return this.url.accessibilityUrl;
   }
 
-  get helpCenterUrl() {
-    return this.url.helpCenterUrl;
+  get supportHomeUrl() {
+    return this.url.supportHomeUrl;
   }
 }

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -67,15 +67,6 @@ export default class Url extends Service {
     return `https://pix.${this.currentDomain.getExtension()}/aide-accessibilite`;
   }
 
-  get helpCenterUrl() {
-    const currentLanguage = this.intl.t('current-lang');
-
-    if (currentLanguage === 'en') {
-      return `https://pix.${this.currentDomain.getExtension()}/help`;
-    }
-    return `https://pix.${this.currentDomain.getExtension()}/aide`;
-  }
-
   get supportHomeUrl() {
     const currentLanguage = this.intl.t('current-lang');
 

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -71,7 +71,7 @@ export default class Url extends Service {
     const currentLanguage = this.intl.t('current-lang');
 
     if (currentLanguage === 'en') {
-      return `https://pix.${this.currentDomain.getExtension()}/en-gb/faq-pix`;
+      return `https://pix.${this.currentDomain.getExtension()}/help`;
     }
     return `https://pix.${this.currentDomain.getExtension()}/aide`;
   }

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -80,8 +80,8 @@ export default class Url extends Service {
     const currentLanguage = this.intl.t('current-lang');
 
     if (currentLanguage === 'en') {
-      return 'https://support.pix.fr/en/support/home';
+      return 'https://support.pix.org/en/support/home';
     }
-    return 'https://support.pix.fr/fr/support/home';
+    return 'https://support.pix.org/fr/support/home';
   }
 }

--- a/mon-pix/app/templates/components/footer.hbs
+++ b/mon-pix/app/templates/components/footer.hbs
@@ -15,7 +15,7 @@
       <nav class="footer-container-content__navigation">
         <ul class="footer-container-content__navigation-list">
           <li>
-            <a href="{{this.helpCenterUrl}}"
+            <a href="{{this.supportHomeUrl}}"
                          target="_blank"
                          class="footer-navigation__item" rel="noopener noreferrer">
             {{t 'navigation.footer.help-center'}}

--- a/mon-pix/tests/acceptance/footer_test.js
+++ b/mon-pix/tests/acceptance/footer_test.js
@@ -32,12 +32,12 @@ describe('Acceptance | Footer', function() {
       expect(find('.footer')).to.not.exist;
     });
 
-    it('should contain link to pix.fr/aide', async function() {
+    it('should contain link to support.pix.org', async function() {
       // when
       await visit('/');
 
       // then
-      expect(find('.footer-container-content__navigation ul li:nth-child(1) a').getAttribute('href')).to.contains('/aide');
+      expect(find('.footer-container-content__navigation ul li:nth-child(1) a').getAttribute('href')).to.contains('support.pix.org');
     });
 
     it('should contain link to pix.fr/accessibilite', async function() {


### PR DESCRIPTION
## :unicorn: Problème
En langue anglaise, on a une url pour l'aide dans le footer qui pointe sur une 404. 

De plus on a 2 fonctions qui reviennent au même: 
-`helpCenterUrl`
-`supportHomeUrl`

## :robot: Solution
- Corriger l'url en de l'aide pour https://pix.org/help
- Utiliser `helpCenterUrl` plutôt que `supportHomeUrl` dans le plan du site

## :rainbow: Remarques
1. Il y une URL vers support.pix.fr qui reste dans le fichier de traduction que je voudrais changer support.pix.org, mais je connais pas la marche a suivre.
1. Je vais changer la redirection de pix-site pour qu'il redirige vers le .org directement, évitant une redirection.

## :100: Pour tester

### EN
Vérifier l'url vers le centre d'aide dans le 
- [footer](https://app-pr3336.review.pix.org/accueil)
- [plan du site](https://app-pr3336.review.pix.org/plan-du-site)

### FR
Vérifier l'url vers le centre d'aide dans le 
- [footer](https://app-pr3336.review.pix.fr/accueil) 
- [plan du site](https://app-pr3336.review.pix.fr/plan-du-site)
