### PR TITLE
[A11Y] Donner plus de sémantique à la page paramètre de la campage (PIX-3055)

### DIFF
--- a/orga/app/components/campaign/header/title.hbs
+++ b/orga/app/components/campaign/header/title.hbs
@@ -8,30 +8,30 @@
     {{@campaign.name}}
   </Ui::PreviousPageButton>
 
-  <div class="campaign-header-title__infos">
+  <dl class="campaign-header-title__infos">
     <div class="campaign-header-title__info-item hide-on-mobile">
-      <h4 class="label-text">
+      <dt class="label-text">
         {{t 'pages.campaign.created-on'}}
-      </h4>
-      <span class="content-text">
+      </dt>
+      <dd class="content-text">
         {{moment-format @campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}
-      </span>
+      </dd>
     </div>
 
     <div class="campaign-header-title__info-item">
-      <h4 class="label-text">
+      <dt class="label-text">
         {{t 'pages.campaign.created-by'}}
-      </h4>
-      <span class="content-text">
+      </dt>
+      <dd class="content-text">
         {{@campaign.creatorFullName}}
-      </span>
+      </dd>
     </div>
 
     <div class="campaign-header-title__info-item">
-      <h4 class="label-text">
+      <dt class="label-text">
         {{t 'pages.campaign.code'}}
-      </h4>
-      <span class="content-text campaign-header-title__campaign-code">
+      </dt>
+      <dd class="content-text campaign-header-title__campaign-code">
         <span>{{@campaign.code}}</span>
         <Campaign::CopyPasteButton
           @clipBoardtext={{@campaign.code}}
@@ -39,7 +39,7 @@
           @defaultMessage={{t 'pages.campaign.copy.code.default'}}
           class="hide-on-mobile"
         />
-      </span>
+      </dd>
     </div>
-  </div>
+  </dl>
 </div>

--- a/orga/app/components/campaign/settings.hbs
+++ b/orga/app/components/campaign/settings.hbs
@@ -1,47 +1,48 @@
 <div class="panel campaign-settings">
-  <div class="campaign-settings-row">
-    {{#if @campaign.isTypeAssessment}}
+  <dl>
+    <div class="campaign-settings-row">
+      {{#if @campaign.isTypeAssessment}}
+        <div class="campaign-settings-content">
+          <dt class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.target-profile'}}</dt>
+          <dd class="content-text campaign-settings-content__text">{{@campaign.targetProfileName}}</dd>
+        </div>
+      {{/if}}
+      {{#if @campaign.idPixLabel}}
+        <div class="campaign-settings-content">
+          <dt class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.external-user-id-label'}}</dt>
+          <dd class="content-text campaign-settings-content__text">{{@campaign.idPixLabel}}</dd>
+        </div>
+      {{/if}}
       <div class="campaign-settings-content">
-        <h4 class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.target-profile'}}</h4>
-        <p class="content-text campaign-settings-content__text">{{@campaign.targetProfileName}}</p>
-      </div>
-    {{/if}}
-    {{#if @campaign.idPixLabel}}
-      <div class="campaign-settings-content">
-        <h4 class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.external-user-id-label'}}</h4>
-        <p class="content-text campaign-settings-content__text">{{@campaign.idPixLabel}}</p>
-      </div>
-    {{/if}}
-    <div class="campaign-settings-content">
-      <h4 class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.direct-link'}}</h4>
-      <div class="campaign-settings-content__clipboard">
-        <p class="content-text campaign-settings-content__text">{{this.campaignsRootUrl}}</p>
-        <Campaign::CopyPasteButton
-          @clipBoardtext={{this.campaignsRootUrl}}
-          @successMessage={{t 'pages.campaign.copy.link.success'}}
-          @defaultMessage={{t 'pages.campaign.copy.link.default'}}
-        />
+        <dt class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.direct-link'}}</dt>
+        <dd class="campaign-settings-content__clipboard">
+          <span class="content-text campaign-settings-content__text">{{this.campaignsRootUrl}}</span>
+          <Campaign::CopyPasteButton
+            @clipBoardtext={{this.campaignsRootUrl}}
+            @successMessage={{t 'pages.campaign.copy.link.success'}}
+            @defaultMessage={{t 'pages.campaign.copy.link.default'}}
+          />
+        </dd>
       </div>
     </div>
-  </div>
-
-  {{#if @campaign.isTypeAssessment}}
+    {{#if @campaign.isTypeAssessment}}
     <div class="campaign-settings-row">
       <div class="campaign-settings-content campaign-settings-content--single">
-        <h4 class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.personalised-test-title'}}</h4>
-        <p class="content-text campaign-settings-content__text">{{@campaign.title}}</p>
+        <dt class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.personalised-test-title'}}</dt>
+        <dd class="content-text campaign-settings-content__text">{{@campaign.title}}</dd>
       </div>
     </div>
-  {{/if}}
+    {{/if}}
 
-  <div class="campaign-settings-row">
-    <div class="campaign-settings-content campaign-settings-content--single">
-      <h4 class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.landing-page-text'}}</h4>
-      <p class="content-text campaign-settings-content__text">
-        <MarkdownToHtml @markdown={{@campaign.customLandingPageText}} />
-      </p>
+    <div class="campaign-settings-row">
+        <div class="campaign-settings-content campaign-settings-content--single">
+          <dt class="label-text campaign-settings-content__label">{{t 'pages.campaign-settings.landing-page-text'}}</dt>
+          <dd class="content-text campaign-settings-content__text">
+            <MarkdownToHtml @markdown={{@campaign.customLandingPageText}} />
+          </dd>
+        </div>
     </div>
-  </div>
+  </dl>
 
   {{#unless @campaign.isArchived}}
     <div class="campaign-settings-buttons">

--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -1,6 +1,6 @@
 <aside class="sidebar">
   <header class="sidebar__logo hide-on-mobile">
-    <LinkTo @route="authenticated.campaigns">
+    <LinkTo @route="authenticated.campaigns" title="{{t 'common.home-page'}}">
       <img src="{{this.rootUrl}}/pix-orga.svg" alt="" role="none">
     </LinkTo>
   </header>

--- a/orga/app/styles/components/campaign/header/title.scss
+++ b/orga/app/styles/components/campaign/header/title.scss
@@ -12,6 +12,8 @@
   &__infos {
     display: flex;
     align-items: center;
+    margin: 0;
+    padding: 0;
 
     & > *  {
       padding-right: 15px;
@@ -27,9 +29,13 @@
   }
 
   &__info-item {
-    h4 {
-      margin-top: 0;
-      margin-bottom: 4px;
+    & > dt {
+      display: block;
+      margin-bottom: 8px;
+    }
+
+    & > dd {
+      margin: 0;
     }
   }
 

--- a/orga/app/styles/components/campaign/settings.scss
+++ b/orga/app/styles/components/campaign/settings.scss
@@ -1,12 +1,15 @@
 .campaign-settings {
   display: flex;
   flex-direction: column;
+
+  > dl {
+    margin:0
+  }
 }
 
 .campaign-settings-row {
-  display: flex;
-  flex-direction: row;
   justify-content: space-between;
+  display: flex;
 
   &:not(:last-child) {
     border-bottom: 1px solid $grey-20;
@@ -14,12 +17,15 @@
 }
 
 .campaign-settings-content {
+  width: 100%;
   display: flex;
   flex-direction: column;
   padding: 24px;
-  width: 100%;
 
   &--single {
+    flex-basis: 100%;
+    border-left: none;
+
     &:first-child {
       width: 55%;
     }
@@ -42,6 +48,7 @@
   }
 
   &__clipboard {
+    margin: 0;
     display: flex;
     flex-direction: row;
   }
@@ -51,6 +58,7 @@
   display: flex;
   padding: 24px;
   width: 100%;
+  box-sizing: border-box;
 
   > *:first-child {
     margin-right: 32px;
@@ -65,5 +73,9 @@
   .campaign-settings-row {
     flex-direction: column;
     justify-content: flex-start;
+  }
+
+  .campaign-settings-content {
+    border-left: none;
   }
 }

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -128,7 +128,7 @@
     transition: all ease-in-out .2s;
     text-decoration: none;
 
-    &:hover {
+    &:hover, &:focus {
       color: $blue;
     }
 

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -121,7 +121,7 @@
     border-bottom: 2px solid transparent;
     outline: none;
     cursor: pointer;
-    color: $grey-30;
+    color: $grey-50;
     font-family: $roboto;
     font-size: 0.9rem;
     font-weight: 500;

--- a/orga/app/styles/globals/texts.scss
+++ b/orga/app/styles/globals/texts.scss
@@ -25,7 +25,7 @@
 }
 
 .label-text {
-  color: $grey-40;
+  color: $grey-50;
   font-family: $roboto;
   font-size: 0.875rem;
   font-weight: 400;

--- a/orga/app/templates/authenticated/campaigns/campaign.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign.hbs
@@ -1,6 +1,6 @@
 {{page-title @model.name}}
 
-<div class="campaign-page">
+<article class="campaign-page">
   <Campaign::Header::Title @campaign={{@model}} />
 
   <Campaign::Header::Tabs @campaign={{@model}} />
@@ -8,4 +8,4 @@
   <Campaign::Header::ArchivedBanner @campaign={{@model}} />
 
   {{outlet}}
-</div>
+</article>

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -132,6 +132,7 @@
       "close": "Close"
     },
     "help-form": "https://pix.org/en-gb/contact-form",
+    "home-page": "Pix Orga home page",
     "loading": "Loading",
     "pagination": {
       "action": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -132,6 +132,7 @@
       "close": "Fermer"
     },
     "help-form": "https://support.pix.fr/support/tickets/new",
+    "home-page": "Page d'accueil Pix Orga",
     "loading": "Chargement en cours",
     "pagination": {
       "action": {


### PR DESCRIPTION
## :unicorn: Problème
Nous ne respections pas les normes HTML niveaux structures / hierarchisations / sémantiques des éléments sur la page paramètres.

Potentiellement les lecteurs d'écrans auraient eu des soucis pour fournir un plan détaillé à son utilisateur

## :robot: Solution
Revoir la sémantique, les balises, rendre accessible la page paramètres.

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur Pix Orga et vérifier que tout s'affiche correctement