### PR TITLE
[BUGFIX] Il est impossible d'éditer les informations d'un candidat né à l'étranger sur PixAdmin (PIX-3104)

### DIFF
--- a/admin/app/components/certification/candidate-edit-modal.js
+++ b/admin/app/components/certification/candidate-edit-modal.js
@@ -69,7 +69,7 @@ export default class CandidateEditModal extends Component {
 
   get selectedCountryOption() {
     if (this.birthCountry === 'FRANCE') return FRANCE_INSEE_CODE;
-    return this.birthInseeCode;
+    return this.selectedCountryInseeCode;
   }
 
   @action
@@ -141,18 +141,38 @@ export default class CandidateEditModal extends Component {
   }
 
   _initForm() {
-    this.firstName = this.args.candidate.firstName;
-    this.lastName = this.args.candidate.lastName;
-    this.birthdate = this.args.candidate.birthdate;
-    this.birthCity = this.args.candidate.birthplace;
-    this.sex = this.args.candidate.sex;
-    this.selectedSex = this.args.candidate.sex;
-    this.birthInseeCode = this.args.candidate.birthInseeCode;
-    this.birthPostalCode = this.args.candidate.birthPostalCode;
-    this.birthCountry = this.args.candidate.birthCountry;
+    const candidate = this.args.candidate;
+    this.firstName = candidate.firstName;
+    this.lastName = candidate.lastName;
+    this.birthdate = candidate.birthdate;
+    this.sex = candidate.sex;
+    this.birthCountry = candidate.birthCountry;
+    this._initBirthInformation(candidate);
+  }
 
-    this.selectBirthGeoCodeOption(this.args.candidate.birthInseeCode ? INSEE_CODE_OPTION : POSTAL_CODE_OPTION);
-    this.selectedCountryInseeCode = this.args.candidate.birthCountry === 'FRANCE' ? FRANCE_INSEE_CODE : this.args.candidate.birthInseeCode;
+  _initBirthInformation(candidate) {
+    this.selectedBirthGeoCodeOption = candidate.birthInseeCode ? INSEE_CODE_OPTION : POSTAL_CODE_OPTION;
+    this.selectedCountryInseeCode = candidate.wasBornInFrance() ? FRANCE_INSEE_CODE : candidate.birthInseeCode;
+
+    if (candidate.wasBornInFrance() && this.isInseeCodeOptionSelected) {
+      this.birthCity = '';
+    } else {
+      this.birthCity = candidate.birthplace;
+    }
+
+    if (this.isPostalCodeOptionSelected) {
+      this.birthInseeCode = '';
+    } else if (this._isFranceSelected()) {
+      this.birthInseeCode = candidate.birthInseeCode;
+    } else {
+      this.birthInseeCode = '99';
+    }
+
+    if (this.isPostalCodeOptionSelected) {
+      this.birthPostalCode = candidate.birthPostalCode;
+    } else {
+      this.birthPostalCode = '';
+    }
   }
 
   _isFranceSelected() {

--- a/admin/app/components/certification/candidate-edit-modal.js
+++ b/admin/app/components/certification/candidate-edit-modal.js
@@ -97,27 +97,22 @@ export default class CandidateEditModal extends Component {
   @action
   async onFormSubmit(event) {
     event.preventDefault();
-    const { firstName, lastName, birthdate, birthplace, sex, birthInseeCode, birthPostalCode, birthCountry } = this.args.candidate;
-    this.args.candidate.firstName = this.firstName;
-    this.args.candidate.lastName = this.lastName;
-    this.args.candidate.birthdate = this.birthdate;
-    this.args.candidate.birthplace = this.birthCity;
-    this.args.candidate.sex = this.sex;
-    this.args.candidate.birthInseeCode = this.birthInseeCode;
-    this.args.candidate.birthPostalCode = this.birthPostalCode;
-    this.args.candidate.birthCountry = this.birthCountry;
+    const informationBeforeUpdate = this.args.candidate.getInformation();
+    this.args.candidate.updateInformation({
+      firstName: this.firstName,
+      lastName: this.lastName,
+      birthdate: this.birthdate,
+      birthplace: this.birthCity,
+      sex: this.sex,
+      birthInseeCode: this.birthInseeCode,
+      birthPostalCode: this.birthPostalCode,
+      birthCountry: this.birthCountry,
+    });
     try {
       await this.args.onFormSubmit();
       this._initForm();
     } catch (_) {
-      this.args.candidate.firstName = firstName;
-      this.args.candidate.lastName = lastName;
-      this.args.candidate.birthdate = birthdate;
-      this.args.candidate.birthplace = birthplace;
-      this.args.candidate.sex = sex;
-      this.args.candidate.birthInseeCode = birthInseeCode;
-      this.args.candidate.birthPostalCode = birthPostalCode;
-      this.args.candidate.birthCountry = birthCountry;
+      this.args.candidate.updateInformation(informationBeforeUpdate);
     }
   }
 

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -113,6 +113,10 @@ export default class Certification extends Model {
     return !this.sex;
   }
 
+  wasBornInFrance() {
+    return this.birthCountry === 'FRANCE';
+  }
+
   getInformation() {
     return {
       firstName: this.firstName,

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -113,6 +113,30 @@ export default class Certification extends Model {
     return !this.sex;
   }
 
+  getInformation() {
+    return {
+      firstName: this.firstName,
+      lastName: this.lastName,
+      birthdate: this.birthdate,
+      birthplace: this.birthplace,
+      sex: this.sex,
+      birthInseeCode: this.birthInseeCode,
+      birthPostalCode: this.birthPostalCode,
+      birthCountry: this.birthCountry,
+    };
+  }
+
+  updateInformation({ firstName, lastName, birthdate, birthplace, sex, birthInseeCode, birthPostalCode, birthCountry }) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.birthdate = birthdate;
+    this.birthplace = birthplace;
+    this.sex = sex;
+    this.birthInseeCode = birthInseeCode;
+    this.birthPostalCode = birthPostalCode;
+    this.birthCountry = birthCountry;
+  }
+
   cancel = memberAction({
     type: 'post',
     urlType: 'cancel',

--- a/admin/tests/integration/components/certification/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certification/candidate-edit-modal_test.js
@@ -46,9 +46,219 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
     });
   });
 
+  module('#form initialization', function() {
+
+    test('it should initialize common information', async function(assert) {
+      // given
+      this.candidate = run(() => store.createRecord('certification', {
+        firstName: 'Fabrice',
+        lastName: 'Gadjo',
+        birthdate: '2000-12-15',
+        sex: 'M',
+        birthInseeCode: null,
+        birthPostalCode: '66440',
+        birthplace: 'Torreilles',
+        birthCountry: 'FRANCE',
+      }));
+      this.countries = [
+        run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+        run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+      ];
+
+      // when
+      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`);
+
+      // then
+      assert.dom('#first-name').hasValue('Fabrice');
+      assert.dom('#last-name').hasValue('Gadjo');
+      assert.dom('#birthdate').hasValue('2000-12-15');
+    });
+
+    module('#sex', function() {
+
+      test('it should check "Homme" option when candidate is male', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'M',
+          birthInseeCode: null,
+          birthPostalCode: '66440',
+          birthplace: 'Torreilles',
+          birthCountry: 'FRANCE',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+
+        // when
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`);
+
+        // then
+        assert.dom('#male').isChecked();
+      });
+
+      test('it should check "Femme" option when candidate is female', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabricia',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: null,
+          birthPostalCode: '66440',
+          birthplace: 'Torreilles',
+          birthCountry: 'FRANCE',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+
+        // when
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`);
+
+        // then
+        assert.dom('#female').isChecked();
+      });
+    });
+
+    module('when candidate birth information are of type foreign country', function() {
+
+      test('it should init the form with expected informations for type foreign country', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'M',
+          birthInseeCode: '99101',
+          birthPostalCode: null,
+          birthplace: 'Copenhague',
+          birthCountry: 'DANEMARK',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+
+        // when
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`);
+
+        // then
+        assert.dom('#birth-insee-code').doesNotExist();
+        assert.dom('#birth-postal-code').doesNotExist();
+        assert.dom('#birth-country > option[selected]').hasText('DANEMARK');
+        assert.dom('#birth-city').hasValue('Copenhague');
+      });
+    });
+
+    module('when candidate birth information are of type France with postal code', function() {
+
+      test('it should init the form with expected informations for type France with postal code', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'M',
+          birthInseeCode: null,
+          birthPostalCode: '66440',
+          birthplace: 'Torreilles',
+          birthCountry: 'FRANCE',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+
+        // when
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`);
+
+        // then
+        assert.dom('#birth-postal-code').hasValue('66440');
+        assert.dom('#birth-insee-code').doesNotExist();
+        assert.dom('#birth-city').hasValue('Torreilles');
+        assert.dom('#birth-country > option[selected]').hasText('FRANCE');
+      });
+    });
+
+    module('when candidate birth information are of type France with INSEE code', function() {
+
+      test('it should init the form with expected informations for type France with INSEE code', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'M',
+          birthInseeCode: '66212',
+          birthPostalCode: null,
+          birthplace: 'Torreilles',
+          birthCountry: 'FRANCE',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+
+        // when
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`);
+
+        // then
+        assert.dom('#birth-insee-code').hasValue('66212');
+        assert.dom('#birth-postal-code').doesNotExist();
+        assert.dom('#birth-city').doesNotExist();
+        assert.dom('#birth-country > option[selected]').hasText('FRANCE');
+      });
+    });
+  });
+
   module('#onCancelButtonsClicked', function() {
 
     test('it should reset form', async function(assert) {
+      // given
+      this.candidate = run(() => store.createRecord('certification', {
+        firstName: 'Fabrice',
+        lastName: 'Gadjo',
+        birthdate: '2000-12-15',
+        sex: 'M',
+        birthInseeCode: '99101',
+        birthplace: 'Copenhague',
+        birthCountry: 'DANEMARK',
+      }));
+      this.countries = [
+        run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+        run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+      ];
+      this.onCancelButtonsClickedStub = sinon.stub();
+      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}}  @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{countries}} />`);
+      await fillInByLabel('Nom de famille', 'Belmans');
+      await fillInByLabel('Prénom', 'Gideona');
+      setFlatpickrDate('#birthdate', new Date('1861-03-17'));
+      await click('#female');
+      await fillInByLabel('Pays de naissance', '99100');
+      await click('#postal-code-choice');
+      await fillInByLabel('Code postal de naissance', '75001');
+      await fillInByLabel('Commune de naissance', 'PARIS 01');
+
+      // when
+      await clickByLabel('Annuler');
+
+      // then
+      assert.dom('#first-name').hasValue('Fabrice');
+      assert.dom('#last-name').hasValue('Gadjo');
+      assert.dom('#birthdate').hasValue('2000-12-15');
+      assert.dom('#male').isChecked;
+      assert.dom('#birth-insee-code').doesNotExist();
+      assert.dom('#birth-postal-code').doesNotExist();
+      assert.dom('#birth-city').hasValue('Copenhague');
+      assert.dom('#birth-country > option[selected]').hasText('DANEMARK');
+    });
+
+    test('it should not alter candidate information', async function(assert) {
       // given
       this.candidate = run(() => store.createRecord('certification', {
         firstName: 'Fabrice',
@@ -59,16 +269,17 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
         birthplace: 'Copenhague',
         birthCountry: 'DANEMARK',
       }));
+      const initialCandidateInformation = this.candidate.getInformation();
       this.countries = [
-        EmberObject.create({ code: '99101', name: 'DANEMARK' }),
-        EmberObject.create({ code: '99100', name: 'FRANCE' }),
+        run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+        run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
       ];
       this.onCancelButtonsClickedStub = sinon.stub();
       await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}}  @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{countries}} />`);
       await fillInByLabel('Nom de famille', 'Belmans');
