### PR TITLE
[BUGFIX]  Afficher un encart "en attente de résultats" dans l'onglet analyse individuelle quand la personne n'a pas encore partagé ses résultats (PIX-3067).

### DIFF
--- a/orga/app/components/campaign/analysis/recommendations.hbs
+++ b/orga/app/components/campaign/analysis/recommendations.hbs
@@ -24,10 +24,15 @@
       </tr>
     </thead>
 
-    <tbody>
-      {{#each this.sortedRecommendations as |tubeRecommendation|}}
-        <Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{tubeRecommendation}} />
-      {{/each}}
-    </tbody>
+    {{#if @displayAnalysis}}
+      <tbody>
+        {{#each this.sortedRecommendations as |tubeRecommendation|}}
+          <Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{tubeRecommendation}} />
+        {{/each}}
+      </tbody>
+    {{/if}}
   </table>
+  {{#unless @displayAnalysis}}
+    <div class="table__empty content-text">{{t 'pages.campaign-review.table.empty'}}</div>
+  {{/unless}}
 </div>

--- a/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendations_test.js
@@ -8,7 +8,7 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
 
   let store;
 
-  module('when the analysis is displayed', function () {
+  module('when the analysis is displayed', function(hooks) {
     hooks.beforeEach(async function() {
       store = this.owner.lookup('service:store');
 
@@ -66,6 +66,18 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
       await click('[aria-label="Trier par pertinence"]');
 
       assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+    });
+  });
+
+  module('when the analysis is not displayed', function() {
+    test('it displays pending results', async function(assert) {
+      this.campaignTubeRecommendations = [];
+
+      await render(hbs`<Campaign::Analysis::Recommendations
+        @campaignTubeRecommendations={{campaignTubeRecommendations}}
+        @displayAnalysis={{false}}
+      />`);
+      assert.contains('En attente de résultats');
     });
   });
 });

--- a/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendations_test.js
@@ -8,62 +8,64 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
 
   let store;
 
-  hooks.beforeEach(async function() {
-    store = this.owner.lookup('service:store');
+  module('when the analysis is displayed', function () {
+    hooks.beforeEach(async function() {
+      store = this.owner.lookup('service:store');
 
-    const campaignTubeRecommendation_1 = store.createRecord('campaign-tube-recommendation', {
-      id: '1_recTubeA',
-      tubeId: 'recTubeA',
-      competenceId: 'recCompA',
-      competenceName: 'Competence A',
-      tubePracticalTitle: 'Tube A',
-      areaColor: 'jaffa',
-      averageScore: 10,
-    });
+      const campaignTubeRecommendation_1 = store.createRecord('campaign-tube-recommendation', {
+        id: '1_recTubeA',
+        tubeId: 'recTubeA',
+        competenceId: 'recCompA',
+        competenceName: 'Competence A',
+        tubePracticalTitle: 'Tube A',
+        areaColor: 'jaffa',
+        averageScore: 10,
+      });
 
-    const campaignTubeRecommendation_2 = store.createRecord('campaign-tube-recommendation', {
-      id: '1_recTubeB',
-      tubeId: 'recTubeB',
-      competenceId: 'recCompB',
-      competenceName: 'Competence B',
-      tubePracticalTitle: 'Tube B',
-      areaColor: 'emerald',
-      averageScore: 30,
-    });
+      const campaignTubeRecommendation_2 = store.createRecord('campaign-tube-recommendation', {
+        id: '1_recTubeB',
+        tubeId: 'recTubeB',
+        competenceId: 'recCompB',
+        competenceName: 'Competence B',
+        tubePracticalTitle: 'Tube B',
+        areaColor: 'emerald',
+        averageScore: 30,
+      });
 
-    this.campaignTubeRecommendations = [campaignTubeRecommendation_1, campaignTubeRecommendation_2];
+      this.campaignTubeRecommendations = [campaignTubeRecommendation_1, campaignTubeRecommendation_2];
 
-    await render(hbs`<Campaign::Analysis::Recommendations
+      await render(hbs`<Campaign::Analysis::Recommendations
       @campaignTubeRecommendations={{campaignTubeRecommendations}}
       @displayAnalysis={{true}}
     />`);
-  });
+    });
 
-  test('it should display the tube analysis list of the campaign', async function(assert) {
-    assert.dom('[aria-label="Sujet"]').exists({ count: 2 });
-    assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
-  });
+    test('it should display the tube analysis list of the campaign', async function(assert) {
+      assert.dom('[aria-label="Sujet"]').exists({ count: 2 });
+      assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+    });
 
-  test('it should display tube details', async function(assert) {
-    const firstTube = '[aria-label="Sujet"]:first-child';
-    assert.dom(firstTube).containsText('Tube A');
-    assert.dom(firstTube).containsText('Competence A');
-  });
+    test('it should display tube details', async function(assert) {
+      const firstTube = '[aria-label="Sujet"]:first-child';
+      assert.dom(firstTube).containsText('Tube A');
+      assert.dom(firstTube).containsText('Competence A');
+    });
 
-  test('it should order by recommendation desc by default', async function(assert) {
-    assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
-  });
+    test('it should order by recommendation desc by default', async function(assert) {
+      assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+    });
 
-  test('it should order by recommendation asc', async function(assert) {
-    await click('[aria-label="Trier par pertinence"]');
+    test('it should order by recommendation asc', async function(assert) {
+      await click('[aria-label="Trier par pertinence"]');
 
-    assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube B');
-  });
+      assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube B');
+    });
 
-  test('it should order by recommendation desc', async function(assert) {
-    await click('[aria-label="Trier par pertinence"]');
-    await click('[aria-label="Trier par pertinence"]');
+    test('it should order by recommendation desc', async function(assert) {
+      await click('[aria-label="Trier par pertinence"]');
+      await click('[aria-label="Trier par pertinence"]');
 
-    assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+      assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+    });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -381,7 +381,8 @@
             }
           },
           "row-title": "Competence"
-        }
+        },
+        "empty": "Pending results"
       }
     },
     "campaigns-list": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -381,7 +381,8 @@
             }
           },
           "row-title": "Compétence"
-        }
+        },
+        "empty": "En attente de résultats"
       }
     },
     "campaigns-list": {


### PR DESCRIPTION
## :unicorn: Problème
Quand l'analyse des résultats n'est pas disponible parce que le participant n'a pas partagé ses résultats on voit un tableau vide s'afficher et on ne sait pas pourquoi.

## :robot: Solution
Afficher un message "En attente de résultats"

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Afficher l'analyse des résultats d'une personne qui n'a pas partagé ses résultats et il doit y avoir le message "En attente de résultats"
