### PR TITLE
[BUGFIX] Eviter qu'un même assessment possède deux réponses pour une même épreuve (PIX-2761).

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -1,5 +1,4 @@
 const {
-  ChallengeAlreadyAnsweredError,
   ForbiddenAccess,
   ChallengeNotAskedError,
 } = require('../errors');
@@ -29,15 +28,6 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   }
   if (assessment.lastChallengeId && assessment.lastChallengeId != answer.challengeId) {
     throw new ChallengeNotAskedError();
-  }
-
-  const answersFind = await answerRepository.findByChallengeAndAssessment({
-    assessmentId: answer.assessmentId,
-    challengeId: answer.challengeId,
-  });
-
-  if (answersFind) {
-    throw new ChallengeAlreadyAnsweredError();
   }
 
   const challenge = await challengeRepository.get(answer.challengeId);


### PR DESCRIPTION
## :unicorn: Problème
Des réponses en double ont été enregistré dans la table `Answers`.

## :robot: Solution
- Déplacer la vérification du doublon de réponse plus bas, au niveau du repository

## :rainbow: Remarques
- On pourrait ajouter une clé unique assessment-challenge coté PG, mais la table answers est déjà assez grosse. A réfléchir.

## :100: Pour tester
