### PR TITLE
[FEATURE] Nouveau message de sortie d'épreuve focus pour la certification (PIX-3069).

### DIFF
--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -35,7 +35,7 @@
       <div class="challenge-actions__focused-out-of-window" role="alert" aria-live="assertive">
         <FaIcon @icon="info-circle" class="challenge-actions-focused-out__icon"/>
         {{#if @isCertification}}
-          <span data-test="certification-focused-out-error-message">{{t 'pages.challenge.has-focused-out-of-window.certification'}}</span>
+          <span data-test="certification-focused-out-error-message">{{t 'pages.challenge.has-focused-out-of-window.certification' htmlSafe=true }}</span>
         {{else}}
           <span data-test="default-focused-out-error-message">{{t 'pages.challenge.has-focused-out-of-window.default' htmlSafe=true }}</span>
         {{/if}}

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -34,7 +34,11 @@
     {{#if @hasFocusedOutOfWindow}}
       <div class="challenge-actions__focused-out-of-window" role="alert" aria-live="assertive">
         <FaIcon @icon="info-circle" class="challenge-actions-focused-out__icon"/>
-        {{t 'pages.challenge.has-focused-out-of-window' htmlSafe=true }}
+        {{#if @isCertification}}
+          <span data-test="certification-focused-out-error-message">{{t 'pages.challenge.has-focused-out-of-window.certification'}}</span>
+        {{else}}
+          <span data-test="default-focused-out-error-message">{{t 'pages.challenge.has-focused-out-of-window.default' htmlSafe=true }}</span>
+        {{/if}}
       </div>
     {{/if}}
 

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -39,6 +39,7 @@
   {{#if @assessment}}
     <ChallengeActions @challenge={{@challenge}}
                       @answer={{@answer}}
+                      @isCertification={{@assessment.isCertification}}
                       @resumeAssessment={{this.resumeAssessment}}
                       @validateAnswer={{this.validateAnswer}}
                       @skipChallenge={{this.skipChallenge}}

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -39,6 +39,7 @@
   {{#if @assessment}}
     <ChallengeActions @challenge={{@challenge}}
                       @answer={{@answer}}
+                      @isCertification={{@assessment.isCertification}}
                       @resumeAssessment={{this.resumeAssessment}}
                       @validateAnswer={{this.validateAnswer}}
                       @skipChallenge={{this.skipChallenge}}

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -121,6 +121,7 @@
   {{#if @assessment}}
     <ChallengeActions @challenge={{@challenge}}
                       @answer={{@answer}}
+                      @isCertification={{@assessment.isCertification}}
                       @resumeAssessment={{this.resumeAssessment}}
                       @isDisabled={{this.isAnswerFieldDisabled}}
                       @validateAnswer={{this.validateAnswer}}

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -40,6 +40,7 @@
   {{#if @assessment}}
     <ChallengeActions @challenge={{@challenge}}
                       @answer={{@answer}}
+                      @isCertification={{@assessment.isCertification}}
                       @resumeAssessment={{this.resumeAssessment}}
                       @validateAnswer={{this.validateAnswer}}
                       @skipChallenge={{this.skipChallenge}}

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -179,6 +179,62 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           expect(find('.challenge-actions__already-answered')).to.exist;
         });
       });
+
+      describe('when user has focused out of the window', function() {
+
+        beforeEach(async function() {
+          // given
+          const user = server.create('user', 'withEmail', {
+            hasSeenFocusedChallengeTooltip: true,
+          });
+          await authenticateByEmail(user);
+        });
+
+        describe('when assessment is of type certification', function() {
+
+          it('should display the certification warning alert', async function() {
+            // given
+            assessment = server.create('assessment', 'ofCertificationType');
+            server.create('challenge', 'forCertification', data.challengeType, 'withFocused');
+
+            const certificationCourse = server.create('certification-course', {
+              accessCode: 'ABCD12',
+              sessionId: 1,
+              nbChallenges: 1,
+              firstName: 'Laura',
+              lastName: 'Bravo',
+            });
+            assessment = certificationCourse.assessment;
+
+            await visit(`/assessments/${assessment.id}/challenges/0`);
+
+            // when
+            await triggerEvent(window, 'blur');
+
+            // then
+            expect(find('[data-test="certification-focused-out-error-message"]')).to.exist;
+            expect(find('[data-test="default-focused-out-error-message"]')).not.to.exist;
+          });
+        });
+
+        describe('when assessment is not of type certification', function() {
+
+          it('should display the default warning alert', async function() {
+            // given
+            assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+            server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+
+            await visit(`/assessments/${assessment.id}/challenges/0`);
+
+            // when
+            await triggerEvent(window, 'blur');
+
+            // then
+            expect(find('[data-test="default-focused-out-error-message"]')).to.exist;
+            expect(find('[data-test="certification-focused-out-error-message"]')).not.to.exist;
+          });
+        });
+      });
     });
 
     describe(`when ${data.challengeType} challenge is not focused`, function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -451,7 +451,10 @@
           "subtitle": "If you switch pages or tabs during a certification test, you answer will not be validated."
         }
       },
-      "has-focused-out-of-window": "We have detected a page/tab switch.'<br>'During a certification test, your answer would not be validated.",
+      "has-focused-out-of-window": {
+        "certification": "We have detected a page/tab switch. Your answer will not be validated.",
+        "default": "We have detected a page/tab switch.'<br>'During a certification test, your answer would not be validated."
+      },
       "parts": {
         "answer-input": "Your answer",
         "feedback": "Report a problem",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -452,8 +452,8 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "We have detected a page/tab switch. Your answer will not be validated.",
-        "default": "We have detected a page/tab switch.'<br>'During a certification test, your answer would not be validated."
+        "certification": "We have detected a page switch.'<br>'Your answer will not be validated.",
+        "default": "We have detected a page switch.'<br>'During a certification test, your answer would not be validated."
       },
       "parts": {
         "answer-input": "Your answer",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -452,8 +452,8 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "Nous avons détecté un changement de page/d'onglet. Votre réponse sera comptée comme fausse.",
-        "default": "Nous avons détecté un changement de page/d'onglet.'<br>'En certification, votre réponse ne serait pas validée."
+        "certification": "Nous avons détecté un changement de page.'<br>'Votre réponse sera comptée comme fausse.",
+        "default": "Nous avons détecté un changement de page.'<br>'En certification, votre réponse ne serait pas validée."
       },
       "parts": {
         "answer-input": "Votre réponse",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -451,7 +451,10 @@
           "subtitle": "En certification, si vous changez de page, votre réponse ne sera pas validée."
         }
       },
-      "has-focused-out-of-window": "Nous avons détecté un changement de page/d'onglet.'<br>'En certification, votre réponse ne serait pas validée.",
+      "has-focused-out-of-window": {
+        "certification": "Nous avons détecté un changement de page/d'onglet. Votre réponse sera comptée comme fausse.",
+        "default": "Nous avons détecté un changement de page/d'onglet.'<br>'En certification, votre réponse ne serait pas validée."
+      },
       "parts": {
         "answer-input": "Votre réponse",
         "feedback": "Signaler un problème",


### PR DESCRIPTION
## :unicorn: Problème

Le message de sortie d'épreuve focus actuel n'est pas valable pour les épreuves passées en certification.

## :robot: Solution

Ajout d'un nouveau message dédié pour la certification.

<img width="1087" alt="Capture d’écran 2021-09-03 à 15 10 44" src="https://user-images.githubusercontent.com/36371437/132010506-d52ab8ff-8a7e-47ff-855d-121b63e13345.png">

## :rainbow: Remarques
N/A

## :100: Pour tester

Pour la certification : 
- Obtenir un profil certifiable en ayant joué des épreuves focus
- Créer une session de certification
- Jouer la certification
- Vérifier que le message de sortie d'épreuve focus diffère de celui affiché en positionnement

