### PR TITLE
[FEATURE] Résolution automatique des signalement concernant les épreuves chronométrées et temps majoré (PIX-3002)

### DIFF
--- a/api/db/seeds/data/certification/certification-data.js
+++ b/api/db/seeds/data/certification/certification-data.js
@@ -648,6 +648,11 @@ const WEAK_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_E
   { source: 'inferred', skillId: 'rec8uNegbB8PDuYRJ', earnedPix: 1.6, status: 'validated', competenceId: 'recfr0ax8XrfvJ3ER', result: 'ok', challengeId: 'recWfwWRISdCDitAr', timeout: null, resultDetails: 'null ' },
 ];
 
+const WEAK_CERTIFIABLE_WITH_TIMED_CHALLENGE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS = [
+  ...WEAK_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
+  { source: 'direct', skillId: 'rechRPFlSryfY3UnG', earnedPix: 8, status: 'validated', competenceId: 'recsvLz0W2ShyfD63', result: 'ok', challengeId: 'rec0EQfC6FVXXrAwk', timeout: null, resultDetails: 'null ' },
+];
+
 const CERTIFICATION_CHALLENGES_DATA = [
   { challengeId: 'reccEwkSAkyPd7e1H', competenceId: 'recudHE5Omrr10qrx', associatedSkillName: '@choixSystème5' },
   { challengeId: 'rec89GEKgYFZ1vqHr', competenceId: 'recudHE5Omrr10qrx', associatedSkillName: '@logicielLibre6' },
@@ -842,6 +847,7 @@ const CERTIFICATION_FAILURE_COMPETENCE_MARKS_DATA = [
 module.exports = {
   STRONG_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
   WEAK_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
+  WEAK_CERTIFIABLE_WITH_TIMED_CHALLENGE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
   CERTIFICATION_CHALLENGES_DATA,
   CERTIFICATION_FAILURE_ANSWERS_DATA,
   CERTIFICATION_SUCCESS_ANSWERS_DATA,

--- a/api/db/seeds/data/certification/user-profiles-builder.js
+++ b/api/db/seeds/data/certification/user-profiles-builder.js
@@ -2,11 +2,12 @@ const _ = require('lodash');
 const {
   CERTIF_SUCCESS_USER_ID, CERTIF_FAILURE_USER_ID,
   CERTIF_REGULAR_USER1_ID, CERTIF_REGULAR_USER2_ID, CERTIF_REGULAR_USER3_ID,
-  CERTIF_REGULAR_USER4_ID, CERTIF_REGULAR_USER5_ID, CERTIF_SCO_STUDENT_ID,
+  CERTIF_REGULAR_USER4_ID, CERTIF_REGULAR_USER5_ID, CERTIF_SCO_STUDENT_ID, CERTIF_REGULAR_USER_WITH_TIMED_CHALLENGE_ID,
 } = require('./users');
 const {
   STRONG_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
   WEAK_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
+  WEAK_CERTIFIABLE_WITH_TIMED_CHALLENGE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
 } = require('./certification-data');
 const { SCO_FOREIGNER_USER_ID, SCO_FRENCH_USER_ID } = require('../organizations-sco-builder');
 
@@ -30,6 +31,13 @@ function certificationUserProfilesBuilder({ databaseBuilder }) {
       const answerId = databaseBuilder.factory.buildAnswer({ ...data, createdAt, updatedAt, assessmentId, value: 'Dummy value' }).id;
       databaseBuilder.factory.buildKnowledgeElement({ ...data, createdAt, answerId, userId, assessmentId });
     });
+  });
+
+  // A user having a timed challenge (for certification testing purpose)
+  const assessmentId = databaseBuilder.factory.buildAssessment({ userId: CERTIF_REGULAR_USER_WITH_TIMED_CHALLENGE_ID, type: 'COMPETENCE_EVALUATION', state: 'completed' }).id;
+  _.each(WEAK_CERTIFIABLE_WITH_TIMED_CHALLENGE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS, (data) => {
+    const answerId = databaseBuilder.factory.buildAnswer({ ...data, createdAt, updatedAt, assessmentId, value: 'Dummy value' }).id;
+    databaseBuilder.factory.buildKnowledgeElement({ ...data, createdAt, answerId, userId: CERTIF_REGULAR_USER_WITH_TIMED_CHALLENGE_ID, assessmentId });
   });
 }
 

--- a/api/db/seeds/data/certification/users.js
+++ b/api/db/seeds/data/certification/users.js
@@ -10,6 +10,7 @@ const CERTIF_REGULAR_USER3_ID = 108;
 const CERTIF_REGULAR_USER4_ID = 109;
 const CERTIF_REGULAR_USER5_ID = 110;
 const CERTIF_DROIT_USER5_ID = 111;
