### PR TITLE
[FEATURE] Afficher le commentaire jury d'une session dans Pix Admin (PIX-3130)

### DIFF
--- a/admin/app/components/sessions/jury-comment.hbs
+++ b/admin/app/components/sessions/jury-comment.hbs
@@ -1,0 +1,8 @@
+<section class="page-section mb_10 session-jury-comment">
+  <h1 class="session-jury-comment__title">Commentaire de l'équipe Certification</h1>
+  <div>
+    <span class="session-jury-comment__author">{{@author}}</span> -
+    <time class="session-jury-comment__date">{{moment-format @date 'DD/MM/YYYY à HH:mm'}}</time>
+  </div>
+  <p class="session-jury-comment__content">{{@comment}}</p>
+</section>

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -45,9 +45,12 @@ export default class Session extends Model {
   @attr() finalizedAt;
   @attr() resultsSentToPrescriberAt;
   @attr() publishedAt;
+  @attr() juryComment;
+  @attr() juryCommentedAt;
 
   @hasMany('jury-certification-summary') juryCertificationSummaries;
   @belongsTo('user') assignedCertificationOfficer;
+  @belongsTo('user') juryCommentAuthor;
 
   @computed('status')
   get isFinalized() {

--- a/admin/app/styles/authenticated/sessions/session/informations.scss
+++ b/admin/app/styles/authenticated/sessions/session/informations.scss
@@ -56,6 +56,33 @@
   }
 }
 
