### PR TITLE
[CLEANUP] Refonte UX de l'affichage des signalement dans Pix Admin (PIX-3088)

### DIFF
--- a/admin/app/components/certification/certification-issue-report.hbs
+++ b/admin/app/components/certification/certification-issue-report.hbs
@@ -1,0 +1,28 @@
+<li class="certification-issue-report">
+  {{#if (or (not @issueReport.isImpactful) @issueReport.resolvedAt)}}
+    <FaIcon
+            aria-label="Résolu"
+            aria-hidden="false"
+            class="certification-issue-report__resolution-status certification-issue-report__resolution-status--resolved"
+            @icon="check-circle"/>
+  {{else}}
+    <FaIcon aria-label="Non résolu"
+            aria-hidden="false"
+            class="certification-issue-report__resolution-status certification-issue-report__resolution-status--unresolved"
+            @icon="times-circle"/>
+  {{/if}}
+
+  <div class="certification-issue-report__details">
+    <div class="certification-issue-report__details__label">
+      {{@issueReport.categoryLabel}}
+      {{#if @issueReport.subcategoryLabel}} : {{@issueReport.subcategoryLabel}}{{/if}}
+      {{#if @issueReport.description}} - {{@issueReport.description}}{{/if}}
+      {{#if @issueReport.questionNumber}} - Question {{@issueReport.questionNumber}}{{/if}}
+    </div>
+    {{#if (and @issueReport.isImpactful @issueReport.resolvedAt)}}
+      <div class="certification-issue-report__details__resolution-message">
+        Résolution : {{#if @issueReport.resolution}}{{@issueReport.resolution}}{{else}}-{{/if}}
+      </div>
+    {{/if}}
+  </div>
+</li>

--- a/admin/app/components/certification/certification-issue-reports.hbs
+++ b/admin/app/components/certification/certification-issue-reports.hbs
@@ -1,0 +1,22 @@
+{{#if @hasImpactfulIssueReports}}
+  <h2
+    class="certification-issue-reports__subtitle certification-issue-reports__subtitle--with-action-required">
+    {{@impactfulCertificationIssueReports.length}} Signalement(s) impactant(s)
+  </h2>
+  <ul class="certification-issue-reports__list">
+    {{#each @impactfulCertificationIssueReports as |issueReport| }}
+      <Certification::CertificationIssueReport @issueReport={{issueReport}}/>
+    {{/each}}
+  </ul>
+{{/if}}
+{{#if @hasUnimpactfulIssueReports}}
+  <h2
+    class="certification-issue-reports__subtitle certification-issue-reports__subtitle--without-action-required">
+    {{@unimpactfulCertificationIssueReports.length}} Signalement(s) non impactant(s)
+  </h2>
+  <ul class="certification-issue-reports__list certification-issue-reports__list--last">
+    {{#each @unimpactfulCertificationIssueReports as |issueReport| }}
+      <Certification::CertificationIssueReport @issueReport={{issueReport}}/>
+    {{/each}}
+  </ul>
+{{/if}}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -42,6 +42,8 @@
 @import 'components/certification-details-answer';
 @import 'components/certification-details-competence';
 @import 'components/certification-info-field';
+@import 'components/certification-issue-report';
+@import 'components/certification-issue-reports';
 @import 'components/certified-profile.scss';
 @import 'components/confirm-popup';
 @import 'components/member-item';

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -29,24 +29,8 @@
     font-weight: bold;
   }
 
-  &__certification-issue-report-title--with-required-action {
-    font-weight: bold;
-    color: $information-dark;
-  }
-
-  &__certification-issue-reports-list {
-    list-style-type: none;
-    padding-left: 16px;
-  }
-
-  &__certification-issue-report--resolved::before {
-    content: "✅";
-    margin-right: 8px;
-  }
-
-  &__certification-issue-report--unresolved::before {
-    content: "🚨";
-    margin-right: 8px;
+  &__certification-issue-reports {
+    padding: 0;
   }
 
   .certification-informations {

--- a/admin/app/styles/components/certification-issue-report.scss
+++ b/admin/app/styles/components/certification-issue-report.scss
@@ -1,0 +1,35 @@
+.certification-issue-report {
+  display: flex;
+  align-items: center;
+  border-bottom: #eaecf0 solid 1px;
+
+  &__resolution-status {
+    margin-left: 24px;
+    margin-top: 24px;
+    margin-bottom: 24px;
+
+    &--resolved {
+      color: $success;
+    }
+
+    &--unresolved {
+      color: $error;
+    }
+  }
+
+  &__details {
+    margin-left: 16px;
+
+    &__label {
+      font-family: $roboto;
+      font-weight: $font-medium;
+      color: $blue-zodiac;
+    }
+
+    &__resolution-message {
+      font-family: $roboto;
+      font-weight: $font-light;
+      color: $grey-30;
+    }
+  }
+}

--- a/admin/app/styles/components/certification-issue-reports.scss
+++ b/admin/app/styles/components/certification-issue-reports.scss
@@ -1,0 +1,33 @@
+.certification-issue-reports {
+
+  &__title {
+    margin-bottom: 16px;
+    font-size: 1.25rem;
+  }
+
+  &__subtitle {
+    font-size: 1rem;
+    font-weight: normal;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    margin: 0;
+
+    &--with-action-required {
+      background-color: $yellow-alert-light;
+      color: $yellow-alert-dark;
+    }
+
+    &--without-action-required {
+      background-color: $grey-10;
+      color: $grey-60;
+    }
+  }
+
+  &__list {
+    padding-left: 0px;
+
+    &--last {
+      margin-bottom: 0px;
+    }
+  }
+}

--- a/admin/app/styles/globals/fonts.scss
+++ b/admin/app/styles/globals/fonts.scss
@@ -1,2 +1,5 @@
 $roboto: 'Roboto', Arial, sans-serif;
 $open-sans: 'Open Sans', Arial, sans-serif;
+
+$font-medium: 500;
+$font-light: 300;

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -16,7 +16,7 @@
       data-test-id="Annuler la certification"
     >
       Annuler la certification
-    </PixButton>
+      </PixButton>
   </div>
   <div class="row">
     <div class="col">
@@ -87,47 +87,17 @@
   </div>
 
   {{#if this.hasIssueReports}}
-    <div class="row">
-      <div class="col">
-        <div class="card {{if this.editingCandidateResults 'border-primary'}}">
-          <div class="card-body">
-            <h5 class="card-title">Signalements</h5>
-
-            {{#if this.hasImpactfulIssueReports}}
-              <div class="card-text">
-                <h6 class="certification-informations__certification-issue-report-title--with-required-action">Signalement(s) impactant(s)</h6>
-                <ul class="certification-informations__certification-issue-reports-list">
-                  {{#each this.impactfulCertificationIssueReports as |issueReport| }}
-                    <li class={{if issueReport.resolvedAt "certification-informations__certification-issue-report--resolved" "certification-informations__certification-issue-report--unresolved"}}>
-                      {{issueReport.categoryLabel}}
-                      {{#if issueReport.subcategoryLabel}}: {{issueReport.subcategoryLabel}}{{/if}}
-                      {{#if issueReport.description}}- {{issueReport.description}}{{/if}}
-                      {{#if issueReport.questionNumber}}- Question {{issueReport.questionNumber}}{{/if}}
-                    </li>
-                  {{/each}}
-                </ul>
-              </div>
-            {{/if}}
-
-            {{#if this.hasUnimpactfulIssueReports}}
-              <div class="card-text">
-                <h6>Signalement(s) non impactant(s)</h6>
-                <ul>
-                  {{#each this.unimpactfulCertificationIssueReports as |issueReport| }}
-                    <li>
-                      {{issueReport.categoryLabel}}
-                      {{#if issueReport.subcategoryLabel}}: {{issueReport.subcategoryLabel}}{{/if}}
-                      {{#if issueReport.description}}- {{issueReport.description}}{{/if}}
-                    </li>
-                  {{/each}}
-                </ul>
-              </div>
-            {{/if}}
-
-          </div>
-        </div>
+    <section class="card certification-informations__certification-issue-reports">
+      <div class="card-body">
+        <h1 class="card-title certification-informations__certification-issue-reports__title">Signalements</h1>
+        <Certification::CertificationIssueReports
+          @hasImpactfulIssueReports={{this.hasImpactfulIssueReports}}
+          @hasUnimpactfulIssueReports={{this.hasUnimpactfulIssueReports}}
+          @impactfulCertificationIssueReports={{this.impactfulCertificationIssueReports}}
+          @unimpactfulCertificationIssueReports={{this.unimpactfulCertificationIssueReports}}
+        />
       </div>
-    </div>
+    </section>
   {{/if}}
 
   <div class="row">

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -26129,8 +26129,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#bebc2f6a4f91de702215b4b42830dfbe11453196",
-      "from": "git://github.com/1024pix/pix-ui.git#v5.4.0",
+      "version": "git://github.com/1024pix/pix-ui.git#b363e01c3464c3b1a2fbb1400e3c1713384f6904",
+      "from": "git://github.com/1024pix/pix-ui.git#v6.2.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
@@ -26520,9 +26520,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001251",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-          "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+          "version": "1.0.30001252",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
           "dev": true
         },
         "colorette": {
@@ -26532,12 +26532,12 @@
           "dev": true
         },
         "core-js-compat": {
-          "version": "3.16.2",
-          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
-          "integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
+          "version": "3.16.4",
+          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.4.tgz",
+          "integrity": "sha512-IzCSomxRdahCYb6G3HiN6pl3JCiM0NMunRcNa1pIeC7g17Vd6Ue3AT9anQiENPIm/svThUVer1pIbLMDERIsFw==",
           "dev": true,
           "requires": {
-            "browserslist": "^4.16.7",
+            "browserslist": "^4.16.8",
             "semver": "7.0.0"
           },
           "dependencies": {
@@ -26559,9 +26559,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.813",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.813.tgz",
-          "integrity": "sha512-YcSRImHt6JZZ2sSuQ4Bzajtk98igQ0iKkksqlzZLzbh4p0OIyJRSvUbsgqfcR8txdfsoYCc4ym306t4p2kP/aw==",
+          "version": "1.3.824",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.824.tgz",
+          "integrity": "sha512-Fk+5aD0HDi9i9ZKt9n2VPOZO1dQy7PV++hz2wJ/KIn+CvVfu4fny39squHtyVDPuHNuoJGAZIbuReEklqYIqfA==",
           "dev": true
         },
         "ember-cli-babel": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -96,7 +96,7 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.1",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.4.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v6.2.0",
     "popper.js": "^1.16.1",
     "query-string": "^7.0.0",
     "qunit": "^2.14.0",

--- a/admin/tests/integration/components/routes/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/certification/informations_test.js
@@ -185,8 +185,9 @@ module('Integration | Component | routes/authenticated/certifications/certificat
           await visit(`/certifications/${certification.id}`);
 
           // then
+          //await this.pauseTest();
           assert.contains('Signalement(s) impactant(s)');
-          assert.dom('.card-text ul li').hasText('Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement impactant');
+          assert.dom('.certification-issue-report__details__label').hasText('Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement impactant');
           assert.notContains('Signalement(s) non impactant(s)');
         });
 
@@ -210,8 +211,8 @@ module('Integration | Component | routes/authenticated/certifications/certificat
             await visit(`/certifications/${certification.id}`);
 
             // then
-            assert.dom('.certification-informations__certification-issue-report--resolved').exists();
-            assert.dom('.certification-informations__certification-issue-report--unresolved').doesNotExist();
+            assert.dom('.certification-issue-report__resolution-status--resolved').exists();
+            assert.dom('.certification-issue-report__resolution-status--unresolved').doesNotExist();
           });
         });
 
@@ -235,8 +236,8 @@ module('Integration | Component | routes/authenticated/certifications/certificat
             await visit(`/certifications/${certification.id}`);
 
             // then
-            assert.dom('.certification-informations__certification-issue-report--unresolved').exists();
-            assert.dom('.certification-informations__certification-issue-report--resolved').doesNotExist();
+            assert.dom('.certification-issue-report__resolution-status--unresolved').exists();
+            assert.dom('.certification-issue-report__resolution-status--resolved').doesNotExist();
           });
         });
       });
@@ -281,7 +282,7 @@ module('Integration | Component | routes/authenticated/certifications/certificat
 
           // then
           assert.contains('Signalement(s) non impactant(s)');
-          assert.dom('.card-text ul li').hasText('Modification infos candidat : Ajout/modification du temps majoré - Un signalement non impactant');
+          assert.dom('.certification-issue-report__details__label').hasText('Modification infos candidat : Ajout/modification du temps majoré - Un signalement non impactant');
           assert.notContains('Signalement(s) impactant(s)');
         });
       });
@@ -324,7 +325,7 @@ module('Integration | Component | routes/authenticated/certifications/certificat
         await visit(`/certifications/${certification.id}`);
 
         // then
-        assert.dom('.card-text ul li').hasText('Problème technique sur une question : L\'image ne s\'affiche pas - image disparue - Question 666');
+        assert.dom('.certification-issue-report__details__label').hasText('Problème technique sur une question : L\'image ne s\'affiche pas - image disparue - Question 666');
       });
 
     });


### PR DESCRIPTION
## :unicorn: Problème
Dans un souci de rapidité, l'affichage des signalements dans Pix Admin avait été fait de façon assez brute. De plus, le message de résolution des signalements impactants n'était pas fait. 

## :robot: Solution
Refondre l'UX de cette section dans Pix Admin en incluant le message de résolution.

**Avant**
<img width="1017" alt="Capture d’écran 2021-08-31 à 11 23 53" src="https://user-images.githubusercontent.com/34715194/131477899-fa3c92c0-cbf5-4c37-9573-c2b3c263ef71.png">

**Après**
<img width="1019" alt="Capture d’écran 2021-08-31 à 11 24 03" src="https://user-images.githubusercontent.com/34715194/131477926-700ea7ab-2cf7-4941-ae2c-71ec4bde67c1.png">

## :rainbow: Remarques
R.A.S

## :100: Pour tester
- Se rendre sur une session de certification comprenant des signalement.

ou :
- créer une session
- inscrire un candidat
- passer la certif (en répondant faux à différentes questions ayant des images, des applications, etc et en prenant soin de noter le numéro de ces questions) 
- finaliser la session en ajoutant des signalements (non impactants, impactants auto et non-impactants)
- se rendre dans Pix Admin et constater le bon affichage des signalement.
