### PR TITLE
[FEATURE] Permettre le filtre par classe sur la liste des élèves SCO (PIX-2026).

### DIFF
--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -32,7 +32,7 @@ function _toUserWithSchoolingRegistrationDTO(BookshelfSchoolingRegistration) {
   });
 }
 
-function _setSchoolingRegistrationFilters(qb, { lastName, firstName, studentNumber, connexionType } = {}) {
+function _setSchoolingRegistrationFilters(qb, { lastName, firstName, studentNumber, division, connexionType } = {}) {
   if (lastName) {
     qb.whereRaw('LOWER("schooling-registrations"."lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
   }
@@ -41,6 +41,9 @@ function _setSchoolingRegistrationFilters(qb, { lastName, firstName, studentNumb
   }
   if (studentNumber) {
     qb.whereRaw('LOWER("schooling-registrations"."studentNumber") LIKE ?', `%${studentNumber.toLowerCase()}%`);
+  }
+  if (division) {
+    qb.whereRaw('LOWER("schooling-registrations"."division") LIKE ?', `%${division.toLowerCase()}%`);
   }
   if (connexionType === 'none') {
     qb.whereRaw('"users"."username" IS NULL');

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1500,6 +1500,25 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         expect(_.map(data, 'studentNumber')).to.deep.equal(['BAR123', 'BAZ123']);
       });
 
+      it('should return school registrations filtered by division', async () => {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: '1', division: '4A' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: '2', division: '3B' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: '3', division: '3A' });
+        await databaseBuilder.commit();
+
+        // when
+        const { data } = await schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations({
+          organizationId: organization.id,
+          filter: { division: '3' },
+        });
+
+        // then
+        expect(_.map(data, 'division')).to.deep.equal(['3B', '3A']);
+      });
+
       it('should return school registrations filtered by firstname AND lastname', async () => {
         // given
         const organization = databaseBuilder.factory.buildOrganization();

--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -25,7 +25,13 @@
           @triggerFiltering={{@onFilter}}
         />
         <Table::Header/>
-        <Table::Header/>
+        <Table::HeaderFilterInput
+          @field="division"
+          @value={{@divisionFilter}}
+          @placeholder={{t "pages.students-sco.table.filter.division.label"}}
+          @ariaLabel={{t "pages.students-sco.table.filter.division.aria-label"}}
+          @triggerFiltering={{@onFilter}}
+        />
         <Table::HeaderFilterSelect
           @field="connexionType"
           @options={{@connectionTypesOptions}}

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -17,6 +17,7 @@ export default class ListController extends Controller {
 
   @tracked lastName = null;
   @tracked firstName = null;
+  @tracked division = null;
   @tracked connexionType = null;
   @tracked pageNumber = null;
   @tracked pageSize = null;

--- a/orga/app/routes/authenticated/sco-students/list.js
+++ b/orga/app/routes/authenticated/sco-students/list.js
@@ -8,6 +8,7 @@ export default class ListRoute extends Route {
   queryParams = {
     lastName: { refreshModel: true },
     firstName: { refreshModel: true },
+    division: { refreshModel: true },
     connexionType: { refreshModel: true },
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
@@ -21,6 +22,7 @@ export default class ListRoute extends Route {
         organizationId: this.currentUser.organization.id,
         lastName: params.lastName,
         firstName: params.firstName,
+        division: params.division,
         connexionType: params.connexionType,
       },
       page: {
@@ -34,6 +36,7 @@ export default class ListRoute extends Route {
     if (isExiting) {
       controller.lastName = null;
       controller.firstName = null;
+      controller.division = null;
       controller.connexionType = null;
       controller.pageNumber = null;
       controller.pageSize = null;

--- a/orga/app/templates/authenticated/sco-students/list.hbs
+++ b/orga/app/templates/authenticated/sco-students/list.hbs
@@ -10,6 +10,7 @@
     @connectionTypesOptions={{this.connectionTypesOptions}}
     @lastNameFilter={{this.lastName}}
     @firstNameFilter={{this.firstName}}
+    @divisionFilter={{this.division}}
     @connexionTypeFilter={{this.connexionType}}
     @onFilter={{this.triggerFiltering}}
     @onDissociateUser={{this.refresh}}

--- a/orga/tests/integration/components/students/sco/list_test.js
+++ b/orga/tests/integration/components/students/sco/list_test.js
@@ -99,6 +99,24 @@ module('Integration | Component | Student::Sco::List', function(hooks) {
       assert.equal(call.args[2].target.value, 'bob');
     });
 
+    test('it should trigger filtering with division', async function(assert) {
+      // given
+      const triggerFiltering = sinon.spy();
+      this.set('triggerFiltering', triggerFiltering);
+      this.set('students', []);
+
+      await render(hbs`<Student::Sco::List @students={{students}} @onFilter={{triggerFiltering}}/>`);
+
+      // when
+      await fillInByLabel('Entrer une classe', '3A');
+
+      // then
+      const call = triggerFiltering.getCall(0);
+      assert.equal(call.args[0], 'division');
+      assert.true(call.args[1]);
+      assert.equal(call.args[2].target.value, '3A');
+    });
+
     test('it should trigger filtering with connexionType', async function(assert) {
       // given
       const triggerFiltering = sinon.spy();

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -604,6 +604,10 @@
         },
         "empty": "No students.",
         "filter": {
+          "division": {
+            "aria-label": "Enter a class",
+            "label": "Search by class"
+          },
           "first-name": {
             "aria-label": "Enter a first name",
             "label": "Search by first name"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -603,6 +603,10 @@
         },
         "empty": "Aucun élève.",
         "filter": {
+          "division": {
+            "aria-label": "Entrer une classe",
+            "label": "Rechercher par classe"
+          },
           "first-name": {
             "aria-label": "Entrer un prénom",
             "label": "Rechercher par prénom"


### PR DESCRIPTION
## :unicorn: Problème
La classe est un élément fort utile pour les prescripteurs SCO. La PR #3340 va afficher la classe dans la liste.

## :robot: Solution
Permettre également de filtrer dessus.

## :rainbow: Remarques
Rien à signaler.

## :100: Pour tester
- Se connecter à Pix Orga en. tant que sco.admin@example.net
- Aller sur l'onglet "élèves"
- Taper quelque chose dans la barre de filtre par classe
- Vérifier que cela filtre correctement