### PR TITLE
[BUGFIX] Corriger le scenario actuel de tests de charge (PIX-3048).

### DIFF
--- a/high-level-tests/load-testing/.eslintignore
+++ b/high-level-tests/load-testing/.eslintignore
@@ -1,3 +1,0 @@
-# https://eslint.org/docs/user-guide/configuring#eslintignore
-# .file are implicitly ignored, unless explicitly specified here
-node_modules/

--- a/high-level-tests/load-testing/config/common.yml
+++ b/high-level-tests/load-testing/config/common.yml
@@ -3,5 +3,7 @@ config:
   environments:
     localhost:
       target: http://localhost:3000
+    development:
+      target: https://pix-api-load-testing.osc-fr1.scalingo.io
     staging:
       target: https://integration.pix.fr

--- a/high-level-tests/load-testing/functions.js
+++ b/high-level-tests/load-testing/functions.js
@@ -1,8 +1,11 @@
 const faker = require('faker');
+const get = require('lodash/get');
+const isUndefined = require('lodash/isUndefined');
 
 module.exports = {
-  setupSignupFormData,
   foundNextChallenge,
+  handleResponseForChallengeId,
+  setupSignupFormData,
 };
 
 function setupSignupFormData(context, events, done) {
@@ -14,6 +17,11 @@ function setupSignupFormData(context, events, done) {
 }
 
 function foundNextChallenge(context, next) {
-  const continueLooping = !!context.vars.challengeId;
+  const continueLooping = !isUndefined(context.vars.challengeId);
   return next(continueLooping);
+}
+
+function handleResponseForChallengeId(requestParams, response, context, events, next) {
+  context.vars.challengeId = get(response, 'body.data.id');
+  return next();
 }

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -9,7 +9,7 @@
     "npm": "6.14.13"
   },
   "scripts": {
-    "arti:cmd": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-placement.yml",
+    "arti:cmd": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-competence-evaluation.yml",
     "arti:run": "npm run db:initialize && npm run arti:cmd",
     "arti:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix npm run arti:run",
     "db:empty": "cd ../../api && npm run db:empty",
@@ -28,6 +28,7 @@
     "eslint": "^7.32.0",
     "eslint-plugin-yaml": "^0.5.0",
     "faker": "^5.5.3",
-    "js2xmlparser": "^4.0.1"
+    "js2xmlparser": "^4.0.1",
+    "lodash": "^4.17.21"
   }
 }

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "arti:cmd": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-competence-evaluation.yml",
+    "arti:cmd:dev": "artillery run --config config/common.yml -e development -o report/index.json scenarios/signup-and-competence-evaluation.yml",
     "arti:run": "npm run db:initialize && npm run arti:cmd",
     "arti:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix npm run arti:run",
     "db:empty": "cd ../../api && npm run db:empty",

