### PR TITLE
[TECH] Réutiliser le champ résultat pour la page "mes parcours" (PIX-3085)

### DIFF
--- a/api/lib/domain/read-models/CampaignParticipationOverview.js
+++ b/api/lib/domain/read-models/CampaignParticipationOverview.js
@@ -14,6 +14,7 @@ class CampaignParticipationOverview {
     campaignTitle,
     campaignArchivedAt,
     targetProfile,
+    masteryPercentage,
   } = {}) {
     this.id = id;
     this.createdAt = createdAt;
@@ -28,20 +29,13 @@ class CampaignParticipationOverview {
     this.campaignTitle = campaignTitle;
     this.campaignArchivedAt = campaignArchivedAt;
     this.targetProfile = targetProfile;
-  }
-
-  get masteryPercentage() {
-    if (!this.isShared) return null;
-
-    if (this.totalSkillsCount === 0) return 0;
-
-    return Math.round(this.validatedSkillsCount * 100 / this.totalSkillsCount);
+    this.masteryPercentage = masteryPercentage;
   }
 
   get validatedStagesCount() {
     if (_.isEmpty(this.targetProfile.stages) || !this.isShared) return null;
 
-    const validatedStages = this._getReachableStages().filter((stage) => stage.threshold <= this.masteryPercentage);
+    const validatedStages = this._getReachableStages().filter((stage) => stage.threshold <= (this.masteryPercentage * 100));
     return validatedStages.length;
   }
 

--- a/api/lib/domain/read-models/CampaignParticipationOverview.js
+++ b/api/lib/domain/read-models/CampaignParticipationOverview.js
@@ -7,7 +7,6 @@ class CampaignParticipationOverview {
     createdAt,
     isShared,
     sharedAt,
-    validatedSkillsCount,
     organizationName,
     assessmentState,
     campaignCode,
@@ -21,8 +20,6 @@ class CampaignParticipationOverview {
     this.isShared = isShared;
     this.sharedAt = sharedAt;
     this.targetProfileId = targetProfile.id;
-    this.validatedSkillsCount = validatedSkillsCount;
-    this.totalSkillsCount = targetProfile.skills.length;
     this.organizationName = organizationName;
     this.assessmentState = assessmentState;
     this.campaignCode = campaignCode;

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -33,7 +33,6 @@ function _findByUserId({ userId }) {
         createdAt: 'campaign-participations.createdAt',
         isShared: 'campaign-participations.isShared',
         sharedAt: 'campaign-participations.sharedAt',
-        validatedSkillsCount: 'campaign-participations.validatedSkillsCount',
         masteryPercentage: 'campaign-participations.masteryPercentage',
         campaignCode: 'campaigns.code',
         campaignTitle: 'campaigns.title',

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -34,6 +34,7 @@ function _findByUserId({ userId }) {
         isShared: 'campaign-participations.isShared',
         sharedAt: 'campaign-participations.sharedAt',
         validatedSkillsCount: 'campaign-participations.validatedSkillsCount',
+        masteryPercentage: 'campaign-participations.masteryPercentage',
         campaignCode: 'campaigns.code',
         campaignTitle: 'campaigns.title',
         targetProfileId: 'campaigns.targetProfileId',

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -53,8 +53,6 @@ describe('Integration | Repository | Campaign Participation Overview', function(
           organizationName: 'Organization ABCD',
           assessmentState: Assessment.states.STARTED,
           targetProfileId: targetProfile.id,
-          totalSkillsCount: 1,
-          validatedSkillsCount: 1,
           masteryPercentage: '0.10',
           totalStagesCount: 1,
           validatedStagesCount: 1,

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -36,7 +36,7 @@ describe('Integration | Repository | Campaign Participation Overview', function(
       it('retrieves information about campaign participation, campaign and organization', async function() {
         const { id: organizationId } = databaseBuilder.factory.buildOrganization({ name: 'Organization ABCD' });
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ title: 'Campaign ABCD', code: 'ABCD', archivedAt: new Date('2020-01-03'), organizationId, targetProfileId: targetProfile.id });
-        const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, createdAt: new Date('2020-01-01'), sharedAt: new Date('2020-01-02'), validatedSkillsCount: 1 });
+        const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, createdAt: new Date('2020-01-01'), sharedAt: new Date('2020-01-02'), validatedSkillsCount: 1, masteryPercentage: '0.10' });
         databaseBuilder.factory.buildAssessment({ campaignParticipationId: participationId, state: Assessment.states.STARTED });
         await databaseBuilder.commit();
 
@@ -55,7 +55,7 @@ describe('Integration | Repository | Campaign Participation Overview', function(
           targetProfileId: targetProfile.id,
           totalSkillsCount: 1,
           validatedSkillsCount: 1,
-          masteryPercentage: 100,
+          masteryPercentage: '0.10',
           totalStagesCount: 1,
           validatedStagesCount: 1,
 

--- a/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
+++ b/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
@@ -17,7 +17,6 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
         isShared: true,
         sharedAt: new Date('2020-03-15T15:00:34Z'),
         targetProfile: targetProfile,
-        validatedSkillsCount: 1,
         organizationName: 'Pix',
         assessmentState: 'completed',
         campaignCode: 'campaignCode',
@@ -31,7 +30,6 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
       expect(campaignParticipationOverview.sharedAt).to.deep.equal(new Date('2020-03-15T15:00:34Z'));
       expect(campaignParticipationOverview.isShared).to.be.true;
       expect(campaignParticipationOverview.targetProfileId).to.equal(2);
-      expect(campaignParticipationOverview.validatedSkillsCount).to.equal(1);
       expect(campaignParticipationOverview.organizationName).to.equal('Pix');
       expect(campaignParticipationOverview.assessmentState).to.equal('completed');
       expect(campaignParticipationOverview.campaignCode).to.equal('campaignCode');

--- a/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
+++ b/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
@@ -22,6 +22,7 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
         assessmentState: 'completed',
         campaignCode: 'campaignCode',
         campaignTitle: 'campaignTitle',
+        masteryPercentage: '0.50',
       });
 
       // then
@@ -35,50 +36,7 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
       expect(campaignParticipationOverview.assessmentState).to.equal('completed');
       expect(campaignParticipationOverview.campaignCode).to.equal('campaignCode');
       expect(campaignParticipationOverview.campaignTitle).to.equal('campaignTitle');
-    });
-  });
-
-  describe('#masteryPercentage', function() {
-    it('should compute mastery percentage', function() {
-      const targetProfile = new TargetProfileWithLearningContent({ skills: [new Skill(), new Skill()] });
-
-      // when
-      const campaignParticipationOverview = new CampaignParticipationOverview({
-        isShared: true,
-        validatedSkillsCount: 1,
-        targetProfile,
-      });
-
-      // then
-      expect(campaignParticipationOverview.masteryPercentage).to.equal(50);
-    });
-
-    it('should return 0 if total skills count is zero', function() {
-      const targetProfile = new TargetProfileWithLearningContent({ skills: [] });
-
-      // when
-      const campaignParticipationOverview = new CampaignParticipationOverview({
-        isShared: true,
-        validatedSkillsCount: 1,
-        targetProfile,
-      });
-
-      // then
-      expect(campaignParticipationOverview.masteryPercentage).to.equal(0);
-    });
-
-    it('should return null the participation is not shared', function() {
-      const targetProfile = new TargetProfileWithLearningContent({ skills: [new Skill()] });
-
-      // when
-      const campaignParticipationOverview = new CampaignParticipationOverview({
-        isShared: false,
-        validatedSkillsCount: 1,
-        targetProfile,
-      });
-
-      // then
-      expect(campaignParticipationOverview.masteryPercentage).to.equal(null);
+      expect(campaignParticipationOverview.masteryPercentage).to.equal('0.50');
     });
   });
 
@@ -103,6 +61,7 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
             isShared: true,
             validatedSkillsCount: 1,
             targetProfile,
+            masteryPercentage: '0.5',
           });
 
           expect(campaignParticipationOverview.validatedStagesCount).to.equal(2);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -23,7 +23,6 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
       isShared: true,
       sharedAt: new Date('2018-02-06T14:12:44Z'),
       createdAt: new Date('2018-02-05T14:12:44Z'),
