### PR TITLE
[TECH] Retirer les async inutiles. 

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -81,4 +81,5 @@ rules:
     - error
   no-multi-spaces:
     - error
-    
+  require-await:
+    - error

--- a/admin/app/routes/authenticated/certifications/certification/informations.js
+++ b/admin/app/routes/authenticated/certifications/certification/informations.js
@@ -5,7 +5,7 @@ import RSVP from 'rsvp';
 
 export default class CertificationInformationsRoute extends Route {
 
-  async model() {
+  model() {
     return RSVP.hash({
       certification: this.modelFor('authenticated.certifications.certification').reload(),
       countries: this.store.findAll('country'),

--- a/admin/app/routes/authenticated/certifications/certification/neutralization.js
+++ b/admin/app/routes/authenticated/certifications/certification/neutralization.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default class CertificationNeutralizationRoute extends Route {
-  async model() {
+  model() {
     const { certification_id } = this.paramsFor('authenticated.certifications.certification');
     return this.store.findRecord('certification-details', certification_id);
   }

--- a/admin/app/routes/authenticated/target-profiles/target-profile/details.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/details.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default class TargetProfileDetailsRoute extends Route {
-  async model() {
+  model() {
     return this.modelFor('authenticated.target-profiles.target-profile');
   }
 }

--- a/admin/app/services/ajax-queue.js
+++ b/admin/app/services/ajax-queue.js
@@ -9,7 +9,7 @@ export default class AjaxQueueService extends Service {
     this._queue = new PQueue({ concurrency: ENV.APP.MAX_CONCURRENT_AJAX_CALLS });
   }
 
-  async add(job) {
+  add(job) {
     return this._queue.add(job);
   }
 }

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -26,7 +26,7 @@ function attachOrganizationsFromExistingTargetProfile(schema, request) {
   return new Response(204);
 }
 
-async function getOrganizationTargetProfiles(schema, request) {
+function getOrganizationTargetProfiles(schema, request) {
   const ownerOrganizationId = request.params.id;
   return schema.targetProfiles.where({ ownerOrganizationId });
 }

--- a/admin/tests/acceptance/authenticated/target-profiles/organizations_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/organizations_test.js
@@ -23,7 +23,7 @@ module('Acceptance | authenticated/targets-profile/target-profile/organizations'
 
   module('with multiple organizations', function(hooks) {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(function() {
       this.server.create('organization', { name: 'My organization' });
       this.server.create('organization', { name: 'My other organization' });
     });

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
@@ -74,7 +74,7 @@ module('Acceptance | Session page', function(hooks) {
 
   });
 
-  async function visitSessionsPage() {
+  function visitSessionsPage() {
     return visit('/sessions');
   }
 

--- a/admin/tests/acceptance/organization-list_test.js
+++ b/admin/tests/acceptance/organization-list_test.js
@@ -49,7 +49,7 @@ module('Acceptance | Organization List', function(hooks) {
 
     module('when filters are used', function(hooks) {
 
-      hooks.beforeEach(async () => {
+      hooks.beforeEach(() => {
         server.createList('organization', 12);
       });
 

--- a/admin/tests/acceptance/organization-memberships-management_test.js
+++ b/admin/tests/acceptance/organization-memberships-management_test.js
@@ -28,7 +28,7 @@ module('Acceptance | organization memberships management', function(hooks) {
   });
 
   module('listing members', function(hooks) {
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(function() {
       server.createList('membership', 12);
     });
 
@@ -151,7 +151,7 @@ module('Acceptance | organization memberships management', function(hooks) {
 
     let membership;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(function() {
       const user = this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });
       membership = this.server.create('membership', { organizationRole: 'ADMIN', user, organization });
     });
@@ -171,7 +171,7 @@ module('Acceptance | organization memberships management', function(hooks) {
 
   module('deactivating a member', function(hooks) {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(function() {
       const user = this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });
       this.server.create('membership', { organizationRole: 'ADMIN', user, organization });
     });

--- a/admin/tests/acceptance/target-profiles-list_test.js
+++ b/admin/tests/acceptance/target-profiles-list_test.js
@@ -50,7 +50,7 @@ module('Acceptance | Target Profiles List', function(hooks) {
 
     module('when filters are used', function(hooks) {
 
-      hooks.beforeEach(async () => {
+      hooks.beforeEach(() => {
         server.createList('target-profile', 12);
       });
 

--- a/admin/tests/acceptance/tools-page_test.js
+++ b/admin/tests/acceptance/tools-page_test.js
@@ -30,7 +30,7 @@ module('Acceptance | tools page', function(hooks) {
       await visit('/tools');
     });
 
-    test('Should content "Learning content" section', async function(assert) {
+    test('Should content "Learning content" section', function(assert) {
       assert.dom('section[data-test-id="learning-content"]').exists();
       assert.dom('button').exists();
     });

--- a/admin/tests/helpers/test-init.js
+++ b/admin/tests/helpers/test-init.js
@@ -5,7 +5,7 @@ import { contains, notContains } from './contains';
 QUnit.assert.contains = contains;
 QUnit.assert.notContains = notContains;
 
-export async function createAuthenticateSession({ userId }) {
+export function createAuthenticateSession({ userId }) {
   return authenticateSession({
     user_id: userId,
     access_token: 'aaa.' + btoa(`{"user_id":${userId},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',

--- a/admin/tests/integration/components/certification/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certification/candidate-edit-modal_test.js
@@ -15,7 +15,7 @@ module('Integration | Component | <Certification::CandidateEditModal/>', functio
 
   let store;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
   });
 

--- a/admin/tests/integration/components/certification/certification-list_test.js
+++ b/admin/tests/integration/components/certification/certification-list_test.js
@@ -11,7 +11,7 @@ module('Integration | Component | CertificationList', function(hooks) {
 
   let store;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
   });
 

--- a/admin/tests/integration/components/member-item_test.js
+++ b/admin/tests/integration/components/member-item_test.js
@@ -40,7 +40,7 @@ module('Integration | Component | member-item', function(hooks) {
       await clickByLabel('Modifier le rôle');
     });
 
-    test('it should display save and cancel button', async function(assert) {
+    test('it should display save and cancel button', function(assert) {
       // then
       assert.contains('Enregistrer');
       assert.dom('button[aria-label="Annuler"]');

--- a/admin/tests/integration/components/modal/dialog_test.js
+++ b/admin/tests/integration/components/modal/dialog_test.js
@@ -19,14 +19,14 @@ module('Integration | Component | modal', function(hooks) {
       return render(hbs`<Modal::Dialog @display={{display}} @title={{title}} @close={{close}} @additionalContainerClass={{additionalContainerClass}}>Mon contenu</Modal::Dialog>`);
     });
 
-    test('should render title and content', async function(assert) {
+    test('should render title and content', function(assert) {
       this.set('display', true);
 
       assert.contains('Mon titre');
       assert.contains('Mon contenu');
     });
 
-    test('should not display the modal', async function(assert) {
+    test('should not display the modal', function(assert) {
       this.set('display', false);
 
       assert.notContains('Mon titre');
@@ -56,7 +56,7 @@ module('Integration | Component | modal', function(hooks) {
       assert.ok(close.called);
     });
 
-    test('should be accessible', async function(assert) {
+    test('should be accessible', function(assert) {
       this.set('display', true);
 
       assert.dom('[aria-modal="true"]').exists();
@@ -65,7 +65,7 @@ module('Integration | Component | modal', function(hooks) {
       assert.dom('#modal_mon_titre_label').exists();
     });
 
-    test('should add additional container class', async function(assert) {
+    test('should add additional container class', function(assert) {
       const additionalContainerClass = 'a_class';
       this.set('display', true);
       this.set('additionalContainerClass', additionalContainerClass);

--- a/admin/tests/integration/components/routes/authenticated/certification-centers/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/certification-centers/list-items_test.js
@@ -7,7 +7,7 @@ module('Integration | Component | routes/authenticated/certification-centers | l
 
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     const triggerFiltering = function() {};
     this.triggerFiltering = triggerFiltering;
   });

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items_test.js
@@ -7,7 +7,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
 
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     const triggerFiltering = function() {};
     this.triggerFiltering = triggerFiltering;
   });

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -72,7 +72,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
 
   module('when the session is finalized', function(hooks) {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(function() {
       const sessionData = {
         status: 'finalized',
         finalizedAt: new Date(),

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-items_test.js
@@ -7,7 +7,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
 
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     const triggerFiltering = function() {};
     const goToTargetProfilePage = function() {};
     this.triggerFiltering = triggerFiltering;

--- a/admin/tests/integration/components/routes/authenticated/users/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/users/list-items_test.js
@@ -7,7 +7,7 @@ module('Integration | Component | routes/authenticated/users | list-items', func
 
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     const triggerFiltering = function() {};
     this.triggerFiltering = triggerFiltering;
   });

--- a/admin/tests/unit/adapters/schooling-registration_test.js
+++ b/admin/tests/unit/adapters/schooling-registration_test.js
@@ -15,7 +15,7 @@ module('Unit | Adapter | schooling-registration', function(hooks) {
 
   module('#urlForDeleteRecord', function() {
 
-    test('it performs the request to dissociate user from student', async function(assert) {
+    test('it performs the request to dissociate user from student', function(assert) {
       // given
       const schoolingRegistration = { id: 12345 };
       const expectedUrl = `${ENV.APP.API_HOST}/api/schooling-registration-user-associations/${schoolingRegistration.id}`;

--- a/admin/tests/unit/components/certification/certification-details-competence_test.js
+++ b/admin/tests/unit/components/certification/certification-details-competence_test.js
@@ -35,7 +35,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
 
   module('#competenceJury', function() {
 
-    test('it should not give jury values when no jury rate is set', async function(assert) {
+    test('it should not give jury values when no jury rate is set', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ko', 'partially'),
@@ -49,7 +49,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.false(actual);
     });
 
-    test('it should give jury values when a jury rate is set and score differs', async function(assert) {
+    test('it should give jury values when a jury rate is set and score differs', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'ko', 25, 17),
@@ -65,7 +65,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should not give jury values when a jury rate is set and score does not differ', async function(assert) {
+    test('it should not give jury values when a jury rate is set and score does not differ', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'ko', 25, 17),
@@ -80,7 +80,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.false(actual);
     });
 
-    test('it should give level n and positioned score when jury rate is set and 3 ok', async function(assert) {
+    test('it should give level n and positioned score when jury rate is set and 3 ok', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'ok', 25, 17, 3, 2),
@@ -96,7 +96,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 ko', async function(assert) {
+    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 ko', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'ko', 25, 17, 3, 2),
@@ -112,7 +112,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 aband', async function(assert) {
+    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 aband', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'aband', 25, 17, 3, 2),
@@ -128,7 +128,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 partially', async function(assert) {
+    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 partially', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'partially', 25, 17, 3, 2),
@@ -144,7 +144,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 timedout', async function(assert) {
+    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 timedout', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'timedout', 25, 17, 3, 2),
@@ -160,7 +160,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 ko', async function(assert) {
+    test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 ko', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'ko', 25, 25, 3, 3),
@@ -176,7 +176,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 17);
     });
 
-    test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 aband', async function(assert) {
+    test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 aband', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'aband', 25, 25, 3, 3),
@@ -192,7 +192,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 17);
     });
 
-    test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 partiallyx  x', async function(assert) {
+    test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 partiallyx  x', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'partially', 25, 25, 3, 3),
@@ -208,7 +208,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 17);
     });
 
-    test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 timedout', async function(assert) {
+    test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 timedout', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'timedout', 25, 25, 3, 3),
@@ -224,7 +224,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 17);
     });
 
-    test('it should give level -1 and score 0 when jury rate is set and 1 ok', async function(assert) {
+    test('it should give level -1 and score 0 when jury rate is set and 1 ok', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ko', 'aband', 25, 25, 3, 3),
@@ -240,7 +240,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 0);
     });
 
-    test('it should give level -1 and score 0 when jury rate is set to 49', async function(assert) {
+    test('it should give level -1 and score 0 when jury rate is set to 49', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'ok', 25, 25, 3, 3),
@@ -256,7 +256,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 0);
     });
 
-    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 skip', async function(assert) {
+    test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 skip', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'skip', 25, 0, 3, -1),
@@ -272,7 +272,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should give level n and positioned score when jury rate is set to 65 and 2 ok and 1 skip', async function(assert) {
+    test('it should give level n and positioned score when jury rate is set to 65 and 2 ok and 1 skip', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'skip', 25, 0, 3, -1),
@@ -288,7 +288,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should give level n when jury rate is set to 90, 1 ok, 1 partially, 1 skip', async function(assert) {
+    test('it should give level n when jury rate is set to 90, 1 ok, 1 partially, 1 skip', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ok', 'skip', 25, 0, 3, -1),
@@ -304,7 +304,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 25);
     });
 
-    test('it should give level n-1 when jury rate is set to 65, 1 ok, 1 partially, 1 skip', async function(assert) {
+    test('it should give level n-1 when jury rate is set to 65, 1 ok, 1 partially, 1 skip', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'partially', 'skip', 25, 0, 3, -1),
@@ -320,7 +320,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
       assert.equal(actual.score, 17);
     });
 
-    test('it should give level -1 when jury rate is set, 1 ok, 1 ko, 1 skip', async function(assert) {
+    test('it should give level -1 when jury rate is set, 1 ok, 1 ko, 1 skip', function(assert) {
       // given
       component.args = {
         competence: competence('ok', 'ko', 'skip', 25, 25, 3, 3),
@@ -338,7 +338,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
 
   });
 
-  test('it should compute widths correctly', async function(assert) {
+  test('it should compute widths correctly', function(assert) {
     // when
     component.args = {
       competence: competence('ok', 'ok', 'ko', 25, 17, 3, 2),
@@ -352,7 +352,7 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
     assert.equal(component.competenceJury.width.toString(), htmlSafe('width:' + Math.round((3 / 8) * 100) + '%'));
   });
 
-  test('it should retrieve answers from competence', async function(assert) {
+  test('it should retrieve answers from competence', function(assert) {
     // when
     component.args = {
       competence: competence('ok', 'partially', 'ko'),

--- a/admin/tests/unit/components/organization-information-section_test.js
+++ b/admin/tests/unit/components/organization-information-section_test.js
@@ -13,7 +13,7 @@ module('Unit | Component | organization-information-section', function(hooks) {
     component = createGlimmerComponent('component:organization-information-section');
   });
 
-  test('it should generate link based on environment and object', async function(assert) {
+  test('it should generate link based on environment and object', function(assert) {
     // given
     const args = { organization: { id: 1 } };
     const baseURL = 'https://metabase.pix.fr/dashboard/137/?id=';

--- a/admin/tests/unit/components/user-detail-personal-information_test.js
+++ b/admin/tests/unit/components/user-detail-personal-information_test.js
@@ -18,7 +18,7 @@ module('Unit | Component | user-detail-personal-information', function(hooks) {
     };
   });
 
-  test('it should generate dashboard URL based on environment and object', async function(assert) {
+  test('it should generate dashboard URL based on environment and object', function(assert) {
     // given
     const args = {
       user: {

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -59,7 +59,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#hasImpactfulIssueReports', () => {
-    test('it should return true when there are some issue reports with required action', async function(assert) {
+    test('it should return true when there are some issue reports with required action', function(assert) {
       // given
       const certificationIssueReports = [
         EmberObject.create({ isImpactful: true }),
@@ -78,7 +78,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       assert.true(controller.hasImpactfulIssueReports);
     });
 
-    test('it should return false when there are no issue reports with required action', async function(assert) {
+    test('it should return false when there are no issue reports with required action', function(assert) {
       // given
       const certificationIssueReports = [
         EmberObject.create({ isImpactful: false }),
@@ -98,7 +98,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#hasUnimpactfulIssueReports', () => {
-    test('it should return true when there are some issue reports without required action', async function(assert) {
+    test('it should return true when there are some issue reports without required action', function(assert) {
       // given
       const certificationIssueReports = [
         EmberObject.create({ isImpactful: false }),
@@ -116,7 +116,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       assert.true(controller.hasUnimpactfulIssueReports);
     });
 
-    test('it should return false when there are no issue reports without required action', async function(assert) {
+    test('it should return false when there are no issue reports without required action', function(assert) {
       // given
       const certificationIssueReports = [
         EmberObject.create({ isImpactful: true }),
@@ -136,7 +136,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#hasIssueReports', () => {
-    test('it should return true when there are some issue reports', async function(assert) {
+    test('it should return true when there are some issue reports', function(assert) {
       // given
       const certificationIssueReports = [
         EmberObject.create({ isImpactful: true }),
@@ -154,7 +154,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       assert.true(controller.hasIssueReports);
     });
 
-    test('it should return false when there are no issue reports', async function(assert) {
+    test('it should return false when there are no issue reports', function(assert) {
       // given
       const certificationIssueReports = [];
       controller.model = {
@@ -208,7 +208,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#impactfulCertificationIssueReports', () => {
-    test('it should return certification issue reports with action required', async function(assert) {
+    test('it should return certification issue reports with action required', function(assert) {
       // given
       const certificationIssueReports = [
         EmberObject.create({ isImpactful: true }),
@@ -228,7 +228,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   });
 
   module('#unimpactfulCertificationIssueReports', () => {
-    test('it should return certification issue reports without action required', async function(assert) {
+    test('it should return certification issue reports without action required', function(assert) {
       // given
       const certificationIssueReports = [
         EmberObject.create({ isImpactful: true }),

--- a/admin/tests/unit/controllers/authenticated/sessions/session/certifications_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/certifications_test.js
@@ -16,7 +16,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
 
   module('#canPublish', function() {
 
-    test('should be false when there is a certification in error', async function(assert) {
+    test('should be false when there is a certification in error', function(assert) {
       // given
       controller.set('model', model);
       controller.model.juryCertificationSummaries = [{ status: 'validated' }, { status: 'error' }];
@@ -28,7 +28,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
       assert.false(result);
     });
 
-    test('should be false when there is a certification started', async function(assert) {
+    test('should be false when there is a certification started', function(assert) {
       // given
       controller.set('model', model);
       controller.model.juryCertificationSummaries = [{ status: 'rejected' }, { status: 'started' }];
@@ -40,7 +40,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
       assert.false(result);
     });
 
-    test('should be true when there is no certification in error orstarted', async function(assert) {
+    test('should be true when there is no certification in error orstarted', function(assert) {
       // given
       controller.set('model', model);
       controller.model.juryCertificationSummaries = [{ status: 'rejected' }, { status: 'validated' }];

--- a/admin/tests/unit/controllers/authenticated/target-profiles/new_test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/new_test.js
@@ -12,7 +12,7 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
   });
 
   module('#goBackToTargetProfileList', function() {
-    test('should delete record and go back target profile list page', async function(assert) {
+    test('should delete record and go back target profile list page', function(assert) {
       controller.store.deleteRecord = sinon.stub();
       controller.transitionToRoute = sinon.stub();
       controller.model = Symbol('targetProfile');
@@ -29,7 +29,7 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
       sinon.restore();
     });
 
-    test('should read the file', async function(assert) {
+    test('should read the file', function(assert) {
       const event = {
         target: {
           files: [Symbol('myFile')],
@@ -43,7 +43,7 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
       assert.ok(FileReader.prototype.readAsText.calledWith(event.target.files[0]));
     });
 
-    test('should parse the file', async function(assert) {
+    test('should parse the file', function(assert) {
       controller.model = {};
       const event = {
         target: {
@@ -65,7 +65,7 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
       assert.deepEqual(controller.model.skillsId, ['skill1', 'skill2']);
       assert.false(controller.isFileInvalid);
     });
-    test('should cannot parse the file', async function(assert) {
+    test('should cannot parse the file', function(assert) {
       controller.model = {};
       const event = {
         target: {

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -8,7 +8,7 @@ module('Unit | Model | certification', function(hooks) {
 
   let store;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
   });
 

--- a/admin/tests/unit/models/jury-certification-summary_test.js
+++ b/admin/tests/unit/models/jury-certification-summary_test.js
@@ -8,7 +8,7 @@ module('Unit | Model | jury-certification-summary', function(hooks) {
 
   let store;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
   });
 

--- a/admin/tests/unit/models/session_test.js
+++ b/admin/tests/unit/models/session_test.js
@@ -8,7 +8,7 @@ module('Unit | Model | session', function(hooks) {
 
   let store;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
   });
 
@@ -119,7 +119,7 @@ module('Unit | Model | session', function(hooks) {
 
         let sessionWithAllCertificationsPublished;
 
-        hooks.beforeEach(async function() {
+        hooks.beforeEach(function() {
           sessionWithAllCertificationsPublished = run(() => {
             const certif1 = store.createRecord('jury-certification-summary', { isPublished: true });
             const certif2 = store.createRecord('jury-certification-summary', { isPublished: true });
@@ -137,7 +137,7 @@ module('Unit | Model | session', function(hooks) {
 
         let sessionWithoutAllCertificationsPublished;
 
-        hooks.beforeEach(async function() {
+        hooks.beforeEach(function() {
           sessionWithoutAllCertificationsPublished = run(() => {
             const certif1 = store.createRecord('jury-certification-summary', { isPublished: true });
             const certif2 = store.createRecord('jury-certification-summary', { isPublished: false });
@@ -154,7 +154,7 @@ module('Unit | Model | session', function(hooks) {
 
         let sessionWithoutAllCertificationsPublished;
 
-        hooks.beforeEach(async function() {
+        hooks.beforeEach(function() {
           sessionWithoutAllCertificationsPublished = run(() => {
             const certif1 = store.createRecord('jury-certification-summary', { isPublished: false });
             const certif2 = store.createRecord('jury-certification-summary', { isPublished: false });
@@ -176,7 +176,7 @@ module('Unit | Model | session', function(hooks) {
     let sessionWithCertificationIssueReports;
     let sessionWithoutCertificationIssueReport;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(function() {
       sessionWithCertificationIssueReports = run(() => {
         const certif = store.createRecord('jury-certification-summary', { numberOfCertificationIssueReports: 5 });
         const certif2 = store.createRecord('jury-certification-summary', { numberOfCertificationIssueReports: 1 });
@@ -203,7 +203,7 @@ module('Unit | Model | session', function(hooks) {
     let sessionWithCertificationIssueReports;
     let sessionWithoutCertificationIssueReport;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(function() {
       sessionWithCertificationIssueReports = run(() => {
         const certif = store.createRecord('jury-certification-summary', { numberOfCertificationIssueReportsWithRequiredAction: 5 });
         const certif2 = store.createRecord('jury-certification-summary', { numberOfCertificationIssueReportsWithRequiredAction: 1 });
@@ -231,7 +231,7 @@ module('Unit | Model | session', function(hooks) {
     let sessionWithOneUncheckedEndScreen;
     let sessionWithOneCheckedEndScreen;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(function() {
       sessionWithOneUncheckedEndScreen = run(() => {
         const certif = store.createRecord('jury-certification-summary', { hasSeenEndTestScreen: false });
         return store.createRecord('session', { juryCertificationSummaries: [certif] });

--- a/admin/tests/unit/models/user_test.js
+++ b/admin/tests/unit/models/user_test.js
@@ -7,7 +7,7 @@ module('Unit | Model | user', function(hooks) {
 
   let store;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
   });
 

--- a/api/db/database-builder/factory/build-correct-answer-and-knowledge-element.js
+++ b/api/db/database-builder/factory/build-correct-answer-and-knowledge-element.js
@@ -2,7 +2,7 @@ const buildAssessment = require('./build-assessment');
 const buildAnswer = require('./build-answer');
 const buildKnowledgeElement = require('./build-knowledge-element');
 
-const buildCorrectAnswerAndKnowledgeElement = async function({
+const buildCorrectAnswerAndKnowledgeElement = function({
   userId,
   competenceId,
   challengeId,

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -62,7 +62,7 @@ knex.on('query-response', function(response, obj) {
   }
 });
 
-async function disconnect() {
+function disconnect() {
   return knex.destroy();
 }
 

--- a/api/db/migrations/20190116013637_update_memberships_add_foreign_key.js
+++ b/api/db/migrations/20190116013637_update_memberships_add_foreign_key.js
@@ -1,6 +1,6 @@
 const TABLE_NAME = 'memberships';
 
-exports.up = async (knex) => {
+exports.up = (knex) => {
   return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.unique(['userId', 'organizationId']);
   });

--- a/api/db/migrations/20191029091642_add_certification_candidates_unique_constraint_on_user_and_session.js
+++ b/api/db/migrations/20191029091642_add_certification_candidates_unique_constraint_on_user_and_session.js
@@ -1,6 +1,6 @@
 const TABLE_NAME = 'certification-candidates';
 
-exports.up = async function(knex) {
+exports.up = function(knex) {
 
   return knex.schema.table(TABLE_NAME, (table) => {
     table.unique(['sessionId', 'userId']);

--- a/api/db/migrations/20191029103059_add_column_status_in_session.js
+++ b/api/db/migrations/20191029103059_add_column_status_in_session.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'sessions';
 const COLUMN_NAME = 'status';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, async (table) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string(COLUMN_NAME).defaultTo('started');
   });
 };

--- a/api/db/migrations/20200114155324_add_archived_at_column_on_campaigns.js
+++ b/api/db/migrations/20200114155324_add_archived_at_column_on_campaigns.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'campaigns';
 const COLUMN_NAME = 'archivedAt';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, async (table) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dateTime(COLUMN_NAME).nullable();
   });
 };

--- a/api/db/migrations/20200212141456_fix_indexes_on_table_memberships.js
+++ b/api/db/migrations/20200212141456_fix_indexes_on_table_memberships.js
@@ -12,7 +12,7 @@ exports.up = async function(knex) {
   });
 };
 
-exports.down = async function(knex) {
+exports.down = function(knex) {
   return knex.schema.table(TABLE_NAME, function(table) {
     table.dropIndex(ORGANIZATIONID_COLUMN);
     table.index(USERID_COLUMN, OLD_INDEX_USERID);

--- a/api/db/migrations/20200327084158_drop_column_status_table_sessions.js
+++ b/api/db/migrations/20200327084158_drop_column_status_table_sessions.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'sessions';
 const COLUMN_NAME = 'status';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, async (table) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn(COLUMN_NAME);
   });
 };

--- a/api/db/migrations/20200327110821_save_acquired_partner_certification_key_on_certif_course_table.js
+++ b/api/db/migrations/20200327110821_save_acquired_partner_certification_key_on_certif_course_table.js
@@ -1,6 +1,6 @@
 const TABLE_NAME = 'certification-partner-acquisitions';
 
-exports.up = async (knex) => {
+exports.up = (knex) => {
 
   return knex.schema.createTable(TABLE_NAME, (table) => {
     table

--- a/api/db/migrations/20200509110115_update-associated-skill-id-column-certification-challenges-table.js
+++ b/api/db/migrations/20200509110115_update-associated-skill-id-column-certification-challenges-table.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-exports.up = async function(knex) {
+exports.up = function(knex) {
   return knex.transaction(async (trx) => {
     const valuesTable = _.map(skills_at_2020_04_30, (skillId, skillName) => `('${skillId}', '${skillName}')`);
     const valuesString = _.join(valuesTable, ',');

--- a/api/db/migrations/20200604161113_rename-certification-partner.js
+++ b/api/db/migrations/20200604161113_rename-certification-partner.js
@@ -1,10 +1,10 @@
 const OLD_TABLE_NAME = 'certification-partner-acquisitions';
 const TABLE_NAME = 'partner-certifications';
 
-exports.up = async function(knex) {
+exports.up = function(knex) {
   return knex.schema.renameTable(OLD_TABLE_NAME, TABLE_NAME);
 };
 
-exports.down = async function(knex) {
+exports.down = function(knex) {
   return knex.schema.renameTable(TABLE_NAME, OLD_TABLE_NAME);
 };

--- a/api/db/migrations/20201026162616_add-schooling-registration-id-column-to-certification-candidate-table.js
+++ b/api/db/migrations/20201026162616_add-schooling-registration-id-column-to-certification-candidate-table.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'certification-candidates';
 const COLUMN_NAME = 'schoolingRegistrationId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, async (table) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer(COLUMN_NAME).references('schooling-registrations.id');
   });
 };

--- a/api/db/migrations/20201029134518_add-unique-constraint-organizationid-targetprofileid-on-target-profile-shares.js
+++ b/api/db/migrations/20201029134518_add-unique-constraint-organizationid-targetprofileid-on-target-profile-shares.js
@@ -18,6 +18,6 @@ exports.up = async function(knex) {
   return knex.schema.table('target-profile-shares', (table) => table.unique(['organizationId', 'targetProfileId']));
 };
 
-exports.down = async function(knex) {
+exports.down = function(knex) {
   return knex.schema.table('target-profile-shares', (table) => table.dropUnique(['organizationId', 'targetProfileId']));
 };

--- a/api/db/migrations/20201106114017_add-lang-column-for-user.js
+++ b/api/db/migrations/20201106114017_add-lang-column-for-user.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'users';
 const COLUMN_NAME = 'lang';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, async (table) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string(COLUMN_NAME).notNullable().defaultTo('fr');
   });
 };

--- a/api/db/migrations/20201113105430_migrate-password-and-shouldChangePassword-to-authentication-methods.js
+++ b/api/db/migrations/20201113105430_migrate-password-and-shouldChangePassword-to-authentication-methods.js
@@ -1,4 +1,4 @@
-exports.up = async (knex) => {
+exports.up = (knex) => {
   return knex.raw('INSERT INTO "authentication-methods" ("userId", "identityProvider", "authenticationComplement") ' +
     'SELECT id AS "userId", ' +
     '\'PIX\' AS "identityProvider", ' +

--- a/api/db/migrations/20201215145328_add-column-max-reachable-level-certification-course.js
+++ b/api/db/migrations/20201215145328_add-column-max-reachable-level-certification-course.js
@@ -1,7 +1,7 @@
 const TABLE_NAME = 'certification-courses';
 const COLUMN_NAME = 'maxReachableLevelOnCertificationDate';
 
-exports.up = async (knex) => {
+exports.up = (knex) => {
   return knex.schema.table(TABLE_NAME, (table) => {
     table.integer(COLUMN_NAME).notNullable().defaultTo(5);
   });

--- a/api/db/migrations/20210506134706_alter_users_pix_roles_add_unique_constraint.js
+++ b/api/db/migrations/20210506134706_alter_users_pix_roles_add_unique_constraint.js
@@ -1,7 +1,7 @@
 const TABLE_NAME = 'users_pix_roles';
 const COLUMNS_NAME = ['user_id', 'pix_role_id'];
 
-exports.up = async function(knex) {
+exports.up = function(knex) {
 
   return knex.schema.table(TABLE_NAME, (table) => {
     table.unique(COLUMNS_NAME);

--- a/api/db/migrations/20210616111928_rename-badge-criteria-scope.js
+++ b/api/db/migrations/20210616111928_rename-badge-criteria-scope.js
@@ -1,5 +1,5 @@
 
-exports.up = async function(knex) {
+exports.up = function(knex) {
   return knex('badge-criteria').update({ scope: 'SkillSet' }).where({ scope: 'SomePartnerCompetences' });
 };
 

--- a/api/lib/application/account-recovery/index.js
+++ b/api/lib/application/account-recovery/index.js
@@ -7,7 +7,7 @@ const accountRecoveryController = require('./account-recovery-controller');
 
 const { passwordValidationPattern } = require('../../config').account;
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -3,7 +3,7 @@ const answerController = require('./answer-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 const { NotFoundError } = require('../../domain/errors');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/assessment-results/index.js
+++ b/api/lib/application/assessment-results/index.js
@@ -1,7 +1,7 @@
 const AssessmentResultController = require('./assessment-result-controller');
 const securityPreHandlers = require('../security-pre-handlers');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -120,7 +120,7 @@ async function _getChallenge(assessment, request) {
   return challenge;
 }
 
-async function _getChallengeByAssessmentType({ assessment, request }) {
+function _getChallengeByAssessmentType({ assessment, request }) {
   const locale = extractLocaleFromRequest(request);
 
   if (assessment.isPreview()) {

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -4,7 +4,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const assessmentAuthorization = require('../preHandlers/assessment-authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -4,7 +4,7 @@ const AuthenticationController = require('./authentication-controller');
 const responseAuthenticationObjectDoc = require('../../infrastructure/open-api-doc/authentication/response-authentication-doc');
 const responseErrorObjectDoc = require('../../infrastructure/open-api-doc/livret-scolaire/response-object-error-doc');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/badges/index.js
+++ b/api/lib/application/badges/index.js
@@ -3,7 +3,7 @@ const badgesController = require('./badges-controller');
 const Joi = require('joi');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/cache/index.js
+++ b/api/lib/application/cache/index.js
@@ -1,7 +1,7 @@
 const securityPreHandlers = require('../security-pre-handlers');
 const CacheController = require('./cache-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'PATCH',

--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 const campaignParticipationController = require('./campaign-participation-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'PATCH',

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -5,7 +5,7 @@ const campaignStatsController = require('./campaign-stats-controller');
 const securityPreHandlers = require('../security-pre-handlers');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -1,7 +1,7 @@
 const certificationCenterMembershipController = require('./certification-center-membership-controller');
 const securityPreHandlers = require('../security-pre-handlers');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
 
     {

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -3,7 +3,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const Joi = require('joi');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
 
     {

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -5,7 +5,7 @@ const certificationCourseController = require('./certification-course-controller
 
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 const certificationIssueReportController = require('./certification-issue-report-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'DELETE',

--- a/api/lib/application/certification-livret-scolaire/index.js
+++ b/api/lib/application/certification-livret-scolaire/index.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 const responseErrorObjectDoc = require('../../infrastructure/open-api-doc/livret-scolaire/response-object-error-doc');
 const certificationsResultsResponseDoc = require('../../infrastructure/open-api-doc/livret-scolaire/certifications-results-doc');
 
-exports.register = async function(server) {
+exports.register = function(server) {
 
   server.route([
     {

--- a/api/lib/application/certification-point-of-contacts/index.js
+++ b/api/lib/application/certification-point-of-contacts/index.js
@@ -4,7 +4,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const certificationPointOfContactController = require('./certification-point-of-contact-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/certification-reports/index.js
+++ b/api/lib/application/certification-reports/index.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 const certificationReportController = require('./certification-report-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -4,7 +4,7 @@ const certificationController = require('./certification-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 const securityPreHandlers = require('../security-pre-handlers');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const challengeController = require('./challenge-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/competence-evaluations/index.js
+++ b/api/lib/application/competence-evaluations/index.js
@@ -1,6 +1,6 @@
 const competenceEvaluationController = require('./competence-evaluation-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/countries/index.js
+++ b/api/lib/application/countries/index.js
@@ -1,6 +1,6 @@
 const countryController = require('./country-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/courses/index.js
+++ b/api/lib/application/courses/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const courseController = require('./course-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/feature-toggles/index.js
+++ b/api/lib/application/feature-toggles/index.js
@@ -1,6 +1,6 @@
 const featureToggleController = require('./feature-toggle-controller');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/feedbacks/index.js
+++ b/api/lib/application/feedbacks/index.js
@@ -1,6 +1,6 @@
 const feedbackController = require('./feedback-controller');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/healthcheck/index.js
+++ b/api/lib/application/healthcheck/index.js
@@ -1,6 +1,6 @@
 const healthcheckController = require('./healthcheck-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/lcms/index.js
+++ b/api/lib/application/lcms/index.js
@@ -1,7 +1,7 @@
 const securityPreHandlers = require('../security-pre-handlers');
 const LcmsController = require('./lcms-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/lcms/lcms-controller.js
+++ b/api/lib/application/lcms/lcms-controller.js
@@ -3,7 +3,7 @@ const logger = require('../../infrastructure/logger');
 
 module.exports = {
 
-  async createRelease(request, h) {
+  createRelease(request, h) {
     usecases.createLcmsRelease()
       .then(() => {
         logger.info('Release created and cache reloaded');

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -4,7 +4,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const membershipController = require('./membership-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const organizationInvitationController = require('./organization-invitation-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -9,7 +9,7 @@ const ERRORS = {
   PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
 };
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -195,7 +195,7 @@ module.exports = {
     return h.response(organizationInvitationSerializer.serialize(organizationInvitation)).created();
   },
 
-  async findPendingInvitations(request) {
+  findPendingInvitations(request) {
     const organizationId = request.params.id;
 
     return usecases.findPendingOrganizationInvitations({ organizationId })

--- a/api/lib/application/passwords/index.js
+++ b/api/lib/application/passwords/index.js
@@ -4,7 +4,7 @@ const XRegExp = require('xregexp');
 const { passwordValidationPattern } = require('../../config').account;
 const passwordController = require('./password-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/pole-emplois/index.js
+++ b/api/lib/application/pole-emplois/index.js
@@ -3,7 +3,7 @@ const poleEmploiController = require('./pole-emploi-controller');
 const poleEmploiErreurDoc = require('../../infrastructure/open-api-doc/pole-emploi/erreur-doc');
 const poleEmploiEnvoisDoc = require('../../infrastructure/open-api-doc/pole-emploi/envois-doc');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/prescribers/index.js
+++ b/api/lib/application/prescribers/index.js
@@ -4,7 +4,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const prescriberController = require('./prescriber-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/progressions/index.js
+++ b/api/lib/application/progressions/index.js
@@ -1,5 +1,5 @@
 const ProgressionController = require('./progression-controller');
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/saml/index.js
+++ b/api/lib/application/saml/index.js
@@ -1,6 +1,6 @@
 const samlController = require('./saml-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -11,7 +11,7 @@ const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
 
 const schoolingRegistrationDependentUserController = require('./schooling-registration-dependent-user-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/schooling-registration-user-associations/index.js
+++ b/api/lib/application/schooling-registration-user-associations/index.js
@@ -5,7 +5,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const schoolingRegistrationUserAssociationController = require('./schooling-registration-user-association-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/scorecards/index.js
+++ b/api/lib/application/scorecards/index.js
@@ -1,6 +1,6 @@
 const scorecardController = require('./scorecard-controller');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -5,7 +5,7 @@ const finalizedSessionController = require('./finalized-session-controller');
 const sessionAuthorization = require('../preHandlers/session-authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -93,7 +93,7 @@ module.exports = {
       .header('Content-Disposition', 'attachment; filename=liste-candidats-session-' + sessionId + '.ods');
   },
 
-  async getCertificationCandidates(request) {
+  getCertificationCandidates(request) {
     const sessionId = request.params.id;
 
     return usecases.getSessionCertificationCandidates({ sessionId })
@@ -127,7 +127,7 @@ module.exports = {
     return juryCertificationSummarySerializer.serialize(juryCertificationSummaries);
   },
 
-  async generateSessionResultsDownloadLink(request, h) {
+  generateSessionResultsDownloadLink(request, h) {
     const sessionId = request.params.id;
     const sessionResultsLink = sessionResultsLinkService.generateResultsLink(sessionId);
 
@@ -163,7 +163,7 @@ module.exports = {
       .header('Content-Disposition', `attachment; filename=${fileName}`);
   },
 
-  async getCertificationReports(request) {
+  getCertificationReports(request) {
     const sessionId = request.params.id;
 
     return usecases.getSessionCertificationReports({ sessionId })

--- a/api/lib/application/simulateErrors/index.js
+++ b/api/lib/application/simulateErrors/index.js
@@ -1,6 +1,6 @@
 const errorController = require('./error-controller');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/stages/index.js
+++ b/api/lib/application/stages/index.js
@@ -3,7 +3,7 @@ const stagesController = require('./stages-controller');
 const Joi = require('joi');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/application/tags/index.js
+++ b/api/lib/application/tags/index.js
@@ -1,7 +1,7 @@
 const securityPreHandlers = require('../security-pre-handlers');
 const tagController = require('./tag-controller');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -5,7 +5,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const targetProfileController = require('./target-profile-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'GET',

--- a/api/lib/application/tutorial-evaluations/index.js
+++ b/api/lib/application/tutorial-evaluations/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const tutorialEvaluationsController = require('./tutorial-evaluations-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'PUT',

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const userOrgaSettingsController = require('./user-orga-settings-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'PUT',

--- a/api/lib/application/user-tutorials/index.js
+++ b/api/lib/application/user-tutorials/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const userTutorialsController = require('./user-tutorials-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async (server) => {
+exports.register = (server) => {
   server.route([
     {
       method: 'PUT',

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -9,7 +9,7 @@ const { passwordValidationPattern } = require('../../config').account;
 const { EntityValidationError } = require('../../domain/errors');
 const identifiersType = require('../../domain/types/identifiers-type');
 
-exports.register = async function(server) {
+exports.register = function(server) {
   server.route([
     {
       method: 'POST',

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -24,7 +24,7 @@ async function handleAutoJury({
     challengeRepository,
   });
 
-  const certificationJuryDoneEvents = await Promise.all(certificationCourses.map(async(certificationCourse) => {
+  const certificationJuryDoneEvents = await Promise.all(certificationCourses.map(async (certificationCourse) => {
 
     const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: certificationCourse.getId() });
 

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -68,11 +68,11 @@ async function neutralizeIfAttachmentStrategy({ certificationIssueReport, certif
   return _neutralizeAndResolve(certificationAssessment, certificationIssueReportRepository, certificationIssueReport);
 }
 
-async function neutralizeWithoutCheckingStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository }) {
+function neutralizeWithoutCheckingStrategy({ certificationIssueReport, certificationAssessment, certificationIssueReportRepository }) {
   return _neutralizeAndResolve(certificationAssessment, certificationIssueReportRepository, certificationIssueReport);
 }
 
-async function doNotResolveStrategy() {
+function doNotResolveStrategy() {
   return CertificationIssueReportResolutionAttempt.unresolved();
 }
 

--- a/api/lib/domain/services/assessment-result-service.js
+++ b/api/lib/domain/services/assessment-result-service.js
@@ -3,7 +3,7 @@ const competenceMarkRepository = require('../../infrastructure/repositories/comp
 const CompetenceMark = require('../models/CompetenceMark');
 const bluebird = require('bluebird');
 
-async function _validatedDataForAllCompetenceMark(competenceMarks) {
+function _validatedDataForAllCompetenceMark(competenceMarks) {
   for (const competenceMark of competenceMarks) {
     competenceMark.validate();
   }

--- a/api/lib/domain/services/course-service.js
+++ b/api/lib/domain/services/course-service.js
@@ -6,7 +6,7 @@ const courseRepository = require('../../infrastructure/repositories/course-repos
 
 module.exports = {
 
-  async getCourse({ courseId }) {
+  getCourse({ courseId }) {
 
     // TODO: delete when campaign assessment does not have courses anymore
     if (_.startsWith(courseId, '[NOT USED] Campaign')) {

--- a/api/lib/domain/services/placement-profile-service.js
+++ b/api/lib/domain/services/placement-profile-service.js
@@ -18,7 +18,7 @@ async function getPlacementProfile({ userId, limitDate, isV2Certification = true
   return _generatePlacementProfileV1({ userId, profileDate: limitDate, competences: pixCompetences });
 }
 
-async function _createUserCompetencesV1({ competences, userLastAssessments, limitDate }) {
+function _createUserCompetencesV1({ competences, userLastAssessments, limitDate }) {
   return bluebird.mapSeries(competences, async (competence) => {
     const assessment = _.find(userLastAssessments, { competenceId: competence.id });
     let estimatedLevel = 0;

--- a/api/lib/domain/services/schooling-registrations-xml-service.js
+++ b/api/lib/domain/services/schooling-registrations-xml-service.js
@@ -4,7 +4,7 @@ module.exports = {
   extractSchoolingRegistrationsInformationFromSIECLE,
 };
 
-async function extractSchoolingRegistrationsInformationFromSIECLE(path, organization) {
+function extractSchoolingRegistrationsInformationFromSIECLE(path, organization) {
   const parser = new SiecleParser(organization, path);
 
   return parser.parse();

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -53,7 +53,7 @@ async function createUserWithPassword({
   return savedUser;
 }
 
-async function updateUsernameAndAddPassword({
+function updateUsernameAndAddPassword({
   userId,
   username,
   hashedPassword,
@@ -70,7 +70,7 @@ async function updateUsernameAndAddPassword({
   });
 }
 
-async function createAndReconcileUserToSchoolingRegistration({
+function createAndReconcileUserToSchoolingRegistration({
   hashedPassword,
   samlId,
   schoolingRegistrationId,

--- a/api/lib/domain/usecases/authenticate-application.js
+++ b/api/lib/domain/usecases/authenticate-application.js
@@ -25,7 +25,7 @@ function _checkAppScope(application, scope) {
   }
 }
 
-module.exports = async function authenticateApplication({
+module.exports = function authenticateApplication({
   clientId,
   clientSecret,
   scope,

--- a/api/lib/domain/usecases/create-organization-invitations.js
+++ b/api/lib/domain/usecases/create-organization-invitations.js
@@ -2,7 +2,7 @@ const bluebird = require('bluebird');
 
 const organizationInvitationService = require('../../domain/services/organization-invitation-service');
 
-module.exports = async function createOrganizationInvitations({
+module.exports = function createOrganizationInvitations({
   organizationRepository, organizationInvitationRepository, organizationId, emails, locale,
 }) {
   const trimmedEmails = emails.map((email) => email.trim());

--- a/api/lib/domain/usecases/create-organization.js
+++ b/api/lib/domain/usecases/create-organization.js
@@ -1,7 +1,7 @@
 const Organization = require('../models/Organization');
 const organizationCreationValidator = require('../validators/organization-creation-validator');
 
-module.exports = async function createOrganization({
+module.exports = function createOrganization({
   createdBy,
   externalId,
   logoUrl,

--- a/api/lib/domain/usecases/disable-membership.js
+++ b/api/lib/domain/usecases/disable-membership.js
@@ -1,4 +1,4 @@
-module.exports = async function disableMembership({
+module.exports = function disableMembership({
   membershipId,
   userId,
   membershipRepository,

--- a/api/lib/domain/usecases/find-latest-ongoing-user-campaign-participations.js
+++ b/api/lib/domain/usecases/find-latest-ongoing-user-campaign-participations.js
@@ -1,3 +1,3 @@
-module.exports = async function findLatestOngoingUserCampaignParticipations({ userId, campaignParticipationRepository }) {
+module.exports = function findLatestOngoingUserCampaignParticipations({ userId, campaignParticipationRepository }) {
   return campaignParticipationRepository.findLatestOngoingByUserId(userId);
 };

--- a/api/lib/domain/usecases/find-target-profile-stages.js
+++ b/api/lib/domain/usecases/find-target-profile-stages.js
@@ -1,4 +1,4 @@
-module.exports = async function findTargetProfileStages(
+module.exports = function findTargetProfileStages(
   {
     targetProfileId,
     stageRepository,

--- a/api/lib/domain/usecases/find-user-private-certificates.js
+++ b/api/lib/domain/usecases/find-user-private-certificates.js
@@ -1,4 +1,4 @@
-module.exports = async function findUserPrivateCertificates({
+module.exports = function findUserPrivateCertificates({
   userId,
   privateCertificateRepository,
 }) {

--- a/api/lib/domain/usecases/get-campaign-details-management.js
+++ b/api/lib/domain/usecases/get-campaign-details-management.js
@@ -1,4 +1,4 @@
-module.exports = async function getCampaignManagement({
+module.exports = function getCampaignManagement({
   campaignId,
   campaignManagementRepository,
 }) {

--- a/api/lib/domain/usecases/get-certification-candidate.js
+++ b/api/lib/domain/usecases/get-certification-candidate.js
@@ -1,4 +1,4 @@
-async function getCertificationCandidate({
+function getCertificationCandidate({
   userId,
   sessionId,
   certificationCandidateRepository,

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -1,7 +1,7 @@
 const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 const Scorecard = require('../models/Scorecard');
 
-module.exports = async function getScorecard({
+module.exports = function getScorecard({
   authenticatedUserId,
   scorecardId,
   scorecardService,

--- a/api/lib/domain/usecases/get-session-certification-candidates.js
+++ b/api/lib/domain/usecases/get-session-certification-candidates.js
@@ -1,3 +1,3 @@
-module.exports = async function getSessionCertificationCandidates({ sessionId, certificationCandidateRepository }) {
+module.exports = function getSessionCertificationCandidates({ sessionId, certificationCandidateRepository }) {
   return certificationCandidateRepository.findBySessionId(sessionId);
 };

--- a/api/lib/domain/usecases/get-session-certification-reports.js
+++ b/api/lib/domain/usecases/get-session-certification-reports.js
@@ -1,3 +1,3 @@
-module.exports = async function getSessionCertificationReports({ sessionId, certificationReportRepository }) {
+module.exports = function getSessionCertificationReports({ sessionId, certificationReportRepository }) {
   return certificationReportRepository.findBySessionId(sessionId);
 };

--- a/api/lib/domain/usecases/get-user-campaign-participation-to-campaign.js
+++ b/api/lib/domain/usecases/get-user-campaign-participation-to-campaign.js
@@ -1,4 +1,4 @@
-module.exports = async function getUserCampaignParticipationToCampaign({
+module.exports = function getUserCampaignParticipationToCampaign({
   userId,
   campaignId,
   campaignParticipationRepository,

--- a/api/lib/domain/usecases/get-user-certification-eligibility.js
+++ b/api/lib/domain/usecases/get-user-certification-eligibility.js
@@ -32,7 +32,7 @@ module.exports = async function getUserCertificationEligibility({
   });
 };
 
-async function _computeCleaCertificationEligibility({
+function _computeCleaCertificationEligibility({
   userId,
   pixCertificationEligible,
   certificationBadgesService,

--- a/api/lib/domain/usecases/get-user-with-memberships.js
+++ b/api/lib/domain/usecases/get-user-with-memberships.js
@@ -1,3 +1,3 @@
-module.exports = async function getUserWithMemberships({ userId, userRepository }) {
+module.exports = function getUserWithMemberships({ userId, userRepository }) {
   return userRepository.getWithMemberships(userId);
 };

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -120,7 +120,7 @@ async function _findChallengesFromPixPlus({
   return _.flatMap(challengesPixPlusByCertifiableBadges);
 }
 
-async function _getCertificationCourseIfCreatedMeanwhile(certificationCourseRepository, userId, sessionId, domainTransaction) {
+function _getCertificationCourseIfCreatedMeanwhile(certificationCourseRepository, userId, sessionId, domainTransaction) {
   return certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({
     userId,
     sessionId,

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -51,7 +51,7 @@ module.exports = async function startCampaignParticipation({
   };
 };
 
-async function _saveCampaignParticipation(campaignParticipation, userId, campaignParticipationRepository, domainTransaction) {
+function _saveCampaignParticipation(campaignParticipation, userId, campaignParticipationRepository, domainTransaction) {
 
   const userParticipation = new CampaignParticipation({ ...campaignParticipation, userId });
   return campaignParticipationRepository.save(userParticipation, domainTransaction);

--- a/api/lib/domain/usecases/update-user-details-for-administration.js
+++ b/api/lib/domain/usecases/update-user-details-for-administration.js
@@ -25,7 +25,7 @@ module.exports = async function updateUserDetailsForAdministration({
   return userRepository.getUserDetailsForAdmin(userId);
 };
 
-async function _checkEmailAndUsernameAreAvailable({ usersWithEmail, usersWithUsername }) {
+function _checkEmailAndUsernameAreAvailable({ usersWithEmail, usersWithUsername }) {
   const isEmailAlreadyUsed = has(usersWithEmail, '[0].email');
   const isUsernameAlreadyUsed = has(usersWithUsername, '[0].username');
 

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -4,7 +4,7 @@ const boom = require('boom');
 const tokenService = require('../domain/services/token-service');
 const config = require('../../lib/config');
 
-async function _checkIsAuthenticated(request, h, { key, validate }) {
+function _checkIsAuthenticated(request, h, { key, validate }) {
 
   if (!request.headers.authorization) {
     return boom.unauthorized(null, 'jwt');

--- a/api/lib/infrastructure/caches/Cache.js
+++ b/api/lib/infrastructure/caches/Cache.js
@@ -1,13 +1,16 @@
 class Cache {
 
+  // eslint-disable-next-line require-await
   async get(/* key, generator */) {
     throw new Error('Method #get(key, generator) must be overridden');
   }
 
+  // eslint-disable-next-line require-await
   async set(/* key, object */) {
     throw new Error('Method #set(key, object) must be overridden');
   }
 
+  // eslint-disable-next-line require-await
   async flushAll() {
     throw new Error('Method #flushAll() must be overridden');
   }

--- a/api/lib/infrastructure/caches/InMemoryCache.js
+++ b/api/lib/infrastructure/caches/InMemoryCache.js
@@ -9,20 +9,21 @@ class InMemoryCache extends Cache {
     this._queue = Promise.resolve();
   }
 
+  // eslint-disable-next-line require-await
   async get(key, generator) {
     return this._syncGet(key, () => this._chainPromise(() => {
       return this._syncGet(key, () => this._generateAndSet(key, generator));
     }));
   }
 
-  async set(key, value) {
+  set(key, value) {
     return this._chainPromise(() => {
       this._cache.set(key, value);
       return value;
     });
   }
 
-  async flushAll() {
+  flushAll() {
     return this._chainPromise(() => {
       this._cache.flushAll();
     });
@@ -34,7 +35,7 @@ class InMemoryCache extends Cache {
     return generatedValue;
   }
 
-  async _chainPromise(fn) {
+  _chainPromise(fn) {
     const queuedPromise = this._queue.then(fn);
     this._queue = queuedPromise.catch(() => {});
     return queuedPromise;

--- a/api/lib/infrastructure/mailers/MailingProvider.js
+++ b/api/lib/infrastructure/mailers/MailingProvider.js
@@ -1,5 +1,6 @@
 class MailingProvider {
 
+  // eslint-disable-next-line require-await
   async sendEmail(/* options */) {
     throw new Error('Method #sendEmail(options) must be overridden');
   }

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -98,7 +98,7 @@ module.exports = {
     return _toDomain(answerDTO);
   },
 
-  async findChallengeIdsFromAnswerIds(ids) {
+  findChallengeIdsFromAnswerIds(ids) {
     return knex
       .distinct()
       .pluck('challengeId')
@@ -106,7 +106,7 @@ module.exports = {
       .whereInArray('id', ids);
   },
 
-  async saveWithKnowledgeElements(answer, knowledgeElements) {
+  saveWithKnowledgeElements(answer, knowledgeElements) {
     const answerForDB = _adaptAnswerToDb(answer);
     return knex.transaction(async (trx) => {
       const alreadySavedAnswer = await trx('answers').select('id').where({ challengeId: answer.challengeId, assessmentId: answer.assessmentId });

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -115,7 +115,7 @@ module.exports = {
     return Boolean(foundAuthenticationMethod);
   },
 
-  async removeByUserIdAndIdentityProvider({ userId, identityProvider }) {
+  removeByUserIdAndIdentityProvider({ userId, identityProvider }) {
     return BookshelfAuthenticationMethod.where({ userId, identityProvider }).destroy({ require: true });
   },
 

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -6,7 +6,7 @@ const bluebird = require('bluebird');
 
 module.exports = {
 
-  async createOrUpdate(badgeAcquisitionsToCreate = [], domainTransaction = DomainTransaction.emptyTransaction()) {
+  createOrUpdate(badgeAcquisitionsToCreate = [], domainTransaction = DomainTransaction.emptyTransaction()) {
     const knexConn = domainTransaction.knexTransaction || Bookshelf.knex;
     return bluebird.mapSeries(badgeAcquisitionsToCreate, async (badgeAcquisitionToCreate) => {
       const alreadyCreatedBadgeAcquisition = await knexConn('badge-acquisitions').select('id').where(badgeAcquisitionToCreate);

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -16,7 +16,8 @@ async function findPaginatedByCampaignId({ page = {}, campaignId, filters = {} }
     pagination,
   };
 }
-async function _getResultListPaginated(campaignId, targetProfile, filters, page) {
+
+function _getResultListPaginated(campaignId, targetProfile, filters, page) {
   const query = _getParticipantsResultList(campaignId, targetProfile, filters);
   return fetchPage(query, page);
 }

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -69,7 +69,7 @@ module.exports = {
     await BookshelfCampaignParticipation.forge(attributes).save();
   },
 
-  async markPreviousParticipationsAsImproved(campaignId, userId, domainTransaction = DomainTransaction.emptyTransaction()) {
+  markPreviousParticipationsAsImproved(campaignId, userId, domainTransaction = DomainTransaction.emptyTransaction()) {
     const knexConn = domainTransaction.knexTransaction || knex;
     return knexConn('campaign-participations')
       .where({ campaignId, userId })

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -108,7 +108,7 @@ module.exports = {
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(CertificationCandidateBookshelf, results)[0]);
   },
 
-  async setSessionCandidates(sessionId, certificationCandidates) {
+  setSessionCandidates(sessionId, certificationCandidates) {
     const certificationCandidatesToInsert = certificationCandidates.map(_adaptModelToDb);
 
     return Bookshelf.knex.transaction(async (trx) => {

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -52,7 +52,7 @@ function _convertSkillsToHints({ skillsWithHints, locale }) {
   });
 }
 
-async function _getTutorials({ userId, skills, tutorialIdsProperty, locale }) {
+function _getTutorials({ userId, skills, tutorialIdsProperty, locale }) {
   const tutorialsIds = _(skills)
     .map((skill) => skill[tutorialIdsProperty])
     .filter((tutorialId) => !_.isEmpty(tutorialId))

--- a/api/lib/infrastructure/repositories/course-repository.js
+++ b/api/lib/infrastructure/repositories/course-repository.js
@@ -29,7 +29,7 @@ async function _get(id) {
 
 module.exports = {
 
-  async get(id) {
+  get(id) {
     return _get(id);
   },
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -90,7 +90,7 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfKnowledgeElement, savedKnowledgeElement);
   },
 
-  async findUniqByUserId({ userId, limitDate, domainTransaction }) {
+  findUniqByUserId({ userId, limitDate, domainTransaction }) {
     return _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction });
   },
 
@@ -137,7 +137,7 @@ module.exports = {
       .where({ campaignId, isShared: 'true' });
 
     const knowledgeElements = _.flatMap(await bluebird.map(sharedCampaignParticipations,
-      async ({ userId, sharedAt }) => {
+      ({ userId, sharedAt }) => {
         return _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate: sharedAt });
       },
       { concurrency: constants.CONCURRENCY_HEAVY_OPERATIONS },
@@ -155,11 +155,11 @@ module.exports = {
     return knowledgeElementsGroupedByUser;
   },
 
-  async countValidatedTargetedByCompetencesForUsers(userIdsAndDates, targetProfileWithLearningContent) {
+  countValidatedTargetedByCompetencesForUsers(userIdsAndDates, targetProfileWithLearningContent) {
     return _countValidatedTargetedByCompetencesForUsers(userIdsAndDates, targetProfileWithLearningContent);
   },
 
-  async countValidatedTargetedByCompetencesForOneUser(userId, limitDate, targetProfileWithLearningContent) {
+  countValidatedTargetedByCompetencesForOneUser(userId, limitDate, targetProfileWithLearningContent) {
     return _countValidatedTargetedByCompetencesForUsers({ [userId]: limitDate }, targetProfileWithLearningContent);
   },
 
@@ -180,7 +180,7 @@ module.exports = {
     return targetProfileWithLearningContent.getValidatedKnowledgeElementsGroupedByTube(_.flatMap(knowledgeElementsGroupedByUser));
   },
 
-  async findSnapshotForUsers(userIdsAndDates) {
+  findSnapshotForUsers(userIdsAndDates) {
     return _findSnapshotsForUsers(userIdsAndDates);
   },
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -60,7 +60,7 @@ module.exports = {
       .then(_toDomain);
   },
 
-  async batchCreateProOrganizations(organizations, domainTransaction = DomainTransaction.emptyTransaction()) {
+  batchCreateProOrganizations(organizations, domainTransaction = DomainTransaction.emptyTransaction()) {
     const organizationsRawData = organizations.map((organization) => _.pick(
       organization,
       ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'email', 'isManagingStudents', 'canCollectProfiles', 'credit', 'createdBy'],

--- a/api/lib/infrastructure/repositories/organization-tag-repository.js
+++ b/api/lib/infrastructure/repositories/organization-tag-repository.js
@@ -45,7 +45,7 @@ module.exports = {
       : [];
   },
 
-  async batchCreate(organizationsTags, domainTransaction = DomainTransaction.emptyTransaction()) {
+  batchCreate(organizationsTags, domainTransaction = DomainTransaction.emptyTransaction()) {
     return Bookshelf.knex.batchInsert('organization-tags', organizationsTags).transacting(domainTransaction.knexTransaction);
   },
 

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -63,7 +63,7 @@ async function _findTargetedKnowledgeElements(campaignId, userId, sharedAt) {
   return knowledgeElementsByUser[userId].filter(({ skillId }) => targetedSkillIds.includes(skillId));
 }
 
-async function _getAcquiredBadgeIds(userId, campaignParticipationId) {
+function _getAcquiredBadgeIds(userId, campaignParticipationId) {
   return knex('badge-acquisitions').select('badgeId').where({ userId, campaignParticipationId });
 }
 
@@ -77,7 +77,7 @@ async function _getTargetProfile(campaignId, locale) {
   return { competences, stages, badges };
 }
 
-async function _getTargetProfileId(campaignId) {
+function _getTargetProfileId(campaignId) {
   return knex('campaigns')
     .select('targetProfileId')
     .where({ 'campaigns.id': campaignId })

--- a/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
@@ -104,7 +104,7 @@ async function _getCleaCompetenceMarks({ certificationCourseId, cleaCompetenceId
   });
 }
 
-async function _getLatestAssessmentResultIdByCertificationCourseIdQuery(queryBuilder, certificationCourseId) {
+function _getLatestAssessmentResultIdByCertificationCourseIdQuery(queryBuilder, certificationCourseId) {
   return queryBuilder.select('assessment-results.id')
     .from('assessments')
     .join('assessment-results', 'assessment-results.assessmentId', 'assessments.id')

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -176,7 +176,7 @@ module.exports = {
     return targetProfileShares.map((targetProfileShare) => targetProfileShare.organizationId);
   },
 
-  async attachOrganizationIds({ targetProfileId, organizationIds }) {
+  attachOrganizationIds({ targetProfileId, organizationIds }) {
     const rows = organizationIds.map((organizationId) => {
       return { organizationId, targetProfileId };
     });

--- a/api/lib/infrastructure/repositories/target-profile-share-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-share-repository.js
@@ -2,7 +2,7 @@ const { knex } = require('../bookshelf');
 
 module.exports = {
 
-  async addTargetProfilesToOrganization({ organizationId, targetProfileIdList }) {
+  addTargetProfilesToOrganization({ organizationId, targetProfileIdList }) {
     const targetProfileShareToAdd = targetProfileIdList.map((targetProfileId) => {
       return { organizationId, targetProfileId };
     });

--- a/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
@@ -19,7 +19,7 @@ const { getTranslatedText } = require('../../domain/services/get-translated-text
 
 module.exports = {
 
-  async get({ id, locale = FRENCH_FRANCE }) {
+  get({ id, locale = FRENCH_FRANCE }) {
     const whereClauseFnc = (queryBuilder) => {
       return queryBuilder
         .where('target-profiles.id', id);
@@ -28,7 +28,7 @@ module.exports = {
     return _get(whereClauseFnc, locale);
   },
 
-  async getByCampaignId({ campaignId, locale = FRENCH_FRANCE }) {
+  getByCampaignId({ campaignId, locale = FRENCH_FRANCE }) {
     const whereClauseFnc = (queryBuilder) => {
       return queryBuilder
         .join('campaigns', 'campaigns.targetProfileId', 'target-profiles.id')

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -15,7 +15,7 @@ module.exports = {
     return tutorials;
   },
 
-  async findByRecordIds(ids) {
+  findByRecordIds(ids) {
     return _findByRecordIds({ ids });
   },
 

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -384,7 +384,7 @@ module.exports = {
     return bookshelfUser ? _toDomain(bookshelfUser) : null;
   },
 
-  async findAnotherUserByEmail(userId, email) {
+  findAnotherUserByEmail(userId, email) {
     return BookshelfUser
       .where('id', '!=', userId)
       .where({ email: email.toLowerCase() })
@@ -392,7 +392,7 @@ module.exports = {
       .then((users) => bookshelfToDomainConverter.buildDomainObjects(BookshelfUser, users));
   },
 
-  async findAnotherUserByUsername(userId, username) {
+  findAnotherUserByUsername(userId, username) {
     return BookshelfUser
       .where('id', '!=', userId)
       .where({ username })

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -16,7 +16,7 @@ module.exports = {
     return userTutorials.map(_toDomain);
   },
 
-  async removeFromUser(userTutorial) {
+  removeFromUser(userTutorial) {
     return BookshelfUserTutorials.where(userTutorial).destroy({ require: false });
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js
@@ -23,7 +23,7 @@ module.exports = {
     }).serialize(accountRecoveryDemand);
   },
 
-  async deserialize(studentInformationForAccountRecovery) {
+  deserialize(studentInformationForAccountRecovery) {
     function transform(record) {
       return {
         ineIna: record['ine-ina'],

--- a/api/lib/infrastructure/serializers/xml/siecle-parser.js
+++ b/api/lib/infrastructure/serializers/xml/siecle-parser.js
@@ -36,7 +36,7 @@ class SiecleParser {
     await this.siecleFileStreamer.perform((stream, resolve, reject) => this._checkUAI(stream, resolve, reject));
   }
 
-  async _checkUAI(stream, resolve, reject) {
+  _checkUAI(stream, resolve, reject) {
     const streamerToParseOrganizationUAI = new saxPath.SaXPath(stream, NODE_ORGANIZATION_UAI);
 
     streamerToParseOrganizationUAI.once('match', (xmlNode) => {

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -1,8 +1,10 @@
 class TemporaryStorage {
+  // eslint-disable-next-line require-await
   async save(/* value, expirationDelaySeconds */) {
     throw new Error('Method #save({ value, expirationDelaySeconds }) must be overridden');
   }
 
+  // eslint-disable-next-line require-await
   async get(/* key */) {
     throw new Error('Method #get(key) must be overridden');
   }

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const moment = require('moment');
 const { getCsvContent } = require('./write-csv-utils');
 
-async function getDivisionCertificationResultsCsv({
+function getDivisionCertificationResultsCsv({
   certificationResults,
 }) {
   const data = _buildFileDataWithoutCertificationCenterName({ certificationResults });
@@ -11,7 +11,7 @@ async function getDivisionCertificationResultsCsv({
   return getCsvContent({ data, fileHeaders });
 }
 
-async function getSessionCertificationResultsCsv({
+function getSessionCertificationResultsCsv({
   session,
   certificationResults,
 }) {

--- a/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -145,7 +145,7 @@ function _atLeastOneWithoutComplementaryCertifications(viewModels) {
   return _.some(viewModels, (viewModel) => !viewModel.shouldDisplayComplementaryCertifications());
 }
 
-async function _loadTemplateByFilename(templateFileName, dirname) {
+function _loadTemplateByFilename(templateFileName, dirname) {
   const path = `${dirname}/files/${templateFileName}`;
   return readFile(path);
 }
@@ -184,7 +184,7 @@ async function _render({ templatePdfPages, pdfDocument, viewModels, rgb, embedde
   }
 }
 
-async function _getTemplatePage(viewModel, templatePdfPages) {
+function _getTemplatePage(viewModel, templatePdfPages) {
   if (viewModel.shouldDisplayComplementaryCertifications()) {
     return templatePdfPages.withComplementaryCertifications;
   } else {

--- a/api/lib/infrastructure/utils/redis-monitor.js
+++ b/api/lib/infrastructure/utils/redis-monitor.js
@@ -9,7 +9,7 @@ class RedisMonitor {
     }
   }
 
-  async ping() {
+  ping() {
     if (!this._client) {
       return false;
     }

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -61,7 +61,7 @@ async function prepareDataForInsert(rawExternalIds) {
   return certificationCenterMembershipsLists.flat();
 }
 
-async function createCertificationCenterMemberships(certificationCenterMemberships) {
+function createCertificationCenterMemberships(certificationCenterMemberships) {
   return knex.batchInsert('certification-center-memberships', certificationCenterMemberships);
 }
 

--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -200,7 +200,7 @@ async function _createCampaign({ organizationId, campaignType, targetProfileId }
   return campaignId;
 }
 
-async function _createUsers({ count, uniqId, trx }) {
+function _createUsers({ count, uniqId, trx }) {
   const userData = [];
   for (let i = 0; i < count; ++i) {
     const identifier = _getIdentifier(uniqId);
@@ -288,7 +288,7 @@ function _buildPROSchoolingRegistration({ userId, organizationId, identifier }) 
   return _buildBaseSchoolingRegistration({ userId, organizationId, identifier });
 }
 
-async function _createAssessments({ userAndCampaignParticipationIds, trx }) {
+function _createAssessments({ userAndCampaignParticipationIds, trx }) {
   const assessmentData = [];
   for (const userAndCampaignParticipationId of userAndCampaignParticipationIds) {
     assessmentData.push({
@@ -302,7 +302,7 @@ async function _createAssessments({ userAndCampaignParticipationIds, trx }) {
   return trx.batchInsert('assessments', assessmentData.flat(), chunkSize).returning(['id', 'userId']);
 }
 
-async function _createCampaignParticipations({ campaignId, userIds, trx }) {
+function _createCampaignParticipations({ campaignId, userIds, trx }) {
   const participationData = [];
   for (const userId of userIds) {
     const createdAt = moment(baseDate).add(_.random(0, 100), 'days').toDate();

--- a/api/scripts/data-generation/generate-certifications-for-organization.js
+++ b/api/scripts/data-generation/generate-certifications-for-organization.js
@@ -234,7 +234,7 @@ async function _createCertificationCoursesAndAssessments({ registrations, sessio
     .batchInsert('assessments', assessmentsData, assessmentsChunkSize).returning('id');
 }
 
-async function _createCertificationResultsInError({ assessmentIds, transaction }) {
+function _createCertificationResultsInError({ assessmentIds, transaction }) {
   const assessmentResultsData = [];
   for (const assessmentId of assessmentIds) {
     assessmentResultsData.push({
@@ -284,7 +284,7 @@ async function _createCertificationResultsWithMarks({ assessmentIds, status, pix
   `, assessmentResultIds.join(','));
 }
 
-async function _createCompetenceMarksForCompetence({ competence, assessmentResultIds, transaction }) {
+function _createCompetenceMarksForCompetence({ competence, assessmentResultIds, transaction }) {
   const chosenRate = _.sample(COMPETENCE_MARK_PARTICIPATION_RATES);
   const chosenCount = parseInt(assessmentResultIds.length * chosenRate);
   const chosenAssessmentResultIds = _.sampleSize(assessmentResultIds, chosenCount);

--- a/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
+++ b/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
@@ -1,7 +1,7 @@
 const { knex } = require('../db/knex-database-connection');
 const bluebird = require('bluebird');
 
-async function getAllBadgeAcquistionsWithoutCampaignParticipationId() {
+function getAllBadgeAcquistionsWithoutCampaignParticipationId() {
   return knex('badge-acquisitions').select().where({ campaignParticipationId: null });
 }
 

--- a/api/scripts/mark-users-for-TermsOfService-revalidation.js
+++ b/api/scripts/mark-users-for-TermsOfService-revalidation.js
@@ -1,7 +1,7 @@
 const Bookshelf = require('../lib/infrastructure/bookshelf');
 const ERROR_RETURN_CODE = 1;
 
-async function markUsersRequiringTermsOfServiceValidationForRevalidation() {
+function markUsersRequiringTermsOfServiceValidationForRevalidation() {
   const subquery = Bookshelf.knex
     .select('users.id')
     .from('users')

--- a/api/scripts/populate-organizations-email.js
+++ b/api/scripts/populate-organizations-email.js
@@ -4,7 +4,7 @@ const { parseCsvWithHeader } = require('../scripts/helpers/csvHelpers');
 
 const BookshelfOrganization = require('../lib/infrastructure/orm-models/Organization');
 
-async function updateOrganizationEmailByExternalId(externalId, email) {
+function updateOrganizationEmailByExternalId(externalId, email) {
   return BookshelfOrganization
     .where({ externalId })
     .save({ email }, { patch: true })
@@ -17,7 +17,7 @@ async function updateOrganizationEmailByExternalId(externalId, email) {
     });
 }
 
-async function populateOrganizations(objectsFromFile) {
+function populateOrganizations(objectsFromFile) {
   return bluebird.mapSeries(objectsFromFile, ({ uai, email }) => {
     return updateOrganizationEmailByExternalId(uai, email);
   });

--- a/api/scripts/prod/cancel-certifications-and-publish-sessions.js
+++ b/api/scripts/prod/cancel-certifications-and-publish-sessions.js
@@ -103,7 +103,7 @@ function _parseSessionId(line) {
   return _.toNumber(sessionIdValue);
 }
 
-async function _parseCertifications(line, sessionId, trx) {
+function _parseCertifications(line, sessionId, trx) {
   const COL_NAME_CERTIFICATIONS = 'certifications';
   const certificationsValue = line[COL_NAME_CERTIFICATIONS];
   if (certificationsValue === 'tout annuler') {

--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
@@ -43,7 +43,7 @@ function _validateAndNormalizeArgs({
   };
 }
 
-async function getEligibleCampaignParticipations(maxSnapshotCount) {
+function getEligibleCampaignParticipations(maxSnapshotCount) {
   return knex('campaign-participations').select('campaign-participations.userId', 'campaign-participations.sharedAt')
     .leftJoin('knowledge-element-snapshots', function() {
       this.on('knowledge-element-snapshots.userId', 'campaign-participations.userId')
@@ -58,7 +58,7 @@ async function getEligibleCampaignParticipations(maxSnapshotCount) {
     .limit(maxSnapshotCount);
 }
 
-async function generateKnowledgeElementSnapshots(campaignParticipationData, concurrency) {
+function generateKnowledgeElementSnapshots(campaignParticipationData, concurrency) {
   return bluebird.map(campaignParticipationData, async (campaignParticipation) => {
     const { userId, sharedAt } = campaignParticipation;
     const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId, limitDate: sharedAt });

--- a/api/scripts/send-invitations-to-sco-organizations.js
+++ b/api/scripts/send-invitations-to-sco-organizations.js
@@ -14,7 +14,7 @@ const organizationInvitationRepository = require('../lib/infrastructure/reposito
 
 const TAGS = ['JOIN_ORGA'];
 
-async function getOrganizationByExternalId(externalId) {
+function getOrganizationByExternalId(externalId) {
   return BookshelfOrganization
     .where({ externalId })
     .fetch()
@@ -32,13 +32,13 @@ async function buildInvitation({ externalId, email }) {
   return { organizationId, email };
 }
 
-async function prepareDataForSending(objectsFromFile) {
+function prepareDataForSending(objectsFromFile) {
   return bluebird.mapSeries(objectsFromFile, ({ uai, email }) => {
     return buildInvitation({ externalId: uai, email });
   });
 }
 
-async function sendJoinOrganizationInvitations(invitations, tags) {
+function sendJoinOrganizationInvitations(invitations, tags) {
   return bluebird.mapSeries(invitations, ({ organizationId, email }, index) => {
     if (require.main === module) {
       process.stdout.write(`${index}/${invitations.length}\r`);

--- a/api/server.js
+++ b/api/server.js
@@ -39,7 +39,7 @@ const setupServer = async () => {
   return server;
 };
 
-const createServer = async function() {
+const createServer = function() {
 
   const serverConfiguration = {
     compression: false,

--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -37,7 +37,7 @@ describe('Acceptance | Controller | answer-controller-save', function() {
 
     context('when the user is linked to the assessment', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         // given
         const learningContent = {
           areas: [{ id: 'recArea1', competenceIds: ['recCompetence'] }],

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -195,7 +195,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
     };
   });
 
-  afterEach(async function() {
+  afterEach(function() {
     return knex('assessment-results').delete();
   });
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-challenge-for-pix-button_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-challenge-for-pix-button_test.js
@@ -53,7 +53,7 @@ describe('Acceptance | API | assessment-controller-get-challenge-answer-for-pix-
       await databaseBuilder.commit();
     });
 
-    afterEach(async function() {
+    afterEach(function() {
       return knex('assessments').delete();
     });
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-last-challenge-id_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-last-challenge-id_test.js
@@ -30,7 +30,7 @@ describe('Acceptance | API | assessment-controller-get-last-challenge-id', funct
       await databaseBuilder.commit();
     });
 
-    afterEach(async function() {
+    afterEach(function() {
       return knex('assessments').delete();
     });
 
@@ -46,7 +46,7 @@ describe('Acceptance | API | assessment-controller-get-last-challenge-id', funct
         };
       });
 
-      afterEach(async function() {
+      afterEach(function() {
         return knex('assessments').delete();
       });
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -79,7 +79,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         });
       });
 
-      afterEach(async function() {
+      afterEach(function() {
         clock.restore();
       });
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -110,7 +110,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         return databaseBuilder.commit();
       });
 
-      it('should return the second challenge', async function() {
+      it('should return the second challenge', function() {
         // given
         const options = {
           method: 'GET',

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -584,7 +584,7 @@ describe('Acceptance | API | Campaign Controller', function() {
 
   describe('GET /api/campaigns/{id}/profiles-collection-participations', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       const learningContent = [{
         id: 'recArea1',
         competences: [{
@@ -713,7 +713,7 @@ describe('Acceptance | API | Campaign Controller', function() {
     let campaign;
     let userId;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       userId = databaseBuilder.factory.buildUser().id;
       const organization = databaseBuilder.factory.buildOrganization();
 
@@ -844,7 +844,7 @@ describe('Acceptance | API | Campaign Controller', function() {
     let campaign;
     let userId;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       userId = databaseBuilder.factory.buildUser().id;
       const organization = databaseBuilder.factory.buildOrganization();
 

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -17,7 +17,7 @@ describe('Acceptance | API | Campaign Participations', function() {
 
     let campaignParticipationId;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       campaignParticipationId = 123111;
 
       const learningContent = [{

--- a/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-find-shared-participations_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-find-shared-participations_test.js
@@ -17,7 +17,7 @@ describe('Acceptance | API | Campaign Participations | Analyses', function() {
     let campaign;
     let userId;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       userId = databaseBuilder.factory.buildUser().id;
       const organization = databaseBuilder.factory.buildOrganization();
 

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -158,7 +158,7 @@ describe('Acceptance | API | Certification Course', function() {
 
     context('when certification course has no assessment', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         ({ id: certificationCourseId } = databaseBuilder.factory.buildCertificationCourse({
           createdAt: new Date('2017-12-21T15:44:38Z'),
           completedAt: new Date('2017-12-21T15:48:38Z'),
@@ -227,7 +227,7 @@ describe('Acceptance | API | Certification Course', function() {
     });
 
     context('when certification course has an assessment', function() {
-      beforeEach(async function() {
+      beforeEach(function() {
         ({ id: certificationCourseId } = databaseBuilder.factory.buildCertificationCourse({
           createdAt: new Date('2017-12-21T15:44:38Z'),
           completedAt: new Date('2017-12-21T15:48:38Z'),
@@ -583,7 +583,7 @@ describe('Acceptance | API | Certification Course', function() {
     let userId;
     let sessionId;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       userId = databaseBuilder.factory.buildUser().id;
       sessionId = databaseBuilder.factory.buildSession({ accessCode: '123' }).id;
       const payload = {

--- a/api/tests/acceptance/application/competence-evaluation-controller-improve_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller-improve_test.js
@@ -56,7 +56,7 @@ describe('Acceptance | API | Improve Competence Evaluation', function() {
             assessment = response.result.data.relationships.assessment.data;
           });
 
-          it('should return 200 and the competence evaluation', async function() {
+          it('should return 200 and the competence evaluation', function() {
             // then
             expect(response.statusCode).to.equal(200);
             expect(response.result.data.id).to.exist;

--- a/api/tests/acceptance/application/competence-evaluation-controller_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller_test.js
@@ -28,7 +28,7 @@ describe('Acceptance | API | Competence Evaluations', function() {
 
     context('When user is authenticated', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         const learningContent = [{
           id: 'recArea1',
           competences: [{

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -362,7 +362,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
       });
 
       context('when a schoolingRegistration is present twice in the file', function() {
-        beforeEach(async function() {
+        beforeEach(function() {
           // given
           const schoolingRegistration1 =
             '<ELEVE ELEVE_ID="0001">' +

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -108,7 +108,7 @@ describe('Acceptance | Application | organization-controller', function() {
         expect(response.statusCode).to.equal(422);
       });
 
-      it('should not keep the user in the database', async function() {
+      it('should not keep the user in the database', function() {
         // given
         payload.data.attributes.type = 'FAK';
 
@@ -757,7 +757,7 @@ describe('Acceptance | Application | organization-controller', function() {
     let organization;
     let options;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       const userPixMaster = databaseBuilder.factory.buildUser.withPixRolePixMaster();
       organization = databaseBuilder.factory.buildOrganization();
       options = {
@@ -1335,7 +1335,7 @@ describe('Acceptance | Application | organization-controller', function() {
 
     let userId, organization, accessToken;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       userId = databaseBuilder.factory.buildUser().id;
       const authHeader = generateValidRequestAuthorizationHeader(userId);
       accessToken = authHeader.replace('Bearer ', '');

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -150,7 +150,7 @@ describe('Acceptance | Controller | saml-controller', function() {
   describe('POST /api/saml/assert', function() {
 
     // Uses samlify to create a valid SAML response
-    async function buildLoginResponse(attributes) {
+    function buildLoginResponse(attributes) {
       const identityProvider = samlify.IdentityProvider(idpConfig);
       const serviceProvider = samlify.ServiceProvider(spConfig);
 

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
@@ -54,7 +54,7 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function(
 
       const email = 'angie@example.net';
 
-      beforeEach(async function() {
+      beforeEach(function() {
         options.payload.data.attributes.email = email;
         options.payload.data.attributes['with-username'] = false;
       });
@@ -114,7 +114,7 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function(
 
       const username = 'angie.go1234';
 
-      beforeEach(async function() {
+      beforeEach(function() {
         options.payload.data.attributes.username = username;
         options.payload.data.attributes['with-username'] = true;
       });

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -95,7 +95,7 @@ describe('Acceptance | Controller | scorecard-controller', function() {
 
   describe('GET /scorecards/{id}', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       options = {
         method: 'GET',
         url: `/api/scorecards/${userId}_${competenceId}`,
@@ -209,7 +209,7 @@ describe('Acceptance | Controller | scorecard-controller', function() {
 
   describe('GET /scorecards/{id}/tutorials', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       options = {
         method: 'GET',
         url: `/api/scorecards/${userId}_${competenceId}/tutorials`,

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -242,7 +242,7 @@ describe('Acceptance | Application | SecurityPreHandlers', function() {
 
   describe('#checkUserIsAdminInSCOOrganizationAndManagesStudents', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       server.route({
         method: 'GET',
         path: '/test_route/{id}',
@@ -298,7 +298,7 @@ describe('Acceptance | Application | SecurityPreHandlers', function() {
 
   describe('#checkUserIsAdminInSUPOrganizationAndManagesStudents', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       server.route({
         method: 'GET',
         path: '/test_route/{id}',

--- a/api/tests/acceptance/application/session/session-controller-get-attendance-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-attendance-sheet_test.js
@@ -27,7 +27,7 @@ describe('Acceptance | Controller | session-controller-get-attendance-sheet', fu
       await databaseBuilder.commit();
     });
 
-    it('should respond with a 200 when session can be found', async function() {
+    it('should respond with a 200 when session can be found', function() {
       // when
       const authHeader = generateValidRequestAuthorizationHeader(user.id);
       const token = authHeader.replace('Bearer ', '');
@@ -45,7 +45,7 @@ describe('Acceptance | Controller | session-controller-get-attendance-sheet', fu
       });
     });
 
-    it('should respond with a 403 when user cant access the session', async function() {
+    it('should respond with a 403 when user cant access the session', function() {
       // when
       const authHeader = generateValidRequestAuthorizationHeader(user.id);
       const token = authHeader.replace('Bearer ', '');

--- a/api/tests/acceptance/application/session/session-controller-get-candidates-import-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-candidates-import-sheet_test.js
@@ -28,7 +28,7 @@ describe('Acceptance | Controller | session-controller-get-candidates-import-she
       await databaseBuilder.commit();
     });
 
-    it('should respond with a 200 when session can be found', async function() {
+    it('should respond with a 200 when session can be found', function() {
       // when
       const authHeader = generateValidRequestAuthorizationHeader(user.id);
       const token = authHeader.replace('Bearer ', '');
@@ -46,7 +46,7 @@ describe('Acceptance | Controller | session-controller-get-candidates-import-she
       });
     });
 
-    it('should respond with a 403 when user cant access the session', async function() {
+    it('should respond with a 403 when user cant access the session', function() {
       // when
       const authHeader = generateValidRequestAuthorizationHeader(user.id);
       const token = authHeader.replace('Bearer ', '');

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -155,7 +155,7 @@ describe('Acceptance | Controller | target-profile-controller', function() {
 
   describe('POST /api/admin/target-profiles/{id}/attach-organizations', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       mockLearningContent(learningContent);
     });
 
@@ -194,7 +194,7 @@ describe('Acceptance | Controller | target-profile-controller', function() {
 
   describe('POST /api/admin/target-profiles/{id}/copy-organizations', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       mockLearningContent(learningContent);
     });
 

--- a/api/tests/acceptance/application/tutorials/tutorial-evaluations-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/tutorial-evaluations-controller_test.js
@@ -35,7 +35,7 @@ describe('Acceptance | Controller | tutorial-evaluations-controller', function()
 
     let options;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       options = {
         method: 'PUT',
         url: '/api/users/tutorials/tutorialId/evaluate',
@@ -45,7 +45,7 @@ describe('Acceptance | Controller | tutorial-evaluations-controller', function()
       };
     });
 
-    afterEach(async function() {
+    afterEach(function() {
       return knex('tutorial-evaluations').delete();
     });
 

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -35,7 +35,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function() {
 
     let options;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       options = {
         method: 'PUT',
         url: '/api/users/tutorials/tutorialId',
@@ -45,7 +45,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function() {
       };
     });
 
-    afterEach(async function() {
+    afterEach(function() {
       return knex('user_tutorials').delete();
     });
 
@@ -94,7 +94,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function() {
 
     let options;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       options = {
         method: 'GET',
         url: '/api/users/tutorials',
@@ -160,7 +160,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function() {
 
     let options;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       options = {
         method: 'DELETE',
         url: '/api/users/tutorials/tutorialId',

--- a/api/tests/acceptance/application/user-orga-settings-controller_test.js
+++ b/api/tests/acceptance/application/user-orga-settings-controller_test.js
@@ -67,7 +67,7 @@ describe('Acceptance | Controller | user-orga-settings-controller', function() {
 
     context('When user is authenticated', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
       });
 

--- a/api/tests/acceptance/application/users/get-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-campaign-assessment-result_test.js
@@ -167,7 +167,7 @@ describe('Acceptance | API | Campaign Assessment Result', function() {
   describe('GET /api/users/{userId}/campaigns/{campaignId}/assessment-result', function() {
     let options;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       options = {
         method: 'GET',
         url: `/api/users/${user.id}/campaigns/${campaign.id}/assessment-result`,

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -51,12 +51,12 @@ describe('Acceptance | Controller | users-controller', function() {
           response = await server.inject(options);
         });
 
-        it('should return status 204 with user', async function() {
+        it('should return status 204 with user', function() {
           // then
           expect(response.statusCode).to.equal(204);
         });
 
-        it('should notify user by email', async function() {
+        it('should notify user by email', function() {
           // then
           expect(mailer.sendEmail).to.have.been.called;
         });

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -66,7 +66,7 @@ describe('Acceptance | Controller | users-controller', function() {
         };
       });
 
-      afterEach(async function() {
+      afterEach(function() {
         nock.cleanAll();
       });
 

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -36,7 +36,7 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
 
   describe('GET /users/{userId}/campaigns/{campaignId}/profile', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
 
       mockLearningContent(learningContent);
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -24,7 +24,7 @@ describe('Integration | API | Controller Error', function() {
   before(async function() {
     const moduleUnderTest = {
       name: 'test-route',
-      register: async function(server) {
+      register: function(server) {
         server.route([{
           method: 'GET',
           path: routeUrl,

--- a/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
@@ -27,7 +27,7 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
 
     context('When registration succeed with email', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         // given
         method = 'POST';
         url = '/api/schooling-registration-dependent-users';
@@ -58,7 +58,7 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
 
     context('When registration succeed with username', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         // given
         method = 'POST';
         url = '/api/schooling-registration-dependent-users';
@@ -89,7 +89,7 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
 
     context('Error cases', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         // given
         method = 'POST';
         url = '/api/schooling-registration-dependent-users';
@@ -240,7 +240,7 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
     let payload;
     let response;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       // given
       method = 'POST';
       url = '/api/schooling-registration-dependent-users/external-user-token';

--- a/api/tests/integration/application/security-pre-handlers_test.js
+++ b/api/tests/integration/application/security-pre-handlers_test.js
@@ -8,7 +8,7 @@ describe('Integration | Application | SecurityPreHandlers', function() {
     beforeEach(async function() {
       const moduleUnderTest = {
         name: 'security-test',
-        register: async function(server) {
+        register: function(server) {
           server.route([{
             method: 'GET',
             path: '/check/{id}',

--- a/api/tests/integration/domain/event/handle-badge-acquisition_test.js
+++ b/api/tests/integration/domain/event/handle-badge-acquisition_test.js
@@ -13,7 +13,7 @@ describe('Integration | Event | Handle Badge Acquisition Service', function() {
 
   describe('#handleBadgeAcquisition', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       const listSkill = ['web1', 'web2', 'web3', 'web4'];
 
       const learningContent = [{

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -67,7 +67,7 @@ describe('Integration | Service | Certification-Badges Service', function() {
       mockLearningContent(learningContentObjects);
 
       // when
-      const badgeAcquisitions = await DomainTransaction.execute(async (domainTransaction) => {
+      const badgeAcquisitions = await DomainTransaction.execute((domainTransaction) => {
         return certificationBadgesService.findStillValidBadgeAcquisitions({ userId, domainTransaction });
       });
 

--- a/api/tests/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
+++ b/api/tests/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
@@ -9,7 +9,7 @@ describe('Integration | UseCase | find-paginated-campaign-participants-activitie
   let userId;
   const page = { number: 1 };
 
-  beforeEach(async function() {
+  beforeEach(function() {
     organizationId = databaseBuilder.factory.buildOrganization().id;
     userId = databaseBuilder.factory.buildUser().id;
     campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;

--- a/api/tests/integration/domain/usecases/get-campaign-participations-activity-by-day_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-activity-by-day_test.js
@@ -7,7 +7,7 @@ describe('Integration | UseCase | get-campaign-participations-activity-by-day', 
   let campaignId;
   let userId;
 
-  beforeEach(async function() {
+  beforeEach(function() {
     organizationId = databaseBuilder.factory.buildOrganization().id;
     userId = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildMembership({ organizationId, userId });

--- a/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-stage_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-stage_test.js
@@ -8,7 +8,7 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
   let userId;
   let stage1, stage2, stage3;
 
-  beforeEach(async function() {
+  beforeEach(function() {
     const learningContentObjects = learningContentBuilder.buildLearningContent([{
       id: 'recArea1',
       titleFrFr: 'area1_Title',

--- a/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-status_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-status_test.js
@@ -8,7 +8,7 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-status',
   let campaignId;
   let userId;
 
-  beforeEach(async function() {
+  beforeEach(function() {
     organizationId = databaseBuilder.factory.buildOrganization().id;
     userId = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildMembership({ organizationId, userId });

--- a/api/tests/integration/infrastructure/event-dispatcher_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher_test.js
@@ -32,7 +32,7 @@ describe('Integration | Infrastructure | EventHandler', function() {
     expect(eventHandler).to.have.been.calledWith({ domainTransaction, event });
   });
 
-  it('thows when duplicate subscription', async function() {
+  it('thows when duplicate subscription', function() {
     // given
     const eventHandler = getEventHandlerMock();
 

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -27,7 +27,7 @@ describe('Integration | Repository | Badge Acquisition', function() {
 
     it('should persist the badge acquisition in db', async function() {
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute((domainTransaction) => {
         return badgeAcquisitionRepository.createOrUpdate([badgeAcquisitionToCreate], domainTransaction);
       });
 
@@ -47,7 +47,7 @@ describe('Integration | Repository | Badge Acquisition', function() {
       await databaseBuilder.commit();
 
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
+      await DomainTransaction.execute((domainTransaction) => {
         return badgeAcquisitionRepository.createOrUpdate([badgeAcquisitionToCreate], domainTransaction);
       });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-analysis-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-analysis-repository_test.js
@@ -40,7 +40,7 @@ describe('Integration | Repository | Campaign analysis repository', function() {
       let targetProfile;
       let campaignId;
 
-      beforeEach(async function() {
+      beforeEach(function() {
         campaignId = databaseBuilder.factory.buildCampaign().id;
 
         const url1 = domainBuilder.buildTargetedSkill({ id: 'recUrl1', tubeId: 'recTubeUrl', name: '@url1' });
@@ -242,7 +242,7 @@ describe('Integration | Repository | Campaign analysis repository', function() {
       let userId;
       let campaignParticipation;
 
-      beforeEach(async function() {
+      beforeEach(function() {
         campaignId = databaseBuilder.factory.buildCampaign().id;
         const sharedAt = new Date('2020-04-01');
         const userWithCampaignParticipation = _createUserWithSharedCampaignParticipation('Fred', campaignId, sharedAt, false);

--- a/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -38,7 +38,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
       let targetProfile;
       let campaignId;
 
-      beforeEach(async function() {
+      beforeEach(function() {
         campaignId = databaseBuilder.factory.buildCampaign().id;
 
         // Competence A - nobody validated skills @url4 and @url5

--- a/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
@@ -17,7 +17,7 @@ describe('Integration | Repository | CampaignToJoin', function() {
       await databaseBuilder.commit();
 
       // when
-      const actualCampaign = await DomainTransaction.execute(async (domainTransaction) => {
+      const actualCampaign = await DomainTransaction.execute((domainTransaction) => {
         return campaignToJoinRepository.get(expectedCampaign.id, domainTransaction);
       });
 
@@ -172,7 +172,7 @@ describe('Integration | Repository | CampaignToJoin', function() {
 
       // when
       try {
-        await DomainTransaction.execute(async (domainTransaction) => {
+        await DomainTransaction.execute((domainTransaction) => {
           return campaignToJoinRepository.checkCampaignIsJoinableByUser(campaignToJoin, userId, domainTransaction);
         });
 
@@ -251,7 +251,7 @@ describe('Integration | Repository | CampaignToJoin', function() {
 
         // when
         try {
-          await DomainTransaction.execute(async (domainTransaction) => {
+          await DomainTransaction.execute((domainTransaction) => {
             return campaignToJoinRepository.checkCampaignIsJoinableByUser(campaignToJoin, userId, domainTransaction);
           });
         } catch (error) {
@@ -292,7 +292,7 @@ describe('Integration | Repository | CampaignToJoin', function() {
 
         // when
         try {
-          await DomainTransaction.execute(async (domainTransaction) => {
+          await DomainTransaction.execute((domainTransaction) => {
             return campaignToJoinRepository.checkCampaignIsJoinableByUser(campaignToJoin, userId, domainTransaction);
           });
         } catch (error) {
@@ -389,7 +389,7 @@ describe('Integration | Repository | CampaignToJoin', function() {
           await databaseBuilder.commit();
 
           try {
-            await DomainTransaction.execute(async (domainTransaction) => {
+            await DomainTransaction.execute((domainTransaction) => {
               return campaignToJoinRepository.checkCampaignIsJoinableByUser(campaignToJoin, userId, domainTransaction);
             });
           } catch (error) {

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -28,7 +28,7 @@ describe('Integration | Repository | CertificationCandidate', function() {
 
     context('when a proper candidate is being saved', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         certificationCandidate = domainBuilder.buildCertificationCandidate({
           firstName: 'Pix',
           lastName: 'Lover',

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -30,7 +30,7 @@ describe('Integration | Repository | Competence Evaluation', function() {
       });
 
       // when
-      const savedCompetenceEvaluation = await DomainTransaction.execute(async (domainTransaction) =>
+      const savedCompetenceEvaluation = await DomainTransaction.execute((domainTransaction) =>
         competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave, domainTransaction }),
       );
 
@@ -54,7 +54,7 @@ describe('Integration | Repository | Competence Evaluation', function() {
       });
 
       // when
-      const savedCompetenceEvaluation = await DomainTransaction.execute(async (domainTransaction) =>
+      const savedCompetenceEvaluation = await DomainTransaction.execute((domainTransaction) =>
         competenceEvaluationRepository.save({ competenceEvaluation: competenceEvaluationToSave, domainTransaction }),
       );
 

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -45,7 +45,7 @@ describe('Integration | Repository | Finalized-session', function() {
 
     context('When the session does exist', function() {
 
-      it('is idempotent', async function() {
+      it('is idempotent', function() {
         // given
         const finalizedSession = new FinalizedSession({
           sessionId: 1234,

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -34,7 +34,7 @@ describe('Integration | Repository | PoleEmploiSending', function() {
     let sending2;
     let sending3;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       originalEnvPoleEmploiSendingsLimit = settings.poleEmploi.poleEmploiSendingsLimit;
       settings.poleEmploi.poleEmploiSendingsLimit = 3;
     });

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -554,11 +554,11 @@ async function _buildValidShareableCertificationWithClea(shareableCertificateDat
   return { certificateId };
 }
 
-async function _buildValidShareableCertificateWithCleaV1(shareableCertificateData) {
+function _buildValidShareableCertificateWithCleaV1(shareableCertificateData) {
   return _buildValidShareableCertificationWithClea(shareableCertificateData, cleaBadgeKeyV1);
 }
 
-async function _buildValidShareableCertificateWithCleaV2(shareableCertificateData) {
+function _buildValidShareableCertificateWithCleaV2(shareableCertificateData) {
   return _buildValidShareableCertificationWithClea(shareableCertificateData, cleaBadgeKeyV2);
 }
 

--- a/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
@@ -124,7 +124,7 @@ describe('Integration | Scripts | create-profile-collection-campaigns', function
       });
     });
 
-    it('should create proper campaign attributes even customLandingPageText is missing', async function() {
+    it('should create proper campaign attributes even customLandingPageText is missing', function() {
       // given
       const name = 'SomeName';
       const customLandingPageText = undefined;

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -78,12 +78,12 @@ describe('Unit | Controller | cache-controller', function() {
         response = await cacheController.refreshCacheEntries(request, hFake);
       });
 
-      it('should reply with http status 202', async function() {
+      it('should reply with http status 202', function() {
         // then
         expect(response.statusCode).to.equal(202);
       });
 
-      it('should call log errors', async function() {
+      it('should call log errors', function() {
         // then
         expect(logger.error).to.have.been.calledOnce;
       });

--- a/api/tests/unit/application/stages/stages-controller_test.js
+++ b/api/tests/unit/application/stages/stages-controller_test.js
@@ -87,7 +87,7 @@ describe('Unit | Controller | stages-controller', function() {
     });
 
     context('successful case', function() {
-      it('should succeed', async function() {
+      it('should succeed', function() {
         // when
         stagesController.getStageDetails(request);
 

--- a/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
+++ b/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
@@ -67,7 +67,7 @@ describe('Unit | Controller | user-orga-settings-controller', function() {
       response = await userOrgaSettingsController.createOrUpdate(request);
     });
 
-    it('should call the usecase to update the userOrgaSetting', async function() {
+    it('should call the usecase to update the userOrgaSetting', function() {
       // then
       expect(usecases.createOrUpdateUserOrgaSettings).to.have.been.calledWith({ userId, organizationId });
     });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -365,7 +365,7 @@ describe('Unit | Domain | Errors', function() {
         { type: 'number.base', why: 'not_a_number' },
         { type: 'number.integer', why: 'not_a_number' },
       ].forEach(({ type, why }) => {
-        it(`should assign why "${why}" to error when joi error type is "${type}"`, async function() {
+        it(`should assign why "${why}" to error when joi error type is "${type}"`, function() {
           // given
           const joiErrorDetail = {
             context: { key: 'someKey' },
@@ -380,7 +380,7 @@ describe('Unit | Domain | Errors', function() {
         });
       });
 
-      it('should let why empty when type is unknown', async function() {
+      it('should let why empty when type is unknown', function() {
         // given
         const joiErrorDetail = {
           context: { key: 'someKey' },
@@ -459,7 +459,7 @@ describe('Unit | Domain | Errors', function() {
           { why: 'not_a_number', content: 'doit être un nombre.' },
           { why: 'required', content: 'est obligatoire.' },
         ].forEach(({ why, content }) => {
-          it(`message should contain "${content}" when why is "${why}"`, async function() {
+          it(`message should contain "${content}" when why is "${why}"`, function() {
             // given
             const invalidCertificationCandidateError = {
               key: 'someKey',

--- a/api/tests/unit/domain/events/check-event-type_test.js
+++ b/api/tests/unit/domain/events/check-event-type_test.js
@@ -13,7 +13,7 @@ describe('Unit | Domain | Events | check-event-types', function() {
     expect(error.message).to.equal('event must be one of types TestEvent1, TestEvent2');
   });
 
-  it('accepts an event of correct type ', async function() {
+  it('accepts an event of correct type ', function() {
     // given
     const correctTypeEvent = new TestEvent1();
 

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -167,7 +167,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
       expect(certificationAssessment.certificationChallenges[2].isNeutralized).to.be.false;
     });
 
-    it('throws when the challenge was not asked', async function() {
+    it('throws when the challenge was not asked', function() {
       // given
       const challengeNotAskedToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
@@ -223,7 +223,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
       expect(certificationAssessment.certificationChallenges[2].isNeutralized).to.be.true;
     });
 
-    it('throws when the challenge was not asked', async function() {
+    it('throws when the challenge was not asked', function() {
       // given
       const challengeNotAskedToBeDeneutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1', isNeutralized: false });
 
@@ -362,7 +362,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
       expect(neutralizationAttempt).to.deep.equal(NeutralizationAttempt.skipped(1));
     });
 
-    it('should fail when the challenge is not asked', async function() {
+    it('should fail when the challenge is not asked', function() {
       // given
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         id: 123,

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -108,7 +108,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
         // eslint-disable-next-line mocha/no-setup-in-describe
         { statusName: 'started', isCancelled: false, assessmentResultStatus: null, validationFunction: 'isStarted' },
       ].forEach(function(testCase) {
-        it(`should build a ${testCase.statusName} CertificationResult`, async function() {
+        it(`should build a ${testCase.statusName} CertificationResult`, function() {
           // given
           const certificationResultDTO = {
             ...certificationResultData,
@@ -159,7 +159,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       // eslint-disable-next-line mocha/no-setup-in-describe
       { statusName: 'started', status: CertificationResult.status.STARTED },
     ].forEach(function(testCase) {
-      it(`should return false when status is ${testCase.statusName}`, async function() {
+      it(`should return false when status is ${testCase.statusName}`, function() {
         // given
         const notCancelledCertificationResult = domainBuilder.buildCertificationResult({
           status: testCase.status,
@@ -200,7 +200,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       // eslint-disable-next-line mocha/no-setup-in-describe
       { statusName: 'started', status: CertificationResult.status.STARTED },
     ].forEach(function(testCase) {
-      it(`should return false when status is ${testCase.statusName}`, async function() {
+      it(`should return false when status is ${testCase.statusName}`, function() {
         // given
         const notValidatedCertificationResult = domainBuilder.buildCertificationResult({
           status: testCase.status,
@@ -241,7 +241,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       // eslint-disable-next-line mocha/no-setup-in-describe
       { statusName: 'started', status: CertificationResult.status.STARTED },
     ].forEach(function(testCase) {
-      it(`should return false when status is ${testCase.statusName}`, async function() {
+      it(`should return false when status is ${testCase.statusName}`, function() {
         // given
         const notRejectedCertificationResult = domainBuilder.buildCertificationResult({
           status: testCase.status,
@@ -282,7 +282,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       // eslint-disable-next-line mocha/no-setup-in-describe
       { statusName: 'started', status: CertificationResult.status.STARTED },
     ].forEach(function(testCase) {
-      it(`should return false when status is ${testCase.statusName}`, async function() {
+      it(`should return false when status is ${testCase.statusName}`, function() {
         // given
         const notInErrorCertificationResult = domainBuilder.buildCertificationResult({
           status: testCase.status,
@@ -323,7 +323,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       // eslint-disable-next-line mocha/no-setup-in-describe
       { statusName: 'error', status: CertificationResult.status.ERROR },
     ].forEach(function(testCase) {
-      it(`should return false when status is ${testCase.statusName}`, async function() {
+      it(`should return false when status is ${testCase.statusName}`, function() {
         // given
         const notStartedCertificationResult = domainBuilder.buildCertificationResult({
           status: testCase.status,
@@ -340,7 +340,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
 
   context('#hasTakenClea', function() {
 
-    it('returns true when Clea certification has been taken in the certification', async function() {
+    it('returns true when Clea certification has been taken in the certification', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
       const certificationResult = domainBuilder.buildCertificationResult({ cleaCertificationResult });
@@ -352,7 +352,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       expect(hasTakenClea).to.be.true;
     });
 
-    it('returns false when Clea certification has not been taken in the certification', async function() {
+    it('returns false when Clea certification has not been taken in the certification', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
       const certificationResult = domainBuilder.buildCertificationResult({ cleaCertificationResult });
@@ -367,7 +367,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
 
   context('#hasAcquiredClea', function() {
 
-    it('returns true when Clea certification has been acquired', async function() {
+    it('returns true when Clea certification has been acquired', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
       const certificationResult = domainBuilder.buildCertificationResult({ cleaCertificationResult });
@@ -379,7 +379,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       expect(hasAcquiredClea).to.be.true;
     });
 
-    it('returns false when Clea certification has not been acquired', async function() {
+    it('returns false when Clea certification has not been acquired', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.rejected();
       const certificationResult = domainBuilder.buildCertificationResult({ cleaCertificationResult });
@@ -394,7 +394,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
 
   context('#hasTakenPixPlusDroitMaitre', function() {
 
-    it('returns true when Pix plus maitre certification has been taken in the certification', async function() {
+    it('returns true when Pix plus maitre certification has been taken in the certification', function() {
       // given
       const pixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
       const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitMaitreCertificationResult });
@@ -406,7 +406,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       expect(hasTakenPixPlusDroitMaitre).to.be.true;
     });
 
-    it('returns false when Pix plus maitre certification has not been taken in the certification', async function() {
+    it('returns false when Pix plus maitre certification has not been taken in the certification', function() {
       // given
       const pixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
       const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitMaitreCertificationResult });
@@ -421,7 +421,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
 
   context('#hasAcquiredPixPlusDroitMaitre', function() {
 
-    it('returns true when Pix plus maitre certification has been acquired', async function() {
+    it('returns true when Pix plus maitre certification has been acquired', function() {
       // given
       const pixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
       const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitMaitreCertificationResult });
@@ -433,7 +433,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       expect(hasAcquiredPixPlusDroitMaitre).to.be.true;
     });
 
-    it('returns false when Pix plus maitre certification has not been acquired', async function() {
+    it('returns false when Pix plus maitre certification has not been acquired', function() {
       // given
       const pixPlusDroitMaitreCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();
       const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitMaitreCertificationResult });
@@ -448,7 +448,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
 
   context('#hasTakenPixPlusDroitExpert', function() {
 
-    it('returns true when Pix plus droit expert certification has been taken in the certification', async function() {
+    it('returns true when Pix plus droit expert certification has been taken in the certification', function() {
       // given
       const pixPlusDroitExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
       const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitExpertCertificationResult });
@@ -460,7 +460,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       expect(hasTakenPixPlusDroitExpert).to.be.true;
     });
 
-    it('returns false when Pix plus droit expert certification has not been taken in the certification', async function() {
+    it('returns false when Pix plus droit expert certification has not been taken in the certification', function() {
       // given
       const pixPlusDroitExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
       const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitExpertCertificationResult });
@@ -475,7 +475,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
 
   context('#hasAcquiredPixPlusDroitExpert', function() {
 
-    it('returns true when Pix plus droit expert certification has been acquired', async function() {
+    it('returns true when Pix plus droit expert certification has been acquired', function() {
       // given
       const pixPlusDroitExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
       const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitExpertCertificationResult });
@@ -487,7 +487,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
       expect(hasAcquiredPixPlusDroitExpert).to.be.true;
     });
 
-    it('returns false when Pix plus droit expert certification has not been acquired', async function() {
+    it('returns false when Pix plus droit expert certification has not been acquired', function() {
       // given
       const pixPlusDroitExpertCertificationResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected();
       const certificationResult = domainBuilder.buildCertificationResult({ pixPlusDroitExpertCertificationResult });

--- a/api/tests/unit/domain/models/CleaCertificationResult_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationResult_test.js
@@ -5,7 +5,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
 
   context('#static buildFrom', function() {
 
-    it('builds a CleaCertificationResult acquired', async function() {
+    it('builds a CleaCertificationResult acquired', function() {
       // when
       const cleaCertificationResult = CleaCertificationResult.buildFrom({ acquired: true });
 
@@ -14,7 +14,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
       expect(cleaCertificationResult.status).to.equal(CleaCertificationResult.cleaStatuses.ACQUIRED);
     });
 
-    it('builds a CleaCertificationResult rejected', async function() {
+    it('builds a CleaCertificationResult rejected', function() {
       // when
       const cleaCertificationResult = CleaCertificationResult.buildFrom({ acquired: false });
 
@@ -26,7 +26,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
 
   context('#static buildNotTaken', function() {
 
-    it('builds a CleaCertificationResult not_taken', async function() {
+    it('builds a CleaCertificationResult not_taken', function() {
       // when
       const cleaCertificationResult = CleaCertificationResult.buildNotTaken();
 
@@ -38,7 +38,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
 
   context('#isTaken', function() {
 
-    it('returns true when CleaCertificationResult has a status acquired', async function() {
+    it('returns true when CleaCertificationResult has a status acquired', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
 
@@ -49,7 +49,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
       expect(isTaken).to.be.true;
     });
 
-    it('returns true when CleaCertificationResult has a status rejected', async function() {
+    it('returns true when CleaCertificationResult has a status rejected', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.rejected();
 
@@ -60,7 +60,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
       expect(isTaken).to.be.true;
     });
 
-    it('returns false when CleaCertificationResult has a status not_taken', async function() {
+    it('returns false when CleaCertificationResult has a status not_taken', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
 
@@ -74,7 +74,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
 
   context('#isAcquired', function() {
 
-    it('returns true when CleaCertificationResult has a status acquired', async function() {
+    it('returns true when CleaCertificationResult has a status acquired', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
 
@@ -85,7 +85,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
       expect(isAcquired).to.be.true;
     });
 
-    it('returns true when CleaCertificationResult has a status rejected', async function() {
+    it('returns true when CleaCertificationResult has a status rejected', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.rejected();
 
@@ -96,7 +96,7 @@ describe('Unit | Domain | Models | CleaCertificationResult', function() {
       expect(isAcquired).to.be.false;
     });
 
-    it('returns false when CleaCertificationResult has a status not_taken', async function() {
+    it('returns false when CleaCertificationResult has a status not_taken', function() {
       // given
       const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
 

--- a/api/tests/unit/domain/models/CleaCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationScoring_test.js
@@ -57,7 +57,7 @@ describe('Unit | Domain | Models | CleaCertificationScoring', function() {
 
   context('#static buildNotEligible', function() {
 
-    it('should build a not eligible CleaCertificationScoring', async function() {
+    it('should build a not eligible CleaCertificationScoring', function() {
       // when
       const notEligibleCleaCertificationScoring = CleaCertificationScoring.buildNotEligible({ certificationCourseId: 123 });
 
@@ -161,7 +161,7 @@ describe('Unit | Domain | Models | CleaCertificationScoring', function() {
         expect(hasAcquiredCertif).to.be.true;
       });
 
-      it('for 70 reproducibility rate, it should not obtain certification when there are no competence marks for clea eligible competences', async function() {
+      it('for 70 reproducibility rate, it should not obtain certification when there are no competence marks for clea eligible competences', function() {
         // given
         const competenceId1 = 'competenceId1', competenceId2 = 'competenceId2',
           competenceId3 = 'competenceId3', competenceId4 = 'competenceId4';

--- a/api/tests/unit/domain/models/HigherSchoolingRegistrationSet_test.js
+++ b/api/tests/unit/domain/models/HigherSchoolingRegistrationSet_test.js
@@ -130,7 +130,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', function() {
     });
 
     context('When there are warnings', function() {
-      it('should add a diploma warning', async function() {
+      it('should add a diploma warning', function() {
         const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
         const registration = {
           firstName: 'Beatrix',
@@ -151,7 +151,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', function() {
         expect(warnings[0]).to.deep.equal({ studentNumber: '123ABC', field: 'diploma', value: 'BAD', code: 'unknown' });
       });
 
-      it('should add a study scheme warning', async function() {
+      it('should add a study scheme warning', function() {
         const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
         const registration = {
           firstName: 'Beatrix',
@@ -172,7 +172,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', function() {
         expect(warnings[0]).to.deep.equal({ studentNumber: '123ABC', field: 'study-scheme', value: 'BAD', code: 'unknown' });
       });
 
-      it('should check diplomas and study schemes with lower case', async function() {
+      it('should check diplomas and study schemes with lower case', function() {
         const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
         const registration = {
           firstName: 'Beatrix',
@@ -191,7 +191,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', function() {
         expect(warnings).to.have.lengthOf(0);
       });
 
-      it('should check diplomas and study schemes with Levenshtein distance', async function() {
+      it('should check diplomas and study schemes with Levenshtein distance', function() {
         const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
         const registration = {
           firstName: 'Beatrix',

--- a/api/tests/unit/domain/models/HigherSchoolingRegistration_test.js
+++ b/api/tests/unit/domain/models/HigherSchoolingRegistration_test.js
@@ -16,7 +16,7 @@ describe('Unit | Domain | Models | HigherSchoolingRegistration', function() {
     };
 
     context('when all required fields are presents', function() {
-      it('is valid', async function() {
+      it('is valid', function() {
         try {
           new HigherSchoolingRegistration(validAttributes);
         } catch (e) {

--- a/api/tests/unit/domain/models/Membership_test.js
+++ b/api/tests/unit/domain/models/Membership_test.js
@@ -22,7 +22,7 @@ describe('Unit | Domain | Models | Membership', function() {
 
     context('when organizationRole is invalid', function() {
 
-      it('should throw an InvalidMembershipOrganizationRoleError error', async function() {
+      it('should throw an InvalidMembershipOrganizationRoleError error', function() {
         // given / when
         const membership = new Membership({
           id: '123',

--- a/api/tests/unit/domain/models/PixPlusDroitExpertCertificationResult_test.js
+++ b/api/tests/unit/domain/models/PixPlusDroitExpertCertificationResult_test.js
@@ -5,7 +5,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
 
   context('#static buildFrom', function() {
 
-    it('builds a PixPlusExpertCertificationResult acquired', async function() {
+    it('builds a PixPlusExpertCertificationResult acquired', function() {
       // when
       const pixPlusResult = PixPlusExpertCertificationResult.buildFrom({ acquired: true });
 
@@ -14,7 +14,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
       expect(pixPlusResult.status).to.equal(PixPlusExpertCertificationResult.statuses.ACQUIRED);
     });
 
-    it('builds a PixPlusExpertCertificationResult rejected', async function() {
+    it('builds a PixPlusExpertCertificationResult rejected', function() {
       // when
       const pixPlusResult = PixPlusExpertCertificationResult.buildFrom({ acquired: false });
 
@@ -26,7 +26,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
 
   context('#static buildNotTaken', function() {
 
-    it('builds a PixPlusExpertCertificationResult not_taken', async function() {
+    it('builds a PixPlusExpertCertificationResult not_taken', function() {
       // when
       const pixPlusResult = PixPlusExpertCertificationResult.buildNotTaken();
 
@@ -38,7 +38,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
 
   context('#isTaken', function() {
 
-    it('returns true when PixPlusExpertCertificationResult has a status acquired', async function() {
+    it('returns true when PixPlusExpertCertificationResult has a status acquired', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
 
@@ -49,7 +49,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
       expect(isTaken).to.be.true;
     });
 
-    it('returns true when PixPlusExpertCertificationResult has a status rejected', async function() {
+    it('returns true when PixPlusExpertCertificationResult has a status rejected', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected();
 
@@ -60,7 +60,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
       expect(isTaken).to.be.true;
     });
 
-    it('returns false when PixPlusExpertCertificationResult has a status not_taken', async function() {
+    it('returns false when PixPlusExpertCertificationResult has a status not_taken', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
 
@@ -74,7 +74,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
 
   context('#isAcquired', function() {
 
-    it('returns true when PixPlusExpertCertificationResult has a status acquired', async function() {
+    it('returns true when PixPlusExpertCertificationResult has a status acquired', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.acquired();
 
@@ -85,7 +85,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
       expect(isAcquired).to.be.true;
     });
 
-    it('returns false when PixPlusExpertCertificationResult has a status rejected', async function() {
+    it('returns false when PixPlusExpertCertificationResult has a status rejected', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected();
 
@@ -96,7 +96,7 @@ describe('Unit | Domain | Models | PixPlusExpertCertificationResult', function()
       expect(isAcquired).to.be.false;
     });
 
-    it('returns false when PixPlusExpertCertificationResult has a status not_taken', async function() {
+    it('returns false when PixPlusExpertCertificationResult has a status not_taken', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
 

--- a/api/tests/unit/domain/models/PixPlusDroitMaitreCertificationResult_test.js
+++ b/api/tests/unit/domain/models/PixPlusDroitMaitreCertificationResult_test.js
@@ -5,7 +5,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
 
   context('#static buildFrom', function() {
 
-    it('builds a PixPlusMaitreCertificationResult acquired', async function() {
+    it('builds a PixPlusMaitreCertificationResult acquired', function() {
       // when
       const pixPlusResult = PixPlusMaitreCertificationResult.buildFrom({ acquired: true });
 
@@ -14,7 +14,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
       expect(pixPlusResult.status).to.equal(PixPlusMaitreCertificationResult.statuses.ACQUIRED);
     });
 
-    it('builds a PixPlusMaitreCertificationResult rejected', async function() {
+    it('builds a PixPlusMaitreCertificationResult rejected', function() {
       // when
       const pixPlusResult = PixPlusMaitreCertificationResult.buildFrom({ acquired: false });
 
@@ -26,7 +26,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
 
   context('#static buildNotTaken', function() {
 
-    it('builds a PixPlusMaitreCertificationResult not_taken', async function() {
+    it('builds a PixPlusMaitreCertificationResult not_taken', function() {
       // when
       const pixPlusResult = PixPlusMaitreCertificationResult.buildNotTaken();
 
@@ -38,7 +38,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
 
   context('#isTaken', function() {
 
-    it('returns true when PixPlusMaitreCertificationResult has a status acquired', async function() {
+    it('returns true when PixPlusMaitreCertificationResult has a status acquired', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
 
@@ -49,7 +49,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
       expect(isTaken).to.be.true;
     });
 
-    it('returns true when PixPlusMaitreCertificationResult has a status rejected', async function() {
+    it('returns true when PixPlusMaitreCertificationResult has a status rejected', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();
 
@@ -60,7 +60,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
       expect(isTaken).to.be.true;
     });
 
-    it('returns false when PixPlusMaitreCertificationResult has a status not_taken', async function() {
+    it('returns false when PixPlusMaitreCertificationResult has a status not_taken', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
 
@@ -74,7 +74,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
 
   context('#isAcquired', function() {
 
-    it('returns true when PixPlusMaitreCertificationResult has a status acquired', async function() {
+    it('returns true when PixPlusMaitreCertificationResult has a status acquired', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
 
@@ -85,7 +85,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
       expect(isAcquired).to.be.true;
     });
 
-    it('returns false when PixPlusMaitreCertificationResult has a status rejected', async function() {
+    it('returns false when PixPlusMaitreCertificationResult has a status rejected', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.rejected();
 
@@ -96,7 +96,7 @@ describe('Unit | Domain | Models | PixPlusMaitreCertificationResult', function()
       expect(isAcquired).to.be.false;
     });
 
-    it('returns false when PixPlusMaitreCertificationResult has a status not_taken', async function() {
+    it('returns false when PixPlusMaitreCertificationResult has a status not_taken', function() {
       // given
       const pixPlusResult = domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
 

--- a/api/tests/unit/domain/models/PrivateCertificate_test.js
+++ b/api/tests/unit/domain/models/PrivateCertificate_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Models | PrivateCertificate', function() {
       maxReachableLevelOnCertificationDate: 5,
     };
 
-    it('builds a cancelled PrivateCertificate', async function() {
+    it('builds a cancelled PrivateCertificate', function() {
       // when
       const privateCertificate = PrivateCertificate.buildFrom({ ...commonData, isCancelled: true });
 
@@ -38,7 +38,7 @@ describe('Unit | Domain | Models | PrivateCertificate', function() {
       expect(privateCertificate).to.deep.equal(expectedPrivateCertificate);
     });
 
-    it('builds a validated PrivateCertificate', async function() {
+    it('builds a validated PrivateCertificate', function() {
       // when
       const privateCertificate = PrivateCertificate.buildFrom({ ...commonData, isCancelled: false, assessmentResultStatus: assessmentResultStatuses.VALIDATED });
 
@@ -48,7 +48,7 @@ describe('Unit | Domain | Models | PrivateCertificate', function() {
       expect(privateCertificate).to.deep.equal(expectedPrivateCertificate);
     });
 
-    it('builds a rejected PrivateCertificate', async function() {
+    it('builds a rejected PrivateCertificate', function() {
       // when
       const privateCertificate = PrivateCertificate.buildFrom({ ...commonData, isCancelled: false, assessmentResultStatus: assessmentResultStatuses.REJECTED });
 
@@ -58,7 +58,7 @@ describe('Unit | Domain | Models | PrivateCertificate', function() {
       expect(privateCertificate).to.deep.equal(expectedPrivateCertificate);
     });
 
-    it('builds an error PrivateCertificate', async function() {
+    it('builds an error PrivateCertificate', function() {
       // when
       const privateCertificate = PrivateCertificate.buildFrom({ ...commonData, isCancelled: false, assessmentResultStatus: assessmentResultStatuses.ERROR });
 
@@ -68,7 +68,7 @@ describe('Unit | Domain | Models | PrivateCertificate', function() {
       expect(privateCertificate).to.deep.equal(expectedPrivateCertificate);
     });
 
-    it('builds a started PrivateCertificate', async function() {
+    it('builds a started PrivateCertificate', function() {
       // when
       const privateCertificate = PrivateCertificate.buildFrom({ ...commonData, isCancelled: false, assessmentResultStatus: null });
 

--- a/api/tests/unit/domain/services/organization-invitation-service_test.js
+++ b/api/tests/unit/domain/services/organization-invitation-service_test.js
@@ -93,7 +93,7 @@ describe('Unit | Service | Organization-Invitation Service', function() {
         });
       });
 
-      it('should re-send an email with same code', async function() {
+      it('should re-send an email with same code', function() {
         // then
         const expectedParameters = {
           email: userEmailAddress, organizationName, organizationInvitationId, code, locale, tags,
@@ -177,7 +177,7 @@ describe('Unit | Service | Organization-Invitation Service', function() {
         });
       });
 
-      it('should re-send an email with same code', async function() {
+      it('should re-send an email with same code', function() {
         // then
         const expectedParameters = {
           email: userEmailAddress, organizationName, organizationInvitationId, firstName, lastName, code, locale, tags,
@@ -242,7 +242,7 @@ describe('Unit | Service | Organization-Invitation Service', function() {
         });
       });
 
-      it('should re-send an email with same code', async function() {
+      it('should re-send an email with same code', function() {
         // then
         const expectedParameters = {
           email: userEmailAddress, name: organizationName, organizationInvitationId, code, locale, tags,

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -141,7 +141,7 @@ describe('Unit | Service | ScorecardService', function() {
       });
 
       // then
-      it('should reset each knowledge elements', async function() {
+      it('should reset each knowledge elements', function() {
         expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
         expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
@@ -176,7 +176,7 @@ describe('Unit | Service | ScorecardService', function() {
       });
 
       // then
-      it('should reset each knowledge elements', async function() {
+      it('should reset each knowledge elements', function() {
         expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
         expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
@@ -205,7 +205,7 @@ describe('Unit | Service | ScorecardService', function() {
       const campaignParticipation2Updated = Symbol('campaign participation 2 updated');
       const shouldResetCompetenceEvaluation = false;
 
-      beforeEach(async function() {
+      beforeEach(function() {
         const skill = domainBuilder.buildSkill({ id: skillId });
         const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
         campaign = domainBuilder.buildCampaign.ofTypeAssessment({ targetProfileId: targetProfile.id, targetProfile });
@@ -356,13 +356,13 @@ describe('Unit | Service | ScorecardService', function() {
       });
 
       // then
-      it('should reset each assessments', async function() {
+      it('should reset each assessments', function() {
         expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
         expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
       });
 
-      it('should not save another assessment', async function() {
+      it('should not save another assessment', function() {
         expect(assessmentRepository.save).to.not.have.been.called;
         expect(assessmentRepository.abortByAssessmentId).to.not.have.been.called;
         expect(resetCampaignParticipation).to.equal(null);

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -132,12 +132,12 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function() {
       });
     });
 
-    it('filter knowledge elements if assessment is an improving one', async function() {
+    it('filter knowledge elements if assessment is an improving one', function() {
       // then
       expect(improvementService.filterKnowledgeElementsIfImproving).to.be.called;
     });
 
-    it('fetches answers, targetsSkills challenges and knowledgeElements', async function() {
+    it('fetches answers, targetsSkills challenges and knowledgeElements', function() {
       // then
       expect(data.lastAnswer).to.deep.equal(answer);
       expect(data.allAnswers).to.deep.equal([answer]);

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -118,7 +118,7 @@ describe('Unit | Service | user-service', function() {
 
     const samlId = 'ABCD';
 
-    beforeEach(async function() {
+    beforeEach(function() {
       user = domainBuilder.buildUser();
       authenticationMethod = domainBuilder.buildAuthenticationMethod({
         externalIdentifier: samlId,

--- a/api/tests/unit/domain/types/identifiers-type_test.js
+++ b/api/tests/unit/domain/types/identifiers-type_test.js
@@ -21,7 +21,7 @@ describe('Unit | Domain | Type | identifier-types', function() {
 
     context('when id is invalid', function() {
 
-      it('should reject outside of lower bound', async function() {
+      it('should reject outside of lower bound', function() {
         // given
         const lowerBoundOutOfRangeId = 0;
 
@@ -32,7 +32,7 @@ describe('Unit | Domain | Type | identifier-types', function() {
         expect(error.message).to.equal('"value" must be greater than or equal to 1');
       });
 
-      it('should reject outside of upper bound', async function() {
+      it('should reject outside of upper bound', function() {
         // given
         const upperBoundOutOfRangeId = 2147483648;
 
@@ -64,7 +64,7 @@ describe('Unit | Domain | Type | identifier-types', function() {
 
     context('when id is invalid', function() {
 
-      it('should reject when empty', async function() {
+      it('should reject when empty', function() {
         // given
         const emptyString = '';
 
@@ -75,7 +75,7 @@ describe('Unit | Domain | Type | identifier-types', function() {
         expect(error.message).to.equal('"value" is not allowed to be empty');
       });
 
-      it('should reject when too large', async function() {
+      it('should reject when too large', function() {
         // given
         const tooLargeString = 'A'.repeat(256);
 

--- a/api/tests/unit/domain/usecases/add-tutorial-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/add-tutorial-evaluation_test.js
@@ -38,7 +38,7 @@ describe('Unit | UseCase | add-tutorial-evaluation', function() {
     it('should throw a Domain error', async function() {
       // Given
       tutorialRepository = {
-        get: async () => {
+        get: () => {
           throw new LearningContentNotFoundError();
         },
       };

--- a/api/tests/unit/domain/usecases/add-tutorial-to-user_test.js
+++ b/api/tests/unit/domain/usecases/add-tutorial-to-user_test.js
@@ -31,7 +31,7 @@ describe('Unit | UseCase | add-tutorial-to-user', function() {
     it('should throw a Domain error', async function() {
       // Given
       tutorialRepository = {
-        get: async () => {
+        get: () => {
           throw new LearningContentNotFoundError();
         },
       };

--- a/api/tests/unit/domain/usecases/archive-campaign_test.js
+++ b/api/tests/unit/domain/usecases/archive-campaign_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | archive-campaign', function() {
       return archiveCampaign({ campaignId, userId, campaignRepository });
     });
 
-    it('should verify that the user has the rights', async function() {
+    it('should verify that the user has the rights', function() {
       expect(campaignRepository.checkIfUserOrganizationHasAccessToCampaign).to.have.been.calledWithExactly(campaignId, userId);
     });
 

--- a/api/tests/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
@@ -12,7 +12,7 @@ describe('Unit | UseCase | delete-unlinked-sertification-candidate', function() 
   let certificationCandidateId;
   let certificationCandidateRepository;
 
-  beforeEach(async function() {
+  beforeEach(function() {
     certificationCandidateId = 'dummy certification candidate id';
     certificationCandidateRepository = {
       isNotLinked: sinon.stub(),

--- a/api/tests/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/unit/domain/usecases/finalize-session_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | finalize-session', function() {
   let sessionRepository;
   let certificationReportRepository;
 
-  beforeEach(async function() {
+  beforeEach(function() {
     sessionId = 'dummy session id';
     updatedSession = domainBuilder.buildSession({
       id: sessionId,

--- a/api/tests/unit/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
+++ b/api/tests/unit/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
@@ -25,7 +25,7 @@ describe('Unit | UseCase | find-campaign-profiles-collection-participation-summa
   context('the user belongs to the organization of the campaign', function() {
     let participationSummaries;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.resolves(true);
     });
 

--- a/api/tests/unit/domain/usecases/find-divisions-by-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/find-divisions-by-certification-center_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | find-divisions-by-certification-center', function() {
     findByOrganizationIdForCurrentSchoolYear: sinon.stub(),
   };
 
-  beforeEach(async function() {
+  beforeEach(function() {
     const externalId = 'AAA111';
     const certificationCenter = domainBuilder.buildCertificationCenter({ id: certificationCenterId, externalId });
     organization = domainBuilder.buildOrganization({ externalId });

--- a/api/tests/unit/domain/usecases/find-students-for-enrollement_test.js
+++ b/api/tests/unit/domain/usecases/find-students-for-enrollement_test.js
@@ -28,7 +28,7 @@ describe('Unit | UseCase | find-students-for-enrollment', function() {
     findBySessionId: sinon.stub(),
   };
 
-  beforeEach(async function() {
+  beforeEach(function() {
     const externalId = 'AAA111';
     const certificationCenter = domainBuilder.buildCertificationCenter({ id: certificationCenterId, externalId });
     organization = domainBuilder.buildOrganization({ externalId });

--- a/api/tests/unit/domain/usecases/find-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-tutorials_test.js
@@ -63,7 +63,7 @@ describe('Unit | UseCase | find-tutorials', function() {
       context('when there is at least one invalidated knowledge element and two inferred knowledge element', function() {
         let expectedTutorialList;
 
-        beforeEach(async function() {
+        beforeEach(function() {
           // given
           const userTutorial = { id: 1, userId: 'userId', tutorialId: 'tuto1' };
           const tutorial1 = domainBuilder.buildTutorial({ id: 'tuto1' });

--- a/api/tests/unit/domain/usecases/find-user-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-user-tutorials_test.js
@@ -21,9 +21,9 @@ describe('Unit | UseCase | find-user-tutorials', function() {
 
   context('when there is no tutorial saved by current user', function() {
     beforeEach(function() {
-      tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
-      tutorialRepository = { findByRecordIds: sinon.spy(async () => []) };
-      userTutorialRepository = { find: sinon.spy(async () => []) };
+      tutorialEvaluationRepository = { find: sinon.spy(() => []) };
+      tutorialRepository = { findByRecordIds: sinon.spy(() => []) };
+      userTutorialRepository = { find: sinon.spy(() => []) };
     });
 
     it('should call the userTutorialRepository', async function() {
@@ -46,9 +46,9 @@ describe('Unit | UseCase | find-user-tutorials', function() {
   context('when there is one tutorial saved by current user', function() {
     beforeEach(function() {
       const userTutorial = { id: userTutorialId, userId, tutorialId };
-      tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
-      userTutorialRepository = { find: sinon.spy(async () => [userTutorial]) };
-      tutorialRepository = { findByRecordIds: sinon.spy(async () => [tutorial]) };
+      tutorialEvaluationRepository = { find: sinon.spy(() => []) };
+      userTutorialRepository = { find: sinon.spy(() => [userTutorial]) };
+      tutorialRepository = { findByRecordIds: sinon.spy(() => [tutorial]) };
     });
 
     it('should call the tutorialRepository', async function() {

--- a/api/tests/unit/domain/usecases/get-attendance-sheet_test.js
+++ b/api/tests/unit/domain/usecases/get-attendance-sheet_test.js
@@ -99,7 +99,7 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', function() {
   const odsBuffer = Buffer.from('some ods file');
 
   describe('getAttendanceSheet', function() {
-    beforeEach(async function() {
+    beforeEach(function() {
       // given
       sinon.stub(sessionRepository, 'getWithCertificationCandidates').resolves(sessionWithCandidates);
       sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
@@ -129,7 +129,7 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', function() {
       it('should have rebuild the ods zip with new content.xml file', function() {
         expect(writeOdsUtils.makeUpdatedOdsByContentXml).to.have.been.calledWithExactly({ stringifiedXml: stringifiedSessionAndCandidatesUpdatedXml, odsFilePath: sinon.match('attendance_sheet_template.ods') });
       });
-      it('should return something when user has access', async function() {
+      it('should return something when user has access', function() {
         expect(result).to.deep.equal(odsBuffer);
       });
     });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -14,7 +14,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       recentKnowledgeElements, actualComputedChallenge,
       challengeUrl21, challengeUrl22, improvementService;
 
-    beforeEach(async function() {
+    beforeEach(function() {
 
       userId = 'dummyUserId';
       competenceId = 'dummyCompetenceId';

--- a/api/tests/unit/domain/usecases/get-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/get-scorecard_test.js
@@ -6,14 +6,10 @@ const getScorecard = require('../../../../lib/domain/usecases/get-scorecard');
 describe('Unit | UseCase | get-scorecard', function() {
 
   let scorecardService;
-  let competenceRepository;
-  let competenceEvaluationRepository;
-  let knowledgeElementRepository;
   let scorecardId;
   let competenceId;
   let authenticatedUserId;
   let parseIdStub;
-  const locale = 'fr';
 
   beforeEach(function() {
     scorecardId = '1_1';
@@ -21,9 +17,6 @@ describe('Unit | UseCase | get-scorecard', function() {
     authenticatedUserId = 1;
     scorecardService = { computeScorecard: sinon.stub() };
     parseIdStub = sinon.stub(Scorecard, 'parseId');
-    competenceRepository = {};
-    competenceEvaluationRepository = {};
-    knowledgeElementRepository = {};
   });
 
   afterEach(function() {
@@ -38,36 +31,11 @@ describe('Unit | UseCase | get-scorecard', function() {
 
     context('And user asks for his own scorecard', function() {
 
-      it('should resolve', function() {
-        // given
-        scorecardService.computeScorecard.withArgs({
-          userId: authenticatedUserId,
-          competenceRepository,
-          competenceEvaluationRepository,
-          knowledgeElementRepository,
-          locale,
-        }).resolves({});
-
-        // when
-        const promise = getScorecard({
-          authenticatedUserId,
-          scorecardId,
-          scorecardService,
-          competenceRepository,
-          competenceEvaluationRepository,
-          knowledgeElementRepository,
-          locale,
-        });
-
-        // then
-        return expect(promise).to.be.fulfilled;
-      });
-
       it('should return the user scorecard', async function() {
         // given
         const scorecard = Symbol('Scorecard');
 
-        scorecardService.computeScorecard.resolves(scorecard);
+        scorecardService.computeScorecard.returns(scorecard);
 
         // when
         const userScorecard = await getScorecard({
@@ -85,17 +53,21 @@ describe('Unit | UseCase | get-scorecard', function() {
       it('should reject a "UserNotAuthorizedToAccessEntityError" domain error', function() {
         // given
         const unauthorizedUserId = 42;
-        scorecardService.computeScorecard.resolves({});
+        scorecardService.computeScorecard.returns({});
 
         // when
-        const promise = getScorecard({
-          authenticatedUserId: unauthorizedUserId,
-          scorecardId,
-          scorecardService,
-        });
+        try {
+          getScorecard({
+            authenticatedUserId: unauthorizedUserId,
+            scorecardId,
+            scorecardService,
+          });
 
-        // then
-        return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntityError);
+          expect.fail('Expected error to have been thrown');
+        } catch (e) {
+          // then
+          expect(e).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
+        }
       });
     });
   });

--- a/api/tests/unit/domain/usecases/unarchive-campaign_test.js
+++ b/api/tests/unit/domain/usecases/unarchive-campaign_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | unarchive-campaign', function() {
       return unarchiveCampaign({ campaignId, userId, campaignRepository });
     });
 
-    it('should verify that the user has the rights', async function() {
+    it('should verify that the user has the rights', function() {
       expect(campaignRepository.checkIfUserOrganizationHasAccessToCampaign).to.have.been.calledWithExactly(campaignId, userId);
     });
 

--- a/api/tests/unit/domain/validators/schooling-registration-validator_test.js
+++ b/api/tests/unit/domain/validators/schooling-registration-validator_test.js
@@ -20,7 +20,7 @@ describe('Unit | Domain | Schooling Registration validator', function() {
     };
 
     context('when all required fields are presents', function() {
-      it('is valid', async function() {
+      it('is valid', function() {
         try {
           checkValidation(validAttributes);
         } catch (e) {
@@ -73,7 +73,7 @@ describe('Unit | Domain | Schooling Registration validator', function() {
 
     context('birthCountryCode', function() {
       context('is valid', function() {
-        it('respects INSEE Code, only number', async function() {
+        it('respects INSEE Code, only number', function() {
           try {
             checkValidation({ ...validAttributes, birthCountryCode: '99123' });
           } catch (e) {
@@ -127,7 +127,7 @@ describe('Unit | Domain | Schooling Registration validator', function() {
         expect(error.why).to.equal('bad_values');
       });
 
-      it('is valid when status is \'ST\'', async function() {
+      it('is valid when status is \'ST\'', function() {
         try {
           checkValidation({ ...validAttributes, status: 'ST' });
         } catch (e) {
@@ -135,7 +135,7 @@ describe('Unit | Domain | Schooling Registration validator', function() {
         }
       });
 
-      it('is valid when status is \'AP\'', async function() {
+      it('is valid when status is \'AP\'', function() {
         try {
           checkValidation({ ...validAttributes, nationalIdentifier: '0123456789F', status: 'AP' });
         } catch (e) {
@@ -181,7 +181,7 @@ describe('Unit | Domain | Schooling Registration validator', function() {
         expect(error.why).to.equal('required');
       });
 
-      it('is valid when birthCity is undefined and birthCountry is France', async function() {
+      it('is valid when birthCity is undefined and birthCountry is France', function() {
         try {
           checkValidation({ ...validAttributes, birthCountryCode: FRANCE_COUNTRY_CODE, birthCityCode: '51430', birthCity: undefined });
         } catch (e) {
@@ -194,7 +194,7 @@ describe('Unit | Domain | Schooling Registration validator', function() {
       context('is valid', function() {
         context('when birthCountryCode equal to France', function() {
 
-          it('respects INSEE Code, with one letter', async function() {
+          it('respects INSEE Code, with one letter', function() {
             try {
               checkValidation({ ...validAttributes, birthCountryCode: FRANCE_COUNTRY_CODE, birthCityCode: '2B125' });
             } catch (e) {
@@ -202,7 +202,7 @@ describe('Unit | Domain | Schooling Registration validator', function() {
             }
           });
 
-          it('respects INSEE Code, only number', async function() {
+          it('respects INSEE Code, only number', function() {
             try {
               checkValidation({ ...validAttributes, birthCountryCode: FRANCE_COUNTRY_CODE, birthCityCode: '13125' });
             } catch (e) {
@@ -212,7 +212,7 @@ describe('Unit | Domain | Schooling Registration validator', function() {
         });
 
         context('when birthCountryCode not equal to France', function() {
-          it('is valid with birthCityCode undefined', async function() {
+          it('is valid with birthCityCode undefined', function() {
             try {
               checkValidation({ ...validAttributes, birthCountryCode: '99125', birthCityCode: undefined });
             } catch (e) {

--- a/api/tests/unit/domain/validators/session-validator_test.js
+++ b/api/tests/unit/domain/validators/session-validator_test.js
@@ -55,7 +55,7 @@ describe('Unit | Domain | Validators | session-validator', function() {
 
       context('on room attribute', function() {
 
-        it('should reject with error when room is missing', async function() {
+        it('should reject with error when room is missing', function() {
           // given
           const expectedErrors = [{
             attribute: 'room',
@@ -231,7 +231,7 @@ describe('Unit | Domain | Validators | session-validator', function() {
 
         context('when certificationCenterName is a string', function() {
 
-          it('should not throw an error', async function() {
+          it('should not throw an error', function() {
             const certificationCenterName = '   Coucou le dév qui lit ce message !   ';
             expect(sessionValidator.validateAndNormalizeFilters({ certificationCenterName })).to.not.throw;
             expect(sessionValidator.validateAndNormalizeFilters({ certificationCenterName }).certificationCenterName).to.equal(certificationCenterName.trim());
@@ -270,7 +270,7 @@ describe('Unit | Domain | Validators | session-validator', function() {
 
         context('when status is in the statuses list', function() {
 
-          it('should not throw an error', async function() {
+          it('should not throw an error', function() {
             expect(sessionValidator.validateAndNormalizeFilters({ status: statuses.CREATED })).to.not.throw;
             expect(sessionValidator.validateAndNormalizeFilters({ status: statuses.FINALIZED })).to.not.throw;
             expect(sessionValidator.validateAndNormalizeFilters({ status: statuses.IN_PROCESS })).to.not.throw;
@@ -310,7 +310,7 @@ describe('Unit | Domain | Validators | session-validator', function() {
 
         context('when resultsSentToPrescriberAt is a boolean', function() {
 
-          it('should not throw an error', async function() {
+          it('should not throw an error', function() {
             expect(sessionValidator.validateAndNormalizeFilters({ resultsSentToPrescriberAt: true })).to.not.throw;
             expect(sessionValidator.validateAndNormalizeFilters({ resultsSentToPrescriberAt: false })).to.not.throw;
           });

--- a/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
+++ b/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
@@ -47,7 +47,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
     });
 
     context('when user share his result', function() {
-      it('should return the complete line with 0 certifiable competence and non certifiable', async function() {
+      it('should return the complete line with 0 certifiable competence and non certifiable', function() {
         //given
         sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(false);
         sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
@@ -90,7 +90,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
       });
 
-      it('should return the complete line with 5 certifiable competence', async function() {
+      it('should return the complete line with 5 certifiable competence', function() {
         //given
         sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(true);
         sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
@@ -135,7 +135,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
     });
 
     context('when user has not share his result yet', function() {
-      it('should return the complete line with 5 certifiable competences', async function() {
+      it('should return the complete line with 5 certifiable competences', function() {
         //given
         sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(true);
         sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
@@ -392,7 +392,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
 
       context('when the participant has a division', function() {
 
-        it('should return the line without division information', async function() {
+        it('should return the line without division information', function() {
           //given
           sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(true);
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
@@ -548,7 +548,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
       });
 
       context('when the participant has a student number', function() {
-        it('should return the line without student number information', async function() {
+        it('should return the line without student number information', function() {
           //given
           sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(true);
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -6,7 +6,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function() {
 
   describe('#serializeLine', function() {
 
-    it('should quote strings', async function() {
+    it('should quote strings', function() {
       // given
       const safeNumberAsString = '-123456';
       const csvExpected =
@@ -25,7 +25,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function() {
       expect(csv).to.equal(csvExpected);
     });
 
-    it('should format numbers in French locale', async function() {
+    it('should format numbers in French locale', function() {
       // given
       const csvExpected =
         '123;' +
@@ -41,7 +41,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function() {
       expect(csv).to.equal(csvExpected);
     });
 
-    it('should escape formula-likes to prevent CSV injections', async function() {
+    it('should escape formula-likes to prevent CSV injections', function() {
       // given
       const csvExpected =
         '"\'=formula-like";' +

--- a/api/tests/unit/scripts/import-certification-cpf-countries_test.js
+++ b/api/tests/unit/scripts/import-certification-cpf-countries_test.js
@@ -140,7 +140,7 @@ describe('Unit | Scripts | import-certification-cpf-countries.js', function() {
 
     describe('#when there are no conflicts', function() {
 
-      it('should not throw an error', async function() {
+      it('should not throw an error', function() {
         const countries = [
           {
             code: '99141',

--- a/api/tests/unit/tooling/http-test-server_test.js
+++ b/api/tests/unit/tooling/http-test-server_test.js
@@ -28,7 +28,7 @@ describe('Unit | Tooling | Http-test-server', function() {
 
       const invalidRoute = {
         name: 'foo-route',
-        register: async function(server) {
+        register: function(server) {
           server.route([{
             method: 'GET',
           }]);

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -87,7 +87,7 @@ export default class AddStudentList extends Component {
   }
 
   @action
-  async selectDivision(divisions) {
+  selectDivision(divisions) {
     this.selectedDivisions = divisions;
     return this.router.replaceWith({ queryParams: { divisions } });
   }

--- a/certif/app/components/user-logged-menu.js
+++ b/certif/app/components/user-logged-menu.js
@@ -43,7 +43,7 @@ export default class UserLoggedMenu extends Component {
   }
 
   @action
-  async onCertificationCenterChange(certificationCenter) {
+  onCertificationCenterChange(certificationCenter) {
     this.currentUser.certificationPointOfContact.currentCertificationCenterId = parseInt(certificationCenter.id);
 
     this.closeMenu();

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -25,7 +25,7 @@ export default class AuthenticatedController extends Controller {
   }
 
   @action
-  async closeBanner() {
+  closeBanner() {
     this.isBannerVisible = false;
   }
 }

--- a/certif/app/routes/authenticated/sessions/finalize.js
+++ b/certif/app/routes/authenticated/sessions/finalize.js
@@ -11,7 +11,7 @@ export default class SessionsFinalizeRoute extends Route {
     return session;
   }
 
-  async afterModel(model, transition) {
+  afterModel(model, transition) {
     if (model.isFinalized) {
       this.notifications.error('Cette session a déjà été finalisée.');
 

--- a/certif/app/services/ajax-queue.js
+++ b/certif/app/services/ajax-queue.js
@@ -9,7 +9,7 @@ export default class AjaxQueueService extends Service {
     this._queue = new PQueue({ concurrency: ENV.APP.MAX_CONCURRENT_AJAX_CALLS });
   }
 
-  async add(job) {
+  add(job) {
     return this._queue.add(job);
   }
 }

--- a/certif/tests/integration/components/add-student-list_test.js
+++ b/certif/tests/integration/components/add-student-list_test.js
@@ -311,7 +311,7 @@ module('Integration | Component | add-student-list', function(hooks) {
             </AddStudentList>`);
           });
 
-          test('it should show "Aucun candidat sélectionné | 2 candidat(s) déjà ajouté(s) à la session"', async function(assert) {
+          test('it should show "Aucun candidat sélectionné | 2 candidat(s) déjà ajouté(s) à la session"', function(assert) {
             // then
             const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
             const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
@@ -319,7 +319,7 @@ module('Integration | Component | add-student-list', function(hooks) {
             assert.dom(candidatesSelectedSelector).includesText('Aucun candidat sélectionné');
           });
 
-          test('it should disable the "Ajouter" button', async function(assert) {
+          test('it should disable the "Ajouter" button', function(assert) {
             // then
             const addButtonDisabled = '.bottom-action-bar__actions--add-button.button--disabled';
             assert.dom(addButtonDisabled).exists();
@@ -355,7 +355,7 @@ module('Integration | Component | add-student-list', function(hooks) {
             </AddStudentList>`);
           });
 
-          test('it should show "2 candidat(s) sélectionné(s) | 2 candidat(s) déjà ajouté(s) à la session"', async function(assert) {
+          test('it should show "2 candidat(s) sélectionné(s) | 2 candidat(s) déjà ajouté(s) à la session"', function(assert) {
             // then
             const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
             const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
@@ -363,7 +363,7 @@ module('Integration | Component | add-student-list', function(hooks) {
             assert.dom(candidatesSelectedSelector).includesText('2 candidat(s) sélectionné(s)');
           });
 
-          test('it should show "Ajouter" button', async function(assert) {
+          test('it should show "Ajouter" button', function(assert) {
             // then
             const addButtonDisabled = '.bottom-action-bar__actions--add-button.button--disabled';
             const addButton = ADD_BUTTON_SELECTOR;

--- a/certif/tests/integration/components/certification-candidate-in-staging-item_test.js
+++ b/certif/tests/integration/components/certification-candidate-in-staging-item_test.js
@@ -23,7 +23,7 @@ module('Integration | Component | certification-candidate-in-staging-item', func
   let updateDataStub;
   let candidateInStaging;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     saveStub = sinon.stub().returns();
     cancelStub = sinon.stub().returns();
     updateBirthdateStub = sinon.stub().returns();
@@ -76,7 +76,7 @@ module('Integration | Component | certification-candidate-in-staging-item', func
   });
 
   module('when filling the line with sufficient correct data', function(hooks) {
-    hooks.beforeEach(async () => {
+    hooks.beforeEach(() => {
       candidateInStaging.set('firstName', 'Salut');
       candidateInStaging.set('lastName', 'Salut');
       candidateInStaging.set('birthCity', 'Salut');
@@ -105,7 +105,7 @@ module('Integration | Component | certification-candidate-in-staging-item', func
   });
 
   module('when filling the line with incorrect ', function(hooks) {
-    hooks.beforeEach(async () => {
+    hooks.beforeEach(() => {
       candidateInStaging.set('firstName', 'Salut');
       candidateInStaging.set('lastName', 'Salut');
       candidateInStaging.set('birthCity', 'Salut');

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -14,7 +14,7 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
   let store;
   let certificationIssueReportA;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
 
     certificationIssueReportA = run(() => store.createRecord('certification-issue-report', {

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -14,7 +14,7 @@ module('Integration | Component | SessionFinalization::UnUncompletedReportsInfor
   let store;
   let certificationIssueReportA;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
 
     certificationIssueReportA = run(() => store.createRecord('certification-issue-report', {

--- a/certif/tests/unit/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/unit/components/new-certification-candidate-modal_test.js
@@ -124,7 +124,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
 
   module('#isBirthGeoCodeQuired', function() {
     module('when selected country is Italy', function() {
-      test('should return false for Italy', async function(assert) {
+      test('should return false for Italy', function(assert) {
         // when
         modal.selectedCountryInseeCode = '99127';
 
@@ -172,7 +172,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
 
   module('#isBirthInseeCodeRequired', function() {
     module('when selected country is other than France', function() {
-      test('should return false for other than France', async function(assert) {
+      test('should return false for other than France', function(assert) {
         // when
         modal.selectedCountryInseeCode = '99123';
 
@@ -182,7 +182,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
     });
 
     module('when selected country is France', function() {
-      test('should return true for insee code option', async function(assert) {
+      test('should return true for insee code option', function(assert) {
         // when
         modal.selectedCountryInseeCode = '99100';
         modal.selectedBirthGeoCodeOption = 'insee';
@@ -191,7 +191,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
         assert.true(modal.isBirthInseeCodeRequired);
       });
 
-      test('should return false for postal code option', async function(assert) {
+      test('should return false for postal code option', function(assert) {
         // when
         modal.selectedCountryInseeCode = '99100';
         modal.selectedBirthGeoCodeOption = 'postal';
@@ -203,7 +203,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
   });
 
   module('#isBirthPostalCodeRequired', function() {
-    test('should return true for postal code option', async function(assert) {
+    test('should return true for postal code option', function(assert) {
       // when
       modal.selectedBirthGeoCodeOption = 'postal';
 
@@ -211,7 +211,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
       assert.true(modal.isBirthPostalCodeRequired);
     });
 
-    test('should return false for insee code option', async function(assert) {
+    test('should return false for insee code option', function(assert) {
       // when
       modal.selectedBirthGeoCodeOption = 'insee';
 
@@ -221,7 +221,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
   });
 
   module('#isBirthCityRequired', function() {
-    test('should return true when country is not France', async function(assert) {
+    test('should return true when country is not France', function(assert) {
       // when
       modal.selectedCountryInseeCode = '99123';
 
@@ -229,7 +229,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
       assert.true(modal.isBirthCityRequired);
     });
 
-    test('should return true if country is France and postal code option is selected', async function(assert) {
+    test('should return true if country is France and postal code option is selected', function(assert) {
       // when
       modal.selectedCountryInseeCode = '99100';
       modal.selectedBirthGeoCodeOption = 'postal';
@@ -238,7 +238,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
       assert.true(modal.isBirthCityRequired);
     });
 
-    test('should return false if country is France and insee code option is selected', async function(assert) {
+    test('should return false if country is France and insee code option is selected', function(assert) {
       // when
       modal.selectedCountryInseeCode = '99100';
       modal.selectedBirthGeoCodeOption = 'insee';
@@ -249,7 +249,7 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
   });
 
   module('#countryOptions', function() {
-    test('should return a list of countries', async function(assert) {
+    test('should return a list of countries', function(assert) {
       // when
       modal.args.countries = [
         { name: 'Wakanda', code: '99817' },

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -124,7 +124,7 @@ async function _getReferentiel({
   }
 }
 
-async function _getChallenge({
+function _getChallenge({
   challenges,
   targetSkills,
   assessment,
@@ -160,13 +160,13 @@ function _getChallengeLevel({ assessment, result }) {
   return chosenSkill ? chosenSkill.difficulty : null;
 }
 
-async function proceedAlgo(challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers, userResult, userKE) {
+function proceedAlgo(challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers, userResult, userKE) {
   let isAssessmentOver = false;
   const algoResult = new AlgoResult();
 
   while (!isAssessmentOver) {
 
-    const { challenge, hasAssessmentEnded, estimatedLevel, challengeLevel } = await _getChallenge({
+    const { challenge, hasAssessmentEnded, estimatedLevel, challengeLevel } = _getChallenge({
       challenges,
       targetSkills,
       assessment,
@@ -232,11 +232,9 @@ async function launchTest(argv) {
     targetProfileRepository,
   });
 
-  const proceedUsers = usersKE.map((userKE) => {
+  const algoResults = usersKE.map((userKE) => {
     return proceedAlgo(challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers, userResult, userKE);
   });
-
-  const algoResults = await Promise.all(proceedUsers);
 
   if (enabledCsvOutput) {
     const writeResults = algoResults.map((algoResult) => {

--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.js
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.js
@@ -61,7 +61,7 @@ export default class BackupEmailConfirmationFormComponent extends Component {
     event.preventDefault();
     this.emailValidation.status = STATUS_MAP['successStatus'];
     this.emailValidation.message = null;
-    this.args.sendEmail(this.email);
+    await this.args.sendEmail(this.email);
   }
 
   _hasAPIRejectedCall() {

--- a/mon-pix/app/components/account-recovery/update-sco-record-form.js
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.js
@@ -64,7 +64,7 @@ export default class UpdateScoRecordFormComponent extends Component {
   }
 
   @action
-  async submitUpdate(event) {
+  submitUpdate(event) {
     event.preventDefault();
     this.passwordValidation.status = STATUS_MAP['successStatus'];
     this.passwordValidation.message = null;

--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -20,7 +20,7 @@ export default class CompetenceCardDefault extends Component {
   }
 
   @action
-  async improveCompetenceEvaluation() {
+  improveCompetenceEvaluation() {
     const userId = this.currentUser.user.id;
     const competenceId = this.args.scorecard.competenceId;
     const scorecardId = this.args.scorecard.id;

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -77,7 +77,7 @@ export default class ScorecardDetails extends Component {
   }
 
   @action
-  async improveCompetenceEvaluation() {
+  improveCompetenceEvaluation() {
     const userId = this.currentUser.user.id;
     const competenceId = this.args.scorecard.competenceId;
     const scorecardId = this.args.scorecard.id;

--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -65,7 +65,7 @@ export default class FindScoRecordController extends Controller {
   }
 
   @action
-  async resetErrors() {
+  resetErrors() {
     this.showAlreadyRegisteredEmailError = false;
   }
 

--- a/mon-pix/app/controllers/user-account/language.js
+++ b/mon-pix/app/controllers/user-account/language.js
@@ -21,7 +21,7 @@ export default class UserAccountPersonalInformationController extends Controller
   }
 
   @action
-  async onChangeLang(event) {
+  onChangeLang(event) {
     if (!this.url.isFrenchDomainExtension) {
       this.location.replace(`/mon-compte/langue?lang=${event.target.value}`);
     }

--- a/mon-pix/app/routes/assessments/results.js
+++ b/mon-pix/app/routes/assessments/results.js
@@ -5,7 +5,7 @@ export default class ResultsRoute extends Route {
     return this.modelFor('assessments').reload();
   }
 
-  async afterModel(assessment) {
+  afterModel(assessment) {
     if (assessment.isCertification) {
       return this.transitionTo('index');
     }

--- a/mon-pix/app/routes/campaigns.js
+++ b/mon-pix/app/routes/campaigns.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default class CampaignsRoute extends Route {
-  async model(params) {
+  model(params) {
     return this.store.queryRecord('campaign', { filter: { code: params.code } });
   }
 }

--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -13,7 +13,7 @@ export default class EvaluationStartOrResumeRoute extends Route.extend(SecuredRo
     super.beforeModel(...arguments);
   }
 
-  async model() {
+  model() {
     return this.modelFor('campaigns');
   }
 

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class CampaignLandingPageRoute extends Route {
 
-  async model() {
+  model() {
     return this.modelFor('campaigns');
   }
 

--- a/mon-pix/app/routes/campaigns/fill-in-participant-external-id.js
+++ b/mon-pix/app/routes/campaigns/fill-in-participant-external-id.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 
 export default class FillInParticipantExternalIdRoute extends Route.extend(SecuredRouteMixin) {
 
-  async model() {
+  model() {
     return this.modelFor('campaigns');
   }
 }

--- a/mon-pix/app/routes/campaigns/profiles-collection/send-profile.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/send-profile.js
@@ -2,7 +2,7 @@ import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 export default class SendProfileRoute extends Route.extend(SecuredRouteMixin) {
-  async model() {
+  model() {
     const user = this.currentUser.user;
     const { campaign, campaignParticipation } = this.modelFor('campaigns.profiles-collection');
     return {

--- a/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
@@ -3,7 +3,7 @@ import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route.extend(SecuredRouteMixin) {
 
-  async model() {
+  model() {
     return this.modelFor('campaigns.profiles-collection');
   }
 

--- a/mon-pix/app/routes/campaigns/restricted/login-or-register-to-access.js
+++ b/mon-pix/app/routes/campaigns/restricted/login-or-register-to-access.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
 export default class LoginOrRegisterToAccessRoute extends Route.extend(UnauthenticatedRouteMixin) {
-  async model() {
+  model() {
     return this.modelFor('campaigns');
   }
 }

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -66,7 +66,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     super.beforeModel(...arguments);
   }
 
-  async model() {
+  model() {
     this.isLoading = true;
     return this.modelFor('campaigns');
   }
@@ -92,7 +92,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     }
   }
 
-  async redirect(campaign) {
+  redirect(campaign) {
     if (this.state.doesUserHaveOngoingParticipation) {
       if (campaign.isProfilesCollection) {
         this.replaceWith('campaigns.profiles-collection.start-or-resume', campaign);

--- a/mon-pix/app/routes/login.js
+++ b/mon-pix/app/routes/login.js
@@ -8,9 +8,9 @@ export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) 
   @service store;
 
   @action
-  async authenticate(login, password) {
+  authenticate(login, password) {
 
-    await this._removeExternalUserContext();
+    this._removeExternalUserContext();
 
     const scope = 'mon-pix';
     const trimedLogin = login ? login.trim() : '';
@@ -18,12 +18,12 @@ export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) 
   }
 
   @action
-  async updateExpiredPassword(username, password) {
+  updateExpiredPassword(username, password) {
     this.store.createRecord('reset-expired-password-demand', { username, oneTimePassword: password });
     return this.replaceWith('update-expired-password');
   }
 
-  async _removeExternalUserContext() {
+  _removeExternalUserContext() {
     if (this.session.data && this.session.expectedUserId) {
       delete this.session.data.expectedUserId;
     }

--- a/mon-pix/app/routes/profile.js
+++ b/mon-pix/app/routes/profile.js
@@ -9,7 +9,7 @@ export default class ProfileRoute extends Route.extend(SecuredRouteMixin) {
     return this.currentUser.user;
   }
 
-  async afterModel(user) {
+  afterModel(user) {
     // This reloads are necessary to keep the ui in sync when the
     // user navigates back to this route
     user.belongsTo('profile').reload();

--- a/mon-pix/app/routes/shared-certification.js
+++ b/mon-pix/app/routes/shared-certification.js
@@ -3,7 +3,7 @@ import Model from '@ember-data/model';
 
 export default class SharedCertificationRoute extends Route {
 
-  async redirect(model, transition) {
+  redirect(model, transition) {
     if (!model || !(model instanceof Model)) {
       if (transition && transition.from) {
         transition.abort();

--- a/mon-pix/app/services/ajax-queue.js
+++ b/mon-pix/app/services/ajax-queue.js
@@ -9,7 +9,7 @@ export default class AjaxQueueService extends Service {
     this._queue = new PQueue({ concurrency: ENV.APP.MAX_CONCURRENT_AJAX_CALLS });
   }
 
-  async add(job) {
+  add(job) {
     return this._queue.add(job);
   }
 }

--- a/mon-pix/app/services/competence-evaluation.js
+++ b/mon-pix/app/services/competence-evaluation.js
@@ -18,7 +18,7 @@ export default class CompetenceEvaluationService extends Service {
     }
   }
 
-  async _reloadScorecard(scorecardId) {
+  _reloadScorecard(scorecardId) {
     return this.store.findRecord('scorecard', scorecardId, { include: 'competence-evaluation', reload: true });
   }
 }

--- a/mon-pix/tests/acceptance/authentication_test.js
+++ b/mon-pix/tests/acceptance/authentication_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Authentication', function() {
 
   describe('Success cases', function() {
 
-    describe('Accessing to the default page page while disconnected', async function() {
+    describe('Accessing to the default page page while disconnected', function() {
 
       it('should redirect to the connexion page', async function() {
         // when

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -181,7 +181,7 @@ describe('Acceptance | Certification | Start Certification Course', function() {
               await fillCertificationStarter({ accessCode: 'ABCD12' });
             });
 
-            it('should be redirected on the first challenge of an assessment', async function() {
+            it('should be redirected on the first challenge of an assessment', function() {
               // then
               expect(currentURL().startsWith(`/assessments/${assessment.id}/challenges`)).to.be.true;
             });

--- a/mon-pix/tests/acceptance/challenge-commons_test.js
+++ b/mon-pix/tests/acceptance/challenge-commons_test.js
@@ -45,7 +45,7 @@ describe('Acceptance | Common behavior to all challenges', function() {
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should display the name of the test', async function() {
+    it('should display the name of the test', function() {
       expect(find('.assessment-banner__title').textContent).to.contain(assessment.title);
     });
 
@@ -80,7 +80,7 @@ describe('Acceptance | Common behavior to all challenges', function() {
       expect(find('.assessment-banner__home-link')).to.exist;
     });
 
-    it('should come back to the home route when the back button is clicked', async function() {
+    it('should come back to the home route when the back button is clicked', function() {
       expect(find('.assessment-banner__home-link').getAttribute('href')).to.equal('/');
     });
 

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -38,7 +38,7 @@ describe('Acceptance | Giving feedback about a challenge', function() {
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should be able to directly send a feedback', async () => {
+    it('should be able to directly send a feedback', () => {
       assertThatFeedbackPanelExist();
     });
 

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -11,7 +11,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
   let assessment;
   let qcmChallenge;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     qcmChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QCM');
   });
@@ -86,7 +86,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should mark checkboxes corresponding to the answer and propose to continue', async () => {
+    it('should mark checkboxes corresponding to the answer and propose to continue', () => {
       // then
       expect(findAll('input[type="checkbox"]')[0].checked).to.be.false;
       expect(findAll('input[type="checkbox"]')[1].checked).to.be.true;
@@ -126,7 +126,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       await visit(`/assessments/${assessment.id}/checkpoint`);
     });
 
-    it('should show the result of previous challenge in checkpoint', async () => {
+    it('should show the result of previous challenge in checkpoint', () => {
       // then
       expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
       expect(find('.result-item__instruction').textContent.trim()).to.equal(qcmChallenge.instruction);

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -11,7 +11,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
   let assessment;
   let qcuChallenge;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     qcuChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QCU');
   });
@@ -84,7 +84,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should mark radio button corresponding to the answer and propose to continue', async () => {
+    it('should mark radio button corresponding to the answer and propose to continue', () => {
       // then
       const radioButtons = findAll('input[type=radio][name="radio"]');
       expect(radioButtons[0].checked).to.be.false;
@@ -125,7 +125,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       await visit(`/assessments/${assessment.id}/checkpoint`);
     });
 
-    it('should show the result of previous challenge in checkpoint', async () => {
+    it('should show the result of previous challenge in checkpoint', () => {
       // then
       expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
       expect(find('.result-item__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -12,7 +12,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
   let qrocChallenge;
 
   describe('with input format', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROC');
     });
@@ -148,7 +148,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should set the input value with the current answer and propose to continue', async () => {
+      it('should set the input value with the current answer and propose to continue', () => {
         // then
         expect(find('.challenge-response__proposal').value).to.equal('Reponse');
         expect(find('.challenge-response__proposal').disabled).to.be.true;
@@ -184,7 +184,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await visit(`/assessments/${assessment.id}/checkpoint`);
       });
 
-      it('should show the result of previous challenge in checkpoint', async () => {
+      it('should show the result of previous challenge in checkpoint', () => {
         // then
         expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
         expect(find('.result-item__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
@@ -253,7 +253,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
   });
 
   describe('with text-area format', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withTextArea');
     });
@@ -334,7 +334,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await visit(`/assessments/${assessment.id}/checkpoint`);
       });
 
-      it('should show the result of previous challenge in checkpoint', async () => {
+      it('should show the result of previous challenge in checkpoint', () => {
         // then
         expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
         expect(find('.result-item__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
@@ -370,7 +370,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
   });
 
   describe('with select format', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCWithSelect');
     });
@@ -444,7 +444,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await visit(`/assessments/${assessment.id}/checkpoint`);
       });
 
-      it('should show the result of previous challenge in checkpoint', async () => {
+      it('should show the result of previous challenge in checkpoint', () => {
         // then
         expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
         expect(find('.result-item__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -11,7 +11,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
   let assessment;
   let qrocmDepChallenge;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     assessment = server.create('assessment', 'ofCompetenceEvaluationType');
   });
 
@@ -132,7 +132,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should set the input text with previous answers and propose to continue', async () => {
+      it('should set the input text with previous answers and propose to continue', () => {
         // then
         expect(find('div[data-test="qrocm-label-0"]').innerHTML).to.contains('Station <strong>1</strong> :');
         expect(find('div[data-test="qrocm-label-1"]').innerHTML).to.contains('Station <em>2</em> :');
@@ -163,7 +163,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should set the select with previous answer and propose to continue', async () => {
+      it('should set the select with previous answer and propose to continue', () => {
         // then
         expect(findAll('select[data-test="challenge-response-proposal-selector"] option')[1].hasAttribute('selected'));
 
@@ -230,7 +230,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       await visit(`/assessments/${assessment.id}/checkpoint`);
     });
 
-    it('should show the result of previous challenges in checkpoint', async () => {
+    it('should show the result of previous challenges in checkpoint', () => {
       // then
       expect(findAll('.result-item__icon')[0].title).to.equal('Réponse incorrecte');
       const instructionStripped = qrocmDepChallenge.instruction.slice(0, 102);

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -37,13 +37,13 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             await visit(`/assessments/${assessment.id}/challenges/0`);
           });
 
-          it('should display an overlay and tooltip', async () => {
+          it('should display an overlay and tooltip', () => {
             // then
             expect(find('.challenge__focused-overlay')).to.exist;
             expect(find('.tooltip-tag__information')).to.exist;
           });
 
-          it('should disable input and buttons', async () => {
+          it('should disable input and buttons', () => {
             // then
             expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.exist;
             expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.exist;
@@ -75,13 +75,13 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await click('.tooltip-tag-information__button');
             });
 
-            it('should hide an overlay and tooltip', async () => {
+            it('should hide an overlay and tooltip', () => {
               // then
               expect(find('.challenge__focused-overlay')).to.not.exist;
               expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
             });
 
-            it('should enable input and buttons', async () => {
+            it('should enable input and buttons', () => {
               // then
               expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
               expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
@@ -141,13 +141,13 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             await visit(`/assessments/${assessment.id}/challenges/0`);
           });
 
-          it('should hide the overlay and tooltip', async function() {
+          it('should hide the overlay and tooltip', function() {
             // then
             expect(find('.challenge__focused-overlay')).to.not.exist;
             expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
           });
 
-          it('should enable input and buttons', async function() {
+          it('should enable input and buttons', function() {
             // then
             expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
             expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
@@ -207,7 +207,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           await visit(`/assessments/${assessment.id}/challenges/0`);
         });
 
-        it('should not display instructions', async function() {
+        it('should not display instructions', function() {
           // then
           expect(find('.focused-challenge-instructions-action__confirmation-button')).to.not.exist;
         });

--- a/mon-pix/tests/acceptance/challenge-timed_test.js
+++ b/mon-pix/tests/acceptance/challenge-timed_test.js
@@ -24,11 +24,11 @@ describe('Acceptance | Timed challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should hide the challenge statement', async () => {
+      it('should hide the challenge statement', () => {
         expect(find('.challenge-statement')).to.not.exist;
       });
 
-      it('should ensure the challenge does not automatically start', async () => {
+      it('should ensure the challenge does not automatically start', () => {
         expect(find('.timeout-gauge')).to.not.exist;
       });
     });
@@ -109,11 +109,11 @@ describe('Acceptance | Timed challenge', () => {
 
     });
 
-    it('should hide the challenge statement of the second challenge', async () => {
+    it('should hide the challenge statement of the second challenge', () => {
       expect(find('.challenge-statement')).to.not.exist;
     });
 
-    it('should ensure the challenge does not automatically start of the second challenge', async () => {
+    it('should ensure the challenge does not automatically start of the second challenge', () => {
       expect(find('.timeout-gauge')).to.not.exist;
     });
 

--- a/mon-pix/tests/acceptance/compare-answer-solution-qroc_test.js
+++ b/mon-pix/tests/acceptance/compare-answer-solution-qroc_test.js
@@ -27,11 +27,11 @@ describe('Acceptance | Compare answers and solutions for QROC questions', functi
       await visit(`/assessments/${assessment.id}/results`);
     });
 
-    it('should display the REPONSE link from the results screen', async function() {
+    it('should display the REPONSE link from the results screen', function() {
       expect(find('.result-item .js-correct-answer').textContent).to.contain('Réponses et tutos');
     });
 
-    it('should not yet display the modal nor its content', async function() {
+    it('should not yet display the modal nor its content', function() {
       expect(find('.comparison-window')).to.be.null;
       expect(find('.comparison-window__header .comparison-window__result-item-index')).to.be.null;
       expect(find('.comparison-window__header .comparison-window__title .comparison-window__title-text')).to.be.null;
@@ -46,23 +46,23 @@ describe('Acceptance | Compare answers and solutions for QROC questions', functi
       await click('.result-item:nth-child(1) .result-item__correction-button');
     });
 
-    it('should be able to access the modal directly from the url', async function() {
+    it('should be able to access the modal directly from the url', function() {
       expect(find('.comparison-window')).to.exist;
     });
 
-    it('should contain an instruction', async function() {
+    it('should contain an instruction', function() {
       expect(find('.comparison-window--body .challenge-statement-instruction__text')).to.exist;
     });
 
-    it('should contain a correction zone', async function() {
+    it('should contain a correction zone', function() {
       expect(find('.comparison-window__corrected-answers--qroc')).to.exist;
     });
 
-    it('should contain a zone reserved for feedback panel', async function() {
+    it('should contain a zone reserved for feedback panel', function() {
       expect(find('.comparison-window__feedback-panel')).to.exist;
     });
 
-    it('should contain a closing button', async function() {
+    it('should contain a closing button', function() {
       expect(find('.pix-modal__close-link > span')).to.exist;
     });
   });

--- a/mon-pix/tests/acceptance/competences-results_test.js
+++ b/mon-pix/tests/acceptance/competences-results_test.js
@@ -65,8 +65,8 @@ describe('Acceptance | competences results', function() {
       expect(find('.pix-return-to').getAttribute('href')).to.equal('/competences');
     });
 
-    context('When user obtained 0 pix', async function() {
-      beforeEach(async function() {
+    context('When user obtained 0 pix', function() {
+      beforeEach(function() {
 
         const area = this.server.schema.areas.find(3);
 
@@ -91,8 +91,8 @@ describe('Acceptance | competences results', function() {
       });
     });
 
-    context('When user obtained 5 pix (less than level 1)', async function() {
-      beforeEach(async function() {
+    context('When user obtained 5 pix (less than level 1)', function() {
+      beforeEach(function() {
 
         const area = this.server.schema.areas.find(3);
 
@@ -117,8 +117,8 @@ describe('Acceptance | competences results', function() {
       });
     });
 
-    context('When user obtained 17 pix and level 2', async function() {
-      beforeEach(async function() {
+    context('When user obtained 17 pix and level 2', function() {
+      beforeEach(function() {
 
         const area = this.server.schema.areas.find(3);
 

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -54,9 +54,9 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
 
   });
 
-  context('When user is logged', async function() {
+  context('When user is logged', function() {
 
-    context('When user has seen send profile page but has not send it', async function() {
+    context('When user has seen send profile page but has not send it', function() {
 
       it('should redirect directly to send profile page', async function() {
         // when
@@ -67,7 +67,7 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
       });
     });
 
-    context('When user has already send his profile', async function() {
+    context('When user has already send his profile', function() {
 
       it('should redirect directly to send already sent page', async function() {
         // given

--- a/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
+++ b/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
@@ -23,7 +23,7 @@ describe('Acceptance | Competence Evaluations | Resume Competence Evaluations',
         await visit('/competences/1/evaluer');
       });
 
-      it('should redirect to signin page', async function() {
+      it('should redirect to signin page', function() {
         expect(currentURL()).to.equal('/connexion');
       });
 
@@ -49,7 +49,7 @@ describe('Acceptance | Competence Evaluations | Resume Competence Evaluations',
           await visit('/competences/1/evaluer');
         });
 
-        it('should redirect to assessment', async function() {
+        it('should redirect to assessment', function() {
           // then
           expect(currentURL()).to.contains(/assessments/);
           expect(find('.assessment-banner')).to.exist;
@@ -61,7 +61,7 @@ describe('Acceptance | Competence Evaluations | Resume Competence Evaluations',
           await visit('/competences/nonExistantCompetenceId/evaluer');
         });
 
-        it('should show an error message', async function() {
+        it('should show an error message', function() {
           expect(find('.error-page__main-content')).to.exist;
         });
       });

--- a/mon-pix/tests/acceptance/sitemap_test.js
+++ b/mon-pix/tests/acceptance/sitemap_test.js
@@ -22,25 +22,25 @@ describe('Acceptance | Sitemap', function() {
       await visit('/plan-du-site');
     });
 
-    it('should contain a link to pix.fr/accessibilite', async function() {
+    it('should contain a link to pix.fr/accessibilite', function() {
       // then
       const accessibilityLink = findAll('.sitemap-content-items-link-resources__resource > a')[0];
       expect(accessibilityLink.getAttribute('href')).to.contains('/accessibilite');
     });
 
-    it('should contain a link to pix.fr/conditions-generales-d-utilisation', async function() {
+    it('should contain a link to pix.fr/conditions-generales-d-utilisation', function() {
       // then
       const cguLink = findAll('.sitemap-content-items-link-resources__resource > a')[1];
       expect(cguLink.getAttribute('href')).to.contains('/conditions-generales-d-utilisation');
     });
 
-    it('should contain a link to pix.fr/aide-accessibilite', async function() {
+    it('should contain a link to pix.fr/aide-accessibilite', function() {
       // then
       const accessibilityHelpLink = findAll('a[data-test-resource-link]')[0];
       expect(accessibilityHelpLink.getAttribute('href')).to.contains('/aide-accessibilite');
     });
 
-    it('should contain a link to pix.fr/politique-protection-donnees-personnelles-app', async function() {
+    it('should contain a link to pix.fr/politique-protection-donnees-personnelles-app', function() {
       // then
       const cguPolicyLink = findAll('a[data-test-resource-link]')[1];
       expect(cguPolicyLink.getAttribute('href')).to.contains('/politique-protection-donnees-personnelles-app');

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -36,14 +36,14 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
       });
 
-      it('should be redirect to connexion page', async function() {
+      it('should be redirect to connexion page', function() {
         // then
         expect(currentURL()).to.equal('/connexion');
       });
 
     });
 
-    describe('When user is logged in', async function() {
+    describe('When user is logged in', function() {
 
       const competenceResultName = 'Competence Nom';
       const partnerCompetenceResultName = 'badge partner competence nom';
@@ -174,7 +174,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         expect(findAll('.badge-acquired-card').length).to.equal(1);
       });
 
-      describe('when campaign has stages', async function() {
+      describe('when campaign has stages', function() {
 
         it('should display reached stage', async function() {
           // given
@@ -253,7 +253,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
     });
   });
 
-  context('when campaign is for Novice and isSimplifiedAccess', async function() {
+  context('when campaign is for Novice and isSimplifiedAccess', function() {
     let campaignForNovice;
 
     beforeEach(function() {

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -93,7 +93,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               await click('.button');
             });
 
-            it('should redirect to assessment', async function() {
+            it('should redirect to assessment', function() {
               // then
               expect(currentURL()).to.contains('/didacticiel');
             });
@@ -122,7 +122,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               await click('.campaign-landing-page__start-button');
             });
 
-            it('should redirect to assessment', async function() {
+            it('should redirect to assessment', function() {
               // then
               expect(currentURL()).to.contains('/didacticiel');
             });
@@ -142,7 +142,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await click('.button');
         });
 
-        it('should redirect to assessment after signup', async function() {
+        it('should redirect to assessment after signup', function() {
           // then
           expect(currentURL()).to.contains('/didacticiel');
         });
@@ -160,7 +160,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await click('.button');
         });
 
-        it('should redirect to assessment after signup', async function() {
+        it('should redirect to assessment after signup', function() {
           // then
           expect(currentURL()).to.contains('/didacticiel');
         });
@@ -173,7 +173,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await visit(`/campagnes/${campaign.code}`);
         });
 
-        it('should redirect to signup page when starting a campaign', async function() {
+        it('should redirect to signup page when starting a campaign', function() {
           // then
           expect(currentURL()).to.contains('/inscription');
         });
@@ -262,7 +262,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await startCampaignByCodeAndExternalId(campaign.code, externalId256Characters);
           });
 
-          it('should redirect to fill in external participant id page', async function() {
+          it('should redirect to fill in external participant id page', function() {
             // then
             expect(currentURL()).to.contains('/identifiant');
           });
@@ -274,7 +274,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await startCampaignByCodeAndExternalId(campaign.code);
           });
 
-          it('should redirect to assessment', async function() {
+          it('should redirect to assessment', function() {
             // then
             expect(currentURL()).to.contains('/didacticiel');
           });
@@ -327,7 +327,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await visit(`campagnes/${campaign.code}`);
         });
 
-        it('should redirect to assessment when starting a campaign', async function() {
+        it('should redirect to assessment when starting a campaign', function() {
           // then
           expect(currentURL()).to.not.contains('/didacticiel');
           expect(currentURL()).to.contains('/assessments');
@@ -345,7 +345,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await visit(`campagnes/${campaign.code}?retry=true`);
           });
 
-          it('should redirect to assessment when retrying the campaign', async function() {
+          it('should redirect to assessment when retrying the campaign', function() {
             // then
             expect(currentURL()).to.contains('/evaluation');
           });
@@ -360,7 +360,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await visit(`campagnes/${campaign.code}?retry=true&hasUserSeenLandingPage=true`);
           });
 
-          it('should redirect to assessment results when retrying the campaign', async function() {
+          it('should redirect to assessment results when retrying the campaign', function() {
             // then
             expect(currentURL()).to.contains('/evaluation/resultats');
           });

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -79,7 +79,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await click('.button');
             });
 
-            it('should redirect to send profile page', async function() {
+            it('should redirect to send profile page', function() {
               // then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
             });
@@ -108,7 +108,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await click('.campaign-landing-page__start-button');
             });
 
-            it('should redirect to send profile page', async function() {
+            it('should redirect to send profile page', function() {
               // then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
             });
@@ -128,7 +128,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           await click('.button');
         });
 
-        it('should redirect to send profile page after signup', async function() {
+        it('should redirect to send profile page after signup', function() {
           // then
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
         });
@@ -146,7 +146,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           await click('.button');
         });
 
-        it('should redirect to send profile page after signup', async function() {
+        it('should redirect to send profile page after signup', function() {
           // then
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
         });
@@ -267,7 +267,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await startCampaignByCodeAndExternalId(campaign.code);
           });
 
-          it('should redirect to send profile page', async function() {
+          it('should redirect to send profile page', function() {
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
           });

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -202,7 +202,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             });
           });
 
-          context('When user must accept Pix last terms of service', async function() {
+          context('When user must accept Pix last terms of service', function() {
 
             it('should redirect to campaign landing page after accept terms of service', async function() {
               // given
@@ -550,7 +550,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           await startCampaignByCode(campaign.code);
         });
 
-        it('should redirect to signin page', async function() {
+        it('should redirect to signin page', function() {
           // then
           expect(currentURL()).to.equal('/inscription');
         });
@@ -608,7 +608,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await click('.button');
           });
 
-          it('should redirect to fill-in-participant-external-id page after signup', async function() {
+          it('should redirect to fill-in-participant-external-id page after signup', function() {
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/identifiant`);
           });
@@ -760,7 +760,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
         context('When association is already done', function() {
 
-          beforeEach(async function() {
+          beforeEach(function() {
             server.create('schooling-registration-user-association', {
               campaignCode: campaign.code,
             });
@@ -827,7 +827,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await startCampaignByCode(campaign.code);
           });
 
-          it('should show the identifiant page after clicking on start button in landing page', async function() {
+          it('should show the identifiant page after clicking on start button in landing page', function() {
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/identifiant`);
           });
         });
@@ -888,7 +888,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           await visit('/campagnes/codefaux');
         });
 
-        it('should show an error message', async function() {
+        it('should show an error message', function() {
           // then
           expect(currentURL()).to.equal('/campagnes/codefaux');
           expect(find('.title').textContent).to.contains('Oups, la page demandée n’est pas accessible.');
@@ -1018,7 +1018,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
           });
 
-          context('When user is already reconciled in another organization', async function() {
+          context('When user is already reconciled in another organization', function() {
 
             it('should reconcile and redirect to landing-page', async function() {
               // given
@@ -1045,7 +1045,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           const externalUserToken = 'aaa.' + btoa('{"first_name":"JeanPrescrit","last_name":"Campagne","saml_id":"SamlId","source":"external","iat":1545321469,"exp":4702193958}') + '.bbb';
 
           beforeEach(async function() {
-            server.post('/schooling-registration-dependent-users/external-user-token', async () => {
+            server.post('/schooling-registration-dependent-users/external-user-token', () => {
               return new Response(409, {}, {
                 errors: [{
                   status: '409',
@@ -1185,7 +1185,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               // given
               const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
 
-              server.post('/schooling-registration-dependent-users/external-user-token', async () => {
+              server.post('/schooling-registration-dependent-users/external-user-token', () => {
                 return new Response(409, {}, {
                   errors: [{
                     status: '409',

--- a/mon-pix/tests/acceptance/starting-a-course_test.js
+++ b/mon-pix/tests/acceptance/starting-a-course_test.js
@@ -10,7 +10,7 @@ describe('Acceptance | Starting a course', function() {
   setupMirage();
   let demoCourse;
 
-  beforeEach(async function() {
+  beforeEach(function() {
     server.createList('challenge', 3, 'forDemo');
     demoCourse = server.create('course', { nbChallenges: 3 });
   });

--- a/mon-pix/tests/acceptance/terms-of-service_test.js
+++ b/mon-pix/tests/acceptance/terms-of-service_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | terms-of-service', function() {
     });
   });
 
-  describe('When user log in and must validate Pix latest terms of service', async function() {
+  describe('When user log in and must validate Pix latest terms of service', function() {
 
     it('should be redirected to terms-of-services page', async function() {
       // when
@@ -30,7 +30,7 @@ describe('Acceptance | terms-of-service', function() {
     });
   });
 
-  describe('when the user has validated terms of service', async function() {
+  describe('when the user has validated terms of service', function() {
     it('should redirect to default page when user validate the terms of service', async function() {
       // given
       await authenticateByEmail(user);

--- a/mon-pix/tests/acceptance/user-dashboard_test.js
+++ b/mon-pix/tests/acceptance/user-dashboard_test.js
@@ -20,7 +20,7 @@ describe('Acceptance | User dashboard page', function() {
 
   describe('Visit the user dashboard page', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       user = server.create('user', 'withEmail');
     });
 
@@ -46,7 +46,7 @@ describe('Acceptance | User dashboard page', function() {
 
   describe('campaign-participation-overviews', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       user = server.create('user', 'withEmail');
     });
 
@@ -207,7 +207,7 @@ describe('Acceptance | User dashboard page', function() {
 
     describe('when user has new information to see', function() {
 
-      beforeEach(async function() {
+      beforeEach(function() {
         user = server.create('user', 'withEmail');
       });
 

--- a/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
@@ -42,7 +42,7 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
     });
   });
 
-  context('when the user does not have an email associated with his account', async function() {
+  context('when the user does not have an email associated with his account', function() {
 
     it('should render recover account backup email confirmation form', async function() {
       // given

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -23,7 +23,7 @@ describe('Integration | Component | ChallengeStatement', function() {
     return render(hbs`<ChallengeStatement @challenge={{this.challenge}} @assessment={{this.assessment}} @onTooltipClose={{this.onTooltipClose}}/>`);
   }
 
-  beforeEach(async function() {
+  beforeEach(function() {
     class currentUser extends Service {
       user = {
         hasSeenFocusedChallengeTooltip: false,

--- a/mon-pix/tests/integration/components/challenge/statement/focused-tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/focused-tooltip_test.js
@@ -33,7 +33,7 @@ describe('Integration | Component | Tooltip', function() {
       await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipClose}}/>`);
     });
 
-    it('should not render the tooltip', async function() {
+    it('should not render the tooltip', function() {
       // then
       expect(find(tooltip)).to.not.exist;
     });
@@ -60,7 +60,7 @@ describe('Integration | Component | Tooltip', function() {
       await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipClose}}/>`);
     });
 
-    it('should render the tooltip with a confirmation button', async function() {
+    it('should render the tooltip with a confirmation button', function() {
       // then
       expect(find(tooltip)).to.exist;
       expect(find(confirmationButton)).to.exist;
@@ -98,7 +98,7 @@ describe('Integration | Component | Tooltip', function() {
     });
 
     describe('when the challenge starts', function() {
-      it('should not render the tooltip', async function() {
+      it('should not render the tooltip', function() {
         // then
         expect(find(tooltip)).to.not.exist;
       });

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -197,7 +197,7 @@ describe('Integration | Component | comparison-window', function() {
       });
 
       describe('when challenge type is QROC', function() {
-        describe('and challenge is not autoReply', async function() {
+        describe('and challenge is not autoReply', function() {
 
           it('should display answers', async function() {
             // given
@@ -212,7 +212,7 @@ describe('Integration | Component | comparison-window', function() {
           });
         });
 
-        describe('and challenge is autoReply', async function() {
+        describe('and challenge is autoReply', function() {
           it('should hide answers when correction has no solutionToDisplay', async function() {
             // given
             challenge = EmberObject.create({ type: 'QROC', autoReply: true });

--- a/mon-pix/tests/integration/components/competence-card-default_test.js
+++ b/mon-pix/tests/integration/components/competence-card-default_test.js
@@ -81,7 +81,7 @@ describe('Integration | Component | competence-card-default', function() {
       expect(find('.score-value').textContent).to.equal(scorecard.level.toString());
     });
 
-    context('when user can start the competence', async function() {
+    context('when user can start the competence', function() {
 
       it('should show the button "Commencer"', async function() {
         // given
@@ -97,7 +97,7 @@ describe('Integration | Component | competence-card-default', function() {
 
     });
 
-    context('when user can continue the competence', async function() {
+    context('when user can continue the competence', function() {
       it('should show the button "Reprendre"', async function() {
         // given
         const scorecard = { area, level: 3, isFinished: false, isStarted: true };
@@ -132,7 +132,7 @@ describe('Integration | Component | competence-card-default', function() {
       });
     });
 
-    context('when user has finished the competence', async function() {
+    context('when user has finished the competence', function() {
       it('should show the improving button when there is no remaining days before improving', async function() {
         // given
         const scorecard = { area, level: 3, isFinished: true, isStarted: false, remainingDaysBeforeImproving: 0 };

--- a/mon-pix/tests/integration/components/competence-card-mobile_test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile_test.js
@@ -80,7 +80,7 @@ describe('Integration | Component | competence-card-mobile', function() {
       expect(find('.score-value').textContent).to.equal(scorecard.level.toString());
     });
 
-    context('when user can continue the competence', async function() {
+    context('when user can continue the competence', function() {
 
       context('and the user has reached the maximum level', function() {
         beforeEach(async function() {
@@ -100,7 +100,7 @@ describe('Integration | Component | competence-card-mobile', function() {
       });
     });
 
-    context('when user has finished the competence', async function() {
+    context('when user has finished the competence', function() {
 
       context('and the user has reached the maximum level', function() {
         beforeEach(async function() {

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -204,7 +204,7 @@ describe('Integration | Component | feedback-panel', function() {
       await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} @alwaysOpenForm={{this.alwaysOpenForm}} />`);
     });
 
-    it('should display the "form" view', async function() {
+    it('should display the "form" view', function() {
       expect(find('.feedback-panel__view--form')).to.exist;
       expect(findAll(DROPDOWN).length).to.equal(1);
     });
@@ -232,7 +232,7 @@ describe('Integration | Component | feedback-panel', function() {
       await click(OPEN_FEEDBACK_BUTTON);
     });
 
-    it('should display the "form" view', async function() {
+    it('should display the "form" view', function() {
       expect(find('.feedback-panel__view--form')).to.exist;
       expect(findAll(DROPDOWN).length).to.equal(1);
     });

--- a/mon-pix/tests/integration/components/navbar-burger-menu_test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu_test.js
@@ -10,7 +10,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
 
   setupIntlRenderingTest();
 
-  beforeEach(async function() {
+  beforeEach(function() {
     class currentUser extends Service { user = {
       fullName: 'Bobby Carotte',
     }}
@@ -55,7 +55,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
   });
 
   context('when user has participations', function() {
-    beforeEach(async function() {
+    beforeEach(function() {
       class currentUser extends Service {
         user = {
           hasAssessmentParticipations: true,
@@ -75,7 +75,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
   });
 
   context('when user has no participations', function() {
-    beforeEach(async function() {
+    beforeEach(function() {
       class currentUser extends Service {
         user = {
           hasAssessmentParticipations: false,

--- a/mon-pix/tests/integration/components/navbar-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-header_test.js
@@ -25,7 +25,7 @@ describe('Integration | Component | navbar-header', function() {
       expect(find('.navbar-desktop-header__container')).to.exist;
     });
 
-    it('should render skip links', async function() {
+    it('should render skip links', function() {
       expect(contains(this.intl.t('common.skip-links.skip-to-content'))).to.exist;
       expect(contains(this.intl.t('common.skip-links.skip-to-footer'))).to.exist;
     });

--- a/mon-pix/tests/integration/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel_test.js
@@ -93,14 +93,14 @@ describe('Integration | Component | QROC solution panel', function() {
           await render(hbs`<QrocSolutionPanel @answer={{this.answer}} @solution={{this.solution}}/>`);
         });
 
-        it('should display the answer in bold green', async function() {
+        it('should display the answer in bold green', function() {
           // then
           expect(find('.correction-qroc-box-answer')).to.exist;
           expect(find('.correction-qroc-box__answer')).to.exist;
           expect(find('.correction-qroc-box-answer--correct')).to.exist;
         });
 
-        it('should not display the solution', async function() {
+        it('should not display the solution', function() {
           // then
           expect(find('.comparison-window-solution')).to.not.exist;
         });

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -95,13 +95,13 @@ describe('Integration | Component | QROCm dep solution panel', function() {
           await render(hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`);
         });
 
-        it('should display one solution in bold green', async function() {
+        it('should display one solution in bold green', function() {
           // then
           const noAnswerSolutionBlockList = findAll(SOLUTION_BLOCK);
           expect(noAnswerSolutionBlockList).to.have.lengthOf(1);
         });
 
-        it('should display the empty answer with the default message "Pas de réponse" in italic', async function() {
+        it('should display the empty answer with the default message "Pas de réponse" in italic', function() {
           // then
           const firstAnswerInput = findAll(ANSWER)[0];
           expect(firstAnswerInput).to.exist;
@@ -111,7 +111,7 @@ describe('Integration | Component | QROCm dep solution panel', function() {
       });
 
       describe('When the answer is wrong', function() {
-        beforeEach(async function() {
+        beforeEach(function() {
           // given
           const answer = EmberObject.create({
             id: 'answer_id',

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -66,13 +66,13 @@ describe('Integration | Component | QROCm ind solution panel', function() {
 
       describe('When the answer is correct', function() {
 
-        it('should display the correct answer in green bold', async function() {
+        it('should display the correct answer in green bold', function() {
           // then
           const correctAnswerText = findAll(ANSWER)[CORRECT_ANSWER_POSITION];
           expect(correctAnswerText.classList.contains('correction-qroc-box-answer--correct')).to.be.true;
         });
 
-        it('should not display the solution block', async function() {
+        it('should not display the solution block', function() {
           // then
           const solutionBlockList = findAll(SOLUTION_BLOCK);
           const correctSolutionBlock = solutionBlockList[CORRECT_ANSWER_POSITION];
@@ -85,7 +85,7 @@ describe('Integration | Component | QROCm ind solution panel', function() {
       describe('When there is no answer', function() {
         const EMPTY_DEFAULT_MESSAGE = 'Pas de réponse';
 
-        it('should display one solution in bold green', async function() {
+        it('should display one solution in bold green', function() {
           // then
           const noAnswerSolutionBlock = findAll(SOLUTION_BLOCK)[NO_ANSWER_POSITION];
           const noAnswerSolutionText = findAll(SOLUTION_TEXT)[NO_ANSWER_POSITION];
@@ -94,7 +94,7 @@ describe('Integration | Component | QROCm ind solution panel', function() {
           expect(noAnswerSolutionText).to.exist;
         });
 
-        it('should display the empty answer with the default message "Pas de réponse" in italic', async function() {
+        it('should display the empty answer with the default message "Pas de réponse" in italic', function() {
           // then
           const answerInput = findAll(ANSWER)[NO_ANSWER_POSITION];
 
@@ -105,7 +105,7 @@ describe('Integration | Component | QROCm ind solution panel', function() {
       });
 
       describe('When the answer is wrong', function() {
-        it('should display one solution in bold green', async function() {
+        it('should display one solution in bold green', function() {
           // then
           const wrongSolutionBlock = findAll(SOLUTION_BLOCK)[WRONG_ANSWER_POSITION];
           const wrongSolutionText = findAll(SOLUTION_TEXT)[WRONG_ANSWER_POSITION];
@@ -125,7 +125,7 @@ describe('Integration | Component | QROCm ind solution panel', function() {
           expect(find('.comparison-window-solution__text').textContent).to.contains(solutionToDisplay);
         });
 
-        it('should display the wrong answer in line-throughed bold', async function() {
+        it('should display the wrong answer in line-throughed bold', function() {
           // then
           const answerInput = findAll(ANSWER)[WRONG_ANSWER_POSITION];
 

--- a/mon-pix/tests/integration/components/qrocm-proposal_test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal_test.js
@@ -146,7 +146,7 @@ describe('Integration | Component | QROCm proposal', function() {
             allInputElements = findAll('.challenge-response__proposal');
           });
 
-          it('should have an aria-label', async function() {
+          it('should have an aria-label', function() {
             // then
             expect(allInputElements.length).to.be.equal(data.expectedAriaLabel.length);
             allInputElements.forEach((element, index) => {
@@ -154,7 +154,7 @@ describe('Integration | Component | QROCm proposal', function() {
             });
           });
 
-          it('should not have a label', async function() {
+          it('should not have a label', function() {
             // then
             expect(find('label')).to.be.null;
           });
@@ -182,7 +182,7 @@ describe('Integration | Component | QROCm proposal', function() {
             allInputElements = findAll('.challenge-response__proposal');
           });
 
-          it('should have a label', async function() {
+          it('should have a label', function() {
             // then
             expect(allLabelElements.length).to.be.equal(allInputElements.length);
             expect(allLabelElements.length).to.be.equal(data.expectedLabel.length);
@@ -191,12 +191,12 @@ describe('Integration | Component | QROCm proposal', function() {
             });
           });
 
-          it('should not have an aria-label', async function() {
+          it('should not have an aria-label', function() {
             // then
             expect(find('.challenge-response__proposal').getAttribute('aria-label')).to.be.null;
           });
 
-          it('should connect the label with the input', async function() {
+          it('should connect the label with the input', function() {
             // then
             expect(allInputElements.length).to.equal(allLabelElements.length);
             const allInputElementsId = allInputElements.map((inputElement) => inputElement.getAttribute('id'));

--- a/mon-pix/tests/integration/components/routes/register-form_test.js
+++ b/mon-pix/tests/integration/components/routes/register-form_test.js
@@ -122,7 +122,7 @@ describe('Integration | Component | routes/register-form', function() {
 
   context('errors management', function() {
 
-    context('When authentication service fails', async function() {
+    context('When authentication service fails', function() {
 
       it('Should display registerErrorMessage when authentication service fails with username error', async function() {
         // given
@@ -366,9 +366,9 @@ describe('Integration | Component | routes/register-form', function() {
       });
     });
 
-    context('When student is already reconciled in the same organization', async function() {
+    context('When student is already reconciled in the same organization', function() {
 
-      context('When student account is authenticated by email only', async function() {
+      context('When student account is authenticated by email only', function() {
 
         it('should display the error message related to the short code S61)', async function() {
           // given
@@ -397,7 +397,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      context('When student account is authenticated by username only', async function() {
+      context('When student account is authenticated by username only', function() {
 
         it('should display the error message related to the short code S62)', async function() {
           // given
@@ -426,7 +426,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      context('When student account is authenticated by SamlId only', async function() {
+      context('When student account is authenticated by SamlId only', function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
@@ -455,7 +455,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      context('When student account is authenticated by SamlId and username', async function() {
+      context('When student account is authenticated by SamlId and username', function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
@@ -484,7 +484,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      context('When student account is authenticated by SamlId and email', async function() {
+      context('When student account is authenticated by SamlId and email', function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
@@ -513,7 +513,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      context('When student account is authenticated by SamlId, email and username', async function() {
+      context('When student account is authenticated by SamlId, email and username', function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
@@ -542,7 +542,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      context('When student account is authenticated by email and username', async function() {
+      context('When student account is authenticated by email and username', function() {
 
         it('should display the error message related to the short code S62)', async function() {
           // given
@@ -573,9 +573,9 @@ describe('Integration | Component | routes/register-form', function() {
 
     });
 
-    context('When student is already reconciled in others organization', async function() {
+    context('When student is already reconciled in others organization', function() {
 
-      describe('When student account is authenticated by email only', async function() {
+      describe('When student account is authenticated by email only', function() {
 
         it('should display the error message related to the short code S51)', async function() {
           // given
@@ -604,7 +604,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by username only', async function() {
+      describe('When student account is authenticated by username only', function() {
 
         it('should display the error message related to the short code S52)', async function() {
           // given
@@ -633,7 +633,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by SamlId only', async function() {
+      describe('When student account is authenticated by SamlId only', function() {
 
         it('should display the error message related to the short code S53)', async function() {
           // given
@@ -662,7 +662,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by SamlId and username', async function() {
+      describe('When student account is authenticated by SamlId and username', function() {
 
         it('should display the error message related to the short code S53)', async function() {
           // given
@@ -691,7 +691,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by SamlId and email', async function() {
+      describe('When student account is authenticated by SamlId and email', function() {
 
         it('should display the error message related to the short code S53)', async function() {
           // given
@@ -720,7 +720,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by SamlId, username and email', async function() {
+      describe('When student account is authenticated by SamlId, username and email', function() {
 
         it('should display the error message related to the short code S53)', async function() {
           // given
@@ -749,7 +749,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by username and email', async function() {
+      describe('When student account is authenticated by username and email', function() {
 
         it('should display the error message related to the short code S52)', async function() {
           // given

--- a/mon-pix/tests/integration/components/scorecard-details_test.js
+++ b/mon-pix/tests/integration/components/scorecard-details_test.js
@@ -97,7 +97,7 @@ describe('Integration | Component | scorecard-details', function() {
       expect(find('.score-value').textContent).to.contain('–');
     });
 
-    context('When the user has finished a competence', async function() {
+    context('When the user has finished a competence', function() {
       let scorecard;
 
       beforeEach(function() {
@@ -152,7 +152,7 @@ describe('Integration | Component | scorecard-details', function() {
         expect(find('.scorecard-details__improvement-countdown').textContent).to.contains('3 jours');
       });
 
-      context('and the user has reached the max level', async function() {
+      context('and the user has reached the max level', function() {
         beforeEach(async function() {
           // given
           const scorecard = {
@@ -222,7 +222,7 @@ describe('Integration | Component | scorecard-details', function() {
       });
     });
 
-    context('When the user has started a competence', async function() {
+    context('When the user has started a competence', function() {
 
       it('should display a button stating "Reprendre"', async function() {
         // given
@@ -258,7 +258,7 @@ describe('Integration | Component | scorecard-details', function() {
         expect(find('.tutorials')).to.not.exist;
       });
 
-      context('and the user has some tutorials', async function() {
+      context('and the user has some tutorials', function() {
         it('should display the tutorial section and the related tutorials', async function() {
           // given
           const tuto1 = EmberObject.create({

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -25,7 +25,7 @@ describe('Integration | Component | signin form', function() {
 
   setupIntlRenderingTest();
 
-  describe('Rendering', async function() {
+  describe('Rendering', function() {
 
     it('should display an input for identifiant field', async function() {
       // when

--- a/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
@@ -49,12 +49,12 @@ describe('Integration | Component | user-certifications-detail-competences-list'
       @maxReachableLevelOnCertificationDate={{this.maxReachableLevelOnCertificationDate}} />`);
   });
 
-  it('renders', async function() {
+  it('renders', function() {
     // then
     expect(find(PARENT_SELECTOR)).to.exist;
   });
 
-  it('should have "Compétences certifiées (niveaux sur 5)" as a title', async function() {
+  it('should have "Compétences certifiées (niveaux sur 5)" as a title', function() {
     // then
     expect(find(`${PARENT_SELECTOR} h2`).textContent).to.equal('Compétences certifiées (niveaux sur 5)');
   });

--- a/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
@@ -37,7 +37,7 @@ describe('Integration | Component | user certifications detail header', function
       await render(hbs`{{user-certifications-detail-header certification=certification}}`);
     });
 
-    it('renders', async function() {
+    it('renders', function() {
       expect(find(PARENT_SELECTOR)).to.exist;
     });
 

--- a/mon-pix/tests/integration/components/user-logged-menu_test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu_test.js
@@ -18,7 +18,7 @@ describe('Integration | Component | user logged menu', function() {
 
   describe('when rendering for logged user', function() {
 
-    beforeEach(async function() {
+    beforeEach(function() {
       // given
       class currentUserService extends Service {
         user = {

--- a/mon-pix/tests/unit/adapters/user-tutorial_test.js
+++ b/mon-pix/tests/unit/adapters/user-tutorial_test.js
@@ -28,7 +28,7 @@ describe('Unit | Adapters | user-tutorial', function() {
   });
 
   describe('#urlForFindAll', () => {
-    it('should return API to find related tutorials', async function() {
+    it('should return API to find related tutorials', function() {
       // when
       const url = adapter.urlForFindAll('user-tutorial');
 
@@ -38,7 +38,7 @@ describe('Unit | Adapters | user-tutorial', function() {
   });
 
   describe('#urlForDeleteRecord', () => {
-    it('should return API to delete a user-tutorial', async function() {
+    it('should return API to delete a user-tutorial', function() {
       // given
       const tutorialId = 'tutorialId';
       const tutorial = { adapterOptions: { tutorialId } };

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco_test.js
@@ -593,7 +593,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
       });
 
-      describe('When another student is already reconciled on the same organization', async function() {
+      describe('When another student is already reconciled on the same organization', function() {
 
         it('should return a conflict error and display the error message related to the short code R70)', async function() {
 

--- a/mon-pix/tests/unit/helpers/jwt_test.js
+++ b/mon-pix/tests/unit/helpers/jwt_test.js
@@ -9,7 +9,7 @@ describe('Unit | Helpers | decodeToken', function() {
 
   describe('decodeToken', function() {
 
-    it('should decode valid token', async function() {
+    it('should decode valid token', function() {
       const accessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiRmlyc3QiLCJsYXN0X25hbWUiOiJMYXN0Iiwic2FtbF9pZCI6InNhbWxJRDEyMzQ1NjciLCJpYXQiOjE1OTc5Mjk0NDgsImV4cCI6MTU5NzkzMzA0OH0.bk7HPPwoa0bx6uxE92HXj1ak8DintQx5Id_1wyudZkg';
       const decodedToken = decodeToken(accessToken);
       const expectedResult = {
@@ -22,7 +22,7 @@ describe('Unit | Helpers | decodeToken', function() {
       expect(decodedToken).to.deep.equal(expectedResult);
     });
 
-    it('should decode valid token with accented characters in firstName, lastName', async function() {
+    it('should decode valid token with accented characters in firstName, lastName', function() {
       const accessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiTm_DqW1pZSIsImxhc3RfbmFtZSI6IkHDrmnDr21hbsOoIiwic2FtbF9pZCI6InNhbWxJRDEyMzQ1NjciLCJpYXQiOjE1OTc5Mjk0NDgsImV4cCI6MTU5NzkzMzA0OH0.XZJCiDE73sTqHrSmVc99ynypQHzxw3wwZahLUvxgdZY';
       const decodedToken = decodeToken(accessToken);
       const expectedResult = {

--- a/mon-pix/tests/unit/helpers/scorecard-aria-label.js
+++ b/mon-pix/tests/unit/helpers/scorecard-aria-label.js
@@ -26,7 +26,7 @@ describe('Unit | Helper | scorecard-aria-label', function() {
       component = createGlimmerComponent('component:scorecard-aria-label');
     });
 
-    it('should return that competence is not started', async function() {
+    it('should return that competence is not started', function() {
       // given
       const scorecard = EmberObject.create({
         isNotStarted: true,
@@ -39,7 +39,7 @@ describe('Unit | Helper | scorecard-aria-label', function() {
       sinon.assert.calledWith(intlServiceStub.t, 'pages.profile.competence-card.image-info.no-level');
     });
 
-    it('should return that first level of competence is started but not finished', async function() {
+    it('should return that first level of competence is started but not finished', function() {
       // given
       const scorecard = EmberObject.create({
         isNotStarted: false,
@@ -57,7 +57,7 @@ describe('Unit | Helper | scorecard-aria-label', function() {
       sinon.assert.calledWith(intlServiceStub.t, 'pages.profile.competence-card.image-info.first-level', expectedTranslationsParams);
     });
 
-    it('should return current level and percentage completed of the next level', async function() {
+    it('should return current level and percentage completed of the next level', function() {
       // given
       const scorecard = EmberObject.create({
         isNotStarted: false,

--- a/mon-pix/tests/unit/mixins/secured-route-mixin_test.js
+++ b/mon-pix/tests/unit/mixins/secured-route-mixin_test.js
@@ -98,7 +98,7 @@ describe('Unit | Mixin | secured-route-mixin', function() {
           currentUser.user.mustValidateTermsOfService = true;
         });
 
-        it('does not returns the upstream promise', async function() {
+        it('does not returns the upstream promise', function() {
           expect(route.beforeModel(transition)).to.be.undefined;
         });
 

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -74,7 +74,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
         challengeId: model.challenge.id,
       });
     });
-    context('when the assessment is a Preview', async function() {
+    context('when the assessment is a Preview', function() {
       beforeEach(function() {
         const assessmentForPreview = {
           answers: [],
@@ -100,7 +100,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
       });
     });
 
-    context('when the asked challenges is already answered', async function() {
+    context('when the asked challenges is already answered', function() {
       beforeEach(function() {
         const assessmentWithAnswers = {
           answers: [{ id: 3, challenge: {
@@ -291,7 +291,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
     });
 
     context('when saving fails', function() {
-      it('should remove temporary answer and send error', async function() {
+      it('should remove temporary answer and send error', function() {
         // given
         const error = { message: 'error' };
         answerToChallengeOne.save = sinon.stub().rejects(error);

--- a/mon-pix/tests/unit/services/ajax-queue_test.js
+++ b/mon-pix/tests/unit/services/ajax-queue_test.js
@@ -23,7 +23,7 @@ describe('Unit | Service | ajax-queue', function() {
       const expectedValue = 1;
 
       // when
-      const actualValue = await ajaxQueueService.add(async () => { return expectedValue; });
+      const actualValue = await ajaxQueueService.add(() => { return expectedValue; });
 
       // then
       expect(actualValue).to.equal(expectedValue);

--- a/mon-pix/tests/unit/services/competence-evaluation_test.js
+++ b/mon-pix/tests/unit/services/competence-evaluation_test.js
@@ -16,7 +16,7 @@ describe('Unit | Service | competence-evaluation', function() {
     const scorecardId = 'scorecardId';
     let store, router;
 
-    beforeEach(async function() {
+    beforeEach(function() {
       // given
       competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
       store = Service.create({
@@ -34,7 +34,7 @@ describe('Unit | Service | competence-evaluation', function() {
         await competenceEvaluationService.improve({ userId, competenceId });
       });
 
-      it('creates a competence-evaluation for improving', async function() {
+      it('creates a competence-evaluation for improving', function() {
         // then
         sinon.assert.calledWith(store.queryRecord, 'competence-evaluation', {
           improve: true,
@@ -43,13 +43,13 @@ describe('Unit | Service | competence-evaluation', function() {
         });
       });
 
-      it('redirects to competences.resume route', async function() {
+      it('redirects to competences.resume route', function() {
         // then
         sinon.assert.calledWith(router.transitionTo, 'competences.resume', competenceId);
       });
     });
 
-    context('when improving fails with ImproveCompetenceEvaluationForbidden error', async function() {
+    context('when improving fails with ImproveCompetenceEvaluationForbidden error', function() {
       beforeEach(async function() {
         // given
         competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
@@ -65,16 +65,16 @@ describe('Unit | Service | competence-evaluation', function() {
         await competenceEvaluationService.improve({ userId, competenceId, scorecardId });
       });
 
-      it('does not redirect to competence.resume route', async function() {
+      it('does not redirect to competence.resume route', function() {
         // then
         sinon.assert.notCalled(router.transitionTo);
       });
     });
 
-    context('when improving fails with another error', async function() {
+    context('when improving fails with another error', function() {
       const error = new Error();
 
-      beforeEach(async function() {
+      beforeEach(function() {
         // given
         competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
         store = Service.create({

--- a/mon-pix/tests/unit/utils/progress-in-assessment_test.js
+++ b/mon-pix/tests/unit/utils/progress-in-assessment_test.js
@@ -98,7 +98,7 @@ describe('Unit | Utility | progress-in-assessment', function() {
       });
     });
 
-    it('should return the current step number modulus maxStepsNumber', async function() {
+    it('should return the current step number modulus maxStepsNumber', function() {
       // given
       const currentChallengeNumber = 8;
 

--- a/orga/app/components/team/members-list-item.js
+++ b/orga/app/components/team/members-list-item.js
@@ -58,7 +58,7 @@ export default class MembersListItem extends Component {
   }
 
   @action
-  async updateRoleOfMember(membership) {
+  updateRoleOfMember(membership) {
     this.isEditionMode = false;
 
     if (!this.selectedNewRole) return false;

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -21,7 +21,7 @@ export default class AssessmentResultsRoute extends Route {
     },
   };
 
-  async model(params) {
+  model(params) {
     const campaign = this.modelFor('authenticated.campaigns.campaign');
     return RSVP.hash({
       campaign,

--- a/orga/app/routes/authenticated/team/list.js
+++ b/orga/app/routes/authenticated/team/list.js
@@ -11,7 +11,7 @@ export default class ListRoute extends Route {
 
   @service currentUser;
 
-  async model(params) {
+  model(params) {
     const organization = this.currentUser.organization;
     const memberships = this.store.query('membership', {
       filter: {

--- a/orga/app/services/ajax-queue.js
+++ b/orga/app/services/ajax-queue.js
@@ -9,7 +9,7 @@ export default class AjaxQueueService extends Service {
     this._queue = new PQueue({ concurrency: ENV.APP.MAX_CONCURRENT_AJAX_CALLS });
   }
 
-  async add(job) {
+  add(job) {
     return this._queue.add(job);
   }
 }

--- a/orga/orga-lint.txt
+++ b/orga/orga-lint.txt
@@ -1,0 +1,91 @@
+/Users/vincenthardouin/dev/pix/pix/orga/app/components/team/members-list-item.js
+  60:3  error  Async method 'updateRoleOfMember' has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/app/routes/authenticated/team/list.js
+  14:3  error  Async method 'model' has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/app/services/ajax-queue.js
+  12:3  error  Async method 'add' has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/acceptance/authentication_test.js
+  59:31  error  Async arrow function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/acceptance/campaign-activity_test.js
+  45:33  error  Async arrow function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/acceptance/campaign-creation_test.js
+  49:69  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/acceptance/campaign-list_test.js
+  83:33  error  Async arrow function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/acceptance/sco-student-list_test.js
+  120:26  error  Async function has no 'await' expression  require-await
+  169:26  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/auth/login-form_test.js
+  168:49  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+  43:70  error  Async function has no 'await' expression  require-await
+  48:44  error  Async function has no 'await' expression  require-await
+  54:63  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
+  12:20  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
+  37:41  error  Async function has no 'await' expression  require-await
+  42:49  error  Async function has no 'await' expression  require-await
+  48:63  error  Async function has no 'await' expression  require-await
+  54:47  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/campaign/header/tabs_test.js
+  31:54  error  Async function has no 'await' expression  require-await
+  35:45  error  Async function has no 'await' expression  require-await
+  51:55  error  Async function has no 'await' expression  require-await
+  55:53  error  Async function has no 'await' expression  require-await
+  72:52  error  Async function has no 'await' expression  require-await
+  76:54  error  Async function has no 'await' expression  require-await
+  80:48  error  Async function has no 'await' expression  require-await
+  84:59  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/modal/dialog_test.js
+  22:45  error  Async function has no 'await' expression  require-await
+  29:42  error  Async function has no 'await' expression  require-await
+  59:34  error  Async function has no 'await' expression  require-await
+  68:51  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/students/sco/dissociate-user-modal_test.js
+  22:66  error  Async function has no 'await' expression  require-await
+  31:69  error  Async function has no 'await' expression  require-await
+  40:66  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/students/sco/header-actions_test.js
+  32:58  error  Async function has no 'await' expression  require-await
+  53:64  error  Async function has no 'await' expression  require-await
+  69:51  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/students/sco/list_test.js
+  154:62  error  Async function has no 'await' expression  require-await
+  160:61  error  Async function has no 'await' expression  require-await
+  208:70  error  Async function has no 'await' expression  require-await
+  212:44  error  Async function has no 'await' expression  require-await
+  234:72  error  Async function has no 'await' expression  require-await
+  238:54  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/integration/components/students/sup/edit-student-number-modal_test.js
+   42:64  error  Async function has no 'await' expression  require-await
+   48:68  error  Async function has no 'await' expression  require-await
+  192:41  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
+  33:56  error  Async function has no 'await' expression  require-await
+  61:54  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/unit/controllers/authenticated/certifications_test.js
+  120:53  error  Async function has no 'await' expression  require-await
+  133:55  error  Async function has no 'await' expression  require-await
+
+/Users/vincenthardouin/dev/pix/pix/orga/tests/unit/services/file-saver_test.js
+  57:28  error  Async function has no 'await' expression  require-await

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -56,7 +56,7 @@ module('Acceptance | authentication', function(hooks) {
 
     let user;
 
-    hooks.beforeEach(async () => {
+    hooks.beforeEach(() => {
       user = createUserWithMembership();
       createPrescriberByUser(user);
     });

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -42,7 +42,7 @@ module('Acceptance | Campaign Activity', function(hooks) {
     });
 
     module('When campaign is of type profiles collection', function(hooks) {
-      hooks.beforeEach(async () => {
+      hooks.beforeEach(() => {
         campaignId = 2;
         server.create('campaign', 'ofTypeProfilesCollection', { id: campaignId, participationsCount: 1 });
         server.create('campaign-profile', { id: 1, campaignId, lastName: 'Bacri' });

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -46,7 +46,7 @@ module('Acceptance | Campaign Creation', function(hooks) {
       notificationMessagesService.clearAll();
     });
 
-    test('it should be accessible for an authenticated prescriber', async function(assert) {
+    test('it should be accessible for an authenticated prescriber', function(assert) {
       // then
       assert.equal(currentURL(), '/campagnes/creation');
       assert.contains('Création d\'une campagne');

--- a/orga/tests/acceptance/campaign-list_test.js
+++ b/orga/tests/acceptance/campaign-list_test.js
@@ -80,7 +80,7 @@ module('Acceptance | Campaign List', function(hooks) {
     module('When using creator filter', function(hooks) {
       let creator;
 
-      hooks.beforeEach(async () => {
+      hooks.beforeEach(() => {
         creator = server.create('user', { firstName: 'Harry', lastName: 'Cojaune' });
         server.create('campaign', { creator });
       });

--- a/orga/tests/acceptance/sco-student-list_test.js
+++ b/orga/tests/acceptance/sco-student-list_test.js
@@ -117,7 +117,7 @@ module('Acceptance | Sco Student List', function(hooks) {
 
       module('when prescriber is looking for students', function(hooks) {
 
-        hooks.beforeEach(async function() {
+        hooks.beforeEach(function() {
           organizationId = user.memberships.models.firstObject.organizationId;
           server.create('student', { organizationId, firstName: 'Chuck', lastName: 'Norris', hasEmail: false });
           server.create('student', { organizationId, firstName: 'John', lastName: 'Rambo', hasEmail: true });
@@ -166,7 +166,7 @@ module('Acceptance | Sco Student List', function(hooks) {
       });
 
       module('when student is associated', function(hooks) {
-        hooks.beforeEach(async function() {
+        hooks.beforeEach(function() {
           organizationId = user.memberships.models.firstObject.organizationId;
 
           server.createList('student', 5, { organizationId });

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -165,7 +165,7 @@ module('Integration | Component | Auth::LoginForm', function(hooks) {
     assert.dom('#login-form-error-message').hasText(expectedErrorMessages);
   });
 
-  test('it should not display context message', async function(assert) {
+  test('it should not display context message', function(assert) {
     assert.dom('login-form__information').doesNotExist();
   });
 

--- a/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendations_test.js
@@ -40,18 +40,18 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
     />`);
     });
 
-    test('it should display the tube analysis list of the campaign', async function(assert) {
+    test('it should display the tube analysis list of the campaign', function(assert) {
       assert.dom('[aria-label="Sujet"]').exists({ count: 2 });
       assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
     });
 
-    test('it should display tube details', async function(assert) {
+    test('it should display tube details', function(assert) {
       const firstTube = '[aria-label="Sujet"]:first-child';
       assert.dom(firstTube).containsText('Tube A');
       assert.dom(firstTube).containsText('Competence A');
     });
 
-    test('it should order by recommendation desc by default', async function(assert) {
+    test('it should order by recommendation desc by default', function(assert) {
       assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
     });
 

--- a/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
@@ -9,7 +9,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
   const campaignId = 1;
   let dataFetcher;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(function() {
     // given
     this.set('campaignId', campaignId);
 

--- a/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
@@ -34,24 +34,24 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
     await render(hbs`<Campaign::Charts::ParticipantsByStage @campaignId={{campaignId}} @onSelectStage={{onSelectStage}} />`);
   });
 
-  test('it should display stage stars', async function(assert) {
+  test('it should display stage stars', function(assert) {
     assert.dom('[data-test-status=acquired]').isVisible({ count: 1 });
     assert.dom('[data-test-status=unacquired]').isVisible({ count: 1 });
   });
 
-  test('it should display participants number', async function(assert) {
+  test('it should display participants number', function(assert) {
     // then
     assert.contains('0 participant');
     assert.contains('5 participants');
   });
 
-  test('it should display participants percentage by stages', async function(assert) {
+  test('it should display participants percentage by stages', function(assert) {
     // then
     assert.contains('0 %');
     assert.contains('100 %');
   });
 
-  test('it should not display empty tooltip', async function(assert) {
+  test('it should not display empty tooltip', function(assert) {
     // then
     assert.dom('[role="tooltip"]').doesNotExist();
   });

--- a/orga/tests/integration/components/campaign/header/tabs_test.js
+++ b/orga/tests/integration/components/campaign/header/tabs_test.js
@@ -28,11 +28,11 @@ module('Integration | Component | Campaign::Header::Tabs', function(hooks) {
       await render(hbs`<Campaign::Header::Tabs @campaign={{campaign}}/>`);
     });
 
-    test('it should display campaign settings item', async function(assert) {
+    test('it should display campaign settings item', function(assert) {
       assert.dom('nav a[href="/campagnes/12/parametres"]').hasText('Paramètres');
     });
 
-    test('it should display activity item', async function(assert) {
+    test('it should display activity item', function(assert) {
       assert.dom('nav a[href="/campagnes/12"]').hasText('Activité');
     });
   });
@@ -48,11 +48,11 @@ module('Integration | Component | Campaign::Header::Tabs', function(hooks) {
       await render(hbs`<Campaign::Header::Tabs @campaign={{campaign}}/>`);
     });
 
-    test('it should display evaluation results item', async function(assert) {
+    test('it should display evaluation results item', function(assert) {
       assert.dom('nav a[href="/campagnes/13/resultats-evaluation"]').hasText('Résultats (10)');
     });
 
-    test('it should display campaign analyse item', async function(assert) {
+    test('it should display campaign analyse item', function(assert) {
       assert.dom('nav a[href="/campagnes/13/analyse"]').hasText('Analyse');
     });
   });
@@ -69,19 +69,19 @@ module('Integration | Component | Campaign::Header::Tabs', function(hooks) {
       await render(hbs`<Campaign::Header::Tabs @campaign={{campaign}}/>`);
     });
 
-    test('it should display profile results item', async function(assert) {
+    test('it should display profile results item', function(assert) {
       assert.dom('nav a[href="/campagnes/13/profils"]').hasText('Résultats (6)');
     });
 
-    test('it should not display participation item', async function(assert) {
+    test('it should not display participation item', function(assert) {
       assert.dom('nav a[href="/campagnes/13/evaluations"]').doesNotExist();
     });
 
-    test('it should not display analyse item', async function(assert) {
+    test('it should not display analyse item', function(assert) {
       assert.dom('nav a[href="/campagnes/13/analyse"]').doesNotExist();
     });
 
-    test('it should not display evaluation results item', async function(assert) {
+    test('it should not display evaluation results item', function(assert) {
       assert.dom('nav a[href="/campagnes/13/resultats-evaluation"]').doesNotExist();
     });
   });

--- a/orga/tests/integration/components/modal/dialog_test.js
+++ b/orga/tests/integration/components/modal/dialog_test.js
@@ -19,14 +19,14 @@ module('Integration | Component | modal', function(hooks) {
       return render(hbs`<Modal::Dialog @display={{display}} @title={{title}} @close={{close}} @additionalContainerClass={{additionalContainerClass}}>Mon contenu</Modal::Dialog>`);
     });
 
-    test('should render title and content', async function(assert) {
+    test('should render title and content', function(assert) {
       this.set('display', true);
 
       assert.contains('Mon titre');
       assert.contains('Mon contenu');
     });
 
-    test('should not display the modal', async function(assert) {
+    test('should not display the modal', function(assert) {
       this.set('display', false);
 
       assert.notContains('Mon titre');
@@ -56,7 +56,7 @@ module('Integration | Component | modal', function(hooks) {
       assert.ok(close.called);
     });
 
-    test('should be accessible', async function(assert) {
+    test('should be accessible', function(assert) {
       this.set('display', true);
 
       assert.dom('[aria-modal="true"]').exists();
@@ -65,7 +65,7 @@ module('Integration | Component | modal', function(hooks) {
       assert.dom('#modal_mon_titre_label').exists();
     });
 
-    test('should add additional container class', async function(assert) {
+    test('should add additional container class', function(assert) {
       const additionalContainerClass = 'a_class';
       this.set('display', true);
       this.set('additionalContainerClass', additionalContainerClass);

--- a/orga/tests/integration/components/students/sco/dissociate-user-modal_test.js
+++ b/orga/tests/integration/components/students/sco/dissociate-user-modal_test.js
@@ -19,7 +19,7 @@ module('Integration | Component | Student::Sco::DissociateUserModal', function(h
 
   module('when the user is authenticated with an email', function() {
 
-    test('it displays a message for user authentified by email', async function(assert) {
+    test('it displays a message for user authentified by email', function(assert) {
       this.set('student', { hasEmail: true, email: 'rocky.balboa@example.net', firstName: 'Rocky', lastName: 'Balboa' });
 
       assert.contains('Souhaitez-vous dissocier le compte Pix de l\'élève Rocky Balboa ?');
@@ -28,7 +28,7 @@ module('Integration | Component | Student::Sco::DissociateUserModal', function(h
 
   module('when the user is authenticated with an username', function() {
 
-    test('it displays a message for user authentified by username', async function(assert) {
+    test('it displays a message for user authentified by username', function(assert) {
       this.set('student', { hasUsername: true, username: 'appolo.creed', firstName: 'Appolo', lastName: 'Creed' });
 
       assert.contains('Souhaitez-vous dissocier le compte Pix de l\'élève Appolo Creed ?');
@@ -37,7 +37,7 @@ module('Integration | Component | Student::Sco::DissociateUserModal', function(h
 
   module('when the user is authenticated with GAR', function() {
 
-    test('it displays a message for user authentified with GAR', async function(assert) {
+    test('it displays a message for user authentified with GAR', function(assert) {
       this.set('student', { hasEmail: false, hasUsername: false, firstName: 'Ivan', lastName: 'Drago' });
 
       assert.contains('Souhaitez-vous dissocier le compte Pix de l\'élève Ivan Drago ?');

--- a/orga/tests/integration/components/students/sco/header-actions_test.js
+++ b/orga/tests/integration/components/students/sco/header-actions_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | Student::Sco::HeaderActions', function(hooks) 
           return render(hbs`<Student::Sco::HeaderActions @onImportStudents={{importStudentsSpy}} />`);
         });
 
-        test('it should display import XML file button', async function(assert) {
+        test('it should display import XML file button', function(assert) {
           assert.contains('Importer (.xml ou .zip)');
         });
       });
@@ -50,7 +50,7 @@ module('Integration | Component | Student::Sco::HeaderActions', function(hooks) 
           return render(hbs`<Student::Sco::HeaderActions @onImportStudents={{importStudentsSpy}} />`);
         });
 
-        test('it should still display import CSV file button', async function(assert) {
+        test('it should still display import CSV file button', function(assert) {
           assert.contains('Importer (.csv)');
         });
       });
@@ -66,7 +66,7 @@ module('Integration | Component | Student::Sco::HeaderActions', function(hooks) 
         return render(hbs`<Student::Sco::HeaderActions />`);
       });
 
-      test('it should not display import button', async function(assert) {
+      test('it should not display import button', function(assert) {
         assert.notContains('Importer (.xml)');
         assert.notContains('Importer (.csv)');
       });

--- a/orga/tests/integration/components/students/sco/list_test.js
+++ b/orga/tests/integration/components/students/sco/list_test.js
@@ -151,13 +151,13 @@ module('Integration | Component | Student::Sco::List', function(hooks) {
       return render(hbs`<Student::Sco::List @students={{students}} @onFilter={{noop}}/>`);
     });
 
-    test('it should display dash for authentication method', async function(assert) {
+    test('it should display dash for authentication method', function(assert) {
       const dash = '\u2013';
 
       assert.dom('[aria-label="Élève"]').containsText(dash);
     });
 
-    test('it should not display actions menu for username', async function(assert) {
+    test('it should not display actions menu for username', function(assert) {
       assert.dom('[aria-label="Afficher les actions"]').doesNotExist();
     });
   });
@@ -205,11 +205,11 @@ module('Integration | Component | Student::Sco::List', function(hooks) {
       return render(hbs`<Student::Sco::List @students={{students}} @onFilter={{noop}}/>`);
     });
 
-    test('it should display "Identifiant" as authentication method', async function(assert) {
+    test('it should display "Identifiant" as authentication method', function(assert) {
       assert.dom('[aria-label="Élève"]').containsText('Identifiant');
     });
 
-    test('it should display actions menu', async function(assert) {
+    test('it should display actions menu', function(assert) {
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 
@@ -231,11 +231,11 @@ module('Integration | Component | Student::Sco::List', function(hooks) {
       return render(hbs`<Student::Sco::List @students={{students}} @onFilter={{noop}}/>`);
     });
 
-    test('it should display "Adresse email" as authentication method', async function(assert) {
+    test('it should display "Adresse email" as authentication method', function(assert) {
       assert.dom('[aria-label="Élève"]').containsText('Adresse e-mail');
     });
 
-    test('it should display actions menu for email', async function(assert) {
+    test('it should display actions menu for email', function(assert) {
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 

--- a/orga/tests/integration/components/students/sup/edit-student-number-modal_test.js
+++ b/orga/tests/integration/components/students/sup/edit-student-number-modal_test.js
@@ -39,13 +39,13 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
   module('when the edit student number modal is open', function() {
 
     module('when there is student number', function() {
-      test('should render component with student number text', async function(assert) {
+      test('should render component with student number text', function(assert) {
         assert.contains(`Numéro étudiant actuel de ${this.student.firstName} ${this.student.lastName} est : ${this.student.studentNumber}`);
       });
     });
 
     module('when there is no student number yet', function() {
-      test('should not render component with student number text', async function(assert) {
+      test('should not render component with student number text', function(assert) {
         this.student.set('studentNumber', null);
         render(hbs`<Student::Sup::EditStudentNumberModal @display={{display}} @onClose={{close}} @student={{this.student}} @onSubmit={{onSaveStudentNumber}}/>`);
 
@@ -189,7 +189,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
   });
 
   module('when the edit student number modal is not open', function() {
-    test('should not render component', async function(assert) {
+    test('should not render component', function(assert) {
       // given
       this.set('display', false);
       render(hbs`<Student::Sup::EditStudentNumberModal @display={{display}} @onClose={{close}} @student={{this.student}}/>`);

--- a/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
@@ -30,7 +30,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
         assert.true(isArchived);
       });
 
-      test('it should display page title as archived', async function(assert) {
+      test('it should display page title as archived', function(assert) {
         // given
         const pageTitle = 'Campagnes archivées';
 
@@ -58,7 +58,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
         assert.false(isArchived);
       });
 
-      test('it should display page title as active', async function(assert) {
+      test('it should display page title as active', function(assert) {
         // given
         const pageTitle = 'Campagnes actives';
 

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -117,7 +117,7 @@ module('Unit | Controller | authenticated/certifications', function(hooks) {
   });
 
   module('#isCertificationAttestationDownloadEnabled', function() {
-    test('should return true if toggle is enabled', async function(assert) {
+    test('should return true if toggle is enabled', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
       const featureToggles = run(() => store.createRecord('feature-toggle', { isDownloadCertificationAttestationByDivisionEnabled: true }));
@@ -130,7 +130,7 @@ module('Unit | Controller | authenticated/certifications', function(hooks) {
       assert.ok(controller.isCertificationAttestationDownloadEnabled);
     });
 
-    test('should return false if toggle is disabled', async function(assert) {
+    test('should return false if toggle is disabled', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
       const featureToggles = run(() => store.createRecord('feature-toggle', { isDownloadCertificationAttestationByDivisionEnabled: false }));

--- a/orga/tests/unit/services/file-saver_test.js
+++ b/orga/tests/unit/services/file-saver_test.js
@@ -54,7 +54,7 @@ module('Unit | Service | file-saver', function(hooks) {
     });
 
     module('when response has not a status 200', function() {
-      test('should throw', async function(assert) {
+      test('should throw', function(assert) {
         // given
         const headers = { get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`) };
         const jsonStub = sinon.stub().resolves({ errors: [] });

--- a/scripts/compute-lead-times/get-git-dates.js
+++ b/scripts/compute-lead-times/get-git-dates.js
@@ -6,7 +6,7 @@ async function getCommitDatesBetweenTags(olderTag, newerTag) {
   return commitDates.split('\n');
 }
 
-async function getTagDate(tag) {
+function getTagDate(tag) {
   return exec(`git show --pretty=format:"%ad" --summary ${tag} | tail -1`);
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Nous avons plein de fonctions qui sont précédées d'un `async` alors qu'elles ne contiennent pas d'`await`. Malgré qu'elles ne contiennent pas d'`await`, le fait d'ajouter un `async` a pour conséquence de créer une promesse qui sera par la suite résolue. 

## :robot: Solution
Ajouter la règle de lint : `require-await` permettant d'indiquer l'usage d'un `async` alors que la fonction ne contient pas d'`await`.

Dans le cas des classes servant "d'interfaces" comme la classe `Cache`. J'ai laissé les async en désactivant le linter, exemple : 

```js 
class Cache {

  // eslint-disable-next-line require-await
  async get(/* key, generator */) {
    throw new Error('Method #get(key, generator) must be overridden');
  }
```

## :rainbow: Remarques
Cette règle ne fixe pas le code automatiquement en appliquant l'option `--fix`.
Pour résoudre les erreurs j'ai donc : 
- Lancé le linter dans chaque répertoire
- Récupéré les erreurs dans un fichier
- Lancé un script awk permettant de résoudre les erreurs qui a pour but de remplacer les `async` des lignes posant problèmes par rien
- Relancer le linter avec l'option `--fix` pour enlever les doubles espaces causés par la suppression des `async`.  

Le script awk en question : 

```awk
BEGIN {
	FS = "\n";
	RS = "";
}
{
	for (i=2; i<=NF; i++) {
		split($i, arr, ":");
		sub(/^[ \t\r\n]+/, "", arr[1]);
		line_number = arr[1]; 
		
		system("sed -i '' '"line_number"s/async//' "$1)
	}
}
END {}
```

## :100: Pour tester
Vérifier que la CI passe. 
