### PR TITLE
[BUGFIX] Corriger la redirection du lien pour créer un Profil Cible (PIX-3115).

### DIFF
--- a/admin/app/templates/authenticated/target-profiles/list.hbs
+++ b/admin/app/templates/authenticated/target-profiles/list.hbs
@@ -2,7 +2,7 @@
   <div class="page-title">Tous les profils cibles</div>
   <div class="page-actions">
      <PixButton
-      @route="authenticated.certification-centers.new"
+      @route="authenticated.target-profiles.new"
       @backgroundColor="transparent-light"
       @isBorderVisible={{true}}
       class="pix-button__secondary"

--- a/admin/tests/acceptance/target-profiles-list_test.js
+++ b/admin/tests/acceptance/target-profiles-list_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { currentURL, click, visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -72,14 +73,26 @@ module('Acceptance | Target Profiles List', function(hooks) {
 
     test('it should redirect to target profile details on click', async function(assert) {
       // given
+      server.create('target-profile', { id: 1, name: 'Mon Super Profil Cible' });
+      await visit('/target-profiles/list');
+
+      // when
+      await clickByLabel('Mon Super Profil Cible');
+
+      // then
+      assert.equal(currentURL(), '/target-profiles/1');
+    });
+
+    test('it should redirect to target profile creation form on click "Nouveau profil cible', async function(assert) {
+      // given
       server.create('target-profile', { id: 1 });
       await visit('/target-profiles/list');
 
       // when
-      await click('[aria-label="Profil cible"]');
+      await clickByLabel('Nouveau profil cible');
 
       // then
-      assert.equal(currentURL(), '/target-profiles/1');
+      assert.equal(currentURL(), '/target-profiles/new');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une PR précédente (https://github.com/1024pix/pix/pull/3342) , le lien pour créer un profil cible a été remplacé par celui pour créer un centre de certification. 
Voir : https://1024pix.slack.com/archives/C6YRM9407/p1630312463002600.

## :robot: Solution
Remettre le bon lien pour la création d'un profil cible.

## :100: Pour tester
Sur PixAdmin : 
- Aller dans l'onglet "Profil cible" `/target-profiles`
- Cliquer sur le bouton "Nouveau profil cible"
- Constater qu'on tombe bien sur la création de profil cible et non de centre de certification.
