### PR TITLE
[TECH] Monitorer les queries Knex avec l'id de corrélation de Hapi JS, un compteur par appel API et une durée d'exécution (PIX-3044).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -64,6 +64,7 @@ module.exports = (function() {
       colorEnabled: false,
       shouldLog5XXErrors: isFeatureEnabled(process.env.SHOULD_LOG_5XX_ERRORS),
       logLevel: (process.env.LOG_LEVEL || 'info'),
+      enableLogKnexQueriesWithCorrelationId: isFeatureEnabled(process.env.LOG_KNEX_QUERIES_WITH_CORRELATION_ID),
     },
 
     mailing: {
@@ -257,6 +258,7 @@ module.exports = (function() {
     config.jwtConfig.poleEmploi = { secret: 'secretPoleEmploi', tokenLifespan: '1h' };
 
     config.logging.enabled = false;
+    config.logging.enableLogKnexQueriesWithCorrelationId = false;
 
     config.caching.redisUrl = null;
     config.caching.redisCacheKeyLockTTL = 0;

--- a/api/lib/infrastructure/performance-tools.js
+++ b/api/lib/infrastructure/performance-tools.js
@@ -1,0 +1,41 @@
+const { get } = require('lodash');
+const logger = require('../infrastructure/logger');
+const { logging } = require('../config');
+
+const { AsyncLocalStorage } = require('async_hooks');
+const asyncLocalStorage = new AsyncLocalStorage();
+
+function logKnexQueriesWithCorrelationId(data, msg) {
+  if (logging.enableLogKnexQueriesWithCorrelationId) {
+    const request = asyncLocalStorage.getStore();
+    const knexQueryId = data.__knexQueryUid;
+    logger.info({
+      request_id: `${get(request, 'info.id', '-')}`,
+      knex_query_id: knexQueryId,
+      knex_query_position: request.knexQueryPosition[knexQueryId],
+      knex_query_sql: data.sql,
+      knex_query_params: [(data.bindings) ? data.bindings.join(',') : ''],
+      duration: get(data, 'duration', '-'),
+      http: {
+        method: request.method,
+        url_detail: {
+          path: get(request, 'path', '-'),
+        },
+      },
+    }, msg);
+  }
+}
+
+function addPositionToQuerieAndIncrementQueriesCounter(knexQueryId) {
+  const request = asyncLocalStorage.getStore();
+  request.knexQueryPosition = request.knexQueryPosition || [];
+  request.queriesCounter = request.queriesCounter || 0;
+  request.queriesCounter++;
+  request.knexQueryPosition[knexQueryId] = request.queriesCounter;
+}
+
+module.exports = {
+  asyncLocalStorage,
+  addPositionToQuerieAndIncrementQueriesCounter,
+  logKnexQueriesWithCorrelationId,
+};

--- a/api/server.js
+++ b/api/server.js
@@ -10,6 +10,15 @@ const swaggers = require('./lib/swaggers');
 const authentication = require('./lib/infrastructure/authentication');
 
 const { handleFailAction } = require('./lib/validate');
+const { asyncLocalStorage } = require('./lib/infrastructure/performance-tools');
+
+const Request = require('@hapi/hapi/lib/request');
+const originalMethod = Request.prototype._execute;
+
+Request.prototype._execute = function(...args) {
+  const request = this;
+  return asyncLocalStorage.run(request, () => originalMethod.call(request, args));
+};
 
 let config;
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'analyse des erreurs ou lenteurs d'APIs en production, il est difficile de trouver rapidement les requêtes knex concernées par ces bugs. Comme les logs knex ne sont pas corrélés, on essaye d'y remédier en se basant sur les plages d'horaires d'exécution. Sauf que c'est imprécis vu le nombre d'appels conséquent qui arrivent simultanément. Et cela rend donc difficile le diagnostic et peut laisser certaines erreurs sans correction. C'est valable aussi dans l'autre sens, lorsque des erreurs Knex remontent, on arrive pas à identifier rapidement les appels http concernées.

## :robot: Solution
Propager l'id de corrélation de Hapi JS dans les logs des requêtes Knex activable via une variable d'environnement.

Testé dans datadog: https://app.datadoghq.eu/logs?query=service%3A%2Areview%2A%20%40request_id%3A%221629384321368%3Apix-api-review-pr3352-web-1%3A23%3Aksiyr62b%3A10082%22&cols=host%2Cservice%2C%40request_id&index=%2A&stream_sort=%40request_id%2Cdesc&from_ts=1626793351578&to_ts=1629385351578&live=true

Initialement le POC était une implémentation en utilisant le module natif de node <[async_hooks](https://nodejs.org/dist/latest-v14.x/docs/api/async_hooks.html)> en le combinant avec l'autre module <[perf_hooks](https://nodejs.org/dist/latest-v14.x/docs/api/perf_hooks.html)> qui a marché. Mais finalement, en cherchant plus loin dans la documentation du module, on voit qu'il est préférable d'utiliser la classe [AsyncLocalStorage](https://nodejs.org/dist/latest-v14.x/docs/api/async_hooks.html#async_hooks_class_asynclocalstorage) ajoutée depuis la version v13.10.0 qui semble être optimisé et performante au lieu d'une implémentation custom qui peut entrainer des lenteurs. 
_This class is used to create asynchronous state within callbacks and promise chains. It allows storing data throughout the lifetime of a web request or any other asynchronous duration. It is similar to thread-local storage in other languages.
While you can create your own implementation on top of the async_hooks module, AsyncLocalStorage should be preferred as it is a performant and memory safe implementation that involves significant optimizations that are non-obvious to implement._

Pour le faire:

```
// On crée une instance de la classe AsyncLocalStorage qui sera unique par contexte d'éxécution.
const { AsyncLocalStorage } = require('async_hooks');
const asyncLocalStorage = new AsyncLocalStorage();

// Une fonction qui récupère l'objet du store qui va contenir le corrélation Id de Hapi Js
function logWithCorrelationId(msg) {
  const request = asyncLocalStorage.getStore();
  logger.info(`${get(request, 'info.id', '-')} ${msg} `);
}

// Un compteur pour compter le nombre de requête par appel Http 
function incrementCounter() {
  const request = asyncLocalStorage.getStore();
  request.info.sqlCounter++;
}

```
En utilisant les [events de Knex ](https://knexjs.org/#Interfaces-Events)

- On peut logger les queries avec leur id de corrélation Hapi
- Calculer des métriques comme le temps de réponse ou autres à venir ( consommation mémoire ... )
- Compter le nombre de requêtes par appel API

```
const queries = new Map();

knex.on('query', function(data) {
  logWithCorrelationId('Data query Id' + data.__knexQueryUid + 'Sql: ' + data.sql);
  incrementCounter();
  const queryStartedTime = new Date();
  queries.set(data.__knexQueryUid, queryStartedTime);
})

knex.on('query-response', function(response, obj) {
  const queryStartedTime = queries.get(obj.__knexQueryUid);
  logger.info('The query ' + obj.__knexQueryUid + 'has take ' + (new Date() - queryStartedTime) + ' ms');
  queries.delete(obj.__knexQueryUid);
})

```
Pour démarrer un contexte d'exécution, il faut utiliser la méthode asyncLocalStorage.run comme s'est fait ici au niveau du controller d'authentification.
Version avant l'override de Hapi pour wrapper les appels au handler via `asyncLocalStorage.run.`
```
async authenticateUser(request, h) {

    request.info.sqlCounter = 0;
    const result = await asyncLocalStorage.run(request, async () => {

      logWithCorrelationId('Start Controller <authenticateUser>');

      const { username, password, scope } = request.payload;

      const accessToken = await usecases.authenticateUser({ username, password, scope, source: 'pix' });

      return h.response({
        token_type: 'bearer',
        access_token: accessToken,
        user_id: tokenService.extractUserId(accessToken),
      })
        .code(200)
        .header('Content-Type', 'application/json;charset=UTF-8')
        .header('Cache-Control', 'no-store')
        .header('Pragma', 'no-cache');
    });
    logger.info('Request with ID=[' + get(request, 'info.id', '-') + '] has ' + request.info.sqlCounter + ' knex queries calls');
    return result;
  },
```

## :rainbow: Remarques
En mode POC encore, il reste à enrichir les tests et à refacto du code.
Enrichir les logs d'acces log de Hapi pour avec les métriques pour une remontée simplifiée dans datadog.
Avoir un mécanisme pour wrapper la méthode await asyncLocalStorage.run implicitement au niveau de Hapi en overridant le comportement de l'appel au handler.

## :100: Pour tester
Activer la variable d'environnement 

En locale:
- Lancer un appel pour générer un jeton et constater l'id de corrélation qui est propagé au niveau des appels Knex.
```sh
curl 'http://localhost:3000/api/correlation/token' \
  --data-raw 'grant_type=password&username=userpix1@example.net&password=pix123&scope=mon-pix' \
  --compressed
```

Verifier la présence des métriques en gras ci-dessous dans les logs knex:
```
{"name":"pix-api","hostname":"MacBook-Pro-de-yahya.local","pid":97072,"level":30,"**request_id**":"1629707796052:MacBook-Pro-de-yahya.local:97072:ksodxt1t:10000","**knex_query_id**":"lCNu8YVvDvezkh1dTjkd2","**knex_query_position**":1,"**knex_query_sql**":"select \"users\".* from \"users\" where \"email\" = $1 or (\"username\" = $2) limit $3","knex_query_params":["userpix1@example.net,userpix1@example.net,1"],"**duration**":15,"http":{"method":"post","url_detail":{"path":"/api/token"}},"msg":"Knex Query","time":"2021-08-23T08:36:36.122Z","v":0}
210823/083636.052, (1629707796052:MacBook-Pro-de-yahya.local:97072:ksodxt1t:10000) [response,api] http://MacBook-Pro-de-yahya.local:3000: post /api/token {} 401 (-1629707796052ms)
```

- Tester une connexion sur la RA
- Vérifier sur le lien Datadog https://app.datadoghq.eu/logs?query=service%3A%2Areview%2A&index=%2A que les données sont bien remontées.
- Ajouter les metrics dans le tableau ci-dessous et voir l'ensemble des métriques dans Datadog
![image](https://user-images.githubusercontent.com/10045497/130255761-9137efed-9347-4ed3-a6f7-e56a64950c2c.png)

