### PR TITLE
[TECH] Ajouter une colonne de statut sur la table "compaign-participations" (PIX-2998).

### DIFF
--- a/api/db/migrations/20210902135810_add-status-column-on-campaign-participations.js
+++ b/api/db/migrations/20210902135810_add-status-column-on-campaign-participations.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'campaign-participations';
+const COLUMN_NAME = 'status';
+const DEFAULT_COLUMN_VALUE = 'STARTED';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).defaultTo(DEFAULT_COLUMN_VALUE);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Plusieurs besoins ont été détecté concernant la donnée statuts d’une participation : 
- depuis que l’on affiche l’onglet activité nous avons la liste des participations et plusieurs utilisateurs nous on remonté le besoin de filtrer sur cette colonne.
- de plus dans cette onglet cette donnée est utilisée pour réaliser des graphiques (couteux en perf/chargement)
- côté perf il serait intéressant d’avoir une donnée non calculé pour le status afin de pouvoir améliorer le chargement/perf globale de nos affichages 'dans Pix Orga mais aussi dans PixApp)

## :robot: Solution
Ajouter la colonne "status" sur campaign-participations

## :rainbow: Remarques
N/A

## :100: Pour tester
N/A