### PR TITLE
[FEATURE] Mettre à jour les PixButton dans Pix App (PIX-3012).

### DIFF
--- a/admin/tests/integration/components/routes/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/certification/informations_test.js
@@ -185,7 +185,6 @@ module('Integration | Component | routes/authenticated/certifications/certificat
           await visit(`/certifications/${certification.id}`);
 
           // then
-          //await this.pauseTest();
           assert.contains('Signalement(s) impactant(s)');
           assert.dom('.certification-issue-report__details__label').hasText('Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement impactant');
           assert.notContains('Signalement(s) non impactant(s)');

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -90,5 +90,5 @@ When(`je retourne au détail de la campagne`, () => {
 });
 
 When('je clique sur le bouton "Associer"', () => {
-  cy.get('[aria-label="Associer"]').click();
+  cy.contains('button', 'Associer').click();
 });

--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
@@ -44,8 +44,7 @@
       <PixButton
         @isBorderVisible={{true}}
         @triggerAction={{@cancelAccountRecovery}}
-        @backgroundColor="transparent-light"
-        class="confirmation-step__actions--cancel">
+        @backgroundColor="transparent-light">
           {{t 'pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.cancel'}}
       </PixButton>
       <PixButton

--- a/mon-pix/app/components/account-recovery/confirmation-email-sent.hbs
+++ b/mon-pix/app/components/account-recovery/confirmation-email-sent.hbs
@@ -12,8 +12,8 @@
   </p>
 
   <div class="account-recovery__content--actions">
-    <PixButton @isLink={{true}} @route='login'>
+    <PixButtonLink @route='login'>
       {{t 'pages.account-recovery.find-sco-record.send-email-confirmation.return' }}
-    </PixButton>
+    </PixButtonLink>
   </div>
 </div>

--- a/mon-pix/app/components/account-recovery/confirmation-step.hbs
+++ b/mon-pix/app/components/account-recovery/confirmation-step.hbs
@@ -47,8 +47,7 @@
     <PixButton
       @isBorderVisible={{true}}
       @triggerAction={{@cancelAccountRecovery}}
-      @backgroundColor="transparent-light"
-      class="confirmation-step__actions--cancel">
+      @backgroundColor="transparent-light">
       {{t 'pages.account-recovery.find-sco-record.confirmation-step.buttons.cancel' }}
     </PixButton>
     <PixButton

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -24,7 +24,6 @@ export default class CertificationJoiner extends Component {
 
   SESSION_ID_VALIDATION_PATTERN = '^[0-9]*$';
 
-  @tracked isLoading = false;
   @tracked errorMessage = null;
   @tracked sessionIdIsNotANumberError = null;
   @tracked validationClassName = '';
@@ -80,7 +79,6 @@ export default class CertificationJoiner extends Component {
       return;
     }
     try {
-      this.isLoading = true;
       currentCertificationCandidate = this.createCertificationCandidate();
       await currentCertificationCandidate.save({ adapterOptions: { joinSession: true, sessionId: this.sessionId } });
       this.args.onStepChange(this.sessionId);
@@ -88,7 +86,6 @@ export default class CertificationJoiner extends Component {
       if (currentCertificationCandidate) {
         currentCertificationCandidate.deleteRecord();
       }
-      this.isLoading = false;
 
       if (_isMatchingReconciledStudentNotFoundError(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account');

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -9,7 +9,6 @@ export default class CertificationJoiner extends Component {
   @service currentUser;
   @service intl;
 
-  @tracked isLoading = false;
   @tracked inputAccessCode = null;
   @tracked errorMessage = null;
   @tracked classNames = [];
@@ -27,7 +26,6 @@ export default class CertificationJoiner extends Component {
       this.errorMessage = this.intl.t('pages.certification-start.error-messages.access-code-error');
       return;
     }
-    this.isLoading = true;
 
     const newCertificationCourse = this.store.createRecord('certification-course', {
       accessCode: this.accessCode,
@@ -45,7 +43,6 @@ export default class CertificationJoiner extends Component {
       } else {
         this.errorMessage = this.intl.t('pages.certification-start.error-messages.generic');
       }
-      this.isLoading = false;
     }
   }
 }

--- a/mon-pix/app/components/password-reset-demand-form.js
+++ b/mon-pix/app/components/password-reset-demand-form.js
@@ -10,7 +10,7 @@ export default class PasswordResetDemandForm extends Component {
 
   @tracked hasFailed = false;
   @tracked hasSucceeded = false;
-  @tracked isButtonEnabled = true;
+  @tracked isButtonDisabled = false;
 
   email = '';
 
@@ -31,7 +31,7 @@ export default class PasswordResetDemandForm extends Component {
     event && event.preventDefault();
     this.hasFailed = false;
     this.hasSucceeded = false;
-    this.isButtonEnabled = false;
+    this.isButtonDisabled = true;
 
     if (!this.email) {
       return;
@@ -43,7 +43,7 @@ export default class PasswordResetDemandForm extends Component {
       this.hasSucceeded = true;
     } catch (error) {
       this.hasFailed = true;
-      this.isButtonEnabled = true;
+      this.isButtonDisabled = false;
     }
   }
 }

--- a/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
@@ -14,9 +14,8 @@
 
       <PixButton
         @type="submit"
-        class="button button--big fill-in-participant-external-id__button"
-        @triggerAction={{action this.submit}}
-        @loading-color="white">
+        class="fill-in-participant-external-id__button"
+        @triggerAction={{action this.submit}}>
           {{t 'pages.fill-in-participant-external-id.buttons.continue'}}
       </PixButton>
       {{#if this.errorMessage}}

--- a/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
@@ -27,8 +27,14 @@
       <img class="fill-in-participant-external-id__help" src={{@campaign.externalIdHelpImageUrl}} alt={{@campaign.alternativeTextToExternalIdHelpImage}}/>
     {{/if}}
 
-    <button type="button" disabled={{this.isLoading}} {{on 'click' this.cancel}} class="button button--regular button--no-color fill-in-participant-external-id__cancel-button">
+    <PixButton
+      @backgroundColor="transparent-light"
+      @triggerAction={{this.cancel}}
+      @size="big"
+      @loadingColor="white"
+      class="fill-in-participant-external-id__cancel-button"
+    >
       {{t 'pages.fill-in-participant-external-id.buttons.cancel'}}
-    </button>
+    </PixButton>
   </form>
 </main>

--- a/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
@@ -5,7 +5,7 @@
     {{t 'pages.fill-in-participant-external-id.announcement'}}
   </p>
 
-  <form class="fill-in-participant-external-id__form">
+  <form {{on 'submit' this.submit}} class="fill-in-participant-external-id__form">
     <div class="fill-in-participant-external-id-form__section">
       <div class="fill-in-participant-external-id__form-field">
         <label for="id-pix-label">{{@campaign.idPixLabel}}</label>
@@ -14,8 +14,7 @@
 
       <PixButton
         @type="submit"
-        class="fill-in-participant-external-id__button"
-        @triggerAction={{action this.submit}}>
+        class="fill-in-participant-external-id__button">
           {{t 'pages.fill-in-participant-external-id.buttons.continue'}}
       </PixButton>
       {{#if this.errorMessage}}

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.hbs
@@ -3,9 +3,13 @@
     <div class="join-error-modal-header__title">
       <h1 class="join-error-modal-header-title__text">{{t 'pages.join.sco.login-information-title'}}</h1>
     </div>
-    <button id="pix-modal__close-button" class="join-error-modal-header__close" type="button" aria-label={{t "common.actions.close"}} {{on 'click' @closeModal}}>
-      <img src="/images/icons/icon-croix.svg" alt={{t 'common.actions.close'}} class="join-error-modal-header-close__icon">
-    </button>
+    <PixIconButton
+      id="pix-modal__close-button"
+      @withBackground={{true}}
+      @ariaLabel={{t "common.actions.close"}}
+      @icon="times"
+      @triggerAction={{@closeModal}}
+    />
   </div>
 
   <div class="join-error-modal__body" {{on-key 'Escape' @closeModal}}>
@@ -14,15 +18,29 @@
 
   <div class="join-error-modal__footer">
     {{#if this.isInformationMode}}
-      <button class="button button--grey" type="button" {{on 'click' this.goToHome}}>{{t 'common.actions.sign-out'}}</button>
-      <button class="button" type="button" aria-label={{t 'pages.join.sco.associate'}} {{on 'click' @associate}}>{{t 'pages.join.sco.associate'}}</button>
+      <PixButton
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @triggerAction={{this.goToHome}}
+      >
+        {{t 'common.actions.sign-out'}}
+      </PixButton>
+
+      <PixButton @triggerAction={{@associate}}>
+        {{t 'pages.join.sco.associate'}}
+      </PixButton>
     {{else}}
-      <button class="button {{if this.displayContinueButton "button--grey"}}" type="button" {{on 'click' this.goToHome}}>
-        {{t 'common.actions.quit'}}</button>
+      <PixButton
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @triggerAction={{this.goToHome}}
+      >
+        {{t 'common.actions.quit'}}
+      </PixButton>
       {{#if this.displayContinueButton}}
-        <button class="button" type="button" aria-label={{t 'pages.join.sco.continue-with-pix'}} {{on 'click' this.goToCampaignConnectionForm}}>
+        <PixButton @triggerAction={{this.goToCampaignConnectionForm}}>
           {{t 'pages.join.sco.continue-with-pix'}}
-        </button>
+        </PixButton>
       {{/if}}
     {{/if}}
   </div>

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -1,7 +1,7 @@
 {{!-- template-lint-disable require-input-label no-triple-curlies no-unknown-arguments-for-builtin-components --}}
 <div class="join-restricted-campaign__title">{{t 'pages.join.sco.first-title' organizationName=@organizationName}}</div>
 <div class="join-restricted-campaign__subtitle">{{t 'pages.join.sco.subtitle'}}</div>
-<form>
+<form onSubmit={{this.submit}}>
   <div class="join-restricted-campaign__row">
     <label class="join-restricted-campaign__label">{{t 'pages.join.fields.firstname.label'}}</label>
     <Input
@@ -57,13 +57,9 @@
   {{#if this.errorMessage}}
     <div class="join-restricted-campaign__error" aria-live="polite">{{{this.errorMessage}}}</div>
   {{/if}}
-  {{#if this.isLoading}}
-    <button type="button" disabled class="button button--big join-restricted-campaign__button"><span class="loader-in-button">&nbsp;</span></button>
-  {{else}}
-    <button type="submit" class="button button--big join-restricted-campaign__button" {{on 'click' this.submit}}>
-      {{t 'pages.join.button'}}
-    </button>
-  {{/if}}
+  <div class="join-restricted-campaign__actions">
+    <PixButton @type="submit">{{t 'pages.join.button'}}</PixButton>
+  </div>
 </form>
 {{#if this.displayInformationModal}}
   <Routes::Campaigns::Restricted::JoinScoInformationModal

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -35,7 +35,6 @@ export default class JoinSco extends Component {
 
   validation = new Validation();
 
-  @tracked isLoading = false;
   @tracked errorMessage;
 
   @tracked displayInformationModal = false;
@@ -83,7 +82,6 @@ export default class JoinSco extends Component {
   @action
   async submit(event) {
     event.preventDefault();
-    this.isLoading = true;
     this.errorMessage = null;
     this.displayInformationModal = false;
     this.reconciliationError = null;
@@ -91,7 +89,7 @@ export default class JoinSco extends Component {
 
     this._validateForm();
     if (this.isFormNotValid) {
-      return this.isLoading = false;
+      return;
     }
 
     const externalUserToken = this.session.get('data.externalUser');
@@ -104,34 +102,29 @@ export default class JoinSco extends Component {
         reconciliationRecord.unloadRecord();
         this._displayWarningMessage();
       }
-      this.isLoading = false;
     } catch (errorResponse) {
       reconciliationRecord.unloadRecord();
       this._setErrorMessageForAttemptNextAction(errorResponse);
-      this.isLoading = false;
     }
   }
 
   @action
   async associate(event) {
     event.preventDefault();
-    this.isLoading = true;
     this.errorMessage = null;
 
     this._validateForm();
     if (this.isFormNotValid) {
-      return this.isLoading = false;
+      return;
     }
 
     const reconciliationRecord = this._getReconciliationRecord();
     try {
       await this.args.onSubmitToReconcile(reconciliationRecord, { withReconciliation: true });
-      this.isLoading = false;
       this.closeModal();
     } catch (errorResponse) {
       reconciliationRecord.unloadRecord();
       this._setErrorMessageForAttemptNextAction(errorResponse);
-      this.isLoading = false;
     }
   }
 

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
@@ -97,11 +97,7 @@
     <div class="join-restricted-campaign__error" aria-live="polite">{{this.errors.global}}</div>
   {{/if}}
 
-  <button type="submit" disabled={{this.isLoading}} class="button button--big join-restricted-campaign__button" {{on 'click' this.submit}}>
-    {{#if this.isLoading}}
-      <span class="loader-in-button">&nbsp;</span>
-    {{else}}
-      {{t 'pages.join.button'}}
-    {{/if}}
-  </button>
+  <PixButton @type="submit" @triggerAction={{this.submit}} class="join-restricted-campaign__button">
+    {{t 'pages.join.button'}}
+  </PixButton>
 </form>

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sup.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sup.js
@@ -39,7 +39,6 @@ export default class JoinSup extends Component {
   @tracked yearOfBirth = '';
   @tracked studentNumber = '';
 
-  @tracked isLoading = false;
   errors = new Errors();
 
   get birthdate() {
@@ -101,8 +100,6 @@ export default class JoinSup extends Component {
 
     if (!this.isValidForm) return;
 
-    this.isLoading = true;
-
     const schoolingRegistration = this.store.createRecord('schooling-registration-user-association', {
       id: `${this.args.campaignCode}_${this.lastName}`,
       studentNumber: this.studentNumber,
@@ -118,7 +115,6 @@ export default class JoinSup extends Component {
       schoolingRegistration.unloadRecord();
       this._setErrorMessage(errorResponse);
     }
-    this.isLoading = false;
   }
 
   _setErrorMessage(errorResponse) {

--- a/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
+++ b/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
@@ -2,7 +2,7 @@
   <div class="user-account-update-email-with-validation__cancel-button">
     <PixIconButton
       @icon="times"
-      aria-label={{t 'pages.user-account.account-update-email-with-validation.cancel-button.aria-label'}}
+      @ariaLabel={{t 'pages.user-account.account-update-email-with-validation.cancel-button.aria-label'}}
       @color="dark-grey"
       @triggerAction={{@disableEmailWithValidationEditionMode}}
       data-test-id="user-account-update-email-with-validation__cancel-button"

--- a/mon-pix/app/controllers/campaigns/assessment/tutorial.js
+++ b/mon-pix/app/controllers/campaigns/assessment/tutorial.js
@@ -1,0 +1,15 @@
+import { action } from '@ember/object';
+import Controller from '@ember/controller';
+
+export default class TutorialController extends Controller {
+
+  @action
+  nextStep() {
+    this.send('next');
+  }
+
+  @action
+  ignoreTutorial() {
+    this.send('submit');
+  }
+}

--- a/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
+++ b/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
@@ -6,13 +6,11 @@ import { tracked } from '@glimmer/tracking';
 export default class SendProfileController extends Controller {
   @service intl;
 
-  @tracked isLoading = false;
   @tracked errorMessage = null;
 
   @action
   async sendProfile() {
     this.errorMessage = null;
-    this.isLoading = true;
 
     const campaignParticipation = this.model.campaignParticipation;
     campaignParticipation.isShared = true;
@@ -23,7 +21,6 @@ export default class SendProfileController extends Controller {
       campaignParticipation.rollbackAttributes();
       this._handleCampaignParticipationSaveErrors(errorResponse.errors);
     }
-    this.isLoading = false;
   }
 
   _handleCampaignParticipationSaveErrors(errors) {

--- a/mon-pix/app/controllers/fill-in-certificate-verification-code.js
+++ b/mon-pix/app/controllers/fill-in-certificate-verification-code.js
@@ -18,7 +18,8 @@ export default class FillInCertificateVerificationCode extends Controller {
   showNotFoundCertificationErrorMessage = false;
 
   @action
-  async checkCertificate() {
+  async checkCertificate(e) {
+    e.preventDefault();
     this.clearErrors();
 
     if (!this.certificateVerificationCode) {

--- a/mon-pix/app/styles/components/_certification-result.scss
+++ b/mon-pix/app/styles/components/_certification-result.scss
@@ -68,24 +68,7 @@
 }
 
 .result-content__button {
-  border: none;
-  display: block;
-  font-size: 1rem;
-  text-align: center;
-  color: $white;
-  padding: 6px 15px;
-  background: $blue;
-  border-radius: 5px;
   margin: 12px auto;
-  width: 170px;
-  height: 40px;
-  text-decoration: none;
-  cursor: pointer;
-
-  &:hover {
-    color: $white;
-    text-decoration: none;
-  }
 
   @include device-is('tablet') {
     margin-top: 8px;

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -106,7 +106,8 @@
 }
 
 .certification-course-page__field-button {
-  text-align: center;
+  display: flex;
+  justify-content: center;
   margin-bottom: 25px;
   margin-top: 25px;
 }

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -44,22 +44,6 @@
   justify-content: center;
 }
 
-.embed__launch-simulator-button {
-  background-color: $blue;
-  color: #FFFFFF;
-  box-shadow: 0 2px 6px 0 rgba(12, 22, 58, 0.11), 0 1px 3px 0 rgba(0, 0, 0, 0.08);
-  border: none;
-  border-radius: 5px;
-  font-family: $font-roboto;
-  font-size: 0.938rem;
-  font-weight: bold;
-  text-align: center;
-  text-transform: uppercase;
-  height: 56px;
-  padding: 0 36px;
-  cursor: pointer;
-}
-
 .embed__simulator {
   -webkit-overflow-scrolling: touch;
   height: calc(100% + 5px);

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -132,7 +132,11 @@
   }
 }
 
-.hexagon-score-content-pix-total__button {
+.pix-button.hexagon-score-content-pix-total__button {
   padding: 0 0 0 4px;
   border: none;
+
+  &:hover {
+    background-color: transparent;
+  }
 }

--- a/mon-pix/app/styles/components/_login-form.scss
+++ b/mon-pix/app/styles/components/_login-form.scss
@@ -26,11 +26,6 @@
   }
 
   .login-button-container {
-    display: flex;
-
-    .button {
-      flex-grow: 1;
-      margin-top: 25px;
-    }
+    margin-top: 25px;
   }
 }

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   max-width: 360px;
+  padding: 4px;
 
   &__login-options {
     margin-bottom: 5px;
@@ -44,7 +45,7 @@
   .register-button-container {
     display: flex;
 
-    .button {
+    button {
       flex-grow: 1;
       margin-top: 25px;
     }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -63,8 +63,8 @@
   }
 
   &__reset-button {
-    color: $grey-50;
-    margin-top: 50px;
+    margin-top: 24px;
+    width: 180px;
   }
 
   &__reset-modal {

--- a/mon-pix/app/styles/components/_user-account-update-email.scss
+++ b/mon-pix/app/styles/components/_user-account-update-email.scss
@@ -41,38 +41,6 @@
   }
 }
 
-.user-account-update-email-actions {
-
-  &__cancel-button {
-    min-width: 120px;
-
-    &:hover {
-      border-color: $grey-90;
-      background-color: $grey-10;
-    }
-
-    &:active {
-      border-color: $grey-90;
-      background-color: $grey-20;
-    }
-  }
-
-  &__confirm-button {
-    min-width: 120px;
-  }
-}
-
 abbr.mandatory-mark {
   text-decoration: none;
-}
-
-.confirm-button-enabled {
-
-  &:hover {
-    background-color: $blue-hover;
-  }
-
-  &:active {
-    background-color: darken($blue, 8%);
-  }
 }

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -139,18 +139,6 @@
     }
   }
 
-  &--bordered {
-    border: 1px solid $blue;
-    color: $blue;
-
-    &:hover,
-    &:active,
-    &:focus {
-      background-color: $blue;
-      color: $white;
-    }
-  }
-
   &--no-color {
     background-color: transparent;
     color: $grey-100;

--- a/mon-pix/app/styles/globals/_pix-modal.scss
+++ b/mon-pix/app/styles/globals/_pix-modal.scss
@@ -117,7 +117,7 @@ $pix-modal-border-radius: 5px;
           flex-direction: row-reverse;
           justify-content: center;
 
-          > .button {
+          > button {
             margin: 0 10px;
           }
         }

--- a/mon-pix/app/styles/pages/_campaign-tutorial.scss
+++ b/mon-pix/app/styles/pages/_campaign-tutorial.scss
@@ -80,12 +80,8 @@
 
   &__next-button {
     display: flex;
-    justify-content: center;
+    align-items: center;
     flex-direction: column;
-    margin: auto;
-  }
-
-  &__next-page-tutorial {
     margin: auto;
   }
 
@@ -93,7 +89,8 @@
     margin: auto auto 50px auto;
   }
 
-  &__ignore-button {
-    margin: 10px auto;
+  &__buttons {
+    width: 180px;
+    margin-top: 10px;
   }
 }

--- a/mon-pix/app/styles/pages/_connexion-methods.scss
+++ b/mon-pix/app/styles/pages/_connexion-methods.scss
@@ -34,6 +34,8 @@
 .user-account-panel-item__value {
   color: $grey-50;
   margin: 0;
+  display: flex;
+  align-items: center;
 }
 
 .user-account-panel-item__button,

--- a/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
+++ b/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
@@ -73,12 +73,12 @@
   display: inline-block;
 }
 
-.fill-in-participant-external-id__help {
-  margin-top: 32px;
-}
-
 .fill-in-participant-external-id__cancel-button {
   margin-top: 50px;
+}
+
+.fill-in-participant-external-id__help {
+  margin-top: 32px;
 }
 
 /* ------------------------ ERROR ------------------------ */

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -137,7 +137,7 @@
     display: flex;
     justify-content: center;
 
-    > .button {
+    > button {
       margin: 0 8px;
     }
   }
@@ -148,15 +148,6 @@
   &__title {
     display: flex;
     align-items: center;
-  }
-
-  &__close {
-    border: none;
-    background-color: transparent;
-
-    &:hover {
-      cursor: pointer;
-    }
   }
 }
 

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -105,6 +105,11 @@
   &__no-student-number {
     margin: 10px 8px 0 0;
   }
+
+  &__actions {
+    display: flex;
+    justify-content: center;
+  }
 }
 
 .ember-modal-overlay.translucent {

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -54,7 +54,8 @@
   }
 
   &__actions {
-    text-align: center;
+    display: flex;
+    justify-content: center;
   }
 }
 

--- a/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
@@ -25,11 +25,19 @@
     </div>
     <div class="campaign-tutorial__next-button">
     {{#if model.showNextButton}}
-      <button type="submit" class="button button--big campaign-tutorial__next-page-tutorial" {{action "next"}}>{{t 'pages.tutorial.next'}}</button>
+      <PixButton
+        @type="submit"
+        @triggerAction={{this.nextStep}}
+        class="campaign-tutorial__buttons"
+      >{{t 'pages.tutorial.next'}}</PixButton>
 
-      <button {{action "submit"}} class="button button--big button--no-color campaign-tutorial__ignore-button" type="button">{{t 'pages.tutorial.pass'}}</button>
+      <PixButton
+        @backgroundColor="transparent-light"
+        @triggerAction={{this.ignoreTutorial}}
+        class="campaign-tutorial__buttons"
+      >{{t 'pages.tutorial.pass'}}</PixButton>
     {{else}}
-      <button type="submit" class="button button--extra-big campaign-tutorial__start-campaign-button" {{action "submit"}}>{{t 'pages.tutorial.start'}}</button>
+      <PixButton @triggerAction={{this.ignoreTutorial}}>{{t 'pages.tutorial.start'}}</PixButton>
     {{/if}}
     </div>
   </main>

--- a/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
@@ -18,7 +18,6 @@
       @sendProfile={{action "sendProfile"}}
       @campaignParticipation={{this.model.campaignParticipation}}
       @campaign={{this.model.campaign}}
-      @isLoading={{this.isLoading}}
       @errorMessage={{this.errorMessage}}
     />
 
@@ -33,7 +32,6 @@
       @sendProfile={{action "sendProfile"}}
       @campaignParticipation={{this.model.campaignParticipation}}
       @campaign={{this.model.campaign}}
-      @isLoading={{this.isLoading}}
       @errorMessage={{this.errorMessage}}
     />
   </div>

--- a/mon-pix/app/templates/components/campaign-share-button.hbs
+++ b/mon-pix/app/templates/components/campaign-share-button.hbs
@@ -11,11 +11,11 @@
   {{/if}}
 {{else}}
   <PixButton
-          class="skill-review-share__button"
-          @backgroundColor="green"
-          @shape="rounded"
-          aria-hidden="true"
-          @triggerAction={{@shareCampaignParticipation}}
+    class="skill-review-share__button"
+    aria-hidden="true"
+    @backgroundColor="green"
+    @shape="rounded"
+    @triggerAction={{@shareCampaignParticipation}}
   >
     {{t 'pages.skill-review.actions.send'}}
   </PixButton>

--- a/mon-pix/app/templates/components/campaign-start-block.hbs
+++ b/mon-pix/app/templates/components/campaign-start-block.hbs
@@ -11,18 +11,18 @@
     {{/if}}
   </div>
 
-  <div class="campaign-landing-page__start__text">
-    <h1 class="campaign-landing-page__start__text__title">{{@titleText}}</h1>
-    <h2 class="campaign-landing-page__start__text__announcement">{{{@announcementText}}}</h2>
-    <PixButton
-      @type="submit"
-      class="campaign-landing-page__start-button"
-      @triggerAction={{action @startCampaignParticipation on="submit"}}
-    >
-      {{@buttonText}}
-    </PixButton>
-    <p class="campaign-landing-page__start__text__legal">{{@legalText}}</p>
-  </div>
+  <form {{action @startCampaignParticipation on="submit"}}>
+    <div class="campaign-landing-page__start__text">
+      <h1 class="campaign-landing-page__start__text__title">{{@titleText}}</h1>
+      <h2 class="campaign-landing-page__start__text__announcement">{{{@announcementText}}}</h2>
+      <PixButton
+        @type="submit"
+        class="campaign-landing-page__start-button"
+        @loading-color='white'
+      >{{@buttonText}}</PixButton>
+      <p class="campaign-landing-page__start__text__legal">{{@legalText}}</p>
+    </div>
+  </form>
 
   {{#if @campaign.customLandingPageText}}
     <div class="campaign-landing-page__start__custom-text">

--- a/mon-pix/app/templates/components/certification-joiner.hbs
+++ b/mon-pix/app/templates/components/certification-joiner.hbs
@@ -58,14 +58,6 @@
       {{#if this.errorMessage}}
           <div class="certification-course-page__errors">{{this.errorMessage}}</div>
       {{/if}}
-      {{#if this.isLoading}}
-          <button class="button button--big button--thin certification-course-page__submit_button" type="button">
-            <span class="loader-in-button">&nbsp;</span>
-          </button>
-      {{else}}
-          <button type="submit" class="button button--big button--thin certification-joiner__attempt-next-btn">
-              {{t "pages.certification-joiner.form.actions.submit"}}
-          </button>
-      {{/if}}
+      <PixButton @type="submit">{{t "pages.certification-joiner.form.actions.submit"}}</PixButton>
     </form>
 </section>

--- a/mon-pix/app/templates/components/certification-results-page.hbs
+++ b/mon-pix/app/templates/components/certification-results-page.hbs
@@ -26,9 +26,11 @@
       </div>
 
       {{#if this.validSupervisor}}
-        <button class="result-content__button result-content__validation-button button button--big button--thin" {{on "click" this.validateBySupervisor}} type="button">{{t "pages.certification-results.action.confirm"}}</button>
+        <PixButton @triggerAction={{this.validateBySupervisor}} class="result-content__button">
+          {{t "pages.certification-results.action.confirm"}}
+        </PixButton>
       {{else}}
-        <button class="result-content__button result-content__button-blocked" type="button">{{t "pages.certification-results.action.confirm"}}</button>
+        <PixButton class="result-content__button result-content__button-blocked">{{t "pages.certification-results.action.confirm"}}</PixButton>
       {{/if}}
     </div>
 

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -15,13 +15,9 @@
 
         <div class="certification-course-page__field-button">
 
-          {{#if this.isLoading}}
-            <button type="button" disabled class="button button--thin certification-course-page__submit_button">
-              <span class="loader-in-button">&nbsp;</span>
-            </button>
-          {{else}}
-              <button type="submit" class="button button--thin certification-course-page__submit_button" {{on "click" this.submit}}>{{t "pages.certification-start.actions.submit"}}</button>
-          {{/if}}
+          <PixButton @type="submit" @triggerAction={{this.submit}}>
+            {{t "pages.certification-start.actions.submit"}}
+          </PixButton>
         </div>
     </form>
 

--- a/mon-pix/app/templates/components/certifications-list-item.hbs
+++ b/mon-pix/app/templates/components/certifications-list-item.hbs
@@ -21,7 +21,7 @@
       <div class="certifications-list-item__cell-detail">
       </div>
     </div>
-  {{ else if this.isRejected}}
+  {{else if this.isRejected}}
   <CpPanel as |panel|>
     <panel.toggle @class="certifications-list-item__row-presentation" @role="tab">
 
@@ -55,7 +55,7 @@
     {{/if}}
 
   </CpPanel>
-  {{ else if this.isValidated}}
+  {{else if this.isValidated}}
     <LinkTo @route="user-certifications.get" @model={{@certification.id}} class="certifications-list-item__row-presentation">
       <div class="certifications-list-item__cell">
         {{moment-format @certification.date 'DD/MM/YYYY'}}

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -9,7 +9,9 @@
   <div class="embed rounded-panel {{if this.isLoadingEmbed 'hidden-visibility' ''}}">
     {{#unless this.isSimulatorLaunched}}
       <div class="embed__acknowledgment-overlay">
-        <button class="embed__launch-simulator-button" type="button" {{on 'click' this.launchSimulator}}>{{t "pages.challenge.embed-simulator.actions.launch"}}</button>
+        <PixButton @triggerAction={{this.launchSimulator}}>
+          {{t "pages.challenge.embed-simulator.actions.launch"}}
+        </PixButton>
       </div>
     {{/unless}}
 

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -29,7 +29,8 @@
                     @options={{block.options}}
                     data-uid="qroc-proposal-uid"
                     @onChange={{this.answerChanged}}
-                    />
+                    @size="big"
+                  />
                 </div>
             {{else if (eq @challenge.format 'paragraphe')}}
               <textarea class="challenge-response__proposal challenge-response__proposal--paragraph"

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -83,14 +83,14 @@
   {{#if @challenge.alternativeInstruction}}
     <div class="challenge-statement__alternative-instruction">
       {{#if this.displayAlternativeInstruction}}
-        <button type="button" {{on "click" this.toggleAlternativeInstruction}}>
+        <PixButton @triggerAction={{this.toggleAlternativeInstruction}}>
           {{t 'pages.challenge.statement.alternative-instruction.actions.hide'}}
-        </button>
+        </PixButton>
         <MarkdownToHtml class="challenge-statement__alternative-instruction-text" @markdown={{@challenge.alternativeInstruction}} />
       {{else}}
-        <button type="button" {{on "click" this.toggleAlternativeInstruction}}>
+        <PixButton @triggerAction={{this.toggleAlternativeInstruction}}>
           {{t 'pages.challenge.statement.alternative-instruction.actions.display'}}
-        </button>
+        </PixButton>
       {{/if}}
     </div>
   {{/if}}

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -45,10 +45,15 @@
             <span class="competence-card-improvement-countdown__count">{{t 'pages.competence-details.actions.improve.description.countdown' daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
           </div>
         {{else}}
-          <PixButton class="button button--extra-thin button--round button--link button--green competence-card__button"
-                     @triggerAction={{this.improveCompetenceEvaluation}}
-                     @loading-color="white">
-            <span class="competence-card-button__label">{{t 'pages.competence-details.actions.improve.label'}}<span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name}}</span>
+          <PixButton
+            class="competence-card__button"
+            @shape="rounded"
+            @backgroundColor="green"
+            @triggerAction={{this.improveCompetenceEvaluation}}
+          >
+            <span class="competence-card-button__label">
+              {{t 'pages.competence-details.actions.improve.label'}}
+              <span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name}}</span>
             </span>
             <span class="competence-card-button__arrow"><FaIcon @icon='long-arrow-alt-right'></FaIcon></span>
           </PixButton>

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -58,12 +58,13 @@
                     {{this.emptyTextBoxMessageError}}
                   </div>
                 {{/if}}
-                <button
-                  type="submit"
-                  class="feedback-panel__button feedback-panel__button--send"
-                  disabled={{this.isSendButtonDisabled}}>
+                <PixButton
+                  @type="submit"
+                  @backgroundColor="grey"
+                  @isDisabled={{this.isSendButtonDisabled}}
+                >
                   {{t 'pages.challenge.feedback-panel.form.actions.submit'}}
-                </button>
+                </PixButton>
               {{/if}}
             </form>
           </div>

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -6,14 +6,14 @@
     <div class="hexagon-score-content__pix-score">{{this.score}}</div>
     <div class="hexagon-score-content__pix-total">
       1024
-      <PixButton role="button"
-                 aria-label={{t 'pages.profile.total-score-helper.title'}}
-                 @backgroundColor="transparent"
-                 @isBorderVisible={{false}}
-                 @triggerAction={{this.toggleTooltip}}
-                 {{on 'focusout' this.hideHelp}}
-                 aria-describedby="hexagon-score-tooltip"
-                 class="hexagon-score-content-pix-total__button">
+      <PixButton
+        aria-label={{t 'pages.profile.total-score-helper.title'}}
+        @backgroundColor="transparent-light"
+        @triggerAction={{this.toggleTooltip}}
+        {{on 'focusout' this.hideHelp}}
+        aria-describedby="hexagon-score-tooltip"
+        class="hexagon-score-content-pix-total__button"
+      >
         <FaIcon @icon="info-circle"/>
       </PixButton>
     </div>

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -48,15 +48,9 @@
       </div>
 
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        {{#if this.isButtonEnabled}}
-          <button type="submit" class="button button--uppercase button--thin button--round">
-           {{t 'pages.password-reset-demand.actions.reset'}}
-          </button>
-        {{else}}
-          <button type="button" disabled class="button button--uppercase button--thin button--round button--big">
-            <span class="loader-in-button">&nbsp;</span>
-          </button>
-        {{/if}}
+          <PixButton @type="submit" @shape="rounded" @isDisabled={{this.isButtonDisabled}}>
+            {{t 'pages.password-reset-demand.actions.reset'}}
+          </PixButton>
         <LinkTo @route="login" class="link link--grey sign-form-link password-reset-demand-form__cancel-link">
           {{t 'pages.password-reset-demand.actions.back-sign-in'}}
         </LinkTo>

--- a/mon-pix/app/templates/components/profile-sharing-form.hbs
+++ b/mon-pix/app/templates/components/profile-sharing-form.hbs
@@ -17,15 +17,9 @@
       {{t "pages.send-profile.form.continue"}}
     </LinkTo>
   {{else}}
-    {{#if @isLoading}}
-      <button type="button" disabled class="button button--big">
-        <span class="loader-in-button">&nbsp;</span>
-      </button>
-    {{else}}
-      <button type="submit" class="button button--big">
-        {{t "pages.send-profile.form.send"}}
-      </button>
-    {{/if}}
+    <PixButton @type="submit">
+      {{t "pages.send-profile.form.send"}}
+    </PixButton>
 
     <p class="send-profile-header__warning">
       <FaIcon @icon="exclamation-circle"></FaIcon>

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -11,16 +11,18 @@
     {{#if (eq block.type 'select')}}
       <div class="challenge-response__proposal challenge-response__proposal--selector">
         <PixSelect
-                data-test="challenge-response-proposal-selector"
-                name={{block.randomName}}
-                disabled={{@isAnswerFieldDisabled}}
-                id="{{block.input}}"
-                aria-label={{block.ariaLabel}}
-                @emptyOptionLabel={{block.placeholder}}
-                @selectedOption={{get @answersValue block.input}}
-                @emptyOptionNotSelectable={{true}}
-                @options={{block.options}}
-                @onChange={{this.setAnswerValue}}/>
+          data-test="challenge-response-proposal-selector"
+          name={{block.randomName}}
+          disabled={{@isAnswerFieldDisabled}}
+          id="{{block.input}}"
+          aria-label={{block.ariaLabel}}
+          @emptyOptionLabel={{block.placeholder}}
+          @selectedOption={{get @answersValue block.input}}
+          @emptyOptionNotSelectable={{true}}
+          @options={{block.options}}
+          @onChange={{this.setAnswerValue}}
+          @size="big"
+        />
       </div>
     {{else if (eq block.type 'input')}}
       {{#if block.input}}

--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -25,9 +25,9 @@
       </div>
 
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        <button type="submit" class="button button--uppercase button--thin button--round button--big">
+        <PixButton @type="submit" @shape="rounded" class="button--big">
           {{t 'pages.reset-password.actions.submit'}}
-        </button>
+        </PixButton>
       </div>
 
     </form>

--- a/mon-pix/app/templates/components/routes/login-form.hbs
+++ b/mon-pix/app/templates/components/routes/login-form.hbs
@@ -27,11 +27,13 @@
                      @autocomplete="current-password" />
     </div>
 
-    <div class="login-button-container">
+    <div class="login-button-container pix-form__actions">
       {{#if this.isLoading}}
         <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
-        <button id="submit-connexion" type="submit" class="button button--uppercase">{{t 'pages.login-or-register.login-form.button'}}</button>
+        <PixButton id="submit-connexion" @type="submit">
+          {{t 'pages.login-or-register.login-form.button'}}
+        </PixButton>
       {{/if}}
     </div>
 

--- a/mon-pix/app/templates/components/routes/login-or-register.hbs
+++ b/mon-pix/app/templates/components/routes/login-or-register.hbs
@@ -9,9 +9,14 @@
       <div class="login-or-register-panel__form">
         <h1 class="form-title">{{t 'pages.login-or-register.register-form.title'}}</h1>
         {{#unless @displayRegisterForm}}
-          <button id="register-button" {{action @toggleFormsVisibility}} class="button button--white button--bordered button--uppercase" type="button">
+          <PixButton
+            id="register-button"
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @triggerAction={{@toggleFormsVisibility}}
+          >
             {{t 'pages.login-or-register.register-form.button'}}
-          </button>
+          </PixButton>
         {{/unless}}
         <div class={{concat "login-or-register-panel-form__expandable" (if @displayRegisterForm " login-or-register-panel-form__expandable--expanded")}}>
           {{#if @displayRegisterForm}}
@@ -23,7 +28,14 @@
       <div class="login-or-register-panel__form">
         <h1 class="form-title">{{t 'pages.login-or-register.login-form.title'}}</h1>
         {{#if @displayRegisterForm}}
-          <button id="login-button" {{action @toggleFormsVisibility}} class="button button--white button--bordered button--uppercase" type="button">{{t 'pages.login-or-register.login-form.button'}}</button>
+          <PixButton
+            id="login-button"
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @triggerAction={{@toggleFormsVisibility}}
+          >
+            {{t 'pages.login-or-register.login-form.button'}}
+          </PixButton>
         {{/if}}
         <div class={{concat "login-or-register-panel-form__expandable" (unless @displayRegisterForm " login-or-register-panel-form__expandable--expanded")}}>
           {{#unless @displayRegisterForm}}

--- a/mon-pix/app/templates/components/routes/register-form.hbs
+++ b/mon-pix/app/templates/components/routes/register-form.hbs
@@ -57,7 +57,9 @@
         {{#if this.isLoading}}
           <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
         {{else}}
-          <button id="submit-search" type="submit" class="button button--uppercase">{{t 'pages.login-or-register.register-form.button-form'}}</button>
+          <PixButton id="submit-search" @type="submit">
+            {{t 'pages.login-or-register.register-form.button-form'}}
+          </PixButton>
         {{/if}}
       </div>
     {{/unless}}
@@ -114,7 +116,9 @@
         {{#if this.isLoading}}
           <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
         {{else}}
-          <button id="submit-registration" type="submit" class="button button--uppercase">{{t 'pages.login-or-register.register-form.button-form'}}</button>
+          <PixButton id="submit-registration" @type="submit">
+            {{t 'pages.login-or-register.register-form.button-form'}}
+          </PixButton>
         {{/if}}
       </div>
 

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -64,9 +64,14 @@
                                                                                daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
             </div>
           {{else}}
-            <PixButton class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button"
-              @triggerAction={{this.improveCompetenceEvaluation}} @loading-color="white">
-                {{t 'pages.competence-details.actions.improve.label'}}<span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name }}</span>
+            <PixButton
+              class="scorecard-details__improve-button"
+              @shape="rounded"
+              @backgroundColor="green"
+              @triggerAction={{this.improveCompetenceEvaluation}}
+            >
+              {{t 'pages.competence-details.actions.improve.label'}}
+              <span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name }}</span>
             </PixButton>
             <span class="scorecard-details__improving-text">{{t 'pages.competence-details.actions.improve.improvingText' }}</span>
           {{/if}}

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -91,10 +91,17 @@
         </LinkTo>
       {{/if}}
       {{#if this.displayResetButton}}
-        <button id="reset-button" class="link link--underline scorecard-details__reset-button" {{on 'click' this.openModal}} type="button">
+        <PixButton
+          id="reset-button"
+          class="scorecard-details__reset-button"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @shape="rounded"
+          @triggerAction={{this.openModal}}
+        >
           {{t 'pages.competence-details.actions.reset.label'}}
           <div class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name}}</div>
-        </button>
+        </PixButton>
       {{else if this.displayWaitSentence}}
         <p class="scorecard-details-content-right__reset-message">{{t 'pages.competence-details.actions.reset.description'
                                                                       daysBeforeReset=@scorecard.remainingDaysBeforeReset}}</p>
@@ -159,12 +166,20 @@
       </div>
 
       <div class="pix-modal-footer pix-modal-footer--with-centered-buttons">
-        <button class="button button--big button--extra-thin button--red" {{on 'click' this.reset}} type="button">
+        <PixButton
+          id="pix-mdoal-footer__button-reset"
+          @backgroundColor="red"
+          @triggerAction={{this.reset}}
+        >
           {{t 'pages.competence-details.actions.reset.label'}}
-        </button>
-        <button class="button button--regular button--extra-thin button--grey" {{on 'click' this.closeModal}} type="button">
+        </PixButton>
+        <PixButton
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @triggerAction={{this.closeModal}}
+        >
           {{t 'common.actions.cancel'}}
-        </button>
+        </PixButton>
       </div>
     </div>
   </PixModal>

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -48,9 +48,9 @@
       {{t 'pages.sign-in.forgotten-password'}}</LinkTo>
 
     <div class="sign-form-body__bottom-button">
-      <button type="submit" class="button button--uppercase button--thin button--round button--border-focus">
+      <PixButton @type="submit" @shape="rounded">
         {{t 'pages.sign-in.actions.submit'}}
-      </button>
+      </PixButton>
     </div>
 
     {{#if this.displayPoleEmploiButton}}

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -105,13 +105,13 @@
     </fieldset>
     <div class="sign-form-body__bottom-button">
       {{#if this.isLoading}}
-        <button type="button" disabled class="button button--uppercase button--thin button--big button--round button--border-focus">
+        <button type="button" disabled class="button button--thin button--big button--round button--border-focus">
           <span class="loader-in-button">&nbsp;</span>
         </button>
       {{else}}
-        <button type="submit" class="button button--uppercase button--thin button--round button--border-focus">
+        <PixButton @type="submit" @shape="rounded">
           {{t 'pages.sign-up.actions.submit'}}
-        </button>
+        </PixButton>
       {{/if}}
     </div>
 

--- a/mon-pix/app/templates/components/skill-review-improve.hbs
+++ b/mon-pix/app/templates/components/skill-review-improve.hbs
@@ -7,7 +7,7 @@
       {{t 'pages.skill-review.improve.description'}}
     </p>
   </div>
-  <button class="button button--dark-grey button--big skill-review__improvement-button" {{on "click" @improve}} type="button">
+  <PixButton @backgroundColor="grey" @triggerAction={{@improve}}>
     {{t 'pages.skill-review.actions.improve'}}
-  </button>
+  </PixButton>
 </div>

--- a/mon-pix/app/templates/components/timed-challenge-instructions.hbs
+++ b/mon-pix/app/templates/components/timed-challenge-instructions.hbs
@@ -18,10 +18,11 @@
   </div>
 
   <div class="timed-challenge-instructions__action">
-    <PixButton {{on "click" @hasUserConfirmedWarning}}
-            class="timed-challenge-instructions-action__confirmation-button"
-            @shape="rounded"
-            @backgroundColor="green"
+    <PixButton 
+      @triggerAction={{@hasUserConfirmedWarning}}
+      class="timed-challenge-instructions-action__confirmation-button"
+      @shape="rounded"
+      @backgroundColor="green"
     >
       {{t 'pages.timed-challenge-instructions.action'}}
     </PixButton>

--- a/mon-pix/app/templates/components/update-expired-password-form.hbs
+++ b/mon-pix/app/templates/components/update-expired-password-form.hbs
@@ -40,9 +40,9 @@
               <span class="loader-in-button">&nbsp;</span>
             </button>
           {{else}}
-            <button type="submit" class="button button--thin button--round update-expired-password-form-body__bottom-button--round">
+            <PixButton @type="submit">
               {{t 'pages.update-expired-password.button'}}
-            </button>
+            </PixButton>
           {{/if}}
         </div>
       </form>

--- a/mon-pix/app/templates/components/user-account-connexion-methods.hbs
+++ b/mon-pix/app/templates/components/user-account-connexion-methods.hbs
@@ -16,6 +16,7 @@
               class="user-account-panel-item__button"
               @triggerAction={{@enableEmailEditionMode}}
               @backgroundColor="transparent-light"
+              @isBorderVisible={{true}}
               data-test-edit-email>
         {{t 'pages.user-account.connexion-methods.edit-button'}}
       </PixButton>

--- a/mon-pix/app/templates/components/user-account-update-email.hbs
+++ b/mon-pix/app/templates/components/user-account-update-email.hbs
@@ -33,16 +33,19 @@
     {{/if}}
     <div class="user-account-update-email__actions">
       <PixButton
-              class="user-account-update-email-actions__cancel-button"
-              @type="button"
-              @triggerAction={{@disableEmailEditionMode}}
-              @backgroundColor="transparent"
-              data-test-cancel-email>
+        @triggerAction={{@disableEmailEditionMode}}
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        data-test-cancel-email
+      >
         {{t 'common.actions.cancel'}}
       </PixButton>
       <PixButton
-        class="user-account-update-email-actions__confirm-button {{if this.isFormValid 'confirm-button-enabled'}}"
-        @type="submit" @isDisabled={{not this.isFormValid}} @triggerAction={{this.onSubmit}} data-test-submit-email>
+        @type="submit"
+        @isDisabled={{not this.isFormValid}}
+        @triggerAction={{this.onSubmit}}
+        data-test-submit-email
+      >
         {{t 'pages.user-account.account-update-email.save-button'}}
       </PixButton>
     </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -32,7 +32,9 @@
   {{#if @certification.verificationCode}}
     <div class="attestation-and-verification-code">
         <div class="attestation">
-          <button class="button" type="button" {{on "click" (fn this.downloadAttestation)}}>{{t "pages.certificate.attestation"}}</button>
+          <PixButton @triggerAction={{this.downloadAttestation}}>
+            {{t "pages.certificate.attestation"}}
+          </PixButton>
         </div>
         <hr>
         <div class="verification-code">

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -46,14 +46,14 @@
               <PixTooltip
                 @text={{this.tooltipText}}
                 @position='bottom'
-                @inline={{true}}
-                >
-                  <CopyButton
-                    @clipboardText={{@certification.verificationCode}}
-                    @success={{this.clipboardSuccess}}
-                    @classNames="icon-button">
-                      <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt={{t "pages.certificate.verification-code.alt"}} />
-                  </CopyButton>
+                @isInline={{true}}
+              >
+                <CopyButton
+                  @clipboardText={{@certification.verificationCode}}
+                  @success={{this.clipboardSuccess}}
+                  @classNames="icon-button">
+                    <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt={{t "pages.certificate.verification-code.alt"}} />
+                </CopyButton>
               </PixTooltip>
             {{/if}}
           </span>

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -37,9 +37,9 @@
           <div class="fill-in-campaign-code__actions">
             <PixButton
               @type="submit"
-              class="button button--extra-big fill-in-campaign-code__start-button"
+              class="fill-in-campaign-code__start-button"
               @triggerAction={{action 'startCampaign'}}
-              @loading-color="white">
+            >
               {{t 'pages.fill-in-campaign-code.start'}}
             </PixButton>
           </div>

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -34,12 +34,13 @@
           </div>
           {{/if}}
 
-          <button
-            type="submit"
-            class="button button--extra-big form__start-button form__actions"
-            {{action 'checkCertificate'}}>
+          <PixButton
+            @type="submit"
+            @triggerAction={{this.checkCertificate}}
+            class="form__actions"
+          >
             {{t "pages.fill-in-certificate-verification-code.verify"}}
-          </button>
+          </PixButton>
 
           {{#if this.showNotFoundCertificationErrorMessage}}
           <PixMessage @type='alert' class="form__error--not-found">

--- a/mon-pix/app/templates/terms-of-service-pe.hbs
+++ b/mon-pix/app/templates/terms-of-service-pe.hbs
@@ -33,7 +33,9 @@
       {{#if this.showErrorTermsOfServiceExpiredAuthenticatedKey }}
         <div class="terms-of-service-form-conditions__validation-error">{{t 'pages.terms-of-service-pe.form.expired-authentication-key'}}</div>
       {{else}}
-      <button type="submit" class="button terms-of-service-form-actions__submit" {{on 'click' this.submit}}>{{t 'pages.terms-of-service-pe.form.button'}}</button>
+        <PixButton @type="submit" @triggerAction={{this.submit}} class="terms-of-service-form-actions__submit">
+          {{t 'pages.terms-of-service-pe.form.button'}}
+        </PixButton>
       {{/if}}
     </div>
 

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -29,8 +29,11 @@
     </div>
 
     <div class="terms-of-service-form__actions">
-      <LinkTo @route="logout" class="button terms-of-service-form-actions__cancel">{{t 'common.actions.back'}}</LinkTo>
-      <button type="submit" class="button terms-of-service-form-actions__submit" {{on 'click' this.submit}}>{{t 'pages.terms-of-service.form.button'}}</button>
+      <PixButtonLink @route="logout" @backgroundColor="grey">{{t 'common.actions.back'}}</PixButtonLink>
+
+      <PixButton @type="submit" @triggerAction={{this.submit}} class="terms-of-service-form-actions__submit">
+        {{t 'pages.terms-of-service-pe.form.button'}}
+      </PixButton>
     </div>
 
   </div>

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -35118,8 +35118,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#3546284f77ae78e252b466a4d59897a908754fb0",
-      "from": "git://github.com/1024pix/pix-ui.git#v6.0.0",
+      "version": "git://github.com/1024pix/pix-ui.git#72993b39210ee90bccd1c5db9b1b12868f191115",
+      "from": "git://github.com/1024pix/pix-ui.git#v7.0.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -35118,8 +35118,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#4ccd573bf48d2ca0a9d866b86e6b1feb40838524",
-      "from": "git://github.com/1024pix/pix-ui.git#v5.5.0",
+      "version": "git://github.com/1024pix/pix-ui.git#3546284f77ae78e252b466a4d59897a908754fb0",
+      "from": "git://github.com/1024pix/pix-ui.git#v6.0.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -35118,8 +35118,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#72993b39210ee90bccd1c5db9b1b12868f191115",
-      "from": "git://github.com/1024pix/pix-ui.git#v7.0.0",
+      "version": "git://github.com/1024pix/pix-ui.git#7995bad08b49a0abf7abdcbad72e1f861e4e6f91",
+      "from": "git://github.com/1024pix/pix-ui.git#v8.0.1",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -113,7 +113,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v6.0.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v7.0.0",
     "sass": "^1.38.0",
     "showdown": "^1.9.1",
     "stylelint": "^13.13.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -113,7 +113,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v7.0.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v8.0.1",
     "sass": "^1.38.0",
     "showdown": "^1.9.1",
     "stylelint": "^13.13.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -113,7 +113,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.5.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v6.0.0",
     "sass": "^1.38.0",
     "showdown": "^1.9.1",
     "stylelint": "^13.13.1",

--- a/mon-pix/tests/acceptance/authentication_test.js
+++ b/mon-pix/tests/acceptance/authentication_test.js
@@ -1,15 +1,18 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { setupApplicationTest } from 'ember-mocha';
-import { click, fillIn, currentURL } from '@ember/test-helpers';
+import { fillIn, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import visit from '../helpers/visit';
 import { authenticateByEmail, authenticateByUsername } from '../helpers/authentication';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Authentication', function() {
 
   setupApplicationTest();
   setupMirage();
+  setupIntl();
 
   let user;
 
@@ -50,7 +53,7 @@ describe('Acceptance | Authentication', function() {
       await fillIn('#password', 'Pix20!!');
 
       // when
-      await click('.button');
+      await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
       // then
       expect(currentURL()).to.equal('/connexion');

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -6,10 +6,12 @@ import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { fillCertificationJoiner, fillCertificationStarter } from '../helpers/certification';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Certification | Start Certification Course', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
 
   let user;
 
@@ -58,8 +60,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
             await visit('/certifications');
 
             // when
-            await fillCertificationJoiner(
-              { sessionId: '1', firstName: 'Laura', lastName: '', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+            await fillCertificationJoiner({
+              sessionId: '1',
+              firstName: 'Laura',
+              lastName: '',
+              dayOfBirth: '04',
+              monthOfBirth: '01',
+              yearOfBirth: '1990',
+              intl: this.intl,
+            });
           });
 
           it('should display an error message', function() {
@@ -71,8 +80,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
         context('when no candidate with given info has been registered in the given session', function() {
           beforeEach(async function() {
             // when
-            await fillCertificationJoiner(
-              { sessionId: '1', firstName: 'Laura', lastName: 'PasInscrite', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+            await fillCertificationJoiner({
+              sessionId: '1',
+              firstName: 'Laura',
+              lastName: 'PasInscrite',
+              dayOfBirth: '04',
+              monthOfBirth: '01',
+              yearOfBirth: '1990',
+              intl: this.intl,
+            });
           });
 
           it('should display an error message', function() {
@@ -84,8 +100,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
         context('when several candidates with given info are found in the given session', function() {
           beforeEach(async function() {
             // when
-            await fillCertificationJoiner(
-              { sessionId: '1', firstName: 'Laura', lastName: 'PlusieursMatchs', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+            await fillCertificationJoiner({
+              sessionId: '1',
+              firstName: 'Laura',
+              lastName: 'PlusieursMatchs',
+              dayOfBirth: '04',
+              monthOfBirth: '01',
+              yearOfBirth: '1990',
+              intl: this.intl,
+            });
           });
 
           it('should display an error message', function() {
@@ -97,8 +120,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
         context('when user has already been linked to another candidate in the session', function() {
           beforeEach(async function() {
             // when
-            await fillCertificationJoiner(
-              { sessionId: '1', firstName: 'Laura', lastName: 'UtilisateurLiéAutre', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+            await fillCertificationJoiner({
+              sessionId: '1',
+              firstName: 'Laura',
+              lastName: 'UtilisateurLiéAutre',
+              dayOfBirth: '04',
+              monthOfBirth: '01',
+              yearOfBirth: '1990',
+              intl: this.intl,
+            });
           });
 
           it('should display an error message', function() {
@@ -110,8 +140,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
         context('when candidate has already been linked to another user in the session', function() {
           beforeEach(async function() {
             // when
-            await fillCertificationJoiner(
-              { sessionId: '1', firstName: 'Laura', lastName: 'CandidatLiéAutre', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+            await fillCertificationJoiner({
+              sessionId: '1',
+              firstName: 'Laura',
+              lastName: 'CandidatLiéAutre',
+              dayOfBirth: '04',
+              monthOfBirth: '01',
+              yearOfBirth: '1990',
+              intl: this.intl,
+            });
           });
 
           it('should display an error message', function() {
@@ -131,8 +168,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
               birthdate: '1990-01-04',
             });
             // when
-            await fillCertificationJoiner(
-              { sessionId: '1', firstName: 'Laura', lastName: 'CandidatLiéUtilisateur', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+            await fillCertificationJoiner({
+              sessionId: '1',
+              firstName: 'Laura',
+              lastName: 'CandidatLiéUtilisateur',
+              dayOfBirth: '04',
+              monthOfBirth: '01',
+              yearOfBirth: '1990',
+              intl: this.intl,
+            });
           });
 
           it('should render the component to provide the access code', function() {
@@ -144,8 +188,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
         context('when user is successfuly linked to the candidate', function() {
           beforeEach(async function() {
             // when
-            await fillCertificationJoiner(
-              { sessionId: '1', firstName: 'Laura', lastName: 'Bravo', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+            await fillCertificationJoiner({
+              sessionId: '1',
+              firstName: 'Laura',
+              lastName: 'Bravo',
+              dayOfBirth: '04',
+              monthOfBirth: '01',
+              yearOfBirth: '1990',
+              intl: this.intl,
+            });
           });
 
           it('should render the component to provide the access code', function() {
@@ -176,8 +227,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
           context('when user enter a correct code session', function() {
             beforeEach(async function() {
               // when
-              await fillCertificationJoiner(
-                { sessionId: '1', firstName: 'Laura', lastName: 'Bravo', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+              await fillCertificationJoiner({
+                sessionId: '1',
+                firstName: 'Laura',
+                lastName: 'Bravo',
+                dayOfBirth: '04',
+                monthOfBirth: '01',
+                yearOfBirth: '1990',
+                intl: this.intl,
+              });
               await fillCertificationStarter({ accessCode: 'ABCD12' });
             });
 
@@ -211,8 +269,15 @@ describe('Acceptance | Certification | Start Certification Course', function() {
 
             it('should be redirected directly on the certification course', async function() {
               // given
-              await fillCertificationJoiner(
-                { sessionId: '1', firstName: 'Laura', lastName: 'Bravo', dayOfBirth: '04', monthOfBirth: '01', yearOfBirth: '1990' });
+              await fillCertificationJoiner({
+                sessionId: '1',
+                firstName: 'Laura',
+                lastName: 'Bravo',
+                dayOfBirth: '04',
+                monthOfBirth: '01',
+                yearOfBirth: '1990',
+                intl: this.intl,
+              });
               await fillCertificationStarter({ accessCode: 'ABCD12' });
 
               await click('.challenge-actions__action-skip');

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -236,7 +236,7 @@ describe('Acceptance | Certification | Start Certification Course', function() {
                 yearOfBirth: '1990',
                 intl: this.intl,
               });
-              await fillCertificationStarter({ accessCode: 'ABCD12' });
+              await fillCertificationStarter({ accessCode: 'ABCD12', intl: this.intl });
             });
 
             it('should be redirected on the first challenge of an assessment', async function() {
@@ -278,7 +278,7 @@ describe('Acceptance | Certification | Start Certification Course', function() {
                 yearOfBirth: '1990',
                 intl: this.intl,
               });
-              await fillCertificationStarter({ accessCode: 'ABCD12' });
+              await fillCertificationStarter({ accessCode: 'ABCD12', intl: this.intl });
 
               await click('.challenge-actions__action-skip');
               await visit('/');

--- a/mon-pix/tests/acceptance/challenge-page-banner_test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner_test.js
@@ -5,10 +5,13 @@ import visit from '../helpers/visit';
 import { authenticateByEmail } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Challenge page banner', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let user;
   let campaign;
 
@@ -24,7 +27,7 @@ describe('Acceptance | Challenge page banner', function() {
       // when
       await visit(`campagnes/${campaign.code}`);
       await click('.campaign-landing-page__start-button');
-      await click('.campaign-tutorial__ignore-button');
+      await clickByLabel(this.intl.t('pages.tutorial.pass'));
 
       // then
       find('.assessment-banner');
@@ -37,7 +40,7 @@ describe('Acceptance | Challenge page banner', function() {
 
       // when
       await visit(`campagnes/${campaign.code}`);
-      await click('.campaign-tutorial__ignore-button');
+      await clickByLabel(this.intl.t('pages.tutorial.pass'));
       const title = find('.assessment-banner__title');
       const a11yText = title.firstChild.textContent;
 
@@ -52,7 +55,7 @@ describe('Acceptance | Challenge page banner', function() {
 
       // when
       await visit(`campagnes/${campaign.code}`);
-      await click('.campaign-tutorial__ignore-button');
+      await clickByLabel(this.intl.t('pages.tutorial.pass'));
       const title = find('.assessment-banner__title');
       const campaignName = title.lastChild.textContent;
 

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -5,10 +5,12 @@ import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Competence details | Afficher la page de détails d\'une compétence', () => {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let user;
   let server;
 
@@ -153,13 +155,13 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
           expect(find('.scorecard-details-reset-modal__important-message').textContent).to.contain(`Votre niveau ${scorecardWithPoints.level} et vos ${scorecardWithPoints.earnedPix} Pix vont être supprimés.`);
         });
 
-        it('should reset competence when user clicks on reset', async () => {
+        it('should reset competence when user clicks on reset', async function() {
           // given
           await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
           await click('.scorecard-details__reset-button');
 
           // when
-          await click('.button--red');
+          await click('#pix-mdoal-footer__button-reset');
 
           // then
           expect(findAll('.competence-card__level .score-value')).to.have.lengthOf(0);
@@ -167,13 +169,13 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
           expect(findAll('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
         });
 
-        it('should reset competence when user clicks on reset from results page', async () => {
+        it('should reset competence when user clicks on reset from results page', async function() {
           // given
           await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
           await click('.scorecard-details__reset-button');
 
           // when
-          await click('.button--red');
+          await click('#pix-mdoal-footer__button-reset');
 
           // then
           expect(findAll('.competence-card__level .score-value')).to.have.lengthOf(0);

--- a/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
@@ -1,21 +1,25 @@
 import { describe, it, context } from 'mocha';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
-import { click, visit, fillIn, currentURL, find } from '@ember/test-helpers';
+import { visit, fillIn, currentURL, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Certificate verification', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
 
   context('when certificate verification code is valid', function() {
+
     it('redirects to certificate details page', async function() {
       // Given
       await visit('/verification-certificat');
       await fillIn('#certificate-verification-code', 'P-123VALID');
 
       // When
-      await click('button[type=submit]');
+      await clickByLabel(this.intl.t('pages.fill-in-certificate-verification-code.verify'));
 
       // Then
       expect(currentURL()).to.equal('/partage-certificat/200');
@@ -29,7 +33,7 @@ describe('Acceptance | Certificate verification', function() {
       await fillIn('#certificate-verification-code', 'P-12345678');
 
       // When
-      await click('button[type=submit]');
+      await clickByLabel(this.intl.t('pages.fill-in-certificate-verification-code.verify'));
 
       // Then
       expect(currentURL()).to.equal('/verification-certificat');
@@ -41,7 +45,7 @@ describe('Acceptance | Certificate verification', function() {
       await fillIn('#certificate-verification-code', 'P-12345678');
 
       // When
-      await click('button[type=submit]');
+      await clickByLabel(this.intl.t('pages.fill-in-certificate-verification-code.verify'));
 
       // Then
       expect(find('.form__error--not-found')).to.exist;

--- a/mon-pix/tests/acceptance/footer_test.js
+++ b/mon-pix/tests/acceptance/footer_test.js
@@ -6,10 +6,12 @@ import { setupApplicationTest } from 'ember-mocha';
 import { authenticateByEmail } from '../helpers/authentication';
 import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
 import visit from '../helpers/visit';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Footer', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let user;
 
   beforeEach(function() {
@@ -26,7 +28,7 @@ describe('Acceptance | Footer', function() {
       const campaign = server.create('campaign', 'withOneChallenge');
 
       // when
-      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false);
+      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false, this.intl);
 
       // then
       expect(find('.footer')).to.not.exist;

--- a/mon-pix/tests/acceptance/login-or-register-to-access-restricted-campaign_test.js
+++ b/mon-pix/tests/acceptance/login-or-register-to-access-restricted-campaign_test.js
@@ -1,14 +1,18 @@
-import { click, find } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Campaigns | Restricted | login-or-register-to-access', function() {
 
   setupApplicationTest();
   setupMirage();
+  setupIntl();
+
   let campaign;
 
   beforeEach(function() {
@@ -36,7 +40,7 @@ describe('Acceptance | Campaigns | Restricted | login-or-register-to-access', fu
   it('should open the login panel and close the register panel when clicking on login button', async function() {
     // when
     await visit(`/campagnes/${campaign.code}/privee/identification`);
-    await click('#login-button');
+    await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
     // then
     expect(find('.register-form')).to.not.exist;
@@ -47,8 +51,8 @@ describe('Acceptance | Campaigns | Restricted | login-or-register-to-access', fu
     // when
     await visit(`/campagnes/${campaign.code}/privee/identification`);
 
-    await click('#login-button');
-    await click('#register-button');
+    await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
+    await clickByLabel(this.intl.t('pages.login-or-register.register-form.button'));
 
     // then
     expect(find('.register-form')).to.exist;

--- a/mon-pix/tests/acceptance/navigation_test.js
+++ b/mon-pix/tests/acceptance/navigation_test.js
@@ -6,10 +6,12 @@ import { setupApplicationTest } from 'ember-mocha';
 import { authenticateByEmail } from '../helpers/authentication';
 import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
 import visit from '../helpers/visit';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Navbar', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let user;
 
   beforeEach(function() {
@@ -53,7 +55,7 @@ describe('Acceptance | Navbar', function() {
       const campaign = server.create('campaign', 'withOneChallenge');
 
       // when
-      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false);
+      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false, this.intl);
 
       // then
       expect(find('.navbar-desktop-header')).to.not.exist;

--- a/mon-pix/tests/acceptance/password-reset_test.js
+++ b/mon-pix/tests/acceptance/password-reset_test.js
@@ -1,13 +1,16 @@
-import { click, fillIn, find, currentURL } from '@ember/test-helpers';
+import { fillIn, find, currentURL } from '@ember/test-helpers';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Reset Password', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
 
   it('can visit /mot-passe-oublie', async function() {
     // when
@@ -38,7 +41,7 @@ describe('Acceptance | Reset Password', function() {
     await fillIn('#email', 'brandone.martins@pix.com');
 
     // when
-    await click('.button');
+    await clickByLabel(this.intl.t('pages.password-reset-demand.actions.reset'));
 
     expect(currentURL()).to.equal('/mot-de-passe-oublie');
     expect(find('.password-reset-demand-form__body')).to.exist;
@@ -57,7 +60,7 @@ describe('Acceptance | Reset Password', function() {
     await fillIn('#email', 'unexisting@user.com');
 
     // when
-    await click('.button');
+    await clickByLabel(this.intl.t('pages.password-reset-demand.actions.reset'));
 
     expect(currentURL()).to.equal('/mot-de-passe-oublie');
     expect(find('.sign-form__notification-message--error')).to.exist;

--- a/mon-pix/tests/acceptance/profile_test.js
+++ b/mon-pix/tests/acceptance/profile_test.js
@@ -7,10 +7,13 @@ import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Profile', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let user;
 
   beforeEach(function() {
@@ -84,7 +87,7 @@ describe('Acceptance | Profile', function() {
       await fillIn('#password', 'Pix20!!');
 
       // when
-      await click('.button');
+      await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
       // then
       expect(currentURL()).to.equal('/connexion');

--- a/mon-pix/tests/acceptance/reset-password_test.js
+++ b/mon-pix/tests/acceptance/reset-password_test.js
@@ -1,14 +1,17 @@
-import { click, currentURL, fillIn, find } from '@ember/test-helpers';
+import { currentURL, fillIn, find } from '@ember/test-helpers';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Reset Password Form', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
 
   it('can visit /changer-mot-de-passe when temporaryKey exists', async function() {
     // given
@@ -51,7 +54,7 @@ describe('Acceptance | Reset Password Form', function() {
     await fillIn('#password', 'newPass12345!');
 
     // when
-    await click('.button');
+    await clickByLabel(this.intl.t('pages.reset-password.actions.submit'));
 
     // then
     expect(currentURL()).to.equal('/changer-mot-de-passe/brandone-reset-key');

--- a/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
+++ b/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
@@ -1,14 +1,17 @@
-import { click, fillIn, currentURL, find } from '@ember/test-helpers';
+import { fillIn, currentURL, find } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | Competence Evaluations | Resume Competence Evaluations', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let user;
 
   beforeEach(function() {
@@ -31,7 +34,7 @@ describe('Acceptance | Competence Evaluations | Resume Competence Evaluations',
         // when
         await fillIn('#login', user.email);
         await fillIn('#password', user.password);
-        await click('.button');
+        await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
         expect(currentURL()).to.contains('/assessments');
       });

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -65,7 +65,6 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           it('should redirect to assessment after completion of external id', async function() {
             // when
             await fillIn('#id-pix-label', 'monmail@truc.fr');
-
             await clickByLabel('Continuer');
 
             // then
@@ -205,7 +204,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           campaign = server.create('campaign', { isRestricted: true, idPixLabel: 'nom de naissance de maman', type: ASSESSMENT, organizationType: 'SCO' });
         });
 
-        context('When association is not already done', function() {
+        describe('When association is not already done', function() {
 
           it('should redirect to tutoriel page', async function() {
             // given
@@ -251,7 +250,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             // when
             await fillIn('#id-pix-label', 'monmail@truc.fr');
             await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
-            await click('.campaign-tutorial__ignore-button');
+            await clickByLabel(this.intl.t('pages.tutorial.pass'));
 
             // then
             expect(currentURL()).to.contains(/assessments/);
@@ -284,7 +283,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
 
           it('should start the assessment when the user has seen tutorial', async function() {
             // when
-            await click('.campaign-tutorial__ignore-button');
+            await clickByLabel(this.intl.t('pages.tutorial.pass'));
 
             // then
             expect(currentURL()).to.contains(/assessments/);

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -102,12 +102,14 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           });
 
           context('When campaign is restricted', function() {
-            beforeEach(async function() {
+
+            it('should redirect to assessment', async function() {
+              // given
               campaign = server.create('campaign', 'restricted', { idPixLabel: 'toto', organizationType: 'SCO', type: ASSESSMENT });
               await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
-
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification`);
 
+              // when
               await click('#login-button');
 
               await fillIn('#login', prescritUser.email);
@@ -120,11 +122,9 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
               await click('.button');
-              await click('button[aria-label="Associer"]');
+              await clickByLabel(this.intl.t('pages.join.sco.associate'));
               await click('.campaign-landing-page__start-button');
-            });
 
-            it('should redirect to assessment', async function() {
               // then
               expect(currentURL()).to.contains('/didacticiel');
             });
@@ -215,7 +215,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
-            await click('button[aria-label="Associer"]');
+            await clickByLabel(this.intl.t('pages.join.sco.associate'));
             await clickByLabel(this.intl.t('pages.campaign-landing.assessment.action'));
             await fillIn('#id-pix-label', 'truc');
 

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -10,12 +10,14 @@ import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 const ASSESSMENT = 'ASSESSMENT';
 
 describe('Acceptance | Campaigns | Start Campaigns with type Assessment', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let campaign;
 
   beforeEach(function() {
@@ -214,11 +216,11 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
             await click('button[aria-label="Associer"]');
-            await click('.campaign-landing-page__start-button');
+            await clickByLabel(this.intl.t('pages.campaign-landing.assessment.action'));
             await fillIn('#id-pix-label', 'truc');
 
             // when
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
@@ -238,7 +240,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           it('should go to the tutorial when the user fill in his id', async function() {
             // when
             await fillIn('#id-pix-label', 'monmail@truc.fr');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
@@ -247,7 +249,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           it('should start the assessment when the user has seen tutorial', async function() {
             // when
             await fillIn('#id-pix-label', 'monmail@truc.fr');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
             await click('.campaign-tutorial__ignore-button');
 
             // then

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -59,7 +59,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await fillIn('#email', prescritUser.email);
             await fillIn('#password', prescritUser.password);
             await click('.signup-form__cgu');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
           });
 
           it('should redirect to assessment after completion of external id', async function() {
@@ -91,7 +91,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               await fillIn('#email', prescritUser.email);
               await fillIn('#password', prescritUser.password);
               await click('.signup-form__cgu');
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
             });
 
             it('should redirect to assessment', async function() {
@@ -140,7 +140,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await fillIn('#email', prescritUser.email);
           await fillIn('#password', prescritUser.password);
           await click('.signup-form__cgu');
-          await click('.button');
+          await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
         });
 
         it('should redirect to assessment after signup', async function() {
@@ -158,7 +158,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await fillIn('#email', prescritUser.email);
           await fillIn('#password', prescritUser.password);
           await click('.signup-form__cgu');
-          await click('.button');
+          await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
         });
 
         it('should redirect to assessment after signup', async function() {

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -121,7 +121,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               await fillIn('#dayOfBirth', '10');
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.join.button'));
               await clickByLabel(this.intl.t('pages.join.sco.associate'));
               await click('.campaign-landing-page__start-button');
 
@@ -206,6 +206,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
         });
 
         context('When association is not already done', function() {
+
           it('should redirect to tutoriel page', async function() {
             // given
             await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
@@ -214,7 +215,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
             await clickByLabel(this.intl.t('pages.campaign-landing.assessment.action'));
             await fillIn('#id-pix-label', 'truc');

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -52,7 +52,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await fillIn('#email', campaignParticipant.email);
             await fillIn('#password', campaignParticipant.password);
             await click('.signup-form__cgu');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
           });
 
           it('should redirect to send profile page after completion of external id', async function() {
@@ -76,7 +76,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#email', campaignParticipant.email);
               await fillIn('#password', campaignParticipant.password);
               await click('.signup-form__cgu');
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
             });
 
             it('should redirect to send profile page', async function() {
@@ -126,7 +126,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           await fillIn('#email', campaignParticipant.email);
           await fillIn('#password', campaignParticipant.password);
           await click('.signup-form__cgu');
-          await click('.button');
+          await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
         });
 
         it('should redirect to send profile page after signup', async function() {
@@ -144,7 +144,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           await fillIn('#email', campaignParticipant.email);
           await fillIn('#password', campaignParticipant.password);
           await click('.signup-form__cgu');
-          await click('.button');
+          await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
         });
 
         it('should redirect to send profile page after signup', async function() {

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -86,12 +86,15 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           });
 
           context('When campaign is restricted', function() {
-            beforeEach(async function() {
+
+            it('should redirect to send profile page', async function() {
+              //given
               campaign = server.create('campaign', { type: PROFILES_COLLECTION, isRestricted: true, idPixLabel: 'toto', organizationType: 'SCO' });
               await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
 
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification`);
 
+              // when
               await click('#login-button');
 
               await fillIn('#login', campaignParticipant.email);
@@ -103,12 +106,10 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#dayOfBirth', '10');
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.join.button'));
               await clickByLabel(this.intl.t('pages.join.sco.associate'));
               await click('.campaign-landing-page__start-button');
-            });
 
-            it('should redirect to send profile page', async function() {
               // then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
             });
@@ -184,7 +185,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
             await clickByLabel(this.intl.t('pages.campaign-landing.profiles-collection.action'));
             await fillIn('#id-pix-label', 'truc');
@@ -214,8 +215,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#dayOfBirth', '10');
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
-
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.join.button'));
 
               //then
               expect(find('.join-error-modal')).to.exist;
@@ -231,8 +231,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#dayOfBirth', '10');
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
-
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.join.button'));
               await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
               //then

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -104,7 +104,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
               await click('.button');
-              await click('button[aria-label="Associer"]');
+              await clickByLabel(this.intl.t('pages.join.sco.associate'));
               await click('.campaign-landing-page__start-button');
             });
 
@@ -185,7 +185,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
-            await click('button[aria-label="Associer"]');
+            await clickByLabel(this.intl.t('pages.join.sco.associate'));
             await clickByLabel(this.intl.t('pages.campaign-landing.profiles-collection.action'));
             await fillIn('#id-pix-label', 'truc');
 
@@ -233,7 +233,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#yearOfBirth', '2000');
 
               await click('.button');
-              await click('button[aria-label="Continuer avec mon compte Pix"]');
+              await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
               //then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification?displayRegisterForm=false`);

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -58,7 +58,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           it('should redirect to send profile page after completion of external id', async function() {
             // when
             await fillIn('#id-pix-label', 'monmail@truc.fr');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -190,7 +190,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await fillIn('#id-pix-label', 'truc');
 
             // when
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -254,7 +254,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           it('should redirect to send profile page when the user fill in his id', async function() {
             // when
             await fillIn('#id-pix-label', 'monmail@truc.fr');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -219,7 +219,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
               // when
               await click('#pix-cgu');
-              await click('.terms-of-service-form-actions__submit');
+              await clickByLabel(this.intl.t('pages.terms-of-service-pe.form.button'));
 
               // then
               expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`.toLowerCase());

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -145,7 +145,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await click('.signup-form__cgu');
 
               // when
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
               // then
               expect(sentCampaignCode).to.equal(campaign.code);
@@ -607,7 +607,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#email', prescritUser.email);
             await fillIn('#password', prescritUser.password);
             await click('.signup-form__cgu');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
           });
 
           it('should redirect to fill-in-participant-external-id page after signup', async function() {

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -19,6 +19,7 @@ import { authenticateByEmail, authenticateByGAR } from '../helpers/authenticatio
 import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helpers/campaign';
 import { currentSession } from 'ember-simple-auth/test-support';
 import ENV from 'mon-pix/config/environment';
+import setupIntl from '../helpers/setup-intl';
 
 const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
@@ -26,6 +27,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
   setupApplicationTest();
   setupMirage();
+  setupIntl();
 
   let campaign;
 
@@ -750,7 +752,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await click('button[aria-label="Associer"]');
 
             // when
-            await click('.campaign-landing-page__start-button');
+            await clickByLabel(this.intl.t('pages.campaign-landing.assessment.action'));
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/identifiant`);
@@ -779,7 +781,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
 
             // when
-            await click('.campaign-landing-page__start-button');
+            await clickByLabel(this.intl.t('pages.campaign-landing.assessment.action'));
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/identifiant`);

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -369,7 +369,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
             await click('.button');
 
-            await click('button[aria-label="Associer"]');
+            await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -395,7 +395,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(currentURL()).to.equal('/inscription');
           });
 
-          it('should be redirect to join page after login', async () => {
+          it('should be redirect to join page after login', async function() {
             // given
             await visit(`/campagnes/${campaign.code}`);
             // when
@@ -734,7 +734,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
             await click('.button');
 
-            await click('button[aria-label="Associer"]');
+            await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -749,7 +749,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
-            await click('button[aria-label="Associer"]');
+            await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             // when
             await clickByLabel(this.intl.t('pages.campaign-landing.assessment.action'));
@@ -795,14 +795,14 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           campaign = server.create('campaign', { isRestricted: true, organizationType: 'SUP' });
         });
 
-        it('should be redirected to join page', async () => {
+        it('should be redirected to join page', async function() {
           // when
           await visit(`/campagnes/${campaign.code}`);
           // then
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
         });
 
-        it('the student has been associated with its student number', async () => {
+        it('the student has been associated with its student number', async function() {
           // given
           await visit(`/campagnes/${campaign.code}`);
 
@@ -1047,7 +1047,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           const externalUserToken = 'aaa.' + btoa('{"first_name":"JeanPrescrit","last_name":"Campagne","saml_id":"SamlId","source":"external","iat":1545321469,"exp":4702193958}') + '.bbb';
 
           beforeEach(async function() {
-            server.post('/schooling-registration-dependent-users/external-user-token', async () => {
+            server.post('/schooling-registration-dependent-users/external-user-token', async function() {
               return new Response(409, {}, {
                 errors: [{
                   status: '409',
@@ -1066,7 +1066,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await visit(`/campagnes?externalUser=${externalUserToken}`);
           });
 
-          it('should land on start campaign page if GAR authentication method has been added', async () => {
+          it('should land on start campaign page if GAR authentication method has been added', async function() {
             // given
             server.create('schooling-registration-user-association', {
               campaignCode: campaign.code,
@@ -1079,7 +1079,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
 
-            await click('button[aria-label="Continuer avec mon compte Pix"]');
+            await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
             // when
             await fillIn('#login', prescritUser.email);
@@ -1094,7 +1094,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(contains('Commencez votre parcours')).to.exist;
           });
 
-          it('should display an specific error message if GAR authentication method adding has failed with http statusCode 4xx', async () => {
+          it('should display an specific error message if GAR authentication method adding has failed with http statusCode 4xx', async function() {
             // given
             const expectedErrorMessage = 'Les données que vous avez soumises ne sont pas au bon format.';
             const errorsApi = new Response(400, {}, {
@@ -1110,7 +1110,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
 
-            await click('button[aria-label="Continuer avec mon compte Pix"]');
+            await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
             // when
             await fillIn('#login', prescritUser.email);
@@ -1122,7 +1122,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(find('#update-form-error-message').textContent).to.equal(expectedErrorMessage);
           });
 
-          it('should display an specific error message if GAR authentication method adding has failed due to wrong connected account', async () => {
+          it('should display an specific error message if GAR authentication method adding has failed due to wrong connected account', async function() {
             // given
             const expectedErrorMessage = 'L\'adresse e-mail ou l\'identifiant est incorrect. Pour continuer, vous devez vous connecter à votre compte qui est sous la forme : ';
             const expectedObfuscatedConnectionMethod = 't***@example.net';
@@ -1143,7 +1143,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
 
-            await click('button[aria-label="Continuer avec mon compte Pix"]');
+            await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
             // when
             await fillIn('#login', prescritUser.email);
@@ -1155,7 +1155,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(find('#update-form-error-message').textContent).to.equal(expectedErrorMessage + expectedObfuscatedConnectionMethod);
           });
 
-          it('should display the default error message if GAR authentication method adding has failed with others http statusCode', async () => {
+          it('should display the default error message if GAR authentication method adding has failed with others http statusCode', async function() {
             // given
             const expectedErrorMessage = 'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.';
             server.post('/token-from-external-user', () => new Response(500));
@@ -1168,7 +1168,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
 
-            await click('button[aria-label="Continuer avec mon compte Pix"]');
+            await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
             // when
             await fillIn('#login', prescritUser.email);
@@ -1187,7 +1187,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               // given
               const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
 
-              server.post('/schooling-registration-dependent-users/external-user-token', async () => {
+              server.post('/schooling-registration-dependent-users/external-user-token', async function() {
                 return new Response(409, {}, {
                   errors: [{
                     status: '409',
@@ -1215,7 +1215,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
               await click('.button');
-              await click('button[aria-label="Continuer avec mon compte Pix"]');
+              await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
               await fillIn('#login', userShouldChangePassword.username);
               await fillIn('#password', userShouldChangePassword.password);
               await click('#submit-connexion');

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -360,6 +360,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await click('#submit-connexion');
 
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
+
             // when
             await fillIn('#firstName', 'Jane');
             await fillIn('#lastName', 'Acme');
@@ -367,8 +368,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
 
-            await click('.button');
-
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             //then
@@ -731,9 +731,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-
-            await click('.button');
-
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             //then
@@ -748,7 +746,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             // when
@@ -993,7 +991,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-            await click('.button');
+            await clickByLabel(this.intl.t('pages.join.button'));
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -1077,8 +1075,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-            await click('.button');
-
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
             // when
@@ -1108,8 +1105,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-            await click('.button');
-
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
             // when
@@ -1141,8 +1137,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-            await click('.button');
-
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
             // when
@@ -1166,8 +1161,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
-            await click('.button');
-
+            await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
             // when
@@ -1214,7 +1208,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await fillIn('#dayOfBirth', '10');
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.join.button'));
               await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
               await fillIn('#login', userShouldChangePassword.username);
               await fillIn('#password', userShouldChangePassword.password);

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -1219,7 +1219,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
               // when
               await fillIn('#password', 'newPass12345!');
-              await click('.button');
+              await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
               // then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);

--- a/mon-pix/tests/acceptance/terms-of-service_test.js
+++ b/mon-pix/tests/acceptance/terms-of-service_test.js
@@ -4,10 +4,13 @@ import { authenticateByEmail } from '../helpers/authentication';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
 
 describe('Acceptance | terms-of-service', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
   let user;
 
   beforeEach(function() {
@@ -37,7 +40,7 @@ describe('Acceptance | terms-of-service', function() {
 
       // when
       await click('#pix-cgu');
-      await click('.terms-of-service-form-actions__submit');
+      await clickByLabel(this.intl.t('pages.terms-of-service-pe.form.button'));
 
       // then
       expect(currentURL()).to.equal('/accueil');

--- a/mon-pix/tests/acceptance/update-expired-password_test.js
+++ b/mon-pix/tests/acceptance/update-expired-password_test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
-import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'ember-cli-mirage';
@@ -9,6 +9,7 @@ import { Response } from 'ember-cli-mirage';
 import { authenticateByUsername } from '../helpers/authentication';
 import setupIntl from '../helpers/setup-intl';
 import { contains } from '../helpers/contains';
+import { clickByLabel } from '../helpers/click-by-label';
 
 describe('Acceptance | Update Expired Password', function() {
 
@@ -26,7 +27,7 @@ describe('Acceptance | Update Expired Password', function() {
     await fillIn('#password', 'newPass12345!');
 
     // when
-    await click('.button');
+    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
     // then
     expect(currentURL()).to.equal('/accueil');
@@ -45,7 +46,7 @@ describe('Acceptance | Update Expired Password', function() {
     await fillIn('#password', 'newPass12345!');
 
     // when
-    await click('.button');
+    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
     // then
     expect(currentURL()).to.equal('/mise-a-jour-mot-de-passe-expire');
@@ -65,7 +66,7 @@ describe('Acceptance | Update Expired Password', function() {
     await fillIn('#password', 'newPass12345!');
 
     // when
-    await click('.button');
+    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
     // then
     expect(currentURL()).to.equal('/mise-a-jour-mot-de-passe-expire');
@@ -81,7 +82,7 @@ describe('Acceptance | Update Expired Password', function() {
     await fillIn('#password', 'newPass12345!');
 
     // when
-    await click('.button');
+    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
     // then
     expect(currentURL()).to.equal('/mise-a-jour-mot-de-passe-expire');
     expect(contains(expectedErrorMessage)).to.exist;

--- a/mon-pix/tests/helpers/authentication.js
+++ b/mon-pix/tests/helpers/authentication.js
@@ -1,18 +1,19 @@
-import { click, fillIn } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
 import visit from './visit';
+import { clickByLabel } from './click-by-label';
 
 export async function authenticateByEmail(user) {
   await visit('/connexion');
   await fillIn('#login', user.email);
   await fillIn('#password', user.password);
-  await click('.button');
+  await clickByLabel('Je me connecte');
 }
 
 export async function authenticateByUsername(user) {
   await visit('/connexion');
   await fillIn('#login', user.username);
   await fillIn('#password', user.password);
-  await click('.button');
+  await clickByLabel('Je me connecte');
 }
 
 export async function authenticateByGAR(user) {

--- a/mon-pix/tests/helpers/campaign.js
+++ b/mon-pix/tests/helpers/campaign.js
@@ -12,14 +12,14 @@ export async function startCampaignByCodeAndExternalId(campaignCode, externalId 
   await click('.campaign-landing-page__start-button');
 }
 
-export async function resumeCampaignOfTypeAssessmentByCode(campaignCode, hasExternalParticipantId) {
+export async function resumeCampaignOfTypeAssessmentByCode(campaignCode, hasExternalParticipantId, intl) {
   await visit(`/campagnes/${campaignCode}`);
   await click('.campaign-landing-page__start-button');
   if (hasExternalParticipantId) {
     await fillIn('#id-pix-label', 'monmail@truc.fr');
     await click('.button');
   }
-  await click('.campaign-tutorial__ignore-button');
+  await clickByLabel(intl.t('pages.tutorial.pass'));
   await click('.challenge-actions__action-skip');
 }
 

--- a/mon-pix/tests/helpers/certification.js
+++ b/mon-pix/tests/helpers/certification.js
@@ -1,13 +1,14 @@
 import { click, fillIn } from '@ember/test-helpers';
+import { clickByLabel } from './click-by-label';
 
-export async function fillCertificationJoiner({ sessionId, firstName, lastName, dayOfBirth, monthOfBirth, yearOfBirth }) {
+export async function fillCertificationJoiner({ sessionId, firstName, lastName, dayOfBirth, monthOfBirth, yearOfBirth, intl }) {
   await fillIn('#certificationJoinerSessionId', sessionId);
   await fillIn('#certificationJoinerFirstName', firstName);
   await fillIn('#certificationJoinerLastName', lastName);
   await fillIn('#certificationJoinerDayOfBirth', dayOfBirth);
   await fillIn('#certificationJoinerMonthOfBirth', monthOfBirth);
   await fillIn('#certificationJoinerYearOfBirth', yearOfBirth);
-  await click('.certification-joiner__attempt-next-btn');
+  await clickByLabel(intl.t('pages.certification-joiner.form.actions.submit'));
 }
 
 export async function fillCertificationStarter({ accessCode }) {

--- a/mon-pix/tests/helpers/certification.js
+++ b/mon-pix/tests/helpers/certification.js
@@ -1,4 +1,4 @@
-import { click, fillIn } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
 import { clickByLabel } from './click-by-label';
 
 export async function fillCertificationJoiner({ sessionId, firstName, lastName, dayOfBirth, monthOfBirth, yearOfBirth, intl }) {
@@ -11,7 +11,7 @@ export async function fillCertificationJoiner({ sessionId, firstName, lastName, 
   await clickByLabel(intl.t('pages.certification-joiner.form.actions.submit'));
 }
 
-export async function fillCertificationStarter({ accessCode }) {
+export async function fillCertificationStarter({ accessCode, intl }) {
   await fillIn('#certificationStarterSessionCode', accessCode);
-  await click('.certification-course-page__submit_button');
+  await clickByLabel(intl.t('pages.certification-start.actions.submit'));
 }

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import sinon from 'sinon';
-import { render, fillIn, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
+import { fillInByLabel } from '../../helpers/fill-in-by-label';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 describe('Integration | Component | certification-joiner', function() {
   setupIntlRenderingTest();
@@ -15,19 +17,19 @@ describe('Integration | Component | certification-joiner', function() {
       // given
       this.set('onStepChange', sinon.stub());
       await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
-      await fillIn('#certificationJoinerSessionId', '123456');
-      await fillIn('#certificationJoinerFirstName', 'Robert  ');
-      await fillIn('#certificationJoinerLastName', '  de Pix');
-      await fillIn('#certificationJoinerDayOfBirth', '02');
-      await fillIn('#certificationJoinerMonthOfBirth', '01');
-      await fillIn('#certificationJoinerYearOfBirth', '2000');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.session-number'), '123456');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert  ');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), '  de Pix');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), '02');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), '01');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
       const store = this.owner.lookup('service:store');
       const createRecordMock = sinon.mock();
       createRecordMock.returns({ save: function() {} });
       store.createRecord = createRecordMock;
 
       // when
-      await click('[type="submit"]');
+      await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
       sinon.assert.calledWith(createRecordMock, 'certification-candidate', {
@@ -42,19 +44,19 @@ describe('Integration | Component | certification-joiner', function() {
       // given
       this.set('onStepChange', sinon.stub());
       await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
-      await fillIn('#certificationJoinerSessionId', '123456');
-      await fillIn('#certificationJoinerFirstName', 'Robert  ');
-      await fillIn('#certificationJoinerLastName', '  de Pix');
-      await fillIn('#certificationJoinerDayOfBirth', '2');
-      await fillIn('#certificationJoinerMonthOfBirth', '1');
-      await fillIn('#certificationJoinerYearOfBirth', '2000');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.session-number'), '123456');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert  ');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), '  de Pix');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), '2');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), '1');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
       const store = this.owner.lookup('service:store');
       const createRecordMock = sinon.mock();
       createRecordMock.returns({ save: function() {} });
       store.createRecord = createRecordMock;
 
       // when
-      await click('[type="submit"]');
+      await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
       sinon.assert.calledWith(createRecordMock, 'certification-candidate', {
@@ -70,19 +72,19 @@ describe('Integration | Component | certification-joiner', function() {
       const stepChangeStub = sinon.stub();
       this.set('onStepChange', stepChangeStub);
       await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
-      await fillIn('#certificationJoinerSessionId', '123456');
-      await fillIn('#certificationJoinerFirstName', 'Robert  ');
-      await fillIn('#certificationJoinerLastName', '  de Pix');
-      await fillIn('#certificationJoinerDayOfBirth', '2');
-      await fillIn('#certificationJoinerMonthOfBirth', '1');
-      await fillIn('#certificationJoinerYearOfBirth', '2000');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.session-number'), '123456');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert  ');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), '  de Pix');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), '2');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), '1');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
       const store = this.owner.lookup('service:store');
       const createRecordMock = sinon.mock();
       createRecordMock.returns({ save: function() {} });
       store.createRecord = createRecordMock;
 
       // when
-      await click('[type="submit"]');
+      await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
       sinon.assert.calledWith(stepChangeStub, '123456');
@@ -92,19 +94,19 @@ describe('Integration | Component | certification-joiner', function() {
       // given
       this.set('onStepChange', sinon.stub());
       await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
-      await fillIn('#certificationJoinerSessionId', '123AAA456AAA');
-      await fillIn('#certificationJoinerFirstName', 'Robert');
-      await fillIn('#certificationJoinerLastName', 'de Pix');
-      await fillIn('#certificationJoinerDayOfBirth', '02');
-      await fillIn('#certificationJoinerMonthOfBirth', '01');
-      await fillIn('#certificationJoinerYearOfBirth', '2000');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.session-number'), '123AAA456AAA');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), 'de Pix');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), '02');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), '01');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
       const store = this.owner.lookup('service:store');
       const createRecordMock = sinon.mock();
       createRecordMock.returns({ save: function() {} });
       store.createRecord = createRecordMock;
 
       // when
-      await click('[type="submit"]');
+      await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
       expect(contains('Le numéro de session est composé uniquement de chiffres.')).to.exist;
@@ -114,12 +116,12 @@ describe('Integration | Component | certification-joiner', function() {
       // given
       this.set('onStepChange', sinon.stub());
       await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
-      await fillIn('#certificationJoinerSessionId', '123456');
-      await fillIn('#certificationJoinerFirstName', 'Robert');
-      await fillIn('#certificationJoinerLastName', 'de Pix');
-      await fillIn('#certificationJoinerDayOfBirth', '02');
-      await fillIn('#certificationJoinerMonthOfBirth', '01');
-      await fillIn('#certificationJoinerYearOfBirth', '2000');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.session-number'), '123456');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), 'de Pix');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), '02');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), '01');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
       const store = this.owner.lookup('service:store');
       const saveStub = sinon.stub();
       saveStub
@@ -138,7 +140,7 @@ describe('Integration | Component | certification-joiner', function() {
       store.createRecord = createRecordMock;
 
       // when
-      await click('[type="submit"]');
+      await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
       expect(contains('Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification.\nPour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant.')).to.exist;
@@ -148,12 +150,12 @@ describe('Integration | Component | certification-joiner', function() {
       // given
       this.set('onStepChange', sinon.stub());
       await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
-      await fillIn('#certificationJoinerSessionId', '123456');
-      await fillIn('#certificationJoinerFirstName', 'Robert');
-      await fillIn('#certificationJoinerLastName', 'de Pix');
-      await fillIn('#certificationJoinerDayOfBirth', '02');
-      await fillIn('#certificationJoinerMonthOfBirth', '01');
-      await fillIn('#certificationJoinerYearOfBirth', '2000');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.session-number'), '123456');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), 'de Pix');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), '02');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), '01');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
       const store = this.owner.lookup('service:store');
       const saveStub = sinon.stub();
       saveStub
@@ -164,7 +166,7 @@ describe('Integration | Component | certification-joiner', function() {
       store.createRecord = createRecordMock;
 
       // when
-      await click('[type="submit"]');
+      await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
       expect(contains('Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.')).to.exist;
@@ -174,12 +176,12 @@ describe('Integration | Component | certification-joiner', function() {
       // given
       this.set('onStepChange', sinon.stub());
       await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
-      await fillIn('#certificationJoinerSessionId', '123456');
-      await fillIn('#certificationJoinerFirstName', 'Robert');
-      await fillIn('#certificationJoinerLastName', 'de Pix');
-      await fillIn('#certificationJoinerDayOfBirth', '02');
-      await fillIn('#certificationJoinerMonthOfBirth', '01');
-      await fillIn('#certificationJoinerYearOfBirth', '2000');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.session-number'), '123456');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), 'de Pix');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), '02');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), '01');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
       const store = this.owner.lookup('service:store');
       const saveStub = sinon.stub();
       saveStub
@@ -190,7 +192,7 @@ describe('Integration | Component | certification-joiner', function() {
       store.createRecord = createRecordMock;
 
       // when
-      await click('[type="submit"]');
+      await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
       expect(contains('Oups ! La session est en cours de traitement par les équipes Pix et n\'est plus accessible.')).to.exist;

--- a/mon-pix/tests/integration/components/certification-results-page_test.js
+++ b/mon-pix/tests/integration/components/certification-results-page_test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 describe('Integration | Component | certification results template', function() {
   setupIntlRenderingTest();
@@ -27,7 +28,7 @@ describe('Integration | Component | certification results template', function() 
       // when
       await render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
       await click('#validSupervisor');
-      await click('.result-content__validation-button');
+      await clickByLabel(this.intl.t('pages.certification-results.action.confirm'));
 
       // then
       expect(find('.result-content__panel-description').textContent).to.contains('Vos résultats seront prochainement disponibles depuis votre compte.');
@@ -37,7 +38,7 @@ describe('Integration | Component | certification results template', function() 
       // when
       await render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
       await click('#validSupervisor');
-      await click('.result-content__validation-button');
+      await clickByLabel(this.intl.t('pages.certification-results.action.confirm'));
 
       // then
       expect(find('.result-content__logout-button')).to.exist;

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
 import Service from '@ember/service';
 import { describe, it } from 'mocha';
-import { render, fillIn, click } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { contains } from '../../helpers/contains';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 describe('Integration | Component | certification-starter', function() {
   setupIntlRenderingTest();
@@ -20,7 +21,7 @@ describe('Integration | Component | certification-starter', function() {
         await render(hbs`<CertificationStarter @sessionId={{this.sessionId}}/>`);
 
         // when
-        await click('[type="submit"]');
+        await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
 
         // then
         expect(contains('Merci de saisir un code d’accès valide.'));
@@ -55,7 +56,7 @@ describe('Integration | Component | certification-starter', function() {
           replaceWithStub.returns('ok');
 
           // when
-          await click('[type="submit"]');
+          await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
 
           // then
           sinon.assert.calledWithExactly(createRecordStub, 'certification-course', { accessCode: 'ABC123', sessionId: '123' });
@@ -90,7 +91,7 @@ describe('Integration | Component | certification-starter', function() {
           certificationCourse.save.rejects({ errors: [ { status: '404' }] });
 
           // when
-          await click('[type="submit"]');
+          await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
 
           // then
           expect(contains('Ce code n’existe pas ou n’est plus valide.'));
@@ -120,7 +121,7 @@ describe('Integration | Component | certification-starter', function() {
           certificationCourse.save.rejects({ errors: [ { status: '412' }] });
 
           // when
-          await click('[type="submit"]');
+          await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
 
           // then
           expect(contains('La session de certification n\'est plus accessible.'));
@@ -150,7 +151,7 @@ describe('Integration | Component | certification-starter', function() {
           certificationCourse.save.rejects({ errors: [ { status: 'other' }] });
 
           // when
-          await click('[type="submit"]');
+          await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
 
           // then
           expect(contains('Une erreur serveur inattendue vient de se produire.'));

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, find, render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { contains } from '../../helpers/contains';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 describe('Integration | Component | Challenge Embed Simulator', function() {
 
@@ -17,14 +19,6 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
       // then
       expect(find('.embed__acknowledgment-overlay')).to.exist;
     });
-
-    it('should contain a button to launch the simulator', async function() {
-      // when
-      await render(hbs`<ChallengeEmbedSimulator />`);
-
-      // then
-      expect(find('.embed__acknowledgment-overlay .embed__launch-simulator-button')).to.exist;
-    });
   });
 
   describe('Launch simulator button', () => {
@@ -34,7 +28,7 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
       await render(hbs`<ChallengeEmbedSimulator />`);
 
       // then
-      expect(find('.embed__acknowledgment-overlay .embed__launch-simulator-button').textContent).to.equal('Je lance l’application');
+      expect(contains(this.intl.t('pages.challenge.embed-simulator.actions.launch')));
     });
 
     it('should close the acknowledgment overlay when clicked', async function() {
@@ -42,7 +36,7 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
       await render(hbs`<ChallengeEmbedSimulator />`);
 
       // when
-      await click('.embed__launch-simulator-button');
+      await clickByLabel(this.intl.t('pages.challenge.embed-simulator.actions.launch'));
 
       // then
       expect(find('.embed__acknowledgment-overlay')).to.not.exist;
@@ -75,7 +69,7 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
       await render(hbs`<ChallengeEmbedSimulator />`);
 
       // when
-      await click('.embed__launch-simulator-button');
+      await clickByLabel(this.intl.t('pages.challenge.embed-simulator.actions.launch'));
 
       // then
       expect(find('.embed__simulator').classList.contains('blurred')).to.be.false;

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -12,6 +12,8 @@ import {
   render,
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { clickByLabel } from '../../helpers/click-by-label';
+import { contains } from '../../helpers/contains';
 
 const OPEN_FEEDBACK_BUTTON = '.feedback-panel__open-button';
 const BUTTON_SEND = '.feedback-panel__button--send';
@@ -71,7 +73,7 @@ describe('Integration | Component | feedback-panel', function() {
       await setContent(CONTENT_VALUE);
 
       // when
-      await click(BUTTON_SEND);
+      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
 
       // then
       expect(find('.feedback-panel__view--form')).to.not.exist;
@@ -96,7 +98,7 @@ describe('Integration | Component | feedback-panel', function() {
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
         expect(find(TEXTAREA)).to.exist;
-        expect(findAll(BUTTON_SEND).length).to.equal(1);
+        expect(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
       });
 
       it('should directly display the tuto without the textbox or the send button when category has a tutorial', async function() {
@@ -117,7 +119,7 @@ describe('Integration | Component | feedback-panel', function() {
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
         expect(find(TUTORIAL_AREA)).to.not.exist;
-        expect(find(BUTTON_SEND)).to.exist;
+        expect(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
         expect(find(TEXTAREA)).to.exist;
       });
 
@@ -129,7 +131,7 @@ describe('Integration | Component | feedback-panel', function() {
         // then
         expect(findAll(DROPDOWN).length).to.equal(1);
         expect(find(TUTORIAL_AREA)).to.not.exist;
-        expect(find(BUTTON_SEND)).to.exist;
+        expect(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
         expect(find(TEXTAREA)).to.exist;
       });
 
@@ -143,7 +145,7 @@ describe('Integration | Component | feedback-panel', function() {
         expect(findAll(DROPDOWN).length).to.equal(2);
         expect(find(TUTORIAL_AREA)).to.exist;
         expect(find(TEXTAREA)).to.exist;
-        expect(find(BUTTON_SEND)).to.exist;
+        expect(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
       });
     });
   });
@@ -258,7 +260,7 @@ describe('Integration | Component | feedback-panel', function() {
       await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
       // when
-      await click(BUTTON_SEND);
+      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
 
       // then
       expect(find('.alert')).to.exist;
@@ -269,7 +271,7 @@ describe('Integration | Component | feedback-panel', function() {
       await setContent('');
 
       // when
-      await click(BUTTON_SEND);
+      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
 
       // then
       expect(find('.alert')).to.exist;
@@ -278,7 +280,7 @@ describe('Integration | Component | feedback-panel', function() {
     it('should not display error if "form" view (with error) was closed and re-opened', async function() {
       // given
       await setContent('   ');
-      await click(BUTTON_SEND);
+      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
 
       // when
       await click(OPEN_FEEDBACK_BUTTON);

--- a/mon-pix/tests/integration/components/password-reset-demand-form_test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form_test.js
@@ -4,10 +4,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { fillIn, find, render, click } from '@ember/test-helpers';
+import { fillIn, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve, reject } from 'rsvp';
 import Service from '@ember/service';
+import { clickByLabel } from '../../helpers/click-by-label';
+import { contains } from '../../helpers/contains';
 
 describe('Integration | Component | password reset demand form', function() {
   setupIntlRenderingTest();
@@ -28,10 +30,10 @@ describe('Integration | Component | password reset demand form', function() {
     expect(find('.sign-form__body')).to.exist;
     expect(find('.form-textfield__label')).to.exist;
     expect(find('.form-textfield__input-field-container')).to.exist;
-    expect(find('.button')).to.exist;
+    expect(contains(this.intl.t('pages.password-reset-demand.actions.reset')));
   });
 
-  it('should display error message and re enable the button when there is an error on password reset demand', async function() {
+  it('should display error message when there is an error on password reset demand', async function() {
     // given
     const storeStub = Service.extend({
       createRecord() {
@@ -48,11 +50,10 @@ describe('Integration | Component | password reset demand form', function() {
 
     // when
     await fillIn('#email', 'test@example.net');
-    await click('.sign-form-body__bottom-button .button');
+    await clickByLabel(this.intl.t('pages.password-reset-demand.actions.reset'));
 
     // then
     expect(find('.sign-form__notification-message--error')).to.exist;
-    expect(find('.button').textContent.trim()).to.equal('Réinitialiser mon mot de passe');
   });
 
   it('should display success message when there is no error on password reset demand', async function() {
@@ -72,7 +73,7 @@ describe('Integration | Component | password reset demand form', function() {
 
     // when
     await fillIn('#email', 'test@example.net');
-    await click('.sign-form-body__bottom-button .button');
+    await clickByLabel(this.intl.t('pages.password-reset-demand.actions.reset'));
 
     // then
     expect(find('.password-reset-demand-form__body')).to.exist;

--- a/mon-pix/tests/integration/components/routes/login-form_test.js
+++ b/mon-pix/tests/integration/components/routes/login-form_test.js
@@ -7,6 +7,7 @@ import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { clickByLabel } from '../../../helpers/click-by-label';
 
 describe('Integration | Component | routes/login-form', function() {
 
@@ -40,7 +41,7 @@ describe('Integration | Component | routes/login-form', function() {
     await render(hbs`<Routes::LoginForm/>`);
     await fillIn('#login', 'pix@example.net');
     await fillIn('#password', 'Mauvais mot de passe');
-    await click('#submit-connexion');
+    await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
     // then
     expect(find('#login-form-error-message')).to.exist;
@@ -90,7 +91,7 @@ describe('Integration | Component | routes/login-form', function() {
       await render(hbs`<Routes::LoginForm/>`);
       await fillIn('#login', 'pix@example.net');
       await fillIn('#password', 'JeMeLoggue1024');
-      await click('#submit-connexion');
+      await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
       expect(find('.form-textfield__input--error')).to.not.exist;
@@ -117,7 +118,7 @@ describe('Integration | Component | routes/login-form', function() {
       await render(hbs`<Routes::LoginForm/>`);
       await fillIn('#login', 'pix@example.net');
       await fillIn('#password', 'JeMeLoggue1024');
-      await click('#submit-connexion');
+      await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
       expect(find('.form-textfield__input--error')).to.not.exist;
@@ -160,7 +161,7 @@ describe('Integration | Component | routes/login-form', function() {
       await render(hbs`<Routes::LoginForm/>`);
       await fillIn('#login', 'pix@example.net');
       await fillIn('#password', 'Mauvais mot de passe');
-      await click('#submit-connexion');
+      await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
       sinon.assert.calledWith(routerObserver.replaceWith, 'update-expired-password');
@@ -209,7 +210,7 @@ describe('Integration | Component | routes/login-form', function() {
       await fillIn('#password', 'JeMeLoggue1024');
 
       // when
-      await click('#submit-connexion');
+      await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
       expect(find('#update-form-error-message').textContent).to.equal(expectedErrorMessage);
@@ -234,7 +235,7 @@ describe('Integration | Component | routes/login-form', function() {
       await fillIn('#password', 'JeMeLoggue1024');
 
       // when
-      await click('#submit-connexion');
+      await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
       expect(find('#update-form-error-message').textContent).to.equal(expectedErrorMessage);
@@ -263,7 +264,7 @@ describe('Integration | Component | routes/login-form', function() {
       await fillIn('#password', 'JeMeLoggue1024');
 
       // when
-      await click('#submit-connexion');
+      await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
       expect(find('#update-form-error-message').textContent).to.equal(expectedErrorMessage);

--- a/mon-pix/tests/integration/components/routes/register-form_test.js
+++ b/mon-pix/tests/integration/components/routes/register-form_test.js
@@ -9,6 +9,7 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { clickByLabel } from '../../../helpers/click-by-label';
 
 const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
 const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
@@ -73,14 +74,14 @@ describe('Integration | Component | routes/register-form', function() {
       await fillIn('#monthOfBirth', '10');
       await fillIn('#yearOfBirth', '2010');
 
-      await click('#submit-search');
+      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
       await click('.pix-toggle__off');
 
       await fillIn('#email', 'shi@fu.me');
       await fillIn('#password', 'Mypassword1');
 
       // when
-      await click('#submit-registration');
+      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // then
       expect(find('.form-textfield__input--error')).to.not.exist;
@@ -102,12 +103,12 @@ describe('Integration | Component | routes/register-form', function() {
       await fillIn('#monthOfBirth', '10');
       await fillIn('#yearOfBirth', '2010');
 
-      await click('#submit-search');
+      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       await fillIn('#password', 'Mypassword1');
 
       // when
-      await click('#submit-registration');
+      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // then
       expect(find('.form-textfield__input--error')).to.not.exist;
@@ -138,11 +139,11 @@ describe('Integration | Component | routes/register-form', function() {
         await fillIn('#monthOfBirth', '10');
         await fillIn('#yearOfBirth', '2010');
 
-        await click('#submit-search');
+        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         await fillIn('#password', 'Mypassword1');
 
-        await click('#submit-registration');
+        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         // then
         expect(find('.register-form__error')).to.exist;
@@ -257,7 +258,7 @@ describe('Integration | Component | routes/register-form', function() {
         await fillIn('#dayOfBirth', '10');
         await fillIn('#monthOfBirth', '10');
         await fillIn('#yearOfBirth', '2010');
-        await click('#submit-search');
+        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         // when
         await click('.pix-toggle__off');
@@ -279,13 +280,13 @@ describe('Integration | Component | routes/register-form', function() {
       await fillIn('#dayOfBirth', '10');
       await fillIn('#monthOfBirth', '10');
       await fillIn('#yearOfBirth', '2010');
-      await click('#submit-search');
+      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // when
       await click('.pix-toggle__off');
       await fillIn('#email', 'shi.fu');
       await triggerEvent('#email', 'focusout');
-      await click('#submit-registration');
+      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // then
       expect(find('#register-email-container #validationMessage-email').textContent).to.equal(EMPTY_EMAIL_ERROR_MESSAGE);
@@ -308,7 +309,7 @@ describe('Integration | Component | routes/register-form', function() {
         await fillIn('#dayOfBirth', '10');
         await fillIn('#monthOfBirth', '10');
         await fillIn('#yearOfBirth', '2010');
-        await click('#submit-search');
+        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         // when
         await fillIn('#password', stringFilledIn);
@@ -329,12 +330,12 @@ describe('Integration | Component | routes/register-form', function() {
       await fillIn('#dayOfBirth', '10');
       await fillIn('#monthOfBirth', '10');
       await fillIn('#yearOfBirth', '2010');
-      await click('#submit-search');
+      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // when
       await fillIn('#password', 'toto');
       await triggerEvent('#password', 'focusout');
-      await click('#submit-registration');
+      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // then
       expect(find('#register-password-container #validationMessage-password').textContent).to.equal(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
@@ -359,7 +360,7 @@ describe('Integration | Component | routes/register-form', function() {
         await fillIn('#yearOfBirth', '2010');
 
         // when
-        await click('#submit-search');
+        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         // then
         expect(find('.register-form__error').innerHTML).to.equal(errorMessage);
@@ -389,7 +390,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -418,7 +419,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -447,7 +448,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -476,7 +477,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -505,7 +506,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -534,7 +535,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -563,7 +564,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -596,7 +597,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -625,7 +626,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -654,7 +655,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -683,7 +684,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -712,7 +713,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -741,7 +742,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
@@ -770,7 +771,7 @@ describe('Integration | Component | routes/register-form', function() {
           await fillInputReconciliationForm();
 
           // when
-          await click('#submit-search');
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
           // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -5,7 +5,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { describe, it } from 'mocha';
 import {
-  click,
   fillIn,
   find,
   render,
@@ -18,6 +17,7 @@ import Service from '@ember/service';
 import ENV from '../../../config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
@@ -48,7 +48,7 @@ describe('Integration | Component | signin form', function() {
       await render(hbs`<SigninForm />`);
 
       // then
-      expect(document.querySelector('button.button')).to.exist;
+      expect(contains(this.intl.t('pages.sign-in.actions.submit')));
     });
 
     it('should display a link to password reset view', async function() {
@@ -78,7 +78,7 @@ describe('Integration | Component | signin form', function() {
         // when
         await fillIn('input#login', 'usernotexist@example.net');
         await fillIn('input#password', 'password');
-        await click('button.button');
+        await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
         expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
@@ -93,7 +93,7 @@ describe('Integration | Component | signin form', function() {
         // when
         await fillIn('input#login', 'usernotexist@example.net');
         await fillIn('input#password', 'password');
-        await click('button.button');
+        await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
         expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
@@ -108,7 +108,7 @@ describe('Integration | Component | signin form', function() {
         // when
         await fillIn('input#login', 'johnharry@example.net');
         await fillIn('input#password', 'password123');
-        await click('button.button');
+        await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
         expect(document.querySelector('div.sign-form__notification-message--error')).to.exist;
@@ -185,7 +185,7 @@ describe('Integration | Component | signin form', function() {
       await triggerEvent('input#password', 'change');
 
       // when
-      await click('button.button');
+      await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
       // Then
       expect(actualEmail).to.equal(expectedEmail);

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { clickByLabel } from '../../helpers/click-by-label';
 
 import {
-  click, fillIn, find, findAll,
+  fillIn, find, findAll,
   render, settled, triggerEvent,
   waitUntil,
 } from '@ember/test-helpers';
@@ -16,6 +16,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 import ENV from '../../../config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { contains } from '../../helpers/contains';
 
 const FORM_CONTAINER = '.sign-form__container';
 const FORM_HEADER_CONTAINER = '.sign-form__header';
@@ -31,7 +32,6 @@ const CHECKBOX_CGU_LABEL = '.signup-form__cgu-label';
 const CGU_LINKS = '.signup-form__cgu-label .link';
 
 const SUBMIT_BUTTON_CONTAINER = '.sign-form-body__bottom-button';
-const SUBMIT_BUTTON = '.button';
 
 const userEmpty = EmberObject.create({});
 
@@ -107,10 +107,8 @@ describe('Integration | Component | SignupForm', function() {
       expect(findAll(CGU_LINKS)).to.have.length(2);
     });
 
-    it('should render a submit button', function() {
-      expect(findAll(SUBMIT_BUTTON)).to.have.length(1);
-      expect(find(SUBMIT_BUTTON).textContent.trim()).to.equal(this.intl.t('pages.sign-up.actions.submit'));
-      expect(find(SUBMIT_BUTTON).nodeName).to.equal('button'.toUpperCase());
+    it('should render a submit button', async function() {
+      expect(contains(this.intl.t('pages.sign-up.actions.submit')));
     });
 
   });
@@ -141,7 +139,7 @@ describe('Integration | Component | SignupForm', function() {
       await render(hbs `<SignupForm @user={{this.user}} />`);
 
       // when
-      await click(SUBMIT_BUTTON);
+      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
       expect(find('.sign-form__notification-message--error')).to.exist;
@@ -170,7 +168,7 @@ describe('Integration | Component | SignupForm', function() {
       await render(hbs `<SignupForm @user={{this.user}} />`);
 
       // when
-      await click(SUBMIT_BUTTON);
+      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
       expect(find('.sign-form__notification-message--error')).to.exist;
@@ -198,7 +196,7 @@ describe('Integration | Component | SignupForm', function() {
       await render(hbs `<SignupForm @user={{this.user}} />`);
 
       // when
-      await click(SUBMIT_BUTTON);
+      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
       expect(find('.sign-form__notification-message--error')).to.exist;
@@ -226,7 +224,7 @@ describe('Integration | Component | SignupForm', function() {
       await render(hbs `<SignupForm @user={{this.user}} />`);
 
       // when
-      await click(SUBMIT_BUTTON);
+      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
       expect(find('.sign-form__notification-message--error')).to.exist;
@@ -254,7 +252,7 @@ describe('Integration | Component | SignupForm', function() {
       await render(hbs `<SignupForm @user={{this.user}} />`);
 
       // when
-      await click(SUBMIT_BUTTON);
+      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
       expect(find('.sign-form__notification-message--error')).to.exist;
@@ -287,7 +285,7 @@ describe('Integration | Component | SignupForm', function() {
         await render(hbs `<SignupForm @user={{this.user}} @signup="signup" @authenticateUser={{action this.authenticateUser}} />`);
 
         // when
-        await click(SUBMIT_BUTTON);
+        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         return settled().then(() => {
@@ -315,7 +313,7 @@ describe('Integration | Component | SignupForm', function() {
         await render(hbs `<SignupForm @user={{this.user}} @signup="signup" @authenticateUser={{action this.authenticateUser}} />`);
 
         // when
-        await click(SUBMIT_BUTTON);
+        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         return settled().then(() => {
@@ -436,7 +434,7 @@ describe('Integration | Component | SignupForm', function() {
         await render(hbs `<SignupForm @user={{this.user}} />`);
 
         // when
-        await click('.button');
+        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         return settled().then(() => {
@@ -470,7 +468,7 @@ describe('Integration | Component | SignupForm', function() {
         await render(hbs `<SignupForm @user={{this.user}} />`);
 
         // when
-        await click('button[type=submit]');
+        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         expect(find('#validationMessage-email').textContent).to.equal(expectedMaxLengthEmailError);
@@ -494,7 +492,7 @@ describe('Integration | Component | SignupForm', function() {
         await render(hbs `<SignupForm @user={{this.user}} />`);
 
         // when
-        await click('.button');
+        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         return settled().then(() => {
@@ -599,7 +597,7 @@ describe('Integration | Component | SignupForm', function() {
         await render(hbs `<SignupForm @user={{this.user}} @authenticateUser={{action this.authenticateUser}} />`);
 
         // when
-        await click('.button');
+        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         return settled().then(() => {
@@ -625,7 +623,7 @@ describe('Integration | Component | SignupForm', function() {
         await render(hbs `<SignupForm @user={{this.user}} @authenticateUser={{action this.authenticateUser}} />`);
 
         // when
-        await click('.button');
+        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         return settled().then(() => {

--- a/mon-pix/tests/integration/components/update-expired-password-form_test.js
+++ b/mon-pix/tests/integration/components/update-expired-password-form_test.js
@@ -2,12 +2,13 @@ import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { resolve, reject } from 'rsvp';
 
-import { click, fillIn, find, render, triggerEvent } from '@ember/test-helpers';
+import { fillIn, find, render, triggerEvent } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 const PASSWORD_INPUT_CLASS = '.form-textfield__input';
 
@@ -57,7 +58,7 @@ describe('Integration | Component | update-expired-password-form', function() {
       await fillIn(PASSWORD_INPUT_CLASS, newPassword);
       await triggerEvent(PASSWORD_INPUT_CLASS, 'change');
 
-      await click('.button');
+      await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
       // then
       expect(isSaveMethodCalled).to.be.true;
@@ -83,7 +84,7 @@ describe('Integration | Component | update-expired-password-form', function() {
       await fillIn(PASSWORD_INPUT_CLASS, newPassword);
       await triggerEvent(PASSWORD_INPUT_CLASS, 'change');
 
-      await click('.button');
+      await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
       // then
       expect(isSaveMethodCalled).to.be.true;

--- a/mon-pix/tests/integration/components/user-account-update-email_test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email_test.js
@@ -114,7 +114,7 @@ describe('Integration | Component | User account update email', () => {
           expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.empty-password'))).to.exist;
         });
 
-        it('should have the autocomplete attribute set to "new-password" in order to prevent the web browsers to autocomplete the password and email fields', async () => {
+        it('should have the autocomplete attribute set to "new-password" in order to prevent the web browsers to autocomplete the password and email fields', async function() {
           // given
           const expectedAutocompleteValue = 'new-password';
 
@@ -122,7 +122,7 @@ describe('Integration | Component | User account update email', () => {
           await render(hbs`<UserAccountUpdateEmail />`);
 
           // then
-          expect(find('#password').autocomplete).to.equal(expectedAutocompleteValue);
+          expect(find('#password').attributes.autocomplete.value).to.equal(expectedAutocompleteValue);
         });
       });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco_test.js
@@ -587,7 +587,6 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           sinon.assert.calledOnce(record.unloadRecord);
           expect(component.displayInformationModal).to.be.true;
           expect(component.reconciliationError).to.equal(error);
-          expect(component.isLoading).to.be.false;
           sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', error.meta.userId);
         });
 
@@ -638,7 +637,6 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           // then
           expect(component.displayInformationModal).to.be.true;
           expect(component.reconciliationError).to.be.null;
-          expect(component.isLoading).to.be.false;
         });
       });
     });

--- a/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
@@ -46,7 +46,6 @@ describe('Unit | Controller | campaigns/profiles-collection/send-profile', funct
       await controller.actions.sendProfile.call(controller);
 
       // then
-      expect(controller.isLoading).to.equal(false);
       expect(controller.errorMessage).to.equal(null);
     });
   });

--- a/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
@@ -25,9 +25,10 @@ describe('Unit | Controller | Fill in certificate verification Code', function()
     it('should set error when certificateVerificationCode code is empty', async () => {
       // given
       controller.set('certificateVerificationCode', '');
+      const event = { preventDefault: sinon.stub() };
 
       // when
-      await controller.actions.checkCertificate.call(controller);
+      await controller.actions.checkCertificate.call(controller, event);
 
       // then
       expect(controller.get('errorMessage')).to.equal('Merci de renseigner le code de vérification.');
@@ -36,9 +37,10 @@ describe('Unit | Controller | Fill in certificate verification Code', function()
     it('should set error when certificateVerificationCode code is not matching the right format', async () => {
       // given
       controller.set('certificateVerificationCode', 'P-879888');
+      const event = { preventDefault: sinon.stub() };
 
       // when
-      await controller.actions.checkCertificate.call(controller);
+      await controller.actions.checkCertificate.call(controller, event);
 
       // then
       expect(controller.get('errorMessage')).to.equal('Veuillez vérifier le format de votre code (P-XXXXXXX).');
@@ -48,9 +50,10 @@ describe('Unit | Controller | Fill in certificate verification Code', function()
       // given
       controller.set('certificateVerificationCode', 'P-222BBB78');
       storeStub.queryRecord.rejects({ errors: [{ status: '404' }] });
+      const event = { preventDefault: sinon.stub() };
 
       // when
-      await controller.actions.checkCertificate.call(controller);
+      await controller.actions.checkCertificate.call(controller, event);
 
       // then
       expect(controller.get('showNotFoundCertificationErrorMessage')).to.equal(true);
@@ -60,9 +63,10 @@ describe('Unit | Controller | Fill in certificate verification Code', function()
       // given
       controller.set('certificateVerificationCode', 'P-222BBBDD');
       storeStub.queryRecord.resolves({ result: { status: '200' } });
+      const event = { preventDefault: sinon.stub() };
 
       // when
-      await controller.actions.checkCertificate.call(controller);
+      await controller.actions.checkCertificate.call(controller, event);
 
       // then
       expect(controller.get('showNotFoundCertificationErrorMessage')).to.equal(false);


### PR DESCRIPTION
## :unicorn: Problème
Pix-UI est bien avancé mais nous n'utilisons pas toujours dans nos application front sa dernière version.

Ce qui peut être problématique pour 2 raisons : 
- le design de PixApp ne suit pas correctement notre design system
- lorsqu'on souhaite utiliser de nouveaux composants Pix-UI , PixApp est trop en retard dans sa version de Pix-UI et demande trop de travail pour le mettre à jour et utiliser les derniers composant pour être intégré dans une PR non dédiée

## :robot: Solution
Mettre à jour Pix-UI sur PixApp et commencer à intégrer les anciens composant.


## :rainbow: Remarques
Cette PR ne change que les anciens button en `PixButton`.
Certains boutons n'ont pas été changés : 
- ceux qui se résument à une icone (pour fermer une modale par ex)
- ceux qui ne ressemblent pas visuellement à des boutons
- ceux qui requièrent de passer des paramètres à leur fonction au clic

Le dernier commit a été rajouté suite à un soucis que je rencontrais en local et que les tests plantaient aussi sur circle-ci : 
<img width="970" alt="image" src="https://user-images.githubusercontent.com/38167520/132474684-437093b3-314d-49b8-8f57-fc49bde2b33e.png">

Il m'était impossible de build ou lancer les tests de mon-pix à cause de caniuse. Le plus étrange c'est qu'en local j'avais aussi ce problème sur dev et les autres app front 🤔 . 
En lançant la commande suggérée `npx browserslist@latest --update-db` cela a résolu le soucis (c'est le contenu du dernier commit).


## :100: Pour tester
Vérifier la non régression des boutons sur tous PixApp.

Scénarios où l'on trouve les boutons : 

- Mon compte 
- Code campagne, commencer la campagne, résultat de la campagne
- CGU à valider
- quand le profil est certifiable : Page certification
-  SCO : déconnecté => entrer les code BADGES123 => double mire 
- SCO : connecté => entrer le même code => First Last 10 10 2010 => modale pour associer
- mot de passe oublié
- inscription / connexion

relancer les seeds au besoin : scalingo -a pix-api-review-pr3367 --region osc-fr1 run "npm run db:seed"