### PR TITLE
[FEATURE] Modification des messages sur les épreuves focus (PIX-3148).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -30,7 +30,6 @@
   margin: 6px;
   display: flex;
   justify-content: center;
-  align-items: flex-end;
   flex-direction: column;
 
   @include device-is('tablet') {

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -34,7 +34,7 @@
     {{#if @hasFocusedOutOfWindow}}
       <div class="challenge-actions__focused-out-of-window" role="alert" aria-live="assertive">
         <FaIcon @icon="info-circle" class="challenge-actions-focused-out__icon"/>
-        {{t 'pages.challenge.has-focused-out-of-window'}}
+        {{t 'pages.challenge.has-focused-out-of-window' htmlSafe=true }}
       </div>
     {{/if}}
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -447,7 +447,7 @@
       },
       "is-focused-challenge": {
         "info-alert": {
-          "title": "Answer this question without searching the internet or using your own tools.",
+          "title": "Answer this question without searching the internet or using any piece of software.",
           "subtitle": "If you switch pages or tabs during a certification test, you answer will not be validated."
         }
       },
@@ -490,7 +490,7 @@
         "tooltip": {
           "aria-label": "Show question's warning",
           "close": "Ok, got it",
-          "focused": "Stay on this page! To answer this question, you should neither search the internet, nor use your own tools.",
+          "focused": "Stay on this page! To answer this question, you should neither search the internet, nor use any piece of software.",
           "regular": ""
         }
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -451,7 +451,7 @@
           "subtitle": "If you switch pages or tabs during a certification test, you answer will not be validated."
         }
       },
-      "has-focused-out-of-window": "We have detected a page/tab switch. During a certification test, your answer would not be validated.",
+      "has-focused-out-of-window": "We have detected a page/tab switch.'<br>'During a certification test, your answer would not be validated.",
       "parts": {
         "answer-input": "Your answer",
         "feedback": "Report a problem",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -447,7 +447,7 @@
       },
       "is-focused-challenge": {
         "info-alert": {
-          "title": "Répondez à cette question sans chercher sur internet ni utiliser vos propres outils.",
+          "title": "Répondez à cette question sans chercher sur internet ni utiliser de logiciels.",
           "subtitle": "En certification, si vous changez de page, votre réponse ne sera pas validée."
         }
       },
@@ -490,7 +490,7 @@
         "tooltip": {
           "aria-label": "Afficher l'indication sur l'épreuve.",
           "close": "J'ai compris",
-          "focused": "Restez sur cette page ! Vous ne devez pas faire une recherche sur internet ni utiliser vos propres outils pour répondre à cette question.",
+          "focused": "Restez sur cette page ! Vous ne devez pas faire une recherche sur internet ni utiliser de logiciels pour répondre à cette question.",
           "regular": "<p>Question libre :</p>Vous pouvez vous aider d'internet et d'applications externes."
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -451,7 +451,7 @@
           "subtitle": "En certification, si vous changez de page, votre réponse ne sera pas validée."
         }
       },
-      "has-focused-out-of-window": "Nous avons détecté un changement de page/d'onglet. En certification, votre réponse ne serait pas validée.",
+      "has-focused-out-of-window": "Nous avons détecté un changement de page/d'onglet.'<br>'En certification, votre réponse ne serait pas validée.",
       "parts": {
         "answer-input": "Votre réponse",
         "feedback": "Signaler un problème",


### PR DESCRIPTION
## :unicorn: Problème

Les messages visibles sur les épreuves focus doivent être modifiés : 

- Remplacement de texte sur la tooltip et l'alerte de sortie de champ de réponse
- Ajout d'un saut de ligne sur le message de sortie de fenêtre

## :robot: Solution
N/A

## :rainbow: Remarques

La modification concernant le passage à la ligne sur le message de sortie de fenêtre ne prend pas en compte le nouveau message disponible pour la certification et ajouté dans #3450 . Des modifications devront être apportées en fonction de l'ordre de merge de ces PR.

## :100: Pour tester

Aller sur une épreuve focus (ex: `rec6PW03oyqtPZ9rK`) et constater des modifications.
