### PR TITLE
[FEATURE] Ne pas afficher l'encart "Repasser" lorsque l'élève/étudiant est désactivé (PIX-2991).

### DIFF
--- a/api/lib/domain/models/SharedProfileForCampaign.js
+++ b/api/lib/domain/models/SharedProfileForCampaign.js
@@ -7,13 +7,25 @@ class SharedProfileForCampaign {
     id,
     sharedAt,
     campaignAllowsRetry,
+    isRegistrationActive,
     scorecards = [],
   }) {
     this.id = id;
     this.sharedAt = sharedAt;
     this.scorecards = scorecards;
     this.pixScore = _.sumBy(this.scorecards, 'earnedPix') || 0;
-    this.canRetry = campaignAllowsRetry && moment().diff(this.sharedAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+    this.canRetry = this._computeCanRetry(campaignAllowsRetry, sharedAt, isRegistrationActive);
+  }
+
+  _computeCanRetry(campaignAllowsRetry, sharedAt, isRegistrationActive) {
+    return campaignAllowsRetry
+      && this._timeBeforeRetryingPassed(sharedAt)
+      && isRegistrationActive;
+  }
+
+  _timeBeforeRetryingPassed(sharedAt) {
+    if (!sharedAt) return false;
+    return sharedAt && moment().diff(sharedAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
   }
 }
 

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -6,7 +6,7 @@ const moment = require('moment');
 
 class AssessmentResult {
 
-  constructor(participationResults, targetProfile, isCampaignMultipleSendings) {
+  constructor(participationResults, targetProfile, isCampaignMultipleSendings, isRegistrationActive) {
     const { knowledgeElements, sharedAt, assessmentCreatedAt } = participationResults;
     const { competences } = targetProfile;
 
@@ -28,7 +28,7 @@ class AssessmentResult {
       this.reachedStage = new ReachedStage(this.masteryPercentage, targetProfile.stages);
     }
     this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt);
-    this.canRetry = this._computeCanRetry(isCampaignMultipleSendings, sharedAt);
+    this.canRetry = this._computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive);
   }
 
   _computeMasteryPercentage() {
@@ -47,13 +47,15 @@ class AssessmentResult {
     }).length > 0;
   }
 
-  _computeCanRetry(isCampaignMultipleSendings, sharedAt) {
+  _computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive) {
     return isCampaignMultipleSendings
-      && this._isSharedLongTimeAgo(sharedAt)
-      && this.masteryPercentage < constants.MAX_MASTERY_POURCENTAGE;
+      && this._timeBeforeRetryingPassed(sharedAt)
+      && this.masteryPercentage < constants.MAX_MASTERY_POURCENTAGE
+      && isRegistrationActive;
   }
 
