### PR TITLE
[FEATURE] Changer le message de la bannière des organisations SCO concernant les dates de certification possibles (PIX-3096)

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -36,7 +36,7 @@
         <PixBanner
         @actionLabel= "En savoir plus"
         @actionUrl= "https://view.genial.ly/6077017b8b37870d98620200"
-      >La certification en collège et lycée est possible jusqu'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ».</PixBanner>
+      >La certification Pix se déroulera du 29/11/21 au 04/03/22 pour les lycées et du 07/03/22 au 20/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées.</PixBanner>
 
     {{/if}}
 

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -57,7 +57,7 @@ module('Acceptance | authenticated', function(hooks) {
 
       // then
       assert.dom('.pix-banner--information').exists();
-      assert.dom('.pix-banner--information').hasText('La certification en collège et lycée est possible jusqu\'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit de changer la date de la session en cliquant sur « modifier ». En savoir plus');
+      assert.dom('.pix-banner--information').hasText('La certification Pix se déroulera du 29/11/21 au 04/03/22 pour les lycées et du 07/03/22 au 20/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées. En savoir plus');
     });
 
     test('it should not display the banner when User is NOT SCO isManagingStudent', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Un bandeau d’informations est actuellement visible pour les utilisateurs Pix Certif d'établissements SCO qui gèrent une liste d'élèves. Le message actuel concernant l’année scolaire précédente, il faut le mettre à jour.

## :robot: Solution
Pour les centre de certif de type SCO qui gèrent une liste d'élèves, modifier le texte du bandeau : 

“La certification Pix se déroulera du 29/11/21 au 04/03/22 pour les lycées et du 07/03/22 au 20/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées.”

## :100: Pour tester
- Se connecter à Pix Certif en tant que SCO isManagingStudent
- Constater la présence du bandeau et son contenu
