### PR TITLE
[TECH] Mise à jour du scénario "Inscription et positionnement" dans Pix Load-Testing (PIX-3082).

### DIFF
--- a/high-level-tests/load-testing/config/common.yml
+++ b/high-level-tests/load-testing/config/common.yml
@@ -1,5 +1,5 @@
 config:
-  processor: "../functions.js"
+  processor: "../processor/functions.js"
   environments:
     localhost:
       target: http://localhost:3000

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -15,6 +15,8 @@
   },
   "scripts": {
     "arti:cmd": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-competence-evaluation.yml",
+    "arti:local:campaign": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-campaign-participation.yml",
+    "arti:dev:campaign": "artillery run --config config/common.yml -e development -o report/index.json scenarios/signup-and-campaign-participation.yml",
     "arti:cmd:dev": "artillery run --config config/common.yml -e development -o report/index.json scenarios/signup-and-competence-evaluation.yml",
     "arti:run": "npm run db:initialize && npm run arti:cmd",
     "arti:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix npm run arti:run",

--- a/high-level-tests/load-testing/processor/functions.js
+++ b/high-level-tests/load-testing/processor/functions.js
@@ -14,7 +14,8 @@ function foundNextChallenge(context, next) {
 }
 
 function handleResponseForChallengeId(requestParams, response, context, events, next) {
-  context.vars.challengeId = get(response, 'body.data.id');
+  const responseBody = JSON.parse(response.body);
+  context.vars.challengeId = get(responseBody, 'data.id');
   return next();
 }
 

--- a/high-level-tests/load-testing/scenarios/signup-and-campaign-participation.yml
+++ b/high-level-tests/load-testing/scenarios/signup-and-campaign-participation.yml
@@ -7,12 +7,12 @@ config:
       arrivalRate: 5
       rampTo: 50
       name: Ramp up load
-    - duration: 600
-      arrivalRate: 50
-      name: Sustained load
+
+  variables:
+    campaignCode: "SIMPLIFIE"
 
 scenarios:
-  - name: 'Inscription et positionnement'
+  - name: 'Inscription, participation à une campagne et partage des résultats'
     flow:
       - function: "setupSignupFormData"
 
@@ -60,35 +60,41 @@ scenarios:
       ### From page /compte ###
       ### ----------------- ###
 
-      # Get first competence
+      # Get campaign target
       - get:
-          url: "/api/courses/recNPB7dTNt5krlMA"
+          url: "/api/campaigns?filter[code]={{ campaignCode }}"
           headers:
             Authorization: "Bearer {{ accessToken }}"
+          capture:
+            json: "$.data.id"
+            as: "campaignId"
 
-      # Get assessments filtered
-      - get:
-          url: "/api/assessments?filter[type]=PLACEMENT&filter[courseId]=recNPB7dTNt5krlMA&filter[resumable]=true"
-          headers:
-            Authorization: "Bearer {{ accessToken }}"
-
-      # Create assessment for competence
+      # Create campaign-participation
       - post:
-          url: "/api/assessments"
+          url: "/api/campaign-participations"
           headers:
             Authorization: "Bearer {{ accessToken }}"
           json:
             data:
+              type: "campaign-participations"
               attributes:
-                type: PLACEMENT
+                participant-external-id: null
               relationships:
-                course:
+                campaign:
                   data:
-                    type: courses
-                    id: "recNPB7dTNt5krlMA"
-              type: assessments
+                    id: "{{ campaignId }}"
+                    type: "campaigns"
           capture:
             json: "$.data.id"
+            as: "campaignParticipationId"
+
+      # Get campaign assessment filtered
+      - get:
+          url: "/api/assessments?filter[type]=CAMPAIGN&filter[codeCampaign]={{ campaignCode }}"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+          capture:
+            json: "$.data[0].id"
             as: "assessmentId"
 
       # Fetch assessment
@@ -109,13 +115,7 @@ scenarios:
       - loop:
           # Fetch answer (if exists)
           - get:
-              url: "/api/answers?assessment={{ assessmentId }}&challenge={{ challengeId }}"
-              headers:
-                Authorization: "Bearer {{ accessToken }}"
-
-          # Fetch next challenge details
-          - get:
-              url: "/api/challenges/{{ challengeId }}"
+              url: "/api/answers?assessmentId={{ assessmentId }}&challengeId={{ challengeId }}"
               headers:
                 Authorization: "Bearer {{ accessToken }}"
 
@@ -135,50 +135,40 @@ scenarios:
                   relationships:
                     assessment:
                       data:
-                        type: "assessments"
                         id: "{{ assessmentId }}"
+                        type: "assessments"
                     challenge:
                       data:
-                        type: "challenges"
                         id: "{{ challengeId }}"
-                  type: answers
-
-          # Fetch assessment
-          - get:
-              url: "/api/assessments/{{ assessmentId }}"
-              headers:
-                Authorization: "Bearer {{ accessToken }}"
+                        type: "challenges"
+                  type: "answers"
 
           # Fetch assessment next challenge
           - get:
               url: "/api/assessments/{{ assessmentId }}/next"
               headers:
                 Authorization: "Bearer {{ accessToken }}"
-              capture:
-                json: "$.data.id"
-                as: "challengeId"
+              afterResponse: "handleResponseForChallengeId"
 
         whileTrue: "foundNextChallenge"
 
-      # Fetch assessment
-      - get:
-          url: "/api/assessments/{{ assessmentId }}"
+      # Complete assessment
+      - patch:
+          url: "/api/assessments/{{ assessmentId }}/complete-assessment"
           headers:
             Authorization: "Bearer {{ accessToken }}"
 
-      # Post assessment-result
-      - post:
-          url: "/api/assessment-results"
+      # Fetch assessment-result
+      - get:
+          url: "/api/users/{{ userId }}/campaigns/{{ campaignId }}/assessment-result"
           headers:
             Authorization: "Bearer {{ accessToken }}"
-          json:
-            data:
-              relationships:
-                assessment:
-                  data:
-                    type: assessments
-                    id: "{{ assessmentId }}"
-              type: assessment-results
+
+      # Share campaign participation
+      - patch:
+          url: "/api/campaign-participations/{{ campaignParticipationId }}"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
 
       ### ----------------------------------------------------- ###
       ### From page /assessment-result, go back to profile page ###

--- a/high-level-tests/load-testing/tests/unit/processor/functions_test.js
+++ b/high-level-tests/load-testing/tests/unit/processor/functions_test.js
@@ -49,14 +49,10 @@ describe('Unit | Processor | Functions', () => {
 
     it('should retrieve challengeId', () => {
       // given
-      const challengeId = 100;
+      const challengeId = 'recZTnGUZgrglFQE3';
       const requestParams = {};
       const response = {
-        body: {
-          data: {
-            id: challengeId,
-          },
-        },
+        body: `{"data":{"id":"${challengeId}"}}`,
       };
       const context = {
         vars: {},


### PR DESCRIPTION
## :unicorn: Problème
Dans l'application Pix Load-Testing, le scenario actuel, concernant l’inscription, le parcours complet d’une campagne et son partage de résultats, ne fonctionne pas.

## :robot: Solution
Mettre à jour ce scénario en choisissant la campagne `SIMPLIFIE`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
### En local
* Lancer l'API
* Lancer le scenario avec commande
    ```sh
    npm run arti:local:campaign
    ```   
### Sur Pix-load-testing
* Mettre à jour la base de données de l'API cible avec la commande
    ```sh
    scalingo --region osc-fr1 -a pix-api-load-testing run npm run db:seed
    ``` 
* Lancer le scenario avec commande
    ```sh
    scalingo --region osc-fr1 -a pix-load-testing run npm run arti:dev:campaign
    ```   