### PR TITLE
[FEATURE] Ajouter un titre de page spécifique pour les épreuves focus (PIX-3149). 

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -5,6 +5,7 @@ import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 import { action } from '@ember/object';
 const defaultPageTitle = 'pages.challenge.title.default';
 const timedOutPageTitle = 'pages.challenge.title.timed-out';
+const focusedPageTitle = 'pages.challenge.title.focused';
 import ENV from 'mon-pix/config/environment';
 import isInteger from 'lodash/isInteger';
 
@@ -14,7 +15,7 @@ export default class ChallengeController extends Controller {
   @service currentUser;
   @tracked newLevel = null;
   @tracked competenceLeveled = null;
-  @tracked challengeTitle = defaultPageTitle;
+  @tracked challengeTitle = this.model.challenge.focused ? focusedPageTitle : defaultPageTitle;
   @tracked hasFocusedOutOfChallenge = false;
   @tracked hasFocusedOutOfWindow = false;
   @tracked isTooltipOverlayDisplayed = !(this.currentUser.user && this.currentUser.user.hasSeenFocusedChallengeTooltip)

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -3,8 +3,8 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 import { action } from '@ember/object';
-const defaultPageTitle = 'pages.challenge.title';
-const timedOutPageTitle = 'pages.challenge.timed-out-title';
+const defaultPageTitle = 'pages.challenge.title.default';
+const timedOutPageTitle = 'pages.challenge.title.timed-out';
 import ENV from 'mon-pix/config/environment';
 import isInteger from 'lodash/isInteger';
 

--- a/mon-pix/tests/unit/controllers/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge_test.js
@@ -35,7 +35,7 @@ describe('Unit | Controller | Assessments | Challenge', function() {
       controller.pageTitle;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.challenge.title', { stepNumber: 2, totalChallengeNumber: 5 });
+      sinon.assert.calledWith(intl.t, 'pages.challenge.title.default', { stepNumber: 2, totalChallengeNumber: 5 });
     });
   });
 

--- a/mon-pix/tests/unit/controllers/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge_test.js
@@ -27,6 +27,9 @@ describe('Unit | Controller | Assessments | Challenge', function() {
       controller.model = {
         assessment: {},
         answer: null,
+        challenge: {
+          focused: false,
+        },
       };
       sinon.stub(progressInAssessment, 'getCurrentStepNumber').returns(2);
       sinon.stub(progressInAssessment, 'getMaxStepsNumber').returns(5);
@@ -36,6 +39,25 @@ describe('Unit | Controller | Assessments | Challenge', function() {
 
       // then
       sinon.assert.calledWith(intl.t, 'pages.challenge.title.default', { stepNumber: 2, totalChallengeNumber: 5 });
+    });
+
+    it('should return focused title when challenge is focused', function() {
+      // given
+      controller.model = {
+        assessment: {},
+        answer: null,
+        challenge: {
+          focused: true,
+        },
+      };
+      sinon.stub(progressInAssessment, 'getCurrentStepNumber').returns(2);
+      sinon.stub(progressInAssessment, 'getMaxStepsNumber').returns(5);
+
+      // when
+      controller.pageTitle;
+
+      // then
+      sinon.assert.calledWith(intl.t, 'pages.challenge.title.focused', { stepNumber: 2, totalChallengeNumber: 5 });
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -314,7 +314,10 @@
       }
     },
     "challenge": {
-      "title": "Question {stepNumber} of {totalChallengeNumber}",
+      "title": {
+        "default": "Question {stepNumber} of {totalChallengeNumber}",
+        "timed-out": "Timed out - Question {stepNumber} of {totalChallengeNumber}"
+      },
       "actions": {
         "continue": "Continue",
         "go-to-next": " and go to the next question",
@@ -492,8 +495,7 @@
       },
       "timed": {
         "cannot-answer": "You've run out of time."
-      },
-      "timed-out-title": "Timed out - Question {stepNumber} of {totalChallengeNumber}"
+      }
     },
     "checkpoint": {
       "title": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -316,7 +316,8 @@
     "challenge": {
       "title": {
         "default": "Question {stepNumber} of {totalChallengeNumber}",
-        "timed-out": "Timed out - Question {stepNumber} of {totalChallengeNumber}"
+        "timed-out": "Timed out - Question {stepNumber} of {totalChallengeNumber}",
+        "focused": "Knowledge Question - Question {stepNumber} of {totalChallengeNumber}"
       },
       "actions": {
         "continue": "Continue",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -314,7 +314,10 @@
       }
     },
     "challenge": {
-      "title": "Épreuve {stepNumber} sur {totalChallengeNumber}",
+      "title": {
+        "default": "Épreuve {stepNumber} sur {totalChallengeNumber}",
+        "timed-out": "Temps écoulé - Épreuve {stepNumber} sur {totalChallengeNumber}"
+      },
       "actions": {
         "continue": "Poursuivre",
         "go-to-next": " et je vais à la prochaine question",
@@ -492,8 +495,7 @@
       },
       "timed": {
         "cannot-answer": "Le temps imparti est écoulé."
-      },
-      "timed-out-title": "Temps écoulé - Épreuve {stepNumber} sur {totalChallengeNumber}"
+      }
     },
     "checkpoint": {
       "title": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -316,7 +316,8 @@
     "challenge": {
       "title": {
         "default": "Épreuve {stepNumber} sur {totalChallengeNumber}",
-        "timed-out": "Temps écoulé - Épreuve {stepNumber} sur {totalChallengeNumber}"
+        "timed-out": "Temps écoulé - Épreuve {stepNumber} sur {totalChallengeNumber}",
+        "focused": "Épreuve de savoir - Épreuve {stepNumber} sur {totalChallengeNumber}"
       },
       "actions": {
         "continue": "Poursuivre",


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons indiquer le plus clairement possible que l'utilisateur se trouve sur une épreuve de test des connaissances (épreuve focus pour les intimes). 

## :robot: Solution
Afficher dans le titre de la page qu'il s'agit d'une épreuve focus. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur une épreuve focus ([rec2dRKsI4aBIsayz](https://app-pr3445.review.pix.fr/challenges/rec2dRKsI4aBIsayz/preview)) et constater que le titre indique que c'est une Épreuve de savoir.
