### PR TITLE
[FEATURE] Ajouter la règle du taux de neutralisation maximal avant le scoring d'une certification (PIX-3045).

### DIFF
--- a/api/lib/domain/events/CertificationAutoCancelCheckDone.js
+++ b/api/lib/domain/events/CertificationAutoCancelCheckDone.js
@@ -1,0 +1,7 @@
+module.exports = class CertificationAutoCancelCheckDone {
+  constructor({ certificationCourseId, juryId, commentForJury }) {
+    this.certificationCourseId = certificationCourseId;
+    this.juryId = juryId;
+    this.commentForJury = commentForJury;
+  }
+};

--- a/api/lib/domain/events/handle-certification-auto-cancel-check.js
+++ b/api/lib/domain/events/handle-certification-auto-cancel-check.js
@@ -1,0 +1,37 @@
+const ChallengeNeutralized = require('./ChallengeNeutralized');
+const ChallengeDeneutralized = require('./ChallengeDeneutralized');
+const CertificationJuryDone = require('./CertificationJuryDone');
+const { checkEventTypes } = require('./check-event-types');
+const CertificationAutoCancelCheckDone = require('./CertificationAutoCancelCheckDone');
+
+const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized, CertificationJuryDone];
+
+async function handleCertificationAutoCancelCheck({
+  event,
+  certificationAssessmentRepository,
+  certificationCourseRepository,
+}) {
+  checkEventTypes(event, eventTypes);
+
+  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: event.certificationCourseId });
+  const certificationCourse = await certificationCourseRepository.get(certificationAssessment.certificationCourseId);
+
+  let commentForJury;
+  if (certificationAssessment.hasMoreThan33PercentNeutralizedChallenges()) {
+    certificationCourse.cancel();
+    commentForJury = 'Certification annulée car plus de 33% des épreuves ont été neutralisées.';
+  } else {
+    certificationCourse.uncancel();
+    commentForJury = '';
+  }
+  await certificationCourseRepository.update(certificationCourse);
+
+  return new CertificationAutoCancelCheckDone({
+    certificationCourseId: event.certificationCourseId,
+    juryId: event.juryId,
+    commentForJury,
+  });
+}
+
+handleCertificationAutoCancelCheck.eventTypes = eventTypes;
+module.exports = handleCertificationAutoCancelCheck;

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -27,6 +27,7 @@ async function handleCertificationRescoring({
     competenceMarkRepository,
     scoringCertificationService,
     juryId: event.juryId,
+    commentForJury: event.commentForJury,
   });
 }
 
