### PR TITLE
[FEATURE] Afficher le message d'alerte des focus via le clavier (PIX-3074).

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -35,8 +35,12 @@ export default class ChallengeController extends Controller {
     return this.model.challenge.focused && this.hasFocusedOutOfChallenge && !this.model.answer;
   }
 
-  get shouldDisplayInfoAlert() {
-    return this.hasFocusedOutOfChallenge && !this.hasFocusedOutOfWindow && !this.model.answer;
+  get couldDisplayInfoAlert() {
+    return !this.hasFocusedOutOfWindow && !this.model.answer && this.model.challenge.focused;
+  }
+
+  get displayInfoAlertForFocusOut() {
+    return this.hasFocusedOutOfChallenge && this.couldDisplayInfoAlert;
   }
 
   get isFocusedChallengeAndTooltipIsDisplayed() {

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -65,9 +65,17 @@
     box-shadow: 0 10px 20px 0 rgba($blue, 0.06);
     background-color: rgba($blue-10, 0.9);
     color: $blue-60;
+    opacity: 0;
+    height: 0;
 
     @include device-is('tablet') {
       padding: 24px 98px;
+    }
+
+    &.challenge__info-alert--show,
+    &:focus.challenge__info-alert--could-show {
+      opacity: 1;
+      height: auto;
     }
   }
 }

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -43,11 +43,13 @@
   <div class="challenge__feedback" role="complementary">
     <FeedbackPanel @assessment={{@model.assessment}} @challenge={{@model.challenge}}/>
   </div>
-
-  {{#if this.shouldDisplayInfoAlert}}
-    <div class="challenge__info-alert"
-         role="alert"
-         aria-live="assertive">
+    <div
+      class="challenge__info-alert
+        {{if this.displayInfoAlertForFocusOut 'challenge__info-alert--show'}}
+        {{if this.couldDisplayInfoAlert 'challenge__info-alert--could-show'}}"
+      tabindex="0"
+      role="alert"
+      aria-live="assertive">
       <div class="challenge-info-alert__icon" />
       <p class="challenge-info-alert__title">
         {{t 'pages.challenge.is-focused-challenge.info-alert.title'}}
@@ -56,7 +58,6 @@
         {{t 'pages.challenge.is-focused-challenge.info-alert.subtitle'}}
       </p>
     </div>
-  {{/if}}
 </div>
 
 {{#if this.showLevelup}}

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -59,7 +59,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             await triggerEvent(challengeItem, 'mouseleave');
 
             // then
-            expect(find('.challenge__info-alert')).to.not.exist;
+            expect(find('.challenge__info-alert--show')).to.not.exist;
             expect(find('.challenge-item__container--focused')).to.not.exist;
             expect(find('.challenge__focused-out-overlay')).to.not.exist;
           });
@@ -102,7 +102,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await triggerEvent(challengeItem, 'mouseleave');
 
               // then
-              expect(find('.challenge__info-alert')).to.exist;
+              expect(find('.challenge__info-alert--could-show')).to.exist;
               expect(find('.challenge-item__container--focused')).to.exist;
               expect(find('.challenge__focused-out-overlay')).to.exist;
             });
@@ -112,7 +112,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               const challengeItem = find('.challenge-item');
               await triggerEvent(challengeItem, 'mouseleave');
 
-              expect(find('.challenge__info-alert')).to.exist;
+              expect(find('.challenge__info-alert--could-show')).to.exist;
               expect(find('.challenge-item__container--focused')).to.exist;
               expect(find('.challenge__focused-out-overlay')).to.exist;
 
@@ -120,7 +120,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await triggerEvent(window, 'blur');
 
               // then
-              expect(find('.challenge__info-alert')).to.not.exist;
+              expect(find('.challenge__info-alert--could-show')).to.not.exist;
               expect(find('.challenge-actions__focused-out-of-window')).to.exist;
               expect(find('.challenge-item__container--focused')).to.exist;
               expect(find('.challenge__focused-out-overlay')).to.exist;
@@ -173,7 +173,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           await triggerEvent(challengeItem, 'mouseleave');
 
           // then
-          expect(find('.challenge__info-alert')).to.not.exist;
+          expect(find('.challenge__info-alert--could-show')).to.not.exist;
           expect(find('.challenge__focused-out-overlay')).to.not.exist;
           expect(find('.challenge-actions__focused-out-of-window')).to.not.exist;
           expect(find('.challenge-actions__already-answered')).to.exist;


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur utilise le clavier, il n'a pas le message d'alerte lui indiquant qu'il risque de sortir, et par conséquent risque de perdre le focus sans le vouloir

## :robot: Solution
Pouvoir afficher le message d'alerte quand on arrive en bas avec le clavier en : 
- Rendant le message accessible au tab
- L'afficher si on tab dessus ou si on focusout à la souris

## :rainbow: Remarques

## :100: Pour tester
Epreuve Focus : `challenge1xvcnxyyvj13v7`
- Afficher le message en sortant via la souris de la partie épreuve
- Afficher le message en sortant via le clavier
- Si on a déjà défocus, ne plus voir le message d'alerte