### PR TITLE
[BUGFIX] Corriger la version anglaise du message d'erreur d'expiration d'authentication (PIX-2990).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1220,7 +1220,7 @@
       "form": {
         "button": "Continue",
         "error-message": "Please agree to the terms and conditions of use.",
-        "expired-authentication-key": "Votre demande d'authentification a expirée, merci de renouveler votre connexion en cliquant sur le boutton retour"
+        "expired-authentication-key": "Your authentication demand has expired. Please click to back button to log in"
       },
       "message": ""
     },


### PR DESCRIPTION
## :unicorn: Problème
Le message d'erreur concernant l'expiration des jetons PE dans les traductions EN est en français.

## :robot: Solution
Mettre le message en version EN.

## :100: Pour tester
Cliquer sur le [lien](https://app-pr3341.review.pix.org/cgu-pole-emploi?authenticationKey=8a985984-2429-4a1b-a249-6743d91dcb2f&lang=EN) et vérifier que le message en anglais.
