### PR TITLE
[FEATURE] Réutiliser le champ résultat pour la page "profil déjà envoyé" sur Pix App (PIX-3124).

### DIFF
--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -16,6 +16,7 @@ class CampaignParticipation {
     campaignId,
     userId,
     validatedSkillsCount,
+    pixScore,
   } = {}) {
     this.id = id;
     this.createdAt = createdAt;
@@ -29,6 +30,7 @@ class CampaignParticipation {
     this.campaignId = campaignId;
     this.userId = userId;
     this.validatedSkillsCount = validatedSkillsCount;
+    this.pixScore = pixScore;
   }
 
   getTargetProfileId() {

--- a/api/lib/domain/models/SharedProfileForCampaign.js
+++ b/api/lib/domain/models/SharedProfileForCampaign.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const moment = require('moment');
 const constants = require('../constants');
 
@@ -6,6 +5,7 @@ class SharedProfileForCampaign {
   constructor({
     id,
     sharedAt,
+    pixScore,
     campaignAllowsRetry,
     isRegistrationActive,
     scorecards = [],
@@ -13,7 +13,7 @@ class SharedProfileForCampaign {
     this.id = id;
     this.sharedAt = sharedAt;
     this.scorecards = scorecards;
-    this.pixScore = _.sumBy(this.scorecards, 'earnedPix') || 0;
+    this.pixScore = pixScore || 0;
     this.canRetry = this._computeCanRetry(campaignAllowsRetry, sharedAt, isRegistrationActive);
   }
 

--- a/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
+++ b/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
@@ -41,6 +41,7 @@ module.exports = async function getUserProfileSharedForCampaign({
   return new SharedProfileForCampaign({
     id: campaignParticipation.id,
     sharedAt: campaignParticipation.sharedAt,
+    pixScore: campaignParticipation.pixScore,
     campaignAllowsRetry,
     isRegistrationActive,
     scorecards,

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -8,6 +8,7 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
   const createdAt = new Date('2019-01-01');
   const createdAfterAt = new Date('2019-01-03');
   const sharedAt = new Date('2019-01-02');
+  const pixScore = 2;
 
   let campaignParticipation;
   let options;
@@ -43,7 +44,7 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
       databaseBuilder.factory.buildUser({ id: userId });
 
       const campaign = databaseBuilder.factory.buildCampaign();
-      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isShared: true, sharedAt });
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isShared: true, sharedAt, pixScore });
 
       const knowledgeElements = [
         { skillId: 'url1', status: 'validated', source: 'direct', competenceId, earnedPix: 2, createdAt, userId },

--- a/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
@@ -12,7 +12,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function() {
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line mocha/no-setup-in-describe
   const campaignId = Symbol('campaign id');
-  const expectedCampaignParticipation = { id: '1', sharedAt };
+  const expectedCampaignParticipation = { id: '1', sharedAt, pixScore: 15 };
   const locale = 'fr';
 
   let campaignParticipationRepository;


### PR DESCRIPTION
## :unicorn: Problème
Le score pix est recalculé à partir des score par compétences à chaque appel.

## :robot: Solution
On utilise le score stocké au niveau de la participation à la campagne qui est calculé au moment du partage.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter avec un compte utilisateur sur Pix App.
Utiliser le code d'un campagne de collecte de profils.
Partager votre profil.
Recharger la page et constater que le score pix est toujours présent.