### PR TITLE
[FEATURE] Récupérer si besoin l'identifiant externe de la participation précédente pour les campagnes à envois multiples (PIX-2675).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -6,7 +6,7 @@ const errorSerializer = require('../infrastructure/serializers/jsonapi/error-ser
 const { extractLocaleFromRequest } = require('../infrastructure/utils/request-response-utils');
 const translations = require('../../translations');
 
-const NOT_VALID_RELATIONSHIPS = ['externalId'];
+const NOT_VALID_RELATIONSHIPS = ['externalId', 'participantExternalId'];
 
 function translateMessage(locale, key) {
   if (translations[locale]['entity-validation-errors'][key]) {

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -374,7 +374,7 @@ function handle(request, h, error) {
   if (error instanceof DomainErrors.EntityValidationError) {
     const locale = extractLocaleFromRequest(request).split('-')[0];
 
-    const jsonApiError = new JSONAPIError(error.invalidAttributes.map(_formatInvalidAttribute.bind(_formatInvalidAttribute, locale)));
+    const jsonApiError = new JSONAPIError(error.invalidAttributes?.map(_formatInvalidAttribute.bind(_formatInvalidAttribute, locale)));
     return h.response(jsonApiError).code(422);
   }
 

--- a/api/lib/domain/usecases/find-answer-by-assessment.js
+++ b/api/lib/domain/usecases/find-answer-by-assessment.js
@@ -12,7 +12,9 @@ module.exports = async function findAnswerByAssessment(
   } = {}) {
   const integerAssessmentId = parseInt(assessmentId);
   if (!Number.isFinite(integerAssessmentId)) {
-    throw new EntityValidationError('This assessment ID is not valid.');
+    throw new EntityValidationError({
+      invalidAttributes: [{ attribute: 'assessmentId', message: 'This assessment ID is not valid.' }],
+    });
   }
 
   const ownedByUser = await assessmentRepository.ownedByUser({ id: assessmentId, userId });

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -13,15 +13,24 @@ module.exports = async function startCampaignParticipation({
 }) {
   const campaignToJoin = await campaignToJoinRepository.get(campaignParticipation.campaignId, domainTransaction);
 
-  if (campaignToJoin.idPixLabel && !campaignParticipation.participantExternalId)
-    throw new EntityValidationError({
-      invalidAttributes: [{ attribute: 'participantExternalId', message: 'Un identifiant externe est requis pour accèder à la campagne.' }],
-    });
-
   await campaignToJoinRepository.checkCampaignIsJoinableByUser(campaignToJoin, userId, domainTransaction);
-  let createdCampaignParticipation;
 
-  if (await campaignParticipationRepository.hasAlreadyParticipated(campaignToJoin.id, userId, domainTransaction)) {
+  const hasAlreadyParticipated = await campaignParticipationRepository.hasAlreadyParticipated(campaignToJoin.id, userId, domainTransaction);
+  if (campaignToJoin.idPixLabel && !campaignParticipation.participantExternalId) {
+    if (campaignToJoin.multipleSendings && hasAlreadyParticipated) {
+      campaignParticipation.participantExternalId = await campaignParticipationRepository.findParticipantExternalId(campaignToJoin.id, userId, domainTransaction);
+    } else {
+      throw new EntityValidationError({
+        invalidAttributes: [{
+          attribute: 'participantExternalId',
+          message: 'Un identifiant externe est requis pour accèder à la campagne.',
+        }],
+      });
+    }
+  }
+
+  let createdCampaignParticipation;
+  if (hasAlreadyParticipated) {
     await campaignParticipationRepository.markPreviousParticipationsAsImproved(campaignToJoin.id, userId, domainTransaction);
     createdCampaignParticipation = await _saveCampaignParticipation(campaignParticipation, userId, campaignParticipationRepository, domainTransaction);
     if (campaignToJoin.isAssessment) {

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -14,7 +14,9 @@ module.exports = async function startCampaignParticipation({
   const campaignToJoin = await campaignToJoinRepository.get(campaignParticipation.campaignId, domainTransaction);
 
   if (campaignToJoin.idPixLabel && !campaignParticipation.participantExternalId)
-    throw new EntityValidationError('Un identifiant externe est requis pour accèder à la campagne.');
+    throw new EntityValidationError({
+      invalidAttributes: [{ attribute: 'participantExternalId', message: 'Un identifiant externe est requis pour accèder à la campagne.' }],
+    });
 
   await campaignToJoinRepository.checkCampaignIsJoinableByUser(campaignToJoin, userId, domainTransaction);
   let createdCampaignParticipation;

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -87,6 +87,14 @@ module.exports = {
     return count > 0;
   },
 
+  async findParticipantExternalId(campaignId, userId, domainTransaction) {
+    const campaignParticipation = await domainTransaction.knexTransaction('campaign-participations')
+      .select('participantExternalId')
+      .where({ campaignId, userId })
+      .first();
+    return campaignParticipation?.participantExternalId;
+  },
+
   async findProfilesCollectionResultDataByCampaignId(campaignId) {
     const results = await knex.with('campaignParticipationWithUser',
       (qb) => {

--- a/api/lib/infrastructure/repositories/campaign-to-join-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-to-join-repository.js
@@ -71,7 +71,6 @@ module.exports = {
 async function _checkCanAccessToCampaign(campaign, userId, domainTransaction) {
   if (campaign.isArchived) {
     throw new ForbiddenAccess('Vous n\'êtes pas autorisé à rejoindre la campagne');
-
   }
 
   if (campaign.isRestricted && await _hasNoActiveSchoolingRegistration(userId, campaign, domainTransaction)) {
@@ -90,7 +89,7 @@ async function _hasNoActiveSchoolingRegistration(userId, campaign, domainTransac
 }
 
 async function _checkCanParticipateToCampaign(campaign, userId, domainTransaction) {
-  if (campaign.multipleSendings && await _cannotImproveResults(campaign.id, userId, domainTransaction)) {
+  if (campaign.multipleSendings && campaign.isAssessment && await _cannotImproveResults(campaign.id, userId, domainTransaction)) {
     throw new ForbiddenAccess('Vous ne pouvez pas repasser la campagne');
   }
   if (!campaign.multipleSendings && await _hasAlreadyParticipatedToCampaign(campaign.id, userId, domainTransaction)) {

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -562,6 +562,30 @@ describe('Integration | API | Controller Error', function() {
       expect(unprocessableErrorOnFirstname.detail).to.equal('Le profile cible n’est pas renseigné.');
     });
 
+    it('responds Unprocessable Entity with invalid data attribute with name ends with Id', async function() {
+      // given
+      const invalidAttributes = [{
+        attribute: 'participantExternalId',
+        message: 'Un identifiant externe est requis pour accèder à la campagne.',
+      }];
+      routeHandler.throws(new DomainErrors.EntityValidationError({ invalidAttributes }));
+
+      // when
+      const response = await server.requestObject(request);
+
+      // then
+      expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
+
+      const payload = JSON.parse(response.payload);
+      expect(payload.errors).to.have.lengthOf(1);
+
+      const unprocessableErrorOnFirstname = payload.errors[0];
+      expect(unprocessableErrorOnFirstname.status).to.equal('422');
+      expect(unprocessableErrorOnFirstname.source.pointer).to.equal('/data/attributes/participant-external-id');
+      expect(unprocessableErrorOnFirstname.title).to.equal('Invalid data attribute "participantExternalId"');
+      expect(unprocessableErrorOnFirstname.detail).to.equal('Un identifiant externe est requis pour accèder à la campagne.');
+    });
+
     it('responds Unprocessable Entity with invalid data attribute, if attribute is undefined', async function() {
       // given
       const invalidAttributes = [{

--- a/api/tests/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/integration/domain/usecases/start-campaign-participation_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder, domainBuilder, knex, catchErr } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder, knex, catchErr, learningContentBuilder, mockLearningContent } = require('../../../test-helper');
 const startCampaignParticipation = require('../../../../lib/domain/usecases/start-campaign-participation');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
@@ -10,16 +10,14 @@ describe('Integration | UseCases | start-campaign-participation', function() {
 
   let userId;
   let organizationId;
-  let targetProfileId;
   let campaignId;
 
   beforeEach(async function() {
+    const learningContentObjects = learningContentBuilder.buildLearningContent([]);
+    mockLearningContent(learningContentObjects);
+
     organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: false }).id;
     userId = databaseBuilder.factory.buildUser().id;
-    databaseBuilder.factory.buildMembership({
-      organizationId, userId,
-    });
-    targetProfileId = databaseBuilder.factory.buildTargetProfile({ organizationId }).id;
     await databaseBuilder.commit();
   });
 
@@ -30,7 +28,7 @@ describe('Integration | UseCases | start-campaign-participation', function() {
 
   it('should save a campaign participation and its assessment when campaign is of type ASSESSMENT', async function() {
     // given
-    campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', creatorId: userId, organizationId, targetProfileId }).id;
+    campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', organizationId }).id;
     await databaseBuilder.commit();
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
 
@@ -48,7 +46,7 @@ describe('Integration | UseCases | start-campaign-participation', function() {
 
   it('should save only a campaign participation when campaign is of type PROFILES_COLLECTION', async function() {
     // given
-    campaignId = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', creatorId: userId, organizationId, targetProfileId: null }).id;
+    campaignId = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', organizationId }).id;
     await databaseBuilder.commit();
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
 
@@ -66,7 +64,7 @@ describe('Integration | UseCases | start-campaign-participation', function() {
 
   it('should throw an error and not create anything when something goes wrong within the transaction', async function() {
     // given
-    campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', creatorId: userId, organizationId, targetProfileId }).id;
+    campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', organizationId }).id;
     await databaseBuilder.commit();
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
 
@@ -85,17 +83,58 @@ describe('Integration | UseCases | start-campaign-participation', function() {
     expect(assessments).to.have.lengthOf(0);
   });
 
+  context('when campaign is multipleSendings', function() {
+    let campaignParticipation;
+
+    beforeEach(async function() {
+      campaignId = databaseBuilder.factory.buildCampaign({ multipleSendings: true, idPixLabel: null, organizationId }).id;
+      await databaseBuilder.commit();
+    });
+
+    it('should save new participation', async function() {
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId }).id;
+      await databaseBuilder.commit();
+      campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
+
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository, domainTransaction });
+      });
+
+      const campaignParticipations = await knex('campaign-participations').where('campaignId', campaignId).andWhere('userId', userId);
+      expect(campaignParticipations).to.have.lengthOf(2);
+    });
+
+    it('should mark old participation as improved', async function() {
+      const oldCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, isImproved: false }).id;
+      await databaseBuilder.commit();
+      campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
+
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository, domainTransaction });
+      });
+
+      const result = await knex('campaign-participations').where('id', oldCampaignParticipationId).first();
+      expect(result.isImproved).to.be.true;
+    });
+  });
+
   context('when campaign has idPixLabel and no participantExternalId', function() {
     let campaignParticipation;
 
     beforeEach(async function() {
-      campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', idPixLabel: 'toto', creatorId: userId, organizationId, targetProfileId }).id;
+      campaignId = databaseBuilder.factory.buildCampaign({ idPixLabel: 'toto', organizationId }).id;
       await databaseBuilder.commit();
       campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId, participantExternalId: null });
     });
 
     it('should throw an error', async function() {
-      const error = await catchErr(startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository });
+      const error = await catchErr(startCampaignParticipation)({
+        campaignParticipation,
+        userId,
+        campaignParticipationRepository,
+        assessmentRepository,
+        campaignToJoinRepository,
+      });
 
       expect(error).to.be.instanceOf(EntityValidationError);
       expect(error.invalidAttributes[0].attribute).to.equal('participantExternalId');
@@ -109,6 +148,33 @@ describe('Integration | UseCases | start-campaign-participation', function() {
       expect(campaignParticipations).to.have.lengthOf(0);
       const assessments = await knex('assessments');
       expect(assessments).to.have.lengthOf(0);
+    });
+
+    context('when campaign is multipleSendings', function() {
+      beforeEach(async function() {
+        campaignId = databaseBuilder.factory.buildCampaign({ multipleSendings: true, idPixLabel: 'identifiant', organizationId }).id;
+        await databaseBuilder.commit();
+      });
+
+      context('when it is its first participation', function() {
+
+        it('should throw an error', async function() {
+          const error = await catchErr(startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository });
+
+          expect(error).to.be.instanceOf(EntityValidationError);
+          expect(error.invalidAttributes[0].attribute).to.equal('participantExternalId');
+          expect(error.invalidAttributes[0].message).to.equal('Un identifiant externe est requis pour accèder à la campagne.');
+        });
+
+        it('should not create anything', async function() {
+          await catchErr(startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository });
+
+          const campaignParticipations = await knex('campaign-participations');
+          expect(campaignParticipations).to.have.lengthOf(0);
+          const assessments = await knex('assessments');
+          expect(assessments).to.have.lengthOf(0);
+        });
+      });
     });
   });
 });

--- a/api/tests/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/integration/domain/usecases/start-campaign-participation_test.js
@@ -175,6 +175,21 @@ describe('Integration | UseCases | start-campaign-participation', function() {
           expect(assessments).to.have.lengthOf(0);
         });
       });
+
+      context('when it is a retry', function() {
+        it('should save new participation with participant external id of first participation', async function() {
+          databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, participantExternalId: '123' }).id;
+          await databaseBuilder.commit();
+          campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId, participantExternalId: null });
+
+          await DomainTransaction.execute(async (domainTransaction) => {
+            await startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignToJoinRepository, domainTransaction });
+          });
+
+          const campaignParticipations = await knex('campaign-participations').where('participantExternalId', 123);
+          expect(campaignParticipations).to.have.lengthOf(2);
+        });
+      });
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -233,6 +233,49 @@ describe('Integration | Repository | Campaign Participation', function() {
     });
   });
 
+  describe('findParticipantExternalId', function() {
+    it('returns participantExternalId', async function() {
+      const participantExternalId = 'kékédu26';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, participantExternalId });
+      await databaseBuilder.commit();
+
+      const result = await DomainTransaction.execute((domainTransaction) => {
+        return campaignParticipationRepository.findParticipantExternalId(campaignId, userId, domainTransaction);
+      });
+
+      expect(result).to.equals(participantExternalId);
+    });
+
+    it('returns null when participantExternalId is null', async function() {
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, participantExternalId: null });
+
+      await databaseBuilder.commit();
+      const result = await DomainTransaction.execute((domainTransaction) => {
+        return campaignParticipationRepository.findParticipantExternalId(campaignId, userId, domainTransaction);
+      });
+
+      expect(result).to.equals(null);
+    });
+
+    it('returns undefined when no participation is found', async function() {
+      const otherCampaignId = '999';
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, participantExternalId: '123' });
+
+      await databaseBuilder.commit();
+      const result = await DomainTransaction.execute((domainTransaction) => {
+        return campaignParticipationRepository.findParticipantExternalId(otherCampaignId, userId, domainTransaction);
+      });
+
+      expect(result).to.equals(undefined);
+    });
+  });
+
   describe('#count', function() {
 
     let campaignId;

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -121,6 +121,27 @@ describe('Unit | Application | ErrorManager', function() {
         ],
       });
     });
