### PR TITLE
[TECH] Optimiser le temps de réponse de l'api /campaign-participations pour la campagne Pôle Emploi (PIX-3091).

### DIFF
--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -1,3 +1,4 @@
+const performanceTool = require('../../infrastructure/performance-tools');
 const usecases = require('../../domain/usecases');
 const events = require('../../domain/events');
 
@@ -24,7 +25,7 @@ module.exports = {
     } = await DomainTransaction.execute((domainTransaction) => {
       return usecases.startCampaignParticipation({ campaignParticipation, userId, domainTransaction });
     });
-    await events.eventDispatcher.dispatch(event);
+    events.eventDispatcher.dispatch(event).catch((error) => performanceTool.logErrorWithCorrelationId(error));
 
     return h.response(campaignParticipationSerializer.serialize(campaignParticipationCreated)).created();
   },

--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -38,7 +38,7 @@ module.exports = {
       userId,
       campaignParticipationId,
     });
-    await events.eventDispatcher.dispatch(event);
+    events.eventDispatcher.dispatch(event).catch((error) => performanceTool.logErrorWithCorrelationId(error));
     return null;
   },
 

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -1,13 +1,12 @@
 const get = require('lodash/get');
 const moment = require('moment');
 const querystring = require('querystring');
-
+const performanceTool = require('../../performance-tools');
 const authenticationMethodRepository = require('../../repositories/authentication-method-repository');
 const AuthenticationMethod = require('../../../domain/models/AuthenticationMethod');
 const httpAgent = require('../../http/http-agent');
 const settings = require('../../../config');
 const { UnexpectedUserAccountError } = require('../../../domain/errors');
