### PR TITLE
[FEATURE] Suppression de l'overlay et des alertes sur les épreuves focus déjà répondues (PIX-3005).

### DIFF
--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -21,7 +21,7 @@ export default class Item extends Component {
 
   @action
   showOutOfFocusBorder() {
-    if (this.isFocusedChallenge && this.isTooltipClosed) {
+    if (this.isFocusedChallenge && this.isTooltipClosed && !this.args.answer) {
       this.args.onFocusOutOfChallenge();
       this.hasFocusedOutOfChallenge = true;
     }

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -32,11 +32,11 @@ export default class ChallengeController extends Controller {
   }
 
   get isFocusedChallengeAndUserHasFocusedOutOfChallenge() {
-    return this.model.challenge.focused && this.hasFocusedOutOfChallenge;
+    return this.model.challenge.focused && this.hasFocusedOutOfChallenge && !this.model.answer;
   }
 
   get shouldDisplayInfoAlert() {
-    return this.hasFocusedOutOfChallenge && !this.hasFocusedOutOfWindow;
+    return this.hasFocusedOutOfChallenge && !this.hasFocusedOutOfWindow && !this.model.answer;
   }
 
   get isFocusedChallengeAndTooltipIsDisplayed() {

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -18,7 +18,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
     { challengeType: 'QCM' },
     { challengeType: 'QCU' },
   ].forEach(function(data) {
-    describe(`when ${data.challengeType} challenge is focused`, () => {
+    describe(`when ${data.challengeType} challenge is focused`, function() {
 
       describe('when user has not seen the challenge tooltip yet', function() {
         beforeEach(async () => {
@@ -126,7 +126,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
         });
       });
 
-      describe('when user has already seen challenge tooltip', () => {
+      describe('when user has already seen challenge tooltip', function() {
         beforeEach(async () => {
           const user = server.create('user', 'withEmail', {
             hasSeenFocusedChallengeTooltip: true,
@@ -139,13 +139,13 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           await visit(`/assessments/${assessment.id}/challenges/0`);
         });
 
-        it('should hide the overlay and tooltip', async () => {
+        it('should hide the overlay and tooltip', async function() {
           // then
           expect(find('.challenge__focused-overlay')).to.not.exist;
           expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
         });
 
-        it('should enable input and buttons', async () => {
+        it('should enable input and buttons', async function() {
           // then
           expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
           expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
@@ -154,8 +154,8 @@ describe('Acceptance | Displaying a challenge of any type', () => {
       });
     });
 
-    describe(`when ${data.challengeType} challenge is not focused`, () => {
-      it('should not display an overlay nor a tooltip', async () => {
+    describe(`when ${data.challengeType} challenge is not focused`, function() {
+      it('should not display an overlay nor a tooltip', async function() {
         // given
         assessment = server.create('assessment', 'ofCompetenceEvaluationType');
         server.create('challenge', 'forCompetenceEvaluation', data.challengeType);

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -20,136 +20,163 @@ describe('Acceptance | Displaying a challenge of any type', () => {
   ].forEach(function(data) {
     describe(`when ${data.challengeType} challenge is focused`, function() {
 
-      describe('when user has not seen the challenge tooltip yet', function() {
-        beforeEach(async () => {
-          // given
-          const user = server.create('user', 'withEmail', {
-            hasSeenFocusedChallengeTooltip: false,
-          });
-          await authenticateByEmail(user);
+      describe('when user has not answered the question', function() {
 
-          assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-          server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
-
-          // when
-          await visit(`/assessments/${assessment.id}/challenges/0`);
-        });
-
-        it('should display an overlay and tooltip', async () => {
-          // then
-          expect(find('.challenge__focused-overlay')).to.exist;
-          expect(find('.tooltip-tag__information')).to.exist;
-        });
-
-        it('should disable input and buttons', async () => {
-          // then
-          expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.exist;
-          expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.exist;
-
-          const responseFields = findAll('[data-test="challenge-response-proposal-selector"]');
-          expect(responseFields).to.have.lengthOf.at.least(1);
-          responseFields.forEach((input) => expect(input.disabled).to.equal(true));
-        });
-
-        it('should not display an info alert with dashed border and overlay', async function() {
-          // when
-          const challengeItem = find('.challenge-item');
-          await triggerEvent(challengeItem, 'mouseleave');
-
-          // then
-          expect(find('.challenge__info-alert')).to.not.exist;
-          expect(find('.challenge-item__container--focused')).to.not.exist;
-          expect(find('.challenge__focused-out-overlay')).to.not.exist;
-        });
-
-        describe('when user closes tooltip', () => {
-          beforeEach(async function() {
+        describe('when user has not seen the challenge tooltip yet', function() {
+          beforeEach(async () => {
             // given
+            const user = server.create('user', 'withEmail', {
+              hasSeenFocusedChallengeTooltip: false,
+            });
+            await authenticateByEmail(user);
+
             assessment = server.create('assessment', 'ofCompetenceEvaluationType');
             server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
 
             // when
             await visit(`/assessments/${assessment.id}/challenges/0`);
-            await click('.tooltip-tag-information__button');
           });
 
-          it('should hide an overlay and tooltip', async () => {
+          it('should display an overlay and tooltip', async () => {
+            // then
+            expect(find('.challenge__focused-overlay')).to.exist;
+            expect(find('.tooltip-tag__information')).to.exist;
+          });
+
+          it('should disable input and buttons', async () => {
+            // then
+            expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.exist;
+            expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.exist;
+
+            const responseFields = findAll('[data-test="challenge-response-proposal-selector"]');
+            expect(responseFields).to.have.lengthOf.at.least(1);
+            responseFields.forEach((input) => expect(input.disabled).to.equal(true));
+          });
+
+          it('should not display an info alert with dashed border and overlay', async function() {
+            // when
+            const challengeItem = find('.challenge-item');
+            await triggerEvent(challengeItem, 'mouseleave');
+
+            // then
+            expect(find('.challenge__info-alert')).to.not.exist;
+            expect(find('.challenge-item__container--focused')).to.not.exist;
+            expect(find('.challenge__focused-out-overlay')).to.not.exist;
+          });
+
+          describe('when user closes tooltip', () => {
+            beforeEach(async function() {
+              // given
+              assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+              server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+
+              // when
+              await visit(`/assessments/${assessment.id}/challenges/0`);
+              await click('.tooltip-tag-information__button');
+            });
+
+            it('should hide an overlay and tooltip', async () => {
+              // then
+              expect(find('.challenge__focused-overlay')).to.not.exist;
+              expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
+            });
+
+            it('should enable input and buttons', async () => {
+              // then
+              expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
+              expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
+              expect(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled')).to.not.exist;
+            });
+
+            it('should display a warning alert', async function() {
+              // when
+              await triggerEvent(window, 'blur');
+
+              // then
+              expect(find('.challenge-actions__focused-out-of-window')).to.exist;
+            });
+
+            it('should display an info alert with dashed border and overlay', async function() {
+              // when
+              const challengeItem = find('.challenge-item');
+              await triggerEvent(challengeItem, 'mouseleave');
+
+              // then
+              expect(find('.challenge__info-alert')).to.exist;
+              expect(find('.challenge-item__container--focused')).to.exist;
+              expect(find('.challenge__focused-out-overlay')).to.exist;
+            });
+
+            it('should display only the warning alert when it has been triggered', async function() {
+              // given
+              const challengeItem = find('.challenge-item');
+              await triggerEvent(challengeItem, 'mouseleave');
+
+              expect(find('.challenge__info-alert')).to.exist;
+              expect(find('.challenge-item__container--focused')).to.exist;
+              expect(find('.challenge__focused-out-overlay')).to.exist;
+
+              // when
+              await triggerEvent(window, 'blur');
+
+              // then
+              expect(find('.challenge__info-alert')).to.not.exist;
+              expect(find('.challenge-actions__focused-out-of-window')).to.exist;
+              expect(find('.challenge-item__container--focused')).to.exist;
+              expect(find('.challenge__focused-out-overlay')).to.exist;
+            });
+          });
+        });
+
+        describe('when user has already seen challenge tooltip', function() {
+          beforeEach(async () => {
+            const user = server.create('user', 'withEmail', {
+              hasSeenFocusedChallengeTooltip: true,
+            });
+            await authenticateByEmail(user);
+
+            assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+            server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+
+            await visit(`/assessments/${assessment.id}/challenges/0`);
+          });
+
+          it('should hide the overlay and tooltip', async function() {
             // then
             expect(find('.challenge__focused-overlay')).to.not.exist;
             expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
           });
 
-          it('should enable input and buttons', async () => {
+          it('should enable input and buttons', async function() {
             // then
             expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
             expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
             expect(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled')).to.not.exist;
           });
-
-          it('should display a warning alert', async function() {
-            // when
-            await triggerEvent(window, 'blur');
-
-            // then
-            expect(find('.challenge-actions__focused-out-of-window')).to.exist;
-          });
-
-          it('should display an info alert with dashed border and overlay', async function() {
-            // when
-            const challengeItem = find('.challenge-item');
-            await triggerEvent(challengeItem, 'mouseleave');
-
-            // then
-            expect(find('.challenge__info-alert')).to.exist;
-            expect(find('.challenge-item__container--focused')).to.exist;
-            expect(find('.challenge__focused-out-overlay')).to.exist;
-          });
-
-          it('should display only the warning alert when it has been triggered', async function() {
-            // given
-            const challengeItem = find('.challenge-item');
-            await triggerEvent(challengeItem, 'mouseleave');
-
-            expect(find('.challenge__info-alert')).to.exist;
-            expect(find('.challenge-item__container--focused')).to.exist;
-            expect(find('.challenge__focused-out-overlay')).to.exist;
-
-            // when
-            await triggerEvent(window, 'blur');
-
-            // then
-            expect(find('.challenge__info-alert')).to.not.exist;
-            expect(find('.challenge-actions__focused-out-of-window')).to.exist;
-            expect(find('.challenge-item__container--focused')).to.exist;
-            expect(find('.challenge__focused-out-overlay')).to.exist;
-          });
         });
       });
 
-      describe('when user has already seen challenge tooltip', function() {
-        beforeEach(async () => {
-          const user = server.create('user', 'withEmail', {
-            hasSeenFocusedChallengeTooltip: true,
-          });
-          await authenticateByEmail(user);
-
+      describe('when user has already answered the question', function() {
+        it('should not display the overlay, dashed-border and warning messages', async function() {
+          // given
           assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-          server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+          server.create('answer', {
+            value: 'Reponse',
+            result: 'ko',
+            assessment,
+            challenge: server.create('challenge', 'forCompetenceEvaluation', `${data.challengeType}`, 'withFocused'),
+          });
 
+          // when
           await visit(`/assessments/${assessment.id}/challenges/0`);
-        });
+          const challengeItem = find('.challenge-item');
+          await triggerEvent(challengeItem, 'mouseleave');
 
-        it('should hide the overlay and tooltip', async function() {
           // then
-          expect(find('.challenge__focused-overlay')).to.not.exist;
-          expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
-        });
-
-        it('should enable input and buttons', async function() {
-          // then
-          expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
-          expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
-          expect(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled')).to.not.exist;
+          expect(find('.challenge__info-alert')).to.not.exist;
+          expect(find('.challenge__focused-out-overlay')).to.not.exist;
+          expect(find('.challenge-actions__focused-out-of-window')).to.not.exist;
+          expect(find('.challenge-actions__already-answered')).to.exist;
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Dans une épreuve focus, si l'utilisateur répond à une question et que l'on revient en arrière, les éléments caractéristiques de ce type d'épreuve réapparaissent à l'écran si l'utilisateur vient à sortir de l'épreuve et/ou cliquer hors de la fenêtre dans son navigateur, à savoir : 

- Overlay et contour en pointillés autour de l'épreuve
- Messages liés à la sortie de l'épreuve et de la fenêtre principale du navigateur

Nous ne souhaitons pas les afficher dans ce cas.

## :robot: Solution

Ajout d'une condition au rendu de ces éléments via la réponse donnée par l'utilisateur.

## :rainbow: Remarques

Plusieurs points: 

• Les conditions de rendu peuvent commencer à paraître longues avec l'ajout de la réponse.
Je n'ai pas extrait de `getter` mais cela reste bien entendu possible, voire extraire la réponse dans une condition propre, cf ci-dessous.

```
  @action
  showOutOfFocusBorder() {
    if(!this.args.answer) {
       if (this.isFocusedChallenge && this.isTooltipClosed) {
        this.args.onFocusOutOfChallenge();
        this.hasFocusedOutOfChallenge = true;
      }
    }
  }

```
• Comme les tests concernant l'affichage de ces élements se font principalement en acceptation, celui concernant leur disparition a également été réalisé comme cela.
J'ai longuement hésité à rajouter des tests d'intégration pour l'affichage ou non du message de sortie de fenêtre dans `challenge-action.hbs` pour en venir à la conclusion que cela n'était finalement pas nécessaire.

 🗣 Tout cela reste bien évidemment ouvert à la discussion.

## :100: Pour tester

- Aller sur une épreuve focus (ex: `rec6PW03oyqtPZ9rK`)
- Répondre à la question ou la passer
- Revenir à la page précédente
- Constater que les éléments mentionnés (overlay, messages d'alerte, bordure) ne soient plus visibles.