+const CERTIF_REGULAR_USER_WITH_TIMED_CHALLENGE_ID = 112;
 const { DEFAULT_PASSWORD } = require('../users-builder');
 
 const { SCO_STUDENT_ID } = require('../organizations-sco-builder');
@@ -124,6 +125,14 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
+  databaseBuilder.factory.buildUser.withRawPassword({
+    id: CERTIF_REGULAR_USER_WITH_TIMED_CHALLENGE_ID,
+    firstName: 'AnneCertifTimedChallenge',
+    lastName: 'CertifTimedChallenge',
+    email: 'certif-timed-challenge@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
 }
 
 module.exports = {
@@ -141,4 +150,5 @@ module.exports = {
   CERTIF_REGULAR_USER4_ID,
   CERTIF_REGULAR_USER5_ID,
   CERTIF_DROIT_USER5_ID,
+  CERTIF_REGULAR_USER_WITH_TIMED_CHALLENGE_ID,
 };

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -38,7 +38,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeWithoutCheckingStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
       });
 
       it('resolves the issue report', async function() {
@@ -90,7 +90,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeWithoutCheckingStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -149,7 +149,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
       });
 
       it('resolves the issue report', async function() {
@@ -204,7 +204,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -257,7 +257,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -316,7 +316,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfImageStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -379,7 +379,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
       });
 
       it('resolves the issue report', async function() {
@@ -436,7 +436,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -490,7 +490,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
         // then
         expect(certificationIssueReport.resolution).to.equal('Cette question n\' a pas été neutralisée car elle ne contient pas d\'application/simulateur');
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -549,7 +549,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfEmbedStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -614,7 +614,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
       });
 
       it('resolves the issue report', async function() {
@@ -673,7 +673,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -726,7 +726,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -787,7 +787,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfAttachmentStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -913,7 +913,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -966,7 +966,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -1027,7 +1027,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         const neutralizationAttempt = await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
 
         // then
-        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+        expect(neutralizationAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
       });
 
       it('resolves the certification issue report anyway', async function() {
@@ -1076,7 +1076,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       const resolutionAttempt = await doNotResolveStrategy({ certificationIssueReport, certificationAssessment: null, certificationIssueReportRepository: null, challengeRepository: null });
 
       // then
-      expect(resolutionAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.unresolved());
+      expect(resolutionAttempt).to.deepEqualInstance(CertificationIssueReportResolutionAttempt.unresolved());
     });
 
     it('does not resolve the certification issue report', async function() {

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -7,6 +7,7 @@ const {
   neutralizeIfImageStrategy,
   neutralizeIfEmbedStrategy,
   neutralizeIfAttachmentStrategy,
+  neutralizeIfTimedChallengeStrategy,
   doNotResolveStrategy,
 } = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 
@@ -822,6 +823,246 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
   });
 
+  context('#NEUTRALIZE_IF_TIMED_CHALLENGE', function() {
+
+    context('When challenge is neutralizable', function() {
+
+      it('neutralizes successfully', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const timedChallenge = domainBuilder.buildChallenge({
+          timer: 1.33,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(timedChallenge),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.deepEqualInstance(CertificationIssueReportResolutionAttempt.resolvedWithEffect());
+      });
+
+      it('resolves the issue report', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+        const certificationAnswer = domainBuilder.buildAnswer.ko(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+
+        const timedChallenge = domainBuilder.buildChallenge({
+          timer: 1.33,
+        });
+
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+
+        const challengeRepository = {
+          get: sinon.stub().resolves(timedChallenge),
+        };
+
+        // when
+        await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('the challenge does not contain the question designated by the question number', function() {
+
+      it('returns a successful resolution attempt without effect', async function() {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: () => {},
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
+          certificationAnswersByDate: [],
+        });
+
+        // when
+        const neutralizationAttempt = await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+      });
+
+      it('resolves the certification issue report anyway', async function() {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
+          certificationAnswersByDate: [],
+        });
+
+        // when
+        await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('the challenge is not timed', function() {
+
+      it('returns a successful resolution without effect', async function() {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const notTimedChallenge = domainBuilder.buildChallenge({});
+        const certificationIssueReportRepository = {
+          save: () => {},
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(notTimedChallenge),
+        };
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
+        });
+
+        // when
+        const neutralizationAttempt = await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+      });
+
+      it('resolves the certification issue report anyway', async function() {
+        // given
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const notTimedChallenge = domainBuilder.buildChallenge({});
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(notTimedChallenge),
+        };
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
+        });
+
+        // when
+        await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+
+    context('When challenge is not neutralizable', function() {
+
+      it('returns a successful resolution without effect', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const timedChallenge = domainBuilder.buildChallenge({
+          timer: 1.33,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(timedChallenge),
+        };
+
+        // when
+        const neutralizationAttempt = await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(neutralizationAttempt).to.deep.equal(CertificationIssueReportResolutionAttempt.resolvedWithoutEffect());
+      });
+
+      it('resolves the certification issue report anyway', async function() {
+        // given
+        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+        const certificationAnswer = domainBuilder.buildAnswer.ok(({ challengeId: certificationChallenge.challengeId }));
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge],
+          certificationAnswersByDate: [certificationAnswer],
+        });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          category: CertificationIssueReportCategories.IN_CHALLENGE,
+          questionNumber: 1,
+        });
+        const timedChallenge = domainBuilder.buildChallenge({
+          timer: 1.33,
+        });
+        const certificationIssueReportRepository = {
+          save: sinon.stub(),
+        };
+        const challengeRepository = {
+          get: sinon.stub().resolves(timedChallenge),
+        };
+
+        // when
+        await neutralizeIfTimedChallengeStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository, challengeRepository });
+
+        // then
+        expect(certificationIssueReport.isResolved()).to.be.true;
+        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+      });
+    });
+  });
+
   context('#DO_NOT_RESOLVE', function() {
     it('returns an unresolved resolution attempt', async function() {
       // given
@@ -921,7 +1162,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
-        strategyToBeApplied: 'doNotResolve',
+        strategyToBeApplied: 'neutralizeIfTimedChallenge',
       },
       // eslint-disable-next-line mocha/no-setup-in-describe
       {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, les questions timées pour les temps majorés nécessitent un traitement manuel de la part du pôle certif lorsqu’un signalement de type E8 - Le candidat bénéficie d’un temps majoré et n’a pas pu répondre à la question dans le temps imparti est remonté par le surveillant. En effet, le pôle certif va alors vérifier la réponse apportée par le candidat en dehors du temps imparti, vérifier le temps de réponse du candidat : si le temps de réponse est respecté et que la réponse est OK, alors le pôle certif modifie le statut de la question de “Temps écoulé” à “Succès” pour simuler une réponse OK et impacter le score du candidat dans ce sens.

Des travaux sont en cours pour ne plus permettre de modifier le statut d’une question et automatiser un maximum de process. Nous devons donc trouver une solution pour traiter ces cas de questions timées pour les temps majoré autrement, et automatiser ce traitement.

## :robot: Solution
Rendre automatique le traitement des signalements de type E8. Lorsqu’un signalement de ce type remonte pour un candidat : 

Vérifier le type d'épreuve (grâce au numéro de question indiqué) pour s’assurer qu’il s’agit bien d’une question timée

Vérifier le statut de la question : 
- SI l'épreuve est bien timée et le statut de la question est différent de “OK”, ALORS la question doit être automatiquement neutralisée
- SINON SI l'épreuve n’est pas timée et/ou que le statut de la question est “OK”, ALORS ne pas modifier le statut de la question

## :rainbow: Remarques
Cette PR contient aussi l'ajout de données de tests (seeds) pour générer un test de certification contenant une épreuve chronométrée.

## :100: Pour tester
**Cas nominal:**
- Se rendre sur Pix Certif (`certifpro@example.net`)
- Inscrire une nouvelle session de certification
- Ajouter un candidat


- Se rendre sur Mon Pix avec l'utilisateur `certif-timed-challenge@example.net`
- Rejoindre la session de certification précédemment créée
- Répondre faux à la première question (qui est chronométrée)
- Passer toutes les autres questions jusqu'à terminer le test de certification


- Retourner sur Pix Certif (`certifpro@example.net`)
- Recharger la page si vous aviez gardé celle-ci dans un onglet
- Cliquer sur "Finaliser la session"
- Ajouter un signalement de Type E8 (le candidat bénéficie d’un temps majoré et n’a pas pu répondre à la question dans le temps imparti) sur la question 1.
- Finaliser la session


- Se rendre du Pix Admin (`pixmaster@example.net`)
- Consulter le détail de la certification
- Constater la neutralisation auto de la question 1
- Constater que le signalement est résolu


**Variantes de tests :**
- Refaire le test en répondant juste à la question 1 : constater que la question 1 n'est pas neutralisée, mais que le signalement est tout de même résolu
- Refaire le test en ajoutant le signalement sur la question 2 (non chronométrée) : constater que la question 2 n'est pas neutralisée, mais que le signalement est tout de même résolu

