### PR TITLE
[A11Y] Amélioration de l'accessibilité de la tooltip des épreuves "focus" (PIX-3073).

### DIFF
--- a/mon-pix/app/components/challenge/statement/tooltip.hbs
+++ b/mon-pix/app/components/challenge/statement/tooltip.hbs
@@ -1,33 +1,31 @@
 {{#if this.isChallengeWithTooltip}}
   <div class="tooltip__tag tooltip__tag{{if this.isFocusedChallenge "--focused" "--regular"}}">
     <button type="button"
-            aria-describedby="tooltip-tag-info"
+            aria-controls="tooltip-tag-info"
+            aria-expanded="{{this.shouldDisplayTooltip}}"
             aria-label={{t 'pages.challenge.statement.tooltip.aria-label'}}
             class="tooltip-tag__icon-button"
             {{on 'mouseenter' (fn this.displayTooltip true)}}
             {{on 'mouseleave' (fn this.displayTooltip false)}}
-            {{on 'click' (fn this.displayTooltip true)}}/>
+            {{on 'click' (fn this.displayTooltip true)}} />
 
-    {{#if this.shouldDisplayTooltip}}
-      <div role="tooltip"
-           id="tooltip-tag-info"
-           class="tooltip-tag__information"
-           tabindex="0"
-           {{on-key 'Escape' (fn this.displayTooltip false) event='keyup'}}
-           {{on 'focusout' (fn this.displayTooltip false)}}>
-        {{#if this.isFocusedChallenge}}
-          <p class="tooltip-tag-information__text">
-            {{t 'pages.challenge.statement.tooltip.focused'}}
-          </p>
-        {{/if}}
-        {{#if this.shouldDisplayButton}}
-          <PixButton class="tooltip-tag-information__button"
-                     @size="small"
-                     @triggerAction={{this.confirmInformationIsRead}}>
-            {{t 'pages.challenge.statement.tooltip.close'}}
-          </PixButton>
-        {{/if}}
-      </div>
-    {{/if}}
+    <div id="tooltip-tag-info"
+         class="tooltip-tag__information"
+         tabindex="0"
+         {{on-key 'Escape' (fn this.displayTooltip false) event='keyup'}}
+         {{on 'focusout' (fn this.displayTooltip false)}}>
+      {{#if this.isFocusedChallenge}}
+        <p class="tooltip-tag-information__text">
+          {{t 'pages.challenge.statement.tooltip.focused'}}
+        </p>
+      {{/if}}
+      {{#if this.shouldDisplayButton}}
+        <PixButton class="tooltip-tag-information__button"
+                   @size="small"
+                   @triggerAction={{this.confirmInformationIsRead}}>
+          {{t 'pages.challenge.statement.tooltip.close'}}
+        </PixButton>
+      {{/if}}
+    </div>
   </div>
 {{/if}}

--- a/mon-pix/app/components/challenge/statement/tooltip.hbs
+++ b/mon-pix/app/components/challenge/statement/tooltip.hbs
@@ -1,7 +1,6 @@
 {{#if this.isChallengeWithTooltip}}
   <div class="tooltip__tag tooltip__tag{{if this.isFocusedChallenge "--focused" "--regular"}}">
     <button type="button"
-            tabindex="0"
             aria-describedby="tooltip-tag-info"
             aria-label={{t 'pages.challenge.statement.tooltip.aria-label'}}
             class="tooltip-tag__icon-button"

--- a/mon-pix/app/styles/components/_tooltip.scss
+++ b/mon-pix/app/styles/components/_tooltip.scss
@@ -101,3 +101,7 @@
     margin-top: 16px;
   }
 }
+
+.tooltip-tag__icon-button[aria-expanded="false"] + .tooltip-tag__information {
+  display: none;
+}

--- a/mon-pix/tests/integration/components/challenge/statement/focused-tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/focused-tooltip_test.js
@@ -62,7 +62,7 @@ describe('Integration | Component | Tooltip', function() {
 
     it('should render the tooltip with a confirmation button', async function() {
       // then
-      expect(find(tooltip)).to.exist;
+      expect(find(tooltip)).to.be.displayed;
       expect(find(confirmationButton)).to.exist;
     });
 
@@ -71,7 +71,7 @@ describe('Integration | Component | Tooltip', function() {
       await click('.tooltip-tag-information__button');
 
       // then
-      expect(find(tooltip)).to.not.exist;
+      expect(find(tooltip)).not.to.be.displayed;
     });
   });
 
@@ -100,7 +100,7 @@ describe('Integration | Component | Tooltip', function() {
     describe('when the challenge starts', function() {
       it('should not render the tooltip', async function() {
         // then
-        expect(find(tooltip)).to.not.exist;
+        expect(find(tooltip)).not.to.be.displayed;
       });
     });
 
@@ -111,7 +111,7 @@ describe('Integration | Component | Tooltip', function() {
           await triggerEvent('.tooltip-tag__icon-button', 'mouseenter');
 
           // then
-          expect(find(tooltip)).to.exist;
+          expect(find(tooltip)).to.be.displayed;
           expect(find(confirmationButton)).to.not.exist;
         });
 
@@ -121,7 +121,7 @@ describe('Integration | Component | Tooltip', function() {
           await triggerEvent('.tooltip-tag__icon-button', 'mouseleave');
 
           // then
-          expect(find(tooltip)).to.not.exist;
+          expect(find(tooltip)).not.to.be.displayed;
         });
       });
 
@@ -129,14 +129,14 @@ describe('Integration | Component | Tooltip', function() {
         it('should hide the tooltip button when escaping', async function() {
           // given
           await triggerEvent('.tooltip-tag__icon-button', 'mouseenter');
-          expect(find(tooltip)).to.exist;
+          expect(find(tooltip)).to.be.displayed;
 
           // when
           const escapeKeyCode = 27;
           await triggerKeyEvent('.tooltip-tag__icon-button', 'keyup', escapeKeyCode);
 
           // then
-          expect(find(tooltip)).to.not.exist;
+          expect(find(tooltip)).not.to.be.displayed;
         });
       });
     });
@@ -147,7 +147,7 @@ describe('Integration | Component | Tooltip', function() {
         await click('.tooltip-tag__icon-button');
 
         // then
-        expect(find(tooltip)).to.exist;
+        expect(find(tooltip)).to.be.displayed;
         expect(find(confirmationButton)).to.not.exist;
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

La tooltip peut voir son accessibilité accrue.

## :robot: Solution

Passage d'un `role=tooltip` à une `disclosure`.

## :rainbow: Remarques

L'implémentation la plus correcte des disclosures se faisant à l'aide des balises `details` et `summary` n'est pas compatible avec IE.
Nous passons donc par l'activation de la visibilité de la tooltip à l'aide de la propriété `aria-expanded`

## :100: Pour tester

Aller sur une épreuve focus (ex: rec6PW03oyqtPZ9rK) et vérifier qu'il n'y ait pas de régression (au clavier et à la souris) par rapport à la précédente implémentation.