-  _isSharedLongTimeAgo(sharedAt) {
+  _timeBeforeRetryingPassed(sharedAt) {
+    if (!this.isShared) return false;
     return sharedAt && moment().diff(sharedAt, 'days') >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
   }
 }

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -57,7 +57,7 @@ class AssessmentResult {
 
   _timeBeforeRetryingPassed(sharedAt) {
     if (!this.isShared) return false;
-    return sharedAt && moment().diff(sharedAt, 'days') >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+    return sharedAt && moment().diff(sharedAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
   }
 }
 

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -40,11 +40,12 @@ class AssessmentResult {
   }
 
   _computeCanImprove(knowledgeElements, assessmentCreatedAt) {
-    return knowledgeElements.filter((knowledgeElement) => {
+    const isImprovementPossible = knowledgeElements.filter((knowledgeElement) => {
       const isOldEnoughToBeImproved = moment(assessmentCreatedAt)
         .diff(knowledgeElement.createdAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
       return knowledgeElement.isInvalidated && isOldEnoughToBeImproved;
     }).length > 0;
+    return isImprovementPossible && !this.isShared;
   }
 
   _computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive) {

--- a/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
+++ b/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
@@ -11,6 +11,7 @@ module.exports = async function getUserProfileSharedForCampaign({
   campaignRepository,
   knowledgeElementRepository,
   competenceRepository,
+  schoolingRegistrationRepository,
   locale,
 }) {
   const campaignParticipation = await campaignParticipationRepository.findOneByCampaignIdAndUserId({ campaignId, userId });
@@ -20,6 +21,7 @@ module.exports = async function getUserProfileSharedForCampaign({
   }
 
   const { multipleSendings: campaignAllowsRetry } = await campaignRepository.get(campaignId);
+  const isRegistrationActive = await schoolingRegistrationRepository.isActive({ campaignId, userId });
   const [knowledgeElementsGroupedByCompetenceId, competencesWithArea] = await Promise.all([
     knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId, limitDate: campaignParticipation.sharedAt }),
     competenceRepository.listPixCompetencesOnly({ locale }),
@@ -40,6 +42,7 @@ module.exports = async function getUserProfileSharedForCampaign({
     id: campaignParticipation.id,
     sharedAt: campaignParticipation.sharedAt,
     campaignAllowsRetry,
+    isRegistrationActive,
     scorecards,
   });
 };

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -360,4 +360,14 @@ module.exports = {
       });
   },
 
+  async isActive({ userId, campaignId }) {
+    const registration = await knex('schooling-registrations')
+      .select('schooling-registrations.isDisabled')
+      .join('organizations', 'organizations.id', 'schooling-registrations.organizationId')
+      .join('campaigns', 'campaigns.organizationId', 'organizations.id')
+      .where({ 'campaigns.id': campaignId })
+      .andWhere({ 'schooling-registrations.userId': userId })
+      .first();
+    return !registration?.isDisabled;
+  },
 };

--- a/api/tests/acceptance/application/users/get-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-campaign-assessment-result_test.js
@@ -190,7 +190,7 @@ describe('Acceptance | API | Campaign Assessment Result', function() {
             'is-shared': true,
             'stage-count': 2,
             'can-retry': false,
-            'can-improve': true,
+            'can-improve': false,
             'participant-external-id': 'participantExternalId',
           },
           relationships: {

--- a/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
@@ -18,44 +18,63 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function() {
   });
 
   describe('#canRetry', function() {
-    context('when the campaign allows retry', function() {
-      context('when the profile has been shared MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
-        beforeEach(function() {
-          const now = new Date('2020-01-06');
-          clock = sinon.useFakeTimers(now);
-        });
-
-        it('return true', function() {
-          const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, scorecards: [], sharedAt: new Date('2020-01-01') });
-
-          expect(sharedProfileForCampaign.canRetry).to.equal(true);
-        });
+    context('when participant is disabled', function() {
+      beforeEach(function() {
+        const now = new Date('2020-01-06');
+        clock = sinon.useFakeTimers(now);
       });
 
-      context('when the profile has been shared less than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
-        beforeEach(function() {
-          const now = new Date('2020-01-06');
-          clock = sinon.useFakeTimers(now);
-        });
+      it('return true', function() {
+        const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, isRegistrationActive: false, scorecards: [], sharedAt: new Date('2020-01-01') });
 
-        it('return false', function() {
-          const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, scorecards: [], sharedAt: new Date('2020-01-04') });
+        expect(sharedProfileForCampaign.canRetry).to.equal(false);
+      });
+    });
 
-          expect(sharedProfileForCampaign.canRetry).to.equal(false);
-        });
+    context('when participation is not shared', function() {
+      it('return true', function() {
+        const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, isRegistrationActive: false, scorecards: [], sharedAt: null });
+
+        expect(sharedProfileForCampaign.canRetry).to.equal(false);
+      });
+    });
+
+    context('when participant is active and the profile has been shared MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
+      beforeEach(function() {
+        const now = new Date('2020-01-06');
+        clock = sinon.useFakeTimers(now);
       });
 
-      context('when the profile has been shared more than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
-        beforeEach(function() {
-          const now = new Date('2020-01-09');
-          clock = sinon.useFakeTimers(now);
-        });
+      it('return true', function() {
+        const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, isRegistrationActive: true, scorecards: [], sharedAt: new Date('2020-01-01') });
 
-        it('return true', function() {
-          const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, scorecards: [], sharedAt: new Date('2020-01-02') });
+        expect(sharedProfileForCampaign.canRetry).to.equal(true);
+      });
+    });
 
