### PR TITLE
[TECH] Supprime les setups de test dans le describe (pix-3378)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -127,7 +127,7 @@
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
-    "test:api:unit": "TEST_DATABASE_URL=postgres://foo REDIS_URL=redis://bar npm run test:api:path -- tests/unit",
+    "test:api:unit": "TEST_DATABASE_URL=postgres://SHOULD_NOT_REACH_DB_IN_UNIT_TESTS REDIS_URL=redis://SHOULD_NOT_REACH_REDIS_IN_UNIT_TESTS npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -6,118 +6,98 @@ const assessmentRepository = require('../../../../lib/infrastructure/repositorie
 const assessmentResultRepository = require('../../../../lib/infrastructure/repositories/assessment-result-repository');
 const getSessionResults = require('../../../../lib/domain/usecases/get-session-results');
 
-describe('Unit | Domain | Use Cases | get-session-results', function() {
+describe('Unit | Domain | Use Cases | get-session-results', function() {
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const sessionWith2Candidates = domainBuilder.buildSession({ date: '2020/01/01', time: '12:00' });
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const sessionId = sessionWith2Candidates.id;
-  const certificationCourseRepository = {};
-  const sessionRepositoryStub = {};
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certifCourse1 = domainBuilder.buildCertificationCourse({ id: 1 });
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certifCourse2 = domainBuilder.buildCertificationCourse({ id: 2 });
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certifCourse3 = domainBuilder.buildCertificationCourse({ id: 3 });
+  let sessionWith2Candidates;
+  let certificationCourseRepository;
+  let sessionRepository;
 
-  const cleaCertificationResults = [
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildCleaCertificationResult.acquired(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildCleaCertificationResult.rejected(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildCleaCertificationResult.notTaken(),
-  ];
-  const pixPlusDroitMaitreCertificationResults = [
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-  ];
-  const pixPlusDroitExpertCertificationResults = [
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
-  ];
-  const assessmentsIds = [ 1, 2, 3 ];
-
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const assessmentResult1 = domainBuilder.buildAssessmentResult({ pixScore: 500, competenceMarks: [], createdAt: 'lundi', assessmentId: assessmentsIds[0] });
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const assessmentResult2 = domainBuilder.buildAssessmentResult({ pixScore: 10, competenceMarks: [], createdAt: 'mardi', assessmentId: assessmentsIds[1], commentForCandidate: 'Son ordinateur a explosé' });
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const assessmentResult3 = domainBuilder.buildAssessmentResult({ pixScore: 400, competenceMarks: [], createdAt: 'mercredi', assessmentId: assessmentsIds[2] });
-
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const firstCertifResult = _buildCertificationResult(certifCourse1, assessmentResult1, cleaCertificationResults[0], pixPlusDroitMaitreCertificationResults[0], pixPlusDroitExpertCertificationResults[0]);
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const secondCertifResult = _buildCertificationResult(certifCourse2, assessmentResult2, cleaCertificationResults[1], pixPlusDroitMaitreCertificationResults[1], pixPlusDroitExpertCertificationResults[1]);
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const thirdCertifResult = _buildCertificationResult(certifCourse3, assessmentResult3, cleaCertificationResults[2], pixPlusDroitMaitreCertificationResults[2], pixPlusDroitExpertCertificationResults[2]);
+  const assessmentId = 1;
+  let certifCourse;
+  let assessmentResult;
+  let cleaCertificationResultRepositoryStub;
+  let pixPlusMaitreCertificationResultRepositoryStub;
+  let pixPlusExpertCertificationResultRepositoryStub;
+  let assessmentRepositoryStub;
+  let assessmentResultRepositoryStub;
 
   beforeEach(function() {
-    // given
-    sessionRepositoryStub.get = sinon.stub().withArgs(sessionId).resolves(sessionWith2Candidates);
+    cleaCertificationResultRepositoryStub = sinon.stub(cleaCertificationResultRepository, 'get');
+    pixPlusMaitreCertificationResultRepositoryStub = sinon.stub(pixPlusMaitreCertificationResultRepository, 'get');
+    pixPlusExpertCertificationResultRepositoryStub = sinon.stub(pixPlusExpertCertificationResultRepository, 'get');
+    assessmentRepositoryStub = sinon.stub(assessmentRepository, 'getIdByCertificationCourseId');
+    assessmentResultRepositoryStub = sinon.stub(assessmentResultRepository, 'findLatestByCertificationCourseIdWithCompetenceMarks');
 
-    certificationCourseRepository.findCertificationCoursesBySessionId = sinon.stub().withArgs({ sessionId }).resolves([certifCourse1, certifCourse2, certifCourse3]);
+    sessionWith2Candidates = domainBuilder.buildSession({ date: '2020/01/01', time: '12:00' });
 
-    const cleaCertificationResultRepositoryStub = sinon.stub(cleaCertificationResultRepository, 'get');
-    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.getId() }).resolves(cleaCertificationResults[0]);
-    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.getId() }).resolves(cleaCertificationResults[1]);
-    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.getId() }).resolves(cleaCertificationResults[2]);
+    certifCourse = domainBuilder.buildCertificationCourse({ id: 1 });
+    assessmentResult = domainBuilder.buildAssessmentResult({ pixScore: 500, competenceMarks: [], createdAt: 'lundi', assessmentId });
 
-    const pixPlusMaitreCertificationResultRepositoryStub = sinon.stub(pixPlusMaitreCertificationResultRepository, 'get');
-    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.getId() }).resolves(pixPlusDroitMaitreCertificationResults[0]);
-    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.getId() }).resolves(pixPlusDroitMaitreCertificationResults[1]);
-    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.getId() }).resolves(pixPlusDroitMaitreCertificationResults[2]);
+    certificationCourseRepository = {
+      findCertificationCoursesBySessionId: sinon.stub(),
+    };
+    sessionRepository = {
+      get: sinon.stub(),
+    };
 
