### PR TITLE
[FEATURE][A11Y] Utiliser des balises HTML sémantiques dans la page "Analyse" de Pix Orga (PIX-3058).

### DIFF
--- a/orga/app/components/campaign/analysis/competences.hbs
+++ b/orga/app/components/campaign/analysis/competences.hbs
@@ -1,33 +1,34 @@
-<h4 class="campaign-details-analysis campaign-details-analysis__header">
-  {{t 'pages.campaign-review.table.competences.title'}}
-</h4>
-
-<table
-  class="panel panel--light-shadow competences-analysis__table content-text content-text--small"
-  aria-label={{t 'pages.campaign-review.table.competences.title'}}
->
-  <thead>
-  <tr>
-    <th class="table__column--wide">{{this.campaignCollectiveResultLabel}}</th>
-    <th class="table__column--wide">{{t 'pages.campaign-review.table.competences.column.results.label'}}</th>
-  </tr>
-  </thead>
-    <tbody>
-    {{#each @campaignCollectiveResult.campaignCompetenceCollectiveResults as |competenceResult|}}
-      <tr aria-label={{t 'pages.campaign-review.table.competences.row-title'}}>
-        <td class="competences-col__name">
-          <span class="competences-col__border competences-col__border--{{competenceResult.areaColor}}"></span>
-          <span>
-            {{competenceResult.competenceName}}
-          </span>
-        </td>
-        <td class="competences-col__gauge">
-          <PixProgressGauge
-            @value={{competenceResult.validatedSkillsPercentage}}
-            @tooltipText={{t 'pages.campaign-review.table.competences.column.results.tooltip' result=competenceResult.validatedSkillsPercentage competence=competenceResult.competenceName htmlSafe=true}}
-          />
-        </td>
-      </tr>
-    {{/each}}
-    </tbody>
-</table>
+<section class="competences-section">
+  <h3 class="campaign-details-analysis campaign-details-analysis__header">
+    {{t 'pages.campaign-review.table.competences.title'}}
+  </h3>
+  <table
+    class="panel panel--light-shadow competences-analysis__table content-text content-text--small"
+    aria-label={{t 'pages.campaign-review.table.competences.title'}}
+  >
+    <thead>
+    <tr>
+      <Table::Header @size="wide" >{{this.campaignCollectiveResultLabel}}</Table::Header>
+      <Table::Header @size="wide" >{{t 'pages.campaign-review.table.competences.column.results.label'}}</Table::Header>
+    </tr>
+    </thead>
+      <tbody>
+      {{#each @campaignCollectiveResult.campaignCompetenceCollectiveResults as |competenceResult|}}
+        <tr aria-label={{t 'pages.campaign-review.table.competences.row-title'}}>
+          <td class="competences-col__name">
+            <span class="competences-col__border competences-col__border--{{competenceResult.areaColor}}"></span>
+            <span>
+              {{competenceResult.competenceName}}
+            </span>
+          </td>
+          <td class="competences-col__gauge">
+            <PixProgressGauge
+              @value={{competenceResult.validatedSkillsPercentage}}
+              @tooltipText={{t 'pages.campaign-review.table.competences.column.results.tooltip' result=competenceResult.validatedSkillsPercentage competence=competenceResult.competenceName htmlSafe=true}}
+            />
+          </td>
+        </tr>
+      {{/each}}
+      </tbody>
+  </table>
+</section>

--- a/orga/app/components/campaign/analysis/recommendations.hbs
+++ b/orga/app/components/campaign/analysis/recommendations.hbs
@@ -17,7 +17,7 @@
         >
           {{t 'pages.campaign-review.table.analysis.column.relevance'}}
         </Table::HeaderSort>
-        <Table::Header @size="small" @align="center" />
+        <Table::Header @size="small" @align="center" aria-label="{{t 'pages.campaign-review.table.analysis.column.tutorial-count.aria-label'}}"/>
         <Table::Header @size="small" />
       </tr>
     </thead>

--- a/orga/app/components/campaign/analysis/recommendations.hbs
+++ b/orga/app/components/campaign/analysis/recommendations.hbs
@@ -1,12 +1,10 @@
-<h4 class="campaign-details-analysis campaign-details-analysis__header">{{t 'pages.campaign-review.sub-title'}}</h4>
+<section class="campaign-details-analysis-section">
+  <h3 class="campaign-details-analysis campaign-details-analysis__header">{{t 'pages.campaign-review.sub-title'}}</h3>
+  <p class="campaign-details-analysis campaign-details-analysis__text">
+    {{this.description}}
+  </p>
 
-<p class="campaign-details-analysis campaign-details-analysis__text">
-  {{this.description}}
-</p>
-
-<div class="panel panel--light-shadow content-text content-text--small campaign-details-analysis__table">
-
-  <table aria-label={{t 'pages.campaign-review.table.analysis.title'}}>
+  <table class="panel panel--light-shadow content-text content-text--small campaign-details-analysis__table" aria-label={{t 'pages.campaign-review.table.analysis.title'}}>
     <thead>
       <tr>
         <Table::Header @size="wide">{{t 'pages.campaign-review.table.analysis.column.subjects' count=this.sortedRecommendations.length}}</Table::Header>
@@ -35,4 +33,4 @@
   {{#unless @displayAnalysis}}
     <div class="table__empty content-text">{{t 'pages.campaign-review.table.empty'}}</div>
   {{/unless}}
-</div>
+</section>

--- a/orga/app/styles/components/campaign/analysis/recommendations.scss
+++ b/orga/app/styles/components/campaign/analysis/recommendations.scss
@@ -22,3 +22,7 @@
     margin-bottom: 20px;
   }
 }
+
+.campaign-details-analysis-section{
+  padding: 0;
+}

--- a/orga/app/styles/components/campaign/analysis/tube-recommendation-row.scss
+++ b/orga/app/styles/components/campaign/analysis/tube-recommendation-row.scss
@@ -15,7 +15,7 @@
   font-family: $open-sans;
   font-weight: 400;
   font-size: 0.75rem;
-  color: $grey-35;
+  color: $grey-50;
 
   &--open {
     color: $grey-60;

--- a/orga/app/styles/globals/competences.scss
+++ b/orga/app/styles/globals/competences.scss
@@ -75,3 +75,7 @@
     }
   }
 }
+
+.competences-section {
+  padding: 0;
+}

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
@@ -1,6 +1,7 @@
 {{page-title (t 'pages.campaign-review.title')}}
 
 {{#if @model.hasSharedParticipations}}
+  <h2 class="sr-only">{{t 'pages.campaign-review.title'}}</h2>
   <Campaign::Analysis::Recommendations
     @campaignTubeRecommendations={{@model.campaignAnalysis.campaignTubeRecommendations}}
     @displayAnalysis={{@model.hasSharedParticipations}}

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -208,7 +208,7 @@
       },
       "archived": "Archived campaign",
       "code": "Code",
-      "copy" : {
+      "copy": {
         "code": {
           "success": "Copied!",
           "default": "Copy code"
@@ -347,7 +347,7 @@
       "tested-items": "Items assessed",
       "title": "Results",
       "validated-items": "Items successfully completed"
-     },
+    },
     "campaign-review": {
       "title": "Review",
       "description": "According to the target profile selected and the results of your campaign, Pix recommends focusing on the following topics, sorted by relevance ({bubble}).",
@@ -371,6 +371,7 @@
               "aria-label": "Show all tutorials"
             },
             "tutorial-count": {
+              "aria-label": "Number of recommended tutorials",
               "value": "{count, plural, =1 {1 tutorial} other {{count} tutorials}}"
             }
           },
@@ -437,7 +438,6 @@
       "documentation-link-notice": "Follow this link to find indications on how to interpret the results: ",
       "download-button": "Export the results",
       "download-attestations-button": "Download attestations",
-
       "errors": {
         "invalid-division": "The class {selectedDivision} does not exist.",
         "no-results": "No certification results for the class {selectedDivision}.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -179,7 +179,7 @@
       "title": "Résultats de {firstName} {lastName}",
       "badges": "Résultats Thématiques",
       "progression": "Avancement",
-      "result":  "Résultat",
+      "result": "Résultat",
       "stages": {
         "label": "Paliers",
         "value": "{count} étoiles sur {total}"
@@ -208,7 +208,7 @@
       },
       "archived": "Campagne archivée",
       "code": "Code",
-      "copy" : {
+      "copy": {
         "code": {
           "success": "Copié !",
           "default": "Copier le code"
@@ -371,6 +371,7 @@
               "aria-label": "Afficher la liste des tutos"
             },
             "tutorial-count": {
+              "aria-label": "Nombre de tutoriels recommandés",
               "value": "{count, plural, =1 {1 tuto} other {{count} tutos}}"
             }
           },


### PR DESCRIPTION
## :unicorn: Problème
Les balises sémantiques HTML ne sont pas correctement utilisés dans pix Orga, Cela pose un problème au niveau d’accessibilité pour la plate-forme 

## :robot: Solution
Revoir la sémantique, les balises, rendre accessible la page Analyse.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur Pix Orga et vérifier que tout s'affiche correctement
