### PR TITLE
[TECH] Création du scénario Inscription et page Profil dans Pix Load-Testing (PIX-3114).

### DIFF
--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -17,6 +17,8 @@
     "arti:cmd": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-competence-evaluation.yml",
     "arti:local:campaign": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-campaign-participation.yml",
     "arti:dev:campaign": "artillery run --config config/common.yml -e development -o report/index.json scenarios/signup-and-campaign-participation.yml",
+    "arti:local:profil": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-profil.yml",
+    "arti:dev:profil": "artillery run --config config/common.yml -e development -o report/index.json scenarios/signup-and-profil.yml",
     "arti:cmd:dev": "artillery run --config config/common.yml -e development -o report/index.json scenarios/signup-and-competence-evaluation.yml",
     "arti:run": "npm run db:initialize && npm run arti:cmd",
     "arti:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix npm run arti:run",

--- a/high-level-tests/load-testing/scenarios/signup-and-profil.yml
+++ b/high-level-tests/load-testing/scenarios/signup-and-profil.yml
@@ -1,0 +1,69 @@
+config:
+  phases:
+    - duration: 60
+      arrivalRate: 5
+      name: Warm up
+    - duration: 120
+      arrivalRate: 5
+      rampTo: 50
+      name: Ramp up load
+    - duration: 300
+      arrivalRate: 25
+      name: Sustained load
+
+scenarios:
+  - name: "Inscription et page Profil"
+    flow:
+      - function: "setupSignupFormData"
+
+      ### ---------------------- ###
+      ### From page /inscription ###
+      ### ---------------------- ###
+
+      # Submit user form
+      - post:
+          url: "/api/users"
+          json:
+            data:
+              attributes:
+                cgu: true
+                email: "{{ email }}"
+                first-name: "{{ firstName }}"
+                last-name: "{{ lastName }}"
+                password: "{{ password }}"
+
+      # Authenticate user
+      - post:
+          url: "/api/token"
+          headers:
+            content-type: "application/x-www-form-urlencoded"
+          body: "grant_type=password&scope=mon-pix&username={{ email }}&password={{ password }}"
+          capture:
+            - json: "$.access_token"
+              as: "accessToken"
+            - json: "$.user_id"
+              as: "userId"
+
+      # Get user data
+      - get:
+          url: "/api/users/me"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+
+      # Fetch campaign participation overviews
+      - get:
+          url: "/api/users/{{ userId }}/campaign-participation-overviews?filter[states]=ONGOING&filter[states]=TO_SHARE&page[number]=1&page[size]=9"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+
+      # Get user profile
+      - get:
+          url: "/api/users/{{ userId }}/profile"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+
+      # Fetch campaign participations
+      - get:
+          url: "/api/users/{{ userId }}/campaign-participations"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pas de scénario minimal (inscription et page profil) dans l'application Pix Load-Testing.

## :robot: Solution
Créer ce scénario

## :rainbow: Remarques
* Les travaux concernant la récupération du reporting sur Scalingo seront effectués dans un prochain ticket (cf. [Publishing metrics / monitoring](https://artillery.io/docs/guides/plugins/plugin-publish-metrics.html))

## :100: Pour tester
### En local
* Lancer l'API
* Lancer le scenario avec commande
    ```sh
    npm run arti:local:profil
    ```   
### Sur Pix-load-testing
* Mettre à jour la base de données de l'API cible avec la commande
    ```sh
    scalingo --region osc-fr1 -a pix-api-load-testing run npm run db:seed
    ``` 
* Lancer le scenario avec commande
    ```sh
    scalingo --region osc-fr1 -a pix-load-testing run npm run arti:dev:profil
    ```   