-      await fillInByLabel('Prénom', 'Gideon');
+      await fillInByLabel('Prénom', 'Gideona');
       setFlatpickrDate('#birthdate', new Date('1861-03-17'));
-      await click('#male');
+      await click('#female');
       await fillInByLabel('Pays de naissance', '99100');
       await click('#postal-code-choice');
       await fillInByLabel('Code postal de naissance', '75001');
@@ -78,20 +289,8 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
       await clickByLabel('Annuler');
 
       // then
-      assert.equal(this.candidate.firstName, 'Fabrice');
-      assert.dom('#first-name').hasValue('Fabrice');
-      assert.equal(this.candidate.lastName, 'Gadjo');
-      assert.dom('#last-name').hasValue('Gadjo');
-      assert.equal(this.candidate.birthdate, '2000-12-15');
-      assert.dom('#birthdate').hasValue('2000-12-15');
-      assert.equal(this.candidate.sex, 'F');
-      assert.dom('#female').isChecked;
-      assert.equal(this.candidate.birthInseeCode, '99101');
-      assert.dom('#birth-insee-code').doesNotExist();
-      assert.equal(this.candidate.birthplace, 'Copenhague');
-      assert.dom('#birth-city').hasValue('');
-      assert.equal(this.candidate.birthCountry, 'DANEMARK');
-      assert.dom('#birth-country > option[selected]').hasText('DANEMARK');
+      const afterCancelCandidateInformation = this.candidate.getInformation();
+      assert.deepEqual(initialCandidateInformation, afterCancelCandidateInformation);
     });
 
     test('it should call the onCancelButtonsClicked action', async function(assert) {
@@ -156,166 +355,216 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
       // then
       assert.ok(this.onFormSubmitStub.called);
-      assert.equal(this.candidate.firstName, 'Gideon');
-      assert.equal(this.candidate.lastName, 'Belmans');
-      assert.equal(this.candidate.birthdate, '1861-03-17');
-      assert.equal(this.candidate.sex, 'M');
-      assert.equal(this.candidate.birthPostalCode, '75001');
-      assert.equal(this.candidate.birthplace, 'PARIS 01');
-      assert.equal(this.candidate.birthCountry, 'FRANCE');
+    });
+
+    module('when editing candidate information with foreign country info', function() {
+
+      test('it should update candidate information with foreign country expected information', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: '75015',
+          birthPostalCode: null,
+          birthplace: 'PARIS 15',
+          birthCountry: 'FRANCE',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+        this.onFormSubmitStub = sinon.stub();
+        this.onFormSubmitStub.resolves();
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`);
+
+        // when
+        await fillInByLabel('Pays de naissance', '99101');
+        await fillInByLabel('Commune de naissance', 'Copenhague');
+        await clickByLabel('Enregistrer');
+
+        // then
+        assert.deepEqual(this.candidate.getInformation(), {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: '99',
+          birthPostalCode: '',
+          birthplace: 'Copenhague',
+          birthCountry: 'DANEMARK',
+        });
+      });
+    });
+
+    module('when editing candidate information with france INSEE code info', function() {
+
+      test('it should update candidate information with france INSEE code expected information', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: '99101',
+          birthPostalCode: null,
+          birthplace: 'Copenhague',
+          birthCountry: 'DANEMARK',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+        this.onFormSubmitStub = sinon.stub();
+        this.onFormSubmitStub.resolves();
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`);
+
+        // when
+        await fillInByLabel('Pays de naissance', '99100');
+        await click('#insee-code-choice');
+        await fillInByLabel('Code Insee de naissance', '66212');
+        await clickByLabel('Enregistrer');
+
+        // then
+        assert.deepEqual(this.candidate.getInformation(), {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: '66212',
+          birthPostalCode: '',
+          birthplace: '',
+          birthCountry: 'FRANCE',
+        });
+      });
+    });
+
+    module('when editing candidate information with france postal code info', function() {
+
+      test('it should update candidate information with france postal code expected information', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: '99101',
+          birthPostalCode: null,
+          birthplace: 'Copenhague',
+          birthCountry: 'DANEMARK',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+        this.onFormSubmitStub = sinon.stub();
+        this.onFormSubmitStub.resolves();
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`);
+
+        // when
+        await fillInByLabel('Pays de naissance', '99100');
+        await click('#postal-code-choice');
+        await fillInByLabel('Code postal de naissance', '66440');
+        await fillInByLabel('Commune de naissance', 'Torreilles');
+        await clickByLabel('Enregistrer');
+
+        // then
+        assert.deepEqual(this.candidate.getInformation(), {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: '',
+          birthPostalCode: '66440',
+          birthplace: 'Torreilles',
+          birthCountry: 'FRANCE',
+        });
+      });
     });
   });
 
-  test('it should display candidate information to edit', async function(assert) {
-    // given
-    this.candidate = run(() => store.createRecord('certification', {
-      firstName: 'Quentin',
-      lastName: 'Lebouc',
-      birthdate: '2000-12-15',
-      sex: 'M',
-      birthPostalCode: '35400',
-      birthplace: 'Saint-Malo',
-      birthCountry: 'FRANCE',
-    }));
-    this.countries = [
-      EmberObject.create({ code: '99101', name: 'DANEMARK' }),
-      EmberObject.create({ code: '99100', name: 'FRANCE' }),
-    ];
+  module('#UI choregraphy', function() {
 
-    // when
-    await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{countries}} />`);
+    module('when a foreign country is selected', () => {
 
-    // then
-    assert.dom('#first-name').hasValue('Quentin');
-    assert.dom('#last-name').hasValue('Lebouc');
-    assert.dom('#birthdate').hasValue('2000-12-15');
-    assert.dom('#male').isChecked();
-    assert.dom('#birth-postal-code').hasValue('35400');
-    assert.dom('#birth-city').hasValue('Saint-Malo');
-    assert.dom('#birth-country > option[selected]').hasText('FRANCE');
-  });
+      test('it shows city field and hides insee code and postal code fields', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: '75015',
+          birthplace: 'PARIS 15',
+          birthCountry: 'FRANCE',
+        }));
+        this.countries = [
+          run(() => store.createRecord('country', { code: '99101', name: 'DANEMARK' })),
+          run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
+        ];
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}}/>`);
 
-  module('on component creation', function() {
+        // when
+        await fillInByLabel('Pays de naissance', '99101');
 
-    test('it should select the insee code option if the candidate insee code is defined', async function(assert) {
-      // given
-      this.candidate = run(() => store.createRecord('certification', {
-        firstName: 'Quentin',
-        lastName: 'Lebouc',
-        birthdate: '2000-12-15',
-        sex: 'M',
-        birthInseeCode: '35400',
-        birthplace: 'Saint-Malo',
-        birthCountry: 'FRANCE',
-      }));
-      this.countries = [];
-
-      // when
-      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{countries}} />`);
-
-      // then
-      assert.dom('#insee-code-choice').isChecked();
+        // then
+        assert.notContains('Code Insee de naissance');
+        assert.notContains('Code postal de naissance');
+        assert.contains('Commune de naissance');
+      });
     });
 
