### PR TITLE
[FEATURE][A11Y] Utiliser des balises HTML sémantiques dans la page "Résultats" et "Résultat individuel" de Pix Orga (PIX-3057).

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -50,7 +50,7 @@ When(`je vois {int} résultats par compétence`, (numberOfResultsByCompetence) =
   if(numberOfResultsByCompetence === 0) {
     cy.get('.table__empty').should('contain', 'En attente de résultat');
   } else {
-    cy.get('[aria-label="Résultats par compétence"]').should('have.lengthOf', numberOfResultsByCompetence);
+    cy.get('[aria-label="Compétence"]').should('have.lengthOf', numberOfResultsByCompetence);
   }
 });
 

--- a/orga/app/components/campaign/charts/participants-by-stage-bar.hbs
+++ b/orga/app/components/campaign/charts/participants-by-stage-bar.hbs
@@ -1,5 +1,5 @@
 <div class="participants-by-stage__graph" role="button" {{on "click" (fn @onClickBar @stageId)}} ...attributes>
-  <div class="participants-by-stage__bar" style={{@barWidth}} />
+  <div class="participants-by-stage__bar" style={{@barWidth}} aria-hidden="true" />
   <div class="participants-by-stage__percentage">
     {{yield}}
   </div>

--- a/orga/app/components/campaign/charts/participants-by-stage.hbs
+++ b/orga/app/components/campaign/charts/participants-by-stage.hbs
@@ -2,13 +2,15 @@
   {{#if this.loading}}
     <Campaign::Charts::ParticipantsByStageLoader />
   {{else}}
+    <ul class="participants-by-stage__wrapper">
     {{#each this.data as |stage index|}}
-      <div class="participants-by-stage">
+      <li class="participants-by-stage">
         <PixStars
           @count={{stage.index}}
           @total={{this.totalStage}}
           @color="blue"
           class="participants-by-stage__stars"
+          aria-hidden="true"
         />
         <div class="participants-by-stage__values">
           {{t 'charts.participants-by-stage.participants' count=stage.value}}
@@ -38,7 +40,8 @@
             </Campaign::Charts::ParticipantsByStageBar>
           </div>
         {{/if}}
-      </div>
+      </li>
     {{/each}}
+    </ul>
   {{/if}}
 </Ui::ChartCard>

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -1,17 +1,19 @@
-<Campaign::Filter::ParticipationFilters
-  @campaign={{@campaign}}
-  @selectedDivisions={{@selectedDivisions}}
-  @selectedBadges={{@selectedBadges}}
-  @selectedStages={{@selectedStages}}
-  @rowCount={{@participations.meta.rowCount}}
+<section ...attributes>
+  <h3 class="sr-only">{{t 'pages.campaign-results.table.title'}}</h3>
 
-  @onResetFilter={{@onResetFilter}}
-  @onFilter={{@onFilter}}
-/>
+  <Campaign::Filter::ParticipationFilters
+    @campaign={{@campaign}}
+    @selectedDivisions={{@selectedDivisions}}
+    @selectedBadges={{@selectedBadges}}
+    @selectedStages={{@selectedStages}}
+    @rowCount={{@participations.meta.rowCount}}
 
-<div class="panel">
-  <div class="table content-text content-text--small">
-    <table>
+    @onResetFilter={{@onResetFilter}}
+    @onFilter={{@onFilter}}
+  />
+
+  <div class="panel">
+    <table class="table content-text content-text--small">
       <thead>
         <tr>
           <th>{{t 'pages.campaign-results.table.column.last-name'}}</th>
@@ -41,20 +43,20 @@
             {{#if @campaign.idPixLabel}}
               <td>{{participation.participantExternalId}}</td>
             {{/if}}
-            <td>
-              {{#if @campaign.hasStages}}
+            {{#if @campaign.hasStages}}
+              <td>
                 <Campaign::StageStars
                   @result={{multiply participation.masteryPercentage 100}}
                   @stages={{@campaign.stages}}
                   @withTooltip={{true}}
                   @tooltipPosition="bottom-left"
                 />
-              {{else}}
-                <span class="participant-list__mastery-percentage">
-                  {{t 'pages.campaign-results.table.column.results.value' percentage=participation.masteryPercentage}}
-                </span>
-              {{/if}}
-            </td>
+              </td>
+            {{else}}
+              <td class="participant-list__mastery-percentage">
+                {{t 'pages.campaign-results.table.column.results.value' percentage=participation.masteryPercentage}}
+              </td>
+            {{/if}}
             {{#if @campaign.hasBadges}}
               <td class="participant-list__badges">
                 <Campaign::Badges @badges={{participation.badges}} />
@@ -67,11 +69,11 @@
     </table>
 
     {{#unless @participations}}
-      <div class="table__empty content-text">{{t 'pages.campaign-results.table.empty'}}</div>
+      <p class="table__empty content-text">{{t 'pages.campaign-results.table.empty'}}</p>
     {{/unless}}
   </div>
-</div>
 
-{{#if @participations}}
-  <Table::PaginationControl @pagination={{@participations.meta}}/>
-{{/if}}
+  {{#if @participations}}
+    <Table::PaginationControl @pagination={{@participations.meta}}/>
+  {{/if}}
+</section>

--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -1,14 +1,16 @@
-<Campaign::Filter::ParticipationFilters
-  @campaign={{@campaign}}
-  @selectedDivisions={{@selectedDivisions}}
-  @rowCount={{@profiles.meta.rowCount}}
-  @onFilter={{@onFilter}}
-  @onReset={{@onReset}}
-/>
+<section ...attributes>
+  <h3 class="sr-only">{{t 'pages.profiles-list.table.title'}}</h3>
 
-<div class="panel">
-  <div class="table content-text content-text--small">
-    <table>
+  <Campaign::Filter::ParticipationFilters
+    @campaign={{@campaign}}
+    @selectedDivisions={{@selectedDivisions}}
+    @rowCount={{@profiles.meta.rowCount}}
+    @onFilter={{@onFilter}}
+    @onReset={{@onReset}}
+  />
+
+  <div class="panel">
+    <table class="table content-text content-text--small">
       <thead>
         <tr>
           <th>{{t 'pages.profiles-list.table.column.last-name'}}</th>
@@ -67,11 +69,12 @@
     </table>
 
     {{#unless @profiles}}
-      <div class="table__empty content-text">{{t 'pages.profiles-list.table.empty'}}</div>
+      <p class="table__empty content-text">{{t 'pages.profiles-list.table.empty'}}</p>
     {{/unless}}
   </div>
-</div>
 
-{{#if (gt @profiles.length 0)}}
-  <Table::PaginationControl @pagination={{@profiles.meta}}/>
-{{/if}}
+  {{#if (gt @profiles.length 0)}}
+    <Table::PaginationControl @pagination={{@profiles.meta}}/>
+  {{/if}}
+
+</section>

--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -15,36 +15,36 @@
   </header>
 
   <div class="panel-header__body">
-    <ul class="panel-header__data">
+    <dl class="panel-header__data">
       {{#if @participation.participantExternalId}}
-        <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">{{@campaign.idPixLabel}}</div>
-          <div class="value-text panel-header-data-content__value">{{@participation.participantExternalId}}</div>
-        </li>
-      {{/if}}
-      <li class="panel-header-data__content">
-        <div class="label-text panel-header-data-content__label">{{t 'pages.campaign-individual-results.start-date'}}</div>
-        <div class="value-text panel-header-data-content__value">
-          {{moment-format @participation.createdAt 'DD MMM YYYY'}}
+        <div class="panel-header-data__content">
+          <dt class="label-text panel-header-data-content__label">{{@campaign.idPixLabel}}</dt>
+          <dd class="value-text panel-header-data-content__value">{{@participation.participantExternalId}}</dd>
         </div>
-      </li>
+      {{/if}}
+      <div class="panel-header-data__content">
+        <dt class="label-text panel-header-data-content__label">{{t 'pages.campaign-individual-results.start-date'}}</dt>
+        <dd class="value-text panel-header-data-content__value">
+          {{moment-format @participation.createdAt 'DD MMM YYYY'}}
+        </dd>
+      </div>
       {{#unless @participation.isShared }}
-        <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">{{t 'pages.assessment-individual-results.progression'}}</div>
-          <div class="value-text panel-header-data-content__value">
+        <div class="panel-header-data__content">
+          <dt class="label-text panel-header-data-content__label">{{t 'pages.assessment-individual-results.progression'}}</dt>
+          <dd class="value-text panel-header-data-content__value">
             {{t 'common.percentage' value=@participation.progression}}
-          </div>
-        </li>
+          </dd>
+        </div>
       {{/unless}}
       {{#if @participation.isShared }}
-        <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">{{t 'pages.campaign-individual-results.shared-date'}}</div>
-            <div class="value-text panel-header-data-content__value">
-              {{moment-format @participation.sharedAt 'DD MMM YYYY'}}
-            </div>
-        </li>
+        <div class="panel-header-data__content">
+          <dt class="label-text panel-header-data-content__label">{{t 'pages.campaign-individual-results.shared-date'}}</dt>
+          <dd class="value-text panel-header-data-content__value">
+            {{moment-format @participation.sharedAt 'DD MMM YYYY'}}
+          </dd>
+        </div>
       {{/if}}
-    </ul>
+    </dl>
 
     {{#if @participation.isShared}}
       <ul class="panel-header__data panel-header__data--highlight">

--- a/orga/app/components/participant/assessment/results.hbs
+++ b/orga/app/components/participant/assessment/results.hbs
@@ -1,5 +1,7 @@
-<div class="panel panel--light-shadow participant-results__details content-text content-text--small">
-  <table>
+<section class="panel panel--light-shadow participant-results__details">
+  <h3 class="sr-only">{{t 'pages.assessment-individual-results.table.title'}}</h3>
+
+  <table class="content-text content-text--small">
     <thead>
     <tr>
       <th class="table__column--wide">{{t 'pages.assessment-individual-results.table.column.competences' count=@results.sortedCompetenceResults.length}}</th>
@@ -10,7 +12,7 @@
     {{#if @displayResults}}
       <tbody>
       {{#each @results.sortedCompetenceResults as |competenceResult|}}
-        <tr aria-label={{t 'pages.assessment-individual-results.table.title'}}>
+        <tr aria-label={{t 'pages.assessment-individual-results.table.row-title'}}>
           <td class="competences-col__name">
             <span class="competences-col__border competences-col__border--{{competenceResult.areaColor}}"></span>
             <span>
@@ -30,6 +32,6 @@
   </table>
 
   {{#unless @displayResults}}
-    <div class="table__empty content-text">{{t 'pages.assessment-individual-results.table.empty'}}</div>
+    <p class="table__empty content-text">{{t 'pages.assessment-individual-results.table.empty'}}</p>
   {{/unless}}
-</div>
+</section>

--- a/orga/app/components/participant/profile/header.hbs
+++ b/orga/app/components/participant/profile/header.hbs
@@ -22,28 +22,28 @@
   </header>
 
   <div class="panel-header__body">
-    <ul class="panel-header__data">
+    <dl class="panel-header__data">
       {{#if @campaignProfile.externalId}}
-        <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">{{@campaign.idPixLabel}}</div>
-          <div class="value-text panel-header-data-content__value">{{@campaignProfile.externalId}}</div>
-        </li>
-      {{/if}}
-      <li class="panel-header-data__content">
-        <div class="label-text panel-header-data-content__label">
-          {{t "pages.campaign-individual-results.start-date"}}
+        <div class="panel-header-data__content">
+          <dt class="label-text panel-header-data-content__label">{{@campaign.idPixLabel}}</dt>
+          <dd class="value-text panel-header-data-content__value">{{@campaignProfile.externalId}}</dd>
         </div>
-        <div class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.createdAt 'DD MMM YYYY'}}</div>
-      </li>
-      {{#if @campaignProfile.isShared}}
-        <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">
-            {{t "pages.campaign-individual-results.shared-date"}}
-          </div>
-            <div class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.sharedAt 'DD MMM YYYY'}}</div>
-        </li>
       {{/if}}
-    </ul>
+      <div class="panel-header-data__content">
+        <dt class="label-text panel-header-data-content__label">
+          {{t "pages.campaign-individual-results.start-date"}}
+        </dt>
+        <dd class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.createdAt 'DD MMM YYYY'}}</dd>
+      </div>
+      {{#if @campaignProfile.isShared}}
+        <div class="panel-header-data__content">
+          <dt class="label-text panel-header-data-content__label">
+            {{t "pages.campaign-individual-results.shared-date"}}
+          </dt>
+            <dd class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.sharedAt 'DD MMM YYYY'}}</dd>
+        </div>
+      {{/if}}
+    </dl>
 
     {{#if @campaignProfile.isShared}}
       <ul class="panel-header__data panel-header__data--highlight">

--- a/orga/app/components/participant/profile/table.hbs
+++ b/orga/app/components/participant/profile/table.hbs
@@ -1,4 +1,5 @@
 <section class="profile-competences panel">
+  <h3 class="sr-only">{{t "pages.profiles-individual-results.table.title"}}</h3>
   <table>
     <thead>
       <tr>
@@ -33,9 +34,9 @@
     </tbody>
   </table>
 
-  {{#unless @isShared }}
-    <div class="table__empty content-text">
+  {{#unless @isShared}}
+    <p class="table__empty content-text">
       {{t "pages.profiles-individual-results.table.empty"}}
-    </div>
+    </p>
   {{/unless}}
 </section>

--- a/orga/app/components/ui/pix-loader.hbs
+++ b/orga/app/components/ui/pix-loader.hbs
@@ -1,8 +1,6 @@
 <div class="app-loader">
-    <p class="app-loader__image">
-      <img src="/images/interwind.gif" alt="" role="presentation">
-    </p>
-    <p class="app-loader__text">
-      {{t "common.loading"}}
-    </p>
+  <img src="/images/interwind.gif" alt="" role="presentation">
+  <p class="app-loader__text">
+    {{t "common.loading"}}
+  </p>
 </div>

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -53,6 +53,7 @@
 @import "pages/authenticated/campaigns/details/activity";
 @import "pages/authenticated/campaigns/details/analysis";
 @import "pages/authenticated/campaigns/details/assessment-results";
+@import "pages/authenticated/campaigns/details/profile-results";
 @import "pages/authenticated/campaigns/details/participants";
 @import "pages/authenticated/campaigns/details/participants/participant";
 @import "pages/authenticated/campaigns/details/participants/participant/header";

--- a/orga/app/styles/components/campaign/charts/participants-by-stage.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-stage.scss
@@ -5,6 +5,11 @@
   justify-content: space-between;
   margin-bottom: 8px;
 
+  &__wrapper {
+    margin: 0;
+    padding: 0;
+  }
+
   &__stars {
     svg {
       width: 18px;

--- a/orga/app/styles/components/login-or-register.scss
+++ b/orga/app/styles/components/login-or-register.scss
@@ -51,7 +51,7 @@
     }
 
     @include device-is('mobile') {
-      flex-flow: column;
+      flex-direction: column;
       margin: 10px 20px 0 20px;
     }
   }

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -84,6 +84,10 @@
     margin-bottom: 8px;
   }
 
+  &__value {
+    margin: 0;
+  }
+
 
   &__stages {
     display: flex;
@@ -165,7 +169,7 @@
   .panel-header__body {
     flex-direction: column;
   }
-  
+
   .panel-header__data {
     flex-direction: column;
     align-items: flex-start;

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -82,6 +82,10 @@
 
   &__label {
     margin-bottom: 8px;
+
+    &::first-letter {
+      text-transform: capitalize;
+    }
   }
 
   &__value {

--- a/orga/app/styles/globals/pix-loader.scss
+++ b/orga/app/styles/globals/pix-loader.scss
@@ -13,7 +13,7 @@
     text-align: center;
   }
 
-  &__image > img {
+  img {
     height: 150px;
     width: 150px;
   }

--- a/orga/app/styles/pages/authenticated/campaigns/details/assessment-results.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/assessment-results.scss
@@ -1,4 +1,8 @@
 .assessment-results {
+  &__list {
+    padding: 0;
+  }
+
   &__charts {
     margin-bottom: 24px;
   }

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
@@ -33,3 +33,7 @@
   }
 }
 
+.participant-filter-banner {
+  margin-bottom: 12px;
+}
+

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants/participant.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants/participant.scss
@@ -1,5 +1,5 @@
 .participant {
   display: flex;
-  flex-flow: column;
+  flex-direction: column;
   width: 100%;
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants/participant/results.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants/participant/results.scss
@@ -2,10 +2,6 @@
   width: 100%;
 
   &__details {
-    margin-bottom: 30px;
+    padding: 0;
   }
-}
-
-.participant-filter-banner {
-  margin-bottom: 12px;
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/profile-results.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/profile-results.scss
@@ -1,0 +1,3 @@
+.profile-results__list {
+  padding: 0;
+}

--- a/orga/app/styles/pages/authenticated/campaigns/participant-profile.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/participant-profile.scss
@@ -1,6 +1,6 @@
 .profile {
   display: flex;
-  flex-flow: column;
+  flex-direction: column;
   width: 100%;
 }
 

--- a/orga/app/styles/pages/authenticated/campaigns/participant-profile.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/participant-profile.scss
@@ -1,4 +1,6 @@
 .profile {
+  display: flex;
+  flex-flow: column;
   width: 100%;
 }
 
@@ -9,7 +11,7 @@
 }
 
 .profile-competences {
-  margin: 24px 0;
+  margin-bottom: 24px;
   padding: 0;
 }
 

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -1,4 +1,6 @@
 {{page-title (t 'pages.campaign-results.title')}}
+<h2 class="sr-only">{{t 'pages.campaign-results.title'}}</h2>
+
 {{#if @model.campaign.hasSharedParticipations}}
   <Campaign::Results::AssessmentCards
     @hasStages={{@model.campaign.hasStages}}
@@ -6,7 +8,6 @@
     @sharedParticipationsCount={{@model.campaign.sharedParticipationsCount}}
     @averageResult={{@model.campaign.averageResult}}
   />
-
 
   <Campaign::Charts::ResultDistribution
     @campaign={{@model.campaign}}
@@ -22,6 +23,7 @@
     @onClickParticipant={{this.goToAssessmentPage}}
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}
+    class="assessment-results__list"
   />
 {{else}}
   <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />

--- a/orga/app/templates/authenticated/campaigns/campaign/profile-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profile-results.hbs
@@ -1,4 +1,5 @@
 {{page-title (t 'pages.profiles-list.title')}}
+<h2 class="sr-only">{{t 'pages.profiles-list.title'}}</h2>
 
 {{#if @model.campaign.hasSharedParticipations}}
   <Campaign::Results::ProfileList
@@ -8,6 +9,7 @@
     @onClickParticipant={{this.goToProfilePage}}
     @onFilter={{this.triggerFiltering}}
     @onReset={{this.resetFiltering}}
+    class="profile-results__list"
   />
 {{else}}
   <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />

--- a/orga/tests/integration/components/participant/assessment/results_test.js
+++ b/orga/tests/integration/components/participant/assessment/results_test.js
@@ -41,8 +41,8 @@ module('Integration | Component | Participant::Assessment::Results', function(ho
     await render(hbs`<Participant::Assessment::Results @results={{campaignAssessmentParticipationResult}} @displayResults={{true}} />`);
 
     // then
-    assert.dom(`[aria-label="${t('pages.assessment-individual-results.table.title')}"]`).exists({ count: 1 });
-    assert.dom(`[aria-label="${t('pages.assessment-individual-results.table.title')}"]`).containsText('Compétence 1');
-    assert.dom(`[aria-label="${t('pages.assessment-individual-results.table.title')}"]`).containsText('50 %');
+    assert.dom(`[aria-label="${t('pages.assessment-individual-results.table.row-title')}"]`).exists({ count: 1 });
+    assert.dom(`[aria-label="${t('pages.assessment-individual-results.table.row-title')}"]`).containsText('Compétence 1');
+    assert.dom(`[aria-label="${t('pages.assessment-individual-results.table.row-title')}"]`).containsText('50 %');
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -340,7 +340,8 @@
           }
         },
         "empty": "No participants",
-        "row-title": "Participant"
+        "row-title": "Participant",
+        "title": "List of submitted results"
       },
       "tested-items": "Items assessed",
       "title": "Results",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -522,7 +522,7 @@
       }
     },
     "profiles-list": {
-      "title": "Participants",
+      "title": "Submitted profiles",
       "table": {
         "column": {
           "certifiable": "Eligible for certification",
@@ -539,7 +539,8 @@
           }
         },
         "empty": "No profiles yet",
-        "row-title": "Profile"
+        "row-title": "Profile",
+        "title": "List of submitted profiles"
       }
     },
     "students-sco": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -519,7 +519,8 @@
           "skill": "Competence"
         },
         "empty": "Pending results",
-        "row-title": "Competence"
+        "row-title": "Competence",
+        "title": "Results by competence"
       }
     },
     "profiles-list": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -189,7 +189,6 @@
         "review": "Review"
       },
       "table": {
-        "title": "Results by competence",
         "column": {
           "competences": "Competences ({count, plural, =0 {-} other {{count}}})",
           "results": {
@@ -197,7 +196,9 @@
             "tooltip": "<span class=\"sr-only\">This participant has validated</span> {result, number, ::percent} <span class=\"sr-only\">of the competence {competence}.</span>"
           }
         },
-        "empty": "Pending results"
+        "empty": "Pending results",
+        "row-title": "Competence",
+        "title": "Results by competence"
       }
     },
     "campaign": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -518,7 +518,8 @@
           "skill": "Compétence"
         },
         "empty": "En attente de résultats",
-        "row-title": "Compétence"
+        "row-title": "Compétence",
+        "title": "Résultats par compétence"
       }
     },
     "profiles-list": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -339,7 +339,8 @@
           }
         },
         "empty": "Aucune participation",
-        "row-title": "Participant"
+        "row-title": "Participant",
+        "title": "Liste des résultats reçus"
       },
       "tested-items": "Acquis évalués",
       "title": "Résultats",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -189,7 +189,6 @@
         "review": "Analyse"
       },
       "table": {
-        "title": "Résultats par compétence",
         "column": {
           "competences": "Compétences ({count, plural, =0 {-} other {{count}}})",
           "results": {
@@ -197,7 +196,9 @@
             "tooltip": "<span class=\"sr-only\">Ce participant a validé</span> {result, number, ::percent} <span class=\"sr-only\">de la compétence {competence}.</span>"
           }
         },
-        "empty": "En attente de résultats"
+        "empty": "En attente de résultats",
+        "row-title": "Compétence",
+        "title": "Résultats par compétence"
       }
     },
     "campaign": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -521,7 +521,7 @@
       }
     },
     "profiles-list": {
-      "title": "Participants",
+      "title": "Profils reçus",
       "table": {
         "column": {
           "certifiable": "Certifiable",
@@ -538,7 +538,8 @@
           }
         },
         "empty": "En attente de profils",
-        "row-title": "Profil"
+        "row-title": "Profil",
+        "title": "Liste des profils reçus"
       }
     },
     "students-sco": {


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Orga, très peu de balises sémantiques sont utilisées. Cela pose un problème pour l'accessibilité de la plateforme.

## :robot: Solution
Corriger cela, page par page. Ici la page "Résultats", et le page "Résultats individuels".

## :rainbow: Remarques
Rien à signaler.

## :100: Pour tester
Aller sur la page Résultats, et sur la page de Résultat individuel.
