### PR TITLE
[FEATURE] Ajout du endpoint pour l'abandon d'une certification (pix-3063)

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -25,6 +25,7 @@ module.exports = function buildCertificationCourse({
   sessionId,
   maxReachableLevelOnCertificationDate = 5,
   isCancelled = false,
+  abortReason = undefined,
 } = {}) {
 
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -51,6 +52,7 @@ module.exports = function buildCertificationCourse({
     sessionId,
     maxReachableLevelOnCertificationDate,
     isCancelled,
+    abortReason,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/db/migrations/20210831140352_add_certification-courses_abort-reason.js
+++ b/api/db/migrations/20210831140352_add_certification-courses_abort-reason.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'abortReason';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.text(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -77,4 +77,10 @@ module.exports = {
     const cancelledCertificationCourse = await usecases.cancelCertificationCourse({ certificationCourseId });
     return certificationCourseSerializer.serialize(cancelledCertificationCourse);
   },
+
+  async abort(request) {
+    const certificationCourseId = request.params.id;
+    const abortReason = request.payload.data.attributes['abort-reason'];
+    return usecases.abortCertificationCourse({ certificationCourseId, abortReason });
+  },
 };

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -126,6 +126,23 @@ exports.register = async function(server) {
         tags: ['api'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/certification-courses/{id}/abort',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: certificationCourseController.abort,
+        tags: ['api'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/usecases/abort-certification-course.js
+++ b/api/lib/domain/usecases/abort-certification-course.js
@@ -1,0 +1,9 @@
+module.exports = async function abortCertificationCourse({
+  certificationCourseRepository,
+  certificationCourseId,
+  abortReason,
+}) {
+  const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
+  certificationCourse.abort(abortReason);
+  return certificationCourseRepository.update(certificationCourse);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -123,6 +123,7 @@ const dependencies = {
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection');
 
 module.exports = injectDependencies({
+  abortCertificationCourse: require('./abort-certification-course'),
   acceptOrganizationInvitation: require('./accept-organization-invitation'),
   acceptPixLastTermsOfService: require('./accept-pix-last-terms-of-service'),
   acceptPixCertifTermsOfService: require('./accept-pix-certif-terms-of-service'),

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -159,6 +159,7 @@ function _pickUpdatableProperties(certificationCourse) {
     'birthCountry',
     'birthINSEECode',
     'birthPostalCode',
+    'abortReason',
     'completedAt',
   ]);
 }

--- a/api/package.json
+++ b/api/package.json
@@ -109,6 +109,7 @@
     "db:delete": "node scripts/database/drop-database",
     "db:empty": "node scripts/database/empty-database",
     "db:migrate": "knex --knexfile db/knexfile.js migrate:latest",
+    "db:rollback:latest": "knex --knexfile db/knexfile.js migrate:down",
     "db:prepare": "npm run db:delete && npm run db:create && npm run db:migrate",
     "db:seed": "knex --knexfile db/knexfile.js seed:run",
     "db:reset": "npm run db:prepare && npm run db:seed",

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -3,6 +3,7 @@ const {
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
   mockLearningContent,
+  insertUserWithRolePixMaster,
   learningContentBuilder,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
@@ -536,6 +537,44 @@ describe('Acceptance | API | Certifications', function() {
         expect(response.headers['content-disposition']).to.include('filename=attestation-pix');
         expect(response.file).not.to.be.null;
       });
+    });
+  });
+
+  describe('GET /api/admin/certification-courses/:id/abort', function() {
+
+    it('should return 200 HTTP status code if certification course is updated', async function() {
+      const pixMaster = await insertUserWithRolePixMaster();
+      databaseBuilder.commit();
+      // given
+      const options = {
+        method: 'POST',
+        url: `/api/admin/certification-courses/${certificationCourse.id}/abort`,
+        payload: { data: { attributes: { 'abort-reason': 'technical' } } },
+        headers: { authorization: generateValidRequestAuthorizationHeader(pixMaster.id) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 403 HTTP status code if user is not PixMaster', async function() {
+      databaseBuilder.commit();
+      // given
+      const options = {
+        method: 'POST',
+        url: `/api/admin/certification-courses/${certificationCourse.id}/abort`,
+        payload: { data: { attributes: { 'abort-reason': 'technical' } } },
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
     });
   });
 });

--- a/api/tests/integration/domain/usecases/abort-certification-course_test.js
+++ b/api/tests/integration/domain/usecases/abort-certification-course_test.js
@@ -1,0 +1,30 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const abortCertificationCourse = require('../../../../lib/domain/usecases/abort-certification-course');
+const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
+
+describe('Integration | UseCase | abort-certification-course', function() {
+
+  beforeEach(function() {
+  });
+
+  context('when abort reason is valid', function() {
+
+    it('should update the certificationCourse with a reason', async function() {
+      // given
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
+      await databaseBuilder.commit();
+
+      const abortReason = 'technical';
+      // when
+      await abortCertificationCourse({ certificationCourseRepository, certificationCourseId: certificationCourse.id, abortReason });
+
+      // then
+      const [abortReasonFound] = await knex('certification-courses')
+        .select('abortReason')
+        .where({ id: certificationCourse.id });
+
+      expect(abortReasonFound).to.deep.equal({ abortReason });
+    });
+  });
+
+});

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -27,6 +27,7 @@ module.exports = function buildCertificationCourse({
   userId = 456,
   sessionId = 789,
   isCancelled = false,
+  abortReason = undefined,
 } = {}) {
 
   const certificationIssueReports = [];
@@ -66,5 +67,6 @@ module.exports = function buildCertificationCourse({
     sessionId,
     userId,
     isCancelled,
+    abortReason,
   });
 };

--- a/api/tests/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/unit/domain/models/CertificationCourse_test.js
@@ -66,6 +66,51 @@ describe('Unit | Domain | Models | CertificationCourse', function() {
     });
   });
 
+  describe('#abort', function() {
+
+    it('should abort a certification course', function() {
+      // given
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        abortReason: null,
+      });
+
+      // when
+      certificationCourse.abort('technical');
+
+      // then
+      expect(certificationCourse.toDTO().abortReason).to.equal('technical');
+    });
+
+    it('should fail if abort reason is unknown', async function() {
+      // given
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        abortReason: null,
+      });
+
+      // then
+      expect(() => {
+        certificationCourse.abort('some random stuff');
+      }).to.throw(EntityValidationError);
+    });
+
+  });
+
+  describe('#unabort', function() {
+
+    it('should unabort a certification course', function() {
+      // given
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        abortReason: 'technical',
+      });
+
+      // when
+      certificationCourse.unabort();
+
+      // then
+      expect(certificationCourse.toDTO().abortReason).to.be.null;
+    });
+  });
+
   describe('#correctBirthdate', function() {
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['2000-13-01', null, undefined, '', 'invalid']

--- a/api/tests/unit/domain/usecases/abort-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/abort-certification-course_test.js
@@ -1,0 +1,54 @@
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const abortCertificationCourse = require('../../../../lib/domain/usecases/abort-certification-course');
+const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | abort-certification-course', function() {
+
+  let certificationCourseRepository;
+
+  beforeEach(function() {
+    certificationCourseRepository = {
+      get: sinon.stub(),
+      update: sinon.stub(),
+    };
+  });
+
+  context('when abort reason is valid', function() {
+
+    it('should update the certificationCourse with a reason', async function() {
+      // given
+      const abortReason = 'technical';
+      const certificationCourse = domainBuilder.buildCertificationCourse(
+        { abortReason: null });
+      certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+
+      // when
+      await abortCertificationCourse({ certificationCourseRepository, certificationCourseId: certificationCourse.getId(), abortReason });
+
+      // then
+      expect(certificationCourseRepository.update).to.have.been.calledWithExactly(
+        new CertificationCourse({
+          ...certificationCourse.toDTO(),
+          abortReason: 'technical',
+        }),
+      );
+    });
+
+    it('should throw an error if abortReason is not provided', async function() {
+      // given
+      const abortReason = null;
+      const certificationCourse = domainBuilder.buildCertificationCourse(
+        { abortReason: null });
+      certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+
+      // when
+      const err = await catchErr(abortCertificationCourse)({ certificationCourseRepository, certificationCourseId: certificationCourse.getId(), abortReason });
+
+      // then
+      expect(err).to.be.instanceOf(EntityValidationError);
+      expect(certificationCourseRepository.update).not.to.have.been.called;
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'[epix 2981 ](https://1024pix.atlassian.net/browse/PIX-2981), on doit pouvoir enregistrer la raison de l'abandon d'une certification

## :robot: Solution
Ajouter un endpoint pour l'abandon de la certification `/api/admin/certification-courses/{id}/abort`

## :rainbow: Remarques
Accessible uniquement avec le rôle PixMaster
L'appel par le front n'est pas encore OK

## :100: Pour tester
Appeler directement l'endpoint