### PR TITLE
[TECH] Utiliser la version de node applicatif au lieu de la version de node embarquée par Cypress dans les tests E2E (PIX-3050).

### DIFF
--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -11,5 +11,6 @@
   "trashAssetsBeforeRuns": true,
   "projectId": "g2rfqp",
   "numTestsKeptInMemory": 0,
-  "viewportWidth": 1500
+  "viewportWidth": 1500,
+  "nodeVersion": "system"
 }


### PR DESCRIPTION
## :unicorn: Problème
La version de node utilisé lors du lancement des tests Cypress est la **v12.16.3**:

`npx cypress run --browser=chrome --parallel --record --group e2e-tests --reporter junit --reporter-options 'mochaFile=/home/circleci/test-results/cypress.xml' && exit`

<img width="570" alt="Capture d’écran 2021-08-19 à 14 02 37" src="https://user-images.githubusercontent.com/10045497/130065278-6c4ff391-6806-4dd2-9e3a-39b528a476ae.png">

Or la version de node applicatif actuelle  est la **v14.17.0** . Cela peut poser problème si notre applicatif utilise des modules non présent dans cette version antérieure. Comme le cas de la PR de corrélation ID avec l'utilisation de la classe AsyncLocalStorage.

## :robot: Solution
La configuration Cypress.json ne surcharge pas la valeur par défault de la version de node.
`nodeVersion : "bundled"`
<img width="714" alt="Capture d’écran 2021-08-19 à 13 53 30" src="https://user-images.githubusercontent.com/10045497/130064217-13779fbd-de80-4b38-b039-e4df27d1cb92.png">
Rajouter cette configuration avec la valeur "system" ce qui va permettre d'utiliser notre version applicatif de NodeJS.

## :rainbow: Remarques
Des problèmes de consommations excessives du processeur ont été remontés avec cette version bundled.
https://github.com/cypress-io/cypress/issues/5943

## :100: Pour tester
Déjà fait en ajoutant un console.log(process.version) dans le script de lancement.
<img width="568" alt="Capture d’écran 2021-08-19 à 14 00 37" src="https://user-images.githubusercontent.com/10045497/130065083-7996e140-14eb-44ae-a7e0-9e85708e4a13.png">

