### PR TITLE
[FEATURE] Ajout de la règle de scoring global lors du scoring d'une certification (PIX-3045)

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -9,6 +9,7 @@ const ChallengeNeutralized = require('./ChallengeNeutralized');
 const ChallengeDeneutralized = require('./ChallengeDeneutralized');
 const CertificationJuryDone = require('./CertificationJuryDone');
 const { checkEventTypes } = require('./check-event-types');
+const { featureToggles } = require('../../config');
 
 const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized, CertificationJuryDone];
 const EMITTER = 'PIX-ALGO-NEUTRALIZATION';
@@ -35,11 +36,13 @@ async function handleCertificationRescoring({
 
     await _saveCompetenceMarks(certificationAssessmentScore, assessmentResultId, competenceMarkRepository);
 
-    await _cancelCertificationCourseIfHasNotEnoughNonNeutralizedChallengesToBeTrusted({
-      certificationCourseId: certificationAssessment.certificationCourseId,
-      hasEnoughNonNeutralizedChallengesToBeTrusted: certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted,
-      certificationCourseRepository,
-    });
+    if (featureToggles.isManageUncompletedCertifEnabled) {
+      await _cancelCertificationCourseIfHasNotEnoughNonNeutralizedChallengesToBeTrusted({
+        certificationCourseId: certificationAssessment.certificationCourseId,
+        hasEnoughNonNeutralizedChallengesToBeTrusted: certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted,
+        certificationCourseRepository,
+      });
+    }
 
     return new CertificationRescoringCompleted({
       userId: certificationAssessment.userId,

--- a/api/lib/domain/models/AnswerCollectionForScoring.js
+++ b/api/lib/domain/models/AnswerCollectionForScoring.js
@@ -16,6 +16,10 @@ module.exports = class AnswerCollectionForScoring {
     return new AnswerCollectionForScoring(answersForScoring, challengesForScoring);
   }
 
+  numberOfChallenges() {
+    return this.challenges.length;
+  }
+
   numberOfCorrectAnswers() {
     let nbOfCorrectAnswers = 0;
     this.answers.forEach((answer) => {

--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -40,7 +40,7 @@ class AssessmentResult {
       emitter,
       commentForJury: error.message,
       pixScore: 0,
-      status: 'error',
+      status: status.ERROR,
       assessmentId,
       juryId,
     });
@@ -64,11 +64,30 @@ class AssessmentResult {
     });
   }
 
+  static buildNotTrustableAssessmentResult({ pixScore, status, assessmentId, juryId, emitter }) {
+    return new AssessmentResult({
+      emitter,
+      commentForCandidate: 'Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification' +
+        ', a/ont affecté la qualité du test de certification. En raison du trop grand nombre de questions auxquelles vous ' +
+        'n\'avez pas pu répondre dans de bonnes conditions, nous ne sommes malheureusement pas en mesure de calculer un ' +
+        'score fiable et de fournir un certificat. La certification est annulée, le prescripteur de votre certification' +
+        '(le cas échéant), en est informé.',
+      commentForOrganization: 'Un ou plusieurs problème(s) technique(s), signalés par ce(cette) candidate au surveillant' +
+        'de la session de certification, a/ont affecté le bon déroulement du test de certification. Nous sommes dans ' +
+        'l\'incapacité de le/la certifier, sa certification est donc annulée. Cette information est à prendre en compte ' +
+        'et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).',
+      commentForJury: 'Computed',
+      pixScore,
+      status,
+      assessmentId,
+      juryId,
+    });
+  }
+
   isValidated() {
     return this.status === status.VALIDATED;
   }
 }
 
 AssessmentResult.status = status;
-
 module.exports = AssessmentResult;

--- a/api/lib/domain/models/CertificationAssessmentScore.js
+++ b/api/lib/domain/models/CertificationAssessmentScore.js
@@ -5,9 +5,11 @@ class CertificationAssessmentScore {
   constructor({
     competenceMarks = [],
     percentageCorrectAnswers = 0,
+    hasEnoughNonNeutralizedChallengesToBeTrusted,
   } = {}) {
     this.competenceMarks = competenceMarks;
     this.percentageCorrectAnswers = percentageCorrectAnswers;
+    this.hasEnoughNonNeutralizedChallengesToBeTrusted = hasEnoughNonNeutralizedChallengesToBeTrusted;
   }
 
   get nbPix() {

--- a/api/lib/domain/models/CertificationContract.js
+++ b/api/lib/domain/models/CertificationContract.js
@@ -46,6 +46,11 @@ class CertificationContract {
       throw new CertificationComputeError('Plusieurs réponses pour une même épreuve');
     }
   }
+
+  static hasEnoughNonNeutralizedChallengesToBeTrusted(numberOfChallenges, numberOfNonNeutralizedChallenges) {
+    const minimalNumberOfNonNeutralizedChallengesToBeTrusted = Math.floor(numberOfChallenges * 0.66);
+    return numberOfNonNeutralizedChallenges >= minimalNumberOfNonNeutralizedChallengesToBeTrusted;
+  }
 }
 
 module.exports = CertificationContract;

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -89,6 +89,10 @@ class CertificationCourse {
     this._isCancelled = true;
   }
 
+  uncancel() {
+    this._isCancelled = false;
+  }
+
   complete({ now }) {
     this._completedAt = now;
   }

--- a/api/lib/domain/services/scoring/scoring-certification-service.js
+++ b/api/lib/domain/services/scoring/scoring-certification-service.js
@@ -80,10 +80,13 @@ function _getResult(answers, certificationChallenges, testedCompetences, continu
     numberOfCorrectAnswers: answerCollection.numberOfCorrectAnswers(),
   });
 
+  const hasEnoughNonNeutralizedChallengesToBeTrusted = CertificationContract.hasEnoughNonNeutralizedChallengesToBeTrusted(answerCollection.numberOfChallenges(), answerCollection.numberOfNonNeutralizedChallenges());
+
   if (!reproducibilityRate.isEnoughToBeCertified()) {
     return new CertificationAssessmentScore({
       competenceMarks: _getCompetenceMarksWithFailedLevel(testedCompetences),
       percentageCorrectAnswers: reproducibilityRate.value,
+      hasEnoughNonNeutralizedChallengesToBeTrusted,
     });
   }
 
@@ -94,7 +97,7 @@ function _getResult(answers, certificationChallenges, testedCompetences, continu
     CertificationContract.assertThatScoreIsCoherentWithReproducibilityRate(scoreAfterRating, reproducibilityRate.value);
   }
 
-  return new CertificationAssessmentScore({ competenceMarks, percentageCorrectAnswers: reproducibilityRate.value });
+  return new CertificationAssessmentScore({ competenceMarks, percentageCorrectAnswers: reproducibilityRate.value, hasEnoughNonNeutralizedChallengesToBeTrusted });
 }
 
 async function _getTestedCompetences({ userId, limitDate, isV2Certification }) {

--- a/api/tests/tooling/domain-builder/factory/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment-result.js
@@ -139,4 +139,36 @@ buildAssessmentResult.started = function({
   });
 };
 
+buildAssessmentResult.notTrustable = function({
+  pixScore,
+  status,
+  assessmentId,
+  juryId,
+  emitter,
+} = {}) {
+  return AssessmentResult.buildNotTrustableAssessmentResult({
+    pixScore,
+    status,
+    assessmentId,
+    juryId,
+    emitter,
+  });
+};
+
+buildAssessmentResult.standard = function({
+  pixScore,
+  status,
+  assessmentId,
+  juryId,
+  emitter,
+} = {}) {
+  return AssessmentResult.buildStandardAssessmentResult({
+    pixScore,
+    status,
+    assessmentId,
+    juryId,
+    emitter,
+  });
+};
+
 module.exports = buildAssessmentResult;

--- a/api/tests/tooling/domain-builder/factory/build-certification-assessment-score.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-assessment-score.js
@@ -3,9 +3,11 @@ const CertificationAssessmentScore = require('../../../../lib/domain/models/Cert
 module.exports = function buildCertificationAssessmentScore({
   competenceMarks = [],
   percentageCorrectAnswers = 0,
+  hasEnoughNonNeutralizedChallengesToBeTrusted = true,
 } = {}) {
   return new CertificationAssessmentScore({
     competenceMarks,
     percentageCorrectAnswers,
+    hasEnoughNonNeutralizedChallengesToBeTrusted,
   });
 };

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -9,16 +9,23 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
 
   it('computes and persists the assessment result and competence marks when computation succeeds', async function() {
     // given
+    const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
     const assessmentResultRepository = { save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+    const certificationCourse = domainBuilder.buildCertificationCourse({
+      isCancelled: false,
+    });
+    const expectedSaveCertificationCourse = domainBuilder.buildCertificationCourse({
+      ...certificationCourse.toDTO(),
+    });
 
-    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+    const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
-      certificationCourseId: 1,
+      certificationCourseId: certificationCourse.getId(),
       createdAt: new Date('2020-01-01'),
       completedAt: new Date('2020-01-01'),
       state: CertificationAssessment.states.STARTED,
@@ -29,7 +36,8 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
       ],
       certificationAnswersByDate: ['answer'],
     });
-    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 1 }).resolves(certificationAssessment);
+    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
 
     const competenceMarkData2 = domainBuilder.buildCompetenceMark();
     const competenceMarkData1 = domainBuilder.buildCompetenceMark();
