### PR TITLE
[BUGFIX] Corriger le message d'erreur lorsque l'adresse e-mail existe déjà sur Pix App (PIX-3111).

### DIFF
--- a/mon-pix/app/components/user-account-update-email.js
+++ b/mon-pix/app/components/user-account-update-email.js
@@ -14,6 +14,7 @@ const STATUS_MAP = {
 
 const ERROR_INPUT_MESSAGE_MAP = {
   wrongEmailFormat: 'pages.user-account.account-update-email.fields.errors.wrong-email-format',
+  emailAlreadyExist: 'pages.user-account.account-update-email.fields.errors.new-email-already-exist',
   mismatchingEmail: 'pages.user-account.account-update-email.fields.errors.mismatching-email',
   emptyPassword: 'pages.user-account.account-update-email.fields.errors.empty-password',
   invalidPassword: 'pages.user-account.account-update-email.fields.errors.invalid-password',
@@ -112,7 +113,11 @@ export default class UserAccountUpdateEmail extends Component {
             this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
           }
         } else if (status === '400' || status === '403') {
+          const code = get(response, 'errors[0].code');
           this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidPassword']);
+          if (code === 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS') {
+            this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emailAlreadyExist']);
+          }
         } else {
           this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']);
         }

--- a/mon-pix/tests/integration/components/user-account-update-email_test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email_test.js
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, fillIn, find, render, triggerEvent } from '@ember/test-helpers';
+import { find, render, triggerEvent } from '@ember/test-helpers';
+import { fillInByLabel } from '../../helpers/fill-in-by-label';
+import { clickByLabel } from '../../helpers/click-by-label';
+import { contains } from '../../helpers/contains';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
@@ -16,9 +19,9 @@ describe('Integration | Component | User account update email', () => {
       await render(hbs`<UserAccountUpdateEmail/>`);
 
       // then
-      expect(find('div[data-test-new-email]')).to.exist;
-      expect(find('button[data-test-cancel-email]')).to.exist;
-      expect(find('button[data-test-submit-email]')).to.exist;
+      expect(contains(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'))).to.exist;
+      expect(contains(this.intl.t('common.actions.cancel'))).to.exist;
+      expect(contains(this.intl.t('pages.user-account.account-update-email.save-button'))).to.exist;
     });
 
     context('when the user cancel edition', function() {
@@ -30,7 +33,7 @@ describe('Integration | Component | User account update email', () => {
         await render(hbs`<UserAccountUpdateEmail @disableEmailEditionMode={{this.disableEmailEditionMode}} />`);
 
         // when
-        await click('button[data-test-cancel-email]');
+        await clickByLabel(this.intl.t('common.actions.cancel'));
 
         // then
         sinon.assert.called(disableEmailEditionMode);
@@ -43,16 +46,16 @@ describe('Integration | Component | User account update email', () => {
 
         it('should display a wrong format error message when focus-out', async function() {
           // given
-          const wrongEmail = 'wrongEmail';
+          const invalidEmail = 'invalidEmail';
 
           await render(hbs`<UserAccountUpdateEmail />`);
 
           // when
-          await fillIn('#newEmail', wrongEmail);
+          await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), invalidEmail);
           await triggerEvent('#newEmail', 'focusout');
 
           // then
-          expect(find('#validationMessage-newEmail').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'));
+          expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'))).to.exist;
         });
       });
 
@@ -60,16 +63,16 @@ describe('Integration | Component | User account update email', () => {
 
         it('should display a wrong format error message when focus-out', async function() {
           // given
-          const wrongEmail = 'wrongEmail';
+          const invalidEmail = 'invalidEmail';
 
           await render(hbs`<UserAccountUpdateEmail />`);
 
           // when
-          await fillIn('#newEmailConfirmation', wrongEmail);
+          await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), invalidEmail);
           await triggerEvent('#newEmailConfirmation', 'focusout');
 
           // then
-          expect(find('#validationMessage-newEmailConfirmation').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'));
+          expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'))).to.exist;
         });
       });
 
@@ -83,12 +86,12 @@ describe('Integration | Component | User account update email', () => {
           await render(hbs`<UserAccountUpdateEmail />`);
 
           // when
-          await fillIn('#newEmail', newEmail);
-          await fillIn('#newEmailConfirmation', newEmailConfirmation);
+          await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), newEmail);
+          await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), newEmailConfirmation);
           await triggerEvent('#newEmailConfirmation', 'focusout');
 
           // then
-          expect(find('#validationMessage-newEmailConfirmation').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.mismatching-email'));
+          expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.mismatching-email'))).to.exist;
         });
       });
 
