### PR TITLE
[BUGFIX] Créer la base de données lors de la configuration du repo.

### DIFF
--- a/api/scripts/PgClient.js
+++ b/api/scripts/PgClient.js
@@ -2,12 +2,21 @@ const { Client } = require('pg');
 
 class PgClient {
   constructor(databaseUrl) {
-    this.client = new Client(databaseUrl);
-    this.client.connect();
+    this.client = new Client({ connectionString: databaseUrl, connectionTimeoutMillis: 10000 });
+  }
+
+  static async getClient(databaseUrl) {
+    const instance = new PgClient(databaseUrl);
+    try {
+      await instance.client.connect();
+    } catch (error) {
+      console.error('Database error', error);
+    }
+    return instance;
   }
 
   end() {
-    this.client.end();
+    return this.client.end();
   }
 
   query_and_log(query) {

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -10,20 +10,18 @@ const DB_TO_CREATE_NAME = url.pathname.slice(1);
 
 url.pathname = '/postgres';
 
-const client = new PgClient(url.href);
-
-client.query_and_log(`CREATE DATABASE ${DB_TO_CREATE_NAME};`)
-  .then(function() {
+PgClient.getClient(url.href).then(async (client) => {
+  try {
+    await client.query_and_log(`CREATE DATABASE ${DB_TO_CREATE_NAME};`);
     console.log('Database created');
-    client.end();
+    await client.end();
     process.exit(0);
-  }).catch((error) => {
+  } catch (error) {
     if (error.code === PGSQL_DUPLICATE_DATABASE_ERROR) {
       console.log(`Database ${DB_TO_CREATE_NAME} already created`);
-      client.end();
+      await client.end();
       process.exit(0);
     }
-    else {
-      throw error;
-    }
-  });
+  }
+});
+

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -10,20 +10,18 @@ const DB_TO_DELETE_NAME = url.pathname.slice(1);
 
 url.pathname = '/postgres';
 
-const client = new PgClient(url.href);
-
-client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME};`)
-  .then(() => {
+PgClient.getClient(url.href).then(async (client) => {
+  try {
+    await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME};`);
     console.log('Database dropped');
-    client.end();
+    await client.end();
     process.exit(0);
-  }).catch((error) => {
+  } catch (error) {
     if (error.code === PGSQL_NON_EXISTENT_DATABASE_ERROR) {
       console.log(`Database ${DB_TO_DELETE_NAME} does not exist`);
-      client.end();
+      await client.end();
       process.exit(0);
     }
-    else {
-      throw error;
-    }
-  });
+  }
+});
+

--- a/api/scripts/delete-user.js
+++ b/api/scripts/delete-user.js
@@ -2,20 +2,20 @@
 /* eslint no-console: ["off"] */
 const PgClient = require('./PgClient');
 
-function initialize() {
-  const client = new PgClient(process.env.DATABASE_URL);
+async function initialize() {
+  const client = await PgClient.getClient(process.env.DATABASE_URL);
 
   const user_email = process.argv[2];
   return { client, user_email };
 }
 
-function terminate(client) {
-  client.end();
+async function terminate(client) {
+  await client.end();
   console.log('END');
 }
 
-function main() {
-  const { client, user_email } = initialize();
+async function main() {
+  const { client, user_email } = await initialize();
   const queryBuilder = new ScriptQueryBuilder();
   const clientQueryAdapter = new ClientQueryAdapter();
   const userEraser = new UserEraser(client, queryBuilder, clientQueryAdapter);


### PR DESCRIPTION
## :unicorn: Problème
Suite à la pull request #3255 l'éxécution du docker-compose ne créer plus la base de donnée. Le script `configure` ne fonctionne plus pour une première installation.

## :robot: Solution
Dans la fonction **setup_and_run_infrastructure** on remplace l'appel du script `db:migrate` par le script `db:reset` qui inclut la migration ainsi que le création/re-création de la base de donnée et les seeds. La fonction load_seed a donc été supprimé.

## :rainbow: Remarques
Un refacto de PgClient a été réalisé pour corriger des soucis d'asynchronisme. Dans le script `configure` après le lancement du docker-compose on attend que le conteneur postgres soit prêt avant de faire les actions sur la DB.

## :100: Pour tester
Lancer le script `npm run configure`.