-      validatedSkillsCount: 1,
       organizationName: 'My organization',
       assessmentState: 'started',
       campaignCode: '1234',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -30,6 +30,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
       campaignTitle: 'My campaign',
       campaignArchivedAt: new Date('2021-01-01'),
       targetProfile,
+      masteryPercentage: '0.50',
     });
 
     let expectedSerializedCampaignParticipationOverview;
@@ -48,7 +49,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
             'campaign-code': '1234',
             'campaign-title': 'My campaign',
             'campaign-archived-at': new Date('2021-01-01'),
-            'mastery-percentage': 50,
+            'mastery-percentage': '0.50',
             'validated-stages-count': 1,
             'total-stages-count': 2,
           },
@@ -82,6 +83,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           campaignTitle: 'My campaign 1',
           campaignArchivedAt: null,
           targetProfile,
+          masteryPercentage: null,
         }),
         new CampaignParticipationOverview({
           id: 7,
@@ -94,6 +96,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           campaignTitle: 'My campaign 2',
           campaignArchivedAt: null,
           targetProfile,
+          masteryPercentage: null,
         }),
       ];
       const pagination = {

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/archived_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/archived_test.js
@@ -49,7 +49,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
           assessmentState: 'completed',
           campaignTitle: 'My campaign',
           organizationName: 'My organization',
-          masteryPercentage: 56,
+          masteryPercentage: '0.56',
         });
         this.set('campaignParticipationOverview', campaignParticipationOverview);
 