-    test('it should select the postal code option if the candidate postal code is defined', async function(assert) {
-      // given
-      this.candidate = run(() => store.createRecord('certification', {
-        firstName: 'Quentin',
-        lastName: 'Lebouc',
-        birthdate: '2000-12-15',
-        sex: 'M',
-        birthPostalCode: '35400',
-        birthplace: 'Saint-Malo',
-        birthCountry: 'FRANCE',
-      }));
-      this.countries = [];
+    module('when the insee code option is selected', () => {
 
-      // when
-      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{countries}} />`);
+      test('it shows insee code field and hides postal code and city fields', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthPostalCode: '75015',
+          birthplace: 'PARIS 15',
+          birthCountry: 'FRANCE',
+        }));
+        this.countries = [];
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}}/>`);
 
-      // then
-      assert.dom('#postal-code-choice').isChecked();
+        // when
+        await click('#insee-code-choice');
+
+        // then
+        assert.contains('Code Insee de naissance');
+        assert.notContains('Code postal de naissance');
+        assert.notContains('Commune de naissance');
+      });
     });
-  });
 
-  module('when a foreign country is selected', () => {
+    module('when the postal code option is selected', () => {
 
-    test('it shows city field and hides insee code and postal code fields', async function(assert) {
-      // given
-      this.candidate = run(() => store.createRecord('certification', {
-        firstName: 'Fabrice',
-        lastName: 'Gadjo',
-        birthdate: '2000-12-15',
-        sex: 'F',
-        birthInseeCode: '75015',
-        birthplace: 'PARIS 15',
-        birthCountry: 'FRANCE',
-      }));
-      this.countries = [
-        EmberObject.create({ code: '99101', name: 'DANEMARK' }),
-        EmberObject.create({ code: '99100', name: 'FRANCE' }),
-      ];
-      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}}/>`);
+      test('it shows postal code and city fields and hides insee code field', async function(assert) {
+        // given
+        this.candidate = run(() => store.createRecord('certification', {
+          firstName: 'Fabrice',
+          lastName: 'Gadjo',
+          birthdate: '2000-12-15',
+          sex: 'F',
+          birthInseeCode: '75115',
+          birthplace: 'PARIS 15',
+          birthCountry: 'FRANCE',
+        }));
+        this.countries = [];
+        await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}}/>`);
 
-      // when
-      await fillInByLabel('Pays de naissance', '99101');
+        // when
+        await click('#postal-code-choice');
 
-      // then
-      assert.notContains('Code Insee de naissance');
-      assert.notContains('Code postal de naissance');
-      assert.contains('Commune de naissance');
-    });
-  });
-
-  module('when the insee code option is selected', () => {
-
-    test('it shows insee code field and hides postal code and city fields', async function(assert) {
-      // given
-      this.candidate = run(() => store.createRecord('certification', {
-        firstName: 'Fabrice',
-        lastName: 'Gadjo',
-        birthdate: '2000-12-15',
-        sex: 'F',
-        birthPostalCode: '75015',
-        birthplace: 'PARIS 15',
-        birthCountry: 'FRANCE',
-      }));
-      this.countries = [];
-      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}}/>`);
-
-      // when
-      await click('#insee-code-choice');
-
-      // then
-      assert.contains('Code Insee de naissance');
-      assert.notContains('Code postal de naissance');
-      assert.notContains('Commune de naissance');
-    });
-  });
-
-  module('when the postal code option is selected', () => {
-
-    test('it shows postal code and city fields and hides insee code field', async function(assert) {
-      // given
-      this.candidate = run(() => store.createRecord('certification', {
-        firstName: 'Fabrice',
-        lastName: 'Gadjo',
-        birthdate: '2000-12-15',
-        sex: 'F',
-        birthInseeCode: '75115',
-        birthplace: 'PARIS 15',
-        birthCountry: 'FRANCE',
-      }));
-      this.countries = [];
-      await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}}/>`);
-
-      // when
-      await click('#postal-code-choice');
-
-      // then
-      assert.notContains('Code INSEE de naissance');
-      assert.contains('Code postal de naissance');
-      assert.contains('Commune de naissance');
+        // then
+        assert.notContains('Code INSEE de naissance');
+        assert.contains('Code postal de naissance');
+        assert.contains('Commune de naissance');
+      });
     });
   });
 });

