### PR TITLE
[BUGFIX] Mettre à jour le scénario des tests de charge pour une exécution locale (PIX-3043).

### DIFF
--- a/high-level-tests/load-testing/.eslintrc.yaml
+++ b/high-level-tests/load-testing/.eslintrc.yaml
@@ -1,4 +1,9 @@
-extends: '../../.eslintrc.yaml'
+plugins:
+  - yaml
+
+extends:
+  - '../../.eslintrc.yaml'
+  - 'plugin:yaml/recommended'
 
 globals:
   include: true

--- a/high-level-tests/load-testing/functions.js
+++ b/high-level-tests/load-testing/functions.js
@@ -8,8 +8,8 @@ module.exports = {
 function setupSignupFormData(context, events, done) {
   context.vars['firstName'] = faker.name.firstName();
   context.vars['lastName'] = faker.name.lastName();
-  context.vars['email'] = faker.internet.exampleEmail();
-  context.vars['password'] = 'L0rem1psum';
+  context.vars['email'] = `${faker.datatype.uuid().slice(19)}@example.net`;
+  context.vars['password'] = 'Password123';
   return done();
 }
 

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -346,6 +346,14 @@
         "update-notifier": "^2.1.0",
         "uuid": "^2.0.3",
         "ws": "^5.1.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        }
       }
     },
     "artillery-plugin-statsd": {
@@ -600,6 +608,16 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -715,6 +733,21 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -770,6 +803,12 @@
       "version": "4.16.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.0.tgz",
       "integrity": "sha512-Zb4tGPANH4SW0LgC9+s9Mnequs9aqn7N3/pCqNbVjs2XhEF6yWNU2Vm4OGl1v2Go9nw8rXt87Cm2QN/o6Vpqgg==",
+      "dev": true
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "debug": {
@@ -1273,6 +1312,33 @@
         }
       }
     },
+    "eslint-plugin-yaml": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-yaml/-/eslint-plugin-yaml-0.5.0.tgz",
+      "integrity": "sha512-Z6km4HEiRptSuvzc96nXBND1Vlg57b7pzRmIJOgb9+3PAE+XpaBaiMx+Dg+3Y15tSrEMKCIZ9WoZMwkwUbPI8A==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^4.1.0",
+        "jshint": "^2.13.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -1399,6 +1465,12 @@
           "dev": true
         }
       }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
     },
     "faker": {
       "version": "5.5.3",
@@ -1909,6 +1981,98 @@
       "resolved": "https://registry.npmjs.org/jsck/-/jsck-0.3.2.tgz",
       "integrity": "sha1-jgazG7V7AJDlA91O5q0PJp3/GlU=",
       "dev": true
+    },
+    "jshint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.1.tgz",
+      "integrity": "sha512-vymzfR3OysF5P774x6zYv0bD4EpH6NWRxpq54wO9mA9RuY49yb1teKSICkLx2Ryx+mfzlVVNNbTBtsRtg78t7g==",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.21",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+          "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "entities": "^2.0.0"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+              "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+              "dev": true
+            },
+            "entities": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+              "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+              "dev": true
+            }
+          }
+        },
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
+      }
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -2516,6 +2680,26 @@
         "strip-json-comments": "~2.0.1"
       }
     },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "regexp.prototype.flags": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
@@ -2637,6 +2821,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
     "signal-exit": {
@@ -2821,6 +3011,12 @@
           }
         }
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -3090,12 +3286,6 @@
       "requires": {
         "prepend-http": "^1.0.1"
       }
-    },
-    "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pix-load-testing",
   "version": "1.193.0",
-  "description": "",
+  "description": "Permet d'exécuter des tests de charge sur l'API de la plateforme Pix.",
   "main": "index.js",
   "author": "GIP Pix",
   "engines": {
@@ -9,18 +9,24 @@
     "npm": "6.14.13"
   },
   "scripts": {
+    "arti:cmd": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-placement.yml",
+    "arti:run": "npm run db:initialize && npm run arti:cmd",
+    "arti:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix npm run arti:run",
+    "db:empty": "cd ../../api && npm run db:empty",
+    "db:initialize": "cd ../../api && npm run db:prepare",
+    "generate-bulk-data:schooling-registrations": "node ./data/generate-schooling-registrations.js",
     "lint": "npm run lint:code",
     "lint:code": "eslint .",
     "lint:fix": "eslint . --fix",
     "preinstall": "npx check-engine",
     "report": "artillery report report/index.json",
-    "start": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-placement.yml",
-    "generate-bulk-data:schooling-registrations": "node ./data/generate-schooling-registrations.js"
+    "start:api:local": "cd ../../api && npm run start:watch"
   },
   "license": "ISC",
   "devDependencies": {
     "artillery": "^1.7.6",
     "eslint": "^7.32.0",
+    "eslint-plugin-yaml": "^0.5.0",
     "faker": "^5.5.3",
     "js2xmlparser": "^4.0.1"
   }

--- a/high-level-tests/load-testing/scenarios/signup-and-placement.yml
+++ b/high-level-tests/load-testing/scenarios/signup-and-placement.yml
@@ -2,11 +2,15 @@ config:
   phases:
     - duration: 60
       arrivalRate: 5
+      name: Warm up
     - duration: 120
       arrivalRate: 5
       rampTo: 50
+      name: Ramp up load
     - duration: 600
       arrivalRate: 50
+      name: Sustained load
+
 scenarios:
   - name: 'Inscription et positionnement'
     flow:
@@ -32,16 +36,14 @@ scenarios:
 
       # Authenticate user
       - post:
-          url: "/api/authentications"
-          json:
-            data:
-              attributes:
-                password: "{{ password }}"
-                email: "{{ email }}"
+          url: "/api/token"
+          headers:
+            content-type: "application/x-www-form-urlencoded"
+          body: "grant_type=password&scope=mon-pix&username={{ email }}&password={{ password }}"
           capture:
-            - json: "$.data.attributes.token"
+            - json: "$.access_token"
               as: "accessToken"
-            - json: "$.data.id"
+            - json: "$.user_id"
               as: "userId"
 
       # Get user profile
@@ -96,7 +98,7 @@ scenarios:
           headers:
             Authorization: "Bearer {{ accessToken }}"
 
-          # Fetch assessment next challenge
+      # Fetch assessment next challenge
       - get:
           url: "/api/assessments/{{ assessmentId }}/next"
           headers:


### PR DESCRIPTION
## :unicorn: Problème
Dans l'application Load-Testing, le scénario de tests de charge comporte une étape d'authentification erronée.

## :robot: Solution
Corriger le endpoint et les paramètres erronés.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* En local
    * Démarrer l'API
    * Lancer les tests de charge : `npm run arti:run:local`
    * Vérifier dans le rapport final qu'il n'y a pas d'erreur 500 ou 404
