### PR TITLE
[TECH] Associer un statut à un participation de campagne à la création et finalisation (PIX-3138)

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -1,3 +1,5 @@
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
+
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
 const { AssessmentEndedError } = require('../../domain/errors');
 const usecases = require('../../domain/usecases');
@@ -91,7 +93,12 @@ module.exports = {
 
   async completeAssessment(request) {
     const assessmentId = request.params.id;
-    const event = await usecases.completeAssessment({ assessmentId });
+
+    let event;
+    await DomainTransaction.execute(async (domainTransaction) => {
+      event = await usecases.completeAssessment({ assessmentId, domainTransaction });
+    });
+
     await events.eventDispatcher.dispatch(event);
 
     return null;

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -40,6 +40,7 @@ const partnerCertificationScoringRepository = injectDependencies(
 dependencies.partnerCertificationScoringRepository = partnerCertificationScoringRepository;
 
 const handlersToBeInjected = {
+  computeCampaignParticipationResults: require('./compute-campaign-participation-results'),
   handleAutoJury: require('./handle-auto-jury'),
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
   handleCertificationScoring: require('./handle-certification-scoring'),
@@ -50,7 +51,6 @@ const handlersToBeInjected = {
   handlePoleEmploiParticipationFinished: require('./handle-pole-emploi-participation-finished'),
   handlePoleEmploiParticipationShared: require('./handle-pole-emploi-participation-shared'),
   handlePoleEmploiParticipationStarted: require('./handle-pole-emploi-participation-started'),
-  computeCampaignParticipationResults: require('./compute-campaign-participation-results'),
   handleSessionFinalized: require('./handle-session-finalized'),
 };
 

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -41,6 +41,15 @@ class CampaignParticipation {
     this.pixScore = pixScore;
   }
 
+  static start(campaignParticipation) {
+    const { isAssessment } = campaignParticipation.campaign;
+    const { STARTED, TO_SHARE } = CampaignParticipation.statuses;
+
+    const status = isAssessment ? STARTED : TO_SHARE;
+
+    return new CampaignParticipation({ ...campaignParticipation, status });
+  }
+
   getTargetProfileId() {
     return _.get(this, 'campaign.targetProfileId', null);
   }

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -21,6 +21,7 @@ class CampaignParticipation {
     assessmentId,
     campaignId,
     userId,
+    status,
     validatedSkillsCount,
     pixScore,
   } = {}) {
@@ -35,6 +36,7 @@ class CampaignParticipation {
     this.assessmentId = assessmentId;
     this.campaignId = campaignId;
     this.userId = userId;
+    this.status = status;
     this.validatedSkillsCount = validatedSkillsCount;
     this.pixScore = pixScore;
   }
@@ -77,10 +79,6 @@ class CampaignParticipation {
     if (this.campaign.isAssessment() && lastAssessmentNotCompleted(this)) {
       throw new AssessmentNotCompletedError();
     }
-  }
-
-  canComputeValidatedSkillsCount() {
-    return this.campaign.isAssessment();
   }
 }
 

--- a/api/lib/domain/usecases/complete-assessment.js
+++ b/api/lib/domain/usecases/complete-assessment.js
@@ -1,4 +1,5 @@
 const AssessmentCompleted = require('../events/AssessmentCompleted');
+const CampaignParticipation = require('../models/CampaignParticipation');
 
 const {
   AlreadyRatedAssessmentError,
@@ -6,15 +7,23 @@ const {
 
 module.exports = async function completeAssessment({
   assessmentId,
+  domainTransaction,
+  campaignParticipationRepository,
   assessmentRepository,
 }) {
-  const assessment = await assessmentRepository.get(assessmentId);
+  const assessment = await assessmentRepository.get(assessmentId, domainTransaction);
 
   if (assessment.isCompleted()) {
     throw new AlreadyRatedAssessmentError();
   }
 
-  await assessmentRepository.completeByAssessmentId(assessmentId);
+  await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
+
+  if (assessment.campaignParticipationId) {
+    const { TO_SHARE } = CampaignParticipation.statuses;
+
+    await campaignParticipationRepository.update({ id: assessment.campaignParticipationId, status: TO_SHARE }, domainTransaction);
+  }
 
   return new AssessmentCompleted({
     assessmentId: assessment.id,

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -27,11 +27,11 @@ module.exports = {
     return assessment;
   },
 
-  async get(id) {
+  async get(id, domainTransaction = DomainTransaction.emptyTransaction()) {
     try {
       const bookshelfAssessment = await BookshelfAssessment
         .where({ id })
-        .fetch();
+        .fetch({ transacting: domainTransaction.knexTransaction });
 
       return bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, bookshelfAssessment);
     } catch (err) {

--- a/api/tests/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/integration/domain/usecases/start-campaign-participation_test.js
@@ -5,6 +5,8 @@ const assessmentRepository = require('../../../../lib/infrastructure/repositorie
 const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
 const campaignToJoinRepository = require('../../../../lib/infrastructure/repositories/campaign-to-join-repository');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
+const Campaign = require('../../../../lib/domain/models/Campaign');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
 
 describe('Integration | UseCases | start-campaign-participation', function() {
 
@@ -28,7 +30,7 @@ describe('Integration | UseCases | start-campaign-participation', function() {
 
   it('should save a campaign participation and its assessment when campaign is of type ASSESSMENT', async function() {
     // given
-    campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', organizationId }).id;
+    campaignId = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT, organizationId }).id;
     await databaseBuilder.commit();
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
 
@@ -40,13 +42,14 @@ describe('Integration | UseCases | start-campaign-participation', function() {
     // then
     const campaignParticipations = await knex('campaign-participations');
     expect(campaignParticipations).to.have.lengthOf(1);
+    expect(campaignParticipations[0].status).to.equal(CampaignParticipation.statuses.STARTED);
     const assessments = await knex('assessments');
     expect(assessments).to.have.lengthOf(1);
   });
 
   it('should save only a campaign participation when campaign is of type PROFILES_COLLECTION', async function() {
     // given
-    campaignId = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', organizationId }).id;
+    campaignId = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION, organizationId }).id;
     await databaseBuilder.commit();
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
 
@@ -58,6 +61,7 @@ describe('Integration | UseCases | start-campaign-participation', function() {
     // then
     const campaignParticipations = await knex('campaign-participations');
     expect(campaignParticipations).to.have.lengthOf(1);
+    expect(campaignParticipations[0].status).to.equal(CampaignParticipation.statuses.TO_SHARE);
     const assessments = await knex('assessments');
     expect(assessments).to.have.lengthOf(0);
   });

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
@@ -11,6 +11,7 @@ module.exports = function buildCampaignParticipation({
   campaignId = campaign.id,
   assessmentId = null,
   userId = 123,
+  status,
   validatedSkillsCount,
 } = {}) {
 
@@ -24,6 +25,7 @@ module.exports = function buildCampaignParticipation({
     campaignId,
     assessmentId,
     userId,
+    status,
     validatedSkillsCount,
   });
 };

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -179,4 +179,33 @@ describe('Unit | Domain | Models | CampaignParticipation', function() {
       });
     });
   });
+
+  describe('#start', function() {
+    it('should return an instance of CampaignParticipation', function() {
+      const campaign = domainBuilder.buildCampaignToJoin();
+      const campaignParticipation = CampaignParticipation.start({ campaign });
+
+      expect(campaignParticipation instanceof CampaignParticipation).to.be.true;
+    });
+
+    context('status', function() {
+      context('when the campaign as the type PROFILES_COLLECTION', function() {
+        it('status to TO_SHARE', function() {
+          const campaign = domainBuilder.buildCampaignToJoin({ type: Campaign.types.PROFILES_COLLECTION });
+          const campaignParticipation = CampaignParticipation.start({ campaign });
+
+          expect(campaignParticipation.status).to.be.equal(CampaignParticipation.statuses.TO_SHARE);
+        });
+      });
+
+      context('when the campaign as the type ASSESSMENT', function() {
+        it('status to STARTED', function() {
+          const campaign = domainBuilder.buildCampaignToJoin({ type: Campaign.types.ASSESSMENT });
+          const campaignParticipation = CampaignParticipation.start({ campaign });
+
+          expect(campaignParticipation.status).to.be.equal(CampaignParticipation.statuses.STARTED);
+        });
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -179,28 +179,4 @@ describe('Unit | Domain | Models | CampaignParticipation', function() {
       });
     });
   });
-
-  describe('canComputeValidatedSkillsCount', function() {
-    context('when the campaign as the type PROFILES_COLLECTION', function() {
-      it('returns false', function() {
-        const campaign = domainBuilder.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
-        const campaignParticipation = new CampaignParticipation({ campaign });
-
-        const canComputeValidatedSkillsCount = campaignParticipation.canComputeValidatedSkillsCount();
-
-        expect(canComputeValidatedSkillsCount).to.be.false;
-      });
-    });
-
-    context('when the campaign as the type ASSESSMENT', function() {
-      it('returns true', function() {
-        const campaign = domainBuilder.buildCampaign({ type: Campaign.types.ASSESSMENT });
-        const campaignParticipation = new CampaignParticipation({ campaign });
-
-        const canComputeValidatedSkillsCount = campaignParticipation.canComputeValidatedSkillsCount();
-
-        expect(canComputeValidatedSkillsCount).to.be.true;
-      });
-    });
-  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous avons rencontré des soucis de performances lorsque nous avons voulu utiliser/filtrer des listes de participants en fonction de leur état d'avancement.

## :robot: Solution
Ajouter un statut à la création/finalisation d'une campagne (tout types) afin de pouvoir gagner en temps de réponse sur les appels qui nécessite de connaitre le statut d'une participation à une campagne.

## :rainbow: Remarques

## :100: Pour tester
