### PR TITLE
[TECH] Encapsuler les requêtes BDD dans une transaction lors du partage d'une participation (PIX-3093).

### DIFF
--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -34,10 +34,14 @@ module.exports = {
     const userId = request.auth.credentials.userId;
     const campaignParticipationId = request.params.id;
 
-    const event = await usecases.shareCampaignResult({
-      userId,
-      campaignParticipationId,
+    const event = await DomainTransaction.execute((domainTransaction) => {
+      return usecases.shareCampaignResult({
+        userId,
+        campaignParticipationId,
+        domainTransaction,
+      });
     });
+
     events.eventDispatcher.dispatch(event).catch((error) => performanceTool.logErrorWithCorrelationId(error));
     return null;
   },

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -5,13 +5,14 @@ module.exports = async function shareCampaignResult({
   userId,
   campaignParticipationId,
   campaignParticipationRepository,
+  domainTransaction,
 }) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, { include: ['campaign'] });
+  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, { include: ['campaign'] }, domainTransaction);
 
   _checkUserIsOwnerOfCampaignParticipation(campaignParticipation, userId);
 
   campaignParticipation.share();
-  await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
+  await campaignParticipationRepository.updateWithSnapshot(campaignParticipation, domainTransaction);
 
   return new CampaignParticipationResultsShared({
     campaignParticipationId: campaignParticipation.id,

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -36,7 +36,9 @@ describe('Unit | Application | Controller | Campaign-Participation', function() 
       sinon.stub(usecases, 'shareCampaignResult');
       sinon.stub(requestResponseUtils, 'extractUserIdFromRequest').returns(userId);
       sinon.stub(performanceTool, 'logErrorWithCorrelationId');
-
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
     });
 
     it('should call the use case to share campaign result', async function() {

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -4,56 +4,59 @@ const CampaignParticipationResultsShared = require('../../../../lib/domain/event
 const shareCampaignResult = require('../../../../lib/domain/usecases/share-campaign-result');
 
 describe('Unit | UseCase | share-campaign-result', function() {
-  const campaignParticipationRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    get: sinon.stub(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    updateWithSnapshot: sinon.stub(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    isAssessmentCompleted: sinon.stub(),
-  };
-  const userId = 123;
-  const campaignParticipationId = 456;
+  let campaignParticipationRepository;
+  let userId;
+  let campaignParticipationId;
+
+  beforeEach(function() {
+    campaignParticipationRepository = {
+      get: sinon.stub(),
+      updateWithSnapshot: sinon.stub(),
+    };
+    userId = 123;
+    campaignParticipationId = 456;
+  });
 
   context('when user is not the owner of the campaign participation', function() {
     it('throws a UserNotAuthorizedToAccessEntityError error ', async function() {
       // given
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves({ userId: userId + 1 });
+      const domainTransaction = Symbol('transaction');
+      campaignParticipationRepository.get.resolves({ userId: userId + 1 });
 
       // when
-      const error = await catchErr(shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository });
+      const error = await catchErr(shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, domainTransaction });
 
       // then
       expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
+
   context('when user is the owner of the campaign participation', function() {
     it('updates the campaign participation', async function() {
       // given
+      const domainTransaction = Symbol('transaction');
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId });
       sinon.stub(campaignParticipation, 'share');
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }, domainTransaction).resolves(campaignParticipation);
 
       // when
-      await shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository });
+      await shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, domainTransaction });
 
       // then
       expect(campaignParticipation.share).to.have.been.called;
-      expect(campaignParticipationRepository.updateWithSnapshot).to.have.been.calledWith(campaignParticipation);
+      expect(campaignParticipationRepository.updateWithSnapshot).to.have.been.calledWithExactly(campaignParticipation, domainTransaction);
     });
 
     it('returns the CampaignParticipationResultsShared event', async function() {
       // given
+      const domainTransaction = Symbol('transaction');
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId });
       sinon.stub(campaignParticipation, 'share');
 
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves(campaignParticipation);
+      campaignParticipationRepository.get.resolves(campaignParticipation);
 
       // when
-      const actualEvent = await shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository });
+      const actualEvent = await shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, domainTransaction });
 
       // then
       expect(actualEvent).to.deep.equal({ campaignParticipationId });


### PR DESCRIPTION
## :unicorn: Problème
Lors du partage d'une participation si la création du snapshot ne marche pas la participation reste partagée, mais elle n'a pas de snapshot.

## :robot: Solution
Utiliser une transaction dans le use case.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour teste
Faire échouer le partage d'une participation à la création d'un snapshot.
Vérifier qu'en BDD la participation n'est pas partagée