### PR TITLE
[TECH] Expliciter la configuration de NODE_ENV.

### DIFF
--- a/api/bin/www
+++ b/api/bin/www
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+require('dotenv').config();
+const validateEnvironmentVariables = require('../lib/infrastructure/validate-environement-variables');
+validateEnvironmentVariables();
+
 const createServer = require('../server');
 const logger = require('../lib/infrastructure/logger');
 const { disconnect } = require('../db/knex-database-connection');

--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -31,23 +31,6 @@ module.exports = {
     process.env.KNEX_ASYNC_STACKTRACE_ENABLED,
   ),
 
-  staging: {
-    client: 'postgresql',
-    connection: process.env.DATABASE_URL,
-    pool: {
-      min: 1,
-      max: (parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10) || 4),
-    },
-    migrations: {
-      tableName: 'knex_migrations',
-      directory: './migrations',
-    },
-    seeds: {
-      directory: './seeds',
-    },
-    asyncStackTraces: (process.env.KNEX_ASYNC_STACKTRACE_ENABLED !== 'false'),
-  },
-
   production: {
     client: 'postgresql',
     connection: process.env.DATABASE_URL,

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -27,6 +27,7 @@ const schema = Joi.object({
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   CACHE_RELOAD_TIME: Joi.string().optional(),
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
+  NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function() {

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -4,7 +4,7 @@ const Blipp = require('blipp');
 const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
 
-const isProduction = ['production', 'staging'].includes(process.env.NODE_ENV);
+const isProduction = process.env.NODE_ENV === 'production';
 
 const consoleReporters =
   isProduction ?

--- a/api/sample.env
+++ b/api/sample.env
@@ -294,6 +294,15 @@ LOG_ENABLED=true
 # default: `false`
 # SHOULD_LOG_5XX_ERRORS=true
 
+# Enable OPS logging
+# If 'production', will log core container metrics
+# Sample output: {"event":"ops","timestamp":1630419363680,"host":"pix-api-production-web-2","pid":22,"os":{"load":[2.16,1.97,1.85],"mem":{"total":42185723904,"free":6782152704},"uptime":8208319.46},"proc":{"uptime":81367.686662047,"mem":{"rss":196128768,"heapTotal":109948928,"heapUsed":104404328,"external":6004718,"arrayBuffers":4416211},"delay":0.11345672607421875},"load":{"requests":{"21344":{"total":55,"disconnects":0,"statusCodes":{"200":43,"201":10,"204":1,"401":1}}},"responseTimes":{"21344":{"avg":19.472727272727273,"max":64}},"sockets":{"http":{"total":0},"https":{"total":0}}}}
+# presence: optional
+# type: String
+# NODE_ENV=production
+
+
+
 # =================
 # Error collecting
 # =================

--- a/api/server.js
+++ b/api/server.js
@@ -1,5 +1,5 @@
 require('dotenv').config();
-const validateEnvironmentVariables = require('./lib/infrastructure/validate-environement-variables');
+
 const Hapi = require('@hapi/hapi');
 
 const preResponseUtils = require('./lib/application/pre-response-utils');
@@ -66,7 +66,6 @@ const createServer = async function() {
 };
 
 const loadConfiguration = function() {
-  validateEnvironmentVariables();
   config = require('./lib/config');
 };
 


### PR DESCRIPTION
## :unicorn: Problème
L'utilisation de NODE_ENV a plusieurs effets, non documentés, par exemple journaliser les métriques système (CPU, mémoire).

De plus, si une valeur incorrecte est fournie, l'API ne démarre pas, car knex ne trouve pas l'environnement correspondant.

```
❯ NODE_ENV=foo npm start

> pix-api@3.94.0 start /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api
> node bin/www

/home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api/node_modules/knex/lib/knex-builder/internal/config-resolver.js:20
    (!parsedConfig.client && !parsedConfig.dialect)
                   ^

TypeError: Cannot read property 'client' of undefined
```

## :robot: Solution
Contrôler la valeur avec le composant existant
Déplcaer son appel avant l'import knex
Documenter le tout dans le `sample.env`

## :rainbow: Remarques

Arrêter de gérer une valeur non-standard de cette variable (staging)

Dans le fond, l'utilisation de `NODE_ENV` dans ces cas n'est pas justifiée
https://seanconnolly.dev/dont-be-fooled-by-node-env

Pour citer @jonathanperret 
> Et s’il y a des configurations qui doivent différer entre intégration et production (ex. activer/désactiver Sentry ?), ça doit se passer dans les autres variables d’environnement de ces applications Scalingo.

Cela ne sera pas traité dans cette PR


## :100: Pour tester

### Valeur correcte
Ne fournissez pas de valeur, vérifier que l'API démarre
Fournissez une valeur `development, test, production`, vérifier que l'API démarre

### Valeur incorrecte
Fournissez une valeur autre que vide, test, development, production.
Vérifiez que le démarrage échoue avec le message suivant
`Configuration is invalid: "NODE_ENV" must be one of [development, test, production], but was: devpment`

```
❯ NODE_ENV=devpment npm start

> pix-api@3.94.0 start /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api
> node bin/www

/home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api/lib/infrastructure/validate-environement-variables.js:35
    throw new Error('Configuration is invalid: ' + error.message + ', but was: ' + error.details[0].context.value);
    ^

Error: Configuration is invalid: "NODE_ENV" must be one of [development, test, production], but was: devpment
    at validateEnvironmentVariables (/home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api/lib/infrastructure/validate-environement-variables.js:35:11)
```

