### PR TITLE
[FEAT] Suppression du champ grisé après la fin du temps imparti sur une question timée.

### DIFF
--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -67,22 +67,17 @@
   &__alert-message {
     display: flex;
     align-items: center;
+    max-width: 600px;
     color: $grey-90;
     font-family: $font-roboto;
     font-size: 0.875rem;
     font-weight: $font-normal;
     letter-spacing: 0.009rem;
     line-height: 1.375rem;
-    margin-right: 0;
-    margin-bottom: 24px;
+    margin: 0 auto 24px 12px;
 
     @include device-is('tablet') {
       margin-bottom: 0;
-      margin-right: auto;
-    }
-
-    &--focused-out-of-window {
-      max-width: 600px;
     }
   }
 }

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -64,10 +64,9 @@
     margin-right: 20px;
   }
 
-  &__focused-out-of-window {
+  &__alert-message {
     display: flex;
     align-items: center;
-    max-width: 600px;
     color: $grey-90;
     font-family: $font-roboto;
     font-size: 0.875rem;
@@ -81,19 +80,14 @@
       margin-bottom: 0;
       margin-right: auto;
     }
-  }
 
-  &__timed-out {
-    font-family: $font-roboto;
-    font-size: 1rem;
-    font-weight: 600;
-    color: $grey-70;
-    letter-spacing: 0.031rem;
-    margin-right: 20px;
+    &--focused-out-of-window {
+      max-width: 600px;
+    }
   }
 }
 