@@ -40,6 +48,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
       status,
       competenceMarks: [competenceMarkData1, competenceMarkData2],
       percentageCorrectAnswers: 80,
+      hasEnoughNonNeutralizedChallengesToBeTrusted: true,
     };
     scoringCertificationService.calculateCertificationAssessmentScore
       .withArgs({ certificationAssessment, continueOnError: false })
@@ -64,6 +73,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
       certificationAssessmentRepository,
       competenceMarkRepository,
       scoringCertificationService,
+      certificationCourseRepository,
     };
 
     // when
@@ -79,25 +89,111 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
     competenceMarkData2.assessmentResultId = savedAssessmentResult.id;
     expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData1);
     expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData2);
+    expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
   });
 
-  it('returns a CertificationRescoringCompleted event', async function() {
+  it('cancel the certification course if certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function() {
     // given
+    const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
     const assessmentResultRepository = { save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+    const certificationCourse = domainBuilder.buildCertificationCourse({
+      isCancelled: false,
+    });
+    const expectedSaveCertificationCourse = domainBuilder.buildCertificationCourse({
+      ...certificationCourse.toDTO(),
+      isCancelled: true,
+    });
 
-    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+    const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
+    const certificationAssessment = new CertificationAssessment({
+      id: 123,
+      userId: 123,
+      certificationCourseId: certificationCourse.getId(),
+      createdAt: new Date('2020-01-01'),
+      completedAt: new Date('2020-01-01'),
+      state: CertificationAssessment.states.STARTED,
+      isV2Certification: true,
+      certificationChallenges: [
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+      ],
+      certificationAnswersByDate: ['answer'],
+    });
+    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+
+    const competenceMarkData2 = domainBuilder.buildCompetenceMark();
+    const competenceMarkData1 = domainBuilder.buildCompetenceMark();
+    const nbPix = Symbol('nbPix');
+    const status = Symbol('status');
+    const certificationAssessmentScore = {
+      nbPix,
+      status,
+      competenceMarks: [competenceMarkData1, competenceMarkData2],
+      percentageCorrectAnswers: 80,
+      hasEnoughNonNeutralizedChallengesToBeTrusted: false,
+    };
+    scoringCertificationService.calculateCertificationAssessmentScore
+      .withArgs({ certificationAssessment, continueOnError: false })
+      .resolves(certificationAssessmentScore);
+
+    const assessmentResultToBeSaved = new AssessmentResult({
+      id: undefined,
+      commentForJury: 'Computed',
+      emitter: 'PIX-ALGO-NEUTRALIZATION',
+      pixScore: nbPix,
+      status: status,
+      assessmentId: 123,
+      juryId: 7,
+    });
+    const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+    assessmentResultRepository.save
+      .withArgs(assessmentResultToBeSaved)
+      .resolves(savedAssessmentResult);
+
+    const dependendencies = {
+      assessmentResultRepository,
+      certificationAssessmentRepository,
+      competenceMarkRepository,
+      scoringCertificationService,
+      certificationCourseRepository,
+    };
+
+    // when
+    await handleCertificationRescoring(
+      {
+        ...dependendencies,
+        event,
+      });
+
+    // then
+    expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
+  });
+
+  it('returns a CertificationRescoringCompleted event', async function() {
+    // given
+    const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
+    const assessmentResultRepository = { save: sinon.stub() };
+    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+    const competenceMarkRepository = { save: sinon.stub() };
+    const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+    const certificationCourse = domainBuilder.buildCertificationCourse();
+
+    const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
     const certificationAssessment = domainBuilder.buildCertificationAssessment({
       userId: 123,
-      certificationCourseId: 1,
+      certificationCourseId: certificationCourse.getId(),
     });
-    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 1 }).resolves(certificationAssessment);
+    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
 
     const certificationAssessmentScore = {
       competenceMarks: [],
       percentageCorrectAnswers: 80,
+      hasEnoughNonNeutralizedChallengesToBeTrusted: true,
     };
     scoringCertificationService.calculateCertificationAssessmentScore
       .withArgs({ certificationAssessment, continueOnError: false })
@@ -109,6 +205,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
       certificationAssessmentRepository,
       competenceMarkRepository,
       scoringCertificationService,
+      certificationCourseRepository,
     };
 
     // when
@@ -119,7 +216,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
 
     // then
     const expectedReturnedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
-      certificationCourseId: 1,
+      certificationCourseId: certificationCourse.getId(),
       userId: 123,
       reproducibilityRate: 80,
     });

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -96,86 +96,152 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
 
   context('when FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED is enabled', function() {
 
-    it('cancel the certification course if certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function() {
-      // given
-      sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(true);
-      const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
-      const assessmentResultRepository = { save: sinon.stub() };
-      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-      const competenceMarkRepository = { save: sinon.stub() };
-      const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        isCancelled: false,
-      });
-      const expectedSaveCertificationCourse = domainBuilder.buildCertificationCourse({
-        ...certificationCourse.toDTO(),
-        isCancelled: true,
-      });
+    context('when the certification has not enough non neutralized challenges to be trusted', function() {
 
-      const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
-      const certificationAssessment = new CertificationAssessment({
-        id: 123,
-        userId: 123,
-        certificationCourseId: certificationCourse.getId(),
-        createdAt: new Date('2020-01-01'),
-        completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
-        isV2Certification: true,
-        certificationChallenges: [
-          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-        ],
-        certificationAnswersByDate: ['answer'],
-      });
-      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
-      certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+      it('cancels the certification and save a not trustable assessment result', async function() {
+        // given
+        sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(true);
+        const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
+        const assessmentResultRepository = { save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+        const competenceMarkRepository = { save: sinon.stub() };
+        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
+        sinon.spy(certificationCourse, 'cancel');
 
-      const competenceMarkData2 = domainBuilder.buildCompetenceMark();
-      const competenceMarkData1 = domainBuilder.buildCompetenceMark();
-      const nbPix = Symbol('nbPix');
-      const status = Symbol('status');
-      const certificationAssessmentScore = {
-        nbPix,
-        status,
-        competenceMarks: [competenceMarkData1, competenceMarkData2],
-        percentageCorrectAnswers: 80,
-        hasEnoughNonNeutralizedChallengesToBeTrusted: false,
-      };
-      scoringCertificationService.calculateCertificationAssessmentScore
-        .withArgs({ certificationAssessment, continueOnError: false })
-        .resolves(certificationAssessmentScore);
+        const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
+        const certificationAssessment = new CertificationAssessment({
+          id: 123,
+          userId: 123,
+          certificationCourseId: 789,
+          createdAt: new Date('2020-01-01'),
+          completedAt: new Date('2020-01-01'),
+          state: CertificationAssessment.states.STARTED,
+          isV2Certification: true,
+          certificationChallenges: [
+            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          ],
+          certificationAnswersByDate: ['answer'],
+        });
+        certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 789 }).resolves(certificationAssessment);
+        certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
+        const competenceMarkData2 = domainBuilder.buildCompetenceMark({ score: 12 });
+        const competenceMarkData1 = domainBuilder.buildCompetenceMark({ score: 18 });
+        const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+          status: AssessmentResult.status.VALIDATED,
+          competenceMarks: [competenceMarkData1, competenceMarkData2],
+          percentageCorrectAnswers: 80,
+          hasEnoughNonNeutralizedChallengesToBeTrusted: false,
+        });
+        scoringCertificationService.calculateCertificationAssessmentScore
+          .withArgs({ certificationAssessment, continueOnError: false })
+          .resolves(certificationAssessmentScore);
 
-      const assessmentResultToBeSaved = new AssessmentResult({
-        id: undefined,
-        commentForJury: 'Computed',
-        emitter: 'PIX-ALGO-NEUTRALIZATION',
-        pixScore: nbPix,
-        status: status,
-        assessmentId: 123,
-        juryId: 7,
-      });
-      const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-      assessmentResultRepository.save
-        .withArgs(assessmentResultToBeSaved)
-        .resolves(savedAssessmentResult);
+        const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.notTrustable({
+          emitter: 'PIX-ALGO-NEUTRALIZATION',
+          pixScore: 30,
+          status: AssessmentResult.status.VALIDATED,
+          assessmentId: 123,
+          juryId: 7,
+        });
+        const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+        assessmentResultRepository.save
+          .resolves(savedAssessmentResult);
 
-      const dependendencies = {
-        assessmentResultRepository,
-        certificationAssessmentRepository,
-        competenceMarkRepository,
-        scoringCertificationService,
-        certificationCourseRepository,
-      };
+        const dependendencies = {
+          assessmentResultRepository,
+          certificationAssessmentRepository,
+          competenceMarkRepository,
+          scoringCertificationService,
+          certificationCourseRepository,
+        };
 
-      // when
-      await handleCertificationRescoring(
-        {
+        // when
+        await handleCertificationRescoring({
           ...dependendencies,
           event,
         });
 
-      // then
-      expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
+        // then
+        expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResultToBeSaved);
+        expect(certificationCourse.cancel).to.have.been.calledOnce;
+        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
+      });
+    });
+
+    context('when the certification has enough non neutralized challenges to be trusted', function() {
+
+      it('uncancels the certification and save a standard assessment result', async function() {
+        // given
+        sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(true);
+        const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
+        const assessmentResultRepository = { save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+        const competenceMarkRepository = { save: sinon.stub() };
+        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
+        sinon.spy(certificationCourse, 'uncancel');
+
+        const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
+        const certificationAssessment = new CertificationAssessment({
+          id: 123,
+          userId: 123,
+          certificationCourseId: 789,
+          createdAt: new Date('2020-01-01'),
+          completedAt: new Date('2020-01-01'),
+          state: CertificationAssessment.states.STARTED,
+          isV2Certification: true,
+          certificationChallenges: [
+            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          ],
+          certificationAnswersByDate: ['answer'],
+        });
+        certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: 789 }).resolves(certificationAssessment);
+        certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
+        const competenceMarkData2 = domainBuilder.buildCompetenceMark({ score: 12 });
+        const competenceMarkData1 = domainBuilder.buildCompetenceMark({ score: 18 });
+        const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+          status: AssessmentResult.status.VALIDATED,
+          competenceMarks: [competenceMarkData1, competenceMarkData2],
+          percentageCorrectAnswers: 80,
+          hasEnoughNonNeutralizedChallengesToBeTrusted: true,
+        });
+        scoringCertificationService.calculateCertificationAssessmentScore
+          .withArgs({ certificationAssessment, continueOnError: false })
+          .resolves(certificationAssessmentScore);
+
+        const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.standard({
+          emitter: 'PIX-ALGO-NEUTRALIZATION',
+          pixScore: 30,
+          status: AssessmentResult.status.VALIDATED,
+          assessmentId: 123,
+          juryId: 7,
+        });
+        const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+        assessmentResultRepository.save
+          .resolves(savedAssessmentResult);
+
+        const dependendencies = {
+          assessmentResultRepository,
+          certificationAssessmentRepository,
+          competenceMarkRepository,
+          scoringCertificationService,
+          certificationCourseRepository,
+        };
+
+        // when
+        await handleCertificationRescoring({
+          ...dependendencies,
+          event,
+        });
+
+        // then
+        expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResultToBeSaved);
+        expect(certificationCourse.uncancel).to.have.been.calledOnce;
+        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
+      });
     });
   });
 

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -4,11 +4,13 @@ const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeu
 const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const { CertificationComputeError } = require('../../../../lib/domain/errors');
