### PR TITLE
[TECH] Réutiliser le champ résultat pour la page "résultats" sur Pix App(PIX-3123)

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -8,7 +8,7 @@ module.exports = {
   MAX_REACHABLE_PIX_BY_COMPETENCE: settings.features.maxReachableLevel * PIX_COUNT_BY_LEVEL,
   MAX_CHALLENGES_PER_SKILL_FOR_CERTIFICATION: 3,
   MAX_CHALLENGES_PER_AREA_FOR_CERTIFICATION_PLUS: 4,
-  MAX_MASTERY_POURCENTAGE: 100,
+  MAX_MASTERY_RATE: 1,
   MINIMUM_DELAY_IN_DAYS_FOR_RESET: settings.features.dayBeforeCompetenceResetV2,
   MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING: settings.features.dayBeforeImproving,
   MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING: settings.features.dayBeforeRetrying,

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -18,22 +18,25 @@ class AssessmentResult {
     this.totalSkillsCount = competences.flatMap(({ skillIds }) => skillIds).length;
     this.testedSkillsCount = knowledgeElements.length;
     this.validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
-    this.masteryPercentage = this._computeMasteryPercentage();
+    this.masteryRate = this._computeMasteryRate(participationResults.masteryRate);
 
     this.competenceResults = competences.map((competence) => _buildCompetenceResults(competence, knowledgeElements));
     this.badgeResults = targetProfile.badges.map((badge) => new BadgeResult(badge, participationResults));
 
     this.stageCount = targetProfile.stages.length;
     if (targetProfile.stages.length > 0) {
-      this.reachedStage = new ReachedStage(this.masteryPercentage, targetProfile.stages);
+      this.reachedStage = new ReachedStage(this.masteryRate, targetProfile.stages);
     }
     this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt);
     this.canRetry = this._computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive);
   }
 
