### PR TITLE
[FEATURE] Enregistrer la dernière date de connexion native (PIX-2736).

### DIFF
--- a/api/db/migrations/20210831124754_add-last-connexion-date-column-in-users-table.js
+++ b/api/db/migrations/20210831124754_add-last-connexion-date-column-in-users-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'lastLoginDate';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20210831124754_add-last-logged-at-column-in-users-table.js
+++ b/api/db/migrations/20210831124754_add-last-logged-at-column-in-users-table.js
@@ -1,5 +1,5 @@
 const TABLE_NAME = 'users';
-const COLUMN_NAME = 'lastLoginDate';
+const COLUMN_NAME = 'lastLoggedAt';
 
 exports.up = function(knex) {
   return knex.schema.table(TABLE_NAME, (table) => {

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -42,6 +42,7 @@ module.exports = async function authenticateUser({
 
     if (!shouldChangePassword) {
       _checkUserAccessScope(scope, foundUser);
+      await userRepository.updateLastLoginDate({ userId: foundUser.id });
       return tokenService.createAccessTokenFromUser(foundUser.id, source);
     } else {
       throw new UserShouldChangePasswordError();

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -42,7 +42,7 @@ module.exports = async function authenticateUser({
 
     if (!shouldChangePassword) {
       _checkUserAccessScope(scope, foundUser);
-      await userRepository.updateLastLoginDate({ userId: foundUser.id });
+      await userRepository.updateLastLoggedAt({ userId: foundUser.id });
       return tokenService.createAccessTokenFromUser(foundUser.id, source);
     } else {
       throw new UserShouldChangePasswordError();

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -400,12 +400,12 @@ module.exports = {
       .then((users) => bookshelfToDomainConverter.buildDomainObjects(BookshelfUser, users));
   },
 
-  async updateLastLoginDate({ userId }) {
+  async updateLastLoggedAt({ userId }) {
     const now = new Date();
 
     await knex('users')
       .where({ id: userId })
-      .update({ lastLoginDate: now });
+      .update({ lastLoggedAt: now });
   },
 };
 

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -399,6 +399,14 @@ module.exports = {
       .fetchAll()
       .then((users) => bookshelfToDomainConverter.buildDomainObjects(BookshelfUser, users));
   },
+
+  async updateLastLoginDate({ userId }) {
+    const now = new Date();
+
+    await knex('users')
+      .where({ id: userId })
+      .update({ lastLoginDate: now });
+  },
 };
 
 function _toUserDetailsForAdminDomain(bookshelfUser) {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -4,7 +4,14 @@ const each = require('lodash/each');
 const map = require('lodash/map');
 const times = require('lodash/times');
 
-const { expect, knex, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
+const {
+  expect,
+  knex,
+  databaseBuilder,
+  domainBuilder,
+  catchErr,
+  sinon,
+} = require('../../../test-helper');
 
 const {
   AlreadyExistingEntityError,
@@ -1509,6 +1516,34 @@ describe('Integration | Infrastructure | Repository | UserRepository', function(
 
       // then
       expect(foundUsers).to.be.an('array').that.is.empty;
+    });
+  });
+
+  describe('#updateLastLoginDate', function() {
+
+    let clock;
+    const now = new Date('2020-01-02');
+
+    beforeEach(function() {
+      clock = sinon.useFakeTimers(now);
+    });
+
+    afterEach(function() {
+      clock.restore();
+    });
+
+    it('should update the last login date to now', async function() {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const userId = user.id;
+      await databaseBuilder.commit();
+
+      // when
+      await userRepository.updateLastLoginDate({ userId });
+
+      // then
+      const userUpdated = await knex('users').select().where({ id: userId }).first();
+      expect(userUpdated.lastLoginDate).to.deep.equal(now);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1519,7 +1519,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function(
     });
   });
 
-  describe('#updateLastLoginDate', function() {
+  describe('#updateLastLoggedAt', function() {
 
     let clock;
     const now = new Date('2020-01-02');
@@ -1539,11 +1539,11 @@ describe('Integration | Infrastructure | Repository | UserRepository', function(
       await databaseBuilder.commit();
 
       // when
-      await userRepository.updateLastLoginDate({ userId });
+      await userRepository.updateLastLoggedAt({ userId });
 
       // then
       const userUpdated = await knex('users').select().where({ id: userId }).first();
-      expect(userUpdated.lastLoginDate).to.deep.equal(now);
+      expect(userUpdated.lastLoggedAt).to.deep.equal(now);
     });
   });
 

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -32,7 +32,7 @@ describe('Unit | Application | UseCase | authenticate-user', function() {
     };
     userRepository = {
       getByUsernameOrEmailWithRoles: sinon.stub(),
-      updateLastLoginDate: sinon.stub(),
+      updateLastLoggedAt: sinon.stub(),
     };
     sinon.stub(authenticationService, 'getUserByUsernameAndPassword');
   });
@@ -84,7 +84,7 @@ describe('Unit | Application | UseCase | authenticate-user', function() {
     });
 
     // then
-    expect(userRepository.updateLastLoginDate).to.have.been.calledWithExactly({ userId: user.id });
+    expect(userRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
   });
 
   it('should rejects an error when given username (email) does not match an existing one', async function() {

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -32,6 +32,7 @@ describe('Unit | Application | UseCase | authenticate-user', function() {
     };
     userRepository = {
       getByUsernameOrEmailWithRoles: sinon.stub(),
+      updateLastLoginDate: sinon.stub(),
     };
     sinon.stub(authenticationService, 'getUserByUsernameAndPassword');
   });
@@ -62,6 +63,28 @@ describe('Unit | Application | UseCase | authenticate-user', function() {
     });
     expect(tokenService.createAccessTokenFromUser)
       .to.have.been.calledWithExactly(user.id, source);
+  });
+
+  it('should save the last date of login when authentication succeeded', async function() {
+    // given
+    const accessToken = 'jwt.access.token';
+    const source = 'pix';
+    const user = domainBuilder.buildUser({ email: userEmail });
+
+    authenticationService.getUserByUsernameAndPassword.resolves(user);
+    tokenService.createAccessTokenFromUser.returns(accessToken);
+
+    // when
+    await authenticateUser({
+      username: userEmail,
+      password,
+      source,
+      tokenService,
+      userRepository,
+    });
+
+    // then
+    expect(userRepository.updateLastLoginDate).to.have.been.calledWithExactly({ userId: user.id });
   });
 
   it('should rejects an error when given username (email) does not match an existing one', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement déterminer la dernière date de connexion d'un utilisateur se fait difficilement.
Afin de pouvoir préparer le terrain lorsque nous allons archiver les comptes des utilisateurs qui n'ont pas été actifs depuis 5 ans, il serait plus pratique d'enregistrer cette dernière date de connexion directement dans la table "users".

## :robot: Solution
Enregistrer la dernière date de connexion dans la table "users".

## :rainbow: Remarques
- La date est enregistré dès qu'on authentifie avec succès la personne, toutes app confondues.
- Le token de connexion durant 7 jours, la date de dernière connexion est donc mise à jour au même moment

## :100: Pour tester
En local :
- `npm run db:reset` dans l'api
- Lancer l'api et le front de votre choix
- Choisissez l'email d'un utilisateur présent dans les seeds, par exemple `pro.admin@example.net`
- `docker-compose exec postgres psql -Upostgres pix -xc 'select * from "users" where "email"='"'pro.admin@example.net'"''`
- Vérifier que la colonne `lastLoginDate` est vide
- Connectez vous avec votre utilisateur sur l'app de votre choix
- `docker-compose exec postgres psql -Upostgres pix -xc 'select * from "users" where "email"='"'pro.admin@example.net'"''`
- Vérifier que la colonne `lastLoginDate` est mise à jour avec la bonne date et heure 
