### PR TITLE
[TECH] Activer à chaud la validation de l'adresse e-mail sur Pix App (PIX-3121).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -142,6 +142,7 @@ module.exports = (function() {
     },
 
     featureToggles: {
+      isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
       isDownloadCertificationAttestationByDivisionEnabled: isFeatureEnabled(process.env.FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
     },

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -26,6 +26,7 @@ const schema = Joi.object({
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   CACHE_RELOAD_TIME: Joi.string().optional(),
+  FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function() {

--- a/api/sample.env
+++ b/api/sample.env
@@ -21,6 +21,14 @@
 # FEATURE-TOGGLE
 # =======
 
+# Enable email validation in Pix App
+#
+# presence: optionnal
+# type: boolean
+# default: false
+
+FT_VALIDATE_EMAIL=false
+
 # =======
 # CACHING
 # =======

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -25,6 +25,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function() {
           attributes: {
             'is-download-certification-attestation-by-division-enabled': false,
             'is-manage-uncompleted-certif-enabled': false,
+            'is-email-validation-enabled': false,
           },
           type: 'feature-toggles',
         },

--- a/mon-pix/app/components/user-account-connexion-methods.js
+++ b/mon-pix/app/components/user-account-connexion-methods.js
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class UserAccountConnexionMethodsComponent extends Component {
+
+  @service featureToggles;
 
   get shouldShowEmail() {
     return !!this.args.user.email;
@@ -8,5 +11,9 @@ export default class UserAccountConnexionMethodsComponent extends Component {
 
   get shouldShowUsername() {
     return !!this.args.user.username;
+  }
+
+  get isEmailValidationEnabled() {
+    return this.featureToggles.featureToggles.isEmailValidationEnabled;
   }
 }

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -1,4 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
+  @attr('boolean') isEmailValidationEnabled;
 }

--- a/mon-pix/app/styles/pages/_connexion-methods.scss
+++ b/mon-pix/app/styles/pages/_connexion-methods.scss
@@ -48,3 +48,8 @@
     background-color: transparent;
   }
 }
+
+.user-account-panel-item__edit-button {
+  margin-left: auto;
+  padding: 0 20px;
+}

--- a/mon-pix/app/templates/components/user-account-connexion-methods.hbs
+++ b/mon-pix/app/templates/components/user-account-connexion-methods.hbs
@@ -4,12 +4,21 @@
       <p class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.connexion-methods.email'}}</p>
       <p class="user-account-panel-item__value" data-test-email>{{@user.email}}</p>
     </div>
-    <PixButton
-            class="user-account-panel-item__button"
+    {{#if this.isEmailValidationEnabled}}
+      <PixButton
+            class="user-account-panel-item__edit-button"
             @triggerAction={{@enableEmailEditionMode}}
             data-test-edit-email>
       {{t 'pages.user-account.connexion-methods.edit-button'}}
-    </PixButton>
+      </PixButton>
+    {{else}}
+      <PixButton
+              class="user-account-panel-item__button"
+              @triggerAction={{@enableEmailEditionMode}}
+              data-test-edit-email>
+        {{t 'pages.user-account.connexion-methods.edit-button'}}
+      </PixButton>
+    {{/if}}
   </div>
 {{/if}}
 

--- a/mon-pix/tests/integration/components/user-account-connexion-methods_test.js
+++ b/mon-pix/tests/integration/components/user-account-connexion-methods_test.js
@@ -3,11 +3,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { contains } from '../../helpers/contains';
 import sinon from 'sinon';
 import Service from '@ember/service';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 describe('Integration | Component | user-account-connexion-methods', function() {
   setupIntlRenderingTest();
@@ -45,8 +46,7 @@ describe('Integration | Component | user-account-connexion-methods', function() 
       await render(hbs`<UserAccountConnexionMethods @user={{user}} />`);
 
       // then
-      expect(find('.user-account-panel-item__edit-button')).to.exist;
-      expect(find('.user-account-panel-item__button')).to.not.exist;
+      expect(contains(this.intl.t('pages.user-account.connexion-methods.edit-button'))).to.exist;
     });
   });
 
@@ -85,7 +85,7 @@ describe('Integration | Component | user-account-connexion-methods', function() 
       await render(hbs`<UserAccountConnexionMethods @user={{user}} />`);
 
       // then
-      expect(find('p[data-test-email]')).to.not.exist;
+      expect(contains(this.intl.t('pages.user-account.connexion-methods.email'))).to.not.exist;
     });
   });
 
@@ -105,7 +105,7 @@ describe('Integration | Component | user-account-connexion-methods', function() 
       await render(hbs`<UserAccountConnexionMethods @user={{this.user}} />`);
 
       // then
-      expect(find('p[data-test-username]')).to.not.exist;
+      expect(contains(this.intl.t('pages.user-account.connexion-methods.username'))).to.not.exist;
     });
   });
 
