### PR TITLE
[TECH] Migrer la colonne knowledge_elements.id de INTEGER en BIG INTEGER (partie 3).

### DIFF
--- a/api/db/migrations/20210820071611_remove-integer-id-from-knowledge-elements.js
+++ b/api/db/migrations/20210820071611_remove-integer-id-from-knowledge-elements.js
@@ -1,0 +1,7 @@
+exports.up = async function(knex) {
+  await knex.raw('ALTER TABLE "knowledge-elements" DROP COLUMN "intId"');
+};
+
+exports.down = async function(knex) {
+  await knex.raw('ALTER TABLE "knowledge-elements" ADD COLUMN "intId" INTEGER');
+};


### PR DESCRIPTION
## :unicorn: Problème
Voir https://github.com/1024pix/pix/pull/3357
La colonne `intId` contient les identifiants avant passage en BIG INTEGER, pour faciliter l'analyse en cas de problème.

Après une période d'observation en production, elle peut être supprimée.

## :robot: Solution
Supprimer la colonne `intId`

## :rainbow: Remarques

Cette PR sera  mergée:
- après la branche de base (https://github.com/1024pix/pix/pull/3364) => :heavy_check_mark:  le 27/08;
- après une période d'observation en production (une semaine)

## :100: Pour tester
Vérifier que la colonne `intId` n'est plus présente
