### PR TITLE
[BUGFIX] Rediriger vers l'organisation rejointe au moment d'accepter l'invitation (PIX-3109).

### DIFF
--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -7,8 +7,13 @@ function _pickDefaultRole(existingMemberships) {
 }
 
 module.exports = async function acceptOrganizationInvitation({
-  organizationInvitationId, code, email,
-  userRepository, membershipRepository, organizationInvitationRepository,
+  organizationInvitationId,
+  code,
+  email,
+  userRepository,
+  membershipRepository,
+  organizationInvitationRepository,
+  userOrgaSettingsRepository,
 }) {
   const foundOrganizationInvitation = await organizationInvitationRepository.getByIdAndCode({
     id: organizationInvitationId,
@@ -34,6 +39,14 @@ module.exports = async function acceptOrganizationInvitation({
     } else {
       const organizationRole = invitationRole || _pickDefaultRole(memberships);
       await membershipRepository.create(userFound.id, organizationId, organizationRole);
+    }
+
+    const userOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(userFound.id);
+
+    if (_.isEmpty(userOrgaSettings)) {
+      await userOrgaSettingsRepository.create(userFound.id, organizationId);
+    } else {
+      await userOrgaSettingsRepository.update(userFound.id, organizationId);
     }
 
     return organizationInvitationRepository.markAsAccepted(organizationInvitationId);

--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -41,13 +41,7 @@ module.exports = async function acceptOrganizationInvitation({
       await membershipRepository.create(userFound.id, organizationId, organizationRole);
     }
 
-    const userOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(userFound.id);
-
-    if (_.isEmpty(userOrgaSettings)) {
-      await userOrgaSettingsRepository.create(userFound.id, organizationId);
-    } else {
-      await userOrgaSettingsRepository.update(userFound.id, organizationId);
-    }
+    await userOrgaSettingsRepository.createOrUpdate({ userId: userFound.id, organizationId });
 
     return organizationInvitationRepository.markAsAccepted(organizationInvitationId);
   }

--- a/api/lib/domain/usecases/create-or-update-user-orga-settings.js
+++ b/api/lib/domain/usecases/create-or-update-user-orga-settings.js
@@ -13,11 +13,5 @@ module.exports = async function createOrUpdateUserOrgaSettings({
     throw new UserNotMemberOfOrganizationError(`L'utilisateur ${userId} n'est pas membre de l'organisation ${organizationId}.`);
   }
 
-  const userOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(userId);
-
-  if (_.isEmpty(userOrgaSettings)) {
-    return userOrgaSettingsRepository.create(userId, organizationId);
-  }
-
-  return userOrgaSettingsRepository.update(userId, organizationId);
+  return userOrgaSettingsRepository.createOrUpdate({ userId, organizationId });
 };

--- a/api/tests/acceptance/application/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitation-controller_test.js
@@ -13,6 +13,10 @@ describe('Acceptance | Application | organization-invitation-controller', functi
     server = await createServer();
   });
 
+  afterEach(async function() {
+    await knex('user-orga-settings').delete();
+  });
+
   describe('POST /api/organization-invitations/{id}/response', function() {
 
     let organizationId;

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -25,9 +25,7 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
       markAsAccepted: sinon.stub(),
     };
     userOrgaSettingsRepository = {
-      create: sinon.stub(),
-      findOneByUserId: sinon.stub(),
-      update: sinon.stub(),
+      createOrUpdate: sinon.stub(),
     };
   });
 
@@ -89,10 +87,6 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
       const expectedUserId = userToInvite.id;
       const { id: organizationInvitationId, organizationId, code } = pendingOrganizationInvitation;
       membershipRepository.findByOrganizationId.withArgs({ organizationId }).resolves([{ user: { id: 2 } }]);
-      const userOrgaSetting = domainBuilder.buildUserOrgaSettings({ user: userToInvite })
-      userOrgaSettingsRepository.findOneByUserId
-        .withArgs(userToInvite.id)
-        .resolves(userOrgaSetting);
 
       // when
       await acceptOrganizationInvitation({
@@ -106,7 +100,10 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
       });
 
       // then
-      expect(userOrgaSettingsRepository.update).to.have.been.calledWith(expectedUserId, organizationId);
+      expect(userOrgaSettingsRepository.createOrUpdate).to.have.been.calledWith({
+        userId: expectedUserId,
+        organizationId,
+      });
     });
 
     context('when the user is the first one to join the organization', function() {

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -9,6 +9,7 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
   let userRepository;
   let membershipRepository;
   let organizationInvitationRepository;
+  let userOrgaSettingsRepository;
 
   beforeEach(function() {
     userRepository = {
@@ -22,6 +23,11 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
     organizationInvitationRepository = {
       getByIdAndCode: sinon.stub(),
       markAsAccepted: sinon.stub(),
+    };
+    userOrgaSettingsRepository = {
+      create: sinon.stub(),
+      findOneByUserId: sinon.stub(),
+      update: sinon.stub(),
     };
   });
 
@@ -78,6 +84,31 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
       userRepository.getByEmail.withArgs(email).resolves(userToInvite);
     });
 
+    it('should update user organization settings', async function() {
+      // given
+      const expectedUserId = userToInvite.id;
+      const { id: organizationInvitationId, organizationId, code } = pendingOrganizationInvitation;
+      membershipRepository.findByOrganizationId.withArgs({ organizationId }).resolves([{ user: { id: 2 } }]);
+      const userOrgaSetting = domainBuilder.buildUserOrgaSettings({ user: userToInvite })
+      userOrgaSettingsRepository.findOneByUserId
+        .withArgs(userToInvite.id)
+        .resolves(userOrgaSetting);
+
+      // when
+      await acceptOrganizationInvitation({
+        organizationInvitationId,
+        code,
+        email,
+        userRepository,
+        membershipRepository,
+        organizationInvitationRepository,
+        userOrgaSettingsRepository,
+      });
+
+      // then
+      expect(userOrgaSettingsRepository.update).to.have.been.calledWith(expectedUserId, organizationId);
+    });
+
     context('when the user is the first one to join the organization', function() {
 
       it('should create a membership with ADMIN role', async function() {
@@ -87,8 +118,13 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
 
         // when
         await acceptOrganizationInvitation({
-          organizationInvitationId, code, email,
-          userRepository, membershipRepository, organizationInvitationRepository,
+          organizationInvitationId,
+          code,
+          email,
+          userRepository,
+          membershipRepository,
+          organizationInvitationRepository,
+          userOrgaSettingsRepository,
         });
 
         // then
@@ -106,8 +142,13 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
 
         // when
         await acceptOrganizationInvitation({
-          organizationInvitationId, code, email,
-          userRepository, membershipRepository, organizationInvitationRepository,
+          organizationInvitationId,
+          code,
+          email,
+          userRepository,
+          membershipRepository,
+          organizationInvitationRepository,
+          userOrgaSettingsRepository,
         });
 
         // then
@@ -126,8 +167,13 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
 
         // when
         await acceptOrganizationInvitation({
-          organizationInvitationId, code, email,
-          userRepository, membershipRepository, organizationInvitationRepository,
+          organizationInvitationId,
+          code,
+          email,
+          userRepository,
+          membershipRepository,
+          organizationInvitationRepository,
+          userOrgaSettingsRepository,
         });
 
         // then
@@ -172,8 +218,13 @@ describe('Unit | UseCase | accept-organization-invitation', function() {
 
           // when
           await acceptOrganizationInvitation({
-            organizationInvitationId, code, email,
-            userRepository, membershipRepository, organizationInvitationRepository,
+            organizationInvitationId,
+            code,
+            email,
+            userRepository,
+            membershipRepository,
+            organizationInvitationRepository,
+            userOrgaSettingsRepository,
           });
 
           // then

--- a/api/tests/unit/domain/usecases/create-or-update-user-orga-settings_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-user-orga-settings_test.js
@@ -11,33 +11,18 @@ describe('Unit | UseCase | create-or-update-user-orga-settings', function() {
 
   beforeEach(function() {
     membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
-    userOrgaSettingsRepository.findOneByUserId = sinon.stub();
-    sinon.stub(userOrgaSettingsRepository, 'update');
-    sinon.stub(userOrgaSettingsRepository, 'create');
+    sinon.stub(userOrgaSettingsRepository, 'createOrUpdate');
   });
 
-  it('should create the user orga settings if it doesn\'t exist', async function() {
+  it('should create or update the user orga settings if user is a member of the organization', async function() {
     // given
     membershipRepository.findByUserIdAndOrganizationId.withArgs({ userId, organizationId }).resolves([{}]);
 
     // when
-    userOrgaSettingsRepository.findOneByUserId.withArgs(userId).resolves([]);
     await createOrUpdateUserOrgaSettings({ userId, organizationId, userOrgaSettingsRepository, membershipRepository });
 
     // then
-    expect(userOrgaSettingsRepository.create).to.have.been.calledWithExactly(userId, organizationId);
-  });
-
-  it('should update the user orga settings if it already exists', async function() {
-    // given
-    membershipRepository.findByUserIdAndOrganizationId.withArgs({ userId, organizationId }).resolves([{}]);
-
-    // when
-    userOrgaSettingsRepository.findOneByUserId.withArgs(userId).resolves([{ id: 22, userId: userId, organizationId: organizationId }]);
-    await createOrUpdateUserOrgaSettings({ userId, organizationId, userOrgaSettingsRepository, membershipRepository });
-
-    // then
-    expect(userOrgaSettingsRepository.update).to.have.been.calledWithExactly(userId, organizationId);
+    expect(userOrgaSettingsRepository.createOrUpdate).to.have.been.calledWithExactly({ userId, organizationId });
   });
 
   it('should throw a UserNotMemberOfOrganizationError if user is not member of the organization', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on reçois une invitation à rejoindre une organisation et qu'on se connecte suite à l'invitation, on tombe sur la gestion d'une autre organisation que celle rejointe (l'organisation sélectionnée dans le menu n'est pas la bonne).

- Je suis un admin ou membre d’une organisation
- J’ai une session active dans Pix Orga et je suis sur une organisation A
- Je reçois une invitation à rejoindre une nouvelle organisation B par e-mail
- Je clique sur le bouton “accepter l’invitation” dans l’e-mail
- Cela me déconnecte de ma session et m’affiche la page double mire
- Je me reconnecte donc avec mes identifiant/mot de passe
- Je tombe sur l’organisation A et non pas la B (bien que je l'ai rejointe)

## :robot: Solution
Au moment de rejoindre une organisation, enregistrer dans les user-orga-settings que la dernière organisation à gérer est l'organisation rejointe.

## :100: Pour tester
Sur PixAdmin : 
- créer une organisation
- s'inviter par email dans cette même organisation

Dans vos email : 
- copier le contenu du lien de redirection et remplacer le domaine de prod par le local en début d'url
- constater qu'on arrive sur la double mire 
- se connecter avec un compte PixOrga ayant déjà plusieurs organisations (pro.admin@example.net)
- constater qu'on est bien connecté et que l'organisation sélectionnée est bien celle qu'on vient de rejoindre