--- a/high-level-tests/load-testing/scenarios/signup-and-competence-evaluation.yml
+++ b/high-level-tests/load-testing/scenarios/signup-and-competence-evaluation.yml
@@ -1,0 +1,161 @@
+config:
+  phases:
+    - duration: 60
+      arrivalRate: 5
+      name: Warm up
+    - duration: 120
+      arrivalRate: 5
+      rampTo: 50
+      name: Ramp up load
+
+  variables:
+    competenceId: "recsvLz0W2ShyfD63"
+
+scenarios:
+  - name: "Inscription et évaluation"
+    flow:
+      - function: "setupSignupFormData"
+
+      ### ---------------------- ###
+      ### From page /inscription ###
+      ### ---------------------- ###
+
+      # Submit user form
+      - post:
+          url: "/api/users"
+          json:
+            data:
+              attributes:
+                cgu: true
+                email: "{{ email }}"
+                first-name: "{{ firstName }}"
+                last-name: "{{ lastName }}"
+                password: "{{ password }}"
+
+      # Authenticate user
+      - post:
+          url: "/api/token"
+          headers:
+            content-type: "application/x-www-form-urlencoded"
+          body: "grant_type=password&scope=mon-pix&username={{ email }}&password={{ password }}"
+          capture:
+            - json: "$.access_token"
+              as: "accessToken"
+            - json: "$.user_id"
+              as: "userId"
+
+      # Get user profile
+      - get:
+          url: "/api/users/me"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+
+      # Fetch campaign participations
+      - get:
+          url: "/api/users/{{ userId }}/campaign-participations"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+
+      ### ----------------- ###
+      ### From page /compte ###
+      ### ----------------- ###
+
+      # Create competence evaluation
+      - post:
+          url: "/api/competence-evaluations/start-or-resume"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+          json:
+            competenceId: "{{ competenceId }}"
+          capture:
+            json: "$.data.relationships.assessment.data.id"
+            as: "assessmentId"
+
+      # Fetch assessment
+      - get:
+          url: "/api/assessments/{{ assessmentId }}"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+
+      # Fetch assessment next challenge
+      - get:
+          url: "/api/assessments/{{ assessmentId }}/next"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+          capture:
+            json: "$.data.id"
+            as: "challengeId"
+
+      - loop:
+          # Fetch answer (if exists)
+          - get:
+              url: "/api/answers?assessment={{ assessmentId }}&challenge={{ challengeId }}"
+              headers:
+                Authorization: "Bearer {{ accessToken }}"
+
+          # Fetch next challenge details
+          - get:
+              url: "/api/challenges/{{ challengeId }}"
+              headers:
+                Authorization: "Bearer {{ accessToken }}"
+
+          ### -------------------------------------------------------------- ###
+          ### From page /assessments/:assessment_id/challenges/:challenge_id ###
+          ### -------------------------------------------------------------- ###
+
+          # Submit "skip" answer
+          - post:
+              url: "/api/answers"
+              headers:
+                Authorization: "Bearer {{ accessToken }}"
+              json:
+                data:
+                  attributes:
+                    value: "#ABAND#"
+                  relationships:
+                    assessment:
+                      data:
+                        type: "assessments"
+                        id: "{{ assessmentId }}"
+                    challenge:
+                      data:
+                        type: "challenges"
+                        id: "{{ challengeId }}"
+                  type: answers
+
+          # Fetch assessment
+          - get:
+              url: "/api/assessments/{{ assessmentId }}"
+              headers:
+                Authorization: "Bearer {{ accessToken }}"
+
+          # Fetch assessment next challenge
+          - get:
+              url: "/api/assessments/{{ assessmentId }}/next"
+              headers:
+                Authorization: "Bearer {{ accessToken }}"
+              afterResponse: "handleResponseForChallengeId"
+
+        whileTrue: "foundNextChallenge"
+
+      # Fetch assessment
+      - get:
+          url: "/api/assessments/{{ assessmentId }}"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+
+      ### ----------------------------------------------------- ###
+      ### From page /assessment-result, go back to profile page ###
+      ### ----------------------------------------------------- ###
+
+      # Get user profile
+      - get:
+          url: "/api/users/me"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+
+      # Fetch campaign participations
+      - get:
+          url: "/api/users/{{ userId }}/campaign-participations"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"

--- a/high-level-tests/load-testing/scenarios/signup-and-placement.yml
+++ b/high-level-tests/load-testing/scenarios/signup-and-placement.yml
@@ -26,13 +26,11 @@ scenarios:
           json:
             data:
               attributes:
+                cgu: true
+                email: "{{ email }}"
                 first-name: "{{ firstName }}"
                 last-name: "{{ lastName }}"
-                email: "{{ email }}"
                 password: "{{ password }}"
-                cgu: true
-                recaptcha-token: "some.recaptcha.token"
-              type: "users"
 
       # Authenticate user
       - post:
@@ -68,6 +66,7 @@ scenarios:
           headers:
             Authorization: "Bearer {{ accessToken }}"
 
+      # Get assessments filtered
       - get:
           url: "/api/assessments?filter[type]=PLACEMENT&filter[courseId]=recNPB7dTNt5krlMA&filter[resumable]=true"
           headers:

