### PR TITLE
[TECH] Modifier le taux de réponses apportées minimal à 66% (PIX-3087)

### DIFF
--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -23,6 +23,8 @@ const certificationAssessmentSchema = Joi.object({
   certificationAnswersByDate: Joi.array().min(0).required(),
 });
 
+const MINIMUM_ACCEPTABLE_ANSWERING_RATE = 66;
+
 class CertificationAssessment {
 
   constructor({
@@ -109,8 +111,8 @@ class CertificationAssessment {
   }
 
   hasUnsufficientAnsweringRateToBeScored() {
-    const answeringRate = (this.certificationAnswersByDate.length / this.certificationChallenges.length) * 100;
-    return answeringRate < 33;
+    const candidateAnsweringRate = (this.certificationAnswersByDate.length / this.certificationChallenges.length) * 100;
+    return candidateAnsweringRate < MINIMUM_ACCEPTABLE_ANSWERING_RATE;
   }
 
   getChallengeRecIdByQuestionNumber(questionNumber) {
@@ -126,5 +128,6 @@ function _isAnswerKoOrSkippedOrPartially(answerStatus) {
 }
 
 CertificationAssessment.states = states;
+CertificationAssessment.MINIMUM_ACCEPTABLE_ANSWERING_RATE = MINIMUM_ACCEPTABLE_ANSWERING_RATE;
 
 module.exports = CertificationAssessment;

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -496,7 +496,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
   });
 
   describe('#hasUnsufficientAnsweringRateToBeScored', function() {
-    it('returns true when answering rate < 33%', function() {
+    it(`returns true when candidate answering rate < ${CertificationAssessment.MINIMUM_ACCEPTABLE_ANSWERING_RATE}`, function() {
       // given
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [
@@ -507,13 +507,14 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
         ],
         certificationAnswersByDate: [
           domainBuilder.buildAnswer(),
+          domainBuilder.buildAnswer(),
         ],
       });
       // when / then
       expect(certificationAssessment.hasUnsufficientAnsweringRateToBeScored()).to.be.true;
     });
 
-    it('returns false when answering rate > 33%', function() {
+    it(`returns false when candidate answering rate > ${CertificationAssessment.MINIMUM_ACCEPTABLE_ANSWERING_RATE}`, function() {
       // given
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [
@@ -523,6 +524,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
           domainBuilder.buildCertificationChallenge(),
         ],
         certificationAnswersByDate: [
+          domainBuilder.buildAnswer(),
           domainBuilder.buildAnswer(),
           domainBuilder.buildAnswer(),
         ],


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, on annule une certification si le taux de réponse est inférieur à 33%, cependant, le taux souhaité est de 66%.

## :robot: Solution
Passer le taux minimum de réponses de 33 à 66%

## :100: Pour tester
- Activer le toggle FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED
- Passer une certification avec au moins deux candidats
- Répondre à toutes les questions avec un candidat
- Répondre à moins de 66% des épreuves avec le deuxième candidat
- Finaliser la session
- Constater dans pix-admin que la certification du candidat ayant répondu à moins de 66% des épreuves est annulée
