### PR TITLE
[FEATURE] Annuler une certification si taux de réponse < 33% (PIX-3046)

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -24,14 +24,20 @@ async function handleAutoJury({
     challengeRepository,
   });
 
-  const certificationJuryDoneEvents = await Promise.all(certificationCourses.map(async(certificationCourse) =>
-    _autoNeutralizeChallenges({
+  const certificationJuryDoneEvents = await Promise.all(certificationCourses.map(async(certificationCourse) => {
+
+    const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: certificationCourse.getId() });
+
+    return _autoNeutralizeChallenges({
       certificationCourse,
+      certificationAssessment,
       certificationIssueReportRepository,
       certificationAssessmentRepository,
       resolutionStrategies,
       logger,
-    })));
+    });
+  },
+  ));
 
   const filteredCertificationJuryDoneEvents = certificationJuryDoneEvents.filter((certificationJuryDoneEvent) => Boolean(certificationJuryDoneEvent));
 
@@ -50,6 +56,7 @@ async function handleAutoJury({
 
 async function _autoNeutralizeChallenges({
   certificationCourse,
+  certificationAssessment,
   certificationIssueReportRepository,
   certificationAssessmentRepository,
   resolutionStrategies,
@@ -59,7 +66,6 @@ async function _autoNeutralizeChallenges({
   if (certificationIssueReports.length === 0) {
     return null;
   }
-  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: certificationCourse.getId() });
 
   const resolutionAttempts = await bluebird.mapSeries(certificationIssueReports, async (certificationIssueReport) => {
     try {

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -28,6 +28,12 @@ async function handleAutoJury({
 
     const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: certificationCourse.getId() });
 
+    if (certificationAssessment.hasUnsufficientAnsweringRateToBeScored()) {
+      certificationCourse.cancel();
+      await certificationCourseRepository.update(certificationCourse);
+      return;
+    }
+
     return _autoNeutralizeChallenges({
       certificationCourse,
       certificationAssessment,
@@ -36,8 +42,7 @@ async function handleAutoJury({
       resolutionStrategies,
       logger,
     });
-  },
-  ));
+  }));
 
   const filteredCertificationJuryDoneEvents = certificationJuryDoneEvents.filter((certificationJuryDoneEvent) => Boolean(certificationJuryDoneEvent));
 

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -108,6 +108,11 @@ class CertificationAssessment {
     return this.state === states.COMPLETED;
   }
 
+  hasUnsufficientAnsweringRateToBeScored() {
+    const answeringRate = (this.certificationAnswersByDate.length / this.certificationChallenges.length) * 100;
+    return answeringRate < 33;
+  }
+
   getChallengeRecIdByQuestionNumber(questionNumber) {
     return this.certificationAnswersByDate[questionNumber - 1]?.challengeId || null;
   }

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -13,9 +13,10 @@ describe('Acceptance | Controller | sessions-controller', function() {
   beforeEach(async function() {
     server = await createServer();
     session = databaseBuilder.factory.buildSession();
-    const report1 = databaseBuilder.factory.buildCertificationReport({ sessionId: session.id });
-    const report2 = databaseBuilder.factory.buildCertificationReport({ sessionId: session.id });
-
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({}).id;
+    const report1 = databaseBuilder.factory.buildCertificationReport({ sessionId: session.id, certificationCourseId });
+    const report2 = databaseBuilder.factory.buildCertificationReport({ sessionId: session.id, certificationCourseId });
+    databaseBuilder.factory.buildAssessment({ certificationCourseId });
     options = {
       method: 'PUT',
       payload: {
@@ -94,6 +95,7 @@ describe('Acceptance | Controller | sessions-controller', function() {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId: session.certificationCenterId });
+
         await databaseBuilder.commit();
         options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
 

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -77,8 +77,21 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
     const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
     const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
+      certificationAnswersByDate: [
+        domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+        domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
+        domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
+      ],
+      certificationChallenges: [
+        domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123' }),
+        domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456' }),
+        domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789' }),
+      ],
+    });
 
     const certificationCourse = domainBuilder.buildCertificationCourse();
+    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
     certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
     certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
 
@@ -162,8 +175,21 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
       const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+          domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
+        ],
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789' }),
+        ],
+      });
 
       const certificationCourse = domainBuilder.buildCertificationCourse();
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
       certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
       certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
       const event = new SessionFinalized({
@@ -292,6 +318,100 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
       // then
       expect(certificationIssueReport2.isResolved()).to.be.true;
       expect(logger.error).to.have.been.calledWith(anError);
+    });
+  });
+
+  context('when there is less than 33 percent answering rate', () => {
+    it('should cancel certification course', async () => {
+      // given
+      const now = Date.now();
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub(), update: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
+        ],
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal1011' }),
+        ],
+      });
+
+      const certificationCourse = domainBuilder.buildCertificationCourse();
+      certificationCourse.cancel = sinon.stub();
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+
+      const event = new SessionFinalized({
+        sessionId: 1234,
+        finalizedAt: now,
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-29',
+        sessionTime: '14:00',
+      });
+
+      // when
+      await handleAutoJury({
+        event,
+        certificationIssueReportRepository,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(certificationCourse.cancel).to.have.been.called;
+    });
+
+    it('should not return CertificationJuryDone event', async () => {
+      // given
+      const now = Date.now();
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub(), update: sinon.stub() };
+      const certificationIssueReportRepository = { save: sinon.stub(), findByCertificationCourseId: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
+        ],
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal1011' }),
+        ],
+      });
+
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, questionNumber: 1 });
+
+      const certificationCourse = domainBuilder.buildCertificationCourse();
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([certificationIssueReport]);
+
+      const event = new SessionFinalized({
+        sessionId: 1234,
+        finalizedAt: now,
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-29',
+        sessionTime: '14:00',
+      });
+
+      // when
+      const events = await handleAutoJury({
+        event,
+        certificationIssueReportRepository,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(events.length).to.equal(1);
+      expect(events[0]).not.to.be.an.instanceOf(CertificationJuryDone);
     });
   });
 });

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -321,8 +321,8 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
     });
   });
 