-          expect(sharedProfileForCampaign.canRetry).to.equal(true);
-        });
+    context('when the profile has been shared less than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
+      beforeEach(function() {
+        const now = new Date('2020-01-06');
+        clock = sinon.useFakeTimers(now);
+      });
+
+      it('return false', function() {
+        const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, isRegistrationActive: true, scorecards: [], sharedAt: new Date('2020-01-04') });
+
+        expect(sharedProfileForCampaign.canRetry).to.equal(false);
+      });
+    });
+
+    context('when participant is active and the profile has been shared more than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
+      beforeEach(function() {
+        const now = new Date('2020-01-09');
+        clock = sinon.useFakeTimers(now);
+      });
+
+      it('return true', function() {
+        const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: true, isRegistrationActive: true, scorecards: [], sharedAt: new Date('2020-01-02') });
+
+        expect(sharedProfileForCampaign.canRetry).to.equal(true);
       });
     });
 
@@ -66,7 +85,7 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function() {
       });
 
       it('return false', function() {
-        const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: false, scorecards: [], sharedAt: new Date('2020-01-01') });
+        const sharedProfileForCampaign = new SharedProfileForCampaign({ campaignAllowsRetry: false, isRegistrationActive: true, scorecards: [], sharedAt: new Date('2020-01-01') });
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
       });

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -218,7 +218,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
-          sharedAt: new Date('2020-01-03'),
+          sharedAt: new Date('2020-01-01T04:06:07Z'),
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
 
@@ -256,7 +256,24 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
-          sharedAt: new Date('2020-01-01'),
+          sharedAt: new Date('2019-12-12'),
+        };
+        const targetProfile = { competences, stages: [], badges: [] };
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings, isRegistrationActive);
+
+        expect(assessmentResult.canRetry).to.be.true;
+      });
+    });
+
+    context('when the campaign allow multiple sendings, the mastery percentage is under 100%, the participant is active and the participation has been shared exactly MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
+      it('returns true', function() {
+        const isCampaignMultipleSendings = true;
+        const isRegistrationActive = true;
+        const competences = [{ id: 'rec1', name: 'C1', index: '1.1', areaName: 'Domaine1', areaColor: 'Couleur1', skillIds: ['skill1', 'skill2', 'skill3'] }];
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
         };
         const targetProfile = { competences, stages: [], badges: [] };
         const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings, isRegistrationActive);

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -20,7 +20,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
     const targetProfile = { competences, stages: [], badges: [] };
 
-    const assessmentResult = new AssessmentResult(participationResults, targetProfile);
+    const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
 
     expect(assessmentResult).to.deep.include({
       id: 12,
@@ -51,7 +51,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
       const targetProfile = { competences, stages: [], badges: [] };
 
-      const assessmentResult = new AssessmentResult(participationResults, targetProfile);
+      const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
 
       expect(assessmentResult.masteryPercentage).to.equal(67);
     });
@@ -74,7 +74,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
     const targetProfile = { competences, stages: [], badges: [] };
 
-    const assessmentResult = new AssessmentResult(participationResults, targetProfile);
+    const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
 
     const competenceResults1 = assessmentResult.competenceResults.find(({ id }) => competences[0].id === id);
     const competenceResults2 = assessmentResult.competenceResults.find(({ id }) => competences[1].id === id);
@@ -103,7 +103,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
       const targetProfile = { competences, stages, badges: [] };
 
-      const assessmentResult = new AssessmentResult(participationResults, targetProfile);
+      const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
 
       expect(assessmentResult.reachedStage).to.deep.include({ id: 2, title: 'Stage2', starCount: 2 });
       expect(assessmentResult.stageCount).to.equal(3);
@@ -139,7 +139,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
       const targetProfile = { competences, stages: [], badges };
 
-      const assessmentResult = new AssessmentResult(participationResults, targetProfile);
+      const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
       const badgeResult1 = assessmentResult.badgeResults.find(({ id }) => id === 1);
       const badgeResult2 = assessmentResult.badgeResults.find(({ id }) => id === 2);
       expect(badgeResult1).to.deep.include({ title: 'Badge Yellow', isAcquired: true });
@@ -166,7 +166,6 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
     context('when the campaign does not allow multiple sendings', function() {
       it('returns false', function() {
-        const isCampaignMultipleSendings = false;
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
@@ -174,7 +173,40 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
 
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings);
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+
+        expect(assessmentResult.canRetry).to.be.false;
+      });
+    });
+
+    context('when participant is disabled', function() {
+      it('returns false', function() {
+        const isCampaignMultipleSendings = true;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          sharedAt: new Date('2020-01-04'),
+        };
+        const targetProfile = { competences: [], stages: [], badges: [] };
+
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings, false);
+
+        expect(assessmentResult.canRetry).to.be.false;
+      });
+    });
+
+    context('when the participation is not shared', function() {
+      it('returns false', function() {
+        const isCampaignMultipleSendings = true;
+        const isRegistrationActive = true;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          sharedAt: null,
+        };
+        const targetProfile = { competences: [], stages: [], badges: [] };
+
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings, isRegistrationActive);
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -190,7 +222,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
 
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings);
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings, false);
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -210,15 +242,16 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         };
         const targetProfile = { competences, stages: [], badges: [] };
 
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings);
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings, false);
 
         expect(assessmentResult.canRetry).to.be.false;
       });
     });
 
