### PR TITLE
[FEATURE] Ajout d'une section pour les certifications non terminées d'une session à finaliser (PIX-3062)

### DIFF
--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -1,6 +1,6 @@
 <div class="table session-finalization-reports-information-step">
   {{#if (gt @session.uncompletedCertificationReports.length 0)}}
-    <div class="session-finalization-reports-information-step__title">
+    <div class="session-finalization-reports-information-step__title-completed">
       <FaIcon @icon="check-circle" class="session-finalization-reports-information-step__icon" />
       Certification(s) terminée(s)
     </div>

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -1,8 +1,10 @@
 <div class="table session-finalization-reports-information-step">
-  <div class="session-finalization-reports-information-step__title">
-    <FaIcon @icon="check-circle" class="session-finalization-reports-information-step__icon" />
-    Certification(s) terminée(s)
-  </div>
+  {{#if (gt @session.uncompletedCertificationReports.length 0)}}
+    <div class="session-finalization-reports-information-step__title">
+      <FaIcon @icon="check-circle" class="session-finalization-reports-information-step__icon" />
+      Certification(s) terminée(s)
+    </div>
+  {{/if}}
   <table>
     <thead>
       <tr>

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -1,4 +1,4 @@
-<div class="table session-finalization-reports-informations-step">
+<div class="table session-finalization-reports-information-step">
   <table>
     <thead>
       <tr>
@@ -7,8 +7,8 @@
         <th>N° de certification</th>
         <th>Signalement</th>
         <th>
-          <div class="session-finalization-reports-informations-step__row">
-            <div class="session-finalization-reports-informations-step__checker" {{on 'click' (fn @onAllHasSeenEndTestScreenCheckboxesClicked this.hasCheckedSomething)}}>
+          <div class="session-finalization-reports-information-step__row">
+            <div class="session-finalization-reports-information-step__checker" {{on 'click' (fn @onAllHasSeenEndTestScreenCheckboxesClicked this.hasCheckedSomething)}}>
               <CertifCheckbox @state={{this.headerCheckboxStatus}}></CertifCheckbox>
             </div>
             Écran de fin du test vu

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -1,5 +1,6 @@
 <div class="table session-finalization-reports-information-step">
   <div class="session-finalization-reports-information-step__title">
+    <FaIcon @icon="check-circle" class="session-finalization-reports-information-step__icon" />
     Certification(s) terminée(s)
   </div>
   <table>

--- a/certif/app/components/session-finalization/completed-reports-information-step.js
+++ b/certif/app/components/session-finalization/completed-reports-information-step.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-export default class ReportsInformationsStep extends Component {
+export default class CompletedReportsInformationStep extends Component {
   textareaMaxLength = 500;
 
   @tracked reportToEdit = null;

--- a/certif/app/components/session-finalization/completed-reports-information-step.js
+++ b/certif/app/components/session-finalization/completed-reports-information-step.js
@@ -8,18 +8,18 @@ export default class CompletedReportsInformationStep extends Component {
   @tracked showAddIssueReportModal = false;
   @tracked showIssueReportsModal = false;
 
-  get certifReportsAreNotEmpty() {
+  get certificationReportsAreNotEmpty() {
     return this.args.certificationReports.length !== 0;
   }
 
   get hasCheckedEverything() {
     const allCertifReportsAreCheck = this.args.certificationReports.every((report) => report.hasSeenEndTestScreen);
-    return this.certifReportsAreNotEmpty && allCertifReportsAreCheck;
+    return this.certificationReportsAreNotEmpty && allCertifReportsAreCheck;
   }
 
   get hasCheckedSomething() {
     const hasOneOrMoreCheck = this.args.certificationReports.any((report) => report.hasSeenEndTestScreen);
-    return this.certifReportsAreNotEmpty && hasOneOrMoreCheck;
+    return this.certificationReportsAreNotEmpty && hasOneOrMoreCheck;
   }
 
   get headerCheckboxStatus() {

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -49,12 +49,12 @@
               {{/if}}
             </div>
           </td>
-          <td class="finalization-report-cancel-reason">
+          <td class="finalization-report-abort-reason">
             <PixSelect
-              id="finalization-report-cancel-reason__select"
+              id="finalization-report-abort-reason__select"
               @emptyOptionLabel="-- Choisissez --"
-              @onChange={{this.onChangeCancelReason}}
-              @options={{this.cancelOptions}} as |option|>
+              @onChange={{this.onChangeAbortReason}}
+              @options={{this.abortOptions}} as |option|>
               {{option.label}}
             </PixSelect>
           </td>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -51,9 +51,10 @@
           </td>
           <td class="finalization-report-abort-reason">
             <PixSelect
-              id="finalization-report-abort-reason__select"
-              @emptyOptionLabel="-- Choisissez --"
+              id={{concat "finalization-report-abort-reason__select" report.id }}
+              @emptyOptionLabel={{"-- Choisissez --"}}
               @onChange={{this.onChangeAbortReason}}
+              @emptyOptionNotSelectable={{true}}
               @options={{this.abortOptions}} as |option|>
               {{option.label}}
             </PixSelect>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -51,6 +51,7 @@
           </td>
           <td class="finalization-report-cancel-reason">
             <PixSelect
+              id="finalization-report-cancel-reason__select"
               @emptyOptionLabel="-- Choisissez --"
               @id={{'add-student-list__multi-select'}}
               @options={{this.cancelOptions}} as |option|>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -53,7 +53,7 @@
             <PixSelect
               id="finalization-report-cancel-reason__select"
               @emptyOptionLabel="-- Choisissez --"
-              @id={{'add-student-list__multi-select'}}
+              @onChange={{this.onChangeCancelReason}}
               @options={{this.cancelOptions}} as |option|>
               {{option.label}}
             </PixSelect>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -10,7 +10,17 @@
         <th>Prénom</th>
         <th>N° de certification</th>
         <th>Signalement</th>
-        <th>Raison de l'abandon</th>
+        <th>
+          <div class="session-finalization-reports-information-step__header_cancel">
+          <span>Raison de l'abandon</span><PixTooltip
+                  @text={{this.tooltipMessage}}
+                  @position="left"
+                  @isWide={{true}}
+          >
+            <FaIcon @icon="info-circle" />
+          </PixTooltip>
+          </div>
+        </th>
       </tr>
     </thead>
     <tbody>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -13,7 +13,7 @@
         <th>
           <div class="session-finalization-reports-information-step__header_cancel">
           <span>Raison de l'abandon</span><PixTooltip
-                  @text={{this.tooltipMessage}}
+                  @text={{escapeHtml "<ul><li>Abandon du candidat :<ul><li>Le candidat est parti avant la fin de son test</li><li>Le candidat n'est pas parvenu à répondre à l'ensemble des questions du test dans le temps imparti, et n'a pas passé les questions restantes jusqu'à arriver à l'écran de fin de test</li></ul><li>Problème technique :<ul><li>Problème technique sur la plateforme Pix, ou lié au réseau du centre de certification</li></ul></li></ul>"}}
                   @position="left"
                   @isWide={{true}}
           >

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -1,6 +1,7 @@
 <div class="table session-finalization-reports-information-step">
   <div class="session-finalization-reports-information-step__title">
-    Certification(s) terminée(s)
+    <FaIcon @icon="exclamation-triangle" class="session-finalization-reports-information-step__icon" />
+    Ces candidats n'ont pas fini leur test de certification
   </div>
   <table>
     <thead>
@@ -9,14 +10,7 @@
         <th>Prénom</th>
         <th>N° de certification</th>
         <th>Signalement</th>
-        <th>
-          <div class="session-finalization-reports-information-step__row">
-            <div class="session-finalization-reports-information-step__checker" {{on 'click' (fn @onAllHasSeenEndTestScreenCheckboxesClicked this.hasCheckedSomething)}}>
-              <CertifCheckbox @state={{this.headerCheckboxStatus}}></CertifCheckbox>
-            </div>
-            Écran de fin du test vu
-          </div>
-        </th>
+        <th>Raison de l'abandon</th>
       </tr>
     </thead>
     <tbody>
@@ -45,12 +39,13 @@
               {{/if}}
             </div>
           </td>
-          <td>
-            <CertifCheckbox
-                    data-test-id="finalization-report-has-seen-end-test-screen_{{report.certificationCourseId}}"
-                    @state={{if report.hasSeenEndTestScreen 'checked' 'unchecked'}}
-              {{on 'click' (fn @onHasSeenEndTestScreenCheckboxClicked report)}}>
-            </CertifCheckbox>
+          <td class="finalization-report-cancel-reason">
+            <PixSelect
+              @emptyOptionLabel="-- Choisissez --"
+              @id={{'add-student-list__multi-select'}}
+              @options={{this.cancelOptions}} as |option|>
+              {{option.label}}
+            </PixSelect>
           </td>
         </tr>
       {{/each}}

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -1,5 +1,5 @@
 <div class="table session-finalization-reports-information-step">
-  <div class="session-finalization-reports-information-step__title">
+  <div class="session-finalization-reports-information-step__title-uncompleted">
     <FaIcon @icon="exclamation-triangle" class="session-finalization-reports-information-step__icon" />
     Ces candidats n'ont pas fini leur test de certification
   </div>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.js
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.js
@@ -43,7 +43,10 @@ export default class UncompletedReportsInformationStep extends Component {
     this.showIssueReportsModal = false;
   }
 
-  @action onChangeCancelReason(event) {
-    this.args.onChangeCancelReason(event.target.value);
+  @action
+  onChangeCancelReason(event) {
+    if (event.target.value) {
+      this.args.onChangeCancelReason(event.target.value);
+    }
   }
 }

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.js
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-export default class CompletedReportsInformationStep extends Component {
+export default class UncompletedReportsInformationStep extends Component {
 
   @tracked reportToEdit = null;
   @tracked showAddIssueReportModal = false;
@@ -12,18 +12,11 @@ export default class CompletedReportsInformationStep extends Component {
     return this.args.certificationReports.length !== 0;
   }
 
-  get hasCheckedEverything() {
-    const allCertifReportsAreCheck = this.args.certificationReports.every((report) => report.hasSeenEndTestScreen);
-    return this.certifReportsAreNotEmpty && allCertifReportsAreCheck;
-  }
-
-  get hasCheckedSomething() {
-    const hasOneOrMoreCheck = this.args.certificationReports.any((report) => report.hasSeenEndTestScreen);
-    return this.certifReportsAreNotEmpty && hasOneOrMoreCheck;
-  }
-
-  get headerCheckboxStatus() {
-    return this.hasCheckedEverything ? 'checked' : this.hasCheckedSomething ? 'partial' : 'unchecked';
+  get cancelOptions() {
+    return [
+      { label: 'Abandon du candidat', value: 'candidate' },
+      { label: 'Problème technique', value: 'technical' },
+    ];
   }
 
   @action

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.js
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.js
@@ -8,11 +8,11 @@ export default class UncompletedReportsInformationStep extends Component {
   @tracked showAddIssueReportModal = false;
   @tracked showIssueReportsModal = false;
 
-  get certifReportsAreNotEmpty() {
+  get certificationReportsAreNotEmpty() {
     return this.args.certificationReports.length !== 0;
   }
 
-  get cancelOptions() {
+  get abortOptions() {
     return [
       { label: 'Abandon du candidat', value: 'candidate' },
       { label: 'Problème technique', value: 'technical' },
@@ -44,9 +44,9 @@ export default class UncompletedReportsInformationStep extends Component {
   }
 
   @action
-  onChangeCancelReason(event) {
+  onChangeAbortReason(event) {
     if (event.target.value) {
-      this.args.onChangeCancelReason(event.target.value);
+      this.args.onChangeAbortReason(event.target.value);
     }
   }
 }

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.js
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { htmlSafe } from '@ember/string';
 
 export default class UncompletedReportsInformationStep extends Component {
 
@@ -43,11 +42,4 @@ export default class UncompletedReportsInformationStep extends Component {
   closeIssueReportsModal() {
     this.showIssueReportsModal = false;
   }
-
-  get tooltipMessage() {
-    const html = '<ul><li>Abandon du candidat :<ul><li>Le candidat est parti avant la fin de son test</li><li>Le candidat n\'est pas parvenu à répondre à l\'ensemble des questions du test dans le temps imparti, et n\'a pas passé les questions restantes jusqu\'à arriver à l\'écran de fin de test</li></ul><li>Problème technique :<ul><li>Problème technique sur la plateforme Pix, ou lié au réseau du centre de certification</li></ul></li></ul>';
-
-    return htmlSafe(html);
-  }
-
 }

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.js
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/string';
 
 export default class UncompletedReportsInformationStep extends Component {
 
@@ -41,6 +42,12 @@ export default class UncompletedReportsInformationStep extends Component {
   @action
   closeIssueReportsModal() {
     this.showIssueReportsModal = false;
+  }
+
+  get tooltipMessage() {
+    const html = '<ul><li>Abandon du candidat :<ul><li>Le candidat est parti avant la fin de son test</li><li>Le candidat n\'est pas parvenu à répondre à l\'ensemble des questions du test dans le temps imparti, et n\'a pas passé les questions restantes jusqu\'à arriver à l\'écran de fin de test</li></ul><li>Problème technique :<ul><li>Problème technique sur la plateforme Pix, ou lié au réseau du centre de certification</li></ul></li></ul>';
+
+    return htmlSafe(html);
   }
 
 }

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.js
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.js
@@ -42,4 +42,8 @@ export default class UncompletedReportsInformationStep extends Component {
   closeIssueReportsModal() {
     this.showIssueReportsModal = false;
   }
+
+  @action onChangeCancelReason(event) {
+    this.args.onChangeCancelReason(event.target.value);
+  }
 }

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -11,6 +11,8 @@ import trim from 'lodash/trim';
 
 export default class SessionsFinalizeController extends Controller {
 
+  @service featureToggles;
+
   @service notifications;
 
   @alias('model') session;
@@ -22,6 +24,10 @@ export default class SessionsFinalizeController extends Controller {
 
   get pageTitle() {
     return `Finalisation | Session ${this.session.id} | Pix Certif`;
+  }
+
+  get isManageUncompletedCertifEnabled() {
+    return this.featureToggles.featureToggles.isManageUncompletedCertifEnabled;
   }
 
   @computed('session.certificationReports.@each.hasSeenEndTestScreen')

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -108,7 +108,7 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   @action
-  onChangeCancelReason(value) {
+  onChangeAbortReason(value) {
     throw new Error('Not implemented', value);
   }
 }

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -106,4 +106,9 @@ export default class SessionsFinalizeController extends Controller {
   _convertStringToNullIfEmpty(str) {
     return isEmpty(trim(str)) ? null : str;
   }
+
+  @action
+  onChangeCancelReason(value) {
+    throw new Error('Not implemented', value);
+  }
 }

--- a/certif/app/helpers/escapeHtml.js
+++ b/certif/app/helpers/escapeHtml.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/template';
+
+function escapeHtml(htmlContent) {
+  return htmlSafe(htmlContent);
+}
+
+export default helper(escapeHtml);

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -18,6 +18,8 @@ export const statusToDisplayName = {
 
 export default class Session extends Model {
   @service session;
+  @service featureToggles;
+
   @attr('string') address;
   @attr('string') accessCode;
   @attr('date-only') date;
@@ -62,7 +64,12 @@ export default class Session extends Model {
   }
 
   get completedCertificationReports() {
-    return this.certificationReports.filter((certificationReport) => certificationReport.isCompleted);
+    if (this.featureToggles.featureToggles.isManageUncompletedCertifEnabled) {
+
+      return this.certificationReports.filter((certificationReport) => certificationReport.isCompleted);
+    }
+
+    return this.certificationReports;
   }
 
   get uncompletedCertificationReports() {

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -60,4 +60,12 @@ export default class Session extends Model {
   get urlToDownloadSessionIssueReportSheet() {
     return ENV.urlToDownloadSessionIssueReportSheet;
   }
+
+  get completedCertificationReports() {
+    return this.certificationReports.filter((certificationReport) => certificationReport.isCompleted);
+  }
+
+  get uncompletedCertificationReports() {
+    return this.certificationReports.filter((certificationReport) => !certificationReport.isCompleted);
+  }
 }

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -35,7 +35,7 @@
 @import "components/finalize";
 @import "components/new-certification-candidate-modal";
 @import "components/session-finalization-step-container";
-@import "components/session-finalization/reports-informations-step";
+@import "components/session-finalization/reports-information-step";
 @import "components/session-finalization/formbuilder-link-step";
 @import "components/session-finalization/examiner-global-comment-step";
 @import "components/session-summary-list";

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -1,4 +1,4 @@
-.session-finalization-reports-informations-step {
+.session-finalization-reports-information-step {
   font-size: 0.8125rem;
 
   table {

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -1,11 +1,20 @@
 .session-finalization-reports-information-step {
   font-size: 0.8125rem;
 
-  &__title {
+  &__title-completed {
     display: flex;
-    background: #F4F5F7;
+    background: #DDF4E6;
     margin: 8px;
-    color: #5E6C84;
+    color: #277848;
+    font-weight: bold;
+    padding: 20px 0 20px 24px;
+  }
+
+  &__title-uncompleted {
+    display: flex;
+    background: #FFECB3;
+    margin: 8px;
+    color: #805F00;
     font-weight: bold;
     padding: 20px 0 20px 24px;
   }

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -63,7 +63,7 @@
 
   }
 
-  .finalization-report-cancel-reason {
+  .finalization-report-abort-reason {
 
     .pix-select {
       max-width: 210px;

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -1,6 +1,20 @@
 .session-finalization-reports-information-step {
   font-size: 0.8125rem;
 
+  &__title {
+    display: flex;
+    background: #F4F5F7;
+    margin: 8px;
+    color: #5E6C84;
+    font-weight: bold;
+    padding: 20px 0 20px 48px;
+  }
+
+  &__icon {
+    margin-right: 12px;
+    font-size: 1rem;
+  }
+
   table {
     table-layout: initial;
   }
@@ -19,6 +33,13 @@
 
     .add-button {
       font-size: 13px;
+    }
+  }
+
+  .finalization-report-cancel-reason {
+
+    .pix-select {
+      max-width: 210px;
     }
   }
 }

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -42,6 +42,7 @@
 
     .pix-tooltip{
       padding-left: 5px;
+      cursor: help;
     }
 
     .pix-tooltip__content--wide{

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -19,6 +19,7 @@
     table-layout: initial;
   }
 
+
   &__row {
     display: flex;
     align-items: center;
@@ -34,6 +35,31 @@
     .add-button {
       font-size: 13px;
     }
+  }
+
+  &__header_cancel{
+    display: flex;
+
+    .pix-tooltip{
+      padding-left: 5px;
+    }
+
+    .pix-tooltip__content--wide{
+      width: 600px;
+    }
+
+    ul{
+      margin-left: 10px;
+
+      li{
+        list-style-type: disc;
+
+        li{
+          list-style-type: '- ';
+        }
+      }
+    }
+
   }
 
   .finalization-report-cancel-reason {

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -7,7 +7,7 @@
     margin: 8px;
     color: #5E6C84;
     font-weight: bold;
-    padding: 20px 0 20px 48px;
+    padding: 20px 0 20px 24px;
   }
 
   &__icon {
@@ -17,8 +17,16 @@
 
   table {
     table-layout: initial;
-  }
 
+    th {
+      width: 20%;
+    }
+
+    th:nth-child(3),
+    th:nth-child(4) {
+      width: 15%;
+    }
+  }
 
   &__row {
     display: flex;

--- a/certif/app/styles/components/session-summary-list.scss
+++ b/certif/app/styles/components/session-summary-list.scss
@@ -1,4 +1,5 @@
 .session-summary-list {
+
   &__link {
     color: $grey-80;
     text-decoration: none;

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -19,7 +19,7 @@
         @certificationReports={{this.session.uncompletedCertificationReports}}
         @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
         @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
-        @onChangeCancelReason={{this.onChangeCancelReason}}
+        @onChangeAbortReason={{this.onChangeAbortReason}}
       />
       {{/if}}
     {{/if}}

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -13,8 +13,13 @@
       @title="Renseigner les informations de vos candidats"
       @icon="/icons/session-finalization-user.svg"
       @iconAlt="">
+    <SessionFinalization::UncompletedReportsInformationStep
+      @certificationReports={{this.session.uncompletedCertificationReports}}
+      @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+      @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
+    />
     <SessionFinalization::CompletedReportsInformationStep
-        @certificationReports={{this.session.certificationReports}}
+        @certificationReports={{this.session.completedCertificationReports}}
         @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
         @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
         @onAllHasSeenEndTestScreenCheckboxesClicked={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -13,11 +13,13 @@
       @title="Renseigner les informations de vos candidats"
       @icon="/icons/session-finalization-user.svg"
       @iconAlt="">
+    {{#if (gt this.session.uncompletedCertificationReports.length 0)}}
     <SessionFinalization::UncompletedReportsInformationStep
       @certificationReports={{this.session.uncompletedCertificationReports}}
       @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
       @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
     />
+    {{/if}}
     <SessionFinalization::CompletedReportsInformationStep
         @certificationReports={{this.session.completedCertificationReports}}
         @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -13,7 +13,7 @@
       @title="Renseigner les informations de vos candidats"
       @icon="/icons/session-finalization-user.svg"
       @iconAlt="">
-    <SessionFinalization::ReportsInformationsStep
+    <SessionFinalization::CompletedReportsInformationStep
         @certificationReports={{this.session.certificationReports}}
         @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
         @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -24,6 +24,7 @@
       {{/if}}
     {{/if}}
     <SessionFinalization::CompletedReportsInformationStep
+        @session={{this.session}}
         @certificationReports={{this.session.completedCertificationReports}}
         @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
         @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -19,6 +19,7 @@
         @certificationReports={{this.session.uncompletedCertificationReports}}
         @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
         @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
+        @onChangeCancelReason={{this.onChangeCancelReason}}
       />
       {{/if}}
     {{/if}}

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -13,12 +13,14 @@
       @title="Renseigner les informations de vos candidats"
       @icon="/icons/session-finalization-user.svg"
       @iconAlt="">
-    {{#if (gt this.session.uncompletedCertificationReports.length 0)}}
-    <SessionFinalization::UncompletedReportsInformationStep
-      @certificationReports={{this.session.uncompletedCertificationReports}}
-      @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
-      @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
-    />
+    {{#if this.isManageUncompletedCertifEnabled}}
+      {{#if (gt this.session.uncompletedCertificationReports.length 0)}}
+      <SessionFinalization::UncompletedReportsInformationStep
+        @certificationReports={{this.session.uncompletedCertificationReports}}
+        @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+        @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
+      />
+      {{/if}}
     {{/if}}
     <SessionFinalization::CompletedReportsInformationStep
         @certificationReports={{this.session.completedCertificationReports}}

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -21457,16 +21457,604 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#c725e9c7b6c613a48b6a15de8e668e1d23379871",
-      "from": "git://github.com/1024pix/pix-ui.git#v5.2.0",
+      "version": "git://github.com/1024pix/pix-ui.git#4ccd573bf48d2ca0a9d866b86e6b1feb40838524",
+      "from": "git://github.com/1024pix/pix-ui.git#v5.5.0",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.23.1",
+        "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.6.2",
         "ember-cli-sass": "^10.0.1",
         "ember-cli-string-utils": "^1.1.0",
         "ember-click-outside": "^2.0.0",
         "ember-truth-helpers": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/compat-data": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+          "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+          "dev": true
+        },
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+          "integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
+          "integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.14.5",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-member-expression-to-functions": "^7.15.0",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/helper-replace-supers": "^7.15.0",
+            "@babel/helper-split-export-declaration": "^7.14.5"
+          }
+        },
+        "@babel/helper-define-polyfill-provider": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+          "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-compilation-targets": "^7.13.0",
+            "@babel/helper-module-imports": "^7.12.13",
+            "@babel/helper-plugin-utils": "^7.13.0",
+            "@babel/traverse": "^7.13.0",
+            "debug": "^4.1.1",
+            "lodash.debounce": "^4.0.8",
+            "resolve": "^1.14.2",
+            "semver": "^6.1.2"
+          },
+          "dependencies": {
+            "@babel/helper-compilation-targets": {
+              "version": "7.15.0",
+              "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+              "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+              "dev": true,
+              "requires": {
+                "@babel/compat-data": "^7.15.0",
+                "@babel/helper-validator-option": "^7.14.5",
+                "browserslist": "^4.16.6",
+                "semver": "^6.3.0"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+          "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.14.5",
+            "@babel/template": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+          "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+          "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+          "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+          "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+          "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.14.5",
+            "@babel/helper-replace-supers": "^7.15.0",
+            "@babel/helper-simple-access": "^7.14.8",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/template": "^7.14.5",
+            "@babel/traverse": "^7.15.0",
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+          "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+          "dev": true
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+          "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.15.0",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/traverse": "^7.15.0",
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+          "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.8"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+          "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/helper-validator-option": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+          "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+          "dev": true
+        },
+        "@babel/plugin-proposal-class-properties": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+          "integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.14.5",
+            "@babel/helper-plugin-utils": "^7.14.5"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.5.tgz",
+          "integrity": "sha512-3lpOU8Vxmp3roC4vzFpSdEpGUWSMsHFreTWOMMLzel2gNGfHE5UWIh/LN6ghHs2xurUp4jRFYMUIZhuFbody1g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.14.5",
+            "@babel/helper-plugin-utils": "^7.14.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3"
+          }
+        },
+        "@babel/plugin-transform-runtime": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz",
+          "integrity": "sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.14.5",
+            "@babel/helper-plugin-utils": "^7.14.5",
+            "babel-plugin-polyfill-corejs2": "^0.2.2",
+            "babel-plugin-polyfill-corejs3": "^0.2.2",
+            "babel-plugin-polyfill-regenerator": "^0.2.2",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.12.18",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+          "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@babel/template": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+          "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "babel-plugin-debug-macros": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
+          "integrity": "sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==",
+          "dev": true,
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "babel-plugin-polyfill-corejs2": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+          "integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.13.11",
+            "@babel/helper-define-polyfill-provider": "^0.2.2",
+            "semver": "^6.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "babel-plugin-polyfill-corejs3": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
+          "integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.2.2",
+            "core-js-compat": "^3.14.0"
+          }
+        },
+        "babel-plugin-polyfill-regenerator": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+          "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.2.2"
+          }
+        },
+        "broccoli-source": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
+          "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
+          "dev": true
+        },
+        "browserslist": {
+          "version": "4.16.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+          "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001251",
+            "colorette": "^1.3.0",
+            "electron-to-chromium": "^1.3.811",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.75"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001252",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "colorette": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+          "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+          "dev": true
+        },
+        "core-js-compat": {
+          "version": "3.16.3",
+          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.3.tgz",
+          "integrity": "sha512-A/OtSfSJQKLAFRVd4V0m6Sep9lPdjD8bpN8v3tCCGwE0Tmh0hOiVDm9tw6mXmWOKOSZIyr3EkywPo84cJjGvIQ==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.16.8",
+            "semver": "7.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+              "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+              "dev": true
+            }
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.818",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.818.tgz",
+          "integrity": "sha512-c/Z9gIr+jDZAR9q+mn40hEc1NharBT+8ejkarjbCDnBNFviI6hvcC5j2ezkAXru//bTnQp5n6iPi0JA83Tla1Q==",
+          "dev": true
+        },
+        "ember-cli-babel": {
+          "version": "7.26.6",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz",
+          "integrity": "sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.0",
+            "@babel/helper-compilation-targets": "^7.12.0",
+            "@babel/plugin-proposal-class-properties": "^7.13.0",
+            "@babel/plugin-proposal-decorators": "^7.13.5",
+            "@babel/plugin-transform-modules-amd": "^7.13.0",
+            "@babel/plugin-transform-runtime": "^7.13.9",
+            "@babel/plugin-transform-typescript": "^7.13.0",
+            "@babel/polyfill": "^7.11.5",
+            "@babel/preset-env": "^7.12.0",
+            "@babel/runtime": "7.12.18",
+            "amd-name-resolver": "^1.3.1",
+            "babel-plugin-debug-macros": "^0.3.4",
+            "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+            "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+            "babel-plugin-module-resolver": "^3.2.0",
+            "broccoli-babel-transpiler": "^7.8.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.2",
+            "broccoli-source": "^2.1.2",
+            "clone": "^2.1.2",
+            "ember-cli-babel-plugin-helpers": "^1.1.1",
+            "ember-cli-version-checker": "^4.1.0",
+            "ensure-posix-path": "^1.0.2",
+            "fixturify-project": "^1.10.0",
+            "resolve-package-path": "^3.1.0",
+            "rimraf": "^3.0.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+          "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^2.0.0",
+            "semver": "^6.3.0",
+            "silent-error": "^1.1.1"
+          },
+          "dependencies": {
+            "resolve-package-path": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+              "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+              "dev": true,
+              "requires": {
+                "path-root": "^0.1.1",
+                "resolve": "^1.13.1"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+          "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.75",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+          "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+          "dev": true
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "pkg-dir": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -87,7 +87,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.3.0",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.2.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.5.0",
     "qunit-dom": "^1.6.0",
     "sass": "^1.32.8",
     "stylelint": "^13.12.0",

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -142,6 +142,7 @@ module('Acceptance | Session Finalization', function(hooks) {
         test('it should show the uncompleted reports table', async function(assert) {
           // given
           const certificationReport = server.create('certification-report', { isCompleted: false });
+          server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
           session.update({ certificationReports: [certificationReport] });
 
           // when

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -123,6 +123,34 @@ module('Acceptance | Session Finalization', function(hooks) {
           assert.contains('1 signalement');
         });
       });
+
+      module('when there is no uncompleted report', function() {
+        test('it should not show the uncompleted reports table', async function(assert) {
+          // given
+          const certificationReport = server.create('certification-report', { isCompleted: true });
+          session.update({ certificationReports: [certificationReport] });
+
+          // when
+          await visit(`/sessions/${session.id}/finalisation`);
+
+          // then
+          assert.notContains('Ces candidats n\'ont pas fini leur test de certification');
+        });
+      });
+
+      module('when there are uncompleted reports', function() {
+        test('it should show the uncompleted reports table', async function(assert) {
+          // given
+          const certificationReport = server.create('certification-report', { isCompleted: false });
+          session.update({ certificationReports: [certificationReport] });
+
+          // when
+          await visit(`/sessions/${session.id}/finalisation`);
+
+          // then
+          assert.contains('Ces candidats n\'ont pas fini leur test de certification');
+        });
+      });
     });
   });
 });

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -7,7 +7,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 
-module('Integration | Component | SessionFinalization::ReportsInformationsStep', function(hooks) {
+module('Integration | Component | SessionFinalization::CompletedReportsInformationStep', function(hooks) {
   setupRenderingTest(hooks);
   let reportA;
   let reportB;
@@ -60,7 +60,7 @@ module('Integration | Component | SessionFinalization::ReportsInformationsStep',
 
     // when
     await render(hbs`
-        <SessionFinalization::ReportsInformationsStep
+        <SessionFinalization::CompletedReportsInformationStep
           @certificationReports={{this.certificationReports}}
           @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
           @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
@@ -93,7 +93,7 @@ module('Integration | Component | SessionFinalization::ReportsInformationsStep',
 
     // when
     await render(hbs`
-        <SessionFinalization::ReportsInformationsStep
+        <SessionFinalization::CompletedReportsInformationStep
           @certificationReports={{this.certificationReports}}
           @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
           @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -104,4 +104,64 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
     // then
     assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${certificationReport.certificationCourseId}"]`).hasText('2 signalements');
   });
+
+  test('it shows "Certification(s) terminée(s)" if there is at least one uncomplete certification report', async function(assert) {
+    // given
+    const certificationReport1 = run(() => store.createRecord('certification-report',
+      { isCompleted: false },
+    ));
+    const certificationReport2 = run(() => store.createRecord('certification-report',
+      { isCompleted: true },
+    ));
+    const session = run(() => store.createRecord('session', {
+      certificationReports: [certificationReport1, certificationReport2],
+    }));
+
+    this.set('certificationReports', [certificationReport1, certificationReport2]);
+    this.set('session', session);
+
+    // when
+    await render(hbs`
+        <SessionFinalization::CompletedReportsInformationStep
+          @session={{this.session}}
+          @certificationReports={{this.certificationReports}}
+          @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+          @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
+          @onAllHasSeenEndTestScreenCheckboxesClicked={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
+        />
+      `);
+
+    // then
+    assert.contains('Certification(s) terminée(s)');
+  });
+
+  test('it does not show "Certification(s) terminée(s)" if there is no uncomplete certification report', async function(assert) {
+    // given
+    const certificationReport1 = run(() => store.createRecord('certification-report',
+      { isCompleted: true },
+    ));
+    const certificationReport2 = run(() => store.createRecord('certification-report',
+      { isCompleted: true },
+    ));
+    const session = run(() => store.createRecord('session', {
+      certificationReports: [certificationReport1, certificationReport2],
+    }));
+
+    this.set('certificationReports', [certificationReport1, certificationReport2]);
+    this.set('session', session);
+
+    // when
+    await render(hbs`
+        <SessionFinalization::CompletedReportsInformationStep
+          @session={{this.session}}
+          @certificationReports={{this.certificationReports}}
+          @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+          @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
+          @onAllHasSeenEndTestScreenCheckboxesClicked={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
+        />
+      `);
+
+    // then
+    assert.notContains('Certification(s) terminée(s)');
+  });
 });

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { A } from '@ember/array';
-import { render } from '@ember/test-helpers';
+import { render, find, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
+import sinon from 'sinon';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 
 module('Integration | Component | SessionFinalization::UnUncompletedReportsInformationStep', function(hooks) {
@@ -96,5 +97,30 @@ module('Integration | Component | SessionFinalization::UnUncompletedReportsInfor
 
     // then
     assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${certificationReport.certificationCourseId}"]`).hasText('2 signalements');
+  });
+
+  test('it calls onChangeCancelReason on select update', async function(assert) {
+    // given
+    const certificationReport = run(() => store.createRecord('certification-report', {
+      isCompleted: false,
+    }));
+    this.set('certificationReports', [certificationReport]);
+    const onChangeCancelReason = sinon.stub().returns();
+    this.set('onChangeCancelReason', onChangeCancelReason);
+
+    // when
+    await render(hbs`
+        <SessionFinalization::UncompletedReportsInformationStep
+          @certificationReports={{this.certificationReports}}
+          @onChangeCancelReason={{this.onChangeCancelReason}}
+        />
+      `);
+
+    const select = await find('#finalization-report-cancel-reason__select');
+    await fillIn(select, 'technical');
+
+    // then
+    sinon.assert.calledWith(onChangeCancelReason, 'technical');
+    assert.true(true);
   });
 });

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -1,0 +1,100 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { A } from '@ember/array';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
+import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
+
+module('Integration | Component | SessionFinalization::UnUncompletedReportsInformationStep', function(hooks) {
+  setupRenderingTest(hooks);
+  let reportA;
+  let reportB;
+  let store;
+  let certificationIssueReportA;
+
+  hooks.beforeEach(async function() {
+    store = this.owner.lookup('service:store');
+
+    certificationIssueReportA = run(() => store.createRecord('certification-issue-report', {
+      description: 'Coucou',
+      category: certificationIssueReportCategories.OTHER,
+    }));
+
+    reportA = run(() => store.createRecord('certification-report', {
+      certificationCourseId: 1234,
+      firstName: 'Alice',
+      lastName: 'Alister',
+      certificationIssueReports: A([certificationIssueReportA]),
+      hasSeenEndTestScreen: null,
+    }));
+
+    reportB = run(() => store.createRecord('certification-report', {
+      certificationCourseId: 3,
+      firstName: 'Bob',
+      lastName: 'Bober',
+      hasSeenEndTestScreen: true,
+    }));
+
+    this.set('certificationReports', [reportA, reportB]);
+    this.set('issueReportDescriptionMaxLength', 500);
+  });
+
+  test('it shows "1 signalement" if there is exactly one certification issue report', async function(assert) {
+    // given
+    const certificationIssueReport = run(() => store.createRecord('certification-issue-report', {
+      description: 'Coucou',
+      category: certificationIssueReportCategories.OTHER,
+    }));
+    const certificationReport = run(() => store.createRecord('certification-report', {
+      certificationCourseId: 1234,
+      firstName: 'Alice',
+      lastName: 'Alister',
+      certificationIssueReports: [certificationIssueReport],
+      hasSeenEndTestScreen: null,
+    }));
+    this.set('certificationReports', [certificationReport]);
+
+    // when
+    await render(hbs`
+        <SessionFinalization::UncompletedReportsInformationStep
+          @certificationReports={{this.certificationReports}}
+          @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+        />
+      `);
+
+    // then
+    assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${certificationReport.certificationCourseId}"]`).hasText('1 signalement');
+  });
+
+  test('it shows "X signalements" (plural) if there is more than one certification issue reports', async function(assert) {
+    // given
+    const certificationIssueReport1 = run(() => store.createRecord('certification-issue-report', {
+      description: 'Coucou',
+      category: certificationIssueReportCategories.OTHER,
+    }));
+    const certificationIssueReport2 = run(() => store.createRecord('certification-issue-report', {
+      description: 'Les zouzous',
+      category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
+    }));
+    const certificationReport = run(() => store.createRecord('certification-report', {
+      certificationCourseId: 1234,
+      firstName: 'Alice',
+      lastName: 'Alister',
+      certificationIssueReports: [certificationIssueReport1, certificationIssueReport2],
+      hasSeenEndTestScreen: null,
+    }));
+    this.set('certificationReports', [certificationReport]);
+
+    // when
+    await render(hbs`
+        <SessionFinalization::UncompletedReportsInformationStep
+          @certificationReports={{this.certificationReports}}
+          @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+        />
+      `);
+
+    // then
+    assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${certificationReport.certificationCourseId}"]`).hasText('2 signalements');
+  });
+});

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -99,28 +99,28 @@ module('Integration | Component | SessionFinalization::UnUncompletedReportsInfor
     assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${certificationReport.certificationCourseId}"]`).hasText('2 signalements');
   });
 
-  test('it calls onChangeCancelReason on select update', async function(assert) {
+  test('it calls onChangeAbortReason on select update', async function(assert) {
     // given
     const certificationReport = run(() => store.createRecord('certification-report', {
       isCompleted: false,
     }));
     this.set('certificationReports', [certificationReport]);
-    const onChangeCancelReason = sinon.stub().returns();
-    this.set('onChangeCancelReason', onChangeCancelReason);
+    const onChangeAbortReason = sinon.stub().returns();
+    this.set('onChangeAbortReason', onChangeAbortReason);
 
     // when
     await render(hbs`
         <SessionFinalization::UncompletedReportsInformationStep
           @certificationReports={{this.certificationReports}}
-          @onChangeCancelReason={{this.onChangeCancelReason}}
+          @onChangeAbortReason={{this.onChangeAbortReason}}
         />
       `);
 
-    const select = await find('#finalization-report-cancel-reason__select');
+    const select = await find('#finalization-report-abort-reason__select');
     await fillIn(select, 'technical');
 
     // then
-    sinon.assert.calledWith(onChangeCancelReason, 'technical');
+    sinon.assert.calledWith(onChangeAbortReason, 'technical');
     assert.true(true);
   });
 });

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -61,4 +61,63 @@ module('Unit | Model | session', function(hooks) {
       assert.equal(model.urlToDownloadSessionIssueReportSheet, config.urlToDownloadSessionIssueReportSheet);
     });
   });
+
+  module('#uncompletedCertificationReports', function() {
+    test('it should return the uncomplete certification reports', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = run(() => store.createRecord('session', { id: 1, certificationReports: [
+        store.createRecord('certification-report', { isCompleted: false }),
+        store.createRecord('certification-report', { isCompleted: true }),
+        store.createRecord('certification-report', { isCompleted: true }),
+      ] }));
+      model.session = { data: { authenticated: { access_token: '123' } } };
+
+      // when/then
+      assert.equal(model.uncompletedCertificationReports.length, 1);
+    });
+  });
+
+  module('#completedCertificationReports', function() {
+
+    module('when isManageUncompletedCertifEnabled is enabled', function() {
+
+      test('it should return the complete certification reports', function(assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = run(() => store.createRecord('session', { id: 1, certificationReports: [
+          store.createRecord('certification-report', { isCompleted: false }),
+          store.createRecord('certification-report', { isCompleted: true }),
+          store.createRecord('certification-report', { isCompleted: true }),
+        ] }));
+
+        model.session = { data: { authenticated: { access_token: '123' } } };
+
+        model.featureToggles = { featureToggles: { isManageUncompletedCertifEnabled: true } };
+
+        // when/then
+        assert.equal(model.completedCertificationReports.length, 2);
+      });
+    });
+
+    module('when isManageUncompletedCertifEnabled is not enabled', function() {
+
+      test('it should return the all certification reports', function(assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = run(() => store.createRecord('session', { id: 1, certificationReports: [
+          store.createRecord('certification-report', { isCompleted: false }),
+          store.createRecord('certification-report', { isCompleted: true }),
+          store.createRecord('certification-report', { isCompleted: true }),
+        ] }));
+
+        model.session = { data: { authenticated: { access_token: '123' } } };
+
+        model.featureToggles = { featureToggles: { isManageUncompletedCertifEnabled: false } };
+
+        // when/then
+        assert.equal(model.completedCertificationReports.length, 3);
+      });
+    });
+  });
 });

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import config from '../../../config/environment';
+import Service from '@ember/service';
 import { CREATED, FINALIZED } from 'pix-certif/models/session';
 
 module('Unit | Model | session', function(hooks) {
@@ -42,8 +43,16 @@ module('Unit | Model | session', function(hooks) {
     test('it should return the correct urlToDownloadAttendanceSheet', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
+      class SessionStub extends Service {
+        data = {
+          authenticated: {
+            access_token: '123',
+          },
+        };
+      }
+
       const model = run(() => store.createRecord('session', { id: 1 }));
-      model.session = { data: { authenticated: { access_token: '123' } } };
+      this.owner.register('service:session', SessionStub);
 
       // when/then
       assert.equal(model.urlToDownloadAttendanceSheet, `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123`);
@@ -54,8 +63,16 @@ module('Unit | Model | session', function(hooks) {
     test('it should return the correct urlToDownloadSessionIssueReportSheet', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
+      class SessionStub extends Service {
+        data = {
+          authenticated: {
+            access_token: '123',
+          },
+        };
+      }
+
       const model = run(() => store.createRecord('session', { id: 1 }));
-      model.session = { data: { authenticated: { access_token: '123' } } };
+      this.owner.register('service:session', SessionStub);
 
       // when/then
       assert.equal(model.urlToDownloadSessionIssueReportSheet, config.urlToDownloadSessionIssueReportSheet);
@@ -66,15 +83,12 @@ module('Unit | Model | session', function(hooks) {
     test('it should return the uncomplete certification reports', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const model = run(() => store.createRecord('session', { id: 1, certificationReports: [
-        store.createRecord('certification-report', { isCompleted: false }),
-        store.createRecord('certification-report', { isCompleted: true }),
-        store.createRecord('certification-report', { isCompleted: true }),
-      ] }));
-      model.session = { data: { authenticated: { access_token: '123' } } };
+
+      const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
 
       // when/then
       assert.equal(model.uncompletedCertificationReports.length, 1);
+      assert.equal(model.uncompletedCertificationReports[0].id, 1);
     });
   });
 
@@ -85,18 +99,22 @@ module('Unit | Model | session', function(hooks) {
       test('it should return the complete certification reports', function(assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const model = run(() => store.createRecord('session', { id: 1, certificationReports: [
-          store.createRecord('certification-report', { isCompleted: false }),
-          store.createRecord('certification-report', { isCompleted: true }),
-          store.createRecord('certification-report', { isCompleted: true }),
-        ] }));
 
-        model.session = { data: { authenticated: { access_token: '123' } } };
+        class FeatureToggleStub extends Service {
+          featureToggles= {
+            isManageUncompletedCertifEnabled: true,
+          }
+        }
 
-        model.featureToggles = { featureToggles: { isManageUncompletedCertifEnabled: true } };
+        this.owner.register('service:featureToggles', FeatureToggleStub);
+
+        const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
 
         // when/then
         assert.equal(model.completedCertificationReports.length, 2);
+        assert.equal(model.completedCertificationReports[0].id, 2);
+        assert.equal(model.completedCertificationReports[1].id, 3);
+
       });
     });
 
@@ -105,19 +123,27 @@ module('Unit | Model | session', function(hooks) {
       test('it should return the all certification reports', function(assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const model = run(() => store.createRecord('session', { id: 1, certificationReports: [
-          store.createRecord('certification-report', { isCompleted: false }),
-          store.createRecord('certification-report', { isCompleted: true }),
-          store.createRecord('certification-report', { isCompleted: true }),
-        ] }));
 
-        model.session = { data: { authenticated: { access_token: '123' } } };
+        class FeatureToggleStub extends Service {
+          featureToggles= {
+            isManageUncompletedCertifEnabled: false,
+          }
+        }
 
-        model.featureToggles = { featureToggles: { isManageUncompletedCertifEnabled: false } };
+        this.owner.register('service:featureToggles', FeatureToggleStub);
 
+        const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
         // when/then
         assert.equal(model.completedCertificationReports.length, 3);
       });
     });
   });
 });
+
+function _createTwoCompleteAndOneUncompleteCertificationReports(store) {
+  return run(() => store.createRecord('session', { id: 1, certificationReports: [
+    store.createRecord('certification-report', { id: 1, isCompleted: false }),
+    store.createRecord('certification-report', { id: 2, isCompleted: true }),
+    store.createRecord('certification-report', { id: 3, isCompleted: true }),
+  ] }));
+}

--- a/high-level-tests/e2e/cypress/fixtures/assessments.json
+++ b/high-level-tests/e2e/cypress/fixtures/assessments.json
@@ -26,5 +26,19 @@
     "state": "completed",
     "type": "CAMPAIGN",
     "userId": 5
+  },
+  {
+    "id": 5,
+    "certificationCourseId": 1,
+    "state": "completed",
+    "type": "CERTIFICATION",
+    "userId": 1
+  },
+  {
+    "id": 6,
+    "certificationCourseId": 2,
+    "state": "completed",
+    "type": "CERTIFICATION",
+    "userId": 2
   }
 ]

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -9,16 +9,16 @@ Given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'target-profiles_skills');
   cy.task('db:fixture', 'campaigns');
   cy.task('db:fixture', 'campaign-participations');
+  cy.task('db:fixture', 'certification-centers');
+  cy.task('db:fixture', 'sessions');
+  cy.task('db:fixture', 'certification-courses');
   cy.task('db:fixture', 'assessments');
   cy.task('db:fixture', 'answers');
   cy.task('db:fixture', 'knowledge-elements');
   cy.task('db:fixture', 'users_pix_roles');
   cy.task('db:fixture', 'schooling-registrations');
-  cy.task('db:fixture', 'certification-centers');
   cy.task('db:fixture', 'certification-center-memberships');
-  cy.task('db:fixture', 'sessions');
   cy.task('db:fixture', 'certification-candidates');
-  cy.task('db:fixture', 'certification-courses');
 });
 
 Given('tous les comptes sont créés', () => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
@@ -51,7 +51,7 @@ Then('je vois le formulaire de finalisation de session de certification', () => 
 });
 
 Then('je vois {int} candidat(s) à finaliser', (candidateCount) => {
-  cy.get('.session-finalization-reports-informations-step table tbody tr').should('have.length', candidateCount);
+  cy.get('.session-finalization-reports-information-step table tbody tr').should('have.length', candidateCount);
 });
 
 Then('je vois le bouton de finalisation désactivé', () => {
@@ -101,7 +101,7 @@ When('je retire un candidat de la liste', () => {
 });
 
 When(`j'oublie de cocher une case d'Écran de fin de test vu`, () => {
-  cy.get('.session-finalization-reports-informations-step table tbody tr').each(function ($element, index, collection) {
+  cy.get('.session-finalization-reports-information-step table tbody tr').each(function ($element, index, collection) {
     const checkBox = $element.find('td:nth-child(5) button');
     if(index !== collection.length - 1 && checkBox.hasClass('checkbox--unchecked')) {
       cy.wrap(checkBox).click();
@@ -112,7 +112,7 @@ When(`j'oublie de cocher une case d'Écran de fin de test vu`, () => {
 });
 
 When(`je coche toutes les cases d'Écran de fin de test vu`, () => {
-  cy.get('.session-finalization-reports-informations-step table tbody tr').each(function ($element) {
+  cy.get('.session-finalization-reports-information-step table tbody tr').each(function ($element) {
     const checkBox = $element.find('td:nth-child(5) button');
     if(checkBox.hasClass('checkbox--unchecked')) {
       cy.wrap(checkBox).click();


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'éPix "Gestion des certifications démarrées", nous avons besoin de différencier les certifications non terminées et celles terminées dans pix-certif.


## :robot: Solution
Afficher les certifications non terminés lors de la finalisation d'une session.
On affichera les certifs dans un tableau intitulé “Ces candidats n'ont pas fini leur test de certification” similaire au tableau des certification terminés. A la place de la colonne "Ecran de fin de test", on affichera une colonne “Raison de l’abandon” : 
une liste déroulante permet de sélectionner la raison de l’abandon - champ obligatoire

- Abandon du candidat

- Problème technique


## :rainbow: Remarques
![image](https://user-images.githubusercontent.com/37305474/130622980-4b54f017-de06-45fb-8eb0-58a5d4b1b433.png)


## :100: Pour tester
- Activer le toggle FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED
- Creer une session de certification
- Inscrire au mons deux candidats
- Passer un test de certification complet avec un candidat
- Rejoindre la session sans la terminer avec le deuxième candidat
- Se rendre dans pix certif et constater un affichage similaire à la capture d'écran plus haut
