### PR TITLE
[TECH] Identifier rapidement les problèmes de nos utilisateurs via Datadog en cherchant via leur identifiant toute requête les concernant (PIX-3153).

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -1,5 +1,5 @@
 const types = require('pg').types;
-const { addPositionToQuerieAndIncrementQueriesCounter, logKnexQueriesWithCorrelationId } = require('../lib/infrastructure/performance-tools');
+const { addPositionToQuerieAndIncrementQueriesCounter, logKnexQueriesWithCorrelationId } = require('../lib/infrastructure/monitoring-tools');
 const { logging } = require('../lib/config');
 /*
 By default, node-postgres casts a DATE value (PostgreSQL type) as a Date Object (JS type).

--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -1,4 +1,4 @@
-const performanceTool = require('../../infrastructure/performance-tools');
+const monitoringTools = require('../../infrastructure/monitoring-tools');
 const usecases = require('../../domain/usecases');
 const events = require('../../domain/events');
 
@@ -25,7 +25,7 @@ module.exports = {
     } = await DomainTransaction.execute((domainTransaction) => {
       return usecases.startCampaignParticipation({ campaignParticipation, userId, domainTransaction });
     });
-    events.eventDispatcher.dispatch(event).catch((error) => performanceTool.logErrorWithCorrelationId(error));
+    events.eventDispatcher.dispatch(event).catch((error) => monitoringTools.logErrorWithCorrelationIds(error));
 
     return h.response(campaignParticipationSerializer.serialize(campaignParticipationCreated)).created();
   },
@@ -42,7 +42,7 @@ module.exports = {
       });
     });
 
-    events.eventDispatcher.dispatch(event).catch((error) => performanceTool.logErrorWithCorrelationId(error));
+    events.eventDispatcher.dispatch(event).catch((error) => monitoringTools.logErrorWithCorrelationIds(error));
     return null;
   },
 

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -1,7 +1,7 @@
 const get = require('lodash/get');
 const moment = require('moment');
 const querystring = require('querystring');
-const performanceTool = require('../../performance-tools');
+const monitoringTools = require('../../monitoring-tools');
 const authenticationMethodRepository = require('../../repositories/authentication-method-repository');
 const AuthenticationMethod = require('../../../domain/models/AuthenticationMethod');
 const httpAgent = require('../../http/http-agent');
@@ -34,7 +34,7 @@ module.exports = {
 
       if (!tokenResponse.isSuccessful) {
         const errorMessage = _getErrorMessage(tokenResponse.data);
-        performanceTool.logErrorWithCorrelationId(errorMessage);
+        monitoringTools.logErrorWithCorrelationIds(errorMessage);
         return {
           isSuccessful: tokenResponse.isSuccessful,
           code: tokenResponse.code || '500',
@@ -62,7 +62,7 @@ module.exports = {
 
     if (!httpResponse.isSuccessful) {
       const errorMessage = _getErrorMessage(httpResponse.data);
-      performanceTool.logErrorWithCorrelationId(errorMessage);
+      monitoringTools.logErrorWithCorrelationIds(errorMessage);
     }
 
     return {

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
-const { logInfoWithCorrelationIds, logErrorWithCorrelationId } = require('../monitoring-tools');
+const { logInfoWithCorrelationIds, logErrorWithCorrelationIds } = require('../monitoring-tools');
 
 class HttpResponse {
   constructor({
@@ -41,7 +41,7 @@ module.exports = {
         data = httpErr.message;
       }
 
-      logErrorWithCorrelationId(`End POST request to ${url} error: ${code} ${data.toString()}`);
+      logErrorWithCorrelationIds(`End POST request to ${url} error: ${code} ${data.toString()}`);
 
       return new HttpResponse({
         code,

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
-const { logInfoWithCorrelationId, logErrorWithCorrelationId } = require('../../infrastructure/performance-tools');
+const { logInfoWithCorrelationId, logErrorWithCorrelationId } = require('../monitoring-tools');
 
 class HttpResponse {
   constructor({

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
-const { logInfoWithCorrelationId, logErrorWithCorrelationId } = require('../monitoring-tools');
+const { logInfoWithCorrelationIds, logErrorWithCorrelationId } = require('../monitoring-tools');
 
 class HttpResponse {
   constructor({
@@ -16,14 +16,14 @@ class HttpResponse {
 
 module.exports = {
   async post({ url, payload, headers }) {
-    logInfoWithCorrelationId(`Starting POST request to ${url}`);
+    logInfoWithCorrelationIds(`Starting POST request to ${url}`);
 
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
       });
 
-      logInfoWithCorrelationId(`End POST request to ${url} success: ${httpResponse.status}`);
+      logInfoWithCorrelationIds(`End POST request to ${url} success: ${httpResponse.status}`);
 
       return new HttpResponse({
         code: httpResponse.status,
@@ -51,13 +51,13 @@ module.exports = {
     }
   },
   async get({ url, payload, headers }) {
-    logInfoWithCorrelationId(`Starting GET request to ${url}`);
+    logInfoWithCorrelationIds(`Starting GET request to ${url}`);
 
     try {
       const config = { data: payload, headers };
       const httpResponse = await axios.get(url, config);
 
-      logInfoWithCorrelationId(`End GET request to ${url} success: ${httpResponse.status}`);
+      logInfoWithCorrelationIds(`End GET request to ${url} success: ${httpResponse.status}`);
 
       return new HttpResponse({
         code: httpResponse.status,
@@ -78,7 +78,7 @@ module.exports = {
         data = null;
       }
 
-      logInfoWithCorrelationId(`End GET request to ${url} error: ${code}`);
+      logInfoWithCorrelationIds(`End GET request to ${url} error: ${code}`);
 
       return new HttpResponse({
         code,

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -29,6 +29,7 @@ function logKnexQueriesWithCorrelationId(data, msg) {
 function logErrorWithCorrelationId(error) {
   const request = asyncLocalStorage.getStore();
   logger.error({
+    user_id: extractUserIdFromRequest(request),
     request_id: `${get(request, 'info.id', '-')}`,
     http: {
       method: get(request, 'method', '-'),
@@ -42,6 +43,7 @@ function logErrorWithCorrelationId(error) {
 function logInfoWithCorrelationId(message) {
   const request = asyncLocalStorage.getStore();
   logger.info({
+    user_id: extractUserIdFromRequest(request),
     request_id: `${get(request, 'info.id', '-')}`,
     http: {
       method: get(request, 'method', '-'),
@@ -62,9 +64,16 @@ function addPositionToQuerieAndIncrementQueriesCounter(knexQueryId) {
   }
 }
 
+function extractUserIdFromRequest(request) {
+  let userId = get(request, 'auth.credentials.userId');
+  if (!userId && get(request, 'headers.authorization')) userId = requestUtils.extractUserIdFromRequest(request);
+  return userId || '-';
+}
+
 module.exports = {
   asyncLocalStorage,
   addPositionToQuerieAndIncrementQueriesCounter,
+  extractUserIdFromRequest,
   logKnexQueriesWithCorrelationId,
   logErrorWithCorrelationId,
   logInfoWithCorrelationId,

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -1,29 +1,11 @@
 const { get } = require('lodash');
 const logger = require('../infrastructure/logger');
 const { logging } = require('../config');
+const requestUtils = require('../infrastructure/utils/request-response-utils');
 
 const { AsyncLocalStorage } = require('async_hooks');
 const asyncLocalStorage = new AsyncLocalStorage();
 
-function logKnexQueriesWithCorrelationId(data, msg) {
-  if (logging.enableLogKnexQueriesWithCorrelationId) {
-    const request = asyncLocalStorage.getStore();
-    const knexQueryId = data.__knexQueryUid;
-    logger.info({
-      request_id: `${get(request, 'info.id', '-')}`,
-      knex_query_id: knexQueryId,
-      knex_query_position: get(request, ['knexQueryPosition', knexQueryId ], '-'),
-      knex_query_sql: data.sql,
-      knex_query_params: [(data.bindings) ? data.bindings.join(',') : ''],
-      duration: get(data, 'duration', '-'),
-      http: {
-        method: get(request, 'method', '-'),
-        url_detail: {
-          path: get(request, 'path', '-'),
-        },
-      },
-    }, msg);
-  }
 function logInfoWithCorrelationIds(message) {
   const request = asyncLocalStorage.getStore();
   logger.info({
@@ -38,7 +20,7 @@ function logInfoWithCorrelationIds(message) {
   }, message);
 }
 
-function logErrorWithCorrelationId(error) {
+function logErrorWithCorrelationIds(error) {
   const request = asyncLocalStorage.getStore();
   logger.error({
     user_id: extractUserIdFromRequest(request),
@@ -94,6 +76,6 @@ module.exports = {
   addPositionToQuerieAndIncrementQueriesCounter,
   extractUserIdFromRequest,
   logKnexQueriesWithCorrelationId,
-  logErrorWithCorrelationId,
+  logErrorWithCorrelationIds,
   logInfoWithCorrelationIds,
 };

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -3,6 +3,16 @@ const settings = require('./config');
 const Blipp = require('blipp');
 const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
+const { asyncLocalStorage, extractUserIdFromRequest } = require('./infrastructure/monitoring-tools');
+
+function requestSerializer(req) {
+  const request = asyncLocalStorage.getStore();
+
+  return {
+    ...req,
+    user_id: extractUserIdFromRequest(request),
+  };
+}
 
 const plugins = [
   Inert,
@@ -23,6 +33,9 @@ const plugins = [
   {
     plugin: require('hapi-pino'),
     options: {
+      serializers: {
+        req: requestSerializer,
+      },
       instance: require('./infrastructure/logger'),
       logQueryParams: true,
     },

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -5,11 +5,10 @@ const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
 const { asyncLocalStorage, extractUserIdFromRequest } = require('./infrastructure/monitoring-tools');
 
-function requestSerializer(req) {
+function logObjectSerializer(obj) {
   const request = asyncLocalStorage.getStore();
-
   return {
-    ...req,
+    ...obj,
     user_id: extractUserIdFromRequest(request),
   };
 }
@@ -34,7 +33,8 @@ const plugins = [
     plugin: require('hapi-pino'),
     options: {
       serializers: {
-        req: requestSerializer,
+        req: logObjectSerializer,
+        err: logObjectSerializer,
       },
       instance: require('./infrastructure/logger'),
       logQueryParams: true,

--- a/api/server.js
+++ b/api/server.js
@@ -11,7 +11,7 @@ const swaggers = require('./lib/swaggers');
 const authentication = require('./lib/infrastructure/authentication');
 
 const { handleFailAction } = require('./lib/validate');
-const { asyncLocalStorage } = require('./lib/infrastructure/performance-tools');
+const { asyncLocalStorage } = require('./lib/infrastructure/monitoring-tools');
 
 const Request = require('@hapi/hapi/lib/request');
 const originalMethod = Request.prototype._execute;

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -12,7 +12,7 @@ const CampaignParticipationResultsShared = require('../../../../lib/domain/event
 const CampaignParticipationStarted = require('../../../../lib/domain/events/CampaignParticipationStarted');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
-const performanceTool = require('../../../../lib/infrastructure/performance-tools');
+const monitoringTools = require('../../../../lib/infrastructure/monitoring-tools');
 
 describe('Unit | Application | Controller | Campaign-Participation', function() {
 
@@ -35,7 +35,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function() 
     beforeEach(function() {
       sinon.stub(usecases, 'shareCampaignResult');
       sinon.stub(requestResponseUtils, 'extractUserIdFromRequest').returns(userId);
-      sinon.stub(performanceTool, 'logErrorWithCorrelationId');
+      sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
         return callback();
       });
@@ -83,7 +83,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function() 
 
       // then
       expect(events.eventDispatcher.dispatch).to.have.been.calledWith(campaignParticipationResultsSharedEvent);
-      expect(performanceTool.logErrorWithCorrelationId).to.have.been.calledWith(errorInHandler);
+      expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith(errorInHandler);
 
     });
 
@@ -115,7 +115,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function() 
       sinon.stub(usecases, 'startCampaignParticipation');
       sinon.stub(campaignParticipationSerializer, 'serialize');
       sinon.stub(events.eventDispatcher, 'dispatch');
-      sinon.stub(performanceTool, 'logErrorWithCorrelationId');
+      sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
       request = {
         headers: { authorization: 'token' },
         auth: { credentials: { userId } },
@@ -221,7 +221,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function() 
       const response = await campaignParticipationController.save(request, hFake);
 
       // then
-      expect(performanceTool.logErrorWithCorrelationId).to.have.been.calledWith(errorInHandler);
+      expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith(errorInHandler);
       expect(campaignParticipationSerializer.serialize).to.have.been.calledWith(campaignParticipation);
       expect(response.statusCode).to.equal(201);
       expect(response.source).to.deep.equal(serializedCampaignParticipation);

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -7,7 +7,7 @@ const AuthenticationMethod = require('../../../../../lib/domain/models/Authentic
 const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
 const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const authenticationMethodRepository = require('../../../../../lib/infrastructure/repositories/authentication-method-repository');
-const performanceTool = require('../../../../../lib/infrastructure/performance-tools');
+const monitoringTools = require('../../../../../lib/infrastructure/monitoring-tools');
 
 describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier', function() {
 
@@ -45,7 +45,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
       sinon.stub(httpAgent, 'post');
       sinon.stub(authenticationMethodRepository, 'findOneByUserIdAndIdentityProvider');
       sinon.stub(authenticationMethodRepository, 'updatePoleEmploiAuthenticationComplementByUserId');
-      sinon.stub(performanceTool, 'logErrorWithCorrelationId');
+      sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
 
       settings.poleEmploi.tokenUrl = 'someTokenUrlToPoleEmploi';
       settings.poleEmploi.sendingUrl = 'someSendingUrlToPoleEmploi';
@@ -216,7 +216,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
             payload: sinon.match.any,
           }).resolves(tokenResponse);
 
-          performanceTool.logErrorWithCorrelationId.resolves();
+          monitoringTools.logErrorWithCorrelationIds.resolves();
 
           const expectedLoggerMessage = `${errorData.error} ${errorData.error_description}`;
           const expectedResult = {
@@ -228,7 +228,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           const result = await notify(userId, payload, poleEmploiSending);
 
           // then
-          expect(performanceTool.logErrorWithCorrelationId).to.have.been.calledWith(expectedLoggerMessage);
+          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith(expectedLoggerMessage);
           expect(result).to.deep.equal(expectedResult);
         });
 
@@ -263,7 +263,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
               payload: sinon.match.any,
             }).resolves(httpResponse);
 
-          performanceTool.logErrorWithCorrelationId.resolves();
+          monitoringTools.logErrorWithCorrelationIds.resolves();
 
           const expectedLoggerMessage = httpResponse.data;
           const expectedResult = {
@@ -275,7 +275,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           const result = await notify(userId, payload, poleEmploiSending);
 
           // then
-          expect(performanceTool.logErrorWithCorrelationId).to.have.been.calledWith(expectedLoggerMessage);
+          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith(expectedLoggerMessage);
           expect(result).to.deep.equal(expectedResult);
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile aujourd'hui d'aider les utilisateurs Pix qui rencontrent des problèmes en production.
Pour trouver l'origine du problème, on dispose de l'erreur et la date ou le problème est survenue. Or, ces informations ne nous permettent pas d'identifier rapidement le problème compte tenue du nombre important de requêtes simultanées.

Voir l'expérience ici: https://1024pix.slack.com/archives/CVDB50C5T/p1629972969003900

## :robot: Solution
Injecter l'identifiant des utilisateurs dans les requêtes Hapi ( INFO et ERROR ) authentifiées ( ou non mais avec un access token envoyé comme même via le front ) afin de pouvoir les retrouver facilement via Datadog. 
On peut donc rapidement tracer les actions de l'utilisateur et corréler les erreurs le concernant.

Exemple ici : https://app.datadoghq.eu/logs?query=service%3Apix-api-review-pr3447%20%40req.user_id%3A199&cols=%40req.url%2C%40res.statusCode%2C%40responseTime%2C%40req.id&index=&from_ts=1628082546738&to_ts=1630674546738&live=true

## :rainbow: Remarques
La durée de rétention de log est de deux semaines, et aujourd'hui l'identifiant de l'utilisateur est déjà visible dans l'api users. 

## :100: Pour tester
Se connecter sur Pix-App:
Vérifier que pour les requêtes authentifiées, on a bien l'identifiant de l'utilisateur qui s'affiche dans les logs.

```
req: {
      "id": "1630662066037:MacBook-Pro-de-yahya.local:51299:kt45zqi5:10005",
      "method": "get",
      "url": "/api/users/1/campaign-participations",
     ...
      },
      "remoteAddress": "127.0.0.1",
      "remotePort": 57900,
      "user_id": 1
    }
```

Et en simulant une error au sein d'un appel authentifié: 

```
req: {
      "id": "1630669033320:MacBook-Pro-de-yahya.local:59252:kt4a8hqg:10004",
      "method": "get",
      "url": "/api/users/1/campaign-participations",
      "headers": {
       ....
      },
      "remoteAddress": "127.0.0.1",
      "remotePort": 64479,
      "user_id": "1"
    }
    err: {
      "isBoom": true,
      "isServer": true,
      "data": null,
      "output": {
        "statusCode": 500,
        "payload": {
          "statusCode": 500,
          "error": "Internal Server Error",
          "message": "An internal server error occurred"
        },
        "headers": {}
      },
      "user_id": 1
 }
```