### PR TITLE
[FEATURE] Changer le status de la participation au partage (PIX-3139)

### DIFF
--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -1,6 +1,12 @@
 const _ = require('lodash');
 const { ArchivedCampaignError, AssessmentNotCompletedError, AlreadySharedCampaignParticipationError } = require('../errors');
 
+const statuses = {
+  STARTED: 'STARTED',
+  TO_SHARE: 'TO_SHARE',
+  SHARED: 'SHARED',
+};
+
 class CampaignParticipation {
 
   constructor({
@@ -46,6 +52,7 @@ class CampaignParticipation {
 
     this.isShared = true;
     this.sharedAt = new Date();
+    this.status = statuses.SHARED;
   }
 
   _canBeShared() {
@@ -68,5 +75,7 @@ class CampaignParticipation {
 function lastAssessmentNotCompleted(campaignParticipation) {
   return !campaignParticipation.lastAssessment || !campaignParticipation.lastAssessment.isCompleted();
 }
+
+CampaignParticipation.statuses = statuses;
 
 module.exports = CampaignParticipation;

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -18,6 +18,7 @@ const ATTRIBUTES_TO_SAVE = [
   'isShared',
   'participantExternalId',
   'sharedAt',
+  'status',
   'campaignId',
   'userId',
   'validatedSkillsCount',

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -168,6 +168,7 @@ describe('Integration | Repository | Campaign Participation', function() {
         ...campaignParticipationToUpdate,
         isShared: true,
         sharedAt: new Date('2021-01-01'),
+        status: CampaignParticipation.statuses.SHARED,
         validatedSkillsCount: 10,
         pixScore: 10,
         masteryPercentage: 0.9,
@@ -176,6 +177,7 @@ describe('Integration | Repository | Campaign Participation', function() {
 
       expect(campaignParticipation.isShared).to.equals(true);
       expect(campaignParticipation.sharedAt).to.deep.equals(new Date('2021-01-01'));
+      expect(campaignParticipation.status).to.equals(CampaignParticipation.statuses.SHARED);
       expect(campaignParticipation.validatedSkillsCount).to.equals(10);
       expect(campaignParticipation.pixScore).to.equals(10);
       expect(campaignParticipation.masteryPercentage).to.equals('0.90');
@@ -714,6 +716,7 @@ describe('Integration | Repository | Campaign Participation', function() {
       campaignParticipation.user = {};
       campaignParticipation.assessmentId = {};
       campaignParticipation.isShared = true;
+      campaignParticipation.status = CampaignParticipation.statuses.SHARED;
       campaignParticipation.participantExternalId = 'Laura';
 
       // when
@@ -722,6 +725,7 @@ describe('Integration | Repository | Campaign Participation', function() {
       const updatedCampaignParticipation = await knex('campaign-participations').where({ id: campaignParticipation.id }).first();
       // then
       expect(updatedCampaignParticipation.isShared).to.be.true;
+      expect(updatedCampaignParticipation.status).to.equals(CampaignParticipation.statuses.SHARED);
       expect(updatedCampaignParticipation.participantExternalId).to.equals('Laura');
     });
 

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -91,6 +91,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function() {
 
           expect(campaignParticipation.isShared).to.be.true;
           expect(campaignParticipation.sharedAt).to.deep.equals(now);
+          expect(campaignParticipation.status).to.equals(CampaignParticipation.statuses.SHARED);
         });
       });
 
@@ -136,6 +137,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function() {
 
             expect(campaignParticipation.isShared).to.be.true;
             expect(campaignParticipation.sharedAt).to.deep.equals(now);
+            expect(campaignParticipation.status).to.equals(CampaignParticipation.statuses.SHARED);
           });
         });
       });


### PR DESCRIPTION
## :unicorn: Problème

La colonne `status`, de la table `campaign-participations` a été ajouté récemment (voir PR #3442), mais sa valeur n'est actuellement pas changée au partage de la participation.

## :robot: Solution

Au moment du partage d'une campagne d'évaluation ou de collecte de profil, passer le statut de la participation à `SHARED`.

## :rainbow: Remarques

N/A

## :100: Pour tester

**Test 1**
1. Passer une campagne d'évaluation
2. Partager ses résultats
3. Vérifier la valeur du statut de la participation en BDD

**Test 2**
1. Réaliser une campagne de collecte de profil
2. Partager son profil
3. Vérifier la valeur du statut de la participation en BDD
