### PR TITLE
[FEATURE][A11Y] Avoir une sémantique html correcte sur la page "Liste des campagnes" (PIX-3054).

### DIFF
--- a/orga/app/components/campaign/list-actions.hbs
+++ b/orga/app/components/campaign/list-actions.hbs
@@ -1,4 +1,5 @@
-<div class="campaign-list-actions__header hide-on-mobile">
+<header class="campaign-list-actions__header hide-on-mobile">
+  <h1 class="sr-only">{{@title}}</h1>
   <button
     role="tab"
     type="submit"
@@ -19,10 +20,7 @@
   >
     {{t 'pages.campaigns-list.action.archived.label'}}
   </button>
-
-  <div class="campaign-list-actions__create-campaign-button">
-    <PixButtonLink @route="authenticated.campaigns.new">
-      {{t 'pages.campaigns-list.action.create'}}
-    </PixButtonLink>
-  </div>
-</div>
+  <PixButtonLink @route="authenticated.campaigns.new" class="campaign-list-actions__create-campaign-button">
+    {{t 'pages.campaigns-list.action.create'}}
+  </PixButtonLink>
+</header>

--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -1,70 +1,58 @@
-<div class="campaign-list" role="tabpanel">
+<section class="campaign-list">
   <div class="panel">
-    <div class="table content-text content-text--small">
-      <table>
-        <thead>
-          <tr>
-            <th class="table__column table__column--wide">
-              {{t 'pages.campaigns-list.table.column.campaign'}}
-            </th>
-            <th class="table__column hide-on-mobile">
-              {{t 'pages.campaigns-list.table.column.created-by'}}
-            </th>
-            <th class="table__column table__column--small hide-on-mobile">
-              {{t 'pages.campaigns-list.table.column.created-on'}}
-            </th>
-            <th class="table__column table__column--small hide-on-mobile">
-              {{t 'pages.campaigns-list.table.column.participants'}}
-            </th>
-            <th class="table__column table__column--small hide-on-mobile">
-              {{t 'pages.campaigns-list.table.column.results'}}
-            </th>
-          </tr>
-          <tr class="hide-on-mobile">
-            <Table::HeaderFilterInput
-              @field="name"
-              @value={{@nameFilter}}
-              @placeholder={{t 'pages.campaigns-list.table.filter.by-name'}}
-              @ariaLabel={{t 'pages.campaigns-list.table.filter.by-name'}}
-              @triggerFiltering={{@onFilter}}
-            />
-            <Table::HeaderFilterInput
-              @field="creatorName"
-              @value={{@creatorNameFilter}}
-              @placeholder={{t 'pages.campaigns-list.table.filter.by-creator'}}
-              @ariaLabel={{t 'pages.campaigns-list.table.filter.by-creator'}}
-              @triggerFiltering={{@onFilter}}
-            />
-            <Table::Header/>
-            <Table::Header/>
-            <Table::Header/>
-          </tr>
-        </thead>
+    <table class="table content-text content-text--small">
+      <thead>
+        <tr>
+          <Table::Header @size="wide">{{t "pages.campaigns-list.table.column.campaign"}}</Table::Header>
+          <Table::Header @size="wide" class="hide-on-mobile">{{t "pages.campaigns-list.table.column.created-by"}}</Table::Header>
+          <Table::Header @size="small" class="hide-on-mobile">{{t "pages.campaigns-list.table.column.created-on"}}</Table::Header>
+          <Table::Header @size="small" class="hide-on-mobile">{{t "pages.campaigns-list.table.column.participants"}}</Table::Header>
+          <Table::Header @size="small" class="hide-on-mobile">{{t "pages.campaigns-list.table.column.results"}}</Table::Header>
+        </tr>
+        <tr class="hide-on-mobile">
+          <Table::HeaderFilterInput
+            @field="name"
+            @value={{@nameFilter}}
+            @placeholder={{t 'pages.campaigns-list.table.filter.by-name'}}
+            @ariaLabel={{t 'pages.campaigns-list.table.filter.by-name'}}
+            @triggerFiltering={{@onFilter}}
+          />
+          <Table::HeaderFilterInput
+            @field="creatorName"
+            @value={{@creatorNameFilter}}
+            @placeholder={{t 'pages.campaigns-list.table.filter.by-creator'}}
+            @ariaLabel={{t 'pages.campaigns-list.table.filter.by-creator'}}
+            @triggerFiltering={{@onFilter}}
+          />
+          <Table::Header/>
+          <Table::Header/>
+          <Table::Header/>
+        </tr>
+      </thead>
 
