### PR TITLE
[TECH] Ajout du feature toggle pour la gestion des certifications non complétées (PIX-3060)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -144,6 +144,7 @@ module.exports = (function() {
       isScoAccountRecoveryEnabled: isFeatureEnabled(process.env.IS_SCO_ACCOUNT_RECOVERY_ENABLED),
       isNewCPFDataEnabled: isFeatureEnabled(process.env.FT_IS_NEW_CPF_DATA_ENABLED),
       isDownloadCertificationAttestationByDivisionEnabled: isFeatureEnabled(process.env.FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED),
+      isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
     },
 
     infra: {

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -26,6 +26,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function() {
             'is-download-certification-attestation-by-division-enabled': false,
             'is-sco-account-recovery-enabled': false,
             'is-new-cpf-data-enabled': false,
+            'is-manage-uncompleted-certif-enabled': false,
           },
           type: 'feature-toggles',
         },

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isNewCpfDataEnabled;
+  @attr('boolean') isManageUncompletedCertifEnabled;
 }


### PR DESCRIPTION
## :unicorn: Problème
Pour la gestion des certifications non complétées nous avons besoin d'activer/désactiver la fonctionnalité à chaud

## :robot: Solution
Ajout d'un feature toggle `FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED`

## :rainbow: Remarques
Le feature toggle n'est pas encore utilisé

## :100: Pour tester
Mettre à jour coté API la variable d'environnement
``FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED=true``

Appeler l'endpoint 
```curl {host}:{port}/api/feature-toggles```
Verifier que l'on ai bien `is-manage-uncompleted-certif-enabled` avec pour valeur `true`
```{"data":{"type":"feature-toggles","id":"0","attributes":{"is-manage-uncompleted-certif-enabled":true}}}```
