### PR TITLE
[FEATURE] N'utiliser que la dernière participation d'une campagne pour chaque utilisateur dans l'onglet analyse(PIX-2964).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-analysis-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-analysis-repository.js
@@ -38,7 +38,7 @@ module.exports = {
 async function _getSharedParticipationsWithUserIdsAndDates(campaignId) {
   const results = await knex('campaign-participations')
     .select('userId', 'sharedAt')
-    .where({ campaignId, isShared: true });
+    .where({ campaignId, isShared: true, isImproved: false });
 
   const userIdsAndDates = [];
   for (const result of results) {


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'implémentation du flag `isImproved` dans la table `campaign-participations`, un même utilisateur peut partager plusieurs fois une même campagne.

Ce qui à pour effet de rendre le score moyen dans chaque compétence dans l'onglet analyse incorrect
 
## :robot: Solution
Filtrer sur isImproved à true dans la requêtes afin de ne plus avoir des doublons de participation pour effectuer ce résultat moyen.
 
## :rainbow: Remarques

## :100: Pour tester
Se connecter sur pro.admin@example.net et vérifier l'onglet analyse des campagnes