### PR TITLE
[FEATURE] Rendre impossible la réconciliation SUP lorsque l'étudiant est désactivé (PIX-2864).

### DIFF
--- a/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
@@ -36,6 +36,7 @@ module.exports = {
       .query((qb) => {
         qb.where('organizationId', organizationId);
         qb.where('birthdate', birthdate);
+        qb.where('isDisabled', false);
         qb.whereRaw('LOWER(?)=LOWER(??)', [studentNumber, 'studentNumber']);
       })
       .fetch({ require: false });

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -214,13 +214,17 @@ module.exports = {
   },
 
   async reconcileUserToSchoolingRegistration({ userId, schoolingRegistrationId }) {
-    const schoolingRegistration = await BookshelfSchoolingRegistration
-      .where({ id: schoolingRegistrationId })
-      .save({ userId }, {
-        patch: true,
-      });
-
-    return bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration);
+    try {
+      const schoolingRegistration = await BookshelfSchoolingRegistration
+        .where({ id: schoolingRegistrationId })
+        .where('isDisabled', false)
+        .save({ userId }, {
+          patch: true,
+        });
+      return bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration);
+    } catch (error) {
+      throw new UserCouldNotBeReconciledError();
+    }
   },
 
   async reconcileUserByNationalStudentIdAndOrganizationId({ nationalStudentId, userId, organizationId }) {

--- a/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
@@ -68,6 +68,21 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
       });
     });
 
+    context('When there is no active registered schooling registrations', () => {
+      beforeEach(async () => {
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, studentNumber, birthdate, isDisabled: true });
+        await databaseBuilder.commit();
+      });
+
+      it('should return null', async () => {
+        // when
+        const result = await higherSchoolingRegistrationRepository.findOneByStudentNumberAndBirthdate({ organizationId, studentNumber, birthdate });
+
+        // then
+        expect(result).to.equal(null);
+      });
+    });
+
     context('When there is no schooling registrations for the organization', () => {
       beforeEach(async () => {
         const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1009,7 +1009,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     });
   });
 
-  describe('#reconcileSchoolingRegistration', () => {
+  describe('#reconcileUserToSchoolingRegistration', () => {
 
     afterEach(() => {
       return knex('schooling-registrations').delete();
@@ -1048,7 +1048,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       const error = await catchErr(schoolingRegistrationRepository.reconcileUserToSchoolingRegistration)({ userId: user.id, schoolingRegistrationId: fakeStudentId });
 
       // then
-      expect(error.message).to.be.equal('No Rows Updated');
+      expect(error).to.be.instanceOf(UserCouldNotBeReconciledError);
     });
 
     it('should return an error when the userId to link don’t match a user', async () => {
@@ -1062,7 +1062,25 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       });
 
       // then
-      expect(error.detail).to.be.equal(`Key (userId)=(${fakeUserId}) is not present in table "users".`);
+      expect(error).to.be.instanceOf(UserCouldNotBeReconciledError);
+    });
+
+    it('should return an error when the schooling registration is disabled', async () => {
+      // given
+      const disabledSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: organization.id,
+        userId: null,
+        isDisabled: true,
+      });
+
+      // when
+      const error = await catchErr(schoolingRegistrationRepository.reconcileUserToSchoolingRegistration)({
+        userId: user.id,
+        schoolingRegistrationId: disabledSchoolingRegistration.id,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(UserCouldNotBeReconciledError);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
À chaque nouvel import, celui-ci remplace les étudiants inscrits par les nouveaux. Ceux de l'année passée (par exemple) sont donc désactivés et ne pourront donc plus participer à de nouvelles campagnes. 

## :robot: Solution
Réconcilier uniquement sur les étudiants actifs.

## :rainbow: Remarques
Rien à signaler

## :100: Pour tester
- Importer un étudiant A depuis Pix Orga lors d'un premier ;
- Importer un étudiant B depuis Pix Orga lors d'un 2e import qui remplace la 1er (l'étudiant A est donc désactivé) ;
- Aller sur Pix App en utilisant un compte non réconcilié (exemple pro.member@example.net) 
- Taper le code campagnes "AZERTY789"
- Vérifier qu'en saisissant les bonnes infos de l'étudiant A, il est impossible de rejoindre la campagne ;
- Vérifier qu'en saisissant les bonnes infos de l'étudiant B, il est possible de rejoindre la campagne.
