### PR TITLE
[TECH] Utiliser le token de github pour sécuriser l'auto merge.

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.8.3"
         env:
-          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
+          GITHUB_TOKEN: "${{ github.token }}"
           MERGE_LABELS: ":rocket: Ready to Merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: ":rocket: Ready to Merge"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,5 @@
 name: automerge check
+
 on:
   pull_request:
     types:
@@ -6,6 +7,12 @@ on:
   check_suite:
     types:
       - completed
+
+permissions:
+  checks: read
+  contents: write
+  actions: write
+
 jobs:
   automerge:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.8.3"
+        uses: "pascalgn/automerge-action@v0.14.3"
         env:
           GITHUB_TOKEN: "${{ github.token }}"
           MERGE_LABELS: ":rocket: Ready to Merge"


### PR DESCRIPTION
## :unicorn: Problème
Un utilisateur externe existe et a un accès `Maintainer` sur le projet pour automatiser le merge des PRs

## :robot: Solution
Github a un token spécifique pour les actions de projet qui sont auto-généré au moment de l'action. Ceci permet d'éviter de donner accès à des comptes externes et de devoir garder le token en variable secrète sur le repo. Voir détail [ici](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)

Montée de version de 0.8.3 à 0.14.3
[CHANGELOG](https://github.com/pascalgn/automerge-action/releases)

## :rainbow: Remarques
On a fait pareil sur Pix-UI : https://github.com/1024pix/pix-ui/pull/150
Voir la doc : https://docs.github.com/en/actions/security-guides/automatic-token-authentication