-const logger = require('../../logger');
 
 module.exports = {
   async notify(userId, payload) {
@@ -35,7 +34,7 @@ module.exports = {
 
       if (!tokenResponse.isSuccessful) {
         const errorMessage = _getErrorMessage(tokenResponse.data);
-        logger.error(errorMessage);
+        performanceTool.logErrorWithCorrelationId(errorMessage);
         return {
           isSuccessful: tokenResponse.isSuccessful,
           code: tokenResponse.code || '500',
@@ -63,7 +62,7 @@ module.exports = {
 
     if (!httpResponse.isSuccessful) {
       const errorMessage = _getErrorMessage(httpResponse.data);
-      logger.error(errorMessage);
+      performanceTool.logErrorWithCorrelationId(errorMessage);
     }
 
     return {

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
-const logger = require('../logger');
+const { logInfoWithCorrelationId, logErrorWithCorrelationId } = require('../../infrastructure/performance-tools');
 
 class HttpResponse {
   constructor({
@@ -16,14 +16,14 @@ class HttpResponse {
 
 module.exports = {
   async post({ url, payload, headers }) {
-    logger.debug(`Starting POST request to ${url}`);
+    logInfoWithCorrelationId(`Starting POST request to ${url}`);
 
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
       });
 
-      logger.debug(`End POST request to ${url} success: ${httpResponse.status}`);
+      logInfoWithCorrelationId(`End POST request to ${url} success: ${httpResponse.status}`);
 
       return new HttpResponse({
         code: httpResponse.status,
@@ -41,7 +41,7 @@ module.exports = {
         data = httpErr.message;
       }
 
-      logger.debug(`End POST request to ${url} error: ${code} ${data.toString()}`);
+      logErrorWithCorrelationId(`End POST request to ${url} error: ${code} ${data.toString()}`);
 
       return new HttpResponse({
         code,
@@ -51,13 +51,13 @@ module.exports = {
     }
   },
   async get({ url, payload, headers }) {
-    logger.debug(`Starting GET request to ${url}`);
+    logInfoWithCorrelationId(`Starting GET request to ${url}`);
 
     try {
       const config = { data: payload, headers };
       const httpResponse = await axios.get(url, config);
 
-      logger.debug(`End GET request to ${url} success: ${httpResponse.status}`);
+      logInfoWithCorrelationId(`End GET request to ${url} success: ${httpResponse.status}`);
 
       return new HttpResponse({
         code: httpResponse.status,
@@ -78,7 +78,7 @@ module.exports = {
         data = null;
       }
 
-      logger.debug(`End GET request to ${url} error: ${code}`);
+      logInfoWithCorrelationId(`End GET request to ${url} error: ${code}`);
 
       return new HttpResponse({
         code,

--- a/api/lib/infrastructure/performance-tools.js
+++ b/api/lib/infrastructure/performance-tools.js
@@ -39,6 +39,19 @@ function logErrorWithCorrelationId(error) {
   }, error);
 }
 
+function logInfoWithCorrelationId(message) {
+  const request = asyncLocalStorage.getStore();
+  logger.info({
+    request_id: `${get(request, 'info.id', '-')}`,
+    http: {
+      method: get(request, 'method', '-'),
+      url_detail: {
+        path: get(request, 'path', '-'),
+      },
+    },
+  }, message);
+}
+
 function addPositionToQuerieAndIncrementQueriesCounter(knexQueryId) {
   const request = asyncLocalStorage.getStore();
   if (request) {
@@ -54,4 +67,5 @@ module.exports = {
   addPositionToQuerieAndIncrementQueriesCounter,
   logKnexQueriesWithCorrelationId,
   logErrorWithCorrelationId,
+  logInfoWithCorrelationId,
 };

--- a/api/lib/infrastructure/performance-tools.js
+++ b/api/lib/infrastructure/performance-tools.js
@@ -26,6 +26,19 @@ function logKnexQueriesWithCorrelationId(data, msg) {
   }
 }
 
+function logErrorWithCorrelationId(error) {
+  const request = asyncLocalStorage.getStore();
+  logger.error({
+    request_id: `${get(request, 'info.id', '-')}`,
+    http: {
+      method: get(request, 'method', '-'),
+      url_detail: {
+        path: get(request, 'path', '-'),
+      },
+    },
+  }, error);
+}
+
 function addPositionToQuerieAndIncrementQueriesCounter(knexQueryId) {
   const request = asyncLocalStorage.getStore();
   if (request) {
@@ -40,4 +53,5 @@ module.exports = {
   asyncLocalStorage,
   addPositionToQuerieAndIncrementQueriesCounter,
   logKnexQueriesWithCorrelationId,
+  logErrorWithCorrelationId,
 };

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -7,7 +7,7 @@ const AuthenticationMethod = require('../../../../../lib/domain/models/Authentic
 const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
 const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const authenticationMethodRepository = require('../../../../../lib/infrastructure/repositories/authentication-method-repository');
-const logger = require('../../../../../lib/infrastructure/logger');
+const performanceTool = require('../../../../../lib/infrastructure/performance-tools');
 
 describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier', function() {
 
@@ -45,7 +45,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
       sinon.stub(httpAgent, 'post');
       sinon.stub(authenticationMethodRepository, 'findOneByUserIdAndIdentityProvider');
       sinon.stub(authenticationMethodRepository, 'updatePoleEmploiAuthenticationComplementByUserId');
-      sinon.stub(logger, 'error');
+      sinon.stub(performanceTool, 'logErrorWithCorrelationId');
 
       settings.poleEmploi.tokenUrl = 'someTokenUrlToPoleEmploi';
       settings.poleEmploi.sendingUrl = 'someSendingUrlToPoleEmploi';
@@ -216,7 +216,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
             payload: sinon.match.any,
           }).resolves(tokenResponse);
 
-          logger.error.resolves();
+          performanceTool.logErrorWithCorrelationId.resolves();
 
           const expectedLoggerMessage = `${errorData.error} ${errorData.error_description}`;
           const expectedResult = {
@@ -228,7 +228,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           const result = await notify(userId, payload, poleEmploiSending);
 
           // then
-          expect(logger.error).to.have.been.calledWith(expectedLoggerMessage);
+          expect(performanceTool.logErrorWithCorrelationId).to.have.been.calledWith(expectedLoggerMessage);
           expect(result).to.deep.equal(expectedResult);
         });
 
@@ -263,7 +263,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
               payload: sinon.match.any,
             }).resolves(httpResponse);
 
-          logger.error.resolves();
+          performanceTool.logErrorWithCorrelationId.resolves();
 
           const expectedLoggerMessage = httpResponse.data;
           const expectedResult = {
@@ -275,7 +275,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           const result = await notify(userId, payload, poleEmploiSending);
 
           // then
-          expect(logger.error).to.have.been.calledWith(expectedLoggerMessage);
+          expect(performanceTool.logErrorWithCorrelationId).to.have.been.calledWith(expectedLoggerMessage);
           expect(result).to.deep.equal(expectedResult);
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
La campagne Pôle Emploi met beaucoup de temps en production à cause de l’appel API /campaign-participations qui met trop de temps à répondre.
![image](https://user-images.githubusercontent.com/10045497/130974780-231d0fc3-d28d-4700-9426-cb586af29a7e.png)
La fonction dispatch de l'eventDispatcher est asynchrone: 
 ` await events.eventDispatcher.dispatch(event);`
Néanmoins le await nous oblige à attendre l'execution du handler qui déclenche un appel API vers Pôle Emploi et attend un résultat. Le temps d'appel vers cet API se rajoute au temps globale de l'api /campaign-participations.

## :robot: Solution
Ne pas attendre le résultat et logger uniquement les erreurs si le handler throw une exception.
Le log en erreur utilise un utilitaire qui permet de corréler la stacktrace avec l'appel qui l'a généré via le request_id.

## :rainbow: Remarques
Dans les logs hapi js, on voit bien la fameux temps négatif qui va être corrigé dans une autre PR, mais en mesurant le gain en locale:
 **X *22** pour l’appel qui déclenche l’événement CampaignParticipationStarted
Avec attente du handler Time: 1107ms
Sans attente du handler : 50ms
**X *68** pour l’appel qui déclenche l’événement CampaignParticipationResultsShared
Avec attente du handler Time: 2586ms
Sans attente du handler : 38ms

**Ordre avec le await sur l’event:**

1. start controller campaign participation save
2. start event
3. start handler PE
4. end handler PE
5. end controller campaign participation save

**Ordre sans le await sur l’event avec le catch:**

1. start controller campaign participation save
2. start event
3. start handler PE
4. End controller campaign participation save [ Reponse retournée sans attendre le handler, en cas d’erreur API, on log l’erreur. Du coup on gagne tout le temps passé dans le handler qui fait l’appel à PE ]
5. End handler PE

## :100: Pour tester
Un test a été effectué en simulant un setTimeout dans le handler pour rallonger le temps de réponse.
Le test d'acceptance passe sans attendre le retour du handler qui s'exécute correctement.

Un test en local avec PE en recette a été fait. Les résultats du logs sont ci-dessous.
Constatez que l'API a retourné un status 200 alors que le handler est toujours en exécution.
D'ailleurs, on voit qu'un autre appel API s'est lancée et s'est bien terminée avant la fin du handler. Ce qui nous fait gagner l'équivalent d'un appel API en terme de temps de réponse.
```
210826/124441.719, (1629981881719:MacBook-Pro-de-yahya.local:98904:kssx1z0l:10012) [response,api,campaign-participation] http://MacBook-Pro-de-yahya.local:3000: post /api/campaign-participations {} 201 (-1629981881719ms)
210826/124518.955, (1629981918955:MacBook-Pro-de-yahya.local:98904:kssx1z0l:10013) [response,api] http://MacBook-Pro-de-yahya.local:3000: get /api/assessments {"filter[type]":"CAMPAIGN","filter[codeCampaign]":"QWERTY789"} 200 (16407ms)
{"name":"pix-api","hostname":"MacBook-Pro-de-yahya.local","pid":98904,"level":30,"request_id":"1629981881719:MacBook-Pro-de-yahya.local:98904:kssx1z0l:10012","http":{"method":"post","url_detail":{"path":"/api/campaign-participations"}},"msg":"Starting POST request to https://api-r.es-qvr.fr/partenaire/peconnect-servicesdigitaux/v1/resultat-service","time":"2021-08-26T12:45:40.260Z","v":0}
{"name":"pix-api","hostname":"MacBook-Pro-de-yahya.local","pid":98904,"level":30,"request_id":"1629981881719:MacBook-Pro-de-yahya.local:98904:kssx1z0l:10012","http":{"method":"post","url_detail":{"path":"/api/campaign-participations"}},"msg":"End POST request to https://api-r.es-qvr.fr/partenaire/peconnect-servicesdigitaux/v1/resultat-service success: 200","time":"2021-08-26T12:45:41.152Z","v":0}
```