### PR TITLE
[TECH] Supprimer le feature toggle IsScoAccountRecoveryEnabled (PIX-3059).

### DIFF
--- a/api/lib/application/account-recovery/index.js
+++ b/api/lib/application/account-recovery/index.js
@@ -1,5 +1,4 @@
 const Joi = require('joi').extend(require('@joi/date'));
-const featureToggles = require('../preHandlers/feature-toggles');
 const XRegExp = require('xregexp');
 const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
 const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
@@ -14,12 +13,6 @@ exports.register = async function(server) {
       method: 'POST',
       path: '/api/account-recovery',
       config: {
-        pre: [
-          {
-            method: featureToggles.isScoAccountRecoveryEnabled,
-            assign: 'isScoAccountRecoveryEnabled',
-          },
-        ],
         auth: false,
         handler: accountRecoveryController.sendEmailForAccountRecovery,
         validate: {
@@ -51,12 +44,6 @@ exports.register = async function(server) {
       config: {
         auth: false,
         handler: accountRecoveryController.checkAccountRecoveryDemand,
-        pre: [
-          {
-            method: featureToggles.isScoAccountRecoveryEnabled,
-            assign: 'isScoAccountRecoveryEnabled',
-          },
-        ],
         validate: {
           params: Joi.object({ temporaryKey: Joi.string().min(32) }),
         },
@@ -69,12 +56,6 @@ exports.register = async function(server) {
       method: 'PATCH',
       path: '/api/account-recovery',
       config: {
-        pre: [
-          {
-            method: featureToggles.isScoAccountRecoveryEnabled,
-            assign: 'isScoAccountRecoveryEnabled',
-          },
-        ],
         auth: false,
         handler: accountRecoveryController.updateUserAccountFromRecoveryDemand,
         validate: {

--- a/api/lib/application/preHandlers/feature-toggles.js
+++ b/api/lib/application/preHandlers/feature-toggles.js
@@ -1,12 +1,3 @@
-const config = require('../../config');
-const { NotFoundError } = require('../../application/http-errors');
-
 module.exports = {
-  async isScoAccountRecoveryEnabled() {
-    if (!config.featureToggles.isScoAccountRecoveryEnabled) {
-      throw new NotFoundError('Cette route est désactivée');
-    }
-    return true;
-  },
 };
 

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -5,7 +5,6 @@ const securityPreHandlers = require('../security-pre-handlers');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const { passwordValidationPattern } = require('../../config').account;
 const identifiersType = require('../../domain/types/identifiers-type');
-const featureToggles = require('../preHandlers/feature-toggles');
 
 const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
 const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
@@ -140,12 +139,6 @@ exports.register = async function(server) {
       method: 'POST',
       path: '/api/schooling-registration-dependent-users/recover-account',
       config: {
-        pre: [
-          {
-            method: featureToggles.isScoAccountRecoveryEnabled,
-            assign: 'isScoAccountRecoveryEnabled',
-          },
-        ],
         auth: false,
         handler: schoolingRegistrationDependentUserController.checkScoAccountRecovery,
         validate: {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -142,7 +142,6 @@ module.exports = (function() {
     },
 
     featureToggles: {
-      isScoAccountRecoveryEnabled: isFeatureEnabled(process.env.IS_SCO_ACCOUNT_RECOVERY_ENABLED),
       isNewCPFDataEnabled: isFeatureEnabled(process.env.FT_IS_NEW_CPF_DATA_ENABLED),
       isDownloadCertificationAttestationByDivisionEnabled: isFeatureEnabled(process.env.FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -24,7 +24,6 @@ const schema = Joi.object({
   LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
   AUTH_SECRET: Joi.string().required(),
-  IS_SCO_ACCOUNT_RECOVERY_ENABLED: Joi.string().optional().valid('true', 'false'),
   FT_IS_NEW_CPF_DATA_ENABLED: Joi.string().optional().valid('true', 'false'),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   CACHE_RELOAD_TIME: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -21,14 +21,6 @@
 # FEATURE-TOGGLE
 # =======
 
-# Display student account recovery in Pix App
-#
-# presence: optional
-# type: boolean
-# default: false
-
-IS_SCO_ACCOUNT_RECOVERY_ENABLED=false
-
 # =======
 # CACHING
 # =======

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-get_test.js
@@ -1,5 +1,4 @@
 const { expect, databaseBuilder } = require('../../../test-helper');
-const { featureToggles } = require('../../../../lib/config');
 const createServer = require('../../../../server');
 
 describe('Acceptance | Application | Account-Recovery | Routes', function() {
@@ -23,7 +22,6 @@ describe('Acceptance | Application | Account-Recovery | Routes', function() {
       });
       await databaseBuilder.commit();
       const server = await createServer();
-      featureToggles.isScoAccountRecoveryEnabled = true;
 
       const options = {
         method: 'GET',

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
@@ -3,7 +3,6 @@ const {
   expect,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const { featureToggles } = require('../../../../lib/config');
 
 describe('Acceptance | Route | Account-recovery', function() {
 
@@ -12,7 +11,6 @@ describe('Acceptance | Route | Account-recovery', function() {
     it('should return 204 HTTP status codes', async function() {
       // given
       const server = await createServer();
-      featureToggles.isScoAccountRecoveryEnabled = true;
 
       const userId = 1234;
       const newEmail = 'newEmail@example.net';
@@ -45,45 +43,6 @@ describe('Acceptance | Route | Account-recovery', function() {
 
       // then
       expect(response.statusCode).to.equal(204);
-    });
-
-    it('should return 404 if IS_SCO_ACCOUNT_RECOVERY_ENABLED is not enabled', async function() {
-      // given
-      const server = await createServer();
-      featureToggles.isScoAccountRecoveryEnabled = false;
-
-      const userId = 1234;
-      const newEmail = 'newEmail@example.net';
-      const password = 'password123#A*';
-      databaseBuilder.factory.buildUser.withRawPassword({ id: userId });
-      const accountRecoveryDemand = databaseBuilder.factory.buildAccountRecoveryDemand({
-        userId,
-        temporaryKey: 'FfgpFXgyuO062nPUPwcb8Wy3KcgkqR2p2GyEuGVaNI4=',
-        newEmail,
-        used: false,
-      });
-      const temporaryKey = accountRecoveryDemand.temporaryKey;
-      await databaseBuilder.commit();
-
-      const options = {
-        method: 'PATCH',
-        url: '/api/account-recovery',
-        payload: {
-          data: {
-            attributes: {
-              'temporary-key': temporaryKey,
-              password,
-            },
-          },
-        },
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(404);
-      expect(response.result.errors[0].detail).to.equal('Cette route est désactivée');
     });
 
   });

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route_test.js
@@ -3,7 +3,6 @@ const {
   expect,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const { featureToggles } = require('../../../../lib/config');
 
 describe('Acceptance | Route | Account-recovery', function() {
 
@@ -13,7 +12,6 @@ describe('Acceptance | Route | Account-recovery', function() {
     beforeEach(async function() {
       //given
       server = await createServer();
-      featureToggles.isScoAccountRecoveryEnabled = true;
     });
 
     afterEach(async function() {
@@ -115,36 +113,6 @@ describe('Acceptance | Route | Account-recovery', function() {
       // then
       expect(response.statusCode).to.equal(400);
       expect(response.result.errors[0].detail).to.equal('Cette adresse e-mail est déjà utilisée.');
-    });
-
-    it('should return 404 if IS_SCO_ACCOUNT_RECOVERY_ENABLED is not enabled', async function() {
-      // given
-      const server = await createServer();
-      featureToggles.isScoAccountRecoveryEnabled = false;
-
-      const newEmail = 'new_email@example.net';
-
-      const options = {
-        method: 'POST',
-        url: '/api/account-recovery',
-        payload: {
-          data: {
-            attributes: {
-              'ine-ina': studentInformation.ineIna,
-              'first-name': studentInformation.firstName,
-              'last-name': studentInformation.lastName,
-              'birthdate': studentInformation.birthdate,
-              email: newEmail,
-            },
-          },
-        },
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(404);
     });
 
   });

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,7 +24,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function() {
           id: '0',
           attributes: {
             'is-download-certification-attestation-by-division-enabled': false,
-            'is-sco-account-recovery-enabled': false,
             'is-new-cpf-data-enabled': false,
             'is-manage-uncompleted-certif-enabled': false,
           },

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
@@ -6,7 +6,6 @@ const {
 } = require('../../test-helper');
 
 const createServer = require('../../../server');
-const { featureToggles } = require('../../../lib/config');
 
 describe('Acceptance | Route | Schooling-registration-dependent-user', function() {
 
@@ -343,8 +342,6 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function(
 
     it('should return a 200 status and student information for account recovery', async function() {
       // given
-      featureToggles.isScoAccountRecoveryEnabled = true;
-
       const studentInformation = {
         ineIna: '123456789AA',
         firstName: 'Jude',
@@ -415,40 +412,6 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function(
           'latest-organization-name': 'Super Collège Hollywoodien',
         },
       });
-    });
-
-    it('should return 404 if IS_SCO_ACCOUNT_RECOVERY_ENABLED is not enabled', async function() {
-      // given
-      featureToggles.isScoAccountRecoveryEnabled = false;
-
-      const studentInformation = {
-        ineIna: '123456789AA',
-        firstName: 'Jude',
-        lastName: 'Law',
-        birthdate: '2016-06-01',
-      };
-
-      const options = {
-        method: 'POST',
-        url: '/api/schooling-registration-dependent-users/recover-account',
-        payload: {
-          data: {
-            type: 'student-information',
-            attributes: {
-              'ine-ina': studentInformation.ineIna,
-              'first-name': studentInformation.firstName,
-              'last-name': studentInformation.lastName,
-              'birthdate': studentInformation.birthdate,
-            },
-          },
-        },
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(404);
     });
   });
 

--- a/api/tests/integration/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/integration/application/account-recovery/account-recovery-controller_test.js
@@ -3,7 +3,6 @@ const {
   sinon,
   HttpTestServer,
 } = require('../../../test-helper');
-const { featureToggles } = require('../../../../lib/config');
 const {
   NotFoundError,
   UserNotFoundError,
@@ -20,7 +19,6 @@ describe('Integration | Application | Account-Recovery | account-recovery-contro
     sinon.stub(usecases, 'getAccountRecoveryDetails');
 
     httpTestServer = new HttpTestServer();
-    featureToggles.isScoAccountRecoveryEnabled = true;
     await httpTestServer.register(moduleUnderTest);
   });
 

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -1,5 +1,4 @@
-import Model, { attr } from '@ember-data/model';
+import Model from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isScoAccountRecoveryEnabled;
 }

--- a/mon-pix/app/routes/account-recovery/find-sco-record.js
+++ b/mon-pix/app/routes/account-recovery/find-sco-record.js
@@ -1,13 +1,4 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 
 export default class FindScoRecordRoute extends Route {
-  @service featureToggles;
-
-  beforeModel() {
-    if (!this.featureToggles.featureToggles.isScoAccountRecoveryEnabled) {
-      this.replaceWith('/connexion');
-    }
-  }
-
 }

--- a/mon-pix/app/routes/account-recovery/update-sco-record.js
+++ b/mon-pix/app/routes/account-recovery/update-sco-record.js
@@ -5,14 +5,7 @@ import get from 'lodash/get';
 export default class UpdateScoRecordRoute extends Route {
 
   @service intl;
-  @service featureToggles;
   @service store;
-
-  beforeModel() {
-    if (!this.featureToggles.featureToggles.isScoAccountRecoveryEnabled) {
-      this.replaceWith('/connexion');
-    }
-  }
 
   async model(params) {
     const temporaryKey = params.temporary_key;

--- a/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
@@ -16,85 +16,219 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function() {
   setupMirage();
   setupIntl();
 
-  context('when account recovery is disabled by default', function() {
+  const ineIna = '0123456789A';
+  const lastName = 'Lecol';
+  const firstName = 'Manuela';
+  const birthdate = '2000-05-20';
+  const username = 'manuela.lecol2005';
 
-    it('should redirect to login page', async function() {
-      // given / when
-      await visit('/recuperer-mon-compte');
+  const fillStudentInformationFormAndSubmit = async (currentThis, {
+    ineIna = '0123456789A',
+    lastName = 'Lecol',
+    firstName = 'Manuela',
+    dayOfBirth = 20,
+    monthOfBirth = 5,
+    yearOfBirth = 2000,
+  } = {}) => {
+    await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.ine-ina'), ineIna);
+    await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.first-name'), firstName);
+    await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.last-name'), lastName);
+    await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.label.birth-day'), dayOfBirth);
+    await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.label.birth-month'), monthOfBirth);
+    await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.label.birth-year'), yearOfBirth);
+    await clickByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.submit'));
+  };
 
-      // then
-      expect(currentURL()).to.equal('/connexion');
-    });
+  it('should display student information form', async function() {
+    // given & when
+    await visit('/recuperer-mon-compte');
+
+    // then
+    expect(currentURL()).to.equal('/recuperer-mon-compte');
+    expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
   });
 
-  context('when account recovery is enabled', () => {
+  context('when submitting information form with valid data', () => {
 
-    const ineIna = '0123456789A';
-    const lastName = 'Lecol';
-    const firstName = 'Manuela';
-    const birthdate = '2000-05-20';
-    const username = 'manuela.lecol2005';
-
-    const fillStudentInformationFormAndSubmit = async (currentThis, {
-      ineIna = '0123456789A',
-      lastName = 'Lecol',
-      firstName = 'Manuela',
-      dayOfBirth = 20,
-      monthOfBirth = 5,
-      yearOfBirth = 2000,
-    } = {}) => {
-      await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.ine-ina'), ineIna);
-      await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.first-name'), firstName);
-      await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.last-name'), lastName);
-      await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.label.birth-day'), dayOfBirth);
-      await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.label.birth-month'), monthOfBirth);
-      await fillInByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.label.birth-year'), yearOfBirth);
-      await clickByLabel(currentThis.intl.t('pages.account-recovery.find-sco-record.student-information.form.submit'));
-    };
-
-    it('should display student information form', async function() {
+    it('should hide student information form and show recover account confirmation step', async function() {
       // given
-      server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+      server.create('user', { id: 1, firstName, lastName, username });
+      server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
-      //when
+      // when
       await visit('/recuperer-mon-compte');
+      await fillStudentInformationFormAndSubmit(this);
 
       // then
-      expect(currentURL()).to.equal('/recuperer-mon-compte');
-      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.not.exist;
+      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))).to.exist;
     });
 
-    context('when submitting information form with valid data', () => {
+    it('should redirect to error page when user has already left SCO', async function() {
+      // given
+      const errorsApi = new Response(403, {}, {
+        errors: [{
+          status: '403',
+        }],
+      });
+      server.post('/schooling-registration-dependent-users/recover-account', () => errorsApi);
 
-      it('should hide student information form and show recover account confirmation step', async function() {
+      // when
+      await visit('/recuperer-mon-compte');
+      await fillStudentInformationFormAndSubmit(this);
+
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
+      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+    });
+
+    context('click on "Cancel" button', () => {
+
+      it('should return to student information form', async function() {
         // given
         server.create('user', { id: 1, firstName, lastName, username });
         server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
 
-        // when
         await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
 
+        // when
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.cancel'));
+
         // then
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.not.exist;
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))).to.exist;
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))).to.not.exist;
+      });
+    });
+
+  });
+
+  context('when submitting information form with invalid data', () => {
+
+    it('should show a not found error', async function() {
+      // given & when
+      await visit('/recuperer-mon-compte');
+      await fillStudentInformationFormAndSubmit(this);
+
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.errors.not-found'))).to.exist;
+    });
+  });
+
+  context('when two students used same account', function() {
+    it('should redirect to account recovery conflict page', async function() {
+      // given
+      server.create('user', {
+        id: 1,
+        firstName,
+        lastName,
+      });
+
+      server.create('student-information', {
+        id: 2,
+        ineIna,
+        firstName,
+        lastName,
+        birthdate: '2000-5-20',
+      });
+
+      //when
+      await visit('/recuperer-mon-compte');
+      await fillStudentInformationFormAndSubmit(this);
+
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.conflict.found-you-but', { firstName }))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.not.exist;
+    });
+  });
+
+  context('when confirming student information', () => {
+
+    context('click on "Confirm" button', () => {
+      it('should hide recover account confirmation step and show recover account backup email confirmation', async function() {
+        // given
+        server.create('user', { id: 1, firstName, lastName, username });
+        server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
+
+        await visit('/recuperer-mon-compte');
+        await fillStudentInformationFormAndSubmit(this);
+
+        // when
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
+
+        // then
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', { firstName }))).to.exist;
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))).to.not.exist;
+      });
+
+      it('should show an error when email already exists', async function() {
+        // given
+        const email = 'john.doe@example.net';
+
+        server.create('user', { id: 1, firstName, lastName, username, email });
+        server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
+
+        await visit('/recuperer-mon-compte');
+        await fillStudentInformationFormAndSubmit(this);
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
+
+        // when
+        await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), email);
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
+
+        // then
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.new-email-already-exist'))).to.exist;
+      });
+
+      it('should show email sent confirmation when user has supplied an email and submitted', async function() {
+        // given
+        const newEmail = 'john.doe@example.net';
+
+        server.create('user', { id: 1, firstName, lastName, username });
+        server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
+
+        await visit('/recuperer-mon-compte');
+        await fillStudentInformationFormAndSubmit(this);
+
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
+
+        // when
+        await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), newEmail);
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
+
+        // then
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', { firstName }))).to.not.exist;
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.title'))).to.exist;
       });
 
       it('should redirect to error page when user has already left SCO', async function() {
         // given
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+        const newEmail = 'john.doe@example.net';
+
+        server.create('user', { id: 1, firstName, lastName, username });
+        server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
         const errorsApi = new Response(403, {}, {
           errors: [{
             status: '403',
           }],
         });
-        server.post('/schooling-registration-dependent-users/recover-account', () => errorsApi);
+        server.post('/account-recovery', () => errorsApi);
 
-        // when
         await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
+
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
+
+        // when
+        await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), newEmail);
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
 
         // then
         expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
@@ -102,219 +236,53 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function() {
         expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
       });
 
-      context('click on "Cancel" button', () => {
-
-        it('should return to student information form', async function() {
-          // given
-          server.create('user', { id: 1, firstName, lastName, username });
-          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
-          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-          await visit('/recuperer-mon-compte');
-          await fillStudentInformationFormAndSubmit(this);
-
-          // when
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.cancel'));
-
-          // then
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))).to.not.exist;
-        });
-      });
-
-    });
-
-    context('when submitting information form with invalid data', () => {
-
-      it('should show a not found error', async function() {
+      it('should redirect to error page when there\'s an internal error', async function() {
         // given
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+        const newEmail = 'john.doe@example.net';
+
+        server.create('user', { id: 1, firstName, lastName, username });
+        server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
+
+        const errorsApi = new Response(500, {}, {
+          errors: [{
+            status: '500',
+          }],
+        });
+        server.post('/account-recovery', () => errorsApi);
+
+        await visit('/recuperer-mon-compte');
+        await fillStudentInformationFormAndSubmit(this);
+
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
 
         // when
-        await visit('/recuperer-mon-compte');
-        await fillStudentInformationFormAndSubmit(this);
+        await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), newEmail);
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
 
         // then
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.errors.not-found'))).to.exist;
+        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+        expect(contains(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
+        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
       });
     });
 
-    context('when two students used same account', function() {
-      it('should redirect to account recovery conflict page', async function() {
+    context('click on "Cancel" button', () => {
+      it('should return to student information form', async function() {
         // given
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
 
-        server.create('user', {
-          id: 1,
-          firstName,
-          lastName,
-        });
+        server.create('user', { id: 1, firstName, lastName, username });
+        server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
-        server.create('student-information', {
-          id: 2,
-          ineIna,
-          firstName,
-          lastName,
-          birthdate: '2000-5-20',
-        });
-
-        //when
         await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
 
+        // when
+        await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.cancel'));
+
         // then
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.conflict.found-you-but', { firstName }))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.not.exist;
-      });
-    });
-
-    context('when confirming student information', () => {
-
-      context('click on "Confirm" button', () => {
-        it('should hide recover account confirmation step and show recover account backup email confirmation', async function() {
-          // given
-          server.create('user', { id: 1, firstName, lastName, username });
-          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
-          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-          await visit('/recuperer-mon-compte');
-          await fillStudentInformationFormAndSubmit(this);
-
-          // when
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
-
-          // then
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', { firstName }))).to.exist;
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))).to.not.exist;
-        });
-
-        it('should show an error when email already exists', async function() {
-          // given
-          const email = 'john.doe@example.net';
-
-          server.create('user', { id: 1, firstName, lastName, username, email });
-          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
-          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-          await visit('/recuperer-mon-compte');
-          await fillStudentInformationFormAndSubmit(this);
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
-
-          // when
-          await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), email);
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
-
-          // then
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.new-email-already-exist'))).to.exist;
-        });
-
-        it('should show email sent confirmation when user has supplied an email and submitted', async function() {
-          // given
-          const newEmail = 'john.doe@example.net';
-
-          server.create('user', { id: 1, firstName, lastName, username });
-          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
-          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-          await visit('/recuperer-mon-compte');
-          await fillStudentInformationFormAndSubmit(this);
-
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
-
-          // when
-          await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), newEmail);
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
-
-          // then
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', { firstName }))).to.not.exist;
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.title'))).to.exist;
-        });
-
-        it('should redirect to error page when user has already left SCO', async function() {
-          // given
-          const newEmail = 'john.doe@example.net';
-
-          server.create('user', { id: 1, firstName, lastName, username });
-          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
-          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-          const errorsApi = new Response(403, {}, {
-            errors: [{
-              status: '403',
-            }],
-          });
-          server.post('/account-recovery', () => errorsApi);
-
-          await visit('/recuperer-mon-compte');
-          await fillStudentInformationFormAndSubmit(this);
-
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
-
-          // when
-          await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), newEmail);
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
-
-          // then
-          expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-          expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
-          expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
-        });
-
-        it('should redirect to error page when there\'s an internal error', async function() {
-          // given
-          const newEmail = 'john.doe@example.net';
-
-          server.create('user', { id: 1, firstName, lastName, username });
-          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
-          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-          const errorsApi = new Response(500, {}, {
-            errors: [{
-              status: '500',
-            }],
-          });
-          server.post('/account-recovery', () => errorsApi);
-
-          await visit('/recuperer-mon-compte');
-          await fillStudentInformationFormAndSubmit(this);
-
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
-
-          // when
-          await fillInByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.email'), newEmail);
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.submit'));
-
-          // then
-          expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-          expect(contains(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
-          expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
-        });
-      });
-
-      context('click on "Cancel" button', () => {
-        it('should return to student information form', async function() {
-          // given
-
-          server.create('user', { id: 1, firstName, lastName, username });
-          server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
-          server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-          await visit('/recuperer-mon-compte');
-          await fillStudentInformationFormAndSubmit(this);
-
-          // when
-          await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.form.actions.cancel'));
-
-          // then
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', { firstName }))).to.not.exist;
-          expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
-        });
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', { firstName }))).to.not.exist;
+        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
       });
     });
   });

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
@@ -18,274 +18,248 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function() {
   setupMirage();
   setupIntl();
 
-  context('when account recovery is disabled by default', function() {
+  context('and user clicks on email link', function() {
 
-    it('should redirect to login page', async function() {
-      // given / when
-      await visit('/recuperer-mon-compte');
+    it('should show reset password form', async function() {
+      // given
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
+
+      //when
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
       // then
-      expect(currentURL()).to.equal('/connexion');
+      expect(currentURL()).to.equal(`/recuperer-mon-compte/${temporaryKey}`);
+      expect(contains(this.intl.t('pages.account-recovery.update-sco-record.welcome-message', { firstName: 'George' }))).to.exist;
+    });
+
+    it('should display an error message when account with email already exists', async function() {
+      // given
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
+
+      const errorsApi = new Response(400, {}, {
+        errors: [{
+          status: '400',
+          code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS',
+        }],
+      });
+      server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
+
+      //when
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.account-exists'))).to.exist;
+      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+    });
+
+    it('should display an error message when user has already left SCO', async function() {
+      // given
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
+
+      const errorsApi = new Response(403, {}, {
+        errors: [{
+          status: '403',
+        }],
+      });
+      server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
+
+      //when
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
+      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+    });
+
+    it('should display an error message when temporary key not found', async function() {
+      // given
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
+
+      const errorsApi = new Response(404, {}, {
+        errors: [{
+          status: '404',
+        }],
+      });
+      server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
+
+      //when
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-invalid'))).to.exist;
+      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+    });
+
+    it('should display an error message when temporary key has expired', async function() {
+      // given
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
+
+      const errorsApi = new Response(401, {}, {
+        errors: [{
+          status: '401',
+        }],
+      });
+      server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
+
+      //when
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-expired'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link'))).to.exist;
     });
   });
 
-  context('when account recovery is enabled', () => {
+  context('and user chooses a new password and accepts cgu and data protection policy', function() {
 
-    context('and user clicks on email link', function() {
+    it('should redirect to homepage after successful password change', async function() {
+      // given
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
-      it('should show reset password form', async function() {
-        // given
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+      const email = 'George@example.net';
+      const password = 'Password123';
+      server.create('user', { id: 2, email, password });
 
-        //when
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
-        // then
-        expect(currentURL()).to.equal(`/recuperer-mon-compte/${temporaryKey}`);
-        expect(contains(this.intl.t('pages.account-recovery.update-sco-record.welcome-message', { firstName: 'George' }))).to.exist;
-      });
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), password);
+      await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-      it('should display an error message when account with email already exists', async function() {
-        // given
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+      // when
+      await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
-        const errorsApi = new Response(400, {}, {
-          errors: [{
-            status: '400',
-            code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS',
-          }],
-        });
-        server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
-
-        //when
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.account-exists'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
-      });
-
-      it('should display an error message when user has already left SCO', async function() {
-        // given
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-        const errorsApi = new Response(403, {}, {
-          errors: [{
-            status: '403',
-          }],
-        });
-        server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
-
-        //when
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
-      });
-
-      it('should display an error message when temporary key not found', async function() {
-        // given
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-        const errorsApi = new Response(404, {}, {
-          errors: [{
-            status: '404',
-          }],
-        });
-        server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
-
-        //when
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-invalid'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
-      });
-
-      it('should display an error message when temporary key has expired', async function() {
-        // given
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-        const errorsApi = new Response(401, {}, {
-          errors: [{
-            status: '401',
-          }],
-        });
-        server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
-
-        //when
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-expired'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link'))).to.exist;
-      });
+      // then
+      expect(currentURL()).to.equal('/accueil');
     });
 
-    context('and user chooses a new password and accepts cgu and data protection policy', function() {
+    it('should display an error message when account with email already exists', async function() {
+      // given
+      const newPassword = 'Pix1234*';
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
-      it('should redirect to homepage after successful password change', async function() {
-        // given
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-
-        const email = 'George@example.net';
-        const password = 'Password123';
-        server.create('user', { id: 2, email, password });
-
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
-
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-
-        await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), password);
-        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
-
-        // when
-        await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
-
-        // then
-        expect(currentURL()).to.equal('/accueil');
+      const errorsApi = new Response(400, {}, {
+        errors: [{
+          status: '400',
+          code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS',
+        }],
       });
+      server.patch('/account-recovery', () => errorsApi);
 
-      it('should display an error message when account with email already exists', async function() {
-        // given
-        const newPassword = 'Pix1234*';
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
+      await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        const errorsApi = new Response(400, {}, {
-          errors: [{
-            status: '400',
-            code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS',
-          }],
-        });
-        server.patch('/account-recovery', () => errorsApi);
+      // when
+      await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-        await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.account-exists'))).to.exist;
+      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+    });
 
-        // when
-        await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
+    it('should display an error message when user has already left SCO', async function() {
+      // given
+      const newPassword = 'Pix1234*';
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.account-exists'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      const errorsApi = new Response(403, {}, {
+        errors: [{
+          status: '403',
+        }],
       });
+      server.patch('/account-recovery', () => errorsApi);
 
-      it('should display an error message when user has already left SCO', async function() {
-        // given
-        const newPassword = 'Pix1234*';
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
+      await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        const errorsApi = new Response(403, {}, {
-          errors: [{
-            status: '403',
-          }],
-        });
-        server.patch('/account-recovery', () => errorsApi);
+      // when
+      await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-        await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
+      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+    });
 
-        // when
-        await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
+    it('should display an error message when temporary key not found', async function() {
+      // given
+      const newPassword = 'Pix1234*';
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      const errorsApi = new Response(404, {}, {
+        errors: [{
+          status: '404',
+        }],
       });
+      server.patch('/account-recovery', () => errorsApi);
 
-      it('should display an error message when temporary key not found', async function() {
-        // given
-        const newPassword = 'Pix1234*';
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
+      await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        const errorsApi = new Response(404, {}, {
-          errors: [{
-            status: '404',
-          }],
-        });
-        server.patch('/account-recovery', () => errorsApi);
+      // when
+      await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-        await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-invalid'))).to.exist;
+      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+    });
 
-        // when
-        await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
+    it('should display an error message when temporary key has expired', async function() {
+      // given
+      const newPassword = 'Pix1234*';
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-invalid'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      const errorsApi = new Response(401, {}, {
+        errors: [{
+          status: '401',
+        }],
       });
+      server.patch('/account-recovery', () => errorsApi);
 
-      it('should display an error message when temporary key has expired', async function() {
-        // given
-        const newPassword = 'Pix1234*';
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
+      await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        const errorsApi = new Response(401, {}, {
-          errors: [{
-            status: '401',
-          }],
-        });
-        server.patch('/account-recovery', () => errorsApi);
+      // when
+      await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-        await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-expired'))).to.exist;
+      expect(contains(this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link'))).to.exist;
+    });
 
-        // when
-        await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
+    it('should display an error message when internal server error returned', async function() {
+      // given
+      const newPassword = 'Pix1234*';
+      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-expired'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link'))).to.exist;
+      const errorsApi = new Response(500, {}, {
+        errors: [{
+          status: '500',
+        }],
       });
+      server.patch('/account-recovery', () => errorsApi);
 
-      it('should display an error message when internal server error returned', async function() {
-        // given
-        const newPassword = 'Pix1234*';
-        const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-        server.create('feature-toggle', { id: 0, isScoAccountRecoveryEnabled: true });
+      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
+      await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
 
-        const errorsApi = new Response(500, {}, {
-          errors: [{
-            status: '500',
-          }],
-        });
-        server.patch('/account-recovery', () => errorsApi);
+      // when
+      await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
-        await visit(`/recuperer-mon-compte/${temporaryKey}`);
-        await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), newPassword);
-        await clickByLabel(this.intl.t('pages.sign-up.fields.cgu.accept'));
-
-        // when
-        await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
-
-        // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
-      });
+      // then
+      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(contains(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
+      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
     });
   });
 });

--- a/mon-pix/tests/unit/services/feature-toggles_test.js
+++ b/mon-pix/tests/unit/services/feature-toggles_test.js
@@ -13,7 +13,6 @@ describe('Unit | Service | feature-toggles', function() {
   describe('feature toggles are loaded', function() {
 
     const featureToggles = Object.create({
-      isScoAccountRecoveryEnabled: false,
     });
 
     let storeStub;


### PR DESCRIPTION
## :unicorn: Problème
La sortie SCO est maintenant en production, il n'est plus nécessaire de garder le feature toggle existant.

## :robot: Solution
Supprimer le feature toggle en front et back.

## :rainbow: Remarques
Suppression des variables sur Scalingo en RA, integ et recette et prod lorsque le ticket sera merge

## :100: Pour tester
Vérifier que les tests passent.
Aller faire une passe sur la sortie SCO pour voir que ça n'impacte rien. https://app-pr3411.review.pix.fr/recuperer-mon-compte