@@ -102,13 +105,13 @@ describe('Integration | Component | User account update email', () => {
           await render(hbs`<UserAccountUpdateEmail />`);
 
           // when
-          await fillIn('#newEmail', newEmail);
-          await fillIn('#newEmailConfirmation', newEmail);
-          await fillIn('#password', emptyPassword);
+          await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), newEmail);
+          await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), newEmail);
+          await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.password.label'), emptyPassword);
           await triggerEvent('#password', 'focusout');
 
           // then
-          expect(find('#validationMessage-password').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.empty-password'));
+          expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.empty-password'))).to.exist;
         });
 
         it('should have the autocomplete attribute set to "new-password" in order to prevent the web browsers to autocomplete the password and email fields', async () => {
@@ -145,10 +148,10 @@ describe('Integration | Component | User account update email', () => {
         await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
-        await fillIn('#newEmail', newEmail);
-        await fillIn('#newEmailConfirmation', newEmail);
-        await fillIn('#password', password);
-        await click('button[data-test-submit-email]');
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.password.label'), password);
+        await clickByLabel(this.intl.t('pages.user-account.account-update-email.save-button'));
 
         // then
         sinon.assert.calledWith(saveNewEmail, newEmail);
@@ -158,7 +161,6 @@ describe('Integration | Component | User account update email', () => {
         // given
         const emailAlreadyExist = 'email@example.net';
         const password = 'password';
-        const expectedErrorMessage = this.intl.t('pages.user-account.account-update-email.fields.errors.new-email-already-exist');
 
         const saveNewEmail = sinon.stub();
         this.set('saveNewEmail', saveNewEmail);
@@ -167,20 +169,19 @@ describe('Integration | Component | User account update email', () => {
         await render(hbs `<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
-        await fillIn('#newEmail', emailAlreadyExist);
-        await fillIn('#newEmailConfirmation', emailAlreadyExist);
-        await fillIn('#password', password);
-        await click('button[data-test-submit-email]');
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), emailAlreadyExist);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), emailAlreadyExist);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.password.label'), password);
+        await clickByLabel(this.intl.t('pages.user-account.account-update-email.save-button'));
 
         // then
-        expect(find('span[data-test-error-message]').textContent).to.equal(expectedErrorMessage);
+        expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.new-email-already-exist'))).to.exist;
       });
 
       it('should display error message from server if response status is 400 or 403', async function() {
         // given
         const newEmail = 'newEmail@example.net';
         const password = 'password';
-        const expectedErrorMessage = this.intl.t('pages.user-account.account-update-email.fields.errors.invalid-password');
 
         const saveNewEmail = sinon.stub();
         this.set('saveNewEmail', saveNewEmail);
@@ -189,13 +190,13 @@ describe('Integration | Component | User account update email', () => {
         await render(hbs `<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
-        await fillIn('#newEmail', newEmail);
-        await fillIn('#newEmailConfirmation', newEmail);
-        await fillIn('#password', password);
-        await click('button[data-test-submit-email]');
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.password.label'), password);
+        await clickByLabel(this.intl.t('pages.user-account.account-update-email.save-button'));
 
         // then
-        expect(find('span[data-test-error-message]').textContent).to.equal(expectedErrorMessage);
+        expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.invalid-password'))).to.exist;
       });
 
       it('should display default error message if response status is unknown', async function() {
@@ -210,13 +211,13 @@ describe('Integration | Component | User account update email', () => {
         await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
-        await fillIn('#newEmail', newEmail);
-        await fillIn('#newEmailConfirmation', newEmail);
-        await fillIn('#password', password);
-        await click('button[data-test-submit-email]');
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.password.label'), password);
+        await clickByLabel(this.intl.t('pages.user-account.account-update-email.save-button'));
 
         // then
-        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.unknown-error'));
+        expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.unknown-error'))).to.exist;
       });
 
       it('should display wrong email format error if response status is 422', async function() {
@@ -231,13 +232,13 @@ describe('Integration | Component | User account update email', () => {
         await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
-        await fillIn('#newEmail', newEmail);
-        await fillIn('#newEmailConfirmation', newEmail);
-        await fillIn('#password', password);
-        await click('button[data-test-submit-email]');
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.password.label'), password);
+        await clickByLabel(this.intl.t('pages.user-account.account-update-email.save-button'));
 
         // then
-        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'));
+        expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'))).to.exist;
       });
 
       it('should display empty password error if response status is 422', async function() {
@@ -252,13 +253,13 @@ describe('Integration | Component | User account update email', () => {
         await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
-        await fillIn('#newEmail', newEmail);
-        await fillIn('#newEmailConfirmation', newEmail);
-        await fillIn('#password', password);
-        await click('button[data-test-submit-email]');
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.new-email-confirmation.label'), newEmail);
+        await fillInByLabel(this.intl.t('pages.user-account.account-update-email.fields.password.label'), password);
+        await clickByLabel(this.intl.t('pages.user-account.account-update-email.save-button'));
 
         // then
-        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.empty-password'));
+        expect(contains(this.intl.t('pages.user-account.account-update-email.fields.errors.empty-password'))).to.exist;
       });
     });
   });

--- a/mon-pix/tests/integration/components/user-account-update-email_test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email_test.js
@@ -154,6 +154,28 @@ describe('Integration | Component | User account update email', () => {
         sinon.assert.calledWith(saveNewEmail, newEmail);
       });
 
+      it('should display wrong email format error if response status is 400', async function() {
+        // given
+        const emailAlreadyExist = 'email@example.net';
+        const password = 'password';
+        const expectedErrorMessage = this.intl.t('pages.user-account.account-update-email.fields.errors.new-email-already-exist');
+
+        const saveNewEmail = sinon.stub();
+        this.set('saveNewEmail', saveNewEmail);
+        saveNewEmail.rejects({ errors: [{ status: '400', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS' }] });
+
+        await render(hbs `<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
+
+        // when
+        await fillIn('#newEmail', emailAlreadyExist);
+        await fillIn('#newEmailConfirmation', emailAlreadyExist);
+        await fillIn('#password', password);
+        await click('button[data-test-submit-email]');
+
+        // then
+        expect(find('span[data-test-error-message]').textContent).to.equal(expectedErrorMessage);
+      });
+
       it('should display error message from server if response status is 400 or 403', async function() {
         // given
         const newEmail = 'newEmail@example.net';

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1286,6 +1286,7 @@
         "email-information": "Please provide a valid email address: it will be used to reset your password if you forget it. '<br>'This will change the email address you use to log in.",
         "fields": {
           "errors": {
+            "new-email-already-exist": "This email address is already in use.",
             "empty-password": "Your password can't be empty.",
             "invalid-password": "There was an error in the password entered.",
             "mismatching-email": "The email addresses you entered do not match. Please check your entry for spelling errors.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1286,6 +1286,7 @@
         "email-information": "Cette adresse e-mail doit être valide en cas de mot de passe oublié. '<br>' Elle sera votre nouvelle adresse de connexion.",
         "fields": {
           "errors": {
+            "new-email-already-exist": "Cette adresse e-mail est déjà utilisée.",
             "empty-password": "Votre mot de passe ne peut pas être vide.",
             "invalid-password": "Le mot de passe que vous avez saisi est invalide.",
             "mismatching-email": "Les deux adresses e-mail ne sont pas identiques. Veuillez vérifier votre saisie.",


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur souhaite changer d'adresse e-mail sur Pix App ( sur mon Compte ) et qu'il entre une adresse e-mail déjà existante en base, un mauvais message d'erreur s'affichait, indiquant que le mot de passe est invalide.

<img width="855" alt="Capture d’écran 2021-08-27 à 17 13 57" src="https://user-images.githubusercontent.com/58915422/131319124-92b882cc-fc35-456d-a907-54b760cf964b.png">

## :robot: Solution
Indiquer le bon message à l'utilisateur : "Cette adresse e-mail est déjà utilisée."

## :rainbow: Remarques
Ajout des helpers dans le fichier de test.

## :100: Pour tester
- Aller sur Mon Compte 
- Remplir l'adresse e-mail existante de l'utilisateur dans les deux champs + mot de passe et valider.
- Le message "Cette adresse e-mail est déjà utilisée." est affiché.