+
+    it('should translate EntityValidationError even if invalidAttributes is undefined', async function() {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: undefined,
+      });
+
+      // when
+      const response = await handle(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [],
+      });
+    });
   });
 
   describe('#_mapToHttpError', function() {

--- a/api/tests/unit/domain/usecases/find-answer-by-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-answer-by-assessment_test.js
@@ -36,12 +36,14 @@ describe('Unit | UseCase | find-answer-by-challenge-and-assessment', function() 
   });
 
   context('when the assessmentid passed is not an integer', function() {
-    it('should return empty array', async function() {
+    it('should throw an error', async function() {
       // when
-      const result = await catchErr(findAnswerByAssessment)({ assessmentId: 'salut', userId, answerRepository, assessmentRepository });
+      const error = await catchErr(findAnswerByAssessment)({ assessmentId: 'salut', userId, answerRepository, assessmentRepository });
 
       // then
-      expect(result).to.be.instanceOf(EntityValidationError);
+      expect(error).to.be.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.equal('assessmentId');
+      expect(error.invalidAttributes[0].message).to.equal('This assessment ID is not valid.');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de campagnes à envois multiples où il est nécéssaire de saisir un identifiant externe, tout se passait correctement lors de la 1ère participation. En revanche, lors de la seconde, on était bloqué car la participation nécessite une identifiant externe et on ne le redemandait pas à l'utilisateur.

Une page d'erreur s'affichait, avec une erreur 500.

## :robot: Solution
- Corriger l'erreur 500 pour renvoyer plutôt une 422 (Unprocessable Entity)
- Déplacer la gestion de droits un peu plus en amont que ce qu'elle n'était
- Lors de la création de la 2ème participation, récupérer l'identifiant saisi lors de la 1ère participation

## :rainbow: Remarques
Rien à signaler

## :100: Pour tester
Pour la collecte de profils :
- Se connecter avec userpix1@example.net à Pix App
- Participer à la campagne SNAPMU789 (Campagne de collecte de profils à envois multiples) une première fois, saisir un identifiant externe, et envoyer son profil
- Ressaisir le code, et participer une seconde fois (sans demande d'identifiant)
- Vérifier que l'on peut ré-envoyer son profil

Pour la campagne d'évaluation :
- Se connecter avec userpix1@example.net à Pix App
- Participer à la campagne FINISHED3 (Campagne d'évaluation à envois multiples) une première fois, saisir un identifiant externe, passer son parcours et envoyer ses résultats
- Ressaisir le code, et participer une seconde fois (sans demande d'identifiant)
- Vérifier que l'on peut repasser son parcours, et ré-envoyer ses résultats