### PR TITLE
[BUGFIX] Le titre de la page d'épreuve n'était pas mise à jour en cas de timeout.

### DIFF
--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -28,7 +28,7 @@
         @challenge={{@model.challenge}}
         @assessment={{@model.assessment}}
         @answer={{@model.answer}}
-        @timeoutChalenge={{this.timeoutChallenge}}
+        @timeoutChallenge={{this.timeoutChallenge}}
         @finishChallenge={{this.finishChallenge}}
         @answerValidated={{route-action "saveAnswerAndNavigate"}}
         @resumeAssessment={{route-action "resumeAssessment"}}


### PR DESCRIPTION
## :unicorn: Problème
Problème de typo qui avait bloqué le fonctionnement de la mise à jour du titre

## :robot: Solution
Corriger la typo

## :rainbow: Remarques

## :100: Pour tester