@@ -125,7 +125,7 @@ describe('Integration | Component | user-account-connexion-methods', function() 
     await render(hbs `<UserAccountConnexionMethods @user={{this.user}} @enableEmailEditionMode={{this.enableEmailEditionMode}} />`);
 
     // when
-    await click('button[data-test-edit-email]');
+    await clickByLabel(this.intl.t('pages.user-account.connexion-methods.edit-button'));
 
     // then
     sinon.assert.called(enableEmailEditionMode);

--- a/mon-pix/tests/integration/components/user-account-connexion-methods_test.js
+++ b/mon-pix/tests/integration/components/user-account-connexion-methods_test.js
@@ -1,13 +1,54 @@
+/* eslint ember/no-classic-classes: 0 */
+
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { contains } from '../../helpers/contains';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 describe('Integration | Component | user-account-connexion-methods', function() {
-  setupRenderingTest();
+  setupIntlRenderingTest();
+
+  beforeEach(function() {
+    const featureTogglesStub = Service.extend({
+      featureToggles: {
+        isEmailValidationEnabled: false,
+      },
+    });
+    this.owner.register('service:featureToggles', featureTogglesStub);
+  });
+
+  context('when isEmailValidationEnabled feature toggle is enabled', function() {
+
+    it('should display edit button', async function() {
+      // given
+      const featureTogglesStub = Service.extend({
+        featureToggles: {
+          isEmailValidationEnabled: true,
+        },
+      });
+
+      this.owner.register('service:featureToggles', featureTogglesStub);
+
+      const user = {
+        firstName: 'John',
+        lastName: 'DOE',
+        email: 'john.doe@example.net',
+        lang: 'fr',
+      };
+      this.set('user', user);
+
+      // when
+      await render(hbs`<UserAccountConnexionMethods @user={{user}} />`);
+
+      // then
+      expect(find('.user-account-panel-item__edit-button')).to.exist;
+      expect(find('.user-account-panel-item__button')).to.not.exist;
+    });
+  });
 
   it('should display user\'s email and username', async function() {
     // given

--- a/mon-pix/tests/unit/services/feature-toggles_test.js
+++ b/mon-pix/tests/unit/services/feature-toggles_test.js
@@ -13,6 +13,7 @@ describe('Unit | Service | feature-toggles', function() {
   describe('feature toggles are loaded', function() {
 
     const featureToggles = Object.create({
+      isEmailValidationEnabled: false,
     });
 
     let storeStub;


### PR DESCRIPTION
## :unicorn: Problème
Pour créer la nouvelle feature de validation au changement de l'adresse e-mail dans Mon Compte sur Pix App, nous avons besoin de masquer les nouveaux ajouts tout en laissant le changement d'adresse actuel fonctionnel.

## :robot: Solution
Ajouter un feature toggle `isEmailValidationEnabled` coté back et front. 

## :rainbow: Remarques

variable à `true` :

<img width="127" alt="Capture d’écran 2021-08-31 à 17 12 39" src="https://user-images.githubusercontent.com/58915422/131528999-75473cd5-4d3d-4057-8e28-104a129e8ee2.png">

variable à `false` :

<img width="127" alt="Capture d’écran 2021-08-31 à 17 13 24" src="https://user-images.githubusercontent.com/58915422/131529008-96043270-0caa-46a0-b404-c8dfa26cec16.png">

- Ce "nouveau" bouton qui apparaît lorsque la variable est à `true` redirige vers la fonctionnalité existante pour l'instant, **mais cela sera modifié sur une prochaine PR.**

- Modification visuelle du "nouveau" bouton pour différencier lorsque la variable est à `true` ou `false` (temporaire).

- Ajout de la variable `FT_VALIDATE_EMAIL` sur pix-api-review et sur la RA.

## :100: Pour tester
En local : Passer la variable `FT_VALIDATE_EMAIL` de false à true pour voir que le bouton change.

En RA : Ajouté par défaut à `true`, à changer pour voir la modification.

Aller sur https://app-pr3423.review.pix.fr/mon-compte/methodes-de-connexion