### PR TITLE
[TECH] Gérer le logging des métriques knex queries lors des exécutions via des scripts SQL (PIX-3090).

### DIFF
--- a/api/lib/infrastructure/performance-tools.js
+++ b/api/lib/infrastructure/performance-tools.js
@@ -12,12 +12,12 @@ function logKnexQueriesWithCorrelationId(data, msg) {
     logger.info({
       request_id: `${get(request, 'info.id', '-')}`,
       knex_query_id: knexQueryId,
-      knex_query_position: request.knexQueryPosition[knexQueryId],
+      knex_query_position: get(request, ['knexQueryPosition', knexQueryId ], '-'),
       knex_query_sql: data.sql,
       knex_query_params: [(data.bindings) ? data.bindings.join(',') : ''],
       duration: get(data, 'duration', '-'),
       http: {
-        method: request.method,
+        method: get(request, 'method', '-'),
         url_detail: {
           path: get(request, 'path', '-'),
         },
@@ -28,10 +28,12 @@ function logKnexQueriesWithCorrelationId(data, msg) {
 
 function addPositionToQuerieAndIncrementQueriesCounter(knexQueryId) {
   const request = asyncLocalStorage.getStore();
-  request.knexQueryPosition = request.knexQueryPosition || [];
-  request.queriesCounter = request.queriesCounter || 0;
-  request.queriesCounter++;
-  request.knexQueryPosition[knexQueryId] = request.queriesCounter;
+  if (request) {
+    request.knexQueryPosition = request.knexQueryPosition || [];
+    request.queriesCounter = request.queriesCounter || 0;
+    request.queriesCounter++;
+    request.knexQueryPosition[knexQueryId] = request.queriesCounter;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## :unicorn: Problème
Quand on lance un script avec l'option LOG_KNEX_QUERIES_WITH_CORRELATION_ID activé.
On obtient l'erreur suivante:
`UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'knexQueryPosition' of undefined.`
Comme les events knex ne sont pas déclenchées par un appel Hapi. La requête Hapi n'est pas présente dans le store de l'async local storage, ce qui empêche d'alimenter le métrique knexQueryPosition.

## :robot: Solution
Sécuriser le code pour afficher les métriques selon leur contexte d'exécution. 

## :100: Pour tester
En locale lancer un reset de la base de donnée:
LOG_KNEX_QUERIES_WITH_CORRELATION_ID=true npm run db:reset 
Vérifier que le script se terminer correctement et que les métriques possibles sont disponibles.