### PR TITLE
[FEATURE] Afficher un graphique de répartition par résultat pour les campagnes sans palier (PIX-2894).

### DIFF
--- a/api/lib/application/campaigns/campaign-stats-controller.js
+++ b/api/lib/application/campaigns/campaign-stats-controller.js
@@ -2,6 +2,7 @@ const usecases = require('../../domain/usecases');
 const participationsByStageSerializer = require('../../infrastructure/serializers/jsonapi/campaign-participations-count-by-stage-serializer');
 const participationsByStatusSerializer = require('../../infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer');
 const participationsByDaySerializer = require('../../infrastructure/serializers/jsonapi/campaign-participations-counts-by-day-serializer');
+const participationsCountByMasteryRateSerializer = require('../../infrastructure/serializers/jsonapi/participations-count-by-mastery-rate');
 
 module.exports = {
   async getParticipationsByStage(request) {
@@ -37,6 +38,18 @@ module.exports = {
     return participationsByDaySerializer.serialize({
       campaignId,
       ...participantsCounts,
+    });
+  },
+
+  async getParticipationsCountByMasteryRate(request) {
+    const { userId } = request.auth.credentials;
+    const campaignId = request.params.id;
+
+    const resultDistribution = await usecases.getParticipationsCountByMasteryRate({ userId, campaignId });
+
+    return participationsCountByMasteryRateSerializer.serialize({
+      campaignId,
+      resultDistribution,
     });
   },
 };

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -353,6 +353,21 @@ exports.register = async function(server) {
         tags: ['api', 'campaign', 'stats'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/campaigns/{id}/stats/participations-by-mastery-rate',
+      config: {
+        validate: {
+          params: Joi.object({ id: identifiersType.campaignId }),
+        },
+        handler: campaignStatsController.getParticipationsCountByMasteryRate,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération de la répartition du pourcentage de réussite',
+        ],
+        tags: ['api', 'campaign', 'stats'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/usecases/get-participations-count-by-mastery-rate.js
+++ b/api/lib/domain/usecases/get-participations-count-by-mastery-rate.js
@@ -1,0 +1,13 @@
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
+module.exports = async function({ campaignId, userId, campaignParticipationsStatsRepository, campaignRepository }) {
+  await _checkUserPermission(campaignId, userId, campaignRepository);
+  return campaignParticipationsStatsRepository.countParticipationsByMasteryRate({ campaignId });
+};
+
+async function _checkUserPermission(campaignId, userId, campaignRepository) {
+  const hasAccess = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
+
+  if (!hasAccess) {
+    throw new UserNotAuthorizedToAccessEntityError();
+  }
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -267,6 +267,7 @@ module.exports = injectDependencies({
   getStageDetails: require('./get-stage-details'),
   getTargetProfileDetails: require('./get-target-profile-details'),
   getAccountRecoveryDetails: require('./account-recovery/get-account-recovery-details'),
+  getParticipationsCountByMasteryRate: require('./get-participations-count-by-mastery-rate'),
   getUserByResetPasswordDemand: require('./get-user-by-reset-password-demand'),
   getUserCampaignAssessmentResult: require('./get-user-campaign-assessment-result'),
   getUserCampaignParticipationToCampaign: require('./get-user-campaign-participation-to-campaign'),

--- a/api/lib/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -8,6 +8,16 @@ const CampaignParticipationsStatsRepository = {
     ]);
     return { startedParticipations, sharedParticipations };
   },
+
+  async countParticipationsByMasteryRate({ campaignId }) {
+    return knex('campaign-participations')
+      .select('masteryPercentage AS  masteryRate')
+      .count()
+      .where({ campaignId, isShared: true, isImproved: false })
+      .whereNotNull('masteryPercentage')
+      .groupBy('masteryPercentage')
+      .orderBy('masteryPercentage', 'ASC');
+  },
 };
 
 async function _getCumulativeParticipationCountsByDay(campaignId, column) {

--- a/api/lib/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate.js
@@ -1,0 +1,10 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(model) {
+    return new Serializer('participations-count-by-mastery-rate', {
+      id: 'campaignId',
+      attributes: ['resultDistribution'],
+    }).serialize(model);
+  },
+};

--- a/api/tests/acceptance/application/campaign-stats/campaign-stats-get-participations-count-by-mastery-rate_test.js
+++ b/api/tests/acceptance/application/campaign-stats/campaign-stats-get-participations-count-by-mastery-rate_test.js
@@ -1,0 +1,35 @@
+const createServer = require('../../../../server');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+
+describe('Acceptance | API | Campaign Stats | GetParticipationCountByMasteryPercentage', function() {
+
+  let server;
+
+  beforeEach(async function() {
+    server = await createServer();
+  });
+
+  describe('GET /api/campaigns/{id}/stats/participations-by-mastery-rate', function() {
+
+    it('should return the mastery percentage distribution', async function() {
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryPercentage: 0.50, isShared: true, sharedAt: '2020-01-01' });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaignId}/stats/participations-by-mastery-rate`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      const { statusCode, result } = await server.inject(options);
+
+      expect(statusCode).to.equal(200);
+      expect(result.data.attributes['result-distribution']).to.deep.equal([{ count: 1, masteryRate: '0.50' }]);
+    });
+  });
+});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -145,7 +145,7 @@ chai.use(function(chai) {
 
   Assertion.addMethod('exactlyContain', function(expectedElements) {
     const errorMessage = `expect [${this._obj}] to exactly contain [${expectedElements}]`;
-    new Assertion(this._obj, errorMessage).to.have.members(expectedElements);
+    new Assertion(this._obj, errorMessage).to.deep.have.members(expectedElements);
   });
 });
 

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -939,4 +939,30 @@ describe('Unit | Application | Router | campaign-router ', function() {
       expect(result.statusCode).to.equal(400);
     });
   });
+
+  describe('GET /api/campaigns/{id}/stats/participations-by-mastery-rate', function() {
+
+    beforeEach(function() {
+      sinon.stub(campaignStatsController, 'getParticipationsCountByMasteryRate').callsFake((request, h) => h.response('ok').code(200));
+    });
+    afterEach(function() {
+      sinon.restore();
+    });
+
+    it('should return 200', async function() {
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/stats/participations-by-mastery-rate');
+
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it('should return 400 with an invalid campaign id', async function() {
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      const result = await httpTestServer.request('GET', '/api/campaigns/invalid/stats/participations-by-mastery-rate');
+
+      expect(result.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/get-participations-count-by-mastery-rate_test.js
+++ b/api/tests/unit/domain/usecases/get-participations-count-by-mastery-rate_test.js
@@ -1,0 +1,35 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const getParticipationsCountByMasteryRate = require('../../../../lib/domain/usecases/get-participations-count-by-mastery-rate');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | getParticipationsCountByMasteryRate', function() {
+  context('when the user has access to the campaign', function() {
+    it('return the distribution of results', async function() {
+      const campaignId = 12;
+      const userId = 12;
+      const expectedResultDistribution = Symbol('ResultDitribution');
+      const campaignParticipationsStatsRepository = { countParticipationsByMasteryRate: sinon.stub() };
+      const campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
+      campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
+      campaignParticipationsStatsRepository.countParticipationsByMasteryRate.withArgs({ campaignId }).resolves(expectedResultDistribution);
+
+      const participationsCountByMasteryRate = await getParticipationsCountByMasteryRate({ campaignId, userId, campaignParticipationsStatsRepository, campaignRepository });
+
+      expect(participationsCountByMasteryRate).to.equal(expectedResultDistribution);
+    });
+  });
+  context('when the user does not have access to the campaign', function() {
+    it('throws an error', async function() {
+      const campaignId = 12;
+      const userId = 12;
+      const campaignParticipationsStatsRepository = { countParticipationsByMasteryRate: sinon.stub() };
+      const campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
+      campaignRepository.checkIfUserOrganizationHasAccessToCampaign.resolves(false);
+      campaignParticipationsStatsRepository.countParticipationsByMasteryRate.rejects();
+
+      const error = await catchErr(getParticipationsCountByMasteryRate)({ campaignId, userId, campaignParticipationsStatsRepository, campaignRepository });
+
+      expect(error).to.be.an.instanceOf(UserNotAuthorizedToAccessEntityError);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate_test.js
@@ -1,0 +1,30 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/participations-count-by-mastery-rate');
+
+describe('Unit | Serializer | JSONAPI | participations-count-by-mastery-rate', function() {
+
+  describe('#serialize', function() {
+    it('should convert a campaign result distribution object into JSON API data', function() {
+      const json = serializer.serialize({
+        campaignId: 1,
+        resultDistribution: [
+          { count: 1, masteryRate: '0.50' },
+          { count: 2, masteryRate: '1.00' },
+        ],
+      });
+
+      expect(json).to.deep.equal({
+        data: {
+          type: 'participations-count-by-mastery-rates',
+          id: '1',
+          attributes: {
+            'result-distribution': [
+              { count: 1, masteryRate: '0.50' },
+              { count: 2, masteryRate: '1.00' },
+            ],
+          },
+        },
+      });
+    });
+  });
+});

--- a/orga/app/adapters/campaign-stats.js
+++ b/orga/app/adapters/campaign-stats.js
@@ -15,4 +15,9 @@ export default class CampaignStatsAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/campaigns/${campaignId}/stats/participations-by-day`;
     return this.ajax(url, 'GET');
   }
+
+  getParticipationsByMasteryRate(campaignId) {
+    const url = `${this.host}/${this.namespace}/campaigns/${campaignId}/stats/participations-by-mastery-rate`;
+    return this.ajax(url, 'GET');
+  }
 }

--- a/orga/app/components/campaign/charts/participants-by-mastery-percentage-loader.hbs
+++ b/orga/app/components/campaign/charts/participants-by-mastery-percentage-loader.hbs
@@ -1,0 +1,2 @@
+<p class="sr-only">{{t 'charts.participants-by-mastery-percentage.loader'}}</p>
+<div class="participants-by-mastery-percentage--loader placeholder-box" aria-hidden="true" />

--- a/orga/app/components/campaign/charts/participants-by-mastery-percentage.hbs
+++ b/orga/app/components/campaign/charts/participants-by-mastery-percentage.hbs
@@ -1,0 +1,18 @@
+<Ui::ChartCard @title={{t 'charts.participants-by-mastery-percentage.title'}} ...attributes>
+  {{#if this.loading}}
+    <Campaign::Charts::ParticipantsByMasteryPercentageLoader />
+  {{else}}
+    <Ui::Chart
+      @type="bar"
+      @options={{this.options}}
+      @data={{this.data}}
+      aria-hidden="true"
+      class="participants-by-mastery-percentage"
+    />
+  {{/if}}
+</Ui::ChartCard>
+<ul class="sr-only">
+  {{#each this.accessibilityLabels as |label|}}
+    <li>{{label}}</li>
+  {{/each}}
+</ul>

--- a/orga/app/components/campaign/charts/participants-by-mastery-percentage.js
+++ b/orga/app/components/campaign/charts/participants-by-mastery-percentage.js
@@ -1,0 +1,104 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import remove from 'lodash/remove';
+import sumBy from 'lodash/sumBy';
+
+export default class ParticipantsByMasteryPercentage extends Component {
+  @service store;
+  @service intl;
+
+  @tracked data = [];
+  @tracked accessibilityLabels = [];
+  @tracked loading = true;
+
+  constructor(...args) {
+    super(...args);
+    const { campaignId } = this.args;
+
+    const adapter = this.store.adapterFor('campaign-stats');
+    adapter
+      .getParticipationsByMasteryRate(campaignId)
+      .then((response) => {
+
+        const { steps, labels, accessibilityLabels } = this._buildChartDatas(response.data.attributes['result-distribution']);
+        this.max = Math.max(...steps);
+        this.accessibilityLabels = accessibilityLabels;
+        this.data = {
+          labels,
+          datasets: [
+            {
+              data: steps,
+              border: '#3D68FF',
+              backgroundColor: '#3D68FF',
+            },
+          ],
+        };
+
+        this.loading = false;
+      });
+  }
+
+  get options() {
+    return {
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        yAxis: {
+          type: 'linear',
+          min: 0,
+          max: this.max,
+          grid: {
+            borderDash: [4, 4],
+          },
+          ticks: {
+            stepSize: 1,
+          },
+        },
+        xAxis: {
+          grid: {
+            display: false,
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          display: false,
+        },
+        tooltip: {
+          callbacks: {
+            title: (tooltipItem) => {
+              return this.intl.t('charts.participants-by-mastery-percentage.tooltip.title', { legend: tooltipItem[0].label });
+            },
+            label: (data) => {
+              return this.intl.t('charts.participants-by-mastery-percentage.tooltip.label', { count: data.raw });
+            },
+          },
+        },
+      },
+    };
+  }
+
+  _buildChartDatas(resultDistributions) {
+    const steps = [];
+    const labels = [];
+    const accessibilityLabels = [];
+
+    for (let i = 10; i <= 100; i += 10) {
+      let from = i - 9;
+      const to = i;
+      if (i === 10) {
+        from = 0.0;
+      }
+      labels.push(this.intl.t('charts.participants-by-mastery-percentage.tooltip.legend', { from: (from / 100), to: (to / 100) }));
+
+      const dataForStep = remove(resultDistributions, ({ masteryRate }) => masteryRate * 100 <= i);
+      const count = sumBy(dataForStep, 'count');
+      steps.push(count);
+      accessibilityLabels.push(this.intl.t('charts.participants-by-mastery-percentage.label-a11y', { from: (from / 100), to: (to / 100), count }));
+    }
+
+    return { steps, labels, accessibilityLabels };
+  }
+}

--- a/orga/app/components/campaign/charts/result-distribution.hbs
+++ b/orga/app/components/campaign/charts/result-distribution.hbs
@@ -1,0 +1,12 @@
+{{#if @campaign.hasStages}}
+  <Campaign::Charts::ParticipantsByStage
+    @campaignId={{@campaign.id}}
+    @onSelectStage={{@onSelectStage}}
+    class="assessment-results__charts hide-on-mobile"
+  />
+{{else}}
+  <Campaign::Charts::ParticipantsByMasteryPercentage
+    @campaignId={{@campaign.id}}
+    class="assessment-results__charts hide-on-mobile"
+  />
+{{/if}}

--- a/orga/app/styles/components/campaign/charts/participants-by-mastery-percentage.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-mastery-percentage.scss
@@ -1,0 +1,7 @@
+.participants-by-mastery-percentage {
+  height: 320px;
+
+  &--loader {
+    height: 240px;
+  }
+}

--- a/orga/app/styles/components/campaign/index.scss
+++ b/orga/app/styles/components/campaign/index.scss
@@ -5,6 +5,7 @@
 @import "analysis/recommendation-indicator";
 @import "analysis/tube-recommendation-row";
 @import "charts/participants-by-day";
+@import "charts/participants-by-mastery-percentage";
 @import "charts/participants-by-stage";
 @import "charts/participants-by-status";
 @import "header/tabs";

--- a/orga/app/styles/pages/authenticated/campaigns/details/assessment-results.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/assessment-results.scss
@@ -1,5 +1,5 @@
 .assessment-results {
-  &__participants-by-stage {
+  &__charts {
     margin-bottom: 24px;
   }
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -7,13 +7,11 @@
     @averageResult={{@model.campaign.averageResult}}
   />
 
-  {{#if @model.campaign.hasStages}}
-    <Campaign::Charts::ParticipantsByStage
-      @campaignId={{@model.campaign.id}}
-      @onSelectStage={{this.filterByStage}}
-      class="assessment-results__participants-by-stage hide-on-mobile"
-    />
-  {{/if}}
+
+  <Campaign::Charts::ResultDistribution
+    @campaign={{@model.campaign}}
+    @onSelectStage={{this.filterByStage}}
+  />
 
   <Campaign::Results::AssessmentList
     @campaign={{@model.campaign}}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -322,6 +322,16 @@ export default function() {
     };
   });
 
+  this.get('/campaigns/:campaignId/stats/participations-by-mastery-rate', () => {
+    return {
+      data: {
+        attributes: {
+          'result-distribution': [],
+        },
+      },
+    };
+  });
+
   this.delete('/schooling-registration-user-associations/:id', (schema, request) => {
     const studentId = request.params.id;
 

--- a/orga/tests/acceptance/campaign-assessment-results_test.js
+++ b/orga/tests/acceptance/campaign-assessment-results_test.js
@@ -9,6 +9,8 @@ import {
   createPrescriberByUser,
 } from '../helpers/test-init';
 
+import setupIntl from '../helpers/setup-intl';
+
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 const pageSize = 25;
@@ -18,6 +20,7 @@ module('Acceptance | Campaign Assessment Results', function(hooks) {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.beforeEach(async () => {
     const user = createUserWithMembershipAndTermsOfServiceAccepted();
@@ -43,7 +46,7 @@ module('Acceptance | Campaign Assessment Results', function(hooks) {
       await visit('/campagnes/1/resultats-evaluation');
 
       // then
-      assert.dom('table tbody tr').exists({ count: pageSize });
+      assert.dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`).exists({ count: pageSize });
       assert.contains('Page 1 / 4');
       assert.dom('.page-size option:checked').hasText('25');
     });
@@ -57,7 +60,7 @@ module('Acceptance | Campaign Assessment Results', function(hooks) {
       await visit(`/campagnes/1/resultats-evaluation?pageNumber=${changedPageNumber}&pageSize=${changedPageSize}`);
 
       // then
-      assert.dom('table tbody tr').exists({ count: changedPageSize });
+      assert.dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`).exists({ count: changedPageSize });
       assert.contains('Page 2 / 2');
       assert.dom('.page-size option:checked').hasText(changedPageSize.toString());
     });
@@ -85,7 +88,7 @@ module('Acceptance | Campaign Assessment Results', function(hooks) {
       await fillInByLabel('Sélectionner une pagination', changedPageSize);
 
       // then
-      assert.dom('table tbody tr').exists({ count: changedPageSize });
+      assert.dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`).exists({ count: changedPageSize });
       assert.contains('Page 1 / 2');
       assert.dom('.page-size option:checked').hasText(changedPageSize.toString());
     });
@@ -96,7 +99,7 @@ module('Acceptance | Campaign Assessment Results', function(hooks) {
 
       await visit('/campagnes/1/resultats-evaluation');
       await fillInByLabel('Sélectionner une pagination', changedPageSize);
-      const someElementFromPage1 = this.element.querySelector('table tbody tr:nth-child(5)').textContent;
+      const someElementFromPage1 = this.element.querySelector('[aria-label="Participant"]:nth-child(5)').textContent;
 
       // when
       await clickByLabel('Aller à la page suivante');
@@ -116,7 +119,7 @@ module('Acceptance | Campaign Assessment Results', function(hooks) {
       await fillInByLabel('Sélectionner une pagination', changedPageSize);
 
       // then
-      assert.dom('table tbody tr').exists({ count: changedPageSize });
+      assert.dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`).exists({ count: changedPageSize });
       assert.contains('Page 1 / 2');
       assert.dom('.page-size option:checked').hasText(changedPageSize.toString());
     });

--- a/orga/tests/integration/components/campaign/charts/participants-by-mastery-percentage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-mastery-percentage_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import sinon from 'sinon';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Campaign::Charts::ParticipantsByMasteryPercentage', function(hooks) {
+  setupIntlRenderingTest(hooks);
+  const campaignId = 1;
+  let dataFetcher;
+
+  hooks.beforeEach(async function() {
+    // given
+    this.set('campaignId', campaignId);
+
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('campaign-stats');
+    dataFetcher = sinon.stub(adapter, 'getParticipationsByMasteryRate');
+  });
+
+  test('it should display chart for participation distribution', async function(assert) {
+    // given
+    dataFetcher.withArgs(campaignId).resolves({
+      data: {
+        attributes: {
+          'result-distribution': [],
+        },
+      },
+    });
+
+    // when
+    await render(hbs`<Campaign::Charts::ParticipantsByMasteryPercentage @campaignId={{campaignId}}/>`);
+
+    assert.contains('Répartition des participants par résultat');
+  });
+});

--- a/orga/tests/integration/components/campaign/charts/result-distribution_test.js
+++ b/orga/tests/integration/components/campaign/charts/result-distribution_test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import sinon from 'sinon';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Campaign::Charts::ResultDistribution', function(hooks) {
+  setupIntlRenderingTest(hooks);
+  let adapter;
+  let dataFetcher;
+
+  hooks.beforeEach(async function() {
+    const store = this.owner.lookup('service:store');
+    adapter = store.adapterFor('campaign-stats');
+  });
+
+  hooks.afterEach(async function() {
+    sinon.restore();
+  });
+
+  module('when the campaign has no stages', function(hooks) {
+    hooks.beforeEach(async function() {
+      dataFetcher = sinon.stub(adapter, 'getParticipationsByMasteryRate');
+    });
+
+    test('it should display chart for participation distribution', async function(assert) {
+      this.campaign = { id: 12, hasStages: false };
+      dataFetcher.resolves({ data: { attributes: { 'result-distribution': [] } } });
+
+      await render(hbs`<Campaign::Charts::ResultDistribution @campaign={{campaign}}/>`);
+
+      assert.contains('Répartition des participants par résultat');
+    });
+  });
+
+  module('when the campaign has stages', function(hooks) {
+    hooks.beforeEach(async function() {
+      dataFetcher = sinon.stub(adapter, 'getParticipationsByStage');
+    });
+
+    test('it should display chart for participation distribution by status', async function(assert) {
+      this.campaign = { id: 12, hasStages: true };
+      this.onSelectStage = () => {};
+      dataFetcher.resolves({ data: { attributes: { data: [ { id: 100498, value: 0 }] } } });
+
+      await render(hbs`<Campaign::Charts::ResultDistribution @campaign={{campaign}} @onSelectStage={{onSelectStage}}/>`);
+      assert.contains('Répartition des participants par paliers');
+    });
+  });
+});

--- a/orga/tests/unit/adapters/campaign-stats_test.js
+++ b/orga/tests/unit/adapters/campaign-stats_test.js
@@ -50,4 +50,16 @@ module('Unit | Adapter | campaign-stats', function(hooks) {
       assert.equal(stats, expectedStats);
     });
   });
+
+  module('getParticipationsByMasteryRate', function() {
+    test('it request participations by mastery percentage', async function(assert) {
+      const campaignId = 12;
+      const url = `${ENV.APP.API_HOST}/api/campaigns/${campaignId}/stats/participations-by-mastery-rate`;
+      const expectedStats = Symbol('result-distribution');
+      ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
+      const stats = await adapter.getParticipationsByMasteryRate(campaignId);
+
+      assert.equal(stats, expectedStats);
+    });
+  });
 });

--- a/orga/tests/unit/adapters/campaign-stats_test.js
+++ b/orga/tests/unit/adapters/campaign-stats_test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import ENV from 'pix-orga/config/environment';
+
+module('Unit | Adapter | campaign-stats', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+  let ajaxStub;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:campaign-stats');
+    ajaxStub = sinon.stub();
+    adapter.set('ajax', ajaxStub);
+  });
+
+  module('getParticipationsByStage', function() {
+    test('it request participations by stage', async function(assert) {
+      const campaignId = 12;
+      const url = `${ENV.APP.API_HOST}/api/campaigns/${campaignId}/stats/participations-by-stage`;
+      const expectedStats = Symbol('participations-by-stage');
+      ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
+      const stats = await adapter.getParticipationsByStage(campaignId);
+
+      assert.equal(stats, expectedStats);
+    });
+  });
+
+  module('getParticipationsByStatus', function() {
+    test('it request participations by status', async function(assert) {
+      const campaignId = 12;
+      const url = `${ENV.APP.API_HOST}/api/campaigns/${campaignId}/stats/participations-by-status`;
+      const expectedStats = Symbol('participations-by-status');
+      ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
+      const stats = await adapter.getParticipationsByStatus(campaignId);
+
+      assert.equal(stats, expectedStats);
+    });
+  });
+
+  module('getParticipationsByDay', function() {
+    test('it request participations by day', async function(assert) {
+      const campaignId = 12;
+      const url = `${ENV.APP.API_HOST}/api/campaigns/${campaignId}/stats/participations-by-day`;
+      const expectedStats = Symbol('participations-by-day');
+      ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
+      const stats = await adapter.getParticipationsByDay(campaignId);
+
+      assert.equal(stats, expectedStats);
+    });
+  });
+});

--- a/orga/tests/unit/components/campaign/charts/participants-by-mastery-percentage_test.js
+++ b/orga/tests/unit/components/campaign/charts/participants-by-mastery-percentage_test.js
@@ -1,0 +1,90 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Campaign::Charts::ParticipantsByMasteryPercentage', (hooks) => {
+  setupIntlRenderingTest(hooks);
+
+  let component, dataFetcher;
+
+  hooks.beforeEach(function() {
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('campaign-stats');
+    dataFetcher = sinon.stub(adapter, 'getParticipationsByMasteryRate');
+  });
+
+  test('it fills the dataset', async function(assert) {
+    dataFetcher.resolves({
+      data: {
+        attributes: {
+          'result-distribution': [
+            { masteryRate: '0.10', count: 1 },
+            { masteryRate: '0.20', count: 2 },
+            { masteryRate: '0.30', count: 3 },
+            { masteryRate: '0.40', count: 4 },
+            { masteryRate: '0.50', count: 5 },
+            { masteryRate: '0.60', count: 6 },
+            { masteryRate: '0.70', count: 7 },
+            { masteryRate: '0.80', count: 8 },
+            { masteryRate: '0.90', count: 9 },
+            { masteryRate: '1.00', count: 10 },
+          ],
+        },
+      },
+    });
+
+    component = await createGlimmerComponent('component:campaign/charts/participants-by-mastery-percentage');
+
+    assert.deepEqual(component.data.datasets[0].data, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  test('it counts the number of participation by range of 10%', async function(assert) {
+    dataFetcher.resolves({
+      data: {
+        attributes: {
+          'result-distribution': [
+            { masteryRate: '0.00', count: 2 },
+            { masteryRate: '0.10', count: 1 },
+            { masteryRate: '0.11', count: 1 },
+            { masteryRate: '0.20', count: 1 },
+            { masteryRate: '0.55', count: 4 },
+            { masteryRate: '0.90', count: 1 },
+            { masteryRate: '1.00', count: 5 },
+          ],
+        },
+      },
+    });
+
+    component = await createGlimmerComponent('component:campaign/charts/participants-by-mastery-percentage');
+
+    assert.deepEqual(component.data.datasets[0].data, [3, 2, 0, 0, 0, 4, 0, 0, 1, 5]);
+  });
+
+  test('it creates labels for each range', async function(assert) {
+    dataFetcher.resolves({
+      data: {
+        attributes: {
+          'result-distribution': [
+          ],
+        },
+      },
+    });
+
+    component = await createGlimmerComponent('component:campaign/charts/participants-by-mastery-percentage');
+
+    const labels = component.data.labels.map((label) => label.replace(/\u00A0/g, ' '));
+    assert.deepEqual(labels, [
+      '0 % - 10 %',
+      '11 % - 20 %',
+      '21 % - 30 %',
+      '31 % - 40 %',
+      '41 % - 50 %',
+      '51 % - 60 %',
+      '61 % - 70 %',
+      '71 % - 80 %',
+      '81 % - 90 %',
+      '91 % - 100 %',
+    ]);
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -74,6 +74,16 @@
     }
   },
   "charts": {
+    "participants-by-mastery-percentage": {
+      "loader": "Loading participants grouped by success rates",
+      "title": "Distribution of participants grouped by success rate",
+      "label-a11y": "From {from, number, ::percent} to {to, number, ::percent}: {count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}}",
+      "tooltip": {
+        "title": "Results {legend}",
+        "legend": "{from, number, ::percent} - {to, number, ::percent}",
+        "label": "Number of participants : {count}"
+      }
+    },
     "participants-by-stage": {
       "loader": "Loading and sorting the participants grouped by success rates",
       "participants": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}}",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -74,6 +74,16 @@
     }
   },
   "charts": {
+    "participants-by-mastery-percentage": {
+      "loader": "Chargement de la répartition des participants par résultat",
+      "title": "Répartition des participants par résultat",
+      "label-a11y": "De {from, number, ::percent} à {to, number, ::percent}: {count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}}",
+      "tooltip": {
+        "title": "Résultats {legend}",
+        "legend": "{from, number, ::percent} - {to, number, ::percent}",
+        "label": "Nombre de participants : {count}"
+      }
+    },
     "participants-by-stage": {
       "loader": "Chargement de la répartition des participants par paliers",
       "participants": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}}",


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteur ne peuvent pas visualiser la répartition des participants en fonction de leur résultat pour une campagne sans palier.

## :robot: Solution
Ajouter un graphique de répartition des résultats

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller sur PixOrga avec le compte pro.admin@example.net
- Consulter la campagne : 
- Aller sur sur l'onglet Résultat
- Il doit y avoir un graphique