### PR TITLE
[CLEAN] Utiliser le numéro d'épreuve pour la barre de progression (PIX-3049).

### DIFF
--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -15,7 +15,7 @@ export default class ProgressBar extends Component {
   }
 
   get currentStepIndex() {
-    return progressInAssessment.getCurrentStepIndex(this.args.assessment, this.args.answerId);
+    return progressInAssessment.getCurrentStepIndex(this.args.assessment, this.args.currentChallengeNumber);
   }
 
   get maxStepsNumber() {
@@ -23,7 +23,7 @@ export default class ProgressBar extends Component {
   }
 
   get currentStepNumber() {
-    return progressInAssessment.getCurrentStepNumber(this.args.assessment, this.args.answerId);
+    return progressInAssessment.getCurrentStepNumber(this.args.assessment, this.args.currentChallengeNumber);
   }
 
   get steps() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -26,7 +25,7 @@ export default class ChallengeController extends Controller {
   }
 
   get pageTitle() {
-    const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, get(this.model, 'answer.id'));
+    const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, this.model.currentChallengeNumber);
     const totalChallengeNumber = progressInAssessment.getMaxStepsNumber(this.model.assessment);
 
     return this.intl.t(this.challengeTitle, { stepNumber, totalChallengeNumber });

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -12,11 +12,11 @@ export default class ChallengeRoute extends Route {
     await assessment.answers;
 
     let challenge;
-
-    const isBackToPreviousChallenge = parseInt(params.challenge_number) < assessment.answers.length;
+    const currentChallengeNumber = parseInt(params.challenge_number);
+    const isBackToPreviousChallenge = currentChallengeNumber < assessment.answers.length;
     if (isBackToPreviousChallenge) {
       const answers = assessment.answers.toArray();
-      const challengeId = answers[params.challenge_number].challenge.get('id');
+      const challengeId = answers[currentChallengeNumber].challenge.get('id');
       challenge = await this.store.findRecord('challenge', challengeId);
     } else {
       if (assessment.isPreview) {
@@ -30,6 +30,7 @@ export default class ChallengeRoute extends Route {
       assessment,
       challenge,
       answer: this.store.queryRecord('answer', { assessmentId: assessment.id, challengeId: challenge.id }),
+      currentChallengeNumber,
     }).catch((err) => {
       const meta = ('errors' in err) ? err.errors.get('firstObject').meta : null;
       if (meta.field === 'authorization') {

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -17,7 +17,7 @@
   </div>
 
   <main class="challenge__content rounded-panel--over-background-banner">
-    <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}}/>
+    <ProgressBar @assessment={{@model.assessment}} @currentChallengeNumber={{@model.currentChallengeNumber}}/>
 
     {{#if this.displayTimedChallengeInstructions}}
       <TimedChallengeInstructions @hasUserConfirmedWarning={{this.setUserConfirmation}} @time={{@model.challenge.timer}} />

--- a/mon-pix/app/utils/progress-in-assessment.js
+++ b/mon-pix/app/utils/progress-in-assessment.js
@@ -1,21 +1,20 @@
 import ENV from 'mon-pix/config/environment';
-const PREVIEW_UNIQUE_STEP = 1;
+const ONE_STEP = 1;
 
 function getMaxStepsNumber(assessment) {
   if (assessment.isPreview) {
-    return PREVIEW_UNIQUE_STEP;
+    return ONE_STEP;
   }
   if (assessment.isCertification) {
     return assessment.get('certificationCourse.nbChallenges');
   }
-  if (assessment.isDemo) {
-    return assessment.get('course.nbChallenges');
-  }
   if (assessment.hasCheckpoints) {
     return ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
   }
-  return assessment.get('course.nbChallenges');
-
+  if (assessment.get('course')) {
+    return assessment.get('course.nbChallenges');
+  }
+  return ONE_STEP;
 }
 
 function getCurrentStepIndex(assessment, currentChallengeNumber) {

--- a/mon-pix/app/utils/progress-in-assessment.js
+++ b/mon-pix/app/utils/progress-in-assessment.js
@@ -1,41 +1,29 @@
 import ENV from 'mon-pix/config/environment';
 const PREVIEW_UNIQUE_STEP = 1;
-const PREVIEW_UNIQUE_CURRENT_STEP_INDEX = 0;
 
 function getMaxStepsNumber(assessment) {
   if (assessment.isPreview) {
     return PREVIEW_UNIQUE_STEP;
   }
-
-  if (assessment.hasCheckpoints) {
-    return ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
-  }
-
   if (assessment.isCertification) {
     return assessment.get('certificationCourse.nbChallenges');
   }
-
+  if (assessment.isDemo) {
+    return assessment.get('course.nbChallenges');
+  }
+  if (assessment.hasCheckpoints) {
+    return ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
+  }
   return assessment.get('course.nbChallenges');
+
 }
 
-function getCurrentStepIndex(assessment, answerId) {
-  if (assessment.isPreview) {
-    return PREVIEW_UNIQUE_CURRENT_STEP_INDEX;
-  }
-  const persistedAnswersIds = assessment.hasMany('answers').ids().filter((id) => id != null);
-  const currentAnswerId = answerId;
-
-  let index = persistedAnswersIds.indexOf(currentAnswerId);
-
-  if (index === -1) {
-    index = persistedAnswersIds.length;
-  }
-
-  return index % getMaxStepsNumber(assessment);
+function getCurrentStepIndex(assessment, currentChallengeNumber) {
+  return currentChallengeNumber % getMaxStepsNumber(assessment);
 }
 
-function getCurrentStepNumber(assessment, answerId) {
-  return getCurrentStepIndex(assessment, answerId) + 1;
+function getCurrentStepNumber(assessment, currentChallengeNumber) {
+  return getCurrentStepIndex(assessment, currentChallengeNumber) + 1;
 }
 
 export {

--- a/mon-pix/tests/unit/utils/progress-in-assessment_test.js
+++ b/mon-pix/tests/unit/utils/progress-in-assessment_test.js
@@ -12,41 +12,27 @@ describe('Unit | Utility | progress-in-assessment', function() {
     beforeEach(function() {
       ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS = 5;
       assessment = EmberObject.create({
-        answers: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
         hasCheckpoints: true,
-        hasMany(relationship) {
-          return { ids: () => { return this[relationship].mapBy('id'); } };
-        },
       });
     });
 
     it('should return the current step index modulus maxStepsNumber', function() {
       // given
-      const answerId = null;
+      const currentChallengeNumber = 6;
       // when
-      const currentStepIndex = progressInAssessment.getCurrentStepIndex(assessment, answerId);
+      const currentStepIndex = progressInAssessment.getCurrentStepIndex(assessment, currentChallengeNumber);
 
       // then
       expect(currentStepIndex).to.equal(1);
     });
 
-    it('should return the current step index for already answered challenge', function() {
-      // given
-      const answerId = 3;
-
-      // when
-      const currentStepIndex = progressInAssessment.getCurrentStepIndex(assessment, answerId);
-
-      // then
-      expect(currentStepIndex).to.equal(2);
-    });
-
-    it('should return O when the assessment is a preview', function() {
+    it('should return 0 when the assessment is a preview', function() {
       // given
       assessment.isPreview = true;
+      const currentChallengeNumber = 0;
 
       // when
-      const currentStepIndex = progressInAssessment.getCurrentStepIndex(assessment);
+      const currentStepIndex = progressInAssessment.getCurrentStepIndex(assessment, currentChallengeNumber);
 
       // then
       expect(currentStepIndex).to.equal(0);
@@ -108,34 +94,19 @@ describe('Unit | Utility | progress-in-assessment', function() {
     beforeEach(function() {
       ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS = 5;
       assessment = EmberObject.create({
-        answers: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
         hasCheckpoints: true,
-        hasMany(relationship) {
-          return { ids: () => { return this[relationship].mapBy('id'); } };
-        },
       });
     });
 
     it('should return the current step number modulus maxStepsNumber', async function() {
       // given
-      const answerId = null;
+      const currentChallengeNumber = 8;
 
       // when
-      const currentStepIndex = progressInAssessment.getCurrentStepNumber(assessment, answerId);
+      const currentStepIndex = progressInAssessment.getCurrentStepNumber(assessment, currentChallengeNumber);
 
       // then
-      expect(currentStepIndex).to.equal(2);
-    });
-
-    it('should return the current step number for already answered challenge', async function() {
-      // given
-      const answerId = 3;
-
-      // when
-      const currentStepIndex = progressInAssessment.getCurrentStepNumber(assessment, answerId);
-
-      // then
-      expect(currentStepIndex).to.equal(3);
+      expect(currentStepIndex).to.equal(4);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la barre de progression utilise la liste des answers et essaie de retrouver l'answer actuelle.

## :robot: Solution
Depuis le refacto pour ne plus afficher les recID dans l'url, un compteur apparait dans l'url. 
On utilise ce challenge_number pour faire la progress-bar

## :rainbow: Remarques

## :100: Pour tester
Passer des compétences/preview/etc... et regarder la barre de progression (et le numéro dans le title).
Essayer de revenir en arrière
Quitter et revenir sur l'assessment testé.