### PR TITLE
[BUGFIX] Les certifications complémentaires ne sont pas affichées comme "Annulées" lorsque la certification Pix est annulée (PIX-3117)

### DIFF
--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -139,16 +139,19 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
 
 function _formatCleaCertificationResult(certificationResult) {
   if (!certificationResult.hasTakenClea()) return 'Non passée';
+  if (certificationResult.isCancelled()) return 'Annulée';
   return certificationResult.hasAcquiredClea() ? 'Validée' : 'Rejetée';
 }
 
 function _formatPixPlusDroitMaitreCertificationResult(certificationResult) {
   if (!certificationResult.hasTakenPixPlusDroitMaitre()) return 'Non passée';
+  if (certificationResult.isCancelled()) return 'Annulée';
   return certificationResult.hasAcquiredPixPlusDroitMaitre() ? 'Validée' : 'Rejetée';
 }
 
 function _formatPixPlusDroitExpertCertificationResult(certificationResult) {
   if (!certificationResult.hasTakenPixPlusDroitExpert()) return 'Non passée';
+  if (certificationResult.isCancelled()) return 'Annulée';
   return certificationResult.hasAcquiredPixPlusDroitExpert() ? 'Validée' : 'Rejetée';
 }
 

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -156,7 +156,7 @@ function _formatPixPlusDroitExpertCertificationResult(certificationResult) {
 }
 
 function _formatPixScore(certificationResult) {
-  if (certificationResult.isCancelled()) return '-';
+  if (certificationResult.isCancelled() || certificationResult.isInError()) return '-';
   if (certificationResult.isRejected()) return '0';
   return certificationResult.pixScore;
 }
@@ -190,7 +190,7 @@ function _getCompetenceLevel({ certificationResult, competenceIndex }) {
   const competence = levelByCompetenceCode[competenceIndex];
   const notTestedCompetence = !competence;
 
-  if (notTestedCompetence || certificationResult.isCancelled()) {
+  if (notTestedCompetence || certificationResult.isCancelled() || certificationResult.isInError()) {
     return '-';
   }
   if (certificationResult.isRejected() || _isCompetenceFailed(competence)) {

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -179,6 +179,41 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Validée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
         expect(result).to.equal(expectedResult);
       });
+
+      it('should return a cancelled clea certification when certification pix is cancelled', async function() {
+        // given
+        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
+        const competencesWithMark = [
+          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
+          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
+        ];
+        const certifResult = domainBuilder.buildCertificationResult.cancelled({
+          id: 123,
+          lastName: 'Oxford',
+          firstName: 'Lili',
+          birthdate: '1990-01-04',
+          birthplace: 'Torreilles',
+          externalId: 'LOLORD',
+          createdAt: new Date('2020-01-01'),
+          pixScore: 55,
+          commentForOrganization: 'RAS',
+          competencesWithMark: competencesWithMark,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
+          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+        });
+
+        const certificationResults = [ certifResult ];
+
+        // when
+        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+
+        // then
+        const expectedResult = '\uFEFF' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Annulée";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"RAS";777;"CentreCertif";"01/01/2020"';
+        expect(result).to.equal(expectedResult);
+      });
     });
 
     context('when at least one candidate has passed Pix plus maitre certification', function() {
@@ -217,6 +252,41 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Rejetée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
         expect(result).to.equal(expectedResult);
       });
+
+      it('should return a cancelled Pix plus maitre certification when certification pix is cancelled', async function() {
+        // given
+        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
+        const competencesWithMark = [
+          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
+          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
+        ];
+        const certifResult = domainBuilder.buildCertificationResult.cancelled({
+          id: 123,
+          lastName: 'Oxford',
+          firstName: 'Lili',
+          birthdate: '1990-01-04',
+          birthplace: 'Torreilles',
+          externalId: 'LOLORD',
+          createdAt: new Date('2020-01-01'),
+          pixScore: 55,
+          commentForOrganization: 'RAS',
+          competencesWithMark: competencesWithMark,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.rejected(),
+          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+        });
+
+        const certificationResults = [ certifResult ];
+
+        // when
+        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+
+        // then
+        const expectedResult = '\uFEFF' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Annulée";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"RAS";777;"CentreCertif";"01/01/2020"';
+        expect(result).to.equal(expectedResult);
+      });
     });
 
     context('when at least one candidate has passed Pix plus expert certification', function() {
@@ -253,6 +323,41 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
         const expectedResult = '\uFEFF' +
           '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
           '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Validée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
+        expect(result).to.equal(expectedResult);
+      });
+
+      it('should return a cancelled Pix plus expert certification when certification pix is cancelled', async function() {
+        // given
+        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
+        const competencesWithMark = [
+          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
+          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
+        ];
+        const certifResult = domainBuilder.buildCertificationResult.cancelled({
+          id: 123,
+          lastName: 'Oxford',
+          firstName: 'Lili',
+          birthdate: '1990-01-04',
+          birthplace: 'Torreilles',
+          externalId: 'LOLORD',
+          createdAt: new Date('2020-01-01'),
+          pixScore: 55,
+          commentForOrganization: 'RAS',
+          competencesWithMark: competencesWithMark,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
+        });
+
+        const certificationResults = [ certifResult ];
+
+        // when
+        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+
+        // then
+        const expectedResult = '\uFEFF' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Annulée";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"RAS";777;"CentreCertif";"01/01/2020"';
         expect(result).to.equal(expectedResult);
       });
     });

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -106,7 +106,6 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
 
     context('when at least one certification course is in error', function() {
 
-      // TODO erreur ne devrait pas afficher de score et de niveaux
       it('should return correct csvContent with error status and dashes as Pix scores', async function() {
         // given
         const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
@@ -138,7 +137,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
         // then
         const expectedResult = '\uFEFF' +
           '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"En erreur";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
+          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"En erreur";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"RAS";777;"CentreCertif";"01/01/2020"';
         expect(result).to.equal(expectedResult);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque la certification Pix est annulée, en principe les certifications complémentaires devraient être considérées comme annulées également auprès du candidat et du prescripteur.
Aujourd'hui, les certifications complémentaires ne sont pas affichées comme étant annulées dans les résultats CSV.

## :robot: Solution
Faire en sorte que les certifications complémentaires soient affichées comme annulées dans les résultats CSV lorsque la certification Pix est annulée

## :rainbow: Remarques
+ Fix de l'affichage des scores lorsque la certification est en erreur

## :100: Pour tester
Passer une / des certifications complémentaires (je crois que Anne-success est éligible à des certifications complémentaires)
Aller jusqu'à la publication de la session.

Télécharger le CSV par le lien de téléchargement sur PixAdmin, constater l'affichage non annulé
Annuler la certification puis re-télécharger le CSV, constater l'affichage annulé.
