### PR TITLE
[CLEAN] Ne pas remonter les answers en doublon (PIX-2801).

### DIFF
--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -78,8 +78,9 @@ module.exports = {
       .from('answers')
       .where({ assessmentId })
       .orderBy('createdAt');
+    const answerDTOsWithoutDuplicate = _.uniqBy(answerDTOs, 'challengeId');
 
-    return _toDomainArray(answerDTOs);
+    return _toDomainArray(answerDTOsWithoutDuplicate);
   },
 
   async findLastByAssessment(assessmentId) {

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -8,8 +8,8 @@ const { knex } = require('../bookshelf');
 
 module.exports = {
 
-  getWithAnswersAndCampaignParticipation(id) {
-    return BookshelfAssessment
+  async getWithAnswersAndCampaignParticipation(id) {
+    const bookshelfAssessment = await BookshelfAssessment
       .where('id', id)
       .fetch({
         require: false,
@@ -20,8 +20,11 @@ module.exports = {
             },
           }, 'campaignParticipation', 'campaignParticipation.campaign',
         ],
-      })
-      .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
+      });
+
+    const assessment = bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, bookshelfAssessment);
+    if (assessment) assessment.answers = _.uniqBy(assessment.answers, 'challengeId');
+    return assessment;
   },
 
   async get(id) {

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -27,8 +27,9 @@ async function _getCertificationAnswersByDate(certificationAssessmentId, knexCon
   const answerRows = await knexConn('answers')
     .where({ assessmentId: certificationAssessmentId })
     .orderBy('createdAt');
+  const answerRowsWithoutDuplicate = _.uniqBy(answerRows, 'challengeId');
 
-  return _.map(answerRows, (answerRow) => new Answer({
+  return _.map(answerRowsWithoutDuplicate, (answerRow) => new Answer({
     ...answerRow,
     result: answerStatusDatabaseAdapter.fromSQLString(answerRow.result),
   }));

--- a/api/tests/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-find_test.js
@@ -158,8 +158,8 @@ describe('Acceptance | Controller | answer-controller-find', function() {
         userId = databaseBuilder.factory.buildUser().id;
         const assessment = databaseBuilder.factory.buildAssessment({ userId, type: 'COMPETENCE_EVALUATION' });
         answers = [
-          databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id }),
-          databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id }),
+          databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id, challengeId: 'rec1' }),
+          databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id, challengeId: 'rec2' }),
         ];
         await databaseBuilder.commit();
         options = {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -124,8 +124,8 @@ describe('Acceptance | API | assessment-controller-get', function() {
     beforeEach(async function() {
       assessmentId = databaseBuilder.factory.buildAssessment({ userId, courseId, state: Assessment.states.COMPLETED, type: Assessment.types.PREVIEW }).id;
 
-      answer1 = databaseBuilder.factory.buildAnswer({ assessmentId });
-      answer2 = databaseBuilder.factory.buildAnswer({ assessmentId });
+      answer1 = databaseBuilder.factory.buildAnswer({ assessmentId, challengeId: 'rec1' });
+      answer2 = databaseBuilder.factory.buildAnswer({ assessmentId, challengeId: 'rec2' });
 
       await databaseBuilder.commit();
     });

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -19,9 +19,10 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     context('when the assessment exists', function() {
 
       beforeEach(async function() {
-        const dateOfFirstAnswer = moment.utc().subtract(2, 'minute').toDate();
-        const dateOfSecondAnswer = moment.utc().subtract(1, 'minute').toDate();
-        const dateOfThirdAnswer = moment.utc().toDate();
+        const dateOfFirstAnswer = moment.utc().subtract(3, 'minute').toDate();
+        const dateOfSecondAnswer = moment.utc().subtract(2, 'minute').toDate();
+        const dateOfThirdAnswer = moment.utc().subtract(1, 'minute').toDate();moment.utc().toDate();
+        const dateOfFourthAnswer = moment.utc().toDate();
 
         assessmentId = databaseBuilder.factory.buildAssessment({
           courseId: 'course_A',
@@ -32,6 +33,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
           { assessmentId, value: '3,1', result: 'ko', challengeId: 'challenge_3_1', createdAt: dateOfFirstAnswer },
           { assessmentId, value: '1,4', result: 'ko', challengeId: 'challenge_1_4', createdAt: dateOfSecondAnswer },
           { assessmentId, value: '2,8', result: 'ko', challengeId: 'challenge_2_8', createdAt: dateOfThirdAnswer },
+          { assessmentId, value: '2,9', result: 'ko', challengeId: 'challenge_2_8', createdAt: dateOfFourthAnswer },
           { value: '5,2', result: 'ko', challengeId: 'challenge_4' },
         ], (answer) => {
           databaseBuilder.factory.buildAnswer(answer);
@@ -54,6 +56,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         expect(assessment.answers[0].challengeId).to.equal('challenge_3_1');
         expect(assessment.answers[1].challengeId).to.equal('challenge_1_4');
         expect(assessment.answers[2].challengeId).to.equal('challenge_2_8');
+        expect(assessment.answers[2].value).to.equal('2,8');
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -62,15 +62,17 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
     let certificationAssessmentId;
     let expectedCertificationCourseId;
     let expectedUserId;
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const expectedState = CertificationAssessment.states.COMPLETED;
-    const expectedCreatedAt = new Date('2020-01-01T00:00:00Z');
-    const expectedCompletedAt = new Date('2020-01-02T00:00:00Z');
+    let expectedState;
+    let expectedCreatedAt;
+    let expectedCompletedAt;
 
     context('when the certification assessment exists', function() {
 
       beforeEach(function() {
+        expectedState = CertificationAssessment.states.COMPLETED;
+        expectedCreatedAt = new Date('2020-01-01T00:00:00Z');
+        expectedCompletedAt = new Date('2020-01-02T00:00:00Z');
+
         const dbf = databaseBuilder.factory;
         expectedUserId = dbf.buildUser().id;
         expectedCertificationCourseId = dbf.buildCertificationCourse({
@@ -84,8 +86,9 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
           certificationCourseId: expectedCertificationCourseId,
           state: expectedState,
         }).id;
-        dbf.buildAnswer({ assessmentId: certificationAssessmentId });
-        dbf.buildAnswer({ assessmentId: certificationAssessmentId });
+        dbf.buildAnswer({ assessmentId: certificationAssessmentId, challengeId: 'recChalA' });
+        dbf.buildAnswer({ assessmentId: certificationAssessmentId, challengeId: 'recChalB' });
+        dbf.buildAnswer({ assessmentId: certificationAssessmentId, challengeId: 'recChalB' });
         dbf.buildCertificationChallenge({ challengeId: 'recChalA', courseId: expectedCertificationCourseId, isNeutralized: true });
         dbf.buildCertificationChallenge({ challengeId: 'recChalB', courseId: expectedCertificationCourseId });
 
@@ -127,17 +130,19 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
     let expectedCertificationAssessmentId;
     let certificationCourseId;
     let expectedUserId;
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const expectedState = CertificationAssessment.states.COMPLETED;
-    const expectedCreatedAt = new Date('2020-01-01T00:00:00Z');
-    const expectedCompletedAt = new Date('2020-01-02T00:00:00Z');
+    let expectedState;
+    let expectedCreatedAt;
+    let expectedCompletedAt;
 
     context('when the certification assessment exists', function() {
       let firstAnswerInTime;
       let secondAnswerInTime;
 
       beforeEach(function() {
+        expectedState = CertificationAssessment.states.COMPLETED;
+        expectedCreatedAt = new Date('2020-01-01T00:00:00Z');
+        expectedCompletedAt = new Date('2020-01-02T00:00:00Z');
+
         const dbf = databaseBuilder.factory;
         expectedUserId = dbf.buildUser().id;
         certificationCourseId = dbf.buildCertificationCourse({
@@ -156,13 +161,20 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         secondAnswerInTime = dbf.buildAnswer({
           assessmentId: expectedCertificationAssessmentId,
           createdAt: new Date('2020-06-24T00:00:01Z'),
+          challengeId: 'recChalA',
         }).id;
 
         firstAnswerInTime = dbf.buildAnswer({
           assessmentId: expectedCertificationAssessmentId,
           createdAt: new Date('2020-06-24T00:00:00Z'),
+          challengeId: 'recChalB',
         }).id;
 
+        dbf.buildAnswer({
+          assessmentId: expectedCertificationAssessmentId,
+          createdAt: new Date('2020-06-25T00:00:01Z'),
+          challengeId: 'recChalA',
+        }).id;
         dbf.buildCertificationChallenge({ challengeId: 'recChalA', courseId: certificationCourseId, id: 123 });
         dbf.buildCertificationChallenge({ challengeId: 'recChalB', courseId: certificationCourseId, id: 456 });
 


### PR DESCRIPTION
## :unicorn: Problème
Des lignes `answers` sont en doublons dans la BDD : même `assessmentId` et même `challengeId`.

## :robot: Solution
Pour éviter des problèmes, lorsqu'on demande les `answers` d'un assessment, on n'en prend qu'un par challengeId.

## :rainbow: Remarques
Un premier ticket pour limiter ce bug a été fait ici : #3339 
Gros soucis qui demanderait un gros chantier BDD pour mettre une contrainte d'unicité. 

## :100: Pour tester
Répondre à des questions