### PR TITLE
[BUGFIX] Corriger la méthode app.services.url.homeUrl dans Pix Orga (PIX-3134).

### DIFF
--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -25,7 +25,7 @@ export default class Url extends Service {
   }
 
   get homeUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.get('primaryLocale');
     return `${this.definedHomeUrl}?lang=${currentLanguage}`;
   }
 

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -1,10 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import setupIntl from '../../helpers/setup-intl';
 import sinon from 'sinon';
 
 module('Unit | Service | url', function(hooks) {
 
   setupTest(hooks);
+  setupIntl(hooks);
 
   module('#isFrenchDomainExtension', function() {
 
@@ -59,6 +61,36 @@ module('Unit | Service | url', function(hooks) {
 
       // then
       assert.equal(campaignsRootUrl, expectedCampaignsRootUrl);
+    });
+  });
+
+  module('#homeUrl', function() {
+
+    test('should call intl to get first locale configured', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      sinon.spy(this.intl, 'get');
+
+      // when
+      service.homeUrl;
+
+      // then
+      assert.ok(this.intl.get.calledWith('primaryLocale'));
+    });
+
+    test('should return home url with current locale', function(assert) {
+      // given
+      const currentLocale = 'en';
+      this.intl.setLocale([currentLocale, 'fr']);
+
+      const service = this.owner.lookup('service:url');
+      const expectedHomeUrl = `${service.definedHomeUrl}?lang=${currentLocale}`;
+
+      // when
+      const homeUrl = service.homeUrl;
+
+      // then
+      assert.equal(homeUrl, expectedHomeUrl);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Cette méthode retourne une erreur si la locale du navigateur ne fait pas partie des locales configurées dans Pix Orga (fr et en).
cf. https://1024pix.slack.com/archives/CQR1H5X54/p1630509987017300

## :robot: Solution
Récupérer la locale courante avec la méthode `intl.get('primaryLocale')`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
