### PR TITLE
[A11Y] Utiliser des balises HTML sémantiques dans la page "Activité" de Pix Orga (PIX-3056).

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -59,7 +59,7 @@ When(`je vois {int} résultats pour la compétence`, (numberOfResultsByCompetenc
 });
 
 Then(`je vois la moyenne des résultats à {int}%`, (averageResult) => {
-  cy.contains('Résultat moyen').parent().within(() => cy.contains(`${averageResult} %`));
+  cy.contains('Résultat moyen').parents().within(() => cy.contains(`${averageResult} %`));
 });
 
 Then(`je vois un résultat global à {int}%`, (globalResult) => {

--- a/orga/app/components/campaign/activity/dashboard.hbs
+++ b/orga/app/components/campaign/activity/dashboard.hbs
@@ -1,4 +1,4 @@
-<div class="activity-dashboard" ...attributes>
+<section class="activity-dashboard" ...attributes>
   <div class="activity-dashboard__row">
     <Campaign::Cards::ParticipantsCount
       @value={{this.total}}
@@ -24,4 +24,4 @@
       class="activity-dashboard__participations-by-status"
     />
   </div>
-</div>
+</section>

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -1,52 +1,50 @@
-<div ...attributes>
+<section ...attributes>
   <div class="panel">
-    <div class="table content-text content-text--small">
-      <table>
-        <thead>
-          <tr>
-            <th>{{t 'pages.campaign-activity.table.column.last-name'}}</th>
-            <th>{{t 'pages.campaign-activity.table.column.first-name'}}</th>
+    <table class="table content-text content-text--small">
+      <thead>
+        <tr>
+          <th>{{t 'pages.campaign-activity.table.column.last-name'}}</th>
+          <th>{{t 'pages.campaign-activity.table.column.first-name'}}</th>
+          {{#if @campaign.idPixLabel}}
+            <th>{{@campaign.idPixLabel}}</th>
+          {{/if}}
+          <th>{{t 'pages.campaign-activity.table.column.status'}}</th>
+        </tr>
+      </thead>
+
+      {{#if @participations}}
+        <tbody>
+        {{#each @participations as |participation|}}
+          <tr aria-label={{t 'pages.campaign-activity.table.row-title'}} role="button" {{on 'click' (fn @onClickParticipant @campaign.id participation.id)}} class="tr--clickable">
+            <td>
+              <LinkTo
+                @route={{if @campaign.isTypeAssessment 'authenticated.campaigns.participant-assessment' 'authenticated.campaigns.participant-profile'}}
+                @models={{array @campaign.id participation.id}}>
+              {{participation.lastName}}
+              </LinkTo>
+            </td>
+            <td>{{participation.firstName}}</td>
             {{#if @campaign.idPixLabel}}
-              <th>{{@campaign.idPixLabel}}</th>
+              <td>{{participation.participantExternalId}}</td>
             {{/if}}
-            <th>{{t 'pages.campaign-activity.table.column.status'}}</th>
+            <td>
+              <Campaign::Activity::ParticipationStatus
+                @status={{participation.status}}
+                @isTypeAssessment={{@campaign.isTypeAssessment}}
+              />
+            </td>
           </tr>
-        </thead>
+        {{/each}}
+        </tbody>
+      {{/if}}
+    </table>
 
-        {{#if @participations}}
-          <tbody>
-          {{#each @participations as |participation|}}
-            <tr aria-label={{t 'pages.campaign-activity.table.row-title'}} role="button" {{on 'click' (fn @onClickParticipant @campaign.id participation.id)}} class="tr--clickable">
-              <td>
-                <LinkTo
-                  @route={{if @campaign.isTypeAssessment 'authenticated.campaigns.participant-assessment' 'authenticated.campaigns.participant-profile'}}
-                  @models={{array @campaign.id participation.id}}>
-                {{participation.lastName}}
-                </LinkTo>
-              </td>
-              <td>{{participation.firstName}}</td>
-              {{#if @campaign.idPixLabel}}
-                <td>{{participation.participantExternalId}}</td>
-              {{/if}}
-              <td>
-                <Campaign::Activity::ParticipationStatus
-                  @status={{participation.status}}
-                  @isTypeAssessment={{@campaign.isTypeAssessment}}
-                />
-              </td>
-            </tr>
-          {{/each}}
-          </tbody>
-        {{/if}}
-      </table>
-
-      {{#unless @participations}}
-        <div class="table__empty content-text">{{t 'pages.campaign-activity.table.empty'}}</div>
-      {{/unless}}
-    </div>
+    {{#unless @participations}}
+      <p class="table__empty content-text">{{t 'pages.campaign-activity.table.empty'}}</p>
+    {{/unless}}
   </div>
 
   {{#if @participations}}
     <Table::PaginationControl @pagination={{@participations.meta}}/>
   {{/if}}
-</div>
+</section>

--- a/orga/app/components/campaign/charts/participants-by-status-loader.hbs
+++ b/orga/app/components/campaign/charts/participants-by-status-loader.hbs
@@ -1,6 +1,6 @@
-<div class="participants-by-status__loader">
-  <p class="sr-only">{{t 'charts.participants-by-stage.loader'}}</p>
-  <div class="participants-by-status__loader--chart placeholder-doughnut" aria-hidden="true" />
-  <div class="participants-by-status__loader--legend placeholder-box" />
-  <div class="participants-by-status__loader--legend placeholder-box" />
+<p class="sr-only">{{t 'charts.participants-by-stage.loader'}}</p>
+<div class="participants-by-status__loader" aria-hidden="true">
+  <span class="participants-by-status__loader--chart placeholder-doughnut" />
+  <span class="participants-by-status__loader--legend placeholder-box" />
+  <span class="participants-by-status__loader--legend placeholder-box" />
 </div>

--- a/orga/app/components/campaign/charts/participants-by-status.hbs
+++ b/orga/app/components/campaign/charts/participants-by-status.hbs
@@ -13,7 +13,7 @@
     <ul class="participants-by-status__legend" aria-hidden="true">
       {{#each this.datasets as |dataset|}}
         <li class="participants-by-status__legend--{{dataset.key}}">
-          <span>{{dataset.legend}}</span>
+          <p>{{dataset.legend}}</p>
           <PixTooltip
             @id="legend-tooltip-{{dataset.key}}"
             @text={{dataset.legendTooltip}}

--- a/orga/app/components/campaign/empty-state.hbs
+++ b/orga/app/components/campaign/empty-state.hbs
@@ -1,8 +1,8 @@
-<div class="panel empty-state">
+<section class="panel empty-state">
     <img src="{{this.rootURL}}/images/empty-state.svg" alt="" role="none">
 
     <div class="empty-state__text">
-        <span>{{t 'pages.campaign.empty-state'}}</span>
+        <p>{{t 'pages.campaign.empty-state'}}</p>
 
         <Campaign::CopyPasteButton
             @clipBoardtext={{this.campaignUrl}}
@@ -10,4 +10,4 @@
             @defaultMessage={{t 'pages.campaign.copy.link.default'}}
         />
     </div>
-</div>
+</section>

--- a/orga/app/components/campaign/header/title.hbs
+++ b/orga/app/components/campaign/header/title.hbs
@@ -1,4 +1,4 @@
-<div class="campaign-header-title">
+<header class="campaign-header-title">
   <Ui::PreviousPageButton
     @route="authenticated.campaigns"
     @backButtonAriaLabel={{t 'common.actions.back'}}
@@ -42,4 +42,4 @@
       </dd>
     </div>
   </dl>
-</div>
+</header>

--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -1,7 +1,7 @@
 <aside class="sidebar">
   <header class="sidebar__logo hide-on-mobile">
-    <LinkTo @route="authenticated.campaigns" title="{{t 'common.home-page'}}">
-      <img src="{{this.rootUrl}}/pix-orga.svg" alt="" role="none">
+    <LinkTo @route="authenticated.campaigns">
+      <img src="{{this.rootUrl}}/pix-orga.svg" alt="{{t 'common.home-page'}}">
     </LinkTo>
   </header>
 

--- a/orga/app/components/ui/chart-card.hbs
+++ b/orga/app/components/ui/chart-card.hbs
@@ -1,8 +1,6 @@
-<div class="chart-card" ...attributes>
-  <h2 class="chart-card__title">
+<section class="chart-card" ...attributes>
+  <h3 class="chart-card__title">
     {{@title}}
-  </h2>
-  <div>
-    {{yield}}
-  </div>
-</div>
+  </h3>
+  {{yield}}
+</section>

--- a/orga/app/components/ui/indicator-card.hbs
+++ b/orga/app/components/ui/indicator-card.hbs
@@ -7,9 +7,9 @@
     <div class="indicator-card__icon {{if @color (concat "indicator-card__icon--" @color)}}" aria-hidden="true">
       <FaIcon @icon={{@icon}}/>
     </div>
-    <div class="indicator-card__content">
-      <label class="indicator-card__title">
-        <span>{{@title}}</span>
+    <dl class="indicator-card__content">
+      <div class="indicator-card__title">
+        <dt>{{@title}}</dt>
         {{#if @info}}
           <PixTooltip
             @id={{@title}}
@@ -26,10 +26,10 @@
             />
           </PixTooltip>
         {{/if}}
-      </label>
-      <div class="indicator-card__value">
-        {{yield}}
       </div>
-    </div>
+      <dd class="indicator-card__value">
+        {{yield}}
+      </dd>
+    </dl>
   {{/if}}
 </section>

--- a/orga/app/styles/components/campaign/charts/participants-by-status.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-status.scss
@@ -13,7 +13,7 @@
       padding-bottom: 8px;
       padding-left: 24px;
       color: $grey-70;
-      
+
       &::before {
         position: absolute;
         left: 0px;
@@ -24,8 +24,12 @@
         border-radius: 50%;
         content: ' ';
       }
+
+      > p {
+        margin: 0;
+      }
     }
-  
+
     > li:last-child {
       padding-bottom: 0px;
     }

--- a/orga/app/styles/components/campaign/header/tabs.scss
+++ b/orga/app/styles/components/campaign/header/tabs.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: space-between;
   margin-bottom: 24px;
+  padding: 0;
 
   &__export-button {
     display: flex;

--- a/orga/app/styles/components/indicator-card.scss
+++ b/orga/app/styles/components/indicator-card.scss
@@ -49,6 +49,7 @@
     font-weight: 600;
     font-size: 2rem;
     line-height: 2rem;
+    margin: 0;
   }
 
   &__tooltip {

--- a/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
@@ -1,9 +1,11 @@
 .activity__dashboard {
   margin-bottom: 24px;
+  padding: 0;
 }
 
 .activity__participants-list {
   margin-bottom: 24px;
+  padding: 0;
 }
 
 @media (max-width: 768px) {

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -1,4 +1,5 @@
 {{page-title (t 'pages.campaign-activity.title')}}
+<h2 class="sr-only">{{t 'pages.campaign-activity.title'}}</h2>
 
 {{#if @model.campaign.hasParticipations}}
   <Campaign::Activity::Dashboard
@@ -6,6 +7,7 @@
     class="activity__dashboard"
   />
 
+  <h3 class="sr-only">{{t 'pages.campaign-activity.table.title'}}</h3>
   <Campaign::Filter::ParticipationFilters
     @campaign={{@model.campaign}}
     @selectedDivisions={{this.divisions}}

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -237,7 +237,8 @@
           "status": "Status"
         },
         "empty": "No participants",
-        "row-title": "Participant"
+        "row-title": "Participant",
+        "title": "List of participants"
       },
       "status": {
         "started-assessment": "In progress",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -178,7 +178,6 @@
     "assessment-individual-results": {
       "title": "Results of {firstName} {lastName}",
       "badges": "Thematic results",
-      "mastery-percentage": "Result",
       "progression": "Progression",
       "result": "Result",
       "stages": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -142,7 +142,7 @@
       "close": "Fermer"
     },
     "help-form": "https://support.pix.fr/support/tickets/new",
-    "home-page": "Page d'accueil Pix Orga",
+    "home-page": "Page d'accueil de Pix Orga",
     "loading": "Chargement en cours",
     "pagination": {
       "action": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -237,7 +237,8 @@
           "status": "Statut"
         },
         "empty": "Aucun participant",
-        "row-title": "Participant"
+        "row-title": "Participant",
+        "title": "Liste des participants"
       },
       "status": {
         "started-assessment": "En cours",


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Orga, très peu de balises sémantiques sont utilisées. Cela pose un problème pour l'accessibilité de la plateforme.

## :robot: Solution
Corriger cela, page par page. Ici la page "Activité".

## :rainbow: Remarques
Un petit SR embarqué, de suppression de traduction inutile.

## :100: Pour tester
Aller sur la page Activité.
