### PR TITLE
[FEATURE] Les épreuves focus sont échouées en certification en cas de perte du focus (PIX-3147).

### DIFF
--- a/admin/app/components/certification/certification-details-answer.js
+++ b/admin/app/components/certification/certification-details-answer.js
@@ -8,6 +8,7 @@ const options = [
   { value: 'ko', label: 'Échec' },
   { value: 'partially', label: 'Succès partiel' },
   { value: 'timedout', label: 'Temps écoulé' },
+  { value: 'focusedOut', label: 'Focus échoué' },
   { value: 'aband', label: 'Abandon' },
   { value: 'skip', label: 'Neutralisée' },
 ];

--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -18,6 +18,7 @@ exports.register = async (server) => {
                 result: Joi.string().allow(null),
                 'result-details': Joi.string().allow(null),
                 timeout: Joi.number().allow(null),
+                'focused-out': Joi.boolean().allow(null),
               }).required(),
               relationships: Joi.object().required(),
               assessment: Joi.object(),

--- a/api/lib/domain/models/Answer.js
+++ b/api/lib/domain/models/Answer.js
@@ -8,6 +8,7 @@ class Answer {
     result,
     resultDetails,
     timeout,
+    focusedOut,
     value,
     levelup,
     assessmentId,
@@ -19,6 +20,7 @@ class Answer {
     this.result = AnswerStatus.from(result);
     this.resultDetails = resultDetails;
     this.timeout = timeout;
+    this.focusedOut = focusedOut || this.result.isFOCUSEDOUT();
     this.value = value;
     this.levelup = levelup;
     this.assessmentId = assessmentId;

--- a/api/lib/domain/models/AnswerStatus.js
+++ b/api/lib/domain/models/AnswerStatus.js
@@ -3,6 +3,7 @@ const OK = 'ok';
 const KO = 'ko';
 const SKIPPED = 'aband';
 const TIMEDOUT = 'timedout';
+const UNFOCUS = 'unfocus';
 const PARTIALLY = 'partially';
 const UNIMPLEMENTED = 'unimplemented';
 
@@ -21,6 +22,7 @@ class AnswerStatus {
   isKO() { return this.status === KO; }
   isSKIPPED() { return this.status === SKIPPED; }
   isTIMEDOUT() { return this.status === TIMEDOUT; }
+  isUNFOCUS() { return this.status === UNFOCUS; }
   isPARTIALLY() { return this.status === PARTIALLY; }
   isUNIMPLEMENTED() { return this.status === UNIMPLEMENTED; }
 
@@ -29,6 +31,7 @@ class AnswerStatus {
   static get KO() { return new AnswerStatus({ status: KO }); }
   static get SKIPPED() { return new AnswerStatus({ status: SKIPPED }); }
   static get TIMEDOUT() { return new AnswerStatus({ status: TIMEDOUT }); }
+  static get UNFOCUS() { return new AnswerStatus({ status: UNFOCUS }); }
   static get PARTIALLY() { return new AnswerStatus({ status: PARTIALLY }); }
   static get UNIMPLEMENTED() { return new AnswerStatus({ status: UNIMPLEMENTED }); }
 

--- a/api/lib/domain/models/AnswerStatus.js
+++ b/api/lib/domain/models/AnswerStatus.js
@@ -3,7 +3,7 @@ const OK = 'ok';
 const KO = 'ko';
 const SKIPPED = 'aband';
 const TIMEDOUT = 'timedout';
-const UNFOCUS = 'unfocus';
+const FOCUSEDOUT = 'focusedOut';
 const PARTIALLY = 'partially';
 const UNIMPLEMENTED = 'unimplemented';
 
@@ -22,7 +22,7 @@ class AnswerStatus {
   isKO() { return this.status === KO; }
   isSKIPPED() { return this.status === SKIPPED; }
   isTIMEDOUT() { return this.status === TIMEDOUT; }
-  isUNFOCUS() { return this.status === UNFOCUS; }
+  isFOCUSEDOUT() { return this.status === FOCUSEDOUT; }
   isPARTIALLY() { return this.status === PARTIALLY; }
   isUNIMPLEMENTED() { return this.status === UNIMPLEMENTED; }
 
@@ -31,7 +31,7 @@ class AnswerStatus {
   static get KO() { return new AnswerStatus({ status: KO }); }
   static get SKIPPED() { return new AnswerStatus({ status: SKIPPED }); }
   static get TIMEDOUT() { return new AnswerStatus({ status: TIMEDOUT }); }
-  static get UNFOCUS() { return new AnswerStatus({ status: UNFOCUS }); }
+  static get FOCUSEDOUT() { return new AnswerStatus({ status: FOCUSEDOUT }); }
   static get PARTIALLY() { return new AnswerStatus({ status: PARTIALLY }); }
   static get UNIMPLEMENTED() { return new AnswerStatus({ status: UNIMPLEMENTED }); }
 
@@ -41,6 +41,7 @@ class AnswerStatus {
   static isKO(otherResult) { return AnswerStatus.from(otherResult).isKO(); }
   static isSKIPPED(otherResult) { return AnswerStatus.from(otherResult).isSKIPPED(); }
   static isPARTIALLY(otherResult) { return AnswerStatus.from(otherResult).isPARTIALLY(); }
+  static isFOCUSEDOUT(otherResult) { return AnswerStatus.from(otherResult).isFOCUSEDOUT(); }
 
   /* PRIVATE */
   static from(other) {

--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -33,8 +33,7 @@ class Examiner {
       correctedAnswer.result = AnswerStatus.TIMEDOUT;
     }
 
-    // TODO BEFORE MERGE : limit to certificationEvaluation
-    if (isCorrectAnswer && answer.focusedOut && (isCertificationEvaluation || !isCertificationEvaluation)) {
+    if (isCorrectAnswer && answer.focusedOut && isCertificationEvaluation) {
       correctedAnswer.result = AnswerStatus.FOCUSEDOUT;
     }
 

--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -12,7 +12,7 @@ class Examiner {
     this.validator = validator;
   }
 
-  evaluate({ answer, challengeFormat }) {
+  evaluate({ answer, challengeFormat, isCertificationEvaluation }) {
 
     const correctedAnswer = new Answer(answer);
 
@@ -27,10 +27,15 @@ class Examiner {
     correctedAnswer.result = answerValidation.result;
     correctedAnswer.resultDetails = answerValidation.resultDetails;
 
-    const isPartiallyOrCorrectAnswer = answerValidation.result.isOK() || answerValidation.result.isPARTIALLY();
+    const isCorrectAnswer = answerValidation.result.isOK();
 
-    if (isPartiallyOrCorrectAnswer && answer.hasTimedOut) {
+    if (isCorrectAnswer && answer.hasTimedOut) {
       correctedAnswer.result = AnswerStatus.TIMEDOUT;
+    }
+
+    // TODO BEFORE MERGE : limit to certificationEvaluation
+    if (isCorrectAnswer && answer.focusedOut && (isCertificationEvaluation || !isCertificationEvaluation)) {
+      correctedAnswer.result = AnswerStatus.FOCUSEDOUT;
     }
 
     return correctedAnswer;

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -31,7 +31,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   }
 
   const challenge = await challengeRepository.get(answer.challengeId);
-  const correctedAnswer = _evaluateAnswer(challenge, answer);
+  const correctedAnswer = _evaluateAnswer({ challenge, answer, assessment });
   const now = dateUtils.getNowDate();
   const lastQuestionDate = assessment.lastQuestionDate || now;
   correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
@@ -85,9 +85,9 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   return answerSaved;
 };
 
-function _evaluateAnswer(challenge, answer) {
+function _evaluateAnswer({ challenge, answer, assessment }) {
   const examiner = new Examiner({ validator: challenge.validator });
-  return examiner.evaluate({ answer, challengeFormat: challenge.format });
+  return examiner.evaluate({ answer, challengeFormat: challenge.format, isCertificationEvaluation: assessment.isCertification() });
 }
 
 async function _getKnowledgeElements({ assessment, answer, challenge, skillRepository, targetProfileRepository, knowledgeElementRepository }) {

--- a/api/lib/infrastructure/adapters/answer-status-database-adapter.js
+++ b/api/lib/infrastructure/adapters/answer-status-database-adapter.js
@@ -4,6 +4,7 @@ const UNIMPLEMENTED = 'unimplemented';
 const TIMEDOUT = 'timedout';
 const PARTIALLY = 'partially';
 const SKIPPED = 'aband';
+const FOCUSEDOUT = 'focusedOut';
 const OK = 'ok';
 const KO = 'ko';
 
@@ -28,6 +29,8 @@ module.exports = {
       return PARTIALLY;
     } else if (answerStatus.isTIMEDOUT()) {
       return TIMEDOUT;
+    } else if (answerStatus.isFOCUSEDOUT()) {
+      return FOCUSEDOUT;
     } else {
       return UNIMPLEMENTED;
     }
@@ -35,7 +38,6 @@ module.exports = {
   },
 
   fromSQLString(answerStatusString) {
-
     if (answerStatusString === OK) {
       return AnswerStatus.OK;
     } else if (answerStatusString === KO) {
@@ -46,6 +48,8 @@ module.exports = {
       return AnswerStatus.TIMEDOUT;
     } else if (answerStatusString === SKIPPED) {
       return AnswerStatus.SKIPPED;
+    } else if (answerStatusString === FOCUSEDOUT) {
+      return AnswerStatus.FOCUSEDOUT;
     } else if (answerStatusString === UNIMPLEMENTED) {
       return AnswerStatus.UNIMPLEMENTED;
     }

--- a/api/lib/infrastructure/adapters/answer-status-json-api-adapter.js
+++ b/api/lib/infrastructure/adapters/answer-status-json-api-adapter.js
@@ -1,5 +1,6 @@
 const UNIMPLEMENTED = 'unimplemented';
 const TIMEDOUT = 'timedout';
+const FOCUSEDOUT = 'focusedOut';
 const PARTIALLY = 'partially';
 const SKIPPED = 'aband';
 const OK = 'ok';
@@ -18,6 +19,8 @@ const AnswerStatusJsonApiAdapter = {
       return PARTIALLY;
     } else if (answerStatus.isTIMEDOUT()) {
       return TIMEDOUT;
+    } else if (answerStatus.isFOCUSEDOUT()) {
+      return FOCUSEDOUT;
     } else {
       return UNIMPLEMENTED;
     }

--- a/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -48,6 +48,7 @@ module.exports = {
       result: null,
       resultDetails: null,
       timeout: payload.data.attributes.timeout,
+      focusedOut: payload.data.attributes['focused-out'],
       assessmentId: payload.data.relationships.assessment.data.id,
       challengeId: payload.data.relationships.challenge.data.id,
     });

--- a/api/tests/tooling/domain-builder/factory/build-answer.js
+++ b/api/tests/tooling/domain-builder/factory/build-answer.js
@@ -10,6 +10,7 @@ function buildAnswer({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 20,
+  focusedOut = false,
 } = {}) {
   return new Answer({
     id,
@@ -20,6 +21,7 @@ function buildAnswer({
     assessmentId,
     challengeId,
     timeSpent,
+    focusedOut,
   });
 }
 
@@ -29,6 +31,7 @@ buildAnswer.uncorrected = function({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 10,
+  focusedOut = false,
 } = {}) {
   return new Answer({
     timeout,
@@ -36,6 +39,7 @@ buildAnswer.uncorrected = function({
     assessmentId,
     challengeId,
     timeSpent,
+    focusedOut,
   });
 };
 
@@ -47,6 +51,7 @@ buildAnswer.ok = function({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 20,
+  focusedOut = false,
 } = {}) {
 
   return buildAnswer({
@@ -58,6 +63,7 @@ buildAnswer.ok = function({
     assessmentId,
     challengeId,
     timeSpent,
+    focusedOut,
   });
 };
 
@@ -69,6 +75,7 @@ buildAnswer.ko = function({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 20,
+  focusedOut = false,
 } = {}) {
 
   return buildAnswer({
@@ -80,6 +87,7 @@ buildAnswer.ko = function({
     assessmentId,
     challengeId,
     timeSpent,
+    focusedOut,
   });
 };
 
@@ -91,6 +99,7 @@ buildAnswer.skipped = function({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 20,
+  focusedOut = false,
 } = {}) {
 
   return buildAnswer({
@@ -102,6 +111,7 @@ buildAnswer.skipped = function({
     assessmentId,
     challengeId,
     timeSpent,
+    focusedOut,
   });
 };
 

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -25,6 +25,7 @@ describe('Unit | Controller | answer-controller', function() {
     const challengeId = 'recdTpx4c0kPPDTtf';
     const result = null;
     const timeout = null;
+    const focusedOut = false;
     const resultDetails = null;
     const value = 'NumA = "4", NumB = "1", NumC = "3", NumD = "2"';
     const locale = 'fr-fr';
@@ -40,6 +41,7 @@ describe('Unit | Controller | answer-controller', function() {
           'result-details': 'resultDetails_value',
           timeout: null,
           result: 'result_value',
+          'focused-out': focusedOut,
         },
         relationships: {
           assessment: {
@@ -69,6 +71,7 @@ describe('Unit | Controller | answer-controller', function() {
               value: value,
               result: result,
               timeout: timeout,
+              'focused-out': focusedOut,
               'result-details': resultDetails,
             },
             relationships: {
@@ -96,6 +99,7 @@ describe('Unit | Controller | answer-controller', function() {
         value,
         assessmentId,
         challengeId,
+        focusedOut,
       });
       deserializedAnswer.id = undefined;
     });

--- a/api/tests/unit/domain/models/AnswerStatus_test.js
+++ b/api/tests/unit/domain/models/AnswerStatus_test.js
@@ -8,11 +8,12 @@ describe('AnswerStatus', function() {
       expect(AnswerStatus.OK.isOK()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses KO, SKIPPED, PARTIALLY, TIMEDOUT, and UNIMPLEMENTED', function() {
+    it('should be false with AnswerStatuses KO, SKIPPED, PARTIALLY, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function() {
       expect(AnswerStatus.KO.isOK()).to.be.false;
       expect(AnswerStatus.SKIPPED.isOK()).to.be.false;
       expect(AnswerStatus.PARTIALLY.isOK()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isOK()).to.be.false;
+      expect(AnswerStatus.FOCUSEDOUT.isOK()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isOK()).to.be.false;
     });
   });
@@ -22,11 +23,12 @@ describe('AnswerStatus', function() {
       expect(AnswerStatus.KO.isKO()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, SKIPPED, PARTIALLY, TIMEDOUT, and UNIMPLEMENTED', function() {
+    it('should be false with AnswerStatuses OK, SKIPPED, PARTIALLY, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function() {
       expect(AnswerStatus.OK.isKO()).to.be.false;
       expect(AnswerStatus.SKIPPED.isKO()).to.be.false;
       expect(AnswerStatus.PARTIALLY.isKO()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isKO()).to.be.false;
+      expect(AnswerStatus.FOCUSEDOUT.isKO()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isKO()).to.be.false;
     });
   });
@@ -36,11 +38,12 @@ describe('AnswerStatus', function() {
       expect(AnswerStatus.SKIPPED.isSKIPPED()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, PARTIALLY, TIMEDOUT, and UNIMPLEMENTED', function() {
+    it('should be false with AnswerStatuses OK, KO, PARTIALLY, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function() {
       expect(AnswerStatus.OK.isSKIPPED()).to.be.false;
       expect(AnswerStatus.KO.isSKIPPED()).to.be.false;
       expect(AnswerStatus.PARTIALLY.isSKIPPED()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isSKIPPED()).to.be.false;
+      expect(AnswerStatus.FOCUSEDOUT.isSKIPPED()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isSKIPPED()).to.be.false;
     });
   });
@@ -50,11 +53,12 @@ describe('AnswerStatus', function() {
       expect(AnswerStatus.PARTIALLY.isPARTIALLY()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, SKIPPED, TIMEDOUT, and UNIMPLEMENTED', function() {
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, TIMEDOUT, FOCUSEDOUTand UNIMPLEMENTED', function() {
       expect(AnswerStatus.OK.isPARTIALLY()).to.be.false;
       expect(AnswerStatus.KO.isPARTIALLY()).to.be.false;
       expect(AnswerStatus.SKIPPED.isPARTIALLY()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isPARTIALLY()).to.be.false;
+      expect(AnswerStatus.FOCUSEDOUT.isPARTIALLY()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isPARTIALLY()).to.be.false;
     });
   });
@@ -64,11 +68,12 @@ describe('AnswerStatus', function() {
       expect(AnswerStatus.TIMEDOUT.isTIMEDOUT()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, and UNIMPLEMENTED', function() {
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, FOCUSEDOUT and UNIMPLEMENTED', function() {
       expect(AnswerStatus.OK.isTIMEDOUT()).to.be.false;
       expect(AnswerStatus.KO.isTIMEDOUT()).to.be.false;
       expect(AnswerStatus.SKIPPED.isTIMEDOUT()).to.be.false;
       expect(AnswerStatus.PARTIALLY.isTIMEDOUT()).to.be.false;
+      expect(AnswerStatus.FOCUSEDOUT.isTIMEDOUT()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isTIMEDOUT()).to.be.false;
     });
   });
@@ -78,12 +83,13 @@ describe('AnswerStatus', function() {
       expect(AnswerStatus.UNIMPLEMENTED.isUNIMPLEMENTED()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, and TIMEDOUT', function() {
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, FOCUSEDOUT and TIMEDOUT', function() {
       expect(AnswerStatus.OK.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.KO.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.SKIPPED.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.PARTIALLY.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isUNIMPLEMENTED()).to.be.false;
+      expect(AnswerStatus.FOCUSEDOUT.isUNIMPLEMENTED()).to.be.false;
     });
   });
 
@@ -92,12 +98,29 @@ describe('AnswerStatus', function() {
       expect(AnswerStatus.OK.isFailed()).to.be.false;
     });
 
-    it('should be true with AnswerStatuses KO, SKIPPED, PARTIALLY, TIMEDOUT, and UNIMPLEMENTED', function() {
+    it('should be true with AnswerStatuses KO, SKIPPED, PARTIALLY, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function() {
       expect(AnswerStatus.KO.isFailed()).to.be.true;
       expect(AnswerStatus.SKIPPED.isFailed()).to.be.true;
       expect(AnswerStatus.PARTIALLY.isFailed()).to.be.true;
       expect(AnswerStatus.TIMEDOUT.isFailed()).to.be.true;
+      expect(AnswerStatus.FOCUSEDOUT.isFailed()).to.be.true;
       expect(AnswerStatus.UNIMPLEMENTED.isFailed()).to.be.true;
     });
   });
+
+  context('AnswerStatus#isFOCUSEDOUT', function() {
+    it('should be true with AnswerStatus.FOCUSEDOUT', function() {
+      expect(AnswerStatus.FOCUSEDOUT.isFOCUSEDOUT()).to.be.true;
+    });
+
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, TIMEDOUT and UNIMPLEMENTED', function() {
+      expect(AnswerStatus.OK.isFOCUSEDOUT()).to.be.false;
+      expect(AnswerStatus.KO.isFOCUSEDOUT()).to.be.false;
+      expect(AnswerStatus.SKIPPED.isFOCUSEDOUT()).to.be.false;
+      expect(AnswerStatus.PARTIALLY.isFOCUSEDOUT()).to.be.false;
+      expect(AnswerStatus.TIMEDOUT.isFOCUSEDOUT()).to.be.false;
+      expect(AnswerStatus.UNIMPLEMENTED.isFOCUSEDOUT()).to.be.false;
+    });
+  });
+
 });

--- a/api/tests/unit/domain/models/Answer_test.js
+++ b/api/tests/unit/domain/models/Answer_test.js
@@ -18,6 +18,7 @@ describe('Unit | Domain | Models | Answer', function() {
         assessmentId: 82,
         levelup: {},
         timeSpent: 30,
+        focusedOut: false,
       };
 
       const expectedAnswer = {
@@ -30,6 +31,7 @@ describe('Unit | Domain | Models | Answer', function() {
         assessmentId: 82,
         levelup: {},
         timeSpent: 30,
+        focusedOut: false,
       };
 
       // when

--- a/api/tests/unit/domain/models/Examiner_test.js
+++ b/api/tests/unit/domain/models/Examiner_test.js
@@ -80,7 +80,7 @@ describe('Unit | Domain | Models | Examiner', function() {
       });
     });
 
-    context('when answer is partially correct and TIMEOUT', function() {
+    context('when answer is correct and FOCUSEDOUT', function() {
 
       let uncorrectedAnswer;
       let correctedAnswer;
@@ -89,18 +89,18 @@ describe('Unit | Domain | Models | Examiner', function() {
 
       beforeEach(function() {
         // given
-        validation = domainBuilder.buildValidation({ result: AnswerStatus.PARTIALLY });
+        validation = domainBuilder.buildValidation({ result: AnswerStatus.OK });
         validator.assess.returns(validation);
-        uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected({ timeout: -12 });
+        uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected({ focusedOut: true });
         examiner = new Examiner({ validator });
 
         // when
         correctedAnswer = examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat });
       });
 
-      it('should return an answer with TIMEOUT as result, and the correct resultDetails', function() {
+      it('should return an answer with FOCUSED as result, and the correct resultDetails', function() {
         const expectedAnswer = new Answer(uncorrectedAnswer);
-        expectedAnswer.result = AnswerStatus.TIMEDOUT;
+        expectedAnswer.result = AnswerStatus.FOCUSEDOUT;
         expectedAnswer.resultDetails = validation.resultDetails;
 
         // then

--- a/api/tests/unit/domain/models/Examiner_test.js
+++ b/api/tests/unit/domain/models/Examiner_test.js
@@ -93,15 +93,30 @@ describe('Unit | Domain | Models | Examiner', function() {
         validator.assess.returns(validation);
         uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected({ focusedOut: true });
         examiner = new Examiner({ validator });
-
-        // when
-        correctedAnswer = examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat });
       });
 
-      it('should return an answer with FOCUSED as result, and the correct resultDetails', function() {
+      it('should return an answer with FOCUSED as result when the assessment is a certification, and the correct resultDetails', function() {
+        // given
         const expectedAnswer = new Answer(uncorrectedAnswer);
         expectedAnswer.result = AnswerStatus.FOCUSEDOUT;
         expectedAnswer.resultDetails = validation.resultDetails;
+
+        // when
+        correctedAnswer = examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat, isCertificationEvaluation: true });
+
+        // then
+        expect(correctedAnswer).to.be.an.instanceOf(Answer);
+        expect(correctedAnswer).to.deep.equal(expectedAnswer);
+      });
+
+      it('should return an answer with OK as result when the assessment is a certification, and the correct resultDetails', function() {
+        // given
+        const expectedAnswer = new Answer(uncorrectedAnswer);
+        expectedAnswer.result = AnswerStatus.OK;
+        expectedAnswer.resultDetails = validation.resultDetails;
+
+        // when
+        correctedAnswer = examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat, isCertificationEvaluation: false });
 
         // then
         expect(correctedAnswer).to.be.an.instanceOf(Answer);
@@ -109,6 +124,9 @@ describe('Unit | Domain | Models | Examiner', function() {
       });
 
       it('should call validator.assess with answer to assess validity of answer', function() {
+        // when
+        examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat, isCertificationEvaluation: true });
+
         // then
         expect(validator.assess).to.have.been.calledWithExactly({ answer: uncorrectedAnswer, challengeFormat });
       });

--- a/api/tests/unit/infrastructure/adapters/answer-status-database-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/answer-status-database-adapter_test.js
@@ -37,6 +37,12 @@ describe('AnswerStatusDatabaseAdapter', function() {
       expect(result).to.equals('aband');
     });
 
+    it('should convert AnswerStatus.FOCUSEDOUT to "focusedOut"', function() {
+      const answerStatus = AnswerStatus.FOCUSEDOUT;
+      const result = AnswerStatusDatabaseAdapter.adapt(answerStatus);
+      expect(result).to.equals('focusedOut');
+    });
+
     it('should convert AnswerStatus.UNIMPLEMENTED to "unimplemented"', function() {
       const answerStatus = AnswerStatus.UNIMPLEMENTED;
       const result = AnswerStatusDatabaseAdapter.adapt(answerStatus);
@@ -69,6 +75,12 @@ describe('AnswerStatusDatabaseAdapter', function() {
       const answerStatus = AnswerStatus.TIMEDOUT;
       const result = AnswerStatusDatabaseAdapter.toSQLString(answerStatus);
       expect(result).to.equals('timedout');
+    });
+
+    it('should convert AnswerStatus.FOCUSEDOUT to "focusedOut"', function() {
+      const answerStatus = AnswerStatus.FOCUSEDOUT;
+      const result = AnswerStatusDatabaseAdapter.toSQLString(answerStatus);
+      expect(result).to.equals('focusedOut');
     });
 
     it('should convert AnswerStatus.SKIPPED to "aband"', function() {
@@ -108,6 +120,12 @@ describe('AnswerStatusDatabaseAdapter', function() {
       const answerStatusString = 'timedout';
       const result = AnswerStatusDatabaseAdapter.fromSQLString(answerStatusString);
       expect(result.isTIMEDOUT()).to.be.true;
+    });
+
+    it('should convert "focusedOut" to AnswerStatus.FOCUSEDOUT', function() {
+      const answerStatusString = 'focusedOut';
+      const result = AnswerStatusDatabaseAdapter.fromSQLString(answerStatusString);
+      expect(result.isFOCUSEDOUT()).to.be.true;
     });
 
     it('should convert "aband" to AnswerStatus.SKIPPED', function() {

--- a/api/tests/unit/infrastructure/adapters/answer-status-json-api-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/answer-status-json-api-adapter_test.js
@@ -32,6 +32,12 @@ describe('AnswerStatusJsonApiAdapter', function() {
       expect(result).to.equals('timedout');
     });
 
+    it('should convert AnswerStatus.FOCUSEDOUT to "focusedOut"', function() {
+      const answerStatus = AnswerStatus.FOCUSEDOUT;
+      const result = AnswerStatusJsonApiAdapter.adapt(answerStatus);
+      expect(result).to.equals('focusedOut');
+    });
+
     it('should convert AnswerStatus.SKIPPED to "aband"', function() {
       const answerStatus = AnswerStatus.SKIPPED;
       const result = AnswerStatusJsonApiAdapter.adapt(answerStatus);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -86,6 +86,7 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
             result: null,
             'result-details': null,
             timeout: null,
+            'focused-out': true,
           },
           relationships: {
             assessment: {
@@ -114,6 +115,7 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
       expect(answer.result).to.deep.equal(AnswerStatus.from(null));
       expect(answer.resultDetails).to.equal(null);
       expect(answer.timeout).to.equal(null);
+      expect(answer.focusedOut).to.equal(true);
       expect(answer.assessmentId).to.equal(assessmentId);
       expect(answer.challengeId).to.equal(challengeId);
     });

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -59,7 +59,7 @@ export default class ChallengeItemGeneric extends Component {
 
     this.errorMessage = null;
 
-    return this.args.answerValidated(this.args.challenge, this.args.assessment, this._getAnswerValue(), this._getTimeout())
+    return this.args.answerValidated(this.args.challenge, this.args.assessment, this._getAnswerValue(), this._getTimeout(), this.args.hasFocusedOutOfWindow)
       .finally(() => {
         this.args.finishChallenge();
       });
@@ -73,8 +73,7 @@ export default class ChallengeItemGeneric extends Component {
   @action
   skipChallenge() {
     this.errorMessage = null;
-
-    return this.args.answerValidated(this.args.challenge, this.args.assessment, '#ABAND#', this._getTimeout())
+    return this.args.answerValidated(this.args.challenge, this.args.assessment, '#ABAND#', this._getTimeout(), this.args.hasFocusedOutOfWindow)
       .finally(() => {
         this.args.finishChallenge();
       });

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -8,6 +8,7 @@ const TEXT_FOR_RESULT = {
   aband: { status: 'aband' },
   partially: { status: 'partially' },
   timedout: { status: 'timedout' },
+  focusedOut: { status: 'ko' },
   okAutoReply: { status: 'ok' },
   koAutoReply: { status: 'ko' },
   abandAutoReply: { status: 'aband' },

--- a/mon-pix/app/components/result-item.js
+++ b/mon-pix/app/components/result-item.js
@@ -10,6 +10,10 @@ const contentReference = {
     icon: 'times-circle',
     color: 'red',
   },
+  focusedOut: {
+    icon: 'times-circle',
+    color: 'red',
+  },
   aband: {
     icon: 'times-circle',
     color: 'grey',

--- a/mon-pix/app/models/answer.js
+++ b/mon-pix/app/models/answer.js
@@ -10,6 +10,7 @@ export default Model.extend(ValueAsArrayOfString, {
   result: attr('string'),
   resultDetails: attr('string'),
   timeout: attr('number'),
+  focusedOut: attr('boolean'),
   assessment: belongsTo('assessment'),
   challenge: belongsTo('challenge'),
   correction: belongsTo('correction'),

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -56,11 +56,12 @@ export default class ChallengeRoute extends Route {
   }
 
   @action
-  async saveAnswerAndNavigate(challenge, assessment, answerValue, answerTimeout) {
+  async saveAnswerAndNavigate(challenge, assessment, answerValue, answerTimeout, answerFocusedOut) {
     const answer = this._findOrCreateAnswer(challenge, assessment);
     answer.setProperties({
       value: answerValue.trim(),
       timeout: answerTimeout,
+      focusedOut: answerFocusedOut,
     });
 
     try {

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -35,6 +35,7 @@
         @onFocusIntoChallenge={{fn this.setFocusedOutOfChallenge false}}
         @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
         @onFocusOutOfWindow={{this.focusedOutOfWindow}}
+        @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
         @onTooltipClose={{this.removeTooltipOverlay}}
       />
     {{/if}}

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -135,6 +135,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
 
     let answerValue = 'example';
     const answerTimeout = 120;
+    const answerFocusedOut = false;
     const challengeOne = EmberObject.create({ id: 'recChallengeOne' });
     const nextChallenge = EmberObject.create({ id: 'recNextChallenge' });
 
@@ -193,7 +194,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
       queryRecordStub.resolves(nextChallenge);
 
       // when
-      route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout);
+      route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout, answerFocusedOut);
 
       // then
       sinon.assert.callOrder(answerToChallengeOne.setProperties, answerToChallengeOne.save);
@@ -201,6 +202,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
       sinon.assert.calledWith(answerToChallengeOne.setProperties, {
         value: answerValue,
         timeout: answerTimeout,
+        focusedOut: answerFocusedOut,
       });
     });
 
@@ -213,7 +215,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
       queryRecordStub.resolves(nextChallenge);
 
       // when
-      route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout);
+      route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout, answerFocusedOut);
 
       // then
       sinon.assert.callOrder(answerToChallengeOne.setProperties, answerToChallengeOne.save);
@@ -221,6 +223,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
       sinon.assert.calledWith(answerToChallengeOne.setProperties, {
         value: answerValueWithoutUselessChar,
         timeout: answerTimeout,
+        focusedOut: answerFocusedOut,
       });
     });
 
@@ -232,7 +235,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
         const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
 
         // when
-        await route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout);
+        await route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout, answerFocusedOut);
 
         // then
         sinon.assert.calledWithExactly(route.transitionTo, 'assessments.resume', assessment.get('id'), { queryParams: {} });
@@ -256,7 +259,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
           } };
 
           // when
-          await route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout);
+          await route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout, answerFocusedOut);
 
           // then
           sinon.assert.calledWithExactly(route.transitionTo, 'assessments.resume', assessment.get('id'), expectedQueryParams);
@@ -269,7 +272,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
           const expectedQueryParams = { queryParams: { } };
 
           // when
-          await route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout);
+          await route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout, answerFocusedOut);
 
           // then
           sinon.assert.calledWithExactly(route.transitionTo, 'assessments.resume', assessment.get('id'), expectedQueryParams);
@@ -281,7 +284,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
           const expectedQueryParams = { queryParams: { } };
 
           // when
-          await route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout);
+          await route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout, answerFocusedOut);
 
           // then
           sinon.assert.calledWithExactly(route.transitionTo, 'assessments.resume', assessment.get('id'), expectedQueryParams);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -566,6 +566,10 @@
           "title": "You gave an incomplete answer",
           "tooltip": "Incomplete answer"
         },
+        "focusedOut": {
+          "title": "You lost focus",
+          "tooltip": "Question focused out"
+        },
         "timedout": {
           "title": "You've run out of time",
           "tooltip": "Out of time"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -550,6 +550,10 @@
           "title": "Vous n’avez pas la bonne réponse",
           "tooltip": "Réponse incorrecte"
         },
+        "focusedOut": {
+          "title": "Vous êtes sorti de l'épreuve",
+          "tooltip": "Épreuve échouée"
+        },
         "koAutoReply": {
           "title": "Vous n’avez pas réussi l’épreuve",
           "tooltip": "Épreuve non réussie"


### PR DESCRIPTION
## :unicorn: Problème
En positionnement, les épreuves Focus ne font qu'indiquer à l'utilisateur que c'est une question de savoir et qu'il n'a pas à aller sur internet.
En certification, ces mêmes épreuves doivent être considérées comme échouées si l'utilisateur est sorti de l'épreuve.

## :robot: Solution
- Ajout d'un nouveau résultat possible dans la colonne `result` : `focusedOut`
- Le front envoie au back s'il y a eu un focusedout ou non

## :rainbow: Remarques
Ces épreuves suivent un fonctionnement proche de celui des épreuves timées : 
- Si l'utilisateur a répondu faux (qu'il soit sorti ou non, ou que le temps soit écoulé ou non) : KO
- Si l'utilisateur a passé (qu'il soit sorti ou non, ou que le temps soit écoulé ou non) : SKIPPED
- Si l'utilisateur a bien répondu et qu'il n'est pas sorti/que le temps ne s'est pas totalement écoulé : OK
- Si l'utilisateur a bien répondu MAIS qu'il est sorti : FOCUSEDOUT
- Si l'utilisateur a bien répondu MAIS que le temps est écoulé : TIMEDOUT

Dans le cas d'un positionnement, on ne fait pas attention au fait qu'il soit sorti, la réponse sera donc OK.
En certification, la réponse pourra donc être FOCUSEDOUT.

## :100: Pour tester
- Se positionner mais pas trop, en ayant vu des focus (et validé)
- Passer une certif
La certif 10000001 a vu des épreuves focus
Le user focus@pix.fr/Test1234 peut se certifier avec des épreuves focus