### PR TITLE
[FEATURE] Embed + focus = :heavy_check_mark:  (PIX-3041).

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -64,7 +64,7 @@ export default class ChallengeItemGeneric extends Component {
   @action
   resumeAssessment() {
     this.args.resetChallengeInfo();
-    return this.args.resumeAssessment(this.args.assessment);
+    this.args.resumeAssessment(this.args.assessment);
   }
 
   @action

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -7,14 +7,19 @@ import ENV from 'mon-pix/config/environment';
 export default class Item extends Component {
 
   @service currentUser;
-  @tracked hasFocusedOutOfWindow = false || this.args.assessment.hasFocusedOutChallenge;
+  @service focus;
   @tracked hasFocusedOutOfChallenge = false;
 
   constructor() {
     super(...arguments);
     if (this.isFocusedChallenge) {
-      this._setOnBlurEventToWindow();
+      this.focus.start(this.args.assessment.hasFocusedOutChallenge);
     }
+  }
+
+  willDestroy() {
+    this.focus.stop();
+    super.willDestroy(...arguments);
   }
 
   @action
@@ -39,19 +44,11 @@ export default class Item extends Component {
     this.args.onTooltipClose();
   }
 
-  _setOnBlurEventToWindow() {
-    window.onblur = () => {
-      this.hasFocusedOutOfWindow = true;
-      this.args.onFocusOutOfWindow();
-      this._clearOnBlurMethod();
-    };
-  }
-
-  _clearOnBlurMethod() {
-    window.onblur = null;
-  }
-
   get isFocusedChallenge() {
     return ENV.APP.FT_FOCUS_CHALLENGE_ENABLED && this.args.challenge.focused;
+  }
+
+  get hasFocusedOutOfWindow() {
+    return !this.focus.currentWindowHasFocus;
   }
 }

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -13,7 +13,7 @@ export default class Item extends Component {
   constructor() {
     super(...arguments);
     if (this.isFocusedChallenge) {
-      this.focus.start(this.args.assessment.hasFocusedOutChallenge);
+      this.focus.start(this.args.assessment);
     }
   }
 

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -12,13 +12,12 @@ import isInteger from 'lodash/isInteger';
 export default class ChallengeController extends Controller {
   queryParams = ['newLevel', 'competenceLeveled', 'challengeId'];
   @service intl;
-  @service store;
+  @service focus;
   @service currentUser;
   @tracked newLevel = null;
   @tracked competenceLeveled = null;
   @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOutOfChallenge = false;
-  @tracked hasFocusedOutOfWindow = false;
   @tracked hasUserConfirmedWarning = false;
 
   get showLevelup() {
@@ -39,6 +38,10 @@ export default class ChallengeController extends Controller {
       return focusedOutPageTitle;
     }
     return focusedPageTitle;
+  }
+
+  get hasFocusedOutOfWindow() {
+    return !this.focus.currentWindowHasFocus;
   }
 
   get isFocusedChallengeAndUserHasFocusedOutOfChallenge() {
@@ -71,12 +74,6 @@ export default class ChallengeController extends Controller {
   @action
   setFocusedOutOfChallenge(value) {
     this.hasFocusedOutOfChallenge = value;
-  }
-
-  @action
-  async focusedOutOfWindow() {
-    this.hasFocusedOutOfWindow = true;
-    await this.model.assessment.save({ adapterOptions: { updateLastQuestionsState: true, state: 'focusedout' } });
   }
 
   @action

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -87,8 +87,10 @@ export default class ChallengeController extends Controller {
     this.challengeTitle = defaultPageTitle;
     this.hasUserConfirmedWarning = false;
     this.hasFocusedOutOfChallenge = false;
-    this.hasFocusedOutOfWindow = false;
     this.model.assessment.lastQuestionState = 'asked';
+    console.log('IN RESET');
+    console.log(this.model.assessment.lastQuestionState);
+    console.log(this.model.assessment.hasFocusedOutChallenge);
   }
 
   get displayHomeLink() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -41,7 +41,7 @@ export default class ChallengeController extends Controller {
   }
 
   get hasFocusedOutOfWindow() {
-    return !this.focus.currentWindowHasFocus;
+    return this.focus.failed;
   }
 
   get isFocusedChallengeAndUserHasFocusedOutOfChallenge() {

--- a/mon-pix/app/services/focus.js
+++ b/mon-pix/app/services/focus.js
@@ -5,12 +5,15 @@ export default class Focus extends Service {
 
   @tracked
   currentWindowHasFocus = true;
+  @tracked
+  failed = false;
   assessment;
 
   start(assessment) {
     this.assessment = assessment;
     if (this.assessment.hasFocusedOutChallenge) {
       this.currentWindowHasFocus = false;
+      this.failed = true;
     } else {
       this._checkFocus();
     }
@@ -35,6 +38,7 @@ export default class Focus extends Service {
   }
 
   async _saveFocusedOut() {
+    this.failed = true;
     await this.assessment.save({ adapterOptions: { updateLastQuestionsState: true, state: 'focusedout' } });
   }
 }

--- a/mon-pix/app/services/focus.js
+++ b/mon-pix/app/services/focus.js
@@ -5,10 +5,15 @@ export default class Focus extends Service {
 
   @tracked
   currentWindowHasFocus = true;
+  assessment;
 
-  start(hasFocusedOutOfChallenge = false) {
-    this.currentWindowHasFocus = !hasFocusedOutOfChallenge;
-    this._checkFocus();
+  start(assessment) {
+    this.assessment = assessment;
+    if (this.assessment.hasFocusedOutChallenge) {
+      this.currentWindowHasFocus = false;
+    } else {
+      this._checkFocus();
+    }
   }
 
   stop() {
@@ -23,6 +28,13 @@ export default class Focus extends Service {
       this.timeout = setTimeout(()=> {
         this._checkFocus();
       }, 1000);
+    } else {
+      this._saveFocusedOut();
+      clearTimeout(this.timeout);
     }
+  }
+
+  async _saveFocusedOut() {
+    await this.assessment.save({ adapterOptions: { updateLastQuestionsState: true, state: 'focusedout' } });
   }
 }

--- a/mon-pix/app/services/focus.js
+++ b/mon-pix/app/services/focus.js
@@ -1,0 +1,28 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class Focus extends Service {
+
+  @tracked
+  currentWindowHasFocus = true;
+
+  start(hasFocusedOutOfChallenge = false) {
+    this.currentWindowHasFocus = !hasFocusedOutOfChallenge;
+    this._checkFocus();
+  }
+
+  stop() {
+    this.currentWindowHasFocus = true;
+    clearTimeout(this.timeout);
+  }
+
+  _checkFocus() {
+    this.currentWindowHasFocus = document.hasFocus();
+
+    if (this.currentWindowHasFocus) {
+      this.timeout = setTimeout(()=> {
+        this._checkFocus();
+      }, 1000);
+    }
+  }
+}

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -31,8 +31,6 @@
         @resumeAssessment={{route-action "resumeAssessment"}}
         @onFocusIntoChallenge={{fn this.setFocusedOutOfChallenge false}}
         @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
-        @onFocusOutOfWindow={{this.focusedOutOfWindow}}
-        @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
         @onTooltipClose={{this.removeTooltipOverlay}}
       />
     {{/if}}

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -24,7 +24,9 @@ describe('Acceptance | Displaying a challenge of any type', () => {
     describe(`when ${data.challengeType} challenge is focused`, function() {
 
       class FocusServiceMock extends Service {
-        start(initialValue = false) { this.currentWindowHasFocus = !initialValue; }
+        start(initialValue = false) {
+          //this.currentWindowHasFocus = !initialValue;
+        }
         stop() {}
 
         @tracked

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -24,13 +24,16 @@ describe('Acceptance | Displaying a challenge of any type', () => {
     describe(`when ${data.challengeType} challenge is focused`, function() {
 
       class FocusServiceMock extends Service {
-        start(initialValue = false) {
-          //this.currentWindowHasFocus = !initialValue;
+        start(assessmentValue = { hasFocusedOutChallenge: false }) {
+          console.log('in this start')
+          this.currentWindowHasFocus = !assessmentValue.hasFocusedOutChallenge;
         }
         stop() {}
 
         @tracked
         currentWindowHasFocus = true;
+        @tracked
+        failed = false;
       }
 
       beforeEach(function() {
@@ -65,6 +68,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
             // when
             await visit(`/assessments/${assessment.id}/challenges/0`);
+
           });
 
           it('should display a tooltip', async () => {
@@ -112,6 +116,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
               // when
               serviceFocus.currentWindowHasFocus = false;
+              serviceFocus.failed = true;
               await settled();
 
               // then
@@ -133,21 +138,15 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               // given
               const serviceFocus = this.owner.lookup('service:focus');
               const challengeItem = find('.challenge-item');
-              await triggerEvent(challengeItem, 'mouseleave');
-
-              expect(find('.challenge__info-alert--could-show')).to.exist;
-              expect(find('.challenge-item__container--focused')).to.exist;
-              expect(find('.challenge__focused-out-overlay')).to.exist;
-
               // when
+              await triggerEvent(challengeItem, 'mouseleave');
               serviceFocus.currentWindowHasFocus = false;
+              serviceFocus.failed = true;
               await settled();
 
               // then
               expect(find('.challenge__info-alert--could-show')).to.not.exist;
               expect(find('[data-test="alert-message-focused-out-of-window"]')).to.exist;
-              expect(find('.challenge-item__container--focused')).to.exist;
-              expect(find('.challenge__focused-out-overlay')).to.exist;
             });
           });
         });
@@ -217,6 +216,8 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
           beforeEach(async function() {
             // given
+            const serviceFocus = this.owner.lookup('service:focus');
+
             assessment = server.create('assessment', 'ofCertificationType');
             server.create('challenge', 'forCertification', data.challengeType, 'withFocused');
 
@@ -228,12 +229,15 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               lastName: 'Bravo',
             });
             assessment = certificationCourse.assessment;
-            const serviceFocus = this.owner.lookup('service:focus');
 
             // when
-            await visit(`/assessments/${assessment.id}/challenges/0`);
             serviceFocus.currentWindowHasFocus = false;
+            serviceFocus.failed = true;
             await settled();
+
+            await visit(`/assessments/${assessment.id}/challenges/0`);
+
+
           });
 
           it('should display the certification warning alert', async function() {
@@ -260,6 +264,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
             // when
             serviceFocus.currentWindowHasFocus = false;
+            serviceFocus.failed = true;
             await settled();
           });
 


### PR DESCRIPTION
## :unicorn: Problème
L'implémentation actuelle des épreuves focus ne permet pas l'utilisation des embeds.

## :robot: Solution
Utiliser la méthode `document.hasFocus()` qui renvoit true si une iframe contenu dans le document a le focus. 

## :rainbow: Remarques
Nous n'avons pas trouvé d'événements qui nous permettrait de ne pas interroger périodiquement le résultat de `document.hasFocus()`

## :100: Pour tester
1. Aller sur un challenge qroc + focus + embed: `rec1Y3cL4enp1lZ97`
2. Lancer le simulateur
3. Constater qu'il n'y a aucun message de sortie de la page
4. Sortir de la page
5. Constater qu'il y a un message de sortie de la page

Deux épreuves : `rec2mZPQeLyz6jiaR` `rec2zZCdSTvyLLJcS`