@@ -36,6 +37,7 @@ async function _calculateCertificationScore({
   competenceMarkRepository,
   scoringCertificationService,
   juryId,
+  commentForJury,
 }) {
   try {
     const certificationAssessmentScore = await scoringCertificationService.calculateCertificationAssessmentScore({
@@ -48,6 +50,7 @@ async function _calculateCertificationScore({
       assessmentResultRepository,
       competenceMarkRepository,
       juryId,
+      commentForJury,
     });
     return new CertificationRescoringCompleted({
       userId: certificationAssessment.userId,
@@ -63,6 +66,7 @@ async function _calculateCertificationScore({
       assessmentResultRepository,
       certificationComputeError: error,
       juryId,
+      commentForJury,
     });
   }
 }
@@ -73,12 +77,14 @@ async function _saveResult({
   assessmentResultRepository,
   competenceMarkRepository,
   juryId,
+  commentForJury,
 }) {
   const assessmentResult = await _createAssessmentResult({
     certificationAssessment,
     certificationAssessmentScore,
     assessmentResultRepository,
     juryId,
+    commentForJury,
   });
 
   await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
@@ -87,13 +93,14 @@ async function _saveResult({
   });
 }
 
-function _createAssessmentResult({ certificationAssessment, certificationAssessmentScore, assessmentResultRepository, juryId }) {
+function _createAssessmentResult({ certificationAssessment, certificationAssessmentScore, assessmentResultRepository, juryId, commentForJury }) {
   const assessmentResult = AssessmentResult.buildStandardAssessmentResult({
     pixScore: certificationAssessmentScore.nbPix,
     status: certificationAssessmentScore.status,
     assessmentId: certificationAssessment.id,
     emitter: EMITTER,
     juryId,
+    commentForJury,
   });
   return assessmentResultRepository.save(assessmentResult);
 }
@@ -103,12 +110,14 @@ async function _saveResultAfterCertificationComputeError({
   assessmentResultRepository,
   certificationComputeError,
   juryId,
+  commentForJury,
 }) {
   const assessmentResult = AssessmentResult.buildAlgoErrorResult({
     error: certificationComputeError,
     assessmentId: certificationAssessment.id,
     juryId,
     emitter: EMITTER,
+    commentForJury,
   });
   await assessmentResultRepository.save(assessmentResult);
 }

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -5,12 +5,10 @@ const bluebird = require('bluebird');
 const {
   CertificationComputeError,
 } = require('../errors');
-const ChallengeNeutralized = require('./ChallengeNeutralized');
-const ChallengeDeneutralized = require('./ChallengeDeneutralized');
-const CertificationJuryDone = require('./CertificationJuryDone');
+const CertificationAutoCancelCheckDone = require('./CertificationAutoCancelCheckDone');
 const { checkEventTypes } = require('./check-event-types');
 
-const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized, CertificationJuryDone];
+const eventTypes = [CertificationAutoCancelCheckDone];
 const EMITTER = 'PIX-ALGO-NEUTRALIZATION';
 
 async function handleCertificationRescoring({

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -42,6 +42,7 @@ dependencies.partnerCertificationScoringRepository = partnerCertificationScoring
 const handlersToBeInjected = {
   handleAutoJury: require('./handle-auto-jury'),
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
+  handleCertificationAutoCancelCheck: require('./handle-certification-auto-cancel-check'),
   handleCertificationScoring: require('./handle-certification-scoring'),
   handleCertificationRescoring: require('./handle-certification-rescoring'),
   handleCleaCertificationScoring: require('./handle-clea-certification-scoring'),

--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -35,10 +35,10 @@ class AssessmentResult {
     this.juryId = juryId;
   }
 
-  static buildAlgoErrorResult({ error, assessmentId, juryId, emitter }) {
+  static buildAlgoErrorResult({ error, assessmentId, juryId, emitter, commentForJury }) {
     return new AssessmentResult({
       emitter,
-      commentForJury: error.message,
+      commentForJury: commentForJury ? `${error.message} - ${commentForJury}` : error.message,
       pixScore: 0,
       status: 'error',
       assessmentId,
@@ -46,10 +46,10 @@ class AssessmentResult {
     });
   }
 
-  static buildStandardAssessmentResult({ pixScore, status, assessmentId, juryId, emitter }) {
+  static buildStandardAssessmentResult({ pixScore, status, assessmentId, juryId, emitter, commentForJury }) {
     return new AssessmentResult({
       emitter,
-      commentForJury: 'Computed',
+      commentForJury: commentForJury ? commentForJury : 'Computed',
       pixScore: pixScore,
       status,
       assessmentId,

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -111,6 +111,11 @@ class CertificationAssessment {
   getChallengeRecIdByQuestionNumber(questionNumber) {
     return this.certificationAnswersByDate[questionNumber - 1]?.challengeId || null;
   }
+
+  hasMoreThan33PercentNeutralizedChallenges() {
+    const neutralizedChallenges = this.certificationChallenges.filter((challenge) => challenge.isNeutralized);
+    return Math.round((neutralizedChallenges.length / this.certificationChallenges.length) * 100) > 33;
+  }
 }
 
 function _isAnswerKoOrSkippedOrPartially(answerStatus) {

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -89,6 +89,10 @@ class CertificationCourse {
     this._isCancelled = true;
   }
 
+  uncancel() {
+    this._isCancelled = false;
+  }
+
   complete({ now }) {
     this._completedAt = now;
   }

--- a/api/tests/unit/domain/events/event-choreography-certification-auto-cancel-check_test.js
+++ b/api/tests/unit/domain/events/event-choreography-certification-auto-cancel-check_test.js
@@ -1,0 +1,45 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
+const ChallengeDeneutralized = require('../../../../lib/domain/events/ChallengeDeneutralized');
+const CertificationJuryDone = require('../../../../lib/domain/events/CertificationJuryDone');
+
+describe('Event Choreography | Certification auto cancel check', function() {
+
+  it('Should trigger handleCertificationAutoCancelCheck on ChallengeNeutralized event', async function() {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+
+    // when
+    await eventDispatcher.dispatch(event);
+
+    // then
+    expect(handlerStubs.handleCertificationAutoCancelCheck).to.have.been.calledWith({ event, domainTransaction: undefined });
+  });
+
+  it('Should trigger handleCertificationAutoCancelCheck on ChallengeDeneutralized event', async function() {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new ChallengeDeneutralized({ certificationCourseId: 1, juryId: 7 });
+
+    // when
+    await eventDispatcher.dispatch(event);
+
+    // then
+    expect(handlerStubs.handleCertificationAutoCancelCheck).to.have.been.calledWith({ event, domainTransaction: undefined });
+  });
+
+  it('Should trigger handleCertificationAutoCancelCheck on CertificationJuryDone event', async function() {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new CertificationJuryDone({ certificationCourseId: 1 });
+
+    // when
+    await eventDispatcher.dispatch(event);
+
+    // then
+    expect(handlerStubs.handleCertificationAutoCancelCheck).to.have.been.calledWith({ event, domainTransaction: undefined });
+  });
+
+});

--- a/api/tests/unit/domain/events/event-choreography-certification-rescoring-after-jury_test.js
+++ b/api/tests/unit/domain/events/event-choreography-certification-rescoring-after-jury_test.js
@@ -1,17 +1,24 @@
 const { expect } = require('../../../test-helper');
 const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
-const CertificationJuryDone = require('../../../../lib/domain/events/CertificationJuryDone');
+const SessionFinalized = require('../../../../lib/domain/events/SessionFinalized');
 
-describe('Event Choreography | CertificationJuryDone', function() {
-  it('Should trigger the certification rescoring', async function() {
+describe('Event Choreography | Certification auto jury', function() {
+
+  it('Should trigger handleAutoJury on SessionFinalized event', async function() {
     // given
     const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
-    const event = new CertificationJuryDone({});
+    const event = new SessionFinalized({
+      sessionId: 1,
+      finalizedAt: new Date(),
+      hasExaminerGlobalComment: false,
+      sessionDate: '2020-01-01',
+      sessionTime: '10:30:00',
+    });
 
     // when
     await eventDispatcher.dispatch(event);
 
     // then
-    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWith({ event, domainTransaction: undefined });
+    expect(handlerStubs.handleAutoJury).to.have.been.calledWith({ event, domainTransaction: undefined });
   });
 });

--- a/api/tests/unit/domain/events/event-choreography-rescore-certification_test.js
+++ b/api/tests/unit/domain/events/event-choreography-rescore-certification_test.js
@@ -1,25 +1,13 @@
 const { expect } = require('../../../test-helper');
 const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
-const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
-const ChallengeDeneutralized = require('../../../../lib/domain/events/ChallengeDeneutralized');
+const CertificationAutoCancelCheckDone = require('../../../../lib/domain/events/CertificationAutoCancelCheckDone');
 
-describe('Event Choreography | Rescore Certification', function() {
-  it('Should trigger Certification Rescoring handler on ChallengeNeutralized event', async function() {
+describe('Event Choreography | Certification rescoring', function() {
+
+  it('Should trigger handleCertificationRescoring on CertificationAutoCancelCheckDone event', async function() {
     // given
     const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
-    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
-
-    // when
-    await eventDispatcher.dispatch(event);
-
-    // then
-    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWith({ domainTransaction: undefined, event });
-  });
-
-  it('Should trigger Certification Rescoring handler on ChallengeDeneutralized event', async function() {
-    // given
-    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
-    const event = new ChallengeDeneutralized({ certificationCourseId: 1, juryId: 7 });
+    const event = new CertificationAutoCancelCheckDone({ certificationCourseId: 1, juryId: 7, commentForJury: '' });
 
     // when
     await eventDispatcher.dispatch(event);

--- a/api/tests/unit/domain/events/handle-certification-auto-cancel-check_test.js
+++ b/api/tests/unit/domain/events/handle-certification-auto-cancel-check_test.js
@@ -1,0 +1,149 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { handleCertificationAutoCancelCheck } = require('../../../../lib/domain/events')._forTestOnly.handlers;
+const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
+const CertificationAutoCancelCheckDone = require('../../../../lib/domain/events/CertificationAutoCancelCheckDone');
+
+describe('Unit | Domain | Events | handle-certification-auto-cancel-check', function() {
+
+  let certificationAssessmentRepository;
+  let certificationCourseRepository;
+
+  beforeEach(function() {
+    certificationAssessmentRepository = {
+      getByCertificationCourseId: sinon.stub(),
+    };
+    certificationCourseRepository = {
+      get: sinon.stub(),
+      update: sinon.stub(),
+    };
+  });
+
+  context('when there is more than 33% neutralized challenges', function() {
+
+    it('should cancel the certification course', async function() {
+      // given
+      const event = new ChallengeNeutralized({ certificationCourseId: 123, juryId: 321 });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 123,
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+      });
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 123 }).resolves(certificationAssessment);
+
+      const certificationCourse = domainBuilder.buildCertificationCourse({ isCancelled: false });
+      sinon.spy(certificationCourse, 'cancel');
+      certificationCourseRepository.get.withArgs(123).resolves(certificationCourse);
+
+      // when
+      await handleCertificationAutoCancelCheck({
+        event,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      expect(certificationCourse.cancel).to.have.been.calledOnce;
+      expect(certificationCourseRepository.update).to.have.been.calledWith(certificationCourse);
+    });
+
+    it('should return a CertificationAutoCancelCheckDone with a comment for jury', async function() {
+      // given
+      const event = new ChallengeNeutralized({ certificationCourseId: 123, juryId: 321 });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 123,
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+      });
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 123 }).resolves(certificationAssessment);
+
+      const certificationCourse = domainBuilder.buildCertificationCourse({ isCancelled: false });
+      certificationCourseRepository.get.withArgs(123).resolves(certificationCourse);
+      certificationCourseRepository.update.resolves();
+
+      // when
+      const certificationAutoCancelCheckDone = await handleCertificationAutoCancelCheck({
+        event,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      expect(certificationAutoCancelCheckDone).to.deepEqualInstance(new CertificationAutoCancelCheckDone({
+        certificationCourseId: 123,
+        juryId: 321,
+        commentForJury: 'Certification annulée car plus de 33% des épreuves ont été neutralisées.',
+      }));
+    });
+
+  });
+
+  context('when there is less than 33% neutralized challenges', function() {
+
+    it('should uncancel the certification course', async function() {
+      // given
+      const event = new ChallengeNeutralized({ certificationCourseId: 123, juryId: 321 });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 123,
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+      });
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 123 }).resolves(certificationAssessment);
+
+      const certificationCourse = domainBuilder.buildCertificationCourse({ isCancelled: true });
+      sinon.spy(certificationCourse, 'uncancel');
+      certificationCourseRepository.get.withArgs(123).resolves(certificationCourse);
+
+      // when
+      await handleCertificationAutoCancelCheck({
+        event,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      expect(certificationCourse.uncancel).to.have.been.calledOnce;
+      expect(certificationCourseRepository.update).to.have.been.calledWith(certificationCourse);
+    });
+
+    it('should return a CertificationAutoCancelCheckDone with an empty comment for jury', async function() {
+      // given
+      const event = new ChallengeNeutralized({ certificationCourseId: 123, juryId: 321 });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 123,
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+      });
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 123 }).resolves(certificationAssessment);
+
+      const certificationCourse = domainBuilder.buildCertificationCourse({ isCancelled: true });
+      certificationCourseRepository.get.withArgs(123).resolves(certificationCourse);
+      certificationCourseRepository.update.resolves();
+
+      // when
+      const certificationAutoCancelCheckDone = await handleCertificationAutoCancelCheck({
+        event,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      expect(certificationAutoCancelCheckDone).to.deepEqualInstance(new CertificationAutoCancelCheckDone({
+        certificationCourseId: 123,
+        juryId: 321,
+        commentForJury: '',
+      }));
+    });
+  });
+});

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const { handleCertificationRescoring } = require('../../../../lib/domain/events')._forTestOnly.handlers;
-const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
+const CertificationAutoCancelCheckDone = require('../../../../lib/domain/events/CertificationAutoCancelCheckDone');
 const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const { CertificationComputeError } = require('../../../../lib/domain/errors');
@@ -14,7 +14,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
-    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+    const event = new CertificationAutoCancelCheckDone({ certificationCourseId: 1, juryId: 7 });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
@@ -88,7 +88,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
-    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+    const event = new CertificationAutoCancelCheckDone({ certificationCourseId: 1, juryId: 7 });
     const certificationAssessment = domainBuilder.buildCertificationAssessment({
       userId: 123,
       certificationCourseId: 1,
@@ -133,7 +133,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
-    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+    const event = new CertificationAutoCancelCheckDone({ certificationCourseId: 1, juryId: 7 });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -14,7 +14,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
-    const event = new CertificationAutoCancelCheckDone({ certificationCourseId: 1, juryId: 7 });
+    const event = new CertificationAutoCancelCheckDone({ certificationCourseId: 1, juryId: 7, commentForJury: 'commentForJury' });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
@@ -47,7 +47,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
 
     const assessmentResultToBeSaved = new AssessmentResult({
       id: undefined,
-      commentForJury: 'Computed',
+      commentForJury: 'commentForJury',
       emitter: 'PIX-ALGO-NEUTRALIZATION',
       pixScore: nbPix,
       status: status,
@@ -133,7 +133,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
-    const event = new CertificationAutoCancelCheckDone({ certificationCourseId: 1, juryId: 7 });
+    const event = new CertificationAutoCancelCheckDone({ certificationCourseId: 1, juryId: 7, commentForJury: 'commentForJury' });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
@@ -157,7 +157,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
     const assessmentResultToBeSaved = new AssessmentResult({
       id: undefined,
       emitter: 'PIX-ALGO-NEUTRALIZATION',
-      commentForJury: 'Oopsie',
+      commentForJury: 'Oopsie - commentForJury',
       pixScore: 0,
       status: 'error',
       assessmentId: 123,

--- a/api/tests/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/unit/domain/models/AssessmentResult_test.js
@@ -2,6 +2,7 @@ const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const BookshelfAssessmentResults = require('../../../../lib/infrastructure/orm-models/AssessmentResult');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const omit = require('lodash/omit');
 
 describe('Unit | Domain | Models | BookshelfAssessmentResult', function() {
 
@@ -113,4 +114,60 @@ describe('Unit | Domain | Models | BookshelfAssessmentResult', function() {
       expect(isValidated).to.be.false;
     });
   });
+
+  describe('#buildAlgoErrorResult', function() {
+
+    it('should build an in error assessment result', function() {
+      // given
+      const error = new Error('error');
+      const assessmentId = 'assessmentId';
+      const juryId = 'juryId';
+      const emitter = 'emitter';
+      const commentForJury = 'commentForJury';
+
+      // when
+      const assessmentResult = AssessmentResult.buildAlgoErrorResult({ error, assessmentId, juryId, emitter, commentForJury });
+
+      // then
+      const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
+        emitter,
+        commentForJury: 'error - commentForJury',
+        pixScore: 0,
+        status: 'error',
+        assessmentId,
+        juryId,
+      });
+      const omittedAttributes = ['id', 'createdAt', 'commentForOrganization', 'commentForCandidate'];
+      expect(omit(assessmentResult, omittedAttributes)).to.deep.equal(omit(expectedAssessmentResult, omittedAttributes));
+    });
+  });
+
+  describe('#buildStandardAssessmentResult', function() {
+
+    it('should build a standard assessment result', function() {
+      // given
+      const emitter = 'emitter';
+      const commentForJury = 'commentForJury';
+      const pixScore = 10;
+      const status = 'status';
+      const assessmentId = 'assessmentId';
+      const juryId = 'juryId';
+
+      // when
+      const assessmentResult = AssessmentResult.buildStandardAssessmentResult({ pixScore, status, assessmentId, juryId, emitter, commentForJury });
+
+      // then
+      const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
+        emitter,
+        commentForJury,
+        pixScore,
+        status,
+        assessmentId,
+        juryId,
+      });
+      const omittedAttributes = ['id', 'createdAt', 'commentForOrganization', 'commentForCandidate'];
+      expect(omit(assessmentResult, omittedAttributes)).to.deep.equal(omit(expectedAssessmentResult, omittedAttributes));
+    });
+  });
+
 });

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -187,7 +187,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
       });
 
       // when / then
-      expect(() => { certificationAssessment.neutralizeChallengeByRecId(challengeNotAskedToBeNeutralized.challengeId); })
+      expect(function() { certificationAssessment.neutralizeChallengeByRecId(challengeNotAskedToBeNeutralized.challengeId); })
         .to.throw(ChallengeToBeNeutralizedNotFoundError);
     });
   });
@@ -243,7 +243,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
       });
 
       // when / then
-      expect(() => { certificationAssessment.deneutralizeChallengeByRecId(challengeNotAskedToBeDeneutralized.challengeId); })
+      expect(function() { certificationAssessment.deneutralizeChallengeByRecId(challengeNotAskedToBeDeneutralized.challengeId); })
         .to.throw(ChallengeToBeDeneutralizedNotFoundError);
     });
   });
@@ -534,6 +534,60 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
 
       // then
       expect(recId).to.equal(null);
+    });
+  });
+
+  describe('#hasMoreThan33PercentNeutralizedChallenges', function() {
+
+    it('should return false if there is no neutralized challenges', function() {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+      });
+
+      // when
+      const neutralizedChallengesRate = certificationAssessment.hasMoreThan33PercentNeutralizedChallenges();
+
+      // then
+      expect(neutralizedChallengesRate).to.be.false;
+    });
+
+    it('should return false if there is one out of three neutralized challenges', function() {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+      });
+
+      // when
+      const neutralizedChallengesRate = certificationAssessment.hasMoreThan33PercentNeutralizedChallenges();
+
+      // then
+      expect(neutralizedChallengesRate).to.be.false;
+    });
+
+    it('should return true if all challenges are neutralized', function() {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: true }),
+        ],
+      });
+
+      // when
+      const neutralizedChallengesRate = certificationAssessment.hasMoreThan33PercentNeutralizedChallenges();
+
+      // then
+      expect(neutralizedChallengesRate).to.be.true;
     });
   });
 });

