### PR TITLE
[TECH] Rendre configurable la liste d'origines des embed autorisés

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -4,13 +4,14 @@ import ChallengeItemGeneric from './challenge-item-generic';
 import { inject as service } from '@ember/service';
 import generateRandomString from 'mon-pix/utils/generate-random-string';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
+import ENV from 'mon-pix/config/environment';
 
 export default class ChallengeItemQroc extends ChallengeItemGeneric {
   @service intl;
 
   @tracked autoReplyAnswer = '';
   postMessageHandler = null;
-  embedOrigins = ['https://epreuves.pix.fr', 'https://1024pix.github.io'];
+  embedOrigins = ENV.APP.EMBED_ALLOWED_ORIGINS;
 
   constructor() {
     super(...arguments);

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -68,6 +68,7 @@ module.exports = function(environment) {
       ENGLISH_NEW_LEVEL_MESSAGE: process.env.ENGLISH_NEW_LEVEL_MESSAGE || '',
       IS_PROD_ENVIRONMENT: (process.env.REVIEW_APP === 'false' && environment === 'production') || false,
       MAX_REACHABLE_LEVEL: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_REACHABLE_LEVEL', defaultValue: 5, minValue: 5 }),
+      EMBED_ALLOWED_ORIGINS: (process.env.EMBED_ALLOWED_ORIGINS || 'https://epreuves.pix.fr,https://1024pix.github.io').split(','),
 
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons pouvoir facilement changer la liste des origines des embed, et surtout permettre d'autoriser des domaines différents entre la recette et la production notamment.  

## :robot: Solution
Permettre de configurer via les variables d'environnement les origines autorisées. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Changer les variables d'environnement et vérifier qu'on peut charger via le domaine récemment ajouté. 