-.challenge-actions-focused-out {
+.challenge-actions-alert-message {
 
   &__icon {
     font-size: 1rem;

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -123,21 +123,6 @@ form .challenge-response {
 
 form .challenge-response.challenge-response--locked {
 
-  .challenge-proposals {
-    opacity: 0.33;
-    transition: 0.3s ease;
-
-    .qroc_input-label {
-      display: inline;
-    }
-
-    ul,
-    ol,
-    p {
-      margin: 0;
-    }
-  }
-
   &:hover {
 
     .challenge-response__locked-overlay {

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -35,7 +35,7 @@
 
   {{else}}
     {{#if @hasFocusedOutOfWindow}}
-      <div class="challenge-actions__alert-message challenge-actions__alert-message--focused-out-of-window" role="alert" aria-live="assertive">
+      <div class="challenge-actions__alert-message" data-test="alert-message-focused-out-of-window" role="alert" aria-live="assertive">
         <FaIcon @icon="info-circle" class="challenge-actions-alert-message__icon"/>
         {{#if @isCertification}}
           <span data-test="certification-focused-out-error-message">{{t 'pages.challenge.has-focused-out-of-window.certification' htmlSafe=true }}</span>

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -19,7 +19,10 @@
     </PixButton>
 
   {{else if @hasChallengeTimedOut}}
-    <span class="challenge-actions__timed-out">{{t "pages.challenge.timed.cannot-answer"}}</span>
+    <div class="challenge-actions__alert-message" role="alert" aria-live="assertive">
+      <FaIcon @icon="info-circle" class="challenge-actions-alert-message__icon"/>
+      {{t "pages.challenge.timed.cannot-answer"}}
+    </div>
     <PixButton
       @triggerAction={{@validateAnswer}}
       @backgroundColor="blue"
@@ -32,8 +35,8 @@
 
   {{else}}
     {{#if @hasFocusedOutOfWindow}}
-      <div class="challenge-actions__focused-out-of-window" role="alert" aria-live="assertive">
-        <FaIcon @icon="info-circle" class="challenge-actions-focused-out__icon"/>
+      <div class="challenge-actions__alert-message challenge-actions__alert-message--focused-out-of-window" role="alert" aria-live="assertive">
+        <FaIcon @icon="info-circle" class="challenge-actions-alert-message__icon"/>
         {{#if @isCertification}}
           <span data-test="certification-focused-out-error-message">{{t 'pages.challenge.has-focused-out-of-window.certification' htmlSafe=true }}</span>
         {{else}}

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -1,6 +1,6 @@
 <form {{on "submit" this.validateAnswer}}>
 
-  <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
+  <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
     <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
     <div class="challenge-proposals">
       <QcmProposals @answer={{@answer}}
@@ -14,11 +14,6 @@
     {{#if @answer}}
       <div class="challenge-response__locked-overlay">
         <FaIcon @icon='lock' class='challenge-response-locked__icon' />
-      </div>
-    {{/if}}
-    {{#if this.hasChallengeTimedOut}}
-      <div class="challenge-response__locked-overlay">
-        <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
       </div>
     {{/if}}
 

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -1,6 +1,6 @@
 <form {{on "submit" this.validateAnswer}}>
 
-  <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}} {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
+  <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
     <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
     <div class="challenge-proposals">
       <QcuProposals @answer={{@answer}}
@@ -14,11 +14,6 @@
     {{#if @answer}}
       <div class="challenge-response__locked-overlay">
         <FaIcon @icon='lock' class='challenge-response-locked__icon' />
-      </div>
-    {{/if}}
-    {{#if this.hasChallengeTimedOut}}
-      <div class="challenge-response__locked-overlay">
-        <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
       </div>
     {{/if}}
 

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -1,8 +1,7 @@
 <form {{will-destroy this.removeEmbedAutoEventListener}} {{on "submit" this.validateAnswer}}>
   {{#if this.showProposal}}
     <div class="rounded-panel__row challenge-response
-      {{if @answer 'challenge-response--locked'}}
-      {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
+      {{if @answer 'challenge-response--locked'}}">
       <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
       <div class="challenge-proposals qroc-proposal">
         {{#each this._blocks as |block|}}
@@ -95,11 +94,6 @@
       {{#if @answer}}
         <div class="challenge-response__locked-overlay">
           <FaIcon @icon='lock' class='challenge-response-locked__icon' />
-        </div>
-      {{/if}}
-      {{#if this.hasChallengeTimedOut}}
-        <div class="challenge-response__locked-overlay">
-          <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
         </div>
       {{/if}}
 

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -1,6 +1,6 @@
 <form {{on "submit" this.validateAnswer}}>
 
-  <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
+  <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
     <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
     <div class="challenge-proposals">
       <QrocmProposal @answer={{@answer}}
@@ -15,11 +15,6 @@
     {{#if @answer}}
       <div class="challenge-response__locked-overlay">
         <FaIcon @icon='lock' class='challenge-response-locked__icon' />
-      </div>
-    {{/if}}
-    {{#if this.hasChallengeTimedOut}}
-      <div class="challenge-response__locked-overlay">
-        <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
       </div>
     {{/if}}
 

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -93,7 +93,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await triggerEvent(window, 'blur');
 
               // then
-              expect(find('.challenge-actions__alert-message--focused-out-of-window')).to.exist;
+              expect(find('[data-test="alert-message-focused-out-of-window"]')).to.exist;
             });
 
             it('should display an info alert with dashed border and overlay', async function() {
@@ -121,7 +121,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
               // then
               expect(find('.challenge__info-alert--could-show')).to.not.exist;
-              expect(find('.challenge-actions__alert-message--focused-out-of-window')).to.exist;
+              expect(find('[data-test="alert-message-focused-out-of-window"]')).to.exist;
               expect(find('.challenge-item__container--focused')).to.exist;
               expect(find('.challenge__focused-out-overlay')).to.exist;
             });

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -93,7 +93,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await triggerEvent(window, 'blur');
 
               // then
-              expect(find('.challenge-actions__focused-out-of-window')).to.exist;
+              expect(find('.challenge-actions__alert-message--focused-out-of-window')).to.exist;
             });
 
             it('should display an info alert with dashed border and overlay', async function() {
@@ -121,7 +121,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
               // then
               expect(find('.challenge__info-alert--could-show')).to.not.exist;
-              expect(find('.challenge-actions__focused-out-of-window')).to.exist;
+              expect(find('.challenge-actions__alert-message--focused-out-of-window')).to.exist;
               expect(find('.challenge-item__container--focused')).to.exist;
               expect(find('.challenge__focused-out-overlay')).to.exist;
             });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -498,7 +498,7 @@
         }
       },
       "timed": {
-        "cannot-answer": "You've run out of time."
+        "cannot-answer": "You've run out of time. Your answer will not be validated."
       }
     },
     "checkpoint": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -498,7 +498,7 @@
         }
       },
       "timed": {
-        "cannot-answer": "Le temps imparti est écoulé."
+        "cannot-answer": "Le temps imparti est écoulé. Votre réponse ne sera pas validée."
       }
     },
     "checkpoint": {


### PR DESCRIPTION
## :unicorn: Problème
Après timeout, le champ grisé indique à l'utilisateur qu'il ne peut plus répondre à l'épreuve.

## :robot: Solution
Afficher le champs normalement.
L'utilisateur peut toujours répondre à une question si timeout, mais elle continuera de compter faux.

## :rainbow: Remarques

A l'heure actuelle, nous avons deux systèmes différents lorsque le message d'alerte apparait : 
- Sur une épreuve focus, les boutons `Passer` et `Valider` sont encore présents
- Sur une épreuve timée, apparait le bouton `Poursuivre` qui remplace les boutons `Passer` et `Valider` une fois le temps imparti dépassé.

--> Une uniformisation des boutons d'action peut-être à envisager.

## :100: Pour tester
Répondre à une épreuve timée (ex: rec1cSZ2hePondDBl) après timeout.
