### PR TITLE
[TECH] Migrer la colonne knowledge_elements.id de INTEGER en BIG INTEGER (partie 2).

### DIFF
--- a/api/db/migrations/20210819161111_use-bigint-for-knowledge-elements-pk.js
+++ b/api/db/migrations/20210819161111_use-bigint-for-knowledge-elements-pk.js
@@ -1,0 +1,58 @@
+const MAX_ROW_COUNT_FOR_CREATING_BACK_PK_IN_DEPLOYMENT = 500000;
+
+exports.up = async function(knex) {
+  await knex.raw('LOCK TABLE "knowledge-elements" IN ACCESS EXCLUSIVE MODE');
+  await knex.raw('DROP TRIGGER "trg_knowledge-elements" ON "knowledge-elements"');
+  await knex.raw('DROP FUNCTION copy_int_id_to_bigint_id');
+  await knex.raw('ALTER SEQUENCE "knowledge-elements_id_seq" OWNED BY "knowledge-elements"."bigintId"');
+  await knex.raw('ALTER SEQUENCE "knowledge-elements_id_seq" AS BIGINT');
+  await knex.raw('ALTER TABLE "knowledge-elements" ALTER COLUMN "bigintId" SET DEFAULT nextval(\'"knowledge-elements_id_seq"\')');
+  await knex.raw('ALTER TABLE "knowledge-elements" ALTER COLUMN "id" DROP DEFAULT');
+  await knex.raw('ALTER TABLE "knowledge-elements" DROP CONSTRAINT "knowledge-elements_pkey"');
+  await knex.raw('ALTER TABLE "knowledge-elements" ALTER COLUMN "id" DROP NOT NULL');
+  await knex.raw('ALTER TABLE "knowledge-elements" ADD CONSTRAINT "knowledge-elements_pkey" PRIMARY KEY USING INDEX "knowledge-elements_bigintId_index"');
+  await knex.raw('ALTER TABLE "knowledge-elements" RENAME COLUMN "id" TO "intId"');
+  await knex.raw('ALTER TABLE "knowledge-elements" RENAME COLUMN "bigintId" TO "id"');
+};
+
+exports.down = async function(knex) {
+  const nbRows = (await knex('knowledge-elements').max('id').first()).max;
+
+  if (nbRows < MAX_ROW_COUNT_FOR_CREATING_BACK_PK_IN_DEPLOYMENT) {
+    await knex.raw('LOCK TABLE "knowledge-elements" IN ACCESS EXCLUSIVE MODE');
+
+    await knex.raw('ALTER SEQUENCE "knowledge-elements_id_seq" OWNED BY "knowledge-elements"."intId"');
+    await knex.raw('ALTER SEQUENCE "knowledge-elements_id_seq" AS INTEGER');
+    await knex.raw('ALTER TABLE "knowledge-elements" ALTER COLUMN "intId" SET DEFAULT nextval(\'"knowledge-elements_id_seq"\')');
+    await knex.raw('ALTER TABLE "knowledge-elements" ALTER COLUMN "id" DROP DEFAULT');
+    await knex.raw('ALTER TABLE "knowledge-elements" DROP CONSTRAINT "knowledge-elements_pkey"');
+    await knex.raw('UPDATE "knowledge-elements" SET "intId" = "id" WHERE "intId" IS NULL');
+    await knex.raw('ALTER TABLE "knowledge-elements" ALTER COLUMN "intId" SET NOT NULL');
+    await knex.raw('ALTER TABLE "knowledge-elements" ADD CONSTRAINT "knowledge-elements_pkey" PRIMARY KEY("intId")');
+    await knex.raw('ALTER TABLE "knowledge-elements" RENAME COLUMN "id" TO "bigintId"');
+    await knex.raw('ALTER TABLE "knowledge-elements" RENAME COLUMN "intId" TO "id"');
+
+    // UNIQUE and NOT NULL constraints cannot be extracted from primary key, so we have to create them afresh
+    await knex.raw('CREATE UNIQUE INDEX "knowledge-elements_bigintId_index" ON "knowledge-elements"("bigintId")');
+    await knex.raw('ALTER TABLE "knowledge-elements" ALTER COLUMN "bigintId" SET NOT NULL');
+
+    await knex.raw(`CREATE OR REPLACE FUNCTION copy_int_id_to_bigint_id()
+                    RETURNS TRIGGER AS
+                    $$
+                    BEGIN
+                      NEW."bigintId" = NEW.id::BIGINT;
+                      RETURN NEW;
+                    END
+                    $$ LANGUAGE plpgsql;`);
+
+    await knex.raw(`CREATE TRIGGER "trg_knowledge-elements"
+                    BEFORE INSERT ON "knowledge-elements"
+                    FOR EACH ROW
+                    EXECUTE FUNCTION copy_int_id_to_bigint_id();`);
+
+  } else {
+    // There is no going back here, as revert will be too time-consuming to be performed during deployment
+    // https://doc.scalingo.com/platform/app/postdeploy-hook#limits
+  }
+
+};

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -37,19 +37,9 @@ describe('Integration | Repository | knowledgeElementRepository', function() {
 
       // then
       let actualKnowledgeElement = await knex.select('*').from('knowledge-elements').first();
-      actualKnowledgeElement = _.omit(actualKnowledgeElement, ['id', 'bigintId', 'createdAt', 'updatedAt']);
+      actualKnowledgeElement = _.omit(actualKnowledgeElement, ['id', 'intId', 'createdAt', 'updatedAt']);
       const expectedKnowledgeElement = _.omit(knowledgeElementToSave, ['id', 'createdAt', 'updatedAt']);
       expect(actualKnowledgeElement).to.deep.equal(expectedKnowledgeElement);
-    });
-
-    it('should trigger filling of bigintId column', async function() {
-      // when
-      const { id } = await knowledgeElementRepository.save(knowledgeElementToSave);
-
-      // then
-      const actualKnowledgeElement = await knex.select('id', 'bigintId').from('knowledge-elements').where({ id }).first();
-      expect(actualKnowledgeElement.bigintId).to.exist;
-      expect(actualKnowledgeElement.bigintId).to.equal(actualKnowledgeElement.id);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Voir https://github.com/1024pix/pix/pull/3357

## :robot: Solution
Promouvoir `bigintId` en identifiant de la table `knowledge-elements`
- le nommer id
- lui ajouter la contrainte PRIMARY KEY
- l'associer à une séquence de type BIGINT (sans recouvrement avec la séquence précédente)

## :rainbow: Remarques
En cas de problème lors de l'exécution de la migration, le rollback effectué par knex assure un retour à la normale. Il est préconisé de n'embarquer que cette PR dans la release pour ne pas avoir de versions différentes des front.

Le revert de migration  (`migrate down`) est effectué  si la volumétrie est inférieure à 500 000 enregistrements. Cela est dû au fait que les index des contraintes UNIQUE et NOT NULL ne peuvent pas être récupérés avant de supprimer une PK.

Cette PR sera  mergée après la fin de l'exécution manuelle du script de la branche de base (PR https://github.com/1024pix/pix/pull/3357) en production, achevée le 26/08 à 23h30

## :100: Pour tester

### Environnement créé en direct

Vérifier que 
- le type de colonne id est BIG INTEGER, et fait partie de la PK
- la présence d'une colonne idInteger, non alimentée et sans constrainte

```
pix=# \d "knowledge-elements"
                                         Table "public.knowledge-elements"
    Column    |           Type           | Collation | Nullable |                     Default                      
--------------+--------------------------+-----------+----------+--------------------------------------------------
 intId        | integer                  |           |          | 
 id           | bigint                   |           | not null | nextval('"knowledge-elements_id_seq"'::regclass)
Indexes:
    "knowledge-elements_pkey" PRIMARY KEY, btree (id)

pix=# select * from "knowledge-elements" limit 7;
 intId | source |  status   |       createdAt        | answerId | assessmentId |      skillId      | earnedPix | userId |   competenceId    |   id   
-------+--------+-----------+------------------------+----------+--------------+-------------------+-----------+--------+-------------------+--------
       | direct | validated | 2019-12-31 00:00:00+00 |   100869 |       100867 | rec1mysPzEa6Y2KUf |  0.666667 |    104 | recNv8qhaY887jQb2 | 100870
       | direct | validated | 2019-12-31 00:00:00+00 |   100871 |       100868 | rec1mysPzEa6Y2KUf |  0.666667 |    105 | recNv8qhaY887jQb2 | 100872
       | direct | validated | 2019-12-31 00:00:00+00 |   100873 |       100867 | recxhMuHFUWbhWHxS |         4 |    104 | recNv8qhaY887jQb2 | 100874
```

Effectuer un parcours et vérifier que les KE sont bien insérés
- avec `id` alimenté
- avec `intId` non alimenté


### Environnement avec données

Déployer le commit parent (déploiement manuel de la branche `dev` ou `tech-ke-int-to-bigint`)

Créer le schéma et alimenter les données `npm run db:reset`

Déployer cette branche

Effectuer la migration `npm run db:migrate`

Vérifier que 
- le type de la colonne `id` est BIG INTEGER, et fait partie de la PK
- la présence d'une colonne `idInteger`, alimentée et sans contrainte
```
pix=# \d "knowledge-elements"
                                         Table "public.knowledge-elements"
    Column    |           Type           | Collation | Nullable |                     Default                      
--------------+--------------------------+-----------+----------+--------------------------------------------------
 intId        | integer                  |           |          | 
 id           | bigint                   |           | not null | nextval('"knowledge-elements_id_seq"'::regclass)
Indexes:
    "knowledge-elements_pkey" PRIMARY KEY, btree (id)

pix=# select * from "knowledge-elements" limit 7;
 intId  | source |  status   |       createdAt        | answerId | assessmentId |      skillId      | earnedPix | userId |   competenceId    |   id   
--------+--------+-----------+------------------------+----------+--------------+-------------------+-----------+--------+-------------------+--------
 100870 | direct | validated | 2019-12-31 00:00:00+00 |   100869 |       100867 | rec1mysPzEa6Y2KUf |  0.666667 |    104 | recNv8qhaY887jQb2 | 100870
 100872 | direct | validated | 2019-12-31 00:00:00+00 |   100871 |       100868 | rec1mysPzEa6Y2KUf |  0.666667 |    105 | recNv8qhaY887jQb2 | 100872
 100874 | direct | validated | 2019-12-31 00:00:00+00 |   100873 |       100867 | recxhMuHFUWbhWHxS |         4 |    104 | recNv8qhaY887jQb2 | 100874
```

Effectuer un parcours et vérifier que les KE sont bien insérés
- avec `id` alimenté
- avec `inTid` non alimenté

### Revert

Exécuter `npx knex --knexfile db/knexfile.js migrate:down`

Vérifier que
- le type de la colonne id est INTEGER, et fait partie de la PK
- la présence d'une colonne bigInteger, alimentée et avec contrainte UNIQUE et NOT NULL


```
pix=# \d "knowledge-elements"
                                         Table "public.knowledge-elements"
    Column    |           Type           | Collation | Nullable |                     Default                      
--------------+--------------------------+-----------+----------+--------------------------------------------------
 id           | integer                  |           | not null | nextval('"knowledge-elements_id_seq"'::regclass)
 bigintId     | bigint                   |           | not null | 
Indexes:
    "knowledge-elements_pkey" PRIMARY KEY, btree (id)
    "knowledge-elements_bigintId_index" UNIQUE, btree ("bigintId")
Triggers:
    "trg_knowledge-elements" BEFORE INSERT ON "knowledge-elements" FOR EACH ROW EXECUTE FUNCTION copy_int_id_to_bigint_id()


pix=# select * from "knowledge-elements" limit 3;
   id   | source |  status   |       createdAt        | answerId | assessmentId |      skillId      | earnedPix | userId |   competenceId    | bigintId 
--------+--------+-----------+------------------------+----------+--------------+-------------------+-----------+--------+-------------------+----------
 100870 | direct | validated | 2019-12-31 00:00:00+00 |   100869 |       100867 | rec1mysPzEa6Y2KUf |  0.666667 |    104 | recNv8qhaY887jQb2 |   100870
 100872 | direct | validated | 2019-12-31 00:00:00+00 |   100871 |       100868 | rec1mysPzEa6Y2KUf |  0.666667 |    105 | recNv8qhaY887jQb2 |   100872
 100874 | direct | validated | 2019-12-31 00:00:00+00 |   100873 |       100867 | recxhMuHFUWbhWHxS |         4 |    104 | recNv8qhaY887jQb2 |   100874
```

Effectuer un parcours et vérifier que les KE sont bien insérés
- avec `id` alimenté
- avec `bigintId` alimenté

Puis revenir à la situation d'origine
`npm run db:migrate`
