### PR TITLE
[FEATURE] Afficher la dernière participation dans l'export d'une campagne de collecte(PIX-2967)

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -112,7 +112,7 @@ module.exports = {
             this.on({ 'campaign-participations.userId': 'schooling-registrations.userId' })
               .andOn({ 'campaigns.organizationId': 'schooling-registrations.organizationId' });
           })
-          .where({ campaignId });
+          .where({ campaignId, isImproved: false });
       })
       .from('campaignParticipationWithUser');
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -455,6 +455,37 @@ describe('Integration | Repository | Campaign Participation', function() {
       });
     });
 
+    context('When the participant has improved its participation', function() {
+      let campaignId, improvedCampaignParticipation;
+
+      beforeEach(async function() {
+        campaignId = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION, multipleSendings: true }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          userId,
+          isShared: true,
+          createdAt: new Date('2016-01-15T14:59:35Z'),
+          isImproved: true,
+        });
+        improvedCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          userId,
+          isShared: true,
+          createdAt: new Date('2016-07-15T14:59:35Z'),
+          isImproved: false,
+        });
+        await databaseBuilder.commit();
+      });
+
+      it('should return the non improved campaign-participation', async function() {
+        const participationResultDatas = await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaignId);
+
+        expect(participationResultDatas.length).to.eq(1);
+        expect(participationResultDatas[0].id).to.eq(improvedCampaignParticipation.id);
+      });
+    });
+
     context('When sharedAt is null', function() {
 
       it('Should return null as shared date', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'ouverture des campagnes à envois multiples, on a maintenant la possibilité de repasser une campagne de collecte de profils. Mais dans l'export, on affichait les résultats de l'ancienne participation.

## :robot: Solution
N'afficher que la dernière participation dans l'export.

## :rainbow: Remarques

## :100: Pour tester
Aller dans pix Orga, exporter les résultats d'une campagne de collecte de profils.
Aller dans mon-pix avec le profil d'un des participants de la campagne et faire progresser le profil puis ressaisir le code de la campagne et partager les résultats. 
Revenir sur pix Orga et refaire un export