### PR TITLE
[FEATURE] Création d'un champ `assessmentMethod` dans les campagnes 'flash' (PIX-2778).

### DIFF
--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -25,10 +25,12 @@ module.exports = function buildCampaign({
   customResultPageButtonText = null,
   customResultPageButtonUrl = null,
   multipleSendings = false,
+  assessmentMethod,
 } = {}) {
 
   if (type === Campaign.types.ASSESSMENT) {
     targetProfileId = _.isUndefined(targetProfileId) ? buildTargetProfile({ ownerOrganizationId: organizationId }).id : targetProfileId;
+    assessmentMethod = Campaign.assessmentMethods.SMART_RANDOM;
   }
 
   organizationId = _.isNil(organizationId) ? buildOrganization().id : organizationId;
@@ -54,6 +56,7 @@ module.exports = function buildCampaign({
     customResultPageButtonText,
     customResultPageButtonUrl,
     multipleSendings,
+    assessmentMethod,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'campaigns',

--- a/api/db/migrations/20210823142553_add-column-assessment-method-to-campaigns-table.js
+++ b/api/db/migrations/20210823142553_add-column-assessment-method-to-campaigns-table.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'campaigns';
+const COLUMN_NAME = 'assessmentMethod';
+const DEFAULT_COLUMN_VALUE = 'SMART_RANDOM';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.text(COLUMN_NAME).defaultTo(DEFAULT_COLUMN_VALUE);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -5,6 +5,10 @@ const types = {
   PROFILES_COLLECTION: 'PROFILES_COLLECTION',
 };
 
+const assessmentMethods = {
+  SMART_RANDOM: 'SMART_RANDOM',
+};
+
 class Campaign {
   constructor({
     id,
@@ -26,6 +30,7 @@ class Campaign {
     customResultPageButtonText,
     customResultPageButtonUrl,
     multipleSendings,
+    assessmentMethod,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -46,6 +51,7 @@ class Campaign {
     this.customResultPageButtonText = customResultPageButtonText;
     this.customResultPageButtonUrl = customResultPageButtonUrl;
     this.multipleSendings = multipleSendings;
+    this.assessmentMethod = assessmentMethod;
   }
 
   get organizationId() {
@@ -70,5 +76,6 @@ class Campaign {
 }
 
 Campaign.types = types;
+Campaign.assessmentMethods = assessmentMethods;
 
 module.exports = Campaign;


### PR DESCRIPTION
## :unicorn: Problème

Pour tester le nouvel algorithme en cours de développement, certains de nos partenaires vont avoir accès à un nouveau type de campagne, les campagne Flash, qui utiliseront ce nouvel algo et la nouvelle notation.

## :robot: Solution

Rajout, d'une nouvelle propriété `assessmentMethod` à l'objet `Campaign`

:rainbow: Remarques

N/A

## :100: Pour tester

