### PR TITLE
[FEATURE] Pouvoir voir les habilitations des centres de certification aux certifications complémentaires sur leur page de détails dans PixAdmin (PIX-3128)

### DIFF
--- a/admin/app/models/accreditation.js
+++ b/admin/app/models/accreditation.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Accreditation extends Model {
+
+  @attr() name;
+}

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -1,8 +1,10 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class CertificationCenter extends Model {
 
   @attr() name;
   @attr() type;
   @attr() externalId;
+
+  @hasMany('accreditation') accreditations;
 }

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -15,6 +15,11 @@
         Type : <span>{{@model.certificationCenter.type}}</span><br>
         Identifiant externe : <span>{{@model.certificationCenter.externalId}}</span><br>
       </p>
+      <ul>
+      {{#each @model.certificationCenter.accreditations as |accreditation|}}
+        <li>{{accreditation.name}}</li>
+      {{/each}}
+      </ul>
     </div>
   </section>
 

--- a/admin/mirage/serializers/certification-center.js
+++ b/admin/mirage/serializers/certification-center.js
@@ -1,6 +1,9 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
+const include = ['accreditations'];
+
 export default JSONAPISerializer.extend({
+  include,
   links(certificationCenter) {
     return {
       certificationCenterMemberships: {

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -65,6 +65,20 @@ module('Acceptance | authenticated/certification-centers/get', function(hooks) {
     assert.contains(certificationCenter.type);
   });
 
+  test('should display Certification center accreditations', async function(assert) {
+    // given
+    const accreditation1 = server.create('accreditation', { name: 'Pix+Edu' });
+    const accreditation2 = server.create('accreditation', { name: 'Pix+Surf' });
+    certificationCenter.update({ accreditations: [accreditation1, accreditation2] });
+
+    // when
+    await visit(`/certification-centers/${certificationCenter.id}`);
+
+    // then
+    assert.contains('Pix+Edu');
+    assert.contains('Pix+Surf');
+  });
+
   test('should display Certification center memberships', async function(assert) {
     // given
     const expectedDate1 = moment(certificationCenterMembership1.createdAt).format('DD-MM-YYYY - HH:mm:ss');

--- a/api/db/database-builder/factory/build-accreditation.js
+++ b/api/db/database-builder/factory/build-accreditation.js
@@ -1,0 +1,18 @@
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildAccreditation({
+  id = databaseBuffer.getNextId(),
+  name = 'UneSuperCertifComplémentaire',
+  createdAt = new Date('2020-01-01'),
+} = {}) {
+
+  const values = {
+    id,
+    name,
+    createdAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'accreditations',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/build-accredited-badge.js
+++ b/api/db/database-builder/factory/build-accredited-badge.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+const buildBadge = require('./build-badge');
+const buildAccreditation = require('./build-accreditation');
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildAccreditedBadge({
+  id = databaseBuffer.getNextId(),
+  accreditationId,
+  badgeId,
+  createdAt = new Date('2020-01-01'),
+} = {}) {
+  accreditationId = _.isNull(accreditationId) ? buildAccreditation().id : accreditationId;
+  badgeId = _.isNull(badgeId) ? buildBadge().id : badgeId;
+
+  const values = {
+    id,
+    accreditationId,
+    badgeId,
+    createdAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'accredited-badges',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/build-granted-accreditation.js
+++ b/api/db/database-builder/factory/build-granted-accreditation.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+const buildCertificationCenter = require('./build-certification-center');
+const buildAccreditation = require('./build-accreditation');
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildGrantedAccreditation({
+  id = databaseBuffer.getNextId(),
+  certificationCenterId,
+  accreditationId,
+  createdAt = new Date('2020-01-01'),
+} = {}) {
+  certificationCenterId = _.isNull(certificationCenterId) ? buildCertificationCenter().id : certificationCenterId;
+  accreditationId = _.isNull(accreditationId) ? buildAccreditation().id : accreditationId;
+
+  const values = {
+    id,
+    certificationCenterId,
+    accreditationId,
+    createdAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'granted-accreditations',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   buildAccountRecoveryDemand: require('./build-account-recovery-demand'),
+  buildAccreditation: require('./build-accreditation'),
+  buildAccreditedBadge: require('./build-accredited-badge'),
   buildAnswer: require('./build-answer'),
   buildAnsweredNotCompletedCertificationAssessment: require('./build-answered-not-completed-certification-assessment'),
   buildAssessment: require('./build-assessment'),
@@ -33,6 +35,7 @@ module.exports = {
   buildCorrectAnswersAndKnowledgeElementsForLearningContent: require('./build-correct-answers-and-knowledge-elements-for-learning-content'),
   buildCorrectAnswerAndKnowledgeElement: require('./build-correct-answer-and-knowledge-element'),
   buildFinalizedSession: require('./build-finalized-session'),
+  buildGrantedAccreditation: require('./build-granted-accreditation'),
   buildKnowledgeElement: require('./build-knowledge-element'),
   buildKnowledgeElementSnapshot: require('./build-knowledge-element-snapshot'),
   buildOrganization: require('./build-organization'),

--- a/api/db/migrations/20210831141356_create-accreditations-table.js
+++ b/api/db/migrations/20210831141356_create-accreditations-table.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'accreditations';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.string('name').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/migrations/20210831142318_create-granted-accreditations-table.js
+++ b/api/db/migrations/20210831142318_create-granted-accreditations-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'granted-accreditations';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.integer('accreditationId').references('accreditations.id').notNullable();
+    t.integer('certificationCenterId').references('certification-centers.id').notNullable();
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/migrations/20210831145630_create-accredited-badges-table.js
+++ b/api/db/migrations/20210831145630_create-accredited-badges-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'accredited-badges';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('accreditationId').references('accreditations.id').notNullable();
+    t.integer('badgeId').references('badges.id').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -14,7 +14,29 @@ const SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_NAME = 'Centre SCO NO MANAGING STUD
 const SCO_EXTERNAL_ID = '1237457A';
 const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = '1237457E';
 
+const { PIX_EMPLOI_CLEA_BADGE_ID, PIX_DROIT_MAITRE_BADGE_ID, PIX_DROIT_EXPERT_BADGE_ID } = require('../badges-builder');
+
 function certificationCentersBuilder({ databaseBuilder }) {
+
+  const cleaAccreditationId = databaseBuilder.factory.buildAccreditation({
+    name: 'CléA Numérique',
+  }).id;
+  databaseBuilder.factory.buildAccreditedBadge({
+    badgeId: PIX_EMPLOI_CLEA_BADGE_ID,
+    accreditationId: cleaAccreditationId,
+  });
+
+  const pixDroitAccreditationId = databaseBuilder.factory.buildAccreditation({
+    name: 'Pix+ Droit',
+  }).id;
+  databaseBuilder.factory.buildAccreditedBadge({
+    badgeId: PIX_DROIT_MAITRE_BADGE_ID,
+    accreditationId: pixDroitAccreditationId,
+  });
+  databaseBuilder.factory.buildAccreditedBadge({
+    badgeId: PIX_DROIT_EXPERT_BADGE_ID,
+    accreditationId: pixDroitAccreditationId,
+  });
 
   databaseBuilder.factory.buildCertificationCenter({
     id: SCO_CERTIF_CENTER_ID,
@@ -35,11 +57,23 @@ function certificationCentersBuilder({ databaseBuilder }) {
     name: PRO_CERTIF_CENTER_NAME,
     type: 'PRO',
   });
+  databaseBuilder.factory.buildGrantedAccreditation({
+    certificationCenterId: PRO_CERTIF_CENTER_ID,
+    accreditationId: cleaAccreditationId,
+  });
 
   databaseBuilder.factory.buildCertificationCenter({
     id: SUP_CERTIF_CENTER_ID,
     name: SUP_CERTIF_CENTER_NAME,
     type: 'SUP',
+  });
+  databaseBuilder.factory.buildGrantedAccreditation({
+    certificationCenterId: SUP_CERTIF_CENTER_ID,
+    accreditationId: cleaAccreditationId,
+  });
+  databaseBuilder.factory.buildGrantedAccreditation({
+    certificationCenterId: SUP_CERTIF_CENTER_ID,
+    accreditationId: pixDroitAccreditationId,
   });
 
   databaseBuilder.factory.buildCertificationCenter({

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -10,10 +10,10 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils'
 
 module.exports = {
 
-  save(request) {
+  async save(request) {
     const certificationCenter = certificationCenterSerializer.deserialize(request.payload);
-    return usecases.saveCertificationCenter({ certificationCenter })
-      .then(certificationCenterSerializer.serialize);
+    const savedCertificationCenter = await usecases.saveCertificationCenter({ certificationCenter });
+    return certificationCenterSerializer.serialize(savedCertificationCenter);
   },
 
   getById(request) {

--- a/api/lib/domain/models/Accreditation.js
+++ b/api/lib/domain/models/Accreditation.js
@@ -1,0 +1,12 @@
+class Accreditation {
+
+  constructor({
+    id,
+    name,
+  }) {
+    this.id = id;
+    this.name = name;
+  }
+}
+
+module.exports = Accreditation;

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -16,12 +16,14 @@ class CertificationCenter {
     externalId,
     type,
     createdAt,
+    accreditations = [],
   } = {}) {
     this.id = id;
     this.name = name;
     this.externalId = externalId;
     this.type = type;
     this.createdAt = createdAt;
+    this.accreditations = accreditations;
   }
 
   get isSco() {

--- a/api/lib/infrastructure/orm-models/Accreditation.js
+++ b/api/lib/infrastructure/orm-models/Accreditation.js
@@ -1,0 +1,11 @@
+const Bookshelf = require('../bookshelf');
+
+const modelName = 'Accreditation';
+
+module.exports = Bookshelf.model(modelName, {
+
+  tableName: 'accreditations',
+  hasTimestamps: ['createdAt', null],
+}, {
+  modelName,
+});

--- a/api/lib/infrastructure/orm-models/CertificationCenter.js
+++ b/api/lib/infrastructure/orm-models/CertificationCenter.js
@@ -1,5 +1,7 @@
 const Bookshelf = require('../bookshelf');
 
+require('./Accreditation');
+
 const modelName = 'CertificationCenter';
 
 module.exports = Bookshelf.model(modelName, {
@@ -9,6 +11,10 @@ module.exports = Bookshelf.model(modelName, {
 
   certificationCenterMemberships() {
     return this.hasMany('CertificationCenterMembership', 'certificationCenterId');
+  },
+
+  accreditations() {
+    return this.belongsToMany('Accreditation', 'granted-accreditations', 'certificationCenterId', 'accreditationId');
   },
 
 }, {

--- a/api/lib/infrastructure/orm-models/CertificationCenterMembership.js
+++ b/api/lib/infrastructure/orm-models/CertificationCenterMembership.js
@@ -1,6 +1,7 @@
 const Bookshelf = require('../bookshelf');
 
 require('./CertificationCenter');
+require('./User');
 
 const modelName = 'CertificationCenterMembership';
 

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -88,6 +88,9 @@ module.exports = {
       .fetchPage({
         page: page.number,
         pageSize: page.size,
+        withRelated: [
+          { accreditations: function(query) { query.orderBy('id'); } },
+        ],
       });
     const { models, pagination } = certificationCenterBookshelf;
     return { models: models.map(_toDomain), pagination };

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -62,7 +62,12 @@ module.exports = {
       .query((qb) => {
         qb.innerJoin('sessions', 'sessions.certificationCenterId', 'certification-centers.id');
       })
-      .fetch({ require: false });
+      .fetch({
+        require: false,
+        withRelated: [
+          { accreditations: function(query) { query.orderBy('id'); } },
+        ],
+      });
 
     if (certificationCenterBookshelf) {
       return _toDomain(certificationCenterBookshelf);

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -96,7 +96,12 @@ module.exports = {
   async findByExternalId({ externalId }) {
     const certificationCenterBookshelf = await BookshelfCertificationCenter
       .where({ externalId })
-      .fetch({ require: false });
+      .fetch({
+        require: false,
+        withRelated: [
+          { accreditations: function(query) { query.orderBy('id'); } },
+        ],
+      });
 
     return certificationCenterBookshelf ? _toDomain(certificationCenterBookshelf) : null;
   },

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
   serialize(certificationCenters, meta) {
     return new Serializer('certification-center', {
       attributes: [
-        'id', 'name', 'type', 'externalId', 'createdAt', 'certificationCenterMemberships',
+        'name', 'type', 'externalId', 'createdAt', 'certificationCenterMemberships', 'accreditations',
       ],
       certificationCenterMemberships: {
         ref: 'id',
@@ -19,6 +19,11 @@ module.exports = {
           },
         },
       },
+      accreditations: {
+        include: true,
+        ref: 'id',
+        attributes: ['name'],
+      },
       meta,
     }).serialize(certificationCenters);
   },
@@ -29,6 +34,8 @@ module.exports = {
       name: jsonAPI.data.attributes.name,
       type: jsonAPI.data.attributes.type,
       externalId: jsonAPI.data.attributes['external-id'],
+      createdAt: null,
+      accreditations: [],
     });
   },
 };

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -1,4 +1,5 @@
 const pick = require('lodash/pick');
+const omit = require('lodash/omit');
 
 const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
 
@@ -145,7 +146,7 @@ describe('Integration | Repository | Certification Center Membership', function(
       } = foundCertificationCenterMembership;
 
       expect(associatedCertificationCenter).to.be.an.instanceof(CertificationCenter);
-      expect(associatedCertificationCenter).to.deep.equal(certificationCenter);
+      expect(omit(associatedCertificationCenter, ['accreditations'])).to.deep.equal(certificationCenter);
 
       expect(associatedUser).to.be.an.instanceOf(User);
       expect(pick(associatedUser, ['id', 'firstName', 'lastName', 'email']))

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -230,7 +230,51 @@ describe('Integration | Repository | Certification Center', function() {
 
       it('should return an Array of CertificationCenters', async function() {
         // given
-        _.times(3, databaseBuilder.factory.buildCertificationCenter);
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'First certification center',
+          externalId: '1',
+          type: 'SUP',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        });
+        const expectedCertificationCenter1 = domainBuilder.buildCertificationCenter({
+          id: 1,
+          name: 'First certification center',
+          type: CertificationCenter.types.SUP,
+          externalId: '1',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [],
+        });
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 2,
+          name: 'Second certification center',
+          externalId: '2',
+          type: 'SCO',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        });
+        const expectedCertificationCenter2 = domainBuilder.buildCertificationCenter({
+          id: 2,
+          name: 'Second certification center',
+          type: CertificationCenter.types.SCO,
+          externalId: '2',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [],
+        });
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 3,
+          name: 'Third certification center',
+          externalId: '3',
+          type: 'PRO',
+          createdAt: new Date('2018-04-01T05:43:10Z'),
+        });
+        const expectedCertificationCenter3 = domainBuilder.buildCertificationCenter({
+          id: 3,
+          name: 'Third certification center',
+          type: CertificationCenter.types.PRO,
+          externalId: '3',
+          createdAt: new Date('2018-04-01T05:43:10Z'),
+          accreditations: [],
+        });
         await databaseBuilder.commit();
 
         const filter = {};
@@ -241,9 +285,7 @@ describe('Integration | Repository | Certification Center', function() {
         const { models: matchingCertificationCenters, pagination } = await certificationCenterRepository.findPaginatedFiltered({ filter, page });
 
         // then
-        expect(matchingCertificationCenters).to.exist;
-        expect(matchingCertificationCenters).to.have.lengthOf(3);
-        expect(matchingCertificationCenters[0]).to.be.an.instanceOf(CertificationCenter);
+        expect(matchingCertificationCenters).to.deepEqualArray([expectedCertificationCenter1, expectedCertificationCenter2, expectedCertificationCenter3]);
         expect(pagination).to.deep.equal(expectedPagination);
       });
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -289,6 +289,109 @@ describe('Integration | Repository | Certification Center', function() {
         expect(pagination).to.deep.equal(expectedPagination);
       });
 
+      it('should return an Array of CertificationCenters and their accreditations', async function() {
+        // given
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'First certification center',
+          externalId: '1',
+          type: 'SUP',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        });
+        databaseBuilder.factory.buildAccreditation({
+          id: 11,
+          name: 'Accreditation name',
+        });
+        databaseBuilder.factory.buildGrantedAccreditation({
+          certificationCenterId: 1,
+          accreditationId: 11,
+        });
+        const expectedAccreditation1 = domainBuilder.buildAccreditation({
+          id: 11,
+          name: 'Accreditation name',
+        });
+        const expectedCertificationCenter1 = domainBuilder.buildCertificationCenter({
+          id: 1,
+          name: 'First certification center',
+          type: CertificationCenter.types.SUP,
+          externalId: '1',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [
+            expectedAccreditation1,
+          ],
+        });
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 2,
+          name: 'Second certification center',
+          externalId: '2',
+          type: 'SCO',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        });
+        databaseBuilder.factory.buildAccreditation({
+          id: 22,
+          name: 'Accreditation name',
+        });
+        databaseBuilder.factory.buildGrantedAccreditation({
+          certificationCenterId: 2,
+          accreditationId: 22,
+        });
+        const expectedAccreditation2 = domainBuilder.buildAccreditation({
+          id: 22,
+          name: 'Accreditation name',
+        });
+        const expectedCertificationCenter2 = domainBuilder.buildCertificationCenter({
+          id: 2,
+          name: 'Second certification center',
+          type: CertificationCenter.types.SCO,
+          externalId: '2',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [
+            expectedAccreditation2,
+          ],
+        });
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 3,
+          name: 'Third certification center',
+          externalId: '3',
+          type: 'PRO',
+          createdAt: new Date('2018-04-01T05:43:10Z'),
+        });
+        databaseBuilder.factory.buildAccreditation({
+          id: 33,
+          name: 'Accreditation name',
+        });
+        databaseBuilder.factory.buildGrantedAccreditation({
+          certificationCenterId: 3,
+          accreditationId: 33,
+        });
+        const expectedAccreditation3 = domainBuilder.buildAccreditation({
+          id: 33,
+          name: 'Accreditation name',
+        });
+        const expectedCertificationCenter3 = domainBuilder.buildCertificationCenter({
+          id: 3,
+          name: 'Third certification center',
+          type: CertificationCenter.types.PRO,
+          externalId: '3',
+          createdAt: new Date('2018-04-01T05:43:10Z'),
+          accreditations: [
+            expectedAccreditation3,
+          ],
+        });
+        await databaseBuilder.commit();
+
+        const filter = {};
+        const page = { number: 1, size: 10 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
+
+        // when
+        const { models: matchingCertificationCenters, pagination } = await certificationCenterRepository.findPaginatedFiltered({ filter, page });
+
+        // then
+        expect(matchingCertificationCenters).to.deepEqualArray([expectedCertificationCenter1, expectedCertificationCenter2, expectedCertificationCenter3]);
+        expect(pagination).to.deep.equal(expectedPagination);
+      });
+
     });
 
     context('when there are lots of CertificationCenters (> 10) in the database', function() {

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -114,20 +114,71 @@ describe('Integration | Repository | Certification Center', function() {
       it('should return the certification center of the given sessionId', async function() {
         // given
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'Given session center',
           externalId: '123456',
           type: 'SCO',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
         }).id;
         const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+        const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
+          id: 1,
+          name: 'Given session center',
+          type: 'SCO',
+          externalId: '123456',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [],
+        });
+
         await databaseBuilder.commit();
 
         // when
         const certificationCenter = await certificationCenterRepository.getBySessionId(sessionId);
 
         // then
-        expect(certificationCenter).to.be.an.instanceOf(CertificationCenter);
-        expect(certificationCenter.id).to.equal(certificationCenterId);
-        expect(certificationCenter.externalId).to.equal('123456');
-        expect(certificationCenter.type).to.equal('SCO');
+        expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
+      });
+
+      it('should return the certification center and accreditations of the given sessionId', async function() {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'certificationCenterName',
+          type: CertificationCenter.types.SUP,
+          externalId: 'externalId',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        }).id;
+        databaseBuilder.factory.buildAccreditation({
+          id: 1234,
+          name: 'Accreditation name',
+        });
+        databaseBuilder.factory.buildGrantedAccreditation({
+          certificationCenterId: 1,
+          accreditationId: 1234,
+        });
+
+        const expectedAccreditation = domainBuilder.buildAccreditation({
+          id: 1234,
+          name: 'Accreditation name',
+        });
+        const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
+          id: 1,
+          name: 'certificationCenterName',
+          type: CertificationCenter.types.SUP,
+          externalId: 'externalId',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [
+            expectedAccreditation,
+          ],
+        });
+        const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenter = await certificationCenterRepository.getBySessionId(sessionId);
+
+        expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -390,15 +390,69 @@ describe('Integration | Repository | Certification Center', function() {
       it('should return the certification center', async function() {
         // given
         const externalId = 'EXTERNAL_ID';
-        databaseBuilder.factory.buildCertificationCenter({ externalId });
+        databaseBuilder.factory.buildCertificationCenter({
+          externalId,
+          id: 1,
+          name: 'Certif center to return by external Id',
+          type: 'SUP',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        });
+        const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
+          id: 1,
+          name: 'Certif center to return by external Id',
+          type: CertificationCenter.types.SUP,
+          externalId: 'EXTERNAL_ID',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        });
         await databaseBuilder.commit();
 
         // when
         const certificationCenter = await certificationCenterRepository.findByExternalId({ externalId });
 
         // then
-        expect(certificationCenter).to.be.an.instanceOf(CertificationCenter);
-        expect(certificationCenter.externalId).to.equal(externalId);
+        expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
+      });
+
+      it('should return the certification center and accreditation', async function() {
+        // given
+        const externalId = 'EXTERNAL_ID';
+        databaseBuilder.factory.buildCertificationCenter({
+          externalId,
+          id: 1,
+          name: 'Certif center to return by external Id',
+          type: 'SUP',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        });
+        databaseBuilder.factory.buildAccreditation({
+          id: 123,
+          name: 'Accreditation test',
+        });
+        databaseBuilder.factory.buildGrantedAccreditation({
+          certificationCenterId: 1,
+          accreditationId: 123,
+        });
+        const expectedAccreditation = domainBuilder.buildAccreditation({
+          id: 123,
+          name: 'Accreditation test',
+        });
+        const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
+          id: 1,
+          name: 'Certif center to return by external Id',
+          type: CertificationCenter.types.SUP,
+          externalId: 'EXTERNAL_ID',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [
+            expectedAccreditation,
+          ],
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenter = await certificationCenterRepository.findByExternalId({ externalId });
+
+        // then
+        expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-accreditation.js
+++ b/api/tests/tooling/domain-builder/factory/build-accreditation.js
@@ -1,0 +1,11 @@
+const Accreditation = require('../../../../lib/domain/models/Accreditation');
+
+module.exports = function buildAccreditation({
+  id = 1,
+  name = 'Accreditation name',
+} = {}) {
+  return new Accreditation({
+    id,
+    name,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-certification-center.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center.js
@@ -6,6 +6,7 @@ module.exports = function buildCertificationCenter({
   type = CertificationCenter.types.SUP,
   externalId = 'externalId',
   createdAt = new Date('2020-01-01'),
+  accreditations = [],
 } = {}) {
   return new CertificationCenter({
     id,
@@ -13,5 +14,6 @@ module.exports = function buildCertificationCenter({
     type,
     externalId,
     createdAt,
+    accreditations,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildAccountRecoveryDemand: require('./build-account-recovery-demand'),
+  buildAccreditation: require('./build-accreditation'),
   buildAnswer: require('./build-answer'),
   buildArea: require('./build-area'),
   buildAssessment: require('./build-assessment'),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
@@ -1,44 +1,34 @@
-const { expect } = require('../../../../test-helper');
+const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-center-serializer');
-const CertificationCenter = require('../../../../../lib/domain/models/CertificationCenter');
 
 describe('Unit | Serializer | JSONAPI | certification-center-serializer', function() {
-
-  let certificationCenterId;
-  let certificationCenterName;
-  let certificationCenterDate;
-  let certificationCenterType;
-  let certificationCenterExternalId;
-
-  beforeEach(function() {
-    certificationCenterId = 42;
-    certificationCenterName = 'My certification center';
-    certificationCenterType = 'PRO';
-    certificationCenterExternalId = 'Identifiant externe';
-    certificationCenterDate = 'Some date';
-  });
 
   describe('#serialize', function() {
 
     it('should convert a Certification Center model object into JSON API data', function() {
       // given
-      const certificationCenter = new CertificationCenter({
-        id: certificationCenterId.toString(),
-        name: certificationCenterName,
-        createdAt: certificationCenterDate,
-        fakeProperty: 'fakeProperty',
+      const accreditation = domainBuilder.buildAccreditation({
+        id: 1,
+        name: 'Pix+surf',
+      });
+      const certificationCenter = domainBuilder.buildCertificationCenter({
+        id: 12,
+        name: 'Centre des dés',
+        type: 'SCO',
+        createdAt: new Date('2018-01-01T05:43:10Z'),
+        externalId: '12345',
+        accreditations: [ accreditation ],
       });
 
       const expectedSerializedCertificationCenter = {
         data: {
           type: 'certification-centers',
-          id: certificationCenterId.toString(),
+          id: '12',
           attributes: {
-            id: certificationCenterId.toString(),
-            name: certificationCenterName,
-            type: undefined,
-            'external-id': undefined,
-            'created-at': certificationCenterDate,
+            name: 'Centre des dés',
+            type: 'SCO',
+            'external-id': '12345',
+            'created-at': new Date('2018-01-01T05:43:10Z'),
           },
           relationships: {
             'certification-center-memberships': {
@@ -46,8 +36,25 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
                 related: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
               },
             },
+            accreditations: {
+              data: [
+                {
+                  id: '1',
+                  type: 'accreditations',
+                },
+              ],
+            },
           },
         },
+        included: [
+          {
+            id: '1',
+            type: 'accreditations',
+            attributes: {
+              name: 'Pix+surf',
+            },
+          },
+        ],
       };
 
       // when
@@ -65,27 +72,30 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
       const jsonApi = {
         data: {
           type: 'certification-centers',
-          id: certificationCenterId.toString(),
+          id: '123',
           attributes: {
-            name: certificationCenterName,
-            type: certificationCenterType,
-            'external-id': certificationCenterExternalId,
+            name: 'Centre des dés',
+            type: 'SCO',
+            'external-id': '12345',
             'created-at': new Date('2018-02-01T01:02:03Z'),
           },
           relationships: {},
         },
       };
+      const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
+        id: '123',
+        name: 'Centre des dés',
+        type: 'SCO',
+        externalId: '12345',
+        createdAt: null,
+        accreditations: [],
+      });
 
       // when
       const deserializedCertificationCenter = serializer.deserialize(jsonApi);
 
       // then
-      expect(deserializedCertificationCenter).to.be.instanceOf(CertificationCenter);
-      expect(deserializedCertificationCenter.id).to.equal(certificationCenterId.toString());
-      expect(deserializedCertificationCenter.name).to.equal(certificationCenterName);
-      expect(deserializedCertificationCenter.type).to.equal(certificationCenterType);
-      expect(deserializedCertificationCenter.externalId).to.equal(certificationCenterExternalId);
-      expect(deserializedCertificationCenter.createdAt).to.be.undefined;
+      expect(deserializedCertificationCenter).to.deepEqualInstance(expectedCertificationCenter);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui aucune règle de gestion n'existe au niveau centre de certification pour les autoriser ou pas à organiser des sessions de certification pouvant certifier sur des certifications complémentaires.
Pour des raisons de facturation et de suivi (mais aussi pour éviter de sur-certifier), on souhaite pouvoir gérer les habilitations aux certifications complémentaires des centres de certification.
On commence cette épix par, d'abord, le fait de pouvoir visualiser les habilitations d'un centre de certification sur PixAdmin.

## :robot: Solution
Cette PR propose l'archi BDD pour la gestion des habilitations.
Création de 3 nouvelles tables (on est en attente des traductions finales):
- Une table `accreditations` qui contient la liste des habilitations existantes
- Une table d'association `granted-accreditations` qui relie une habilitation à un centre de certification
- Une table d'association `accredited-badges` qui relie une habilitation à un badge rendant éligible à une certification complémentaire

Introduction de ces nouveaux modèles/concepts + affichage côté PixAdmin des habilitations d'un centre de certification.

~~Pour le moment, nous avons décidé de mettre la feature sous toggle : `FT_ACCREDITATIONS_ENABLED`~~

## :rainbow: Remarques
On a modifié des seeds pour que :
- le centre de certif PRO soit habilité CléA.
- le centre de certif SUP soit habilité CléA et Pix+Droit

## :100: Pour tester
 - Se connecter à Pix Admin en tant que Pix Master.
 - Se rendre sur le centre de certification 3.
 - Constater la présence de deux habilitations à des certifications complémentaires, affiché sous les informations du centre.
