### PR TITLE
[TECH] Réutiliser le champ résultat pour le détail du profil d'un participant dans une campagne de collecte de profils(PIX-3083)

### DIFF
--- a/api/lib/domain/read-models/CampaignProfile.js
+++ b/api/lib/domain/read-models/CampaignProfile.js
@@ -12,6 +12,8 @@ class CampaignProfile {
     sharedAt,
     isShared,
     createdAt,
+    pixScore,
+
   }) {
     this.firstName = firstName;
     this.lastName = lastName;
@@ -22,13 +24,7 @@ class CampaignProfile {
     this.isShared = isShared;
     this.createdAt = createdAt;
     this.placementProfile = placementProfile;
-  }
-
-  get pixScore() {
-    if (this.isShared) {
-      return this.placementProfile.getPixScore();
-    }
-    return null;
+    this.pixScore = pixScore;
   }
 
   get isCertifiable() {

--- a/api/lib/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profile-repository.js
@@ -29,6 +29,7 @@ async function _fetchCampaignProfileAttributesFromCampaignParticipation(campaign
         'campaign-participations.sharedAt',
         'campaign-participations.isShared',
         'campaign-participations.participantExternalId',
+        'campaign-participations.pixScore',
       ])
         .from('campaign-participations')
         .leftJoin('users', 'campaign-participations.userId', 'users.id')

--- a/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
@@ -190,7 +190,7 @@ describe('Integration | Repository | CampaignProfileRepository', function() {
         expect(campaignProfile.certifiableCompetencesCount).to.equal(1);
       });
 
-      it('return the total pix score limited to MAX_REACHABLE_PIX_BY_COMPETENCE', async function() {
+      it('return the total pix score', async function() {
         databaseBuilder.factory.buildCampaign().id;
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
@@ -199,6 +199,7 @@ describe('Integration | Repository | CampaignProfileRepository', function() {
           userId: user.id,
           sharedAt: new Date('2020-01-02'),
           isShared: true,
+          pixScore: 80,
         });
         databaseBuilder.factory.buildKnowledgeElement({ userId: user.id,
           earnedPix: 1024,
@@ -220,7 +221,7 @@ describe('Integration | Repository | CampaignProfileRepository', function() {
         expect(campaignProfile.pixScore).to.equal(80);
       });
 
-      it('computes certification informations with knowledge elements acquired before the sharing date of the campaign participation', async function() {
+      it('computes certifiable competences acquired before the sharing date of the campaign participation', async function() {
         databaseBuilder.factory.buildCampaign().id;
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
@@ -245,7 +246,6 @@ describe('Integration | Repository | CampaignProfileRepository', function() {
 
         const campaignProfile = await CampaignProfileRepository.findProfile({ campaignId, campaignParticipationId: campaignParticipation.id, locale });
 
-        expect(campaignProfile.pixScore).to.equal(PIX_COUNT_BY_LEVEL);
         expect(campaignProfile.certifiableCompetencesCount).to.equal(1);
       });
     });

--- a/api/tests/unit/domain/read-models/CampaignProfile_test.js
+++ b/api/tests/unit/domain/read-models/CampaignProfile_test.js
@@ -2,30 +2,6 @@ const { expect } = require('../../../test-helper');
 const CampaignProfile = require('../../../../lib/domain/read-models/CampaignProfile');
 
 describe('Unit | Domain | Read-Models | CampaignProfile', function() {
-  describe('#pixScore', function() {
-    context('when the campaign participation is shared', function() {
-      it('compute the total pix score certification profile', function() {
-        const params = { isShared: true };
-        const placementProfile = { getPixScore: () => 8 };
-
-        const campaignProfile = new CampaignProfile({ ...params, placementProfile });
-
-        expect(campaignProfile.pixScore).to.equal(8);
-      });
-    });
-
-    context('when the campaign participation is not shared', function() {
-      it('does not compute the pix score', function() {
-        const params = { isShared: false };
-        const placementProfile = { getPixScore: () => 2 };
-
-        const campaignProfile = new CampaignProfile({ ...params, placementProfile });
-
-        expect(campaignProfile.pixScore).to.equal(null);
-      });
-    });
-  });
-
   describe('#isCertifiable', function() {
     describe('when the  campaign participation is shared', function() {
       it('compute the number of certifiable competence', function() {
@@ -203,6 +179,16 @@ describe('Unit | Domain | Read-Models | CampaignProfile', function() {
       const campaignProfile = new CampaignProfile(params);
 
       expect(campaignProfile.createdAt).to.deep.equal(new Date('2020-01-02'));
+    });
+  });
+
+  describe('#pixScore', function() {
+    it('returns the pixScore', function() {
+      const params = { pixScore: 768 };
+
+      const campaignProfile = new CampaignProfile(params);
+
+      expect(campaignProfile.pixScore).to.equal(768);
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-profile-serializer_test.js
@@ -18,6 +18,7 @@ describe('Unit | Serializer | JSONAPI | campaign-profile-serializer', function()
       participantExternalId: 'anExternalId',
       createdAt: '2020-01-01',
       sharedAt: '2020-01-02',
+      pixScore: 12,
       placementProfile: new PlacementProfile({
         userCompetences: [
           new UserCompetence({


### PR DESCRIPTION
## :unicorn: Problème
Nous avons récemment enregistré en base les scores Pix des participants aux campagnes. Cela ayant pour but d'améliorer les performances et également de réduire les problèmes d'affichages.

## :robot: Solution
Utilisation de la colonne "scorePix" pour le détail du profil d'un participant dans une campagne de collecte de profils

## :rainbow: Remarques

## :100: Pour tester
Se connecter à Pix Orga, et vérifier le bon fonctionnement du tableau des résultats d'une campagne de collecte de profils.