### PR TITLE
[BUGFIX] Réparer l'affichage de la liste déroulante de sélection d'une sous catégorie pour un signalement "E1-E9 Problème technique sur une question" (PIX-3084).

### DIFF
--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -98,12 +98,12 @@
       }
 
       .pix-select {
-        height: 35px;
         background: $white;
         border: 1.2px solid $grey-45;
         border-radius: 4px;
 
         select[id^="subcategory-for-category"] {
+          height: 35px;
           font-size: 14px;
           color: $grey-90;
         }


### PR DESCRIPTION
## :unicorn: Problème
![image (3)](https://user-images.githubusercontent.com/1216570/130624131-3a1ee085-61ff-4dee-a79b-b14ee7ca6ed0.png)

## :robot: Solution
- Réparer l'affichage de la liste déroulante

## :100: Pour tester
- Se connecter à Pix Certif avec le compte `certifsco@example.net`
- Finaliser la session 4
- Ajouter un signalement de type "E1-E9 Problème technique sur une question"
- Vérifier l'affichage de la liste déroulante de sélection d'une sous-catégorie