@@ -71,7 +71,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
           assessmentState: 'completed',
           campaignTitle: 'My campaign',
           organizationName: 'My organization',
-          masteryPercentage: 56,
+          masteryPercentage: '0.56',
           totalStagesCount: 3,
           validatedStagesCount: 1,
         });

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ended_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ended_test.js
@@ -45,7 +45,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Ended
           sharedAt: '2020-12-18T15:16:20.109Z',
           assessmentState: 'completed',
           campaignTitle: 'My campaign',
-          masteryPercentage: 20,
+          masteryPercentage: '0.20',
           totalStagesCount: 0,
         });
         this.set('campaignParticipationOverview', campaignParticipationOverview);
@@ -67,7 +67,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Ended
           sharedAt: '2020-12-18T15:16:20.109Z',
           assessmentState: 'completed',
           campaignTitle: 'My campaign',
-          masteryPercentage: 70,
+          masteryPercentage: '0.70',
           validatedStagesCount: 4,
           totalStagesCount: 6,
         });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -153,7 +153,7 @@
       "title": "Customised test",
       "card": {
         "finished-at": "Finished the {date}",
-        "results": "Success rate: {result}%",
+        "results": "Success rate: {result, number, ::percent}",
         "resume": "Resume",
         "see-more": "See more",
         "send": "Submit my results",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -153,7 +153,7 @@
       "title": "Parcours",
       "card": {
         "finished-at": "Terminé le {date}",
-        "results": "{result} % de réussite",
+        "results": "{result, number, ::percent} de réussite",
         "resume": "Reprendre",
         "see-more": "Voir le détail",
         "send": "Envoyer mes résultats",


### PR DESCRIPTION
## :unicorn: Problème
Nous avons récemment enregistré en base les résultats des participants aux campagnes. Cela ayant pour but d'améliorer les performances et également de réduire les problèmes d'affichages.

## :robot: Solution
Utilisation de la colonne "masteryPercentage" pour  la page "mes parcours"

## :rainbow: Remarques

## :100: Pour tester
Aller sur la page "mes parcours" sur mon-pix.
