### PR TITLE
[FEATURE] Ne récupérer que la dernière participation d'une campagne pour chaque utilisateur dans l'onglet analyse (partie compétences) (PIX-2966).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
@@ -28,7 +28,7 @@ module.exports = {
 async function _getChunksSharedParticipationsWithUserIdsAndDates(campaignId) {
   const results = await knex('campaign-participations')
     .select('userId', 'sharedAt')
-    .where({ campaignId, isShared: true });
+    .where({ campaignId, isShared: true, isImproved: false });
 
   const userIdsAndDates = [];
   for (const result of results) {

--- a/orga/app/components/campaign/analysis/competences.js
+++ b/orga/app/components/campaign/analysis/competences.js
@@ -6,8 +6,9 @@ export default class CompetencesAnalysis extends Component {
   @service intl;
 
   get campaignCollectiveResultLabel() {
+    const competenceCollectiveResultsCount = this.args.campaignCollectiveResult.get('campaignCompetenceCollectiveResults').length;
     return htmlSafe(this.intl.t('pages.campaign-review.table.competences.column.competences',
-      { count: this.args.sharedParticipationsCount ? this.args.campaignCollectiveResult.get('campaignCompetenceCollectiveResults').length : '-' },
+      { count: competenceCollectiveResultsCount ? competenceCollectiveResultsCount : '-' },
     ));
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Maintenant un utilisateur peut améliorer ses résultats en participant plusieurs fois à la même campagne. cette modification a rendu le calcul des percentages par compétence dans l'onglet analyse incorrect, Car le calcul se base sur plusieurs participations et non seulement la dernière.

## :robot: Solution
Ajouter la condition `isImproved  = false` dans la requête sql qui récupère le nombre de participations à fin de récupérer la dernière participation uniquement et ne plus avoir des doublons.

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur pro.admin@example.net et vérifier  le calcul des percentage par compétence dans la liste 'Résultats par compétence' dans l'onglet analyse des campagnes

