### PR TITLE
[TECH] Améliorer l'accessibilité de la navigation et des tooltip dans Pix Orga (PIX-2955)

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
@@ -61,9 +61,7 @@ Then(`je suis redirigé vers le profil de {string}`, (firstName) => {
 
 Then(`je suis redirigé vers le compte Orga de {string}`, (fullName) => {
   cy.url().should('include', '/campagnes');
-  cy.get('.logged-user-summary__name').should((userName) => {
-    expect(userName.text()).to.contains(fullName);
-  });
+  cy.contains(fullName).should('be.visible');
   cy.get('.list-campaigns-page').should((list) => {
     expect(list).to.exist;
   });
@@ -82,8 +80,8 @@ When(`je me déconnecte`, () => {
 });
 
 When(`je me déconnecte de Pix Orga`, () => {
-  cy.get('.topbar__user-logged-menu').click();
-  cy.get('.logged-user-menu-item:last-of-type').click();
+  cy.get('[aria-label="Ouvrir le menu utilisateur"]').click();
+  cy.contains('Se déconnecter').click();
 });
 
 When(`je me déconnecte de Pix Certif`, () => {

--- a/orga/app/components/campaign/badges.hbs
+++ b/orga/app/components/campaign/badges.hbs
@@ -1,9 +1,15 @@
 {{#each @badges as |badge|}}
   <PixTooltip
+    @id="badge-tooltip-{{badge.id}}"
     @text={{badge.title}}
     @position='bottom'
     @isInline={{true}}
   >
-    <img src={{badge.imageUrl}} alt={{badge.altMessage}} />
+    <img
+      src={{badge.imageUrl}}
+      alt={{badge.altMessage}}
+      tabindex="0"
+      aria-describedby="badge-tooltip-{{badge.id}}"
+    />
   </PixTooltip>
 {{/each}}

--- a/orga/app/components/campaign/charts/participants-by-stage-bar.hbs
+++ b/orga/app/components/campaign/charts/participants-by-stage-bar.hbs
@@ -1,4 +1,4 @@
-<div class="participants-by-stage__graph" role="button" {{on "click" (fn @onClickBar @stageId)}}>
+<div class="participants-by-stage__graph" role="button" {{on "click" (fn @onClickBar @stageId)}} ...attributes>
   <div class="participants-by-stage__bar" style={{@barWidth}} />
   <div class="participants-by-stage__percentage">
     {{yield}}

--- a/orga/app/components/campaign/charts/participants-by-stage.hbs
+++ b/orga/app/components/campaign/charts/participants-by-stage.hbs
@@ -2,7 +2,7 @@
   {{#if this.loading}}
     <Campaign::Charts::ParticipantsByStageLoader />
   {{else}}
-    {{#each this.data as |stage|}}
+    {{#each this.data as |stage index|}}
       <div class="participants-by-stage">
         <PixStars
           @count={{stage.index}}
@@ -15,14 +15,19 @@
         </div>
         {{#if stage.displayTooltip}}
           <PixTooltip
-            role="tooltip"
+            @id="chart-stage-{{index}}"
             @text={{stage.tooltip}}
             @position="bottom-right"
             @isWide={{true}}
-            @isLight={{true}}
             class="participants-by-stage__container"
-            >
-              <Campaign::Charts::ParticipantsByStageBar @onClickBar={{this.onClickBar}} @stageId={{stage.id}} @barWidth={{stage.barWidth}}>
+          >
+              <Campaign::Charts::ParticipantsByStageBar
+                @onClickBar={{this.onClickBar}}
+                @stageId={{stage.id}}
+                @barWidth={{stage.barWidth}}
+                tabindex="0"
+                aria-describedby="chart-stage-{{index}}"
+              >
                 {{t 'charts.participants-by-stage.percentage' percentage=stage.percentage}}
               </Campaign::Charts::ParticipantsByStageBar>
           </PixTooltip>

--- a/orga/app/components/campaign/charts/participants-by-status.hbs
+++ b/orga/app/components/campaign/charts/participants-by-status.hbs
@@ -14,8 +14,18 @@
       {{#each this.datasets as |dataset|}}
         <li class="participants-by-status__legend--{{dataset.key}}">
           <span>{{dataset.legend}}</span>
-          <PixTooltip @text={{dataset.legendTooltip}} @isWide="true" @position="top-left">
-            <FaIcon @icon="question-circle" class="participants-by-status__legend-tooltip" />
+          <PixTooltip
+            @id="legend-tooltip-{{dataset.key}}"
+            @text={{dataset.legendTooltip}}
+            @isWide="true"
+            @position="top-left"
+          >
+            <FaIcon
+              @icon="question-circle"
+              class="participants-by-status__legend-tooltip"
+              tabindex="0"
+              aria-describedby="legend-tooltip-{{dataset.key}}"
+            />
           </PixTooltip>
         </li>
       {{/each}}

--- a/orga/app/components/campaign/copy-paste-button.hbs
+++ b/orga/app/components/campaign/copy-paste-button.hbs
@@ -1,11 +1,13 @@
 {{#if (is-clipboard-supported)}}
   <PixTooltip
+    @id="copy-paste-button"
     @text={{this.tooltipText}}
     @position='top'
     @isInline={{true}}
     class="copy-paste-button__tooltip hide-on-mobile">
     <CopyButton
       aria-label={{@defaultMessage}}
+      aria-describedby="copy-paste-button"
       @clipboardText={{@clipBoardtext}}
       @success={{this.onClipboardSuccess}}
       {{on 'mouseLeave' this.onClipboardOut}}

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -48,6 +48,7 @@
         @onChange={{this.setSelectedTargetProfile}}
         @options={{this.targetProfilesOptions}}
         @emptyOptionLabel=""
+        @size="big"
       />
       {{#if @campaign.errors.targetProfile}}
         <div class='form__error error-message'>

--- a/orga/app/components/campaign/stage-stars.hbs
+++ b/orga/app/components/campaign/stage-stars.hbs
@@ -8,14 +8,18 @@
   />
   {{#if this.displayTooltip}}
     <PixTooltip
-      role="tooltip"
+      @id="stage-tooltip-{{this.reachedStage.id}}"
       @text={{this.tooltipText}}
       @position={{@tooltipPosition}}
       @isWide={{true}}
-      @isLight={{true}}
       class="hide-on-mobile"
     >
-      <FaIcon @icon="info-circle" class="stage-stars__info-icon"/>
+      <FaIcon
+        @icon="info-circle"
+        class="stage-stars__info-icon"
+        tabindex="0"
+        aria-describedby="stage-tooltip-{{this.reachedStage.id}}"
+      />
     </PixTooltip>
   {{/if}}
 </div>

--- a/orga/app/components/dropdown/item.hbs
+++ b/orga/app/components/dropdown/item.hbs
@@ -1,3 +1,10 @@
-<li class="dropdown__item" role="button" {{on 'click' @onClick}} ...attributes>
+<li
+  class="dropdown__item"
+  role="button"
+  tabindex="0"
+  {{on 'click' @onClick}}
+  {{on 'keydown' this.handleKeyDown}}
+  ...attributes
+>
   {{yield}}
 </li>

--- a/orga/app/components/dropdown/item.js
+++ b/orga/app/components/dropdown/item.js
@@ -1,0 +1,11 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class DropdownItem extends Component {
+  @action
+  handleKeyDown(event) {
+    if (event.key === 'Enter') {
+      this.args.onClick();
+    }
+  }
+}

--- a/orga/app/components/layout/organization-credit-info.hbs
+++ b/orga/app/components/layout/organization-credit-info.hbs
@@ -1,12 +1,20 @@
 {{#if this.canShowCredit}}
   <div class="organization-credit-info">
     <span class="organization-credit-info__label">{{t 'navigation.credits.number' count=this.currentUser.organization.credit}}</span>
+    
     <PixTooltip
+      @id="credit-info-tooltip"
       @text={{t 'navigation.credits.tooltip-text' htmlSafe=true}}
       @position='bottom-left'
       @isWide={{true}}
-      @isLight={{true}}>
-        <FaIcon @icon="info-circle" class="info-icon"/>
+      @isLight={{true}}
+    >
+        <FaIcon
+          @icon="info-circle"
+          class="info-icon"
+          tabindex="0"
+          aria-describedby="credit-info-tooltip"
+        />
     </PixTooltip>
   </div>
 {{/if}}

--- a/orga/app/components/layout/topbar.hbs
+++ b/orga/app/components/layout/topbar.hbs
@@ -2,7 +2,5 @@
   <div class="topbar__organization-credit-info hide-on-mobile">
     <Layout::OrganizationCreditInfo />
   </div>
-  <div class="topbar__user-logged-menu">
-    <Layout::UserLoggedMenu />
-  </div>
+  <Layout::UserLoggedMenu class="topbar__user-logged-menu" />
 </div>

--- a/orga/app/components/layout/user-logged-menu.hbs
+++ b/orga/app/components/layout/user-logged-menu.hbs
@@ -1,28 +1,32 @@
-<div class="dropdown logged-user-summary content-text content-text--small">
-  <a href="#" aria-label={{t 'navigation.user-logged-menu.summary'}} class="link logged-user-summary__link" {{on 'click' this.toggleUserMenu}} aria-haspopup="listbox" aria-expanded="{{this.isMenuOpen}}">
-    <div>
-      <div class="logged-user-summary__name">{{this.currentUser.prescriber.firstName}} {{this.currentUser.prescriber.lastName}}</div>
-      <div class="logged-user-summary__organization">{{this.organizationNameAndExternalId}}</div>
-    </div>
-    {{#if this.isMenuOpen}}
-      <FaIcon @icon="chevron-up" @class="logged-user-summary__chevron logged-user-summary__chevron-up"></FaIcon>
-    {{else}}
-      <FaIcon @icon="chevron-down" @class="logged-user-summary__chevron"></FaIcon>
-    {{/if}}
-  </a>
-</div>
+<button
+  type="button"
+  {{on 'click' this.toggleUserMenu}}
+  aria-haspopup="listbox"
+  aria-expanded="{{this.isMenuOpen}}"
+  aria-label={{t 'navigation.user-logged-menu.button'}}
+  class="user-logged-button"
+  ...attributes
+>
+  <span class="user-logged-button__text">
+    <span>{{this.currentUser.prescriber.firstName}} {{this.currentUser.prescriber.lastName}}</span>
+    <span>{{this.organizationNameAndExternalId}}</span>
+  </span>
+  {{#if this.isMenuOpen}}
+    <FaIcon @icon="chevron-up" @class="user-logged-button__chevron user-logged-button__chevron--up"></FaIcon>
+  {{else}}
+    <FaIcon @icon="chevron-down" @class="user-logged-button__chevron"></FaIcon>
+  {{/if}}
+</button>
 
-<Dropdown::Content @display={{this.isMenuOpen}} @close={{this.closeMenu}} class="logged-user-menu">
+<Dropdown::Content @display={{this.isMenuOpen}} @close={{this.closeMenu}} class="user-logged-menu">
   {{#each this.eligibleOrganizations as |organization|}}
-    <Dropdown::Item @onClick={{fn this.onOrganizationChange organization}} title="{{organization.name}}" class="logged-user-menu-item">
-      <span class="logged-user-menu-item__organization-name">{{organization.name}}</span>
-      {{#if organization.externalId}}
-        <span class="logged-user-menu-item__organization-externalId">({{organization.externalId}})</span>
-      {{/if}}
+    <Dropdown::Item @onClick={{fn this.onOrganizationChange organization}}>
+      {{organization.name}}
+      {{#if organization.externalId}}({{organization.externalId}}){{/if}}
     </Dropdown::Item>
   {{/each}}
-  <Dropdown::ItemLink @linkTo="logout" class="logged-user-menu-item logged-user-menu-item__last">
-      <FaIcon @icon="power-off" @class="logged-user-menu-item__icon"></FaIcon>
+  <Dropdown::ItemLink @linkTo="logout">
+      <FaIcon @icon="power-off" @class="user-logged-menu__icon"></FaIcon>
       {{t 'navigation.user-logged-menu.logout'}}
   </Dropdown::ItemLink>
 </Dropdown::Content>

--- a/orga/app/components/student/sco/manage-authentication-method-modal.hbs
+++ b/orga/app/components/student/sco/manage-authentication-method-modal.hbs
@@ -33,6 +33,7 @@
             />
             {{#if (is-clipboard-supported)}}
               <PixTooltip
+                @id="copy-email-tooltip"
                 @text={{this.tooltipTextEmail}}
                 @position='top'
                 @isInline={{true}}
@@ -42,7 +43,9 @@
                   @clipboardText={{@student.email}}
                   @success={{this.clipboardSuccessEmail}}
                   {{ on 'mouseout' this.clipboardOutEmail}}
-                  @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button">
+                  @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button"
+                  aria-describedby="copy-email-tooltip"
+                >
                   <FaIcon @icon="copy" @prefix="far" />
                 </CopyButton>
               </PixTooltip>
@@ -79,6 +82,7 @@
                 />
                 {{#if (is-clipboard-supported)}}
                   <PixTooltip
+                    @id="copy-username-tooltip"
                     @text={{this.tooltipTextUsername}}
                     @position='top'
                     @isInline={{true}}
@@ -88,7 +92,9 @@
                       @clipboardText={{@student.username}}
                       @success={{this.clipboardSuccessUsername}}
                       {{ on 'mouseout' this.clipboardOutUsername}}
-                      @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button">
+                      @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button"
+                      aria-describedby="copy-username-tooltip"
+                    >
                       <FaIcon @icon="copy" @prefix="far" />
                     </CopyButton>
                   </PixTooltip>
@@ -117,6 +123,7 @@
                 />
                 {{#if (is-clipboard-supported)}}
                   <PixTooltip
+                    @id="copy-password-tooltip"
                     @text={{this.tooltipTextGeneratedPassword}}
                     @position='top'
                     @isInline={{true}}
@@ -126,7 +133,9 @@
                       @clipboardText={{this.generatedPassword}}
                       @success={{this.clipboardSuccessGeneratedPassword}}
                       {{on 'mouseout' this.clipboardOutGeneratedPassword}}
-                      @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button">
+                      @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button"
+                      aria-describedby="copy-password-tooltip"
+                    >
                       <FaIcon @icon="copy" @prefix="far" class="fa-inverse" />
                     </CopyButton>
                   </PixTooltip>

--- a/orga/app/components/ui/indicator-card.hbs
+++ b/orga/app/components/ui/indicator-card.hbs
@@ -12,13 +12,18 @@
         <span>{{@title}}</span>
         {{#if @info}}
           <PixTooltip
-            role="tooltip"
+            @id={{@title}}
             @text={{@info}}
             @position="top"
             @isWide={{true}}
             class="indicator-card__tooltip hide-on-mobile"
           >
-            <FaIcon @icon="question-circle" class="indicator-card__tooltip-icon"/>
+            <FaIcon
+              @icon="question-circle"
+              class="indicator-card__tooltip-icon"
+              tabindex="0"
+              aria-describedby={{@title}}
+            />
           </PixTooltip>
         {{/if}}
       </label>

--- a/orga/app/styles/components/campaign/stage-stars.scss
+++ b/orga/app/styles/components/campaign/stage-stars.scss
@@ -20,7 +20,7 @@
   }
 
   &__info-icon {
-    color: $grey-40;
+    color: $grey-30;
     margin: 0 8px;
   }
 }

--- a/orga/app/styles/components/dropdown.scss
+++ b/orga/app/styles/components/dropdown.scss
@@ -25,10 +25,26 @@
 
     &--link {
       padding: 0;
+    
       > a {
+        color: $grey-60;
         padding: 12px 16px;
         width: 100%;
         height: 100%;
+
+        &:hover,
+        &:active,
+        &:focus {
+          background-color: $grey-10;
+          color: $grey-60;
+          text-decoration: none;
+        }
+
+        &:focus {
+          border-radius: 4px;
+          box-shadow: inset 0px 0px 0px 1.6px $blue;
+          outline: none;
+        }
       }
     }
 
@@ -37,6 +53,12 @@
     &:focus {
       background-color: $grey-10;
       color: $grey-60;
+    }
+
+    &:focus {
+      border-radius: 4px;
+      box-shadow: inset 0px 0px 0px 1.6px $blue;
+      outline: none;
     }
   }
 }

--- a/orga/app/styles/components/indicator-card.scss
+++ b/orga/app/styles/components/indicator-card.scss
@@ -56,7 +56,6 @@
   }
 
   &__tooltip-icon {
-    font-size: 0.75rem;
     color: $grey-30;
     margin: 0 8px;
   }

--- a/orga/app/styles/components/layout/organization-credit-info.scss
+++ b/orga/app/styles/components/layout/organization-credit-info.scss
@@ -1,16 +1,16 @@
 .organization-credit-info {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.875rem;
 
   &__label {
-		font-size: 0.875rem;
-		font-weight: 500;
-		color: $grey-90;
-	}
+    font-weight: 500;
+    color: $grey-90;
+  }
 
-	.info-icon {
-		color: $grey-40;
-		margin: 0 8px;
-	}
+  .info-icon {
+    color: $grey-30;
+    margin: 0 8px;
+  }
 }

--- a/orga/app/styles/components/layout/topbar.scss
+++ b/orga/app/styles/components/layout/topbar.scss
@@ -5,21 +5,7 @@
   background-color: $white;
   min-height: 60px;
 
-  &__user-logged-menu {
-    padding: 0 30px;
-    border-left: 1px solid $grey-20;
-  }
-
   &__organization-credit-info {
     padding: 0 30px;
-  }
-}
-
-@include device-is('mobile') {
-  .topbar {
-    &__user-logged-menu {
-      padding: 0 16px;
-      border-left-width: 0px;
-    }
   }
 }

--- a/orga/app/styles/components/layout/user-logged-menu.scss
+++ b/orga/app/styles/components/layout/user-logged-menu.scss
@@ -1,33 +1,43 @@
-.logged-user-container{
-  position: relative;
-}
+.user-logged-button {
+  color: $grey-60;
+  cursor: pointer;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 30px;
+  background-color: transparent;
+  border-width: 0;
+  border-left: 1px solid $grey-20;
 
-.logged-user-summary {
-  letter-spacing: 0.03125rem;
-  text-align: right;
+  &:hover,
+  &:active,
+  &:focus {
+    color: $grey-70;
+    text-decoration: none;
+  }
 
-  &__link {
-    color: $grey-60;
-    cursor: pointer;
+  &:focus {
+    border-radius: 4px;
+    box-shadow: inset 0px 0px 0px 1.6px $blue;
+    outline: none;
+  }
+
+  &__text {
     display: flex;
-
-    &:hover,
-    &:active,
-    &:focus {
-      color: $grey-70;
-      text-decoration: none;
-    }
-  }
-
-  &__name {
+    flex-direction: column;
+    justify-content: center;
+    text-align: right;
     font-size: 0.875rem;
-    font-weight: bold;
-    height: 19px;
+    font-weight: 700;
+    letter-spacing: .03125rem;
+    height: 100%;
     text-transform: capitalize;
+    line-height: 1.1rem;
   }
 
-  &__organization {
-    height: 18px;
+  &__text > *:last-child {
+    font-weight: normal;
+    font-size: 0.8125rem;
   }
 
   &__chevron {
@@ -35,57 +45,26 @@
     margin-left: 18px;
     vertical-align: middle;
 
-    &-up {
+    &--up {
       color: $blue;
     }
   }
 }
 
-.logged-user-menu {
+.user-logged-menu {
   right: 0;
-  top: 49px;
+  top: 60px;
   width: 400px;
   max-width: 100%;
 
-  &-item {
-    color: $grey-60;
-    text-decoration: none;
-
-    &:hover,
-    &:active,
-    &:focus {
-      color: $grey-60;
-      text-decoration: none;
-    }
-
-    &__icon {
-      margin-right: 8px;
-    }
-
-    &__last:not(:first-child) {
-      border-top: 1px solid $grey-20;
-    }
-
-    &__organization-name {
-      margin-right: 3px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    &__organization-externalId {
-      flex: 0;
-    }
+  &__icon {
+    margin-right: 8px;
   }
 }
 
 @include device-is('mobile') {
-  .logged-user-summary {
-    &__name {
-      overflow: hidden;
-    }
-  
-    &__organization {
+  .user-logged-summary {
+    &__text {
       overflow: hidden;
     }
   }

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -116,7 +116,7 @@
   font-size: 0.75rem;
 }
 
-.pix-select > select, .pix-select > input {
+.pix-select > select, .pix-select > input, .pix-textarea > textarea {
   border-radius: 4px;
   border: 1px solid $grey-40;
 

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11987,12 +11987,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
-      "integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.4.tgz",
+      "integrity": "sha512-IzCSomxRdahCYb6G3HiN6pl3JCiM0NMunRcNa1pIeC7g17Vd6Ue3AT9anQiENPIm/svThUVer1pIbLMDERIsFw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.7",
+        "browserslist": "^4.16.8",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -12010,9 +12010,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001251",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-          "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+          "version": "1.0.30001252",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
           "dev": true
         },
         "colorette": {
@@ -12022,9 +12022,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.813",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.813.tgz",
-          "integrity": "sha512-YcSRImHt6JZZ2sSuQ4Bzajtk98igQ0iKkksqlzZLzbh4p0OIyJRSvUbsgqfcR8txdfsoYCc4ym306t4p2kP/aw==",
+          "version": "1.3.826",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.826.tgz",
+          "integrity": "sha512-bpLc4QU4B8PYmdO4MSu2ZBTMD8lAaEXRS43C09lB31BvYwuk9UxgBRXbY5OJBw7VuMGcg2MZG5FyTaP9u4PQnw==",
           "dev": true
         },
         "node-releases": {
@@ -25714,8 +25714,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#bebc2f6a4f91de702215b4b42830dfbe11453196",
-      "from": "git://github.com/1024pix/pix-ui.git#v5.4.0",
+      "version": "git://github.com/1024pix/pix-ui.git#78671a275dec092cd4bc17593d08198512fc5dc3",
+      "from": "git://github.com/1024pix/pix-ui.git#v8.0.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
@@ -26198,9 +26198,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001251",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-          "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+          "version": "1.0.30001252",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
           "dev": true
         },
         "colorette": {
@@ -26219,9 +26219,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.813",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.813.tgz",
-          "integrity": "sha512-YcSRImHt6JZZ2sSuQ4Bzajtk98igQ0iKkksqlzZLzbh4p0OIyJRSvUbsgqfcR8txdfsoYCc4ym306t4p2kP/aw==",
+          "version": "1.3.826",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.826.tgz",
+          "integrity": "sha512-bpLc4QU4B8PYmdO4MSu2ZBTMD8lAaEXRS43C09lB31BvYwuk9UxgBRXbY5OJBw7VuMGcg2MZG5FyTaP9u4PQnw==",
           "dev": true
         },
         "ember-cli-babel": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -93,7 +93,7 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v5.4.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v8.0.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",
     "sass": "^1.32.8"

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -177,7 +177,7 @@ module('Acceptance | authentication', function(hooks) {
         await visit('/');
 
         // then
-        assert.dom('.logged-user-summary__organization').hasText('BRO & Evil Associates (EXTBRO)');
+        assert.contains('BRO & Evil Associates (EXTBRO)');
       });
 
       test('it should redirect prescriber to the campaigns list on root url', async function(assert) {

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -189,7 +189,7 @@ module('Acceptance | join', function(hooks) {
         // then
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
 
-        assert.dom('.logged-user-summary__name').hasText('Harry Cover');
+        assert.contains('Harry Cover');
       });
     });
 

--- a/orga/tests/acceptance/switch-organization_test.js
+++ b/orga/tests/acceptance/switch-organization_test.js
@@ -30,18 +30,19 @@ module('Acceptance | Switch Organization', function(hooks) {
       await visit('/');
 
       // then
-      assert.dom('.logged-user-summary__organization').hasText('BRO & Evil Associates (EXTBRO)');
+      assert.contains('BRO & Evil Associates (EXTBRO)');
     });
 
-    test('should have no organization in menu', async function(assert) {
+    test('should only have disconnect item in menu', async function(assert) {
       // given
       await visit('/');
 
       // when
-      await clickByLabel('Résumé utilisateur');
+      await clickByLabel('Ouvrir le menu utilisateur');
 
       // then
-      assert.dom('.logged-user-menu-item__organization-name').doesNotExist();
+      assert.dom('.user-logged-menu > li').exists({ count: 1 });
+      assert.dom('.user-logged-menu > li').hasText('Se déconnecter');
     });
   });
 
@@ -58,35 +59,33 @@ module('Acceptance | Switch Organization', function(hooks) {
 
     test('should have an organization in menu', async function(assert) {
       // when
-      await clickByLabel('Résumé utilisateur');
+      await clickByLabel('Ouvrir le menu utilisateur');
 
       // then
-      assert.dom('.logged-user-menu-item__organization-name').exists();
-      assert.dom('.logged-user-menu-item__organization-name').hasText('My Heaven Company');
-      assert.dom('.logged-user-menu-item__organization-externalId').hasText('(HEAVEN)');
+      assert.dom('.user-logged-menu > li').exists({ count: 2 });
+      assert.dom('.user-logged-menu > li').hasText('My Heaven Company (HEAVEN)');
     });
 
     module('When prescriber click on an organization', function() {
 
       test('should change main organization in summary', async function(assert) {
         // when
-        await clickByLabel('Résumé utilisateur');
+        await clickByLabel('Ouvrir le menu utilisateur');
         await clickByLabel('My Heaven Company');
 
         // then
-        assert.dom('.logged-user-summary__organization').hasText('My Heaven Company (HEAVEN)');
+        assert.contains('My Heaven Company (HEAVEN)');
       });
 
       test('should have the old main organization in the menu', async function(assert) {
         // when
-        await clickByLabel('Résumé utilisateur');
+        await clickByLabel('Ouvrir le menu utilisateur');
         await clickByLabel('My Heaven Company');
-        await clickByLabel('Résumé utilisateur');
+        await clickByLabel('Ouvrir le menu utilisateur');
 
         // then
-        assert.dom('.logged-user-menu-item__organization-name').exists();
-        assert.dom('.logged-user-menu-item__organization-name').hasText('BRO & Evil Associates');
-        assert.dom('.logged-user-menu-item__organization-externalId').hasText('(EXTBRO)');
+        assert.dom('.user-logged-menu > li').exists({ count: 2 });
+        assert.dom('.user-logged-menu > li').hasText('BRO & Evil Associates (EXTBRO)');
       });
 
       module('When prescriber is on campaign page with pagination', function() {
@@ -96,7 +95,7 @@ module('Acceptance | Switch Organization', function(hooks) {
           await visit('/campagnes?pageNumber=2&pageSize=10&name=test&status=archived');
 
           // when
-          await clickByLabel('Résumé utilisateur');
+          await clickByLabel('Ouvrir le menu utilisateur');
           await clickByLabel('My Heaven Company');
 
           // then
@@ -108,7 +107,7 @@ module('Acceptance | Switch Organization', function(hooks) {
 
         test('it should display student menu item', async function(assert) {
           // when
-          await clickByLabel('Résumé utilisateur');
+          await clickByLabel('Ouvrir le menu utilisateur');
           await clickByLabel('My Heaven Company');
 
           // then

--- a/orga/tests/helpers/contains.js
+++ b/orga/tests/helpers/contains.js
@@ -1,7 +1,7 @@
 import { getRootElement } from '@ember/test-helpers';
 
 function _isChildrenContainsText(element, text) {
-  if (element.textContent.trim() === text) {
+  if (element.textContent.trim().includes(text)) {
     return true;
   } else if (element.children.length > 0) {
     for (let i = 0; i < element.children.length; i++) {

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -77,7 +77,7 @@ module('Integration | Component | Campaign::Results::AssessmentList', function(h
 
     test('it should display badge and tooltip', async function(assert) {
       // given
-      const badge = store.createRecord('badge', { imageUrl: 'url-badge' });
+      const badge = store.createRecord('badge', { id: 1, imageUrl: 'url-badge' });
       const campaign = store.createRecord('campaign', {
         badges: [badge],
       });
@@ -93,7 +93,7 @@ module('Integration | Component | Campaign::Results::AssessmentList', function(h
       await render(hbs`<Campaign::Results::AssessmentList @campaign={{campaign}} @participations={{participations}} @onClickParticipant={{goToAssessmentPage}}/>`);
 
       // then
-      assert.dom('.pix-tooltip__content').exists();
+      assert.dom('[aria-describedby="badge-tooltip-1"]').exists();
       assert.dom('img[src="url-badge"]').exists();
     });
   });

--- a/orga/tests/integration/components/layout/user-logged-menu_test.js
+++ b/orga/tests/integration/components/layout/user-logged-menu_test.js
@@ -60,7 +60,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function(hooks) {
   test('should display the chevron-up icon when menu is open', async function(assert) {
     // when
     await render(hbs`<Layout::UserLoggedMenu />`);
-    await clickByLabel('Résumé utilisateur');
+    await clickByLabel('Ouvrir le menu utilisateur');
 
     // then
     assert.dom('.fa-chevron-up').exists();
@@ -70,7 +70,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function(hooks) {
   test('should display the disconnect link when menu is open', async function(assert) {
     // when
     await render(hbs`<Layout::UserLoggedMenu />`);
-    await clickByLabel('Résumé utilisateur');
+    await clickByLabel('Ouvrir le menu utilisateur');
 
     // then
     assert.contains('Se déconnecter');
@@ -79,7 +79,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function(hooks) {
   test('should display the organizations name and externalId when menu is open', async function(assert) {
     // when
     await render(hbs`<Layout::UserLoggedMenu  />`);
-    await clickByLabel('Résumé utilisateur');
+    await clickByLabel('Ouvrir le menu utilisateur');
 
     // then
     assert.contains(organization2.name);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -171,7 +171,7 @@
     "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Log out",
-      "summary": "User summary"
+      "button": "Open user menu"
     }
   },
   "pages": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -171,7 +171,7 @@
     "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Se déconnecter",
-      "summary": "Résumé utilisateur"
+      "button": "Ouvrir le menu utilisateur"
     }
   },
   "pages": {


### PR DESCRIPTION
## :unicorn: Problème

Plusieurs problèmes d'accessibilité ont été relevée dans Pix Orga: 
- Les tooltips ne sont pas focusables
- Les tooltips n'ont pas les propriétés `aria-describedby`
- La navigation de la topbar ne fonctionne pas au clavier

## :robot: Solution

1. Mettre à jour Pix UI afin de rendre les tooltips focusables
2. Ajouter "tabindex=0" pour les éléments (non focusable nativement) qui nécessite le focus
2. Indiquer les `aria-describedby` et `id` associé sur toutes les tooltips
3. Corriger les problèmes de focus et navigation clavier dans la topbar

## :rainbow: Remarques

Montée de version majeure de Pix UI a nécessité des modifications minimes (2eme commit)

## :100: Pour tester

Se connecter en PRO et tester la navigation clavier dans la topbar.
Au focus les tooltip doivent s'afficher:
- crédits info dans la topbar
- description et titre prescripteur sur les paliers
- détail des résultats thématiques
- Bouton de code campagne: "copier", "copié !"
- les cartes d'indicateurs
- les légendes des graphiques