-  _computeMasteryPercentage() {
-    if (this.totalSkillsCount !== 0) {
-      return Math.round(this.validatedSkillsCount * 100 / this.totalSkillsCount);
+  _computeMasteryRate(masteryRate) {
+    if (this.isShared) {
+      return masteryRate;
+    } else if (this.totalSkillsCount > 0) {
+      const rate = (this.validatedSkillsCount / this.totalSkillsCount).toPrecision(2);
+      return parseFloat(rate);
     } else {
       return 0;
     }
@@ -51,7 +54,7 @@ class AssessmentResult {
   _computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive) {
     return isCampaignMultipleSendings
       && this._timeBeforeRetryingPassed(sharedAt)
-      && this.masteryPercentage < constants.MAX_MASTERY_POURCENTAGE
+      && this.masteryRate < constants.MAX_MASTERY_RATE
       && isRegistrationActive;
   }
 

--- a/api/lib/domain/read-models/participant-results/ReachedStage.js
+++ b/api/lib/domain/read-models/participant-results/ReachedStage.js
@@ -1,8 +1,8 @@
 class ReachedStage {
 
-  constructor(masteryPercentage, stages) {
+  constructor(masteryRate, stages) {
     const stagesOrdered = stages.sort((a, b) => a.threshold - b.threshold);
-    const stagesReached = stagesOrdered.filter(({ threshold }) => threshold <= masteryPercentage);
+    const stagesReached = stagesOrdered.filter(({ threshold }) => threshold <= (masteryRate * 100));
     const lastStageReached = stagesReached[stagesReached.length - 1];
 
     this.id = lastStageReached.id;

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -22,7 +22,7 @@ const ParticipantResultRepository = {
 
 async function _getParticipationResults(userId, campaignId) {
 
-  const { isCompleted, campaignParticipationId, sharedAt, assessmentCreatedAt, participantExternalId } = await _getParticipationAttributes(userId, campaignId);
+  const { isCompleted, campaignParticipationId, sharedAt, assessmentCreatedAt, participantExternalId, masteryRate } = await _getParticipationAttributes(userId, campaignId);
 
   const knowledgeElements = await _findTargetedKnowledgeElements(campaignId, userId, sharedAt);
 
@@ -35,13 +35,14 @@ async function _getParticipationResults(userId, campaignId) {
     assessmentCreatedAt,
     participantExternalId,
     knowledgeElements,
+    masteryRate,
     acquiredBadgeIds: acquiredBadgeIds.map(({ badgeId }) => badgeId),
   };
 }
 
 async function _getParticipationAttributes(userId, campaignId) {
   const participationAttributes = await knex('campaign-participations')
-    .select(['state', 'campaignParticipationId', 'sharedAt', 'assessments.createdAt AS assessmentCreatedAt', 'participantExternalId'])
+    .select(['state', 'campaignParticipationId', 'sharedAt', 'assessments.createdAt AS assessmentCreatedAt', 'participantExternalId', knex.raw('CAST("masteryPercentage" AS FLOAT) AS "masteryRate"')])
     .join('assessments', 'campaign-participations.id', 'assessments.campaignParticipationId')
     .where({ 'campaign-participations.campaignId': campaignId })
     .andWhere({ 'campaign-participations.userId': userId })
@@ -52,15 +53,15 @@ async function _getParticipationAttributes(userId, campaignId) {
     throw new NotFoundError(`Participation not found for user ${userId} and campaign ${campaignId}`);
   }
 
-  const { state, campaignParticipationId, sharedAt, assessmentCreatedAt, participantExternalId } = participationAttributes;
-  return { isCompleted: state === Assessment.states.COMPLETED, campaignParticipationId, sharedAt, assessmentCreatedAt, participantExternalId };
+  const { state, campaignParticipationId, sharedAt, assessmentCreatedAt, participantExternalId, masteryRate } = participationAttributes;
+  return { isCompleted: state === Assessment.states.COMPLETED, campaignParticipationId, sharedAt, assessmentCreatedAt, participantExternalId, masteryRate };
 }
 
 async function _findTargetedKnowledgeElements(campaignId, userId, sharedAt) {
   const { targetProfileId } = await _getTargetProfileId(campaignId);
   const targetedSkillIds = await _findTargetedSkillIds(targetProfileId);
-  const knowledgeElementsByUser = await knowledgeElementRepository.findSnapshotForUsers({ [userId]: sharedAt });
-  return knowledgeElementsByUser[userId].filter(({ skillId }) => targetedSkillIds.includes(skillId));
+  const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId, limitDate: sharedAt });
+  return knowledgeElements.filter(({ skillId }) => targetedSkillIds.includes(skillId));
 }
 
 async function _getAcquiredBadgeIds(userId, campaignParticipationId) {

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
     return new Serializer('campaign-participation-results', {
       transform,
       attributes: [
-        'masteryPercentage',
+        'masteryRate',
         'totalSkillsCount',
         'testedSkillsCount',
         'validatedSkillsCount',

--- a/api/tests/acceptance/application/users/get-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-campaign-assessment-result_test.js
@@ -34,6 +34,7 @@ describe('Acceptance | API | Campaign Assessment Result', function() {
       userId: user.id,
       sharedAt: recentDate,
       isShared: true,
+      masteryPercentage: 0.38,
     });
     assessment = databaseBuilder.factory.buildAssessment({
       campaignParticipationId: campaignParticipation.id,
@@ -182,7 +183,7 @@ describe('Acceptance | API | Campaign Assessment Result', function() {
           type: 'campaign-participation-results',
           id: campaignParticipation.id.toString(),
           attributes: {
-            'mastery-percentage': 38,
+            'mastery-rate': 0.38,
             'total-skills-count': 8,
             'tested-skills-count': 5,
             'validated-skills-count': 3,

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -34,26 +34,68 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
   });
 
   describe('masteryPercentage computation', function() {
-    it('computes the mastery percentage', function() {
-      const competences = [
-        { id: 'rec1', name: 'C1', index: '1.1', areaName: 'Domaine1', areaColor: 'Couleur1', skillIds: ['skill1', 'skill2', 'skill2'] },
-        { id: 'rec2', name: 'C2', index: '2.1', areaName: 'Domaine2', areaColor: 'Couleur2', skillIds: ['skill5', 'skill5', 'skill6'] },
-      ];
+    context('when the participation is not shared', function() {
+      context('when there are assessed competences', function() {
+        it('computes the mastery rate using knowledge elements', function() {
+          const competences = [
+            { id: 'rec1', name: 'C1', index: '1.1', areaName: 'Domaine1', areaColor: 'Couleur1', skillIds: ['skill1', 'skill2', 'skill3'] },
+            { id: 'rec2', name: 'C2', index: '2.1', areaName: 'Domaine2', areaColor: 'Couleur2', skillIds: ['skill4', 'skill5', 'skill6'] },
+          ];
 
-      const knowledgeElements = [
-        domainBuilder.buildKnowledgeElement({ skillId: 'skill1', status: KnowledgeElement.StatusType.VALIDATED }),
-        domainBuilder.buildKnowledgeElement({ skillId: 'skill2', status: KnowledgeElement.StatusType.INVALIDATED }),
-        domainBuilder.buildKnowledgeElement({ skillId: 'skill3', status: KnowledgeElement.StatusType.VALIDATED }),
-        domainBuilder.buildKnowledgeElement({ skillId: 'skill4', status: KnowledgeElement.StatusType.VALIDATED }),
-        domainBuilder.buildKnowledgeElement({ skillId: 'skill5', status: KnowledgeElement.StatusType.VALIDATED }),
-      ];
-      const participationResults = { campaignParticipationId: 12, isCompleted: true, knowledgeElements, acquiredBadgeIds: [] };
+          const knowledgeElements = [
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill1', status: KnowledgeElement.StatusType.VALIDATED }),
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill2', status: KnowledgeElement.StatusType.INVALIDATED }),
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill3', status: KnowledgeElement.StatusType.VALIDATED }),
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill4', status: KnowledgeElement.StatusType.VALIDATED }),
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill5', status: KnowledgeElement.StatusType.VALIDATED }),
+          ];
+          const participationResults = { campaignParticipationId: 12, isCompleted: true, knowledgeElements, acquiredBadgeIds: [], sharedAt: null };
 
-      const targetProfile = { competences, stages: [], badges: [] };
+          const targetProfile = { competences, stages: [], badges: [] };
 
-      const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+          const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
 
-      expect(assessmentResult.masteryPercentage).to.equal(67);
+          expect(assessmentResult.masteryRate).to.equal(0.67);
+        });
+      });
+
+      context('when there is no assessed competences', function() {
+        it('returns 0', function() {
+          const competences = [];
+
+          const knowledgeElements = [
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill1', status: KnowledgeElement.StatusType.VALIDATED }),
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill2', status: KnowledgeElement.StatusType.INVALIDATED }),
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill3', status: KnowledgeElement.StatusType.VALIDATED }),
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill4', status: KnowledgeElement.StatusType.VALIDATED }),
+            domainBuilder.buildKnowledgeElement({ skillId: 'skill5', status: KnowledgeElement.StatusType.VALIDATED }),
+          ];
+          const participationResults = { campaignParticipationId: 12, isCompleted: true, knowledgeElements, acquiredBadgeIds: [], sharedAt: null };
+
+          const targetProfile = { competences, stages: [], badges: [] };
+
+          const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+
+          expect(assessmentResult.masteryRate).to.equal(0);
+        });
+      });
+
+    });
+
+    context('when the participation is shared', function() {
+      it('return the mastery rate of the participation', function() {
+        const competences = [
+          { id: 'rec1', name: 'C1', index: '1.1', areaName: 'Domaine1', areaColor: 'Couleur1', skillIds: ['skill1', 'skill2', 'skill2'] },
+        ];
+
+        const participationResults = { campaignParticipationId: 12, isCompleted: true, knowledgeElements: [], acquiredBadgeIds: [], sharedAt: new Date('2021-09-25'), masteryRate: 0.5 };
+
+        const targetProfile = { competences, stages: [], badges: [] };
+
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+
+        expect(assessmentResult.masteryRate).to.equal(0.5);
+      });
     });
   });
 
@@ -93,7 +135,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         domainBuilder.buildKnowledgeElement({ skillId: 'skill2', status: KnowledgeElement.StatusType.INVALIDATED }),
         domainBuilder.buildKnowledgeElement({ skillId: 'skill3', status: KnowledgeElement.StatusType.VALIDATED }),
       ];
-      const participationResults = { knowledgeElements, acquiredBadgeIds: [] };
+      const participationResults = { knowledgeElements, acquiredBadgeIds: [], masteryRate: '0.65' };
 
       const stages = [
         { id: 1, title: 'Stage1', message: 'message1', threshold: 25 },
@@ -228,7 +270,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       });
     });
 
-    context('when the mastery percentage is 100%', function() {
+    context('when the mastery rate equals to 1', function() {
       it('returns false', function() {
         const isCampaignMultipleSendings = true;
         const competences = [{ id: 'rec1', name: 'C1', index: '1.1', areaName: 'Domaine1', areaColor: 'Couleur1', skillIds: ['skill1'] }];
@@ -248,7 +290,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       });
     });
 
-    context('when the campaign allow multiple sendings, the mastery percentage is under 100%, the participant is active and the participation has been shared more than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
+    context('when the campaign allow multiple sendings, the mastery rate is under 1.0, the participant is active and the participation has been shared more than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
       it('returns true', function() {
         const isCampaignMultipleSendings = true;
         const isRegistrationActive = true;
@@ -256,6 +298,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
+          masteryRate: '0.45',
           sharedAt: new Date('2019-12-12'),
         };
         const targetProfile = { competences, stages: [], badges: [] };
@@ -265,7 +308,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       });
     });
 
-    context('when the campaign allow multiple sendings, the mastery percentage is under 100%, the participant is active and the participation has been shared exactly MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
+    context('when the campaign allow multiple sendings, the mastery rate is under 1, the participant is active and the participation has been shared exactly MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function() {
       it('returns true', function() {
         const isCampaignMultipleSendings = true;
         const isRegistrationActive = true;
@@ -273,6 +316,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
+          masteryRate: '0.34',
           sharedAt: new Date('2020-01-01T05:06:07Z'),
         };
         const targetProfile = { competences, stages: [], badges: [] };

--- a/api/tests/unit/domain/read-models/participant-results/ReachedStage_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/ReachedStage_test.js
@@ -11,7 +11,7 @@ describe('Unit | Domain | Read-Models | ParticipantResults | ReachedStage', func
       { id: 3, title: 'Stage3', message: 'message3', threshold: 90 },
     ];
 
-    const profileStage = new ReachedStage(66, stages);
+    const profileStage = new ReachedStage(0.66, stages);
 
     expect(profileStage).to.deep.equal({
       id: 2,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -32,6 +32,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         knowledgeElements: knowledgeElements,
         acquiredBadgeIds: [3],
         participantExternalId: 'greg@lafleche.fr',
+        masteryRate: 0.5,
       };
 
       const competences = [
@@ -71,7 +72,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           attributes: {
             'is-completed': true,
             'is-shared': true,
-            'mastery-percentage': 50,
+            'mastery-rate': 0.5,
             'tested-skills-count': 2,
             'total-skills-count': 2,
             'validated-skills-count': 1,
@@ -172,5 +173,4 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
       expect(json).to.deep.equal(expectedSerializedCampaignParticipationResult);
     });
   });
-
 });

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -63,7 +63,10 @@ Then(`je vois la moyenne des résultats à {int}%`, (averageResult) => {
 });
 
 Then(`je vois un résultat global à {int}%`, (globalResult) => {
-  cy.get('[aria-label="Résultat global"]').contains(`${globalResult}%`);
+  cy.get('[aria-label="Résultat global"]').invoke('text').then((text) => {
+    //TODO: update cypress to handle insecable space https://glebbahmutov.com/cypress-examples/6.5.0/recipes/non-breaking-space.html#via-cy-contains
+    expect(text.replace(/\u00a0/g, ' ')).contains(`${globalResult} %`);
+  });
 });
 
 Then(`je vois que j'ai partagé mon profil`, () => {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -23,7 +23,7 @@
         <ReachedStage
                 @stageCount={{this.stageCount}}
                 @starCount={{this.reachedStage.starCount}}
-                @percentage={{@model.campaignParticipationResult.masteryPercentage}}
+                @masteryRate={{this.masteryRate}}
                 @imageUrl={{@model.campaign.targetProfileImageUrl}}
         />
       {{/if}}
@@ -41,7 +41,7 @@
           </div>
         {{else}}
           <p class="rounded-panel-title skill-review-result-abstract__text">
-            {{t 'pages.skill-review.abstract' percentage=@model.campaignParticipationResult.masteryPercentage htmlSafe=true}}
+            {{t 'pages.skill-review.abstract' rate=this.masteryRate htmlSafe=true}}
           </p>
         {{/if}}
         <h2 class="sr-only">{{t 'pages.skill-review.send-title'}}</h2>
@@ -131,7 +131,6 @@
     <SkillReviewImprove @improve={{this.improve}}/>
   {{/if}}
 
-
   {{#unless @model.campaign.isForAbsoluteNovice}}
 
   <main class="skill-review-result-detail__content">
@@ -139,9 +138,9 @@
       <h2 class="skill-review-result-detail__subtitle">
         {{t 'pages.skill-review.details.title'}}
       </h2>
-      <CircleChart @value={{@model.campaignParticipationResult.masteryPercentage}}>
+      <CircleChart @value={{this.masteryPercentage}}>
           <span aria-label="{{t "pages.skill-review.details.result"}}" class="skill-review-table-header__circle-chart-value">
-            {{@model.campaignParticipationResult.masteryPercentage}}%
+            {{t "pages.skill-review.details.percentage" rate=this.masteryRate}}
           </span>
       </CircleChart>
     </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -71,8 +71,15 @@ export default class SkillReview extends Component {
     return Boolean(this.customButtonText && this.customButtonUrl);
   }
 
+  get masteryRate() {
+    return this.args.model.campaignParticipationResult.masteryRate;
+  }
+
   get masteryPercentage() {
-    return this.args.model.campaignParticipationResult.masteryPercentage;
+    if (this.args.model.campaignParticipationResult.masteryRate >= 0) {
+      return this.args.model.campaignParticipationResult.masteryRate * 100;
+    }
+    return null;
   }
 
   get participantExternalId() {
@@ -84,8 +91,8 @@ export default class SkillReview extends Component {
     if (buttonUrl) {
       const params = {};
 
-      if (!isNil(this.masteryPercentage)) {
-        params.masteryPercentage = this.masteryPercentage;
+      if (!isNil(this.masteryRate)) {
+        params.masteryPercentage = parseInt(this.masteryRate * 100);
       }
 
       if (!isNil(this.participantExternalId)) {

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -3,7 +3,7 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class CampaignParticipationResult extends Model {
 
   // attributes
-  @attr('number') masteryPercentage;
+  @attr('number') masteryRate;
   @attr('number') totalSkillsCount;
   @attr('number') testedSkillsCount;
   @attr('number') validatedSkillsCount;

--- a/mon-pix/app/templates/components/reached-stage.hbs
+++ b/mon-pix/app/templates/components/reached-stage.hbs
@@ -16,7 +16,7 @@
         {{/if}}
       </div>
       <div class="reached-stage-score__percentage-text">
-        {{t 'pages.skill-review.stage.masteryPercentage' percentage=@percentage}}
+        {{t 'pages.skill-review.stage.masteryPercentage' rate=@masteryRate}}
       </div>
     </div>
     {{#if @imageUrl}}

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -5,7 +5,7 @@ export default ApplicationSerializer.extend({
     'totalSkillsCount',
     'testedSkillsCount',
     'validatedSkillsCount',
-    'masteryPercentage',
+    'masteryRate',
     'stageCount',
     'canRetry',
     'canImprove',

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -258,6 +258,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
 
     beforeEach(function() {
       campaignForNovice = server.create('campaign', { isForAbsoluteNovice: true, isSimplifiedAccess: true });
+      server.create('campaign-participation-result', { masteryRate: '1.0' });
       campaignParticipation = server.create('campaign-participation', { campaign: campaignForNovice });
     });
 
@@ -277,6 +278,8 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
       await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
 
       await visit(`/campagnes/${campaignForNovice.code}`);
+      //TODO: locale is UNDEFINED after using visit
+      this.intl.setLocale(['fr']);
       await clickByLabel(this.intl.t('pages.checkpoint.actions.next-page.results'));
       await clickByLabel(this.intl.t('pages.skill-review.actions.continue'));
 

--- a/mon-pix/tests/integration/components/reached-stage_test.js
+++ b/mon-pix/tests/integration/components/reached-stage_test.js
@@ -10,17 +10,17 @@ describe('Integration | Component | reached-stage', function() {
   beforeEach(function() {
     // given
     this.set('reachedStageStarCount', 3);
-    this.set('percentage', 50);
+    this.set('rate', 0.5);
     this.set('stageCount', 5);
   });
 
   it('should render the reached stage', async function() {
     // when
-    await render(hbs`<ReachedStage @starCount={{this.reachedStageStarCount}} @percentage={{this.percentage}} @stageCount={{this.stageCount}} />`);
+    await render(hbs`<ReachedStage @starCount={{this.reachedStageStarCount}} @masteryRate={{this.rate}} @stageCount={{this.stageCount}} />`);
 
     // then
     expect(find('.reached-stage-score__stars')).to.exist;
-    expect(find('.reached-stage-score__percentage-text').textContent.trim()).to.equal('50 % de réussite');
+    expect(find('.reached-stage-score__percentage-text').textContent.trim()).to.equal('50\u00A0% de réussite');
     _expectStars(this.reachedStageStarCount, this.stageCount);
   });
 
@@ -39,7 +39,7 @@ describe('Integration | Component | reached-stage', function() {
         this.set('stageCount', stageCount);
 
         // when
-        await render(hbs`<ReachedStage @starCount={{this.reachedStageStarCount}} @percentage={{this.percentage}} @stageCount={{this.stageCount}} />`);
+        await render(hbs`<ReachedStage @starCount={{this.reachedStageStarCount}} @masteryRate={{this.rate}} @stageCount={{this.stageCount}} />`);
 
         // then
         _expectStars(starCount, stageCount);

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -155,7 +155,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             };
             const campaignParticipationResult = {
               isShared: true,
-              masteryPercentage: 50,
+              masteryRate: '0.5',
               participantExternalId: '1234G56',
               reachedStage,
               campaignParticipationBadges: [],
@@ -183,7 +183,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             };
             const campaignParticipationResult = {
               isShared: true,
-              masteryPercentage: null,
+              masteryRate: null,
               participantExternalId: null,
               reachedStage: null,
               campaignParticipationBadges: [],

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
@@ -260,7 +260,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
         it('should add the masteryPercentage to the url', function() {
           // given
           component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
-          component.args.model.campaignParticipationResult.masteryPercentage = 56;
+          component.args.model.campaignParticipationResult.masteryRate = '0.56';
 
           // when
           const url = component.customButtonUrl;
@@ -274,7 +274,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
         it('should add the masteryPercentage to the url', function() {
           // given
           component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
-          component.args.model.campaignParticipationResult.masteryPercentage = 0;
+          component.args.model.campaignParticipationResult.masteryRate = '0.0';
 
           // when
           const url = component.customButtonUrl;
@@ -305,7 +305,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
           reachedStage.get.withArgs('threshold').returns(6);
           component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
           component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
-          component.args.model.campaignParticipationResult.masteryPercentage = 56;
+          component.args.model.campaignParticipationResult.masteryRate = '0.56';
           component.args.model.campaignParticipationResult.reachedStage = reachedStage;
 
           // when
@@ -324,7 +324,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
           component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats?foo=bar';
           component.args.model.campaignParticipationResult.reachedStage = reachedStage;
           component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
-          component.args.model.campaignParticipationResult.masteryPercentage = 56;
+          component.args.model.campaignParticipationResult.masteryRate = '0.56';
 
           // when
           const url = component.customButtonUrl;
@@ -342,7 +342,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
           component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/#page1';
           component.args.model.campaignParticipationResult.reachedStage = reachedStage;
           component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
-          component.args.model.campaignParticipationResult.masteryPercentage = 56;
+          component.args.model.campaignParticipationResult.masteryRate = '0.56';
 
           // when
           const url = component.customButtonUrl;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1177,7 +1177,7 @@
     },
     "skill-review": {
       "title": "Result",
-      "abstract": "You have mastered '<strong>'{percentage}%'</strong><br>' of the competences tested.",
+      "abstract": "You have mastered '<strong>'{rate, number, ::percent}'</strong><br>' of the competences tested.",
       "abstract-title": "Your result for this customised test",
       "actions": {
         "continue": "Continue my Pix experience",
@@ -1192,7 +1192,8 @@
         "header-result": "Results",
         "header-skill": "Competences tested",
         "result": "Overall result",
-        "result-by-skill": "Your results for the competence"
+        "result-by-skill": "Your results for the competence",
+        "percentage": "{rate, number, ::percent}"
       },
       "improve": {
         "title": "Want to improve your results?",
@@ -1211,7 +1212,7 @@
       },
       "send-title": "Submit your results",
       "stage": {
-        "masteryPercentage": "Success rate: {percentage} %",
+        "masteryPercentage": "Success rate: {rate, number, ::percent}",
         "starsAcquired": "{acquired, plural, =0 {no star} other {# stars}} acquired over {total}"
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1177,7 +1177,7 @@
     },
     "skill-review": {
       "title": "Résultat",
-      "abstract": "Vous maîtrisez '<strong>'{percentage}%'</strong><br>' des compétences testées.",
+      "abstract": "Vous maîtrisez '<strong>'{rate, number, ::percent}'</strong><br>'des compétences testées.",
       "abstract-title": "Votre résultat pour ce parcours",
       "actions": {
         "continue": "Continuez votre expérience Pix",
@@ -1192,7 +1192,8 @@
         "header-result": "Résultats",
         "header-skill": "Compétences testées",
         "result": "Résultat global",
-        "result-by-skill": "Votre résultat pour la compétence"
+        "result-by-skill": "Votre résultat pour la compétence",
+        "percentage": "{rate, number, ::percent}"
       },
       "improve": {
         "title": "Envie d'améliorer vos résultats ?",
@@ -1211,7 +1212,7 @@
       },
       "send-title": "Envoyez vos résultats",
       "stage": {
-        "masteryPercentage": "{percentage} % de réussite",
+        "masteryPercentage": "{rate, number, ::percent} de réussite",
         "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} other {# étoiles acquises}} sur {total}"
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Nous avons récemment enregistré en base les résultats des participants aux campagnes. Cela ayant pour but d'améliorer les performances et également de réduire les problèmes d'affichages.
## :robot: Solution
Utilisation de la colonne "masteryPercentage" pour la page des résultats d'un participant dans pix app.

## :rainbow: Remarques


## :100: Pour tester
Aller sur la page des résultats dans mon-pix.