+const { featureToggles } = require('../../../../lib/config');
 
 describe('Unit | Domain | Events | handle-certification-rescoring', function() {
 
   it('computes and persists the assessment result and competence marks when computation succeeds', async function() {
     // given
+    sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(true);
     const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
     const assessmentResultRepository = { save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
@@ -92,85 +94,173 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function() {
     expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
   });
 
-  it('cancel the certification course if certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function() {
-    // given
-    const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
-    const assessmentResultRepository = { save: sinon.stub() };
-    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-    const competenceMarkRepository = { save: sinon.stub() };
-    const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-    const certificationCourse = domainBuilder.buildCertificationCourse({
-      isCancelled: false,
-    });
-    const expectedSaveCertificationCourse = domainBuilder.buildCertificationCourse({
-      ...certificationCourse.toDTO(),
-      isCancelled: true,
-    });
+  context('when FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED is enabled', function() {
 
-    const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
-    const certificationAssessment = new CertificationAssessment({
-      id: 123,
-      userId: 123,
-      certificationCourseId: certificationCourse.getId(),
-      createdAt: new Date('2020-01-01'),
-      completedAt: new Date('2020-01-01'),
-      state: CertificationAssessment.states.STARTED,
-      isV2Certification: true,
-      certificationChallenges: [
-        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-      ],
-      certificationAnswersByDate: ['answer'],
-    });
-    certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
-    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
-
-    const competenceMarkData2 = domainBuilder.buildCompetenceMark();
-    const competenceMarkData1 = domainBuilder.buildCompetenceMark();
-    const nbPix = Symbol('nbPix');
-    const status = Symbol('status');
-    const certificationAssessmentScore = {
-      nbPix,
-      status,
-      competenceMarks: [competenceMarkData1, competenceMarkData2],
-      percentageCorrectAnswers: 80,
-      hasEnoughNonNeutralizedChallengesToBeTrusted: false,
-    };
-    scoringCertificationService.calculateCertificationAssessmentScore
-      .withArgs({ certificationAssessment, continueOnError: false })
-      .resolves(certificationAssessmentScore);
-
-    const assessmentResultToBeSaved = new AssessmentResult({
-      id: undefined,
-      commentForJury: 'Computed',
-      emitter: 'PIX-ALGO-NEUTRALIZATION',
-      pixScore: nbPix,
-      status: status,
-      assessmentId: 123,
-      juryId: 7,
-    });
-    const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-    assessmentResultRepository.save
-      .withArgs(assessmentResultToBeSaved)
-      .resolves(savedAssessmentResult);
-
-    const dependendencies = {
-      assessmentResultRepository,
-      certificationAssessmentRepository,
-      competenceMarkRepository,
-      scoringCertificationService,
-      certificationCourseRepository,
-    };
-
-    // when
-    await handleCertificationRescoring(
-      {
-        ...dependendencies,
-        event,
+    it('cancel the certification course if certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function() {
+      // given
+      sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(true);
+      const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
+      const assessmentResultRepository = { save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+      const competenceMarkRepository = { save: sinon.stub() };
+      const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        isCancelled: false,
+      });
+      const expectedSaveCertificationCourse = domainBuilder.buildCertificationCourse({
+        ...certificationCourse.toDTO(),
+        isCancelled: true,
       });
 
-    // then
-    expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
+      const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
+      const certificationAssessment = new CertificationAssessment({
+        id: 123,
+        userId: 123,
+        certificationCourseId: certificationCourse.getId(),
+        createdAt: new Date('2020-01-01'),
+        completedAt: new Date('2020-01-01'),
+        state: CertificationAssessment.states.STARTED,
+        isV2Certification: true,
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+        certificationAnswersByDate: ['answer'],
+      });
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+      certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+
+      const competenceMarkData2 = domainBuilder.buildCompetenceMark();
+      const competenceMarkData1 = domainBuilder.buildCompetenceMark();
+      const nbPix = Symbol('nbPix');
+      const status = Symbol('status');
+      const certificationAssessmentScore = {
+        nbPix,
+        status,
+        competenceMarks: [competenceMarkData1, competenceMarkData2],
+        percentageCorrectAnswers: 80,
+        hasEnoughNonNeutralizedChallengesToBeTrusted: false,
+      };
+      scoringCertificationService.calculateCertificationAssessmentScore
+        .withArgs({ certificationAssessment, continueOnError: false })
+        .resolves(certificationAssessmentScore);
+
+      const assessmentResultToBeSaved = new AssessmentResult({
+        id: undefined,
+        commentForJury: 'Computed',
+        emitter: 'PIX-ALGO-NEUTRALIZATION',
+        pixScore: nbPix,
+        status: status,
+        assessmentId: 123,
+        juryId: 7,
+      });
+      const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+      assessmentResultRepository.save
+        .withArgs(assessmentResultToBeSaved)
+        .resolves(savedAssessmentResult);
+
+      const dependendencies = {
+        assessmentResultRepository,
+        certificationAssessmentRepository,
+        competenceMarkRepository,
+        scoringCertificationService,
+        certificationCourseRepository,
+      };
+
+      // when
+      await handleCertificationRescoring(
+        {
+          ...dependendencies,
+          event,
+        });
+
+      // then
+      expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
+    });
+  });
+
+  context('when FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED is not enabled', function() {
+
+    it('does not cancel the certification course if certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function() {
+      // given
+      sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(false);
+      const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
+      const assessmentResultRepository = { save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+      const competenceMarkRepository = { save: sinon.stub() };
+      const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        isCancelled: false,
+      });
+
+      certificationCourse.cancel = sinon.stub();
+
+      const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
+      const certificationAssessment = new CertificationAssessment({
+        id: 123,
+        userId: 123,
+        certificationCourseId: certificationCourse.getId(),
+        createdAt: new Date('2020-01-01'),
+        completedAt: new Date('2020-01-01'),
+        state: CertificationAssessment.states.STARTED,
+        isV2Certification: true,
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+        certificationAnswersByDate: ['answer'],
+      });
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+      certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+
+      const competenceMarkData2 = domainBuilder.buildCompetenceMark();
+      const competenceMarkData1 = domainBuilder.buildCompetenceMark();
+      const nbPix = Symbol('nbPix');
+      const status = Symbol('status');
+      const certificationAssessmentScore = {
+        nbPix,
+        status,
+        competenceMarks: [competenceMarkData1, competenceMarkData2],
+        percentageCorrectAnswers: 80,
+        hasEnoughNonNeutralizedChallengesToBeTrusted: false,
+      };
+      scoringCertificationService.calculateCertificationAssessmentScore
+        .withArgs({ certificationAssessment, continueOnError: false })
+        .resolves(certificationAssessmentScore);
+
+      const assessmentResultToBeSaved = new AssessmentResult({
+        id: undefined,
+        commentForJury: 'Computed',
+        emitter: 'PIX-ALGO-NEUTRALIZATION',
+        pixScore: nbPix,
+        status: status,
+        assessmentId: 123,
+        juryId: 7,
+      });
+      const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+      assessmentResultRepository.save
+        .withArgs(assessmentResultToBeSaved)
+        .resolves(savedAssessmentResult);
+
+      const dependendencies = {
+        assessmentResultRepository,
+        certificationAssessmentRepository,
+        competenceMarkRepository,
+        scoringCertificationService,
+        certificationCourseRepository,
+      };
+
+      // when
+      await handleCertificationRescoring(
+        {
+          ...dependendencies,
+          event,
+        });
+
+      // then
+      expect(certificationCourseRepository.update).to.not.have.been.called;
+      expect(certificationCourse.cancel).to.not.have.been.called;
+    });
   });
 
   it('returns a CertificationRescoringCompleted event', async function() {

--- a/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
@@ -4,6 +4,26 @@ const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 
 describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
 
+  context('#numberOfChallenges', function() {
+
+    it('counts the number of challenges', function() {
+      // given
+      const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1' });
+      const challenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2' });
+      const challenge3 = _buildDecoratedCertificationChallenge({ challengeId: 'chal3' });
+      const answerCollection = AnswerCollectionForScoring.from({
+        challenges: [challenge1, challenge2, challenge3],
+        answers: [],
+      });
+
+      // when
+      const numberOfChallenges = answerCollection.numberOfChallenges();
+
+      // then
+      expect(numberOfChallenges).to.equal(3);
+    });
+  });
+
   context('#numberOfNonNeutralizedChallenges', function() {
 
     it('equals 0 when no challenges asked', function() {
@@ -76,6 +96,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       expect(numberOfChallenges).to.equal(0);
     });
   });
+
   context('#numberOfCorrectAnswers', function() {
 
     it('equals 0 when no answers', function() {
@@ -188,6 +209,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       expect(numberOfChallengesAnswered).to.equal(1);
     });
   });
+
   context('#numberOfChallengesForCompetence', function() {
     it('equals 0 when no challenges asked for given competence', function() {
       // given
@@ -315,6 +337,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       expect(numberOfChallenges).to.equal(2);
     });
   });
+
   context('#numberOfCorrectAnswersForCompetence', function() {
 
     it('equals 0 when no answers for given competence', function() {
@@ -495,6 +518,7 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       expect(numberOfChallengesAnswered).to.equal(1);
     });
   });
+
   context('#numberOfNeutralizedChallengesForCompetence', function() {
 
     it('equals 0 when there are no answers for given competence', function() {

--- a/api/tests/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/unit/domain/models/AssessmentResult_test.js
@@ -39,31 +39,128 @@ describe('Unit | Domain | Models | BookshelfAssessmentResult', function() {
     });
   });
 
-  describe('#buildStartedAssessmentResult', function() {
+  describe('#buildAlgoErrorResult', function() {
 
-    it('should return true if the campaign is of type ASSESSMENT', function() {
+    it('should return an algo error AssessmentResult', function() {
       // given
-      const assessmentId = 123;
+      const error = {
+        message: 'message for jury',
+      };
 
       // when
-      const result = AssessmentResult.buildStartedAssessmentResult({ assessmentId });
+      const actualAssessmentResult = AssessmentResult.buildAlgoErrorResult({
+        error,
+        assessmentId: 123,
+        juryId: 456,
+        emitter: 'Moi',
+      });
 
       // then
-      const startedAssessmentResult = {
-        id: undefined,
-        assessmentId,
-        status: Assessment.states.STARTED,
-        commentForCandidate: undefined,
-        commentForOrganization: undefined,
-        commentForJury: undefined,
-        createdAt: undefined,
-        emitter: undefined,
-        juryId: undefined,
-        pixScore: undefined,
+      const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
+        assessmentId: 123,
+        juryId: 456,
+        emitter: 'Moi',
+        commentForJury: 'message for jury',
+        status: AssessmentResult.status.ERROR,
+        pixScore: 0,
         competenceMarks: [],
-      };
-      expect(result).to.be.instanceOf(AssessmentResult);
-      expect(result).to.deep.equal(startedAssessmentResult);
+      });
+      expectedAssessmentResult.id = undefined;
+      expectedAssessmentResult.commentForCandidate = undefined;
+      expectedAssessmentResult.commentForOrganization = undefined;
+      expectedAssessmentResult.createdAt = undefined;
+      expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
+    });
+  });
+
+  describe('#buildStandardAssessmentResult', function() {
+
+    it('should return a standard AssessmentResult', function() {
+      // when
+      const actualAssessmentResult = AssessmentResult.buildStandardAssessmentResult({
+        pixScore: 55,
+        status: AssessmentResult.status.VALIDATED,
+        assessmentId: 123,
+        juryId: 456,
+        emitter: 'Moi',
+      });
+
+      // then
+      const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
+        assessmentId: 123,
+        juryId: 456,
+        emitter: 'Moi',
+        commentForJury: 'Computed',
+        status: AssessmentResult.status.VALIDATED,
+        pixScore: 55,
+        competenceMarks: [],
+      });
+      expectedAssessmentResult.id = undefined;
+      expectedAssessmentResult.commentForCandidate = undefined;
+      expectedAssessmentResult.commentForOrganization = undefined;
+      expectedAssessmentResult.createdAt = undefined;
+      expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
+    });
+  });
+
+  describe('#buildNotTrustableAssessmentResult', function() {
+
+    it('should return a not trustable AssessmentResult', function() {
+      // when
+      const actualAssessmentResult = AssessmentResult.buildNotTrustableAssessmentResult({
+        pixScore: 55,
+        status: AssessmentResult.status.VALIDATED,
+        assessmentId: 123,
+        juryId: 456,
+        emitter: 'Moi',
+      });
+
+      // then
+      const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
+        assessmentId: 123,
+        juryId: 456,
+        emitter: 'Moi',
+        commentForJury: 'Computed',
+        status: AssessmentResult.status.VALIDATED,
+        pixScore: 55,
+        competenceMarks: [],
+        commentForCandidate: 'Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification' +
+          ', a/ont affecté la qualité du test de certification. En raison du trop grand nombre de questions auxquelles vous ' +
+          'n\'avez pas pu répondre dans de bonnes conditions, nous ne sommes malheureusement pas en mesure de calculer un ' +
+          'score fiable et de fournir un certificat. La certification est annulée, le prescripteur de votre certification' +
+          '(le cas échéant), en est informé.',
+        commentForOrganization: 'Un ou plusieurs problème(s) technique(s), signalés par ce(cette) candidate au surveillant' +
+          'de la session de certification, a/ont affecté le bon déroulement du test de certification. Nous sommes dans ' +
+          'l\'incapacité de le/la certifier, sa certification est donc annulée. Cette information est à prendre en compte ' +
+          'et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).',
+      });
+      expectedAssessmentResult.id = undefined;
+      expectedAssessmentResult.createdAt = undefined;
+      expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
+    });
+  });
+
+  describe('#buildStartedAssessmentResult', function() {
+
+    it('should return a started AssessmentResult', function() {
+      // when
+      const actualAssessmentResult = AssessmentResult.buildStartedAssessmentResult({ assessmentId: 123 });
+
+      // then
+      const expectedAssessmentResult = domainBuilder.buildAssessmentResult({
+        assessmentId: 123,
+        status: Assessment.states.STARTED,
+        competenceMarks: [],
+      });
+      expectedAssessmentResult.id = undefined;
+      expectedAssessmentResult.commentForCandidate = undefined;
+      expectedAssessmentResult.commentForOrganization = undefined;
+      expectedAssessmentResult.commentForJury = undefined;
+      expectedAssessmentResult.createdAt = undefined;
+      expectedAssessmentResult.emitter = undefined;
+      expectedAssessmentResult.juryId = undefined;
+      expectedAssessmentResult.pixScore = undefined;
+      expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
     });
   });
 

--- a/api/tests/unit/domain/models/CertificationContract_test.js
+++ b/api/tests/unit/domain/models/CertificationContract_test.js
@@ -4,8 +4,10 @@ const CertificationContract = require('../../../../lib/domain/models/Certificati
 const _ = require('lodash');
 
 describe('Unit | Domain | Models | CertificationContract', function() {
-  describe('#assertThatWeHaveEnoughAnswers', function() {
-    describe('when there is less answers than challenges', function() {
+
+  context('#assertThatWeHaveEnoughAnswers', function() {
+
+    context('when there is less answers than challenges', function() {
 
       it('should throw', async function() {
         // given
@@ -34,8 +36,9 @@ describe('Unit | Domain | Models | CertificationContract', function() {
     });
   });
 
-  describe('#assertThatCompetenceHasAtLeastOneChallenge', function() {
-    describe('when there not enough challenges for one competence', function() {
+  context('#assertThatCompetenceHasAtLeastOneChallenge', function() {
+
+    context('when there not enough challenges for one competence', function() {
 
       it('should throw', async function() {
         // given
@@ -53,8 +56,9 @@ describe('Unit | Domain | Models | CertificationContract', function() {
     });
   });
 
-  describe('#assertThatCompetenceHasAtLeastOneAnswer', function() {
-    describe('when there is not enough answers for one competence', function() {
+  context('#assertThatCompetenceHasAtLeastOneAnswer', function() {
+
+    context('when there is not enough answers for one competence', function() {
 
       it('should throw', async function() {
         // given
@@ -72,8 +76,9 @@ describe('Unit | Domain | Models | CertificationContract', function() {
     });
   });
 
-  describe('#assertThatScoreIsCoherentWithReproducibilityRate', function() {
-    describe('when score is < 1 and reproductibility rate is > 50%', function() {
+  context('#assertThatScoreIsCoherentWithReproducibilityRate', function() {
+
+    context('when score is < 1 and reproductibility rate is > 50%', function() {
 
       it('should throw', async function() {
         // given
@@ -91,8 +96,9 @@ describe('Unit | Domain | Models | CertificationContract', function() {
     });
   });
 
-  describe('#assertThatEveryAnswerHasMatchingChallenge', function() {
-    describe('when an answer does not match a challenge', function() {
+  context('#assertThatEveryAnswerHasMatchingChallenge', function() {
+
+    context('when an answer does not match a challenge', function() {
 
       it('should throw', async function() {
         // given
@@ -121,8 +127,9 @@ describe('Unit | Domain | Models | CertificationContract', function() {
     });
   });
 
-  describe('#assertThatNoChallengeHasMoreThanOneAnswer', function() {
-    describe('when there are several answers for the same challenge', function() {
+  context('#assertThatNoChallengeHasMoreThanOneAnswer', function() {
+
+    context('when there are several answers for the same challenge', function() {
 
       it('should throw', async function() {
         // given
@@ -141,6 +148,39 @@ describe('Unit | Domain | Models | CertificationContract', function() {
         // then
         expect(error).to.be.instanceOf(CertificationComputeError);
         expect(error.message).to.equal('Plusieurs réponses pour une même épreuve');
+      });
+    });
+  });
+
+  describe('#hasEnoughNonNeutralizedChallengesToBeTrusted', function() {
+
+    context('when certification has more than 66% of non neutralized challenges', function() {
+
+      it('should return true', function() {
+        // given
+        const numberOfChallenges = 6;
+        const numberOfNonNeutralizedChallenges = 4;
+
+        // when
+        const hasEnoughNonNeutralizedChallengeToBeTrusted = CertificationContract.hasEnoughNonNeutralizedChallengesToBeTrusted(numberOfChallenges, numberOfNonNeutralizedChallenges);
+
+        // then
+        expect(hasEnoughNonNeutralizedChallengeToBeTrusted).to.be.true;
+      });
+    });
+
+    context('when certification has less than 66% of non neutralized challenges', function() {
+
+      it('should return false', function() {
+        // given
+        const numberOfChallenges = 6;
+        const numberOfNonNeutralizedChallenges = 2;
+
+        // when
+        const hasEnoughNonNeutralizedChallengeToBeTrusted = CertificationContract.hasEnoughNonNeutralizedChallengesToBeTrusted(numberOfChallenges, numberOfNonNeutralizedChallenges);
+
+        // then
+        expect(hasEnoughNonNeutralizedChallengeToBeTrusted).to.be.false;
       });
     });
   });

--- a/api/tests/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/unit/domain/models/CertificationCourse_test.js
@@ -34,6 +34,38 @@ describe('Unit | Domain | Models | CertificationCourse', function() {
     });
   });
 
+  describe('#cancel #uncancelled', function() {
+
+    it('should uncancel a certification course', function() {
+      // given
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        isCancelled: true,
+      });
+
+      // when
+      certificationCourse.uncancel();
+
+      // then
+      expect(certificationCourse.toDTO().isCancelled).to.be.false;
+    });
+
+    describe('when certification course is not cancelled', function() {
+      it('should not change isCancelled value', function() {
+        // given
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          isCancelled: true,
+        });
+
+        // when
+        certificationCourse.uncancel();
+        certificationCourse.uncancel();
+
+        // then
+        expect(certificationCourse.toDTO().isCancelled).to.be.false;
+      });
+    });
+  });
+
   describe('#correctBirthdate', function() {
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['2000-13-01', null, undefined, '', 'invalid']

--- a/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
@@ -108,65 +108,49 @@ const userCompetences = [
 describe('Unit | Service | Certification Result Service', function() {
 
   context('#calculateCertificationAssessmentScore', function() {
-    let certificationAssessment;
-    const certificationAssessmentData = {
-      id: 1,
-      userId: 11,
-      certificationCourseId: 111,
-      createdAt: '2020-02-01T00:00:00Z',
-      completedAt: '2020-02-01T00:00:00Z',
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      state: states.COMPLETED,
-      isV2Certification: true,
-    };
+    let certificationAssessment, certificationAssessmentData, expectedCertifiedCompetences;
+    let competenceWithMarks_1_1, competenceWithMarks_2_2, competenceWithMarks_3_3, competenceWithMarks_4_4;
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const competenceWithMarks_1_1 = domainBuilder.buildCompetenceMark({
-      level: UNCERTIFIED_LEVEL,
-      score: 0,
-      area_code: '1',
-      competence_code: '1.1',
-      competenceId: 'competence_1',
+    beforeEach(function() {
+      certificationAssessmentData = {
+        id: 1,
+        userId: 11,
+        certificationCourseId: 111,
+        createdAt: '2020-02-01T00:00:00Z',
+        completedAt: '2020-02-01T00:00:00Z',
+        state: states.COMPLETED,
+        isV2Certification: true,
+      };
+      competenceWithMarks_1_1 = domainBuilder.buildCompetenceMark({
+        level: UNCERTIFIED_LEVEL,
+        score: 0,
+        area_code: '1',
+        competence_code: '1.1',
+        competenceId: 'competence_1',
+      });
+      competenceWithMarks_2_2 = domainBuilder.buildCompetenceMark({
+        level: UNCERTIFIED_LEVEL,
+        score: 0,
+        area_code: '2',
+        competence_code: '2.2',
+        competenceId: 'competence_2',
+      });
+      competenceWithMarks_3_3 = domainBuilder.buildCompetenceMark({
+        level: UNCERTIFIED_LEVEL,
+        score: 0,
+        area_code: '3',
+        competence_code: '3.3',
+        competenceId: 'competence_3',
+      });
+      competenceWithMarks_4_4 = domainBuilder.buildCompetenceMark({
+        level: UNCERTIFIED_LEVEL,
+        score: 0,
+        area_code: '4',
+        competence_code: '4.4',
+        competenceId: 'competence_4',
+      });
+      expectedCertifiedCompetences = [competenceWithMarks_1_1, competenceWithMarks_2_2, competenceWithMarks_3_3, competenceWithMarks_4_4];
     });
-
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const competenceWithMarks_2_2 = domainBuilder.buildCompetenceMark({
-      level: UNCERTIFIED_LEVEL,
-      score: 0,
-      area_code: '2',
-      competence_code: '2.2',
-      competenceId: 'competence_2',
-    });
-
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const competenceWithMarks_3_3 = domainBuilder.buildCompetenceMark({
-      level: UNCERTIFIED_LEVEL,
-      score: 0,
-      area_code: '3',
-      competence_code: '3.3',
-      competenceId: 'competence_3',
-    });
-
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const competenceWithMarks_4_4 = domainBuilder.buildCompetenceMark({
-      level: UNCERTIFIED_LEVEL,
-      score: 0,
-      area_code: '4',
-      competence_code: '4.4',
-      competenceId: 'competence_4',
-    });
-
-    const expectedCertifiedCompetences = [
-      competenceWithMarks_1_1,
-      competenceWithMarks_2_2,
-      competenceWithMarks_3_3,
-      competenceWithMarks_4_4,
-    ];
 
     context('When at least one challenge have more than one answer ', function() {
 


### PR DESCRIPTION
## :unicorn: Problème
Manuellement, jusqu'à présent, le pôle certif estimait qu'à partir d'un certain volume d'épreuves neutralisées, la certification n'était pas scorable et donc devait être annulée.

Cette règle est automatisable, la voici :
- Si le taux d'épreuves neutralisées est supérieur à 33% du nombre d'épreuves total, alors la certification doit être annulée (+ messages dédiées pour le prescripteur et le candidat)
- Sinon, la certification n'est pas annulée

## :robot: Solution
Mise en place de cette règle. On a décidé de quoiqu'il arrive procéder au scoring de toutes les certifications. D'une part car il est plus simple dans le code de manipuler des certifications qui passent dans les mêmes tunnels de code, et d'autre part car il est nécessaire de disposer d'un assessment-result afin de transmettre des messages au candidat et au prescripteur (notamment dans le cas de l'annulation).

Cette règle de scoring est évaluée à chaque scoring.

## :rainbow: Remarques
- Mettre sous toggle car le pôle certif est encore en train d'affiner le wording des messages d'erreur.
- Il a fallu ne pas oublier de désannuler une certif dont le taux de neutralisation repasse en dessous du seuil (dans le cas d'une déneutralisation d'épreuve par exemple).

## :100: Pour tester
Passer une certification.
Sur la page de neutralisation sur PixAdmin, jouer avec les neutralisations pour faire basculer le statut de la certification d'un sens vers l'autre et inversement.