--- a/api/tests/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/unit/domain/models/CertificationCourse_test.js
@@ -2,7 +2,8 @@ const { expect, domainBuilder } = require('../../../test-helper');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | Models | CertificationCourse', function() {
-  describe('#cancel #isCancelled', function() {
+
+  describe('#cancel', function() {
 
     it('should cancel a certification course', function() {
       // given
@@ -26,10 +27,46 @@ describe('Unit | Domain | Models | CertificationCourse', function() {
 
         // when
         certificationCourse.cancel();
+        const firstTimeDTO = certificationCourse.toDTO();
         certificationCourse.cancel();
+        const secondTimeDTO = certificationCourse.toDTO();
 
         // then
-        expect(certificationCourse.toDTO().isCancelled).to.be.true;
+        expect(firstTimeDTO).to.deep.equal(secondTimeDTO);
+      });
+    });
+  });
+
+  describe('#uncancel', function() {
+
+    it('should uncancel a certification course', function() {
+      // given
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        isCancelled: true,
+      });
+
+      // when
+      certificationCourse.uncancel();
+
+      // then
+      expect(certificationCourse.toDTO().isCancelled).to.be.false;
+    });
+
+    describe('when certification course is already uncancelled', function() {
+      it('should not change isCancelled value', function() {
+        // given
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          isCancelled: true,
+        });
+
+        // when
+        certificationCourse.uncancel();
+        const firstTimeDTO = certificationCourse.toDTO();
+        certificationCourse.uncancel();
+        const secondTimeDTO = certificationCourse.toDTO();
+
+        // then
+        expect(firstTimeDTO).to.deep.equal(secondTimeDTO);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une certification possède un taux d'épreuves neutralisées supérieur à 33%, celle-ci est annulée. Cependant, il n'existe de moyen automatique de gérer ce cas.

## :robot: Solution
Implémenter un event handler déclenché avant le scoring d'une certification afin qu'il annule/dés-annule une certification en fonction du taux d'épreuves neutralisées de cette dernière.

## :100: Pour tester
- Passer une certification et la finaliser. 
- Se rendre sur Pix Admin et neutraliser plus de 33% de épreuves.
    - Vérifier que que la certification est bien annulée
- Dé-neutraliser des épreuves jusqu'à avoir moins de 33% d'épreuves neutralisées 
    - Vérifier que la certification n'est plus annulée      
