### PR TITLE
[FEATURE] Mettre à jour la bannière des parcours de rentrée SCO pour la rentrée 2021 (PIX-3101).

### DIFF
--- a/orga/app/components/banner/information.hbs
+++ b/orga/app/components/banner/information.hbs
@@ -1,5 +1,5 @@
 {{#if this.displayNewYearSchoolingRegistrationsImportBanner}}
-  <PixBanner  @type='information'>
+  <PixBanner @type='information'>
     <Ui::TranslateExtended
       @key='banners.import.message'
       @options={{hash
@@ -12,7 +12,15 @@
     />
   </PixBanner>
 {{else if this.displayNewYearCampaignsBanner}}
-  <PixBanner @type='information' @actionLabel={{t 'banners.campaigns.actionLabel'}} @actionUrl={{this.documentationLink}}>
-    {{t 'banners.campaigns.message' htmlSafe=true}}
+  <PixBanner @type='information'>
+    <Ui::TranslateExtended
+      @key='banners.campaigns.message'
+      @options={{hash
+      faIcon=(component 'fa-icon' icon='external-link-alt')
+      middleSchoolDocumentationLink=this.campaignMiddleSchoolDocumentationLink
+      highSchoolDocumentationLink=this.campaignHighSchoolDocumentationLink
+      externalLinkClasses='"link link--banner link--bold link--underlined"'
+    }}
+    />
   </PixBanner>
 {{/if}}

--- a/orga/app/components/banner/information.js
+++ b/orga/app/components/banner/information.js
@@ -22,10 +22,24 @@ export default class InformationBanner extends Component {
   }
 
   get displayNewYearCampaignsBanner() {
-    return this.currentUser.isSCOManagingStudents && !this._isOnCertificationsPage;
+    return this.currentUser.organization.isSco && !this._isOnCertificationsPage;
   }
 
-  get documentationLink() {
-    return 'https://view.genial.ly/6077017b8b37870d98620200';
+  get campaignMiddleSchoolDocumentationLink() {
+    if (this.currentUser.isSCOManagingStudents && this.currentUser.isAgriculture) {
+      return 'https://view.genial.ly/5f687a0451337070914e54f9?idSlide=cf788556-ff93-4aba-a5c2-312c450c7553';
+    } else if (this.currentUser.isSCOManagingStudents) {
+      return 'https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba';
+    }
+    return 'https://kutt.it/prefe';
+  }
+
+  get campaignHighSchoolDocumentationLink() {
+    if (this.currentUser.isSCOManagingStudents && this.currentUser.isAgriculture) {
+      return 'https://view.genial.ly/5f687a0451337070914e54f9?idSlide=cf788556-ff93-4aba-a5c2-312c450c7553';
+    } else if (this.currentUser.isSCOManagingStudents) {
+      return 'https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba';
+    }
+    return 'https://kutt.it/prefe';
   }
 }

--- a/orga/tests/integration/components/banner/information_test.js
+++ b/orga/tests/integration/components/banner/information_test.js
@@ -12,6 +12,7 @@ module('Integration | Component | Banner::Information', function(hooks) {
       module('when prescriber has not imported student yet', function() {
         class CurrentUserStub extends Service {
           prescriber = { areNewYearSchoolingRegistrationsImported: false }
+          organization = { isSco: true }
           isSCOManagingStudents = true;
         }
 
@@ -58,6 +59,7 @@ module('Integration | Component | Banner::Information', function(hooks) {
         // given
         class CurrentUserStub extends Service {
           prescriber = { areNewYearSchoolingRegistrationsImported: true }
+          organization = { isSco: true }
           isSCOManagingStudents = true;
         }
         this.owner.register('service:current-user', CurrentUserStub);
@@ -76,6 +78,7 @@ module('Integration | Component | Banner::Information', function(hooks) {
         // given
         class CurrentUserStub extends Service {
           prescriber = { areNewYearSchoolingRegistrationsImported: false }
+          organization = { isSco: false }
           isSCOManagingStudents = false;
         }
         this.owner.register('service:current-user', CurrentUserStub);
@@ -91,12 +94,12 @@ module('Integration | Component | Banner::Information', function(hooks) {
   });
 
   module('Campaign Banner', () => {
-    module('when prescriber’s organization is of type SCO that manages students', function() {
-      test('should render the campaign banner for non agriculture', async function(assert) {
+    module('when prescriber’s organization is of type SCO', function() {
+      test('should render the campaign banner', async function(assert) {
         // given
         class CurrentUserStub extends Service {
           prescriber = { areNewYearSchoolingRegistrationsImported: true }
-          isSCOManagingStudents = true;
+          organization = { isSco: true }
         }
         this.owner.register('service:current-user', CurrentUserStub);
 
@@ -104,17 +107,74 @@ module('Integration | Component | Banner::Information', function(hooks) {
         await render(hbs`<Banner::Information />`);
 
         // then
-        assert.dom('a[href="https://view.genial.ly/6077017b8b37870d98620200"]').exists();
-        assert.dom('.pix-banner').includesText('La certification en collège et lycée est possible jusqu\'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit, dans Pix Certif, de changer la date de la session en cliquant sur « modifier ».');
+        assert.dom('.pix-banner').includesText('Parcours de rentrée 2021 : N’oubliez pas de créer les campagnes de rentrée et de diffuser les codes aux élèves avant la Toussaint. Plus d’info collège et lycée (GT et Pro)');
+      });
+
+      module('when prescriber’s organization is managing students and is AGRICULTURE', function() {
+        test('should display AGRICULTURE links', async function(assert) {
+          // given
+          class CurrentUserStub extends Service {
+            prescriber = { areNewYearSchoolingRegistrationsImported: true }
+            organization = { isSco: true }
+            isSCOManagingStudents = true
+            isAgriculture = true
+          }
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          await render(hbs`<Banner::Information />`);
+
+          // then
+          assert.dom('a[href="https://view.genial.ly/5f687a0451337070914e54f9?idSlide=cf788556-ff93-4aba-a5c2-312c450c7553"').exists();
+        });
+      });
+
+      module('when prescriber’s organization is managing students but is not AGRICULTURE', function() {
+        test('should display links', async function(assert) {
+          // given
+          class CurrentUserStub extends Service {
+            prescriber = { areNewYearSchoolingRegistrationsImported: true }
+            organization = { isSco: true }
+            isSCOManagingStudents = true
+            isAgriculture = false
+          }
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          await render(hbs`<Banner::Information />`);
+
+          // then
+          assert.dom('a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"').exists();
+          assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"').exists();
+        });
+      });
+
+      module('when prescriber’s organization is not managing students', function() {
+        test('should display default links', async function(assert) {
+          // given
+          class CurrentUserStub extends Service {
+            prescriber = { areNewYearSchoolingRegistrationsImported: true }
+            organization = { isSco: true }
+            isSCOManagingStudents = false
+            isAgriculture = false
+          }
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          await render(hbs`<Banner::Information />`);
+
+          // then
+          assert.dom('a[href="https://kutt.it/prefe"').exists();
+        });
       });
     });
 
-    module('when prescriber’s organization is not of type SCO that manages students', function() {
+    module('when prescriber’s organization is not of type SCO', function() {
       test('should not display the campaign banner', async function(assert) {
         // given
         class CurrentUserStub extends Service {
           prescriber = { areNewYearSchoolingRegistrationsImported: true }
-          isSCOManagingStudents = false;
+          organization = { isSco: false }
         }
         this.owner.register('service:current-user', CurrentUserStub);
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -45,8 +45,7 @@
   },
   "banners": {
     "campaigns": {
-      "actionLabel": "Learn more.",
-      "message": "Certification in middle and high schools is open until 25 June. To reschedule sessions already scheduled, simply change the date of the session by clicking on 'edit' in Pix Certif."
+      "message": "Don't forget to create your back-to-school campaigns and share the codes with your students before November. More info for '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'middle schools {faIcon}'</a>' and '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'high schools {faIcon}'</a>'"
     },
     "import": {
       "link-to": "import or reimport the students database",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -45,8 +45,7 @@
   },
   "banners": {
     "campaigns": {
-      "actionLabel": "En savoir plus",
-      "message": "La certification en collège et lycée est possible jusqu'au 25 juin. Pour reporter des sessions déjà programmées, il vous suffit, dans Pix Certif, de changer la date de la session en cliquant sur « modifier »."
+      "message": "'<strong>'Parcours de rentrée 2021'</strong>' : N’oubliez pas de créer les campagnes de rentrée et de diffuser les codes aux élèves avant la Toussaint. Plus d’info '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
     },
     "import": {
       "link-to": "importer ou ré-importer la base élèves",


### PR DESCRIPTION
## :unicorn: Problème
La bannière n'est pas à jour, elle fait référence à des sessions de certifications pour l'année scolaire 2020-2021. Or celle-ci est terminée.

## :robot: Solution
La mettre à jour

## :rainbow: Remarques
Rien à signaler.

## :100: Pour tester
- Se connecter à Pix Orga en tant que sco.admin@example.net, et vérifier le bon affichage (et les bons liens) de la bannière sur les orgas :
  - `Collège The Night Watch`
  - `Lycée The Night Watch`
  - `Lycée Agricole`
  - `AEFE`