--- a/admin/tests/integration/components/certification/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certification/candidate-edit-modal_test.js
@@ -4,6 +4,7 @@ import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
 import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
 
 import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
@@ -12,11 +13,17 @@ import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-
 module('Integration | Component | <Certification::CandidateEditModal/>', function(hooks) {
   setupRenderingTest(hooks);
 
+  let store;
+
+  hooks.beforeEach(async function() {
+    store = this.owner.lookup('service:store');
+  });
+
   module('#display', function() {
 
     test('it should display the modal', async function(assert) {
       // given
-      this.candidate = EmberObject.create({ birthdate: '2000-12-15' });
+      this.candidate = run(() => store.createRecord('certification', { birthdate: '2000-12-15' }));
       this.countries = [];
 
       // when
@@ -28,7 +35,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it should not display the modal', async function(assert) {
       // given
-      this.candidate = EmberObject.create({ birthdate: '2000-12-15' });
+      this.candidate = run(() => store.createRecord('certification', { birthdate: '2000-12-15' }));
       this.countries = [];
 
       // when
@@ -43,7 +50,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it should reset form', async function(assert) {
       // given
-      this.candidate = EmberObject.create({
+      this.candidate = run(() => store.createRecord('certification', {
         firstName: 'Fabrice',
         lastName: 'Gadjo',
         birthdate: '2000-12-15',
@@ -51,7 +58,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
         birthInseeCode: '99101',
         birthplace: 'Copenhague',
         birthCountry: 'DANEMARK',
-      });
+      }));
       this.countries = [
         EmberObject.create({ code: '99101', name: 'DANEMARK' }),
         EmberObject.create({ code: '99100', name: 'FRANCE' }),
@@ -89,7 +96,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it should call the onCancelButtonsClicked action', async function(assert) {
       // given
-      this.candidate = EmberObject.create({ birthdate: '2000-12-15' });
+      this.candidate = run(() => store.createRecord('certification', { birthdate: '2000-12-15' }));
       this.countries = [];
       this.onCancelButtonsClickedStub = sinon.stub();
       await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}}  @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{countries}} />`);
@@ -106,7 +113,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it should not call the onFormSubmit action if a field is not filled', async function(assert) {
       // given
-      this.candidate = EmberObject.create({ birthdate: '2000-12-15' });
+      this.candidate = run(() => store.createRecord('certification', { birthdate: '2000-12-15' }));
       this.countries = [];
       this.onFormSubmitStub = sinon.stub();
       await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @onFormSubmit={{this.onFormSubmitStub}} @countries={{countries}} />`);
@@ -120,7 +127,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it should call the onFormSubmit action if all fields are filled', async function(assert) {
       // given
-      this.candidate = EmberObject.create({
+      this.candidate = run(() => store.createRecord('certification', {
         firstName: 'Fabrice',
         lastName: 'Gadjo',
         birthdate: '2000-12-15',
@@ -128,7 +135,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
         birthInseeCode: '99101',
         birthplace: 'Copenhague',
         birthCountry: 'DANEMARK',
-      });
+      }));
       this.countries = [
         EmberObject.create({ code: '99101', name: 'DANEMARK' }),
         EmberObject.create({ code: '99100', name: 'FRANCE' }),
@@ -161,7 +168,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
   test('it should display candidate information to edit', async function(assert) {
     // given
-    this.candidate = EmberObject.create({
+    this.candidate = run(() => store.createRecord('certification', {
       firstName: 'Quentin',
       lastName: 'Lebouc',
       birthdate: '2000-12-15',
@@ -169,7 +176,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
       birthPostalCode: '35400',
       birthplace: 'Saint-Malo',
       birthCountry: 'FRANCE',
-    });
+    }));
     this.countries = [
       EmberObject.create({ code: '99101', name: 'DANEMARK' }),
       EmberObject.create({ code: '99100', name: 'FRANCE' }),
@@ -192,7 +199,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it should select the insee code option if the candidate insee code is defined', async function(assert) {
       // given
-      this.candidate = EmberObject.create({
+      this.candidate = run(() => store.createRecord('certification', {
         firstName: 'Quentin',
         lastName: 'Lebouc',
         birthdate: '2000-12-15',
@@ -200,7 +207,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
         birthInseeCode: '35400',
         birthplace: 'Saint-Malo',
         birthCountry: 'FRANCE',
-      });
+      }));
       this.countries = [];
 
       // when
@@ -212,7 +219,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it should select the postal code option if the candidate postal code is defined', async function(assert) {
       // given
-      this.candidate = EmberObject.create({
+      this.candidate = run(() => store.createRecord('certification', {
         firstName: 'Quentin',
         lastName: 'Lebouc',
         birthdate: '2000-12-15',
@@ -220,7 +227,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
         birthPostalCode: '35400',
         birthplace: 'Saint-Malo',
         birthCountry: 'FRANCE',
-      });
+      }));
       this.countries = [];
 
       // when
@@ -235,7 +242,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it shows city field and hides insee code and postal code fields', async function(assert) {
       // given
-      this.candidate = EmberObject.create({
+      this.candidate = run(() => store.createRecord('certification', {
         firstName: 'Fabrice',
         lastName: 'Gadjo',
         birthdate: '2000-12-15',
@@ -243,7 +250,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
         birthInseeCode: '75015',
         birthplace: 'PARIS 15',
         birthCountry: 'FRANCE',
-      });
+      }));
       this.countries = [
         EmberObject.create({ code: '99101', name: 'DANEMARK' }),
         EmberObject.create({ code: '99100', name: 'FRANCE' }),
@@ -264,7 +271,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it shows insee code field and hides postal code and city fields', async function(assert) {
       // given
-      this.candidate = EmberObject.create({
+      this.candidate = run(() => store.createRecord('certification', {
         firstName: 'Fabrice',
         lastName: 'Gadjo',
         birthdate: '2000-12-15',
@@ -272,7 +279,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
         birthPostalCode: '75015',
         birthplace: 'PARIS 15',
         birthCountry: 'FRANCE',
-      });
+      }));
       this.countries = [];
       await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}}/>`);
 
@@ -290,7 +297,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
     test('it shows postal code and city fields and hides insee code field', async function(assert) {
       // given
-      this.candidate = EmberObject.create({
+      this.candidate = run(() => store.createRecord('certification', {
         firstName: 'Fabrice',
         lastName: 'Gadjo',
         birthdate: '2000-12-15',
@@ -298,7 +305,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
         birthInseeCode: '75115',
         birthplace: 'PARIS 15',
         birthCountry: 'FRANCE',
-      });
+      }));
       this.countries = [];
       await render(hbs`<Certification::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}} @countries={{this.countries}}/>`);
 

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -355,4 +355,29 @@ module('Unit | Model | certification', function(hooks) {
       });
     });
   });
+
+  module('#wasBornInFrance', function() {
+
+    test('it should return true when candidate was born in France', function(assert) {
+      // given
+      const certification = run(() => store.createRecord('certification', { birthCountry: 'FRANCE' }));
+
+      // when
+      const wasBornInFrance = certification.wasBornInFrance();
+
+      // then
+      assert.true(wasBornInFrance);
+    });
+
+    test('it should return false when candidate was not born in France', function(assert) {
+      // given
+      const certification = run(() => store.createRecord('certification', { birthCountry: 'OTHER_COUNTRY' }));
+
+      // when
+      const wasBornInFrance = certification.wasBornInFrance();
+
+      // then
+      assert.false(wasBornInFrance);
+    });
+  });
 });

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -282,4 +282,77 @@ module('Unit | Model | certification', function(hooks) {
       assert.equal(juryCertificationSummary.completionDate, '30/06/2021, 15:10:45');
     });
   });
+
+  module('#getInformation', function() {
+
+    test('it should return the certification candidate information', function(assert) {
+      // given
+      const certification = run(() => store.createRecord('certification', {
+        firstName: 'Buffy',
+        lastName: 'Summers',
+        birthdate: '1981-01-19',
+        birthplace: 'Torreilles',
+        sex: 'F',
+        birthInseeCode: '66212',
+        birthPostalCode: null,
+        birthCountry: 'FRANCE',
+      }));
+
+      // when
+      const information = certification.getInformation();
+
+      // then
+      assert.deepEqual(information, {
+        firstName: 'Buffy',
+        lastName: 'Summers',
+        birthdate: '1981-01-19',
+        birthplace: 'Torreilles',
+        sex: 'F',
+        birthInseeCode: '66212',
+        birthPostalCode: null,
+        birthCountry: 'FRANCE',
+      });
+    });
+  });
+
+  module('#updateInformation', function() {
+
+    test('it should update the certification candidate information', function(assert) {
+      // given
+      const certification = run(() => store.createRecord('certification', {
+        firstName: 'Buffy',
+        lastName: 'Summers',
+        birthdate: '1981-01-19',
+        birthplace: 'Torreilles',
+        sex: 'F',
+        birthInseeCode: '66212',
+        birthPostalCode: null,
+        birthCountry: 'FRANCE',
+      }));
+
+      // when
+      certification.updateInformation({
+        firstName: 'Xander',
+        lastName: 'Harris',
+        birthdate: '1981-02-22',
+        birthplace: 'Argelès',
+        sex: 'M',
+        birthInseeCode: '99120',
+        birthPostalCode: null,
+        birthCountry: 'TheMoon !',
+      });
+
+      // then
+      assert.deepEqual(certification.getInformation(), {
+        firstName: 'Xander',
+        lastName: 'Harris',
+        birthdate: '1981-02-22',
+        birthplace: 'Argelès',
+        sex: 'M',
+        birthInseeCode: '99120',
+        birthPostalCode: null,
+        birthCountry: 'TheMoon !',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Pour reproduire :
- Créer une session, inscrire un candidat né à l'étranger, le faire participer à la session puis la finaliser (classique)
- Se rendre du PixAdmin, sur la certification dudit candidat. Tenter d'éditer ses informations.
- Constat 1 : la ville de naissance n'est pas recopiée dans le champ de la modale
- Constat 2 : impossible de faire des modifications sur le candidat, échec à la sauvegarde (erreur concernant un code INSEE)

## :robot: Solution
Le composant de modale n'était pas correctement initialisé.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Essayer de reproduire le bug et ne pas réussir + non régression sur l'édition des informations