--- a/high-level-tests/load-testing/tests/files/postman/load-testing.postman_collection.json
+++ b/high-level-tests/load-testing/tests/files/postman/load-testing.postman_collection.json
@@ -1,0 +1,763 @@
+{
+	"info": {
+		"_postman_id": "4fdcaf2c-5738-4615-85c5-a5c6c433631a",
+		"name": "PIX - Load-Testing",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "signup-and-placement",
+			"item": [
+				{
+					"name": "Submit user form",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"content-type": true,
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"data\": {\n    \"attributes\": {\n      \"cgu\": true,\n      \"email\": \"{{email}}\",\n      \"first-name\": \"user\",\n      \"last-name\": \"loadtesting\",\n      \"password\": \"{{password}}\"\n    }\n  }\n}"
+						},
+						"url": {
+							"raw": "{{ENV}}/api/users",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Authenticate user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"accessToken\", jsonData[\"access_token\"]);",
+									"postman.setEnvironmentVariable(\"userId\", jsonData[\"user_id\"]);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "grant_type",
+									"value": "password",
+									"type": "text"
+								},
+								{
+									"key": "scope",
+									"value": "mon-pix",
+									"type": "text"
+								},
+								{
+									"key": "username",
+									"value": "{{email}}",
+									"type": "text"
+								},
+								{
+									"key": "password",
+									"value": "{{password}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{ENV}}/api/token",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get user profile",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/users/me",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"users",
+								"me"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch campaign participations",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/users/{{userId}}/campaign-participations",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"users",
+								"{{userId}}",
+								"campaign-participations"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create competence evaluation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"assessmentId\", jsonData.data.relationships.assessment.data.id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "competenceId",
+									"value": "{{competenceId}}",
+									"type": "text"
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{ENV}}/api/competence-evaluations/start-or-resume",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"competence-evaluations",
+								"start-or-resume"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch assessment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/assessments/{{assessmentId}}",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"assessments",
+								"{{assessmentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch assessment next challenge",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/assessments/{{assessmentId}}",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"assessments",
+								"{{assessmentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch answer (if exists)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/assessments/{{assessmentId}}",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"assessments",
+								"{{assessmentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch next challenge details",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/challenges/{{challengeId}}",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"challenges",
+								"{{challengeId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Submit \"skip\" answer",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/answers",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"answers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch assessment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/assessments/{{assessmentId}}",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"assessments",
+								"{{assessmentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch assessment next challenge",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"challengeId\", jsonData.data.id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/assessments/{{assessmentId}}/next",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"assessments",
+								"{{assessmentId}}",
+								"next"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch assessment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/assessments/{{assessmentId}}",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"assessments",
+								"{{assessmentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get user profile",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/users/me",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"users",
+								"me"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch campaign participations",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept-encoding": true,
+							"connection": true,
+							"user-agent": true,
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": true
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{accessToken}}"
+							}
+						],
+						"url": {
+							"raw": "{{ENV}}/api/users/{{userId}}/campaign-participations",
+							"host": [
+								"{{ENV}}"
+							],
+							"path": [
+								"api",
+								"users",
+								"{{userId}}",
+								"campaign-participations"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}

--- a/high-level-tests/load-testing/tests/files/postman/pix-localhost.postman_environment.json
+++ b/high-level-tests/load-testing/tests/files/postman/pix-localhost.postman_environment.json
@@ -1,0 +1,49 @@
+{
+	"id": "95b47481-1501-4ffc-a4d4-112089afae5d",
+	"name": "PIX - LOCALHOST",
+	"values": [
+		{
+			"key": "ENV",
+			"value": "localhost:3000",
+			"enabled": true
+		},
+		{
+			"key": "email",
+			"value": "user.loading.testing@example.net",
+			"enabled": true
+		},
+		{
+			"key": "password",
+			"value": "Password123",
+			"enabled": true
+		},
+		{
+			"key": "accessToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "userId",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "assessmentId",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "challengeId",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "competenceId",
+			"value": "recsvLz0W2ShyfD63",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2021-08-19T16:25:16.104Z",
+	"_postman_exported_using": "Postman/8.10.0"
+}


### PR DESCRIPTION
## :unicorn: Problème
Le scenario actuel a été écrit il y a deux ans.
Il est nécessaire de vérifier qu’il est encore valide.

## :robot: Solution
* Utiliser Postman pour vérifier que tous les steps du scénario actuel sont valides
* Corriger les erreurs afin que le scenario fonctionne en local
* Créer un environnement dédié

## :rainbow: Remarques
Un environnement Scalingo `pix-api-load-testing` a été créé, dédié aux développements des tests de charge.

## :100: Pour tester
### 1. Effectuer les tests de charge sur l'API en local
* Lancer l'API
* Lancer les tests de charge avec la commande
    ```sh
     npm run arti:run:local
     ```
* Vérifier que plusieurs `scenarios` ont le statut : `completed`
* Vérifier le reporting avec la commande
     ```sh
     npm run report
     ```
![Capture d’écran 2021-08-19 à 16 43 28](https://user-images.githubusercontent.com/88607/130089256-2d565903-a282-4836-83ca-3b992fa44724.png)

### 2. Effectuer les tests de charge sur `pix-api-load-testing`
* Lancer les tests de charge avec la commande
    ```sh
     npm run arti:run:dev
     ```
* Vérifier que plusieurs `scenarios` ont le statut : `completed`
* Vérifier le reporting avec la commande
     ```sh
     npm run report
     ```