-  context('when there is less than 33 percent answering rate', () => {
-    it('should cancel certification course', async () => {
+  context('when there is less than 33 percent answering rate', function() {
+    it('should cancel certification course', async function() {
       // given
       const now = Date.now();
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub(), update: sinon.stub() };
@@ -367,7 +367,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
       expect(certificationCourse.cancel).to.have.been.called;
     });
 
-    it('should not return CertificationJuryDone event', async () => {
+    it('should not return CertificationJuryDone event', async function() {
       // given
       const now = Date.now();
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub(), update: sinon.stub() };

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -495,6 +495,43 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
     });
   });
 
+  describe('#hasUnsufficientAnsweringRateToBeScored', function() {
+    it('returns true when answering rate < 33%', function() {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallenge(),
+          domainBuilder.buildCertificationChallenge(),
+          domainBuilder.buildCertificationChallenge(),
+          domainBuilder.buildCertificationChallenge(),
+        ],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer(),
+        ],
+      });
+      // when / then
+      expect(certificationAssessment.hasUnsufficientAnsweringRateToBeScored()).to.be.true;
+    });
+
+    it('returns false when answering rate > 33%', function() {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallenge(),
+          domainBuilder.buildCertificationChallenge(),
+          domainBuilder.buildCertificationChallenge(),
+          domainBuilder.buildCertificationChallenge(),
+        ],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer(),
+          domainBuilder.buildAnswer(),
+        ],
+      });
+      // when / then
+      expect(certificationAssessment.hasUnsufficientAnsweringRateToBeScored()).to.be.false;
+    });
+  });
+
   describe('#getChallengeRecIdByQuestionNumber', function() {
     it('returns the recId when question number exists', function() {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Pour les certifications non terminées, on souhaite les annuler dès lors que le taux de réponses apportées par le candidat est < 33% au nombre d'épreuves prévues pour lui, et ce quelle que soit la raison.

## :robot: Solution
Vérifier le taux de réponses apportées et annuler la certification si en dessous de 33%


## :100: Pour tester
- Passer une certification avec au moins deux candidats
- Répondre à toutes les questions avec un candidat
- Répondre à moins de 33% avec le deuxième candidat
- Finaliser la session
- constater dans pix-admin que la certification du candidat ayant répondu à moins de 33% des épreuves est annulée 

![image](https://user-images.githubusercontent.com/37305474/130045016-925ad576-ad26-4368-996f-3ff33490c051.png)