-    const pixPlusExpertCertificationResultRepositoryStub = sinon.stub(pixPlusExpertCertificationResultRepository, 'get');
-    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.getId() }).resolves(pixPlusDroitExpertCertificationResults[0]);
-    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.getId() }).resolves(pixPlusDroitExpertCertificationResults[1]);
-    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.getId() }).resolves(pixPlusDroitExpertCertificationResults[2]);
-
-    const assessmentRepositoryStub = sinon.stub(assessmentRepository, 'getIdByCertificationCourseId');
-    assessmentRepositoryStub.withArgs(certifCourse1.getId()).resolves(assessmentsIds[0]);
-    assessmentRepositoryStub.withArgs(certifCourse2.getId()).resolves(assessmentsIds[1]);
-    assessmentRepositoryStub.withArgs(certifCourse3.getId()).resolves(assessmentsIds[2]);
-
-    const assessmentResultRepositoryStub = sinon.stub(assessmentResultRepository, 'findLatestByCertificationCourseIdWithCompetenceMarks');
-    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.getId() }).resolves(assessmentResult1);
-    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.getId() }).resolves(assessmentResult2);
-    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.getId() }).resolves(assessmentResult3);
+    sessionRepository.get.withArgs(sessionWith2Candidates.id).resolves(sessionWith2Candidates);
   });
 
   it('should return all certification results', async function() {
+    //before
+    const assessmentId2 = 2;
+    const assessmentId3 = 3;
+    const certifCourse2 = domainBuilder.buildCertificationCourse({ id: 2 });
+    const assessmentResult2 = domainBuilder.buildAssessmentResult({ pixScore: 10, competenceMarks: [], createdAt: 'mardi', assessmentId: assessmentId2, commentForCandidate: 'Son ordinateur a explosé' });
+    const certifCourse3 = domainBuilder.buildCertificationCourse({ id: 3 });
+    const assessmentResult3 = domainBuilder.buildAssessmentResult({ pixScore: 400, competenceMarks: [], createdAt: 'mercredi', assessmentId: assessmentId3 });
+
+    const cleaCertificationResults = [
+      domainBuilder.buildCleaCertificationResult.acquired(),
+      domainBuilder.buildCleaCertificationResult.rejected(),
+      domainBuilder.buildCleaCertificationResult.notTaken(),
+    ];
+    const pixPlusDroitMaitreCertificationResults = [
+      domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired(),
+      domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected(),
+      domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
+    ];
+    const pixPlusDroitExpertCertificationResults = [
+      domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired(),
+      domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected(),
+      domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
+    ];
+
+    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse.getId() }).resolves(cleaCertificationResults[0]);
+    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.getId() }).resolves(cleaCertificationResults[1]);
+    cleaCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.getId() }).resolves(cleaCertificationResults[2]);
+
+    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse.getId() }).resolves(pixPlusDroitMaitreCertificationResults[0]);
+    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.getId() }).resolves(pixPlusDroitMaitreCertificationResults[1]);
+    pixPlusMaitreCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.getId() }).resolves(pixPlusDroitMaitreCertificationResults[2]);
+
+    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse.getId() }).resolves(pixPlusDroitExpertCertificationResults[0]);
+    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.getId() }).resolves(pixPlusDroitExpertCertificationResults[1]);
+    pixPlusExpertCertificationResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.getId() }).resolves(pixPlusDroitExpertCertificationResults[2]);
+
+    const firstCertifResult = _buildCertificationResult(certifCourse, assessmentResult, cleaCertificationResults[0], pixPlusDroitMaitreCertificationResults[0], pixPlusDroitExpertCertificationResults[0]);
+    const secondCertifResult = _buildCertificationResult(certifCourse2, assessmentResult2, cleaCertificationResults[1], pixPlusDroitMaitreCertificationResults[1], pixPlusDroitExpertCertificationResults[1]);
+    const thirdCertifResult = _buildCertificationResult(certifCourse3, assessmentResult3, cleaCertificationResults[2], pixPlusDroitMaitreCertificationResults[2], pixPlusDroitExpertCertificationResults[2]);
+
+    assessmentRepositoryStub.withArgs(certifCourse.getId()).resolves(assessmentId);
+    assessmentRepositoryStub.withArgs(certifCourse2.getId()).resolves(assessmentId2);
+    assessmentRepositoryStub.withArgs(certifCourse3.getId()).resolves(assessmentId3);
+
+    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse.getId() }).resolves(assessmentResult);
+    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.getId() }).resolves(assessmentResult2);
+    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.getId() }).resolves(assessmentResult3);
+
+    certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: sessionWith2Candidates.id }).resolves([certifCourse, certifCourse2, certifCourse3]);
+
     // when
     const { certificationResults } = await getSessionResults({
-      sessionId,
-      sessionRepository: sessionRepositoryStub,
+      sessionId: sessionWith2Candidates.id,
+      sessionRepository,
       certificationCourseRepository,
     });
 