-    context('when the campaign allow multiple sendings, the mastery percentage is under 100% and the participation has been shared more than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
+    context('when the campaign allow multiple sendings, the mastery percentage is under 100%, the participant is active and the participation has been shared more than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
       it('returns true', function() {
         const isCampaignMultipleSendings = true;
+        const isRegistrationActive = true;
         const competences = [{ id: 'rec1', name: 'C1', index: '1.1', areaName: 'Domaine1', areaColor: 'Couleur1', skillIds: ['skill1', 'skill2', 'skill3'] }];
         const participationResults = {
           knowledgeElements: [],
@@ -226,7 +259,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           sharedAt: new Date('2020-01-01'),
         };
         const targetProfile = { competences, stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings);
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings, isRegistrationActive);
 
         expect(assessmentResult.canRetry).to.be.true;
       });
@@ -266,7 +299,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
 
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false);
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
 
         expect(assessmentResult.canImprove).to.be.false;
       });
@@ -282,7 +315,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
 
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false);
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
 
         expect(assessmentResult.canImprove).to.be.false;
       });
@@ -297,7 +330,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           assessmentCreatedAt,
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false);
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
 
         expect(assessmentResult.canImprove).to.be.true;
       });

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -321,13 +321,30 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       });
     });
 
-    context('when the knowledge element is invalidated and has bee created more than MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING days before assessment was created', function() {
+    context('when participation is shared', function() {
+      it('returns false', function() {
+        const ke = domainBuilder.buildKnowledgeElement({ status: KnowledgeElement.StatusType.INVALIDATED, createdAt: new Date('2020-01-01') });
+        const participationResults = {
+          knowledgeElements: [ke],
+          acquiredBadgeIds: [],
+          assessmentCreatedAt,
+          sharedAt: new Date(),
+        };
+        const targetProfile = { competences: [], stages: [], badges: [] };
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+
+        expect(assessmentResult.canImprove).to.be.false;
+      });
+    });
+
+    context('when participation is not shared and the knowledge element is invalidated and created more than MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING days before assessment was created', function() {
       it('returns true', function() {
         const ke = domainBuilder.buildKnowledgeElement({ status: KnowledgeElement.StatusType.INVALIDATED, createdAt: new Date('2020-01-01') });
         const participationResults = {
           knowledgeElements: [ke],
           acquiredBadgeIds: [],
           assessmentCreatedAt,
+          sharedAt: null,
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
         const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);

--- a/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
@@ -19,6 +19,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function() {
   let knowledgeElementRepository;
   let competenceRepository;
   let campaignRepository;
+  let schoolingRegistrationRepository;
 
   context('When user has shared its profile for the campaign', function() {
 
@@ -27,6 +28,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function() {
       knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
       competenceRepository = { listPixCompetencesOnly: sinon.stub() };
       campaignRepository = { get: sinon.stub() };
+      schoolingRegistrationRepository = { isActive: sinon.stub() };
       sinon.stub(Scorecard, 'buildFrom');
     });
 
@@ -43,6 +45,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function() {
       knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.withArgs({ userId, limitDate: sharedAt }).resolves(knowledgeElements);
       competenceRepository.listPixCompetencesOnly.withArgs({ locale: 'fr' }).resolves(competences);
       campaignRepository.get.withArgs(campaignId).resolves(campaign);
+      schoolingRegistrationRepository.isActive.withArgs({ campaignId, userId }).resolves(false);
       Scorecard
         .buildFrom
         .withArgs({ userId, knowledgeElements: knowledgeElements['competence1'], competence: competences[0] })
@@ -60,6 +63,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function() {
         knowledgeElementRepository,
         competenceRepository,
         campaignRepository,
+        schoolingRegistrationRepository,
         locale,
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -77,7 +77,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             'validated-skills-count': 1,
             'stage-count': 3,
             'can-retry': true,
-            'can-improve': true,
+            'can-improve': false,
             'participant-external-id': 'greg@lafleche.fr',
           },
           id: '1',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -11,6 +11,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
 
     beforeEach(function() {
       const isCampaignMultipleSendings = true;
+      const isRegistrationActive = true;
       const knowledgeElements = [
         domainBuilder.buildKnowledgeElement({
           skillId: 'skill1',
@@ -60,7 +61,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
       }];
 
       const targetProfile = { competences, stages, badges };
-      assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings);
+      assessmentResult = new AssessmentResult(participationResults, targetProfile, isCampaignMultipleSendings, isRegistrationActive);
     });
 
     it('should convert a CampaignParticipationResult model object into JSON API data', function() {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -39,6 +39,7 @@ describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer',
       id: '1',
       sharedAt: new Date('2020-01-01'),
       campaignAllowsRetry: true,
+      isRegistrationActive: true,
       scorecards: expectedScorecards,
     });
 

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -128,9 +128,7 @@
   {{/if}}
 
   {{#if @model.campaignParticipationResult.canImprove}}
-    <SkillReviewImprove
-            @isShared={{@model.campaignParticipationResult.isShared}}
-            @improve={{this.improve}}/>
+    <SkillReviewImprove @improve={{this.improve}}/>
   {{/if}}
 
 

--- a/mon-pix/app/templates/components/skill-review-improve.hbs
+++ b/mon-pix/app/templates/components/skill-review-improve.hbs
@@ -1,15 +1,13 @@
-{{#unless @isShared}}
-  <div class="skill-review__begin-improvement">
-    <div>
-      <h2 class="skill-review__subtitle">
-        {{t 'pages.skill-review.improve.title'}}
-      </h2>
-      <p class="skill-review__explain-text">
-        {{t 'pages.skill-review.improve.description'}}
-      </p>
-    </div>
-    <button class="button button--dark-grey button--big skill-review__improvement-button" {{on "click" @improve}} type="button">
-      {{t 'pages.skill-review.actions.improve'}}
-    </button>
+<div class="skill-review__begin-improvement">
+  <div>
+    <h2 class="skill-review__subtitle">
+      {{t 'pages.skill-review.improve.title'}}
+    </h2>
+    <p class="skill-review__explain-text">
+      {{t 'pages.skill-review.improve.description'}}
+    </p>
   </div>
-{{/unless}}
+  <button class="button button--dark-grey button--big skill-review__improvement-button" {{on "click" @improve}} type="button">
+    {{t 'pages.skill-review.actions.improve'}}
+  </button>
+</div>

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -335,12 +335,12 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       });
     });
 
-    context('when user cannot retry', function() {
+    context('when user cannot improve', function() {
       beforeEach(async function() {
         const campaign = {};
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
-          canRetry: false,
+          canImprove: false,
         };
         this.set('model', { campaign, campaignParticipationResult });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une schooling-registration est désactivée, alors le "Repasser" n'est pas possible. Cependant, jusqu'alors on affichait quand même l'encart disant que l'on pouvait le faire. L'utilisateur cliquait alors dessus et finalement voyait une page "la campagne n'est pas accessible".

## :robot: Solution
Ne pas créer d'incompréhension en cachant cet encart "Repasser.

## :rainbow: Remarques
- Des petits Scout Rules en bonus.
- Une mise à l'identique de la comparaison des dates (avec l'ajout de precise: true)

## :100: Pour tester
Pour la campagne d'évaluation :
- Créer une campagne d'évaluation SCO à envois multiples
- Se connecter à Pix App en tant que student.disabled1234
- Taper le code campagne, passer le parcours et envoyer les résultats
- Re-taper le code campagne et s'assurer que l'on voit l'encart "Repasser"
- Désactiver la schooling-registration en base
- Re-taper le code campagne et s'assurer que l'on NE voit PAS l'encart "Repasser"

Pour la campagne de collecte de profils :
- Créer une campagne de collecte de profils SCO à envois multiples
- Se connecter à Pix App en tant que student.disabled1234
- Taper le code campagne et envoyer le profil
- Re-taper le code campagne et s'assurer que l'on voit l'encart "Repasser"
- Désactiver la schooling-registration en base
- Re-taper le code campagne et s'assurer que l'on NE voit PAS l'encart "Repasser"