### PR TITLE
[TECH] Mesurer les temps de réponses API des appels externes à Pix via un métrique duration (PIX-3171).

### DIFF
--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
+const { performance } = require('perf_hooks');
 const { logInfoWithCorrelationIds, logErrorWithCorrelationIds } = require('../monitoring-tools');
 
 class HttpResponse {
@@ -16,14 +17,14 @@ class HttpResponse {
 
 module.exports = {
   async post({ url, payload, headers }) {
-    logInfoWithCorrelationIds(`Starting POST request to ${url}`);
-
+    logInfoWithCorrelationIds({ message: `Starting POST request to ${url}` });
+    const startTime = performance.now();
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
       });
-
-      logInfoWithCorrelationIds(`End POST request to ${url} success: ${httpResponse.status}`);
+      const duration = performance.now() - startTime;
+      logInfoWithCorrelationIds({ metrics: { duration }, message: `End POST request to ${url} success: ${httpResponse.status}` });
 
       return new HttpResponse({
         code: httpResponse.status,
@@ -41,7 +42,7 @@ module.exports = {
         data = httpErr.message;
       }
 
-      logErrorWithCorrelationIds(`End POST request to ${url} error: ${code} ${data.toString()}`);
+      logErrorWithCorrelationIds({ message: `End POST request to ${url} error: ${code} ${data.toString()}` });
 
       return new HttpResponse({
         code,
@@ -51,13 +52,13 @@ module.exports = {
     }
   },
   async get({ url, payload, headers }) {
-    logInfoWithCorrelationIds(`Starting GET request to ${url}`);
-
+    logInfoWithCorrelationIds({ message: `Starting GET request to ${url}` });
+    const startTime = performance.now();
     try {
       const config = { data: payload, headers };
       const httpResponse = await axios.get(url, config);
-
-      logInfoWithCorrelationIds(`End GET request to ${url} success: ${httpResponse.status}`);
+      const duration = performance.now() - startTime;
+      logInfoWithCorrelationIds({ metrics: { duration }, message: `End GET request to ${url} success: ${httpResponse.status}` });
 
       return new HttpResponse({
         code: httpResponse.status,
@@ -78,7 +79,7 @@ module.exports = {
         data = null;
       }
 
-      logInfoWithCorrelationIds(`End GET request to ${url} error: ${code}`);
+      logErrorWithCorrelationIds(`End GET request to ${url} error: ${code}`);
 
       return new HttpResponse({
         code,

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -17,7 +17,6 @@ class HttpResponse {
 
 module.exports = {
   async post({ url, payload, headers }) {
-    logInfoWithCorrelationIds({ message: `Starting POST request to ${url}` });
     const startTime = performance.now();
     try {
       const httpResponse = await axios.post(url, payload, {
@@ -52,7 +51,6 @@ module.exports = {
     }
   },
   async get({ url, payload, headers }) {
-    logInfoWithCorrelationIds({ message: `Starting GET request to ${url}` });
     const startTime = performance.now();
     try {
       const config = { data: payload, headers };


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, on trace via un logger les appels HTTP externes à Pix. Néanmoins, ce n'est pas évident d'avoir les temps de réponses facilement et de les suivre via un métrique dans Datadog.

<img width="1225" alt="Capture d’écran 2021-09-06 à 16 06 58" src="https://user-images.githubusercontent.com/10045497/132229518-ac5e85ca-fc30-4d30-8cb4-804c2d007878.png">


## :robot: Solution
Calculer un métrique duration pour les appels externes et le tracer via le logger.

<img width="1680" alt="Capture d’écran 2021-09-06 à 16 02 51" src="https://user-images.githubusercontent.com/10045497/132229743-ea8098a4-64f1-4f72-8d91-7d0d9ea7c859.png">


## :rainbow: Remarques
On peut calculer des custom métriques et les afficher automatiquement via le logger.

## :100: Pour tester
En locale:

1- Démarrer mon Pix avec la commande suivante:

POLE_EMPLOI_CLIENT_ID=CHANGE_ME npm start -- --port 8080

2- Se connecter via le button Pôle Emploi via un utilisateur

3- Rejoindre et démarrer la campagne QWERTY789 

Constatez que les logs des appels vers PE avec le message : `End POST request to` contiennent un attribut duration avec le temps de réponse en millisecond.




