### PR TITLE
[BUGFIX] Changer la couleur d'un lien d'aide pour qu'il soit plus accessible.

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -197,12 +197,12 @@
 
   &--link {
     text-decoration: underline;
-    color: $blue;
+    color: $blue-hover;
 
     &:active,
     &:focus,
     &:hover {
-      color: $blue-hover;
+      color: $dark-blue-pro;
     }
 
     &:visited {


### PR DESCRIPTION
## :unicorn: Problème
Problème de contraste sur un lien d'aide

## :robot: Solution
Changer la couleur

## :rainbow: Remarques
Règle le soucis des tests e2e

## :100: Pour tester
