### PR TITLE
[BUGFIX] Eviter les dépassements mémoire lors de finalisation de session avec beaucoup de candidats (PIX-3136)

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -24,11 +24,13 @@ async function handleAutoJury({
     challengeRepository,
   });
 
-  const certificationJuryDoneEvents = await Promise.all(certificationCourses.map(async(certificationCourse) => {
+  const certificationJuryDoneEvents = [];
+
+  for (const certificationCourse of certificationCourses) {
 
     const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: certificationCourse.getId() });
 
-    return _autoNeutralizeChallenges({
+    const certificationJuryDoneEvent = await _autoNeutralizeChallenges({
       certificationCourse,
       certificationAssessment,
       certificationIssueReportRepository,
@@ -36,7 +38,9 @@ async function handleAutoJury({
       resolutionStrategies,
       logger,
     });
-  }));
+
+    certificationJuryDoneEvents.push(certificationJuryDoneEvent);
+  }
 
   const filteredCertificationJuryDoneEvents = certificationJuryDoneEvents.filter((certificationJuryDoneEvent) => Boolean(certificationJuryDoneEvent));
 

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -23,7 +23,7 @@
     <div class="session-details-content session-details-content--multiple">
       <h4 class="label-text session-details-content__label">Code d'accès</h4>
       <div class="session-details-content__clipboard">
-        <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>e
+        <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>
         {{#if (is-clipboard-supported)}}
           <PixTooltip
             @text={{this.tooltipText}}


### PR DESCRIPTION
## :unicorn: Problème
Récemment on a rencontré quelques problèmes en production : des containers ont crashé à cause de dépassement mémoire.
En cause, le traitement auto-jury consécutif à la finalisation de session de certification : en effet, pour chaque certification, nous faisons une passe d'auto-jury pour prendre en compte les signalements automatiquement par exemple.
Dans le code, malheureusement, ce traitement était fait en simultané sur toutes les certifications de la session (`Promise.all`). De fait, lorsque la session contient beaucoup de candidats, le container charge toutes les données nécessaires au traitement auto-jury des 70 certifications en même temps (et ça peut impliquer bcp de données).

## :robot: Solution
Pour éviter l'overflow, et de manière générale dès lors qu'on effectue des tâches qui sollicitent la BDD/qui chargent beaucoup de données, il vaut mieux les effectuer séquentiellement.

On a donc changé le `Promise.all` en boucle `for`.

## :rainbow: Remarques
On souhaite également améliorer le logging des erreurs dans les flux d'events. Fait dans une PR consécutive.

## :100: Pour tester
Tester la non régression du flow de finalisation de session.
