### PR TITLE
[TECH] Migrer la colonne knowledge_elements.id de INTEGER en BIG INTEGER (partie 1).

### DIFF
--- a/api/db/migrations/20210818132942_add-bigintId-to-knowledge-elements.js
+++ b/api/db/migrations/20210818132942_add-bigintId-to-knowledge-elements.js
@@ -1,0 +1,32 @@
+const TABLE_NAME = 'knowledge-elements';
+const COLUMN_NAME = 'bigintId';
+const FAKE_VALUE_TO_COMPLY_WITH_NOT_NULL_CONSTRAINT_MANDATORY_FOR_FUTURE_PK = -1;
+
+exports.up = async function(knex) {
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.bigInteger(COLUMN_NAME).notNullable().defaultTo(FAKE_VALUE_TO_COMPLY_WITH_NOT_NULL_CONSTRAINT_MANDATORY_FOR_FUTURE_PK);
+  });
+
+  await knex.raw(`CREATE OR REPLACE FUNCTION copy_int_id_to_bigint_id()
+  RETURNS TRIGGER AS
+  $$
+  BEGIN
+    NEW."bigintId" = NEW.id::BIGINT;
+    RETURN NEW;
+  END
+  $$ LANGUAGE plpgsql;`);
+
+  await knex.raw(`CREATE TRIGGER "trg_knowledge-elements"
+  BEFORE INSERT ON "knowledge-elements"
+  FOR EACH ROW
+  EXECUTE FUNCTION copy_int_id_to_bigint_id();`);
+};
+
+exports.down = async function(knex) {
+  await knex.raw('DROP TRIGGER "trg_knowledge-elements" ON "knowledge-elements"');
+  await knex.raw('DROP FUNCTION copy_int_id_to_bigint_id');
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20210818155256_copy_id_to_bigintid_on_knowledge-elements.js
+++ b/api/db/migrations/20210818155256_copy_id_to_bigintid_on_knowledge-elements.js
@@ -1,0 +1,14 @@
+const MAX_ROW_COUNT_FOR_SYNCHRONOUS_MIGRATION = 10000000;
+
+exports.up = async function(knex) {
+  const nbRows = (await knex('knowledge-elements').max('id').first()).max;
+
+  if (nbRows < MAX_ROW_COUNT_FOR_SYNCHRONOUS_MIGRATION) {
+    await knex.raw('UPDATE "knowledge-elements" SET "bigintId" = id');
+    await knex.raw('CREATE UNIQUE INDEX "knowledge-elements_bigintId_index" ON "knowledge-elements"("bigintId")');
+  }
+};
+
+exports.down = async function(knex) {
+  await knex.raw('DROP INDEX IF EXISTS "knowledge-elements_bigintId_index"');
+};

--- a/api/sample.env
+++ b/api/sample.env
@@ -96,6 +96,14 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # sample: KNEX_ASYNC_STACKTRACE_ENABLED=true
 # KNEX_ASYNC_STACKTRACE_ENABLED=
 
+# Size of the chunk during knowledge-elements migration (changing ID type from Integer to BigInteger)
+#
+# presence: mandatory for script "api/scripts/migrate-rows-concurrently.js"
+# type: Number
+# default: none
+# sample: KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=1000000
+# KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=
+
 # ========
 # EMAILING
 # ========

--- a/api/scripts/prepare-ke-bigint-id-to-be-used-as-primary-key.js
+++ b/api/scripts/prepare-ke-bigint-id-to-be-used-as-primary-key.js
@@ -1,0 +1,38 @@
+require('dotenv').config();
+
+const { knex } = require('../db/knex-database-connection');
+const logger = require('../lib/infrastructure/logger');
+
+const migrateExistingData = async () => {
+
+  const chunkSize = parseInt(process.env.KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE);
+  if (isNaN(chunkSize) || chunkSize <= 0) {
+    logger.fatal('Environment variable "KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE" must be set as a positive integer');
+    process.exit(1);
+  }
+
+  let rowsUpdatedCount = 0;
+  const maxId = (await knex('knowledge-elements').max('id').first()).max;
+
+  for (let startId = 0; startId < maxId; startId += chunkSize) {
+    const result = await knex.raw(`
+        UPDATE "knowledge-elements"
+        SET "bigintId" = id
+        WHERE ID BETWEEN ?? AND ??`, [startId, startId + chunkSize]);
+
+    rowsUpdatedCount = result.rowCount;
+    logger.info(`Updated rows : ${rowsUpdatedCount}`);
+  }
+};
+
+const buildIndexConcurrently = async () => {
+  logger.info('Building index concurrently..');
+  await knex.raw('CREATE UNIQUE INDEX CONCURRENTLY "knowledge-elements_bigintId_index" ON "knowledge-elements"("bigintId")');
+  logger.info('Done');
+};
+
+(async () => {
+  await migrateExistingData();
+  await buildIndexConcurrently();
+})();
+

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -37,18 +37,19 @@ describe('Integration | Repository | knowledgeElementRepository', function() {
 
       // then
       let actualKnowledgeElement = await knex.select('*').from('knowledge-elements').first();
-      actualKnowledgeElement = _.omit(actualKnowledgeElement, ['id', 'createdAt', 'updatedAt']);
+      actualKnowledgeElement = _.omit(actualKnowledgeElement, ['id', 'bigintId', 'createdAt', 'updatedAt']);
       const expectedKnowledgeElement = _.omit(knowledgeElementToSave, ['id', 'createdAt', 'updatedAt']);
       expect(actualKnowledgeElement).to.deep.equal(expectedKnowledgeElement);
     });
 
-    it('should return a domain object with the id', async function() {
+    it('should trigger filling of bigintId column', async function() {
       // when
-      const savedKnowledgeElement = await knowledgeElementRepository.save(knowledgeElementToSave);
+      const { id } = await knowledgeElementRepository.save(knowledgeElementToSave);
 
       // then
-      const actualKnowledgeElement = await knex.select('*').from('knowledge-elements').first();
-      expect(actualKnowledgeElement).to.deep.equal(savedKnowledgeElement);
+      const actualKnowledgeElement = await knex.select('id', 'bigintId').from('knowledge-elements').where({ id }).first();
+      expect(actualKnowledgeElement.bigintId).to.exist;
+      expect(actualKnowledgeElement.bigintId).to.equal(actualKnowledgeElement.id);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Historiquement, les identifiants des tables de données utilisateur (PostgreSQL) sont de type Integer.

Si on ne fait rien, d’ici quelques mois, nous risquons de taper la limite des enregistrements possibles sur la table `knowledge-elements` qui est de loin la table la plus volumineuse de Pix (700M de lignes), avec un fonctionnement qui se rapproche d’un comportement évènementiel (énormément d’insertions par secondes).

Pour tenir les échéances à venir, nous devons changer le type de de l’ID (clé primaire) des tables les plus volumineuses risquées : `knowledge-elements` et `answers` en tête.

Au vu de la quantité de données, les risques sont : 
- nécessiter une (très importante) indispo de la plateforme
- corrompre ou perdre des données
- fracasser toutes les données / la plateforme

## :robot: Solution
Après [étude / POC](https://github.com/1024pix/pix-int-to-bigint), nous en sommes venus à la conclusion que la meilleure façon de procéder, avec le minimum de downtime + gestion de projet / com / partenaires et le maximum de contrôle, consiste à développer et exécuter un script / une procédure de changement de type.

Le principe général de ce script est le suivant : 
1. une première phase de "préparation des données" au cours de laquelle on recopie l'identifiant (`Integer`) vers une nouvelle colonne de type `BigInteger` (nommée `bigintId`). Cette phase prend plusieurs heures sur plusieurs centaines de millions de lignes.
2. une seconde phase dite de "maintenance" dans laquelle on bloque l'accès (via un `lock`) à la table `knowledge-elements` (en lecture et écriture) afin de réaliser le renommage des meta-data (faire de la colonne `bigintId` la nouvelle colonne `id`)

Lors de notre étude (menées sur des volumes et types de données se rapprochant de la prod, sur zone SecNum Cloud), nous avons obtenu un passage de plusieurs heures de maintenance avec une approche naïve (un bête `ALTER TABLE xxx`) à une fenêtre de maintenance de moins d'un dixième (< 50ms) d'une seconde (!). En tenant compte d'éventuel passage à l'échelle de la réalité, nous estimons qu'avec cette solution, nous aurons moins de 5 secondes de downtime.

## :rainbow: Remarques
Cette PR est la première d'un lot de 3 PR:
- [partie 2](https://github.com/1024pix/pix/pull/3364)
- [partie 3](https://github.com/1024pix/pix/pull/3365)

Son but est de : 
- fournir un premier script de migration qui ajoute la colonne temporaire `bigint`
- faire en sorte qu'il s'exécute automatiquement sur les bases / environnement non-prod (nombre de lignes sur la table `KE` < 10 millions)
- fournir le script Node à exécuter manuellement sur la base de production qui réalise la première phase de préparation (cf. solution ci-dessus)

Notre méthode pour la rédaction des scripts (migration et traitement des données) a été de copier petit à petit – et en y ajoutant des tests autant que possible – les instructions du POC vers le repository.

Il est conseillé de lire les commits unitairement.

## :100: Pour tester

### Migration des données si faible volumétrie

#### Localhost ou RA

**1/** Exécuter les migrations (depuis `/api/`) : 
```
npm run db:reset
```

**2/** Rollback les 2 dernières migrations (car c'est tout l'intérêt de cette PR)
```
npx knex migrate:down --knexfile db/knexfile.js 20210811153908_alter_table_account-recovery-demands_add_foreign_key_not_null_userId.js
```

**3/** Vérifier qu'il y a bien 2 migrations à jouer 
```
npx knex migrate:list --knexfile db/knexfile.js
```

**4/** Jouer la première migration, qui ajoute la colonne `knowledge-elements.bigintId` ainsi que le trigger
```
npx knex migrate:up --knexfile db/knexfile.js 20210818155256_copy_id_to_bigintid_on_knowledge-elements.js
```

**5/** Vérifier que la colonne et le trigger sont bien déployés en se connectant à la base en local
```
$ psql postgresql://postgres@localhost/pix_test
> \d "knowledge-elements"
```
![image](https://user-images.githubusercontent.com/265963/130093363-8fb8d635-6971-41c4-8d45-01d8d12438f7.png)

**6/** Jouer la seconde migration
```
npx knex migrate:up --knexfile db/knexfile.js 
```

**7/** Vérifier qu'il n'existe plus de KE avec un champ `bigintId` ayant pour valeur `-1` (valeur par défaut)
```
$ psql postgresql://postgres@localhost/pix_test
> select * from "knowledge-elements" where "bigintId"=-1;
```

![image](https://user-images.githubusercontent.com/265963/130093917-18c76466-2850-47fd-a947-95ac70467870.png)



### Migration des données si forte volumétrie

#### RA

Simuler que les données n'ont pas été migrées
```sql
UPDATE "knowledge-elements" SET "bigintId" = -1;
DROP INDEX IF EXISTS "knowledge-elements_bigintId_index";
```

Paramétrer la variable d'environnement
```
KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=10000
```

Exécuter la migration
```
scalingo --region osc-fr1 --app pix-api-review-pr3357 run --detached "node scripts/prepare-ke-bigint-id-to-be-used-as-primary-key.js"
```

Vérifier dans les logs que la migration a eu lieu et s'est arrêtée
```
2021-08-19 12:32:40.084123841 +0200 CEST [one-off-2954] {"name":"pix-api","hostname":"pix-api-review-pr3357-one-off-2954","pid":24,"level":30,"msg":"Updated rows : 50","time":"2021-08-19T10:32:40.083Z","v":0}`
2021-08-19 12:32:40.485565540 +0200 CEST [manager] container [one-off-2954] (611e33466ffbd90d43fcc7ea) has stopped
```

Note: dû à la structure des seeeds (discontinuité des identifiants), les logs mentionnent

```
2021-08-19 12:32:40.084123841 +0200 CEST [one-off-2954] {"name":"pix-api","hostname":"pix-api-review-pr3357-one-off-2954","pid":24,"level":30,"msg":"Updated rows : 0","time":"2021-08-19T10:32:40.083Z","v":0}`
```

Vérifier en BDD que les données ont été migrées
```sql
SELECT * FROM "knowledge-elements" WHERE "bigintId" = -1; 
(0 rows)

SELECT * FROM "knowledge-elements" WHERE "bigintId" <> "id";
(0 rows)
```

Vérifier que l'index est créé et valide

```
SELECT ndx.indisvalid 
FROM pg_index ndx INNER JOIN pg_class cls ON ndx.indexrelid = cls.oid
WHERE cls.relname  = 'knowledge-elements_bigintId_index'
```

#### Copie de la production
TODO (dump en cours de restauration)
```
scalingo --regionosc-secnum-fr1 --app pix-int-to-bigint-test run --detached "node scripts/prepare-ke-bigint-id-to-be-used-as-primary-key.js"
```
