### PR TITLE
[TECH] Mettre l'annulation via taux de réponse sous toggle (PIX-3077)

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -5,6 +5,7 @@ const AutoJuryDone = require('./AutoJuryDone');
 const CertificationJuryDone = require('./CertificationJuryDone');
 const bluebird = require('bluebird');
 const { CertificationIssueReportResolutionStrategies } = require('../models/CertificationIssueReportResolutionStrategies');
+const { featureToggles } = require('../../config');
 
 const eventTypes = [ SessionFinalized ];
 
@@ -28,7 +29,7 @@ async function handleAutoJury({
 
     const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: certificationCourse.getId() });
 
-    if (certificationAssessment.hasUnsufficientAnsweringRateToBeScored()) {
+    if (featureToggles.isManageUncompletedCertifEnabled && certificationAssessment.hasUnsufficientAnsweringRateToBeScored()) {
       certificationCourse.cancel();
       await certificationCourseRepository.update(certificationCourse);
       return;


### PR DESCRIPTION
## :unicorn: Problème
Il reste encore des interrogations sur le besoin introduit dans la PR #3359. Pour éviter tout effet de bord d'une feature en cours de réflexion, nous allons soumettre son implémentation à feature toggle

## :robot: Solution
Implementer l'annulation seulement si le toggle FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED est activé


## :100: Pour tester
Activer le toggle FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED:

Passer une certification avec au moins deux candidats
- Répondre à toutes les questions avec un candidat
- Répondre à moins de 33% avec le deuxième candidat
- Finaliser la session
- Constater dans pix-admin que la certification du candidat ayant répondu à moins de 33% des épreuves est annulée

Désactiver le toggle FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED:

Passer une certification avec au moins deux candidats
- Répondre à toutes les questions avec un candidat
- Répondre à moins de 33% avec le deuxième candidat
- Finaliser la session
- Constater dans pix-admin que la certification du candidat ayant répondu à moins de 33% des épreuves est n'est pas annulée et en statut "Démarrée"