@@ -127,10 +107,13 @@ describe('Unit | Domain | Use Cases | get-session-results', function() {
   });
 
   it('should return the session', async function() {
+    // given
+    certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: sessionWith2Candidates.id }).resolves([certifCourse]);
+
     // when
     const { session } = await getSessionResults({
-      sessionId,
-      sessionRepository: sessionRepositoryStub,
+      sessionId: sessionWith2Candidates.id,
+      sessionRepository,
       certificationCourseRepository,
     });
 
@@ -140,15 +123,18 @@ describe('Unit | Domain | Use Cases | get-session-results', function() {
   });
 
   it('should return the fileName', async function() {
+    // given
+    certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: sessionWith2Candidates.id }).resolves([certifCourse]);
+
     // when
     const { fileName } = await getSessionResults({
-      sessionId,
-      sessionRepository: sessionRepositoryStub,
+      sessionId: sessionWith2Candidates.id,
+      sessionRepository,
       certificationCourseRepository,
     });
 
     // then
-    const expectedFileName = `20200101_1200_resultats_session_${sessionId}.csv`;
+    const expectedFileName = `20200101_1200_resultats_session_${sessionWith2Candidates.id}.csv`;
     expect(fileName).to.deep.equal(expectedFileName);
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les setups de tests directement dans le describe peut aboutir à des conflits/erreurs/flaky
[no-setup-in-describe](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md)

## :robot: Solution
Déplacer le setup dans un beforeEach/dans les tests

## :rainbow: Remarques
Une grosse partie du setup n'est utilisé que par un seul des tests
Un commit spécifique renomme les URL des fake ressources externes (BDD/cache) afin que les messages d'erreurs soient plus parlant:

> Error: getaddrinfo ENOTFOUND should_not_reach_db_in_unit_tests

au lieu de 

> Error: getaddrinfo ENOTFOUND foo


## :100: Pour tester
Lancer les tests
