### PR TITLE
[TECH] Corréler et enrichir la sortie de log Hapi d'un appel API avec des métriques concernant les queries Knex associées (PIX-3168).

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -43,22 +43,21 @@ try {
 const knexConfig = knexConfigs[environment];
 const knex = require('knex')(knexConfig);
 
-const queries = new Map();
-
 knex.on('query', function(data) {
   if (logging.enableLogKnexQueriesWithCorrelationId && doesStoreContainsRequest()) {
+    const store = asyncLocalStorage.getStore();
     const queryStartedTime = performance.now();
-    queries.set(data.__knexQueryUid, queryStartedTime);
+    store.knexQueriesUUIDs[data.__knexQueryUid] = queryStartedTime;
   }
 });
 
 knex.on('query-response', function(response, obj) {
   if (logging.enableLogKnexQueriesWithCorrelationId && doesStoreContainsRequest()) {
-    const queryStartedTime = queries.get(obj.__knexQueryUid);
+    const store = asyncLocalStorage.getStore();
+    const queryStartedTime = store.knexQueriesUUIDs[obj.__knexQueryUid];
     const duration = performance.now() - queryStartedTime;
     obj.duration = duration;
     addKnexMetricsToRequestContext(obj);
-    queries.delete(obj.__knexQueryUid);
   }
 });
 

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -1,6 +1,7 @@
 const types = require('pg').types;
 const { addPositionToQuerieAndIncrementQueriesCounter, logKnexQueriesWithCorrelationId } = require('../lib/infrastructure/monitoring-tools');
 const { logging } = require('../lib/config');
+const { performance } = require('perf_hooks');
 /*
 By default, node-postgres casts a DATE value (PostgreSQL type) as a Date Object (JS type).
 But, when dealing with dates with no time (such as birthdate for example), we want to
@@ -46,7 +47,7 @@ const queries = new Map();
 
 knex.on('query', function(data) {
   if (logging.enableLogKnexQueriesWithCorrelationId) {
-    const queryStartedTime = new Date();
+    const queryStartedTime = performance.now();
     queries.set(data.__knexQueryUid, queryStartedTime);
     addPositionToQuerieAndIncrementQueriesCounter(data.__knexQueryUid);
   }
@@ -55,7 +56,7 @@ knex.on('query', function(data) {
 knex.on('query-response', function(response, obj) {
   if (logging.enableLogKnexQueriesWithCorrelationId) {
     const queryStartedTime = queries.get(obj.__knexQueryUid);
-    const duration = new Date() - queryStartedTime;
+    const duration = performance.now() - queryStartedTime;
     obj.duration = duration;
     logKnexQueriesWithCorrelationId(obj, 'Knex Query');
     queries.delete(obj.__knexQueryUid);

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -46,6 +46,7 @@ module.exports = (function() {
 
     hapi: {
       options: {},
+      enableRequestMonitoring: isFeatureEnabled(process.env.ENABLE_REQUEST_MONITORING),
     },
 
     domain: {
@@ -65,7 +66,7 @@ module.exports = (function() {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: false,
       logLevel: (process.env.LOG_LEVEL || 'info'),
-      enableLogKnexQueriesWithCorrelationId: isFeatureEnabled(process.env.LOG_KNEX_QUERIES_WITH_CORRELATION_ID),
+      enableLogKnexQueries: isFeatureEnabled(process.env.LOG_KNEX_QUERIES),
       emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,
     },
 
@@ -258,7 +259,7 @@ module.exports = (function() {
     config.jwtConfig.poleEmploi = { secret: 'secretPoleEmploi', tokenLifespan: '1h' };
 
     config.logging.enabled = false;
-    config.logging.enableLogKnexQueriesWithCorrelationId = false;
+    config.logging.enableLogKnexQueries = false;
 
     config.caching.redisUrl = null;
     config.caching.redisCacheKeyLockTTL = 0;

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -1,4 +1,5 @@
-const { get } = require('lodash');
+const settings = require('../config');
+const { get, set, update } = require('lodash');
 const logger = require('../infrastructure/logger');
 const requestUtils = require('../infrastructure/utils/request-response-utils');
 
@@ -21,34 +22,76 @@ function logErrorWithCorrelationIds(error) {
   }, error);
 }
 
-function addKnexMetricsToRequestContext(data) {
-  const store = asyncLocalStorage.getStore();
-  if (store && store.request && store.metrics) {
-    store.metrics.queriesCounter++;
-    store.metrics.knexQueries.push({
-      id: data.__knexQueryUid,
-      sql: data.sql,
-      params: [(data.bindings) ? data.bindings.join(',') : ''],
-      duration: get(data, 'duration', '-'),
-    });
-  }
-}
-
 function extractUserIdFromRequest(request) {
   let userId = get(request, 'auth.credentials.userId');
   if (!userId && get(request, 'headers.authorization')) userId = requestUtils.extractUserIdFromRequest(request);
   return userId || '-';
 }
 
-function doesStoreContainsRequest() {
-  return (asyncLocalStorage.getStore() !== undefined);
+function getInContext(path, value) {
+  const store = asyncLocalStorage.getStore();
+  if (!store) return;
+  return get(store, path, value);
+}
+
+function setInContext(path, value) {
+  const store = asyncLocalStorage.getStore();
+  if (!store) return;
+  set(store, path, value);
+}
+
+function incrementInContext(path) {
+  const store = asyncLocalStorage.getStore();
+  if (!store) return;
+  update(store, path, (v) => (v ?? 0) + 1);
+}
+
+function getContext() {
+  return asyncLocalStorage.getStore();
+}
+
+function pushInContext(path, value) {
+  const store = asyncLocalStorage.getStore();
+  if (!store) return;
+  let array = get(store, path);
+  if (!array) {
+    array = [value];
+    set(store, path, array);
+  } else {
+    array.push(value);
+  }
+}
+
+function installHapiHook() {
+  if (!settings.hapi.enableRequestMonitoring) return;
+
+  if (require('@hapi/hapi/package.json').version !== '20.1.3') {
+    throw new Error('Hapi version changed, please check if patch still works');
+  }
+
+  const Request = require('@hapi/hapi/lib/request');
+
+  const originalMethod = Request.prototype._execute;
+
+  if (!originalMethod) {
+    throw new Error('Hapi method Request.prototype._execute not found while patch');
+  }
+
+  Request.prototype._execute = function(...args) {
+    const request = this;
+    const context = { request };
+    return asyncLocalStorage.run(context, () => originalMethod.call(request, args));
+  };
 }
 
 module.exports = {
-  asyncLocalStorage,
-  addKnexMetricsToRequestContext,
   extractUserIdFromRequest,
-  doesStoreContainsRequest,
+  getContext,
+  getInContext,
+  incrementInContext,
+  installHapiHook,
   logErrorWithCorrelationIds,
   logInfoWithCorrelationIds,
+  pushInContext,
+  setInContext,
 };

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -34,27 +34,6 @@ function logErrorWithCorrelationIds(error) {
   }, error);
 }
 
-function logKnexQueriesWithCorrelationId(data, msg) {
-  if (logging.enableLogKnexQueriesWithCorrelationId) {
-    const request = asyncLocalStorage.getStore();
-    const knexQueryId = data.__knexQueryUid;
-    logger.info({
-      request_id: `${get(request, 'info.id', '-')}`,
-      knex_query_id: knexQueryId,
-      knex_query_position: get(request, ['knexQueryPosition', knexQueryId ], '-'),
-      knex_query_sql: data.sql,
-      knex_query_params: [(data.bindings) ? data.bindings.join(',') : ''],
-      duration: get(data, 'duration', '-'),
-      http: {
-        method: get(request, 'method', '-'),
-        url_detail: {
-          path: get(request, 'path', '-'),
-        },
-      },
-    }, msg);
-  }
-}
-
 function addKnexMetricsToRequestContext(data) {
   const store = asyncLocalStorage.getStore();
   if (store && store.request && store.metrics) {
@@ -83,7 +62,6 @@ module.exports = {
   addKnexMetricsToRequestContext,
   extractUserIdFromRequest,
   doesStoreContainsRequest,
-  logKnexQueriesWithCorrelationId,
   logErrorWithCorrelationIds,
   logInfoWithCorrelationIds,
 };

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -1,6 +1,5 @@
 const { get } = require('lodash');
 const logger = require('../infrastructure/logger');
-const { logging } = require('../config');
 const requestUtils = require('../infrastructure/utils/request-response-utils');
 
 const { AsyncLocalStorage } = require('async_hooks');
@@ -11,12 +10,6 @@ function logInfoWithCorrelationIds(message) {
   logger.info({
     user_id: extractUserIdFromRequest(request),
     request_id: `${get(request, 'info.id', '-')}`,
-    http: {
-      method: get(request, 'method', '-'),
-      url_detail: {
-        path: get(request, 'path', '-'),
-      },
-    },
   }, message);
 }
 
@@ -25,12 +18,6 @@ function logErrorWithCorrelationIds(error) {
   logger.error({
     user_id: extractUserIdFromRequest(request),
     request_id: `${get(request, 'info.id', '-')}`,
-    http: {
-      method: get(request, 'method', '-'),
-      url_detail: {
-        path: get(request, 'path', '-'),
-      },
-    },
   }, error);
 }
 

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -56,18 +56,13 @@ function logKnexQueriesWithCorrelationId(data, msg) {
 }
 
 function addKnexMetricsToRequestContext(data) {
-  const request = asyncLocalStorage.getStore();
-  if (request) {
-    request.knexQueryPosition = request.knexQueryPosition || [];
-    request.knexQueries = request.knexQueries || [];
-    request.queriesCounter = request.queriesCounter || 0;
-    request.queriesCounter++;
-    request.knexQueryPosition[data.__knexQueryUid] = request.queriesCounter;
-    request.knexQueries.push({
-      knex_query_id: data.__knexQueryUid,
-      knex_query_position: request.queriesCounter,
-      knex_query_sql: data.sql,
-      knex_query_params: [(data.bindings) ? data.bindings.join(',') : ''],
+  const store = asyncLocalStorage.getStore();
+  if (store && store.request && store.metrics) {
+    store.metrics.queriesCounter++;
+    store.metrics.knexQueries.push({
+      id: data.__knexQueryUid,
+      sql: data.sql,
+      params: [(data.bindings) ? data.bindings.join(',') : ''],
       duration: get(data, 'duration', '-'),
     });
   }

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -4,15 +4,19 @@ const Blipp = require('blipp');
 const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
 const { get } = require('lodash');
-const { asyncLocalStorage, extractUserIdFromRequest } = require('./infrastructure/monitoring-tools');
+const monitoringTools = require('./infrastructure/monitoring-tools');
 
 function logObjectSerializer(obj) {
-  const store = asyncLocalStorage.getStore();
-  return {
-    ...obj,
-    user_id: get(store, 'request') ? extractUserIdFromRequest(store.request) : '-',
-    knexQueries: get(store, 'metrics.knexQueries', '-'),
-  };
+  if (settings.hapi.enableRequestMonitoring) {
+    const context = monitoringTools.getContext();
+    return {
+      ...obj,
+      user_id: get(context, 'request') ? monitoringTools.extractUserIdFromRequest(context.request) : '-',
+      metrics: get(context, 'metrics'),
+    };
+  } else {
+    return { ... obj };
+  }
 }
 
 const plugins = [
@@ -36,7 +40,6 @@ const plugins = [
     options: {
       serializers: {
         req: logObjectSerializer,
-        err: logObjectSerializer,
       },
       instance: require('./infrastructure/logger'),
       logQueryParams: true,

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -7,11 +7,11 @@ const { get } = require('lodash');
 const { asyncLocalStorage, extractUserIdFromRequest } = require('./infrastructure/monitoring-tools');
 
 function logObjectSerializer(obj) {
-  const request = asyncLocalStorage.getStore();
+  const store = asyncLocalStorage.getStore();
   return {
     ...obj,
-    user_id: extractUserIdFromRequest(request),
-    knexQueries: get(request, 'knexQueries', '-'),
+    user_id: get(store, 'request') ? extractUserIdFromRequest(store.request) : '-',
+    knexQueries: get(store, 'metrics.knexQueries', '-'),
   };
 }
 

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -3,6 +3,7 @@ const settings = require('./config');
 const Blipp = require('blipp');
 const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
+const { get } = require('lodash');
 const { asyncLocalStorage, extractUserIdFromRequest } = require('./infrastructure/monitoring-tools');
 
 function logObjectSerializer(obj) {
@@ -10,6 +11,7 @@ function logObjectSerializer(obj) {
   return {
     ...obj,
     user_id: extractUserIdFromRequest(request),
+    knexQueries: get(request, 'knexQueries', '-'),
   };
 }
 

--- a/api/server.js
+++ b/api/server.js
@@ -18,7 +18,8 @@ const originalMethod = Request.prototype._execute;
 
 Request.prototype._execute = function(...args) {
   const request = this;
-  return asyncLocalStorage.run(request, () => originalMethod.call(request, args));
+  const store = { request, metrics: { knexQueries: [], queriesCounter: 0 }, knexQueriesUUIDs: {} };
+  return asyncLocalStorage.run(store, () => originalMethod.call(request, args));
 };
 
 let config;

--- a/api/server.js
+++ b/api/server.js
@@ -11,16 +11,9 @@ const swaggers = require('./lib/swaggers');
 const authentication = require('./lib/infrastructure/authentication');
 
 const { handleFailAction } = require('./lib/validate');
-const { asyncLocalStorage } = require('./lib/infrastructure/monitoring-tools');
+const monitoringTools = require('./lib/infrastructure/monitoring-tools');
 
-const Request = require('@hapi/hapi/lib/request');
-const originalMethod = Request.prototype._execute;
-
-Request.prototype._execute = function(...args) {
-  const request = this;
-  const store = { request, metrics: { knexQueries: [], queriesCounter: 0 }, knexQueriesUUIDs: {} };
-  return asyncLocalStorage.run(store, () => originalMethod.call(request, args));
-};
+monitoringTools.installHapiHook();
 
 let config;
 


### PR DESCRIPTION
## :unicorn: Problème
Compte tenue du nombre important d'appel Knex par requête Http, les logs concernant les métriques Knex de ces queries augmentent la quantité des logs facturés par Datadog. 
Aujourd'hui, ces logs sont désactivés en production via la variable d'environnement LOG_KNEX_QUERIES_WITH_CORRELATION_ID.

<img width="730" alt="Capture d’écran 2021-09-06 à 15 03 10" src="https://user-images.githubusercontent.com/10045497/132221990-9d1597f0-2fe6-4978-a71d-697c74a15440.png">


## :robot: Solution
Enrichir l'entrée de log Hapi avec ces métriques sans rajouter de nouveaux logs.

## :rainbow: Remarques
La facturation Datadog, fonctionne par événement. La quantité de logs par événement permet de ne pas augmenter la facture.

## :100: Pour tester
Activer la variable d'env LOG_KNEX_QUERIES_WITH_CORRELATION_ID=true
Et constatez dans les logs la sortie Hapi d'un appel API:

```
[1630931321924] INFO (20761 on MacBook-Pro-de-yahya.local): request completed
    queryParams: {}
    req: {
      "id": "1630931321548:MacBook-Pro-de-yahya.local:20761:kt8me9mz:10003",
      "method": "get",
      "url": "/api/users/1/profile",
      "headers": {
        "x-forwarded-host": "localhost:4200",
        "x-forwarded-proto": "http",
        "x-forwarded-port": "4200",
        "x-forwarded-for": "::1",
        "x-broccoli": "[object Object]",
        "accept-encoding": "gzip, deflate, br",
        "referer": "http://localhost:4200/accueil",
        "sec-fetch-dest": "empty",
        "sec-fetch-mode": "cors",
        "sec-fetch-site": "same-origin",
        "sec-ch-ua-platform": "\"macOS\"",
        "x-requested-with": "XMLHttpRequest",
        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
        "accept": "application/vnd.api+json",
        "authorization": "[Redacted]",
        "sec-ch-ua-mobile": "?0",
        "accept-language": "fr",
        "sec-ch-ua": "\"Google Chrome\";v=\"93\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"93\"",
        "connection": "close",
        "host": "localhost:3000"
      },
      "remoteAddress": "127.0.0.1",
      "remotePort": 55010,
      "user_id": 1,
      "knexQueries": [
        {
          "knex_query_id": "_TlL5ANm29JVkLYOKzDJ2",
          "knex_query_position": 1,
          "knex_query_sql": "select * from \"knowledge-elements\" where (\"userId\" = $1)",
          "knex_query_params": [
            "1"
          ],
          "duration": 7.418085008859634
        },
        {
          "knex_query_id": "pSBcXe0BL4w4GRztP5SAV",
          "knex_query_position": 2,
          "knex_query_sql": "select \"competence-evaluations\".* from \"competence-evaluations\" where \"userId\" = $1 order by \"competence-evaluations\".\"createdAt\" desc",
          "knex_query_params": [
            "1"
          ],
          "duration": 9.877793997526169
        },
        {
          "knex_query_id": "RcyXn6oHx5MRcbwc57MQS",
          "knex_query_position": 3,
          "knex_query_sql": "select distinct \"assessments\".* from \"assessments\" where \"assessments\".\"id\" in ($1, $2, $3, $4, $5)",
          "knex_query_params": [
            "106321,106334,106344,106355,106364"
          ],
          "duration": 4.1783479899168015
        }
      ]
    }
    res: {
      "statusCode": 200,
      "headers": {
        "content-type": "application/json; charset=utf-8",
        "vary": "origin",
        "access-control-expose-headers": "WWW-Authenticate,Server-Authorization",
        "cache-control": "no-cache",
        "content-length": 13575,
        "accept-ranges": "bytes"
      }
    }
    responseTime: 376
[1630931321961] INFO (20761 on MacBook-Pro-de-yahya.local): request completed
```

