### PR TITLE
[FEATURE] Mise à jour du bandeau d'import SCO pour la rentrée 2021 (PIX-3100).

### DIFF
--- a/orga/app/components/banner/information.hbs
+++ b/orga/app/components/banner/information.hbs
@@ -5,8 +5,8 @@
       @options={{hash
         faIcon=(component 'fa-icon' icon='external-link-alt')
         linkTo=(component 'link-to' (t 'banners.import.link-to') 'authenticated.sco-students' class="link link--banner link--bold link--underlined")
-        middleSchoolDocumentationLink='"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"'
-        highSchoolDocumentationLink='"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"'
+        middleSchoolDocumentationLink=this.importMiddleSchoolDocumentationLink
+        highSchoolDocumentationLink=this.importHighSchoolDocumentationLink
         externalLinkClasses='"link link--banner link--bold link--underlined"'
       }}
     />

--- a/orga/app/components/banner/information.js
+++ b/orga/app/components/banner/information.js
@@ -10,10 +10,15 @@ export default class InformationBanner extends Component {
   }
 
   get displayNewYearSchoolingRegistrationsImportBanner() {
-    return !this.currentUser.prescriber.areNewYearSchoolingRegistrationsImported &&
-      this.currentUser.isSCOManagingStudents &&
-      !this.currentUser.isAgriculture &&
-      !this._isOnCertificationsPage;
+    return !this.currentUser.prescriber.areNewYearSchoolingRegistrationsImported && this.currentUser.isSCOManagingStudents && !this._isOnCertificationsPage;
+  }
+
+  get importMiddleSchoolDocumentationLink() {
+    return this.currentUser.isAgriculture ? 'https://view.genial.ly/5f687a0451337070914e54f9?idSlide=50100e2e-cbe3-41ff-b424-d965e5eeac7c' : 'https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23';
+  }
+
+  get importHighSchoolDocumentationLink() {
+    return this.currentUser.isAgriculture ? 'https://view.genial.ly/5f687a0451337070914e54f9?idSlide=50100e2e-cbe3-41ff-b424-d965e5eeac7c' : 'https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23';
   }
 
   get displayNewYearCampaignsBanner() {

--- a/orga/tests/integration/components/banner/information_test.js
+++ b/orga/tests/integration/components/banner/information_test.js
@@ -25,25 +25,48 @@ module('Integration | Component | Banner::Information', function(hooks) {
           // then
           assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').exists();
           assert.dom('a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').exists();
-          assert.dom('.pix-banner').includesText('Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)');
+          assert.dom('.pix-banner').includesText('Rentrée 2021 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)');
         });
       });
+    });
 
-      module('when prescriber has already imported students', function() {
-        test('should not render the banner', async function(assert) {
+    module('when prescriber’s organization is of type SCO that manages AGRI students', function() {
+      module('when prescriber has not imported student yet', function() {
+        class CurrentUserStub extends Service {
+          prescriber = { areNewYearSchoolingRegistrationsImported: false }
+          isSCOManagingStudents = true;
+          isAgriculture = true;
+        }
+
+        test('should  render the banner', async function(assert) {
           // given
-          class CurrentUserStub extends Service {
-            prescriber = { areNewYearSchoolingRegistrationsImported: true }
-            isSCOManagingStudents = true;
-          }
           this.owner.register('service:current-user', CurrentUserStub);
 
           // when
           await render(hbs`<Banner::Information />`);
 
           // then
-          assert.dom('.pix-banner').doesNotIncludeText('Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)');
+          assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').doesNotExist();
+          assert.dom('a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').doesNotExist();
+          assert.dom('.pix-banner').includesText('Rentrée 2021 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)');
         });
+      });
+    });
+
+    module('when prescriber has already imported students', function() {
+      test('should not render the banner', async function(assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { areNewYearSchoolingRegistrationsImported: true }
+          isSCOManagingStudents = true;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        // when
+        await render(hbs`<Banner::Information />`);
+
+        // then
+        assert.dom('.pix-banner').doesNotIncludeText('Rentrée 2021 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)');
       });
     });
 

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -50,7 +50,7 @@
     },
     "import": {
       "link-to": "importer ou ré-importer la base élèves",
-      "message": "Rentrée 2020 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
+      "message": "Rentrée 2021 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
     }
   },
   "cards": {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la rentrée scolaire 2021, on doit afficher les bannières d'import.

## :robot: Solution
Ajouter les liens et les bons wordings pour le SCO

## :rainbow: Remarques

## :100: Pour tester
Aller sur pix orga, tester en tant que sco et sco agri
