### PR TITLE
[TECH] Réutiliser le champ résultat pour une campagne de collecte de profils dans l'onglet 'Résultat' (PIX-3064).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -1,4 +1,3 @@
-const sumBy = require('lodash/sumBy');
 const chunk = require('lodash/chunk');
 const bluebird = require('bluebird');
 const { knex } = require('../bookshelf');
@@ -21,6 +20,7 @@ const CampaignProfilesCollectionParticipationSummaryRepository = {
         knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
         'campaign-participations.participantExternalId',
         'campaign-participations.sharedAt',
+        'campaign-participations.pixScore AS pixScore',
       )
       .from('campaign-participations')
       .join('users', 'users.id', 'campaign-participations.userId')
@@ -49,7 +49,6 @@ const CampaignProfilesCollectionParticipationSummaryRepository = {
 
         return new CampaignProfilesCollectionParticipationSummary({
           ...result,
-          pixScore: sumBy(placementProfile.userCompetences, 'pixScore'),
           certifiable: placementProfile.isCertifiable(),
           certifiableCompetencesCount: placementProfile.getCertifiableCompetencesCount(),
         });

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -86,7 +86,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       beforeEach(async function() {
         const createdAt = new Date('2018-04-06T10:00:00Z');
         const userId = 999;
-        campaignParticipation = { id: 888, userId, campaignId, isShared: true, sharedAt, participantExternalId: 'JeBu' };
+        campaignParticipation = { id: 888, userId, campaignId, isShared: true, sharedAt, participantExternalId: 'JeBu', pixScore: 46 };
         databaseBuilder.factory.buildCampaignParticipationWithUser({ id: userId, firstName: 'Jérémy', lastName: 'bugietta' }, campaignParticipation, false);
 
         databaseBuilder.factory.buildKnowledgeElement({


### PR DESCRIPTION
## :unicorn: Problème
Nous avons récemment enregistré en base les scores Pix des participants aux campagnes. Cela ayant pour but d'améliorer les performances et également de réduire les problèmes d'affichages.

## :robot: Solution
Utilisation de la colonne "scorePix" pour la liste des résultats d'une campagne de collecte de profils

## :rainbow: Remarques

## :100: Pour tester
Se connecter à Pix Orga, et vérifier le bon fonctionnement du tableau des résultats d'une campagne de collecte de profils.