+.session-jury-comment {
+  color: $grey-70;
+  font-family: $roboto;
+
+  &__title {
+    font-family: $open-sans;
+    font-weight: normal;
+    font-size: 1.25rem;
+    margin-bottom: 16px;
+  }
+
+  &__author {
+    font-weight: bold;
+    margin-bottom: 4px;
+  }
+
+  &__date {
+    color: $grey-40;
+    font-size: 0.9rem;
+  }
+
+  &__content {
+    background-color: $grey-10;
+    padding: 8px 24px;
+  }
+}
+
 .ember-modal-dialog {
   padding: 0; margin: 0;
   min-width: 35vw;

--- a/admin/app/templates/authenticated/sessions/session.hbs
+++ b/admin/app/templates/authenticated/sessions/session.hbs
@@ -18,7 +18,5 @@
         Certifications
     </LinkTo>
   </nav>
-  <section>
-      {{outlet}}
-  </section>
+  {{outlet}}
 </main>

--- a/admin/app/templates/authenticated/sessions/session/certifications.hbs
+++ b/admin/app/templates/authenticated/sessions/session/certifications.hbs
@@ -1,37 +1,39 @@
 {{!-- template-lint-disable no-action --}}
 {{page-title "Session " @model.id " Certifications - Pix admin" replace=true}}
-<div class="certification-list-page">
+<section>
+  <div class="certification-list-page">
 
-  <header class="certification-list-page__header">
-    <h2>Certifications</h2>
-    <div class="btn-group" role="group">
+    <header class="certification-list-page__header">
+      <h2>Certifications</h2>
+      <div class="btn-group" role="group">
 
-      {{#if this.model.isPublished}}
-        <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}>Dépublier la session</PixButton>
-      {{else}}
-
-        {{#if this.canPublish}}
-          <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}>Publier la session</PixButton>
+        {{#if this.model.isPublished}}
+          <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}>Dépublier la session</PixButton>
         {{else}}
-          <PixTooltip
-            @text="Vous ne pouvez pas publier la session tant qu'il reste des certifications en 'error' ou 'started'."
-            @position="left"
-            @isWide={{true}}
-          >
-            <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}} @isDisabled={{true}}>
-              Publier la session
-            </PixButton>
-          </PixTooltip>
+
+          {{#if this.canPublish}}
+            <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}>Publier la session</PixButton>
+          {{else}}
+            <PixTooltip
+              @text="Vous ne pouvez pas publier la session tant qu'il reste des certifications en 'error' ou 'started'."
+              @position="left"
+              @isWide={{true}}
+            >
+              <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}} @isDisabled={{true}}>
+                Publier la session
+              </PixButton>
+            </PixTooltip>
+          {{/if}}
+
         {{/if}}
+      </div>
+    </header>
 
-      {{/if}}
+    <div>
+      <Certification::CertificationList @certifications={{this.model.juryCertificationSummaries}} />
     </div>
-  </header>
-
-  <div>
-    <Certification::CertificationList @certifications={{this.model.juryCertificationSummaries}} />
   </div>
-</div>
+</section>
 
 <ConfirmPopup @message={{this.confirmMessage}}
               @confirm={{action this.toggleSessionPublication}}

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -130,6 +130,14 @@
   </div>
 </section>
 
+{{#if this.sessionModel.juryComment}}
+  <Sessions::JuryComment
+    @author={{this.sessionModel.juryCommentAuthor.fullName}}
+    @date={{this.sessionModel.juryCommentedAt}}
+    @comment={{this.sessionModel.juryComment}}
+  />
+{{/if}}
+
 {{#if this.isShowingAssignmentModal}}
   <ModalDialog
     @targetAttachment="center"

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -1,132 +1,134 @@
-<div class="session-info">
+<section class="page-section mb_10">
+  <div class="session-info">
 
-  <div class="session-info__certification-officer-assigned">
-    <span>{{this.sessionModel.assignedCertificationOfficer.fullName}}</span>
-  </div>
-
-  <div class="session-info__details">
-    <div class="row">
-      <div class="col">Centre :</div>
-      <div class="col">
-        <LinkTo
-          @route="authenticated.certification-centers.get"
-          @model={{this.sessionModel.certificationCenterId}}
-        >
-          {{this.sessionModel.certificationCenterName}}
-        </LinkTo>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col">Adresse :</div>
-      <div class="col">{{this.sessionModel.address}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Pièce :</div>
-      <div class="col">{{this.sessionModel.room}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Surveillant :</div>
-      <div class="col">{{this.sessionModel.examiner}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Date :</div>
-      <div class="col">{{format-date this.sessionModel.date}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Heure :</div>
-      <div class="col">{{this.sessionModel.time}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Description :</div>
-      <div class="col">{{this.sessionModel.description}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Code d'accès :</div>
-      <div class="col">{{this.sessionModel.accessCode}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Statut :</div>
-      <div class="col">{{this.sessionModel.displayStatus}}</div>
+    <div class="session-info__certification-officer-assigned">
+      <span>{{this.sessionModel.assignedCertificationOfficer.fullName}}</span>
     </div>
 
-    {{#if this.sessionModel.finalizedAt}}
+    <div class="session-info__details">
       <div class="row">
-        <div class="col">Date de finalisation :</div>
-        <div class="col" data-test-id="session-info__finalized-at">{{format-date this.sessionModel.finalizedAt}}</div>
+        <div class="col">Centre :</div>
+        <div class="col">
+          <LinkTo
+            @route="authenticated.certification-centers.get"
+            @model={{this.sessionModel.certificationCenterId}}
+          >
+            {{this.sessionModel.certificationCenterName}}
+          </LinkTo>
+        </div>
       </div>
-    {{/if}}
-    {{#if this.sessionModel.publishedAt}}
       <div class="row">
-        <div class="col">Date de publication :</div>
-        <div class="col" data-test-id="session-info__published-at">{{format-date this.sessionModel.publishedAt}}</div>
+        <div class="col">Adresse :</div>
+        <div class="col">{{this.sessionModel.address}}</div>
       </div>
-    {{/if}}
-    {{#if this.sessionModel.resultsSentToPrescriberAt}}
       <div class="row">
-        <div class="col">Date d'envoi des résultats au prescripteur :</div>
-        <div class="col" data-test-id="session-info__sent-to-prescriber-at">{{format-date this.sessionModel.resultsSentToPrescriberAt}}</div>
+        <div class="col">Pièce :</div>
+        <div class="col">{{this.sessionModel.room}}</div>
       </div>
-    {{/if}}
-  </div>
-
-
-  {{#if this.sessionModel.finalizedAt}}
-  <div class="session-info__stats">
-    <div class="row">
-      <div class="col">Nombre de signalements impactants non résolus:</div>
-      <div class="col" data-test-id="session-info__number-of-blocking-report">{{this.sessionModel.countCertificationIssueReportsWithActionRequired}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Nombre de signalements :</div>
-      <div class="col" data-test-id="session-info__number-of-issue-report">{{this.sessionModel.countCertificationIssueReports}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Nombre d'écrans de fin de test non renseignés :</div>
-      <div class="col" data-test-id="session-info__number-of-not-checked-end-screen">{{this.sessionModel.countNotCheckedEndScreen}}</div>
-    </div>
-    <div class="row">
-      <div class="col">Nombre de certifications démarrées/en erreur :</div>
-      <div class="col" data-test-id="session-info__number-of-started-or-error-certifications">{{this.sessionModel.countStartedAndInErrorCertifications}}</div>
-    </div>
-    {{#if this.sessionModel.hasExaminerGlobalComment}}
-    <div class="row">
-      <div class="col">Commentaire global :</div>
-      <div class="col" data-test-id="session-info__examiner-global-comment">{{this.sessionModel.examinerGlobalComment}}</div>
-    </div>
-    {{/if}}
-  </div>
-  {{/if}}
-
-  <div class="session-info__actions">
-    <div class="row row--btn">
+      <div class="row">
+        <div class="col">Surveillant :</div>
+        <div class="col">{{this.sessionModel.examiner}}</div>
+      </div>
+      <div class="row">
+        <div class="col">Date :</div>
+        <div class="col">{{format-date this.sessionModel.date}}</div>
+      </div>
+      <div class="row">
+        <div class="col">Heure :</div>
+        <div class="col">{{this.sessionModel.time}}</div>
+      </div>
+      <div class="row">
+        <div class="col">Description :</div>
+        <div class="col">{{this.sessionModel.description}}</div>
+      </div>
+      <div class="row">
+        <div class="col">Code d'accès :</div>
+        <div class="col">{{this.sessionModel.accessCode}}</div>
+      </div>
+      <div class="row">
+        <div class="col">Statut :</div>
+        <div class="col">{{this.sessionModel.displayStatus}}</div>
+      </div>
 
       {{#if this.sessionModel.finalizedAt}}
-        {{#if this.isCurrentUserAssignedToSession}}
-          <PixButton @size="small" @isDisabled={{true}}>Vous êtes assigné à cette session</PixButton>
-        {{else}}
-          <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
-        {{/if}}
+        <div class="row">
+          <div class="col">Date de finalisation :</div>
+          <div class="col" data-test-id="session-info__finalized-at">{{format-date this.sessionModel.finalizedAt}}</div>
+        </div>
       {{/if}}
-
-      <div class="session-info__copy-button">
-        {{#if this.isCopyButtonClicked}}
-          <p>{{this.copyButtonText}}</p>
-        {{/if}}
-
-        <PixButton size="small" @triggerAction={{this.copyResultsDownloadLink}} @backgroundColor="grey">
-          <FaIcon @icon="copy" @prefix="far" class="fa-inverse" aria-label="Copier" />
-          Lien de téléchargement des résultats
-        </PixButton>
-      </div>
-
-      {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
-        <PixButton size="small" @triggerAction={{this.tagSessionAsSentToPrescriber}} @backgroundColor="grey">
-          Résultats transmis au prescripteur
-        </PixButton>
+      {{#if this.sessionModel.publishedAt}}
+        <div class="row">
+          <div class="col">Date de publication :</div>
+          <div class="col" data-test-id="session-info__published-at">{{format-date this.sessionModel.publishedAt}}</div>
+        </div>
+      {{/if}}
+      {{#if this.sessionModel.resultsSentToPrescriberAt}}
+        <div class="row">
+          <div class="col">Date d'envoi des résultats au prescripteur :</div>
+          <div class="col" data-test-id="session-info__sent-to-prescriber-at">{{format-date this.sessionModel.resultsSentToPrescriberAt}}</div>
+        </div>
       {{/if}}
     </div>
+
+
+    {{#if this.sessionModel.finalizedAt}}
+    <div class="session-info__stats">
+      <div class="row">
+        <div class="col">Nombre de signalements impactants non résolus:</div>
+        <div class="col" data-test-id="session-info__number-of-blocking-report">{{this.sessionModel.countCertificationIssueReportsWithActionRequired}}</div>
+      </div>
+      <div class="row">
+        <div class="col">Nombre de signalements :</div>
+        <div class="col" data-test-id="session-info__number-of-issue-report">{{this.sessionModel.countCertificationIssueReports}}</div>
+      </div>
+      <div class="row">
+        <div class="col">Nombre d'écrans de fin de test non renseignés :</div>
+        <div class="col" data-test-id="session-info__number-of-not-checked-end-screen">{{this.sessionModel.countNotCheckedEndScreen}}</div>
+      </div>
+      <div class="row">
+        <div class="col">Nombre de certifications démarrées/en erreur :</div>
+        <div class="col" data-test-id="session-info__number-of-started-or-error-certifications">{{this.sessionModel.countStartedAndInErrorCertifications}}</div>
+      </div>
+      {{#if this.sessionModel.hasExaminerGlobalComment}}
+      <div class="row">
+        <div class="col">Commentaire global :</div>
+        <div class="col" data-test-id="session-info__examiner-global-comment">{{this.sessionModel.examinerGlobalComment}}</div>
+      </div>
+      {{/if}}
+    </div>
+    {{/if}}
+
+    <div class="session-info__actions">
+      <div class="row row--btn">
+
+        {{#if this.sessionModel.finalizedAt}}
+          {{#if this.isCurrentUserAssignedToSession}}
+            <PixButton @size="small" @isDisabled={{true}}>Vous êtes assigné à cette session</PixButton>
+          {{else}}
+            <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
+          {{/if}}
+        {{/if}}
+
+        <div class="session-info__copy-button">
+          {{#if this.isCopyButtonClicked}}
+            <p>{{this.copyButtonText}}</p>
+          {{/if}}
+
+          <PixButton size="small" @triggerAction={{this.copyResultsDownloadLink}} @backgroundColor="grey">
+            <FaIcon @icon="copy" @prefix="far" class="fa-inverse" aria-label="Copier" />
+            Lien de téléchargement des résultats
+          </PixButton>
+        </div>
+
+        {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
+          <PixButton size="small" @triggerAction={{this.tagSessionAsSentToPrescriber}} @backgroundColor="grey">
+            Résultats transmis au prescripteur
+          </PixButton>
+        {{/if}}
+      </div>
+    </div>
   </div>
-</div>
+</section>
 
 {{#if this.isShowingAssignmentModal}}
   <ModalDialog

--- a/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
@@ -1,0 +1,81 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | authenticated/sessions/session/informations', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When user is not logged in', function() {
+
+    test('it should not be accessible by an unauthenticated user', async function(assert) {
+      // when
+      await visit('/sessions/1');
+
+      // then
+      assert.equal(currentURL(), '/login');
+    });
+  });
+
+  module('When user is logged in', function(hooks) {
+
+    hooks.beforeEach(async function() {
+      // given
+      const { id: userId } = server.create('user');
+      await createAuthenticateSession({ userId });
+      server.create('session', { id: '1' });
+    });
+
+    test('visiting /sessions/1', async function(assert) {
+      // when
+      await visit('/sessions/1');
+
+      // then
+      assert.equal(currentURL(), '/sessions/1');
+    });
+
+    module('When session has a no jury comment', function() {
+      test('it should not display a jury comment for session', async function(assert) {
+        // given
+        server.create('session', {
+          id: '2',
+          juryComment: null,
+          juryCommentedAt: null,
+          juryCommentAuthor: null,
+        });
+
+        // when
+        await visit('/sessions/2');
+
+        // then
+        assert.notContains('Commentaire de l\'équipe Certification');
+      });
+    });
+
+    module('When session has a jury comment', function() {
+      test('it should display a jury comment for session', async function(assert) {
+        // given
+        const author = server.create('user', {
+          firstName: 'Jernau',
+          lastName: 'Gurgeh',
+          fullName: 'Jernau Gurgeh',
+        });
+        server.create('session', {
+          id: '3',
+          juryComment: 'Le surveillant prétend qu\'une météorite est tombée sur le centre.',
+          juryCommentedAt: new Date('2012-12-21T00:12:21Z'),
+          juryCommentAuthor: author,
+        });
+
+        // when
+        await visit('/sessions/3');
+
+        // then
+        assert.contains('Commentaire de l\'équipe Certification');
+      });
+    });
+  });
+});

--- a/admin/tests/integration/components/sessions/jury-comment_test.js
+++ b/admin/tests/integration/components/sessions/jury-comment_test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import moment from 'moment';
+
+module('Integration | Component | Sessions::JuryComment', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // given
+    this.set('author', 'Vernon Sanders Law');
+    this.set('date', new Date('2021-06-21T14:30:21Z'));
+    this.set('comment', 'L\'expérience est un professeur cruel car elle vous fait passer l\'examen, avant de vous expliquer la leçon.');
+    const expectedDate = moment(this.date).format('DD/MM/YYYY à HH:mm');
+
+    // when
+    await render(hbs`
+      <Sessions::JuryComment
+        @author={{this.author}}
+        @date={{this.date}}
+        @comment={{this.comment}}
+      />
+    `);
+
+    // then
+    assert.contains('Commentaire de l\'équipe Certification');
+    assert.dom('.session-jury-comment__author').hasText('Vernon Sanders Law');
+    assert.dom('.session-jury-comment__date').hasText(expectedDate);
+    assert.dom('.session-jury-comment__content').hasText('L\'expérience est un professeur cruel car elle vous fait passer l\'examen, avant de vous expliquer la leçon.');
+  });
+});

--- a/api/db/database-builder/factory/build-session.js
+++ b/api/db/database-builder/factory/build-session.js
@@ -19,6 +19,9 @@ module.exports = function buildSession({
   resultsSentToPrescriberAt = null,
   publishedAt = null,
   assignedCertificationOfficerId,
+  juryComment = null,
+  juryCommentAuthorId = null,
+  juryCommentedAt = null,
 } = {}) {
 
   if (_.isUndefined(certificationCenterId)) {
@@ -43,6 +46,9 @@ module.exports = function buildSession({
     resultsSentToPrescriberAt,
     publishedAt,
     assignedCertificationOfficerId,
+    juryComment,
+    juryCommentAuthorId,
+    juryCommentedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/db/migrations/20210831141155_add-columns-for-session-jury-comments.js
+++ b/api/db/migrations/20210831141155_add-columns-for-session-jury-comments.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'sessions';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.text('juryComment').defaultsTo(null);
+    table.integer('juryCommentAuthorId').unsigned().references('users.id').defaultsTo(null);
+    table.dateTime('juryCommentedAt').defaultsTo(null);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn('juryComment');
+    table.dropColumn('juryCommentAuthorId');
+    table.dropColumn('juryCommentedAt');
+  });
+};

--- a/api/db/seeds/data/certification/certification-sessions-builder.js
+++ b/api/db/seeds/data/certification/certification-sessions-builder.js
@@ -78,6 +78,9 @@ function certificationSessionsBuilder({ databaseBuilder }) {
     examinerGlobalComment: 'Une météorite est tombée sur le centre de certification pendant la session !!',
     finalizedAt: new Date('2020-05-05T15:00:34Z'),
     assignedCertificationOfficerId: PIX_MASTER_ID,
+    juryComment: 'Tu te rends compte, si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart !',
+    juryCommentAuthorId: PIX_MASTER_ID,
+    juryCommentedAt: new Date('2021-04-28T00:42:03Z'),
   });
 
   databaseBuilder.factory.buildFinalizedSession({

--- a/api/lib/domain/models/JurySession.js
+++ b/api/lib/domain/models/JurySession.js
@@ -21,6 +21,7 @@ class JurySession {
     assignedCertificationOfficer,
     juryComment,
     juryCommentedAt,
+    juryCommentAuthor,
   } = {}) {
     this.id = id;
     this.certificationCenterName = certificationCenterName;
@@ -41,6 +42,7 @@ class JurySession {
     this.assignedCertificationOfficer = assignedCertificationOfficer;
     this.juryComment = juryComment;
     this.juryCommentedAt = juryCommentedAt;
+    this.juryCommentAuthor = juryCommentAuthor;
   }
 
   get status() {

--- a/api/lib/domain/models/JurySession.js
+++ b/api/lib/domain/models/JurySession.js
@@ -19,6 +19,8 @@ class JurySession {
     resultsSentToPrescriberAt,
     publishedAt,
     assignedCertificationOfficer,
+    juryComment,
+    juryCommentedAt,
   } = {}) {
     this.id = id;
     this.certificationCenterName = certificationCenterName;
@@ -37,6 +39,8 @@ class JurySession {
     this.resultsSentToPrescriberAt = resultsSentToPrescriberAt;
     this.publishedAt = publishedAt;
     this.assignedCertificationOfficer = assignedCertificationOfficer;
+    this.juryComment = juryComment;
+    this.juryCommentedAt = juryCommentedAt;
   }
 
   get status() {

--- a/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
@@ -26,8 +26,12 @@ module.exports = {
         'finalizedAt',
         'resultsSentToPrescriberAt',
         'publishedAt',
+        'juryComment',
+        'juryCommentAuthorId',
+        'juryCommentedAt',
         // included
         'assignedCertificationOfficer',
+        'juryCommentAuthor',
         // links
         'juryCertificationSummaries',
       ],
@@ -46,6 +50,11 @@ module.exports = {
         included: true,
         attributes: ['firstName', 'lastName'],
       },
+      juryCommentAuthor: {
+        ref: 'id',
+        included: true,
+        attributes: ['firstName', 'lastName'],
+      },
       transform(jurySession) {
         const transformedJurySession = Object.assign({}, jurySession);
         transformedJurySession.status = jurySession.status;
@@ -53,6 +62,9 @@ module.exports = {
       },
       typeForAttribute: function(attribute) {
         if (attribute === 'assignedCertificationOfficer') {
+          return 'user';
+        }
+        if (attribute === 'juryCommentAuthor') {
           return 'user';
         }
         return attribute;

--- a/api/tests/tooling/domain-builder/factory/build-jury-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-session.js
@@ -1,0 +1,59 @@
+const JurySession = require('../../../../lib/domain/models/JurySession');
+const domainBuilder = require('../domain-builder');
+const _ = require('lodash');
+
+const buildJurySession = function({
+  id = 123,
+  certificationCenterName = null,
+  certificationCenterType = null,
+  certificationCenterId = null,
+  certificationCenterExternalId = null,
+  address = '11 allée des Peupliers 54180 Houdemont',
+  room = '28D',
+  examiner = 'M. Salicales',
+  date = '2021-01-01',
+  time = '14:30',
+  accessCode = 'ABCD123',
+  description = 'Bonne année',
+  examinerGlobalComment,
+  finalizedAt = null,
+  resultsSentToPrescriberAt = null,
+  publishedAt = null,
+  assignedCertificationOfficer = null,
+  juryComment = null,
+  juryCommentedAt = null,
+  juryCommentAuthor = null,
+} = {}) {
+  if (_.isUndefined(certificationCenterId)) {
+    const certificationCenter = domainBuilder.buildCertificationCenter();
+    certificationCenterId = certificationCenter.id;
+    certificationCenterName = certificationCenter.id;
+    certificationCenterType = certificationCenter.type;
+    certificationCenterExternalId = certificationCenter.externalId;
+  }
+
+  return new JurySession({
+    id,
+    certificationCenterName,
+    certificationCenterType,
+    certificationCenterId,
+    certificationCenterExternalId,
+    address,
+    room,
+    examiner,
+    date,
+    time,
+    accessCode,
+    description,
+    examinerGlobalComment,
+    finalizedAt,
+    resultsSentToPrescriberAt,
+    publishedAt,
+    assignedCertificationOfficer,
+    juryComment,
+    juryCommentedAt,
+    juryCommentAuthor,
+  });
+};
+
+module.exports = buildJurySession;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -61,6 +61,7 @@ module.exports = {
   buildFinalizedSession: require('./build-finalized-session'),
   buildHint: require('./build-hint'),
   buildHigherSchoolingRegistration: require('./build-higher-schooling-registration'),
+  buildJurySession: require('./build-jury-session'),
   buildKnowledgeElement: require('./build-knowledge-element'),
   buildMembership: require('./build-membership'),
   buildOrganization: require('./build-organization'),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
@@ -25,40 +25,8 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function() {
   describe('#serialize()', function() {
 
     let modelSession;
-    let expectedJsonApi;
 
     beforeEach(function() {
-      expectedJsonApi = {
-        data: {
-          type: 'sessions',
-          id: '1',
-          attributes: {
-            'certification-center-name': 'someCenterName',
-            'certification-center-type': 'someCenterType',
-            'certification-center-id': 'someCenterId',
-            'certification-center-external-id': 'someCenterExternalId',
-            address: 'someAddress',
-            room: 'someRoom',
-            examiner: 'someExaminer',
-            date: '2017-01-20',
-            time: '14:30',
-            'access-code': 'someAccessCode',
-            status: 'someStatus',
-            description: 'someDescription',
-            'examiner-global-comment': 'someComment',
-            'finalized-at': new Date('2020-02-17T14:23:56Z'),
-            'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
-            'published-at': new Date('2020-02-21T14:23:56Z'),
-          },
-          relationships: {
-            'jury-certification-summaries': {
-              links: {
-                related: '/api/admin/sessions/1/jury-certification-summaries',
-              },
-            },
-          },
-        },
-      };
       modelSession = {
         id: 1,
         certificationCenterName: 'someCenterName',
@@ -77,6 +45,8 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function() {
         finalizedAt: new Date('2020-02-17T14:23:56Z'),
         resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
         publishedAt: new Date('2020-02-21T14:23:56Z'),
+        juryComment: 'Si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart.',
+        juryCommentedAt: new Date('2021-02-21T14:23:56Z'),
       };
     });
 
@@ -84,25 +54,16 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function() {
 
       it('should convert a Session model object into JSON API data with included officer', function() {
         // given
-        const meta = { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 };
-        const included = [{
-          type: 'user',
-          id: '2',
-          attributes: {
-            'first-name': 'Jean',
-            'last-name': 'de la Flûte',
-          },
-        }];
-        const assignedCertificationOfficerRelationship = {
-          data: {
-            id: '2',
+        const expectedResult = _buildExpectedJsonAPI(
+          [{
             type: 'user',
-          },
-        };
-        let expectedResult = Object.assign(expectedJsonApi, { meta });
-        expectedResult = Object.assign(expectedResult, { included });
-        expectedResult.data.relationships = Object.assign(expectedResult.data.relationships,
-          { ...expectedResult.data.relationships, 'assigned-certification-officer': assignedCertificationOfficerRelationship });
+            id: '2',
+            attributes: { 'first-name': 'Jean', 'last-name': 'de la Flûte' },
+          }],
+          { 'assigned-certification-officer': {
+            data: { id: '2', type: 'user' },
+          } },
+        );
         modelSession.assignedCertificationOfficer = {
           id: 2,
           firstName: 'Jean',
@@ -110,28 +71,101 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function() {
         };
 
         // when
-        const json = serializer.serialize(modelSession, meta);
+        const json = serializer.serialize(modelSession, { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 });
 
         // then
         expect(json).to.deep.equal(expectedResult);
       });
     });
 
-    context('when there is no assigned certification officer', function() {
+    context('when there is a jury comment', function() {
+
+      it('should convert a Session model object into JSON API data with included comment', function() {
+        // given
+        const expectedResult = _buildExpectedJsonAPI(
+          [{
+            type: 'user',
+            id: '3',
+            attributes: { 'first-name': 'Phil', 'last-name': 'Hippo' },
+          }],
+          {
+            'jury-comment-author': {
+              data: { id: '3', type: 'user' },
+            },
+          },
+        );
+
+        modelSession.juryCommentAuthor = {
+          id: 3,
+          firstName: 'Phil',
+          lastName: 'Hippo',
+        };
+
+        // when
+        const json = serializer.serialize(modelSession, { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 });
+
+        // then
+        expect(json).to.deep.equal(expectedResult);
+      });
+    });
+
+    context('when there is neither assigned certification officer nor jury comment', function() {
 
       it('should convert a Session model object into JSON API data', function() {
         // given
-        const meta = { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 };
-        const expectedResult = Object.assign(expectedJsonApi, { meta });
+        const expectedResult = _buildExpectedJsonAPI();
 
         // when
-        const json = serializer.serialize(modelSession, meta);
+        const json = serializer.serialize(modelSession, { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 });
 
         // then
         expect(json).to.deep.equal(expectedResult);
       });
     });
-
   });
 
 });
+
+function _buildExpectedJsonAPI(included, relationships = {}) {
+  const expectedJsonAPI = {
+    data: {
+      type: 'sessions',
+      id: '1',
+      attributes: {
+        'certification-center-name': 'someCenterName',
+        'certification-center-type': 'someCenterType',
+        'certification-center-id': 'someCenterId',
+        'certification-center-external-id': 'someCenterExternalId',
+        address: 'someAddress',
+        room: 'someRoom',
+        examiner: 'someExaminer',
+        date: '2017-01-20',
+        time: '14:30',
+        'access-code': 'someAccessCode',
+        status: 'someStatus',
+        description: 'someDescription',
+        'examiner-global-comment': 'someComment',
+        'finalized-at': new Date('2020-02-17T14:23:56Z'),
+        'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
+        'published-at': new Date('2020-02-21T14:23:56Z'),
+        'jury-comment': 'Si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart.',
+        'jury-commented-at': new Date('2021-02-21T14:23:56Z'),
+      },
+      relationships: {
+        ...relationships,
+        'jury-certification-summaries': {
+          links: {
+            related: '/api/admin/sessions/1/jury-certification-summaries',
+          },
+        },
+      },
+    },
+    meta: { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 },
+  };
+
+  if (included) {
+    expectedJsonAPI.included = included;
+  }
+
+  return expectedJsonAPI;
+}


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l'epix [Comm session pôle certif](https://1024pix.atlassian.net/browse/PIX-3127), nous voulons pouvoir visualiser dans Pix Admin un commentaire jury associé à une session de certification.

## :robot: Solution

Afficher dans Pix Admin le commentaire jury associé à une session de certification.

- [x] [API] Ajouter les champs nécessaires à la base de données
- [x] [API] Retourner ces nouvelles propriétés dans l'API
- [x] [API] Retourner le nom de l'auteur du commentaire dans l'API
- [x] [ADMIN] Afficher le commentaire sur la page de session de Pix Admin s'il existe

## :rainbow: Remarques

*RAS*

## :100: Pour tester

- Se connecter à Pix Admin
- Se rendre sur une page de session de certification pour laquelle il existe un commentaire jury *
- Constater le bon affichage du commentaire

\* Pour l'instant, il n'est pas possible d'ajouter un commentaire via Pix Admin. Il faut le créer manuellement via la base de données. Dans les seeds, il existe une session avec un commentaire (n° 6). 