### PR TITLE
[TECH] Supprimer les indexes de la table account-recovery-demands (PIX-2983).

### DIFF
--- a/api/db/migrations/20210830100754_delete-index-on-account-recovery-demands-table.js
+++ b/api/db/migrations/20210830100754_delete-index-on-account-recovery-demands-table.js
@@ -2,7 +2,6 @@ const TABLE_NAME = 'account-recovery-demands';
 
 exports.up = function(knex) {
   return knex.schema.table(TABLE_NAME, function(table) {
-    table.dropIndex('userId');
     table.dropIndex('oldEmail');
     table.dropIndex('newEmail');
     table.dropIndex('temporaryKey');
@@ -11,7 +10,6 @@ exports.up = function(knex) {
 
 exports.down = function(knex) {
   return knex.schema.table(TABLE_NAME, function(table) {
-    table.index('userId');
     table.index('oldEmail');
     table.index('newEmail');
     table.index('temporaryKey');

--- a/api/db/migrations/20210830100754_delete-index-on-account-recovery-demands-table.js
+++ b/api/db/migrations/20210830100754_delete-index-on-account-recovery-demands-table.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'account-recovery-demands';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex('userId');
+    table.dropIndex('oldEmail');
+    table.dropIndex('newEmail');
+    table.dropIndex('temporaryKey');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index('userId');
+    table.index('oldEmail');
+    table.index('newEmail');
+    table.index('temporaryKey');
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Le principe d'un index en BDD est le même qu'un sommaire dans un livre.
Un sommaire n'est efficace que s'il ne contient pas tous les mots d'un livre, ainsi il ne faut se limiter qu'aux grandes parties, celles les plus pertinentes / les plus utilisées.
Ce n'est pas le cas des colonnes `userId`, `oldEmail`, `newEmail` et `temporaryKey` de la table `account-recovery-demands`. En effet, cette table permet d'enregistrer les demandes de récupération de compte des élèves sortant de leur collège / lycée. L'utilisation de cette table est donc occasionnelle.

Voir la discussion de cette décision ici : https://1024pix.slack.com/archives/CKS2SRZN2/p1628597312066000

## :robot: Solution
Enlever les indexes de la table `account-recovery-demands`.

## :rainbow: Remarques
A voir si à la longue les demandes augmentent et que les indexes deviennent nécessaires : https://app.datadoghq.eu/logs?query=%22api%2Fschooling-registration-dependent-users%2Frecover-account%22%20host%3Arouter&index=&from_ts=1629713838387&to_ts=1630318638387&live=true

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