-        <tbody>
-        {{#each @campaigns as |campaign|}}
-          <tr aria-label={{t 'pages.campaigns-list.table.row-title'}} {{on 'click' (fn @onClickCampaign campaign.id)}} class="tr--clickable">
-            <td class="table__column">
-              <LinkTo @route="authenticated.campaigns.campaign"
-                      @model={{campaign}}>
-                {{campaign.name}}
-              </LinkTo>
-            </td>
-            <td class="table__column--truncated hide-on-mobile">{{campaign.creatorFullName}}</td>
-            <td class="hide-on-mobile">{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
-            <td class="hide-on-mobile">{{campaign.participationsCount}}</td>
-            <td class="hide-on-mobile">{{campaign.sharedParticipationsCount}}</td>
-          </tr>
-        {{/each}}
-        </tbody>
-      </table>
-      {{#if (eq @campaigns.length 0)}}
-        <div class="table__empty content-text">
-          {{t 'pages.campaigns-list.table.empty'}}
-        </div>
-      {{/if}}
-    </div>
+      <tbody>
+      {{#each @campaigns as |campaign|}}
+        <tr aria-label={{t 'pages.campaigns-list.table.row-title'}} {{on 'click' (fn @onClickCampaign campaign.id)}} class="tr--clickable">
+          <td class="table__column">
+            <LinkTo @route="authenticated.campaigns.campaign"
+                    @model={{campaign}}>
+              {{campaign.name}}
+            </LinkTo>
+          </td>
+          <td class="table__column--truncated hide-on-mobile">{{campaign.creatorFullName}}</td>
+          <td class="hide-on-mobile">{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
+          <td class="hide-on-mobile">{{campaign.participationsCount}}</td>
+          <td class="hide-on-mobile">{{campaign.sharedParticipationsCount}}</td>
+        </tr>
+      {{/each}}
+      </tbody>
+    </table>
+    {{#if (eq @campaigns.length 0)}}
+      <p class="table__empty content-text">
+        {{t 'pages.campaigns-list.table.empty'}}
+      </p>
+    {{/if}}
   </div>
-</div>
 
-<Table::PaginationControl @pagination={{@campaigns.meta}}/>
+  <Table::PaginationControl @pagination={{@campaigns.meta}}/>
+</section>

--- a/orga/app/components/campaign/no-campaign-panel.hbs
+++ b/orga/app/components/campaign/no-campaign-panel.hbs
@@ -1,18 +1,14 @@
-<div class="no-campaign-panel">
-  <div class="no-campaign-panel__explain-create-campaign">
-    <img src="{{this.rootURL}}/icons/icon-campagne-start.svg" alt="" role="none">
-    <h1 class="page-title">
-      {{t 'pages.campaigns-list.no-campaign.title'}}
-    </h1>
+<section class="no-campaign-panel">
+  <img src="{{this.rootURL}}/icons/icon-campagne-start.svg" alt="" role="none">
+  <h1 class="page-title">
+    {{t 'pages.campaigns-list.no-campaign.title'}}
+  </h1>
 
-    <div class="no-campaign-panel__information-text information-text">
-      {{t 'pages.campaigns-list.no-campaign.description'}}
-    </div>
+  <p class="no-campaign-panel__information-text information-text">
+    {{t 'pages.campaigns-list.no-campaign.description'}}
+  </p>
 
-    <div class="no-campaign-panel__link-to-create">
-      <PixButtonLink @route="authenticated.campaigns.new">
-        {{t 'pages.campaigns-list.action.create'}}
-      </PixButtonLink>
-    </div>
-  </div>
-</div>
+  <PixButtonLink @route="authenticated.campaigns.new">
+    {{t 'pages.campaigns-list.action.create'}}
+  </PixButtonLink>
+</section>

--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -1,4 +1,4 @@
-<form {{on 'submit' @onSubmit}}>
+<form class="form" {{on 'submit' @onSubmit}}>
   <div class="form__field">
     <label for="campaign-name" class="label">{{ t 'pages.campaign-modification.campaign-name' }}</label>
     <Input
@@ -36,7 +36,7 @@
   </div>
 
   <div class="form__validation">
-    <PixButton 
+    <PixButton
       @triggerAction={{fn @onCancel @campaign.id}}
       @backgroundColor="transparent-light"
     >

--- a/orga/app/components/table/pagination-control.hbs
+++ b/orga/app/components/table/pagination-control.hbs
@@ -1,8 +1,6 @@
-<div class="pagination-control content-text content-text--small">
-  <div class="page-size">
-    <div class="page-size__label">
-      {{t 'common.pagination.result-by-page'}}
-    </div>
+<footer class="pagination-control content-text content-text--small">
+  <section class="page-size">
+    <p class="page-size__label">{{t 'common.pagination.result-by-page'}}</p>
     <PixSelect
       aria-label={{t 'common.pagination.action.select-page-size'}}
       class="page-size__choice"
@@ -10,34 +8,32 @@
       @onChange={{this.changePageSize}}
       @options={{this.pageOptions}}
     />
-  </div>
-  <div class="page-navigation">
-    <div class="page-navigation__arrow page-navigation__arrow--previous">
-      <PixIconButton
-        @icon="arrow-left"
-        aria-label={{t 'common.pagination.action.previous'}}
-        @triggerAction={{this.goToPreviousPage}}
-        @withBackground={{false}}
-        @size="small"
-        @color="dark-grey"
-        disabled={{eq this.currentPage 1}}
-        aria-disabled="{{eq this.currentPage 1}}"
-      />
-    </div>
-    <div>
+  </section>
+  <section class="page-navigation">
+    <PixIconButton
+      @icon="arrow-left"
+      aria-label={{t 'common.pagination.action.previous'}}
+      @triggerAction={{this.goToPreviousPage}}
+      @withBackground={{false}}
+      @size="small"
+      @color="dark-grey"
+      disabled={{eq this.currentPage 1}}
+      aria-disabled="{{eq this.currentPage 1}}"
+      class="page-navigation__arrow page-navigation__arrow--previous"
+    />
+    <p>
       {{t 'common.pagination.page-number' current=this.currentPage total=(if this.pageCount this.pageCount 1)}}
-    </div>
-    <div class="page-navigation__arrow page-navigation__arrow--next">
-      <PixIconButton
-        @icon="arrow-right"
-        aria-label={{t 'common.pagination.action.next'}}
-        @triggerAction={{this.goToNextPage}}
-        @withBackground={{false}}
-        @size="small"
-        @color="dark-grey"
-        disabled={{or (eq this.currentPage this.pageCount) (eq this.pageCount 0)}}
-        aria-disabled="{{or (eq this.currentPage this.pageCount) (eq this.pageCount 0)}}"
-      />
-    </div>
-  </div>
-</div>
+    </p>
+    <PixIconButton
+      @icon="arrow-right"
+      aria-label={{t 'common.pagination.action.next'}}
+      @triggerAction={{this.goToNextPage}}
+      @withBackground={{false}}
+      @size="small"
+      @color="dark-grey"
+      disabled={{or (eq this.currentPage this.pageCount) (eq this.pageCount 0)}}
+      aria-disabled="{{or (eq this.currentPage this.pageCount) (eq this.pageCount 0)}}"
+      class="page-navigation__arrow page-navigation__arrow--next"
+    />
+  </section>
+</footer>

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -46,7 +46,6 @@
 @import "pages/join";
 @import "pages/join-request";
 @import "pages/authenticated";
-@import "pages/authenticated/campaigns";
 @import "pages/authenticated/campaigns/campaign";
 @import "pages/authenticated/campaigns/new";
 @import "pages/authenticated/campaigns/new-item";

--- a/orga/app/styles/components/campaign/list-actions.scss
+++ b/orga/app/styles/components/campaign/list-actions.scss
@@ -6,7 +6,6 @@
   }
 
   &__create-campaign-button {
-    margin-top: 20px;
     margin-left: auto;
   }
 

--- a/orga/app/styles/components/campaign/list.scss
+++ b/orga/app/styles/components/campaign/list.scss
@@ -1,6 +1,5 @@
 .campaign-list {
-  display: flex;
-  flex-direction: column;
+  padding: 0;
 
   &__link {
     color: $grey-80;

--- a/orga/app/styles/components/campaign/no-campaign-panel.scss
+++ b/orga/app/styles/components/campaign/no-campaign-panel.scss
@@ -2,19 +2,11 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-
-  &__explain-create-campaign {
-    text-align: center;
-    margin: 5%;
-  }
+  align-items: center;
+  text-align: center;
+  margin: 5%;
 
   &__information-text {
-    margin: 30px 30%;
-  }
-
-  &__link-to-create {
-    display: flex;
-    justify-content: center;
-    padding-top: 20px;
+    margin: 0 30% 30px 30%;
   }
 }

--- a/orga/app/styles/components/pagination-control.scss
+++ b/orga/app/styles/components/pagination-control.scss
@@ -8,6 +8,7 @@
 .page-size {
   display: flex;
   align-items: center;
+  padding: 0;
 
   &__label {
     margin-right: 16px;
@@ -24,6 +25,7 @@ select.page-size__choice {
 .page-navigation {
   display: flex;
   align-items: center;
+  padding: 0;
 
   &__arrow {
     &--previous {

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -66,7 +66,7 @@ tbody {
     > a {
       color: $grey-80;
       text-decoration: none;
-  
+
       &:hover,
       &:focus,
       &:active {
@@ -152,5 +152,6 @@ th::first-letter {
   align-items: center;
   height: 180px;
   text-align: center;
-  border-top: 2px solid $grey-10;
+  border-top: 1px solid $grey-15;
+  margin: 0;
 }

--- a/orga/app/styles/pages/authenticated/campaigns.scss
+++ b/orga/app/styles/pages/authenticated/campaigns.scss
@@ -1,3 +1,0 @@
-.campaign-layout {
-  display: flex;
-}

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -6,9 +6,9 @@
 
     <Banner::Information />
 
-    <div class="main-content__body page">
+    <main class="main-content__body page">
       {{outlet}}
-    </div>
+    </main>
   </div>
 
   <NotificationContainer @position="bottom-right" />

--- a/orga/app/templates/authenticated/campaigns.hbs
+++ b/orga/app/templates/authenticated/campaigns.hbs
@@ -1,3 +1,1 @@
-<div class="campaign-layout">
-  {{outlet}}
-</div>
+{{outlet}}

--- a/orga/app/templates/authenticated/campaigns/list.hbs
+++ b/orga/app/templates/authenticated/campaigns/list.hbs
@@ -2,7 +2,8 @@
 
 <article class="list-campaigns-page">
   {{#if @model.meta.hasCampaigns}}
-    <Campaign::ListActions 
+    <Campaign::ListActions
+      @title={{this.pageTitle}}
       @isArchived={{this.isArchived}}
       @onClickStatusFilter={{this.updateCampaignStatus}}
     />

--- a/orga/app/templates/authenticated/campaigns/list.hbs
+++ b/orga/app/templates/authenticated/campaigns/list.hbs
@@ -1,6 +1,6 @@
 {{page-title this.pageTitle}}
 
-<div class="list-campaigns-page">
+<article class="list-campaigns-page">
   {{#if @model.meta.hasCampaigns}}
     <Campaign::ListActions 
       @isArchived={{this.isArchived}}
@@ -16,4 +16,4 @@
   {{else}}
     <Campaign::NoCampaignPanel />
   {{/if}}
-</div>
+</article>


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Orga, très peu de balises sémantiques sont utilisées. Cela pose un problème pour l'accessibilité de la plateforme.

## :robot: Solution
Corriger cela, page par page. Ici la page de la liste des campagnes.

## :rainbow: Remarques
Rien à signaler

## :100: Pour tester
Vérifier la non-régression de :
- la liste des campagnes actives
- la liste des campagnes archivées
- le bouton "créer une campagne"
- la pagination de la liste
- le panel par défaut quand il n'y a pas de campagnes (no-campaign-panel)
- le panel par défaut quand toutes les campagnes sont filtrées ("Aucune campagne")
