### PR TITLE
[TECH] Migration des status de campagne participations (PIX-3000)

### DIFF
--- a/api/scripts/prod/compute-participation-statuses.js
+++ b/api/scripts/prod/compute-participation-statuses.js
@@ -1,0 +1,94 @@
+// Usage: node compute-participation-statuses.js
+const { knex } = require('../../db/knex-database-connection');
+
+let logEnable;
+
+async function computeParticipantStatuses(log = true) {
+  logEnable = log;
+  _log('Update SHARED campaign participations (Assessment and Profiles collection)...');
+  await _updateSharedCampaignParticipations();
+  _log('Update TO_SHARE campaign participations (Assessment only)...');
+  await _updateToShareAssessmentParticipations();
+  _log('Update TO_SHARE campaign participations (Profiles collection only)...');
+  await _updateToShareProfileCollectionParticipations();
+}
+
+function _updateSharedCampaignParticipations() {
+  return knex('campaign-participations')
+    .where({ isShared: true })
+    .update({ status: 'SHARED' });
+}
+
+function _updateToShareAssessmentParticipations() {
+  return knex.raw(`
+  UPDATE
+    "campaign-participations"
+  SET
+    "status" = 'TO_SHARE'
+  WHERE
+    "campaign-participations"."id" = ANY (
+      SELECT
+        "participations"."id"
+      FROM
+        "campaign-participations" AS "participations"
+        INNER JOIN "assessments" ON "assessments"."campaignParticipationId" = "participations"."id"
+        LEFT JOIN "assessments" AS "newerAssessments" ON "newerAssessments"."campaignParticipationId" = "participations"."id"
+          AND "assessments"."createdAt" < "newerAssessments"."createdAt"
+      WHERE
+        "participations"."isShared" = FALSE
+        AND "newerAssessments" IS NULL
+        AND "assessments"."state" = 'completed'
+    )
+  `);
+}
+
+function _updateToShareProfileCollectionParticipations() {
+  return knex.raw(`
+  UPDATE "campaign-participations"
+  SET "status" = 'TO_SHARE'
+  WHERE
+    "campaign-participations"."id" = ANY (
+      SELECT
+        "participations"."id"
+      FROM
+        "campaign-participations" AS "participations"
+        JOIN "campaigns" ON "campaigns"."id" = "participations"."campaignId"
+      WHERE
+        "participations"."isShared" = false
+        AND "campaigns"."type" = 'PROFILES_COLLECTION'
+    )
+  `);
+}
+
+module.exports = computeParticipantStatuses;
+
+let exitCode;
+const SUCCESS = 0;
+const FAILURE = 1;
+
+if (require.main === module) {
+  computeParticipantStatuses()
+    .then(handleSuccess)
+    .catch(handleError)
+    .finally(exit);
+}
+
+function handleSuccess() {
+  exitCode = SUCCESS;
+}
+
+function handleError(err) {
+  console.error(err);
+  exitCode = FAILURE;
+}
+
+function exit() {
+  console.log('code', exitCode);
+  process.exit(exitCode);
+}
+
+function _log(...args) {
+  if (logEnable) {
+    console.log(...args);
+  }
+}

--- a/api/tests/integration/scripts/prod/compute-participation-statuses_test.js
+++ b/api/tests/integration/scripts/prod/compute-participation-statuses_test.js
@@ -1,0 +1,164 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const computeParticipantStatuses = require('../../../../scripts/prod/compute-participation-statuses');
+const Campaign = require('../../../../lib/domain/models/Campaign');
+
+describe('compute-participation-statuses script', function() {
+  context('For profile collection campaign', function() {
+    beforeEach(async function() {
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        participantExternalId: 'shared participation',
+        isShared: true,
+        sharedAt: new Date('2020-01-02'),
+      });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        participantExternalId: 'to share participation',
+        isShared: false,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('computes "TO SHARE" participations status', async function() {
+      await computeParticipantStatuses(false);
+
+      const campaignParticipation = await knex('campaign-participations').where({ participantExternalId: 'to share participation' }).first();
+      expect(campaignParticipation.status).to.equals('TO_SHARE');
+    });
+
+    it('computes "SHARED" participations status', async function() {
+      await computeParticipantStatuses(false);
+
+      const campaignParticipation = await knex('campaign-participations').where({ participantExternalId: 'shared participation' }).first();
+      expect(campaignParticipation.status).to.equals('SHARED');
+    });
+  });
+
+  context('For assessment campaign', function() {
+    beforeEach(async function() {
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT });
+
+      _buildParticipationWithAssessment({
+        campaignId,
+        participantExternalId: 'shared participation',
+        isShared: true,
+        assessmentState: 'completed',
+      });
+
+      _buildParticipationWithAssessment({
+        campaignId,
+        participantExternalId: 'to share participation',
+        isShared: false,
+        withMultipleAssessments: true,
+      });
+
+      _buildParticipationWithAssessment({
+        campaignId,
+        participantExternalId: 'started participation',
+        isShared: false,
+        assessmentState: 'started',
+        withMultipleAssessments: true,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('computes "STARTED" participations status', async function() {
+      await computeParticipantStatuses(false);
+
+      const campaignParticipation = await knex('campaign-participations').where({ participantExternalId: 'started participation' }).first();
+      expect(campaignParticipation.status).to.equals('STARTED');
+    });
+
+    it('computes "TO_SHARE" participations status', async function() {
+      await computeParticipantStatuses(false);
+
+      const campaignParticipation = await knex('campaign-participations').where({ participantExternalId: 'to share participation' }).first();
+      expect(campaignParticipation.status).to.equals('TO_SHARE');
+    });
+
+    it('computes "SHARED" participations status', async function() {
+      await computeParticipantStatuses(false);
+
+      const campaignParticipation = await knex('campaign-participations').where({ participantExternalId: 'shared participation' }).first();
+      expect(campaignParticipation.status).to.equals('SHARED');
+    });
+  });
+
+  context('For multiple campaign types', function() {
+    it('computes participation statuses of each campaign', async function() {
+      const { id: campaignId1 } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT });
+      const { id: campaignId2 } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
+
+      _buildParticipationWithAssessment({
+        campaignId: campaignId1,
+        participantExternalId: 'shared participation',
+        isShared: true,
+        assessmentState: 'completed',
+      });
+
+      _buildParticipationWithAssessment({
+        campaignId: campaignId2,
+        participantExternalId: 'to share participation',
+        isShared: false,
+        withMultipleAssessments: true,
+      });
+
+      await databaseBuilder.commit();
+
+      await computeParticipantStatuses(false);
+
+      const campaignParticipation1 = await knex('campaign-participations').where({ participantExternalId: 'shared participation' }).first();
+      expect(campaignParticipation1.status).to.equals('SHARED');
+
+      const campaignParticipation2 = await knex('campaign-participations').where({ participantExternalId: 'to share participation' }).first();
+      expect(campaignParticipation2.status).to.equals('TO_SHARE');
+    });
+  });
+});
+
+function _buildParticipationWithAssessment({ campaignId, participantExternalId, isShared, assessmentState, withMultipleAssessments }) {
+  const userId = databaseBuilder.factory.buildUser().id;
+
+  const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+    campaignId,
+    userId,
+    participantExternalId,
+    isShared,
+    sharedAt: isShared ? new Date('2020-01-02') : null,
+  }).id;
+
+  databaseBuilder.factory.buildAssessment({
+    campaignParticipationId,
+    userId,
+    state: assessmentState,
+    createdAt: new Date('2020-01-02'),
+  });
+
+  if (withMultipleAssessments) {
+    databaseBuilder.factory.buildAssessment({
+      campaignParticipationId,
+      userId,
+      state: 'aborted',
+      createdAt: new Date('2020-01-01'),
+    });
+
+    databaseBuilder.factory.buildAssessment({
+      campaignParticipationId,
+      userId,
+      state: 'completed',
+      createdAt: new Date('2019-01-01'),
+    });
+
+    databaseBuilder.factory.buildAssessment({
+      campaignParticipationId,
+      userId,
+      state: 'started',
+      createdAt: new Date('2019-01-01'),
+    });
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème

Le colonne `status` sur la table `campaign-participations` a récemment été ajoutée (voir PR #3442).
Nous devons créer un script permettant de renseigner l'état de chaque participation.

## :robot: Solution

Réaliser le script de migration pour les participations aux campagnes d'évaluation et de collectes de profils.

L'état d'une campagne participation est calculée de la façon suivante.
 
**Pour un campagne d'évaluation:**
- `STARTED`: Si le dernier assessment lié à la participation a un état `started`
- `TO_SHARE`: Si le dernier assessment lié à la participation a un état `completed` et la participation n'est pas partagée.
- `SHARED`: Si la participation est partagée

**Pour une campagne de collecte de profil:**
- `TO_SHARE`: Si la participation n'est pas partagée.
- `SHARED`: Si la participation est partagée

## :rainbow: Remarques

N/A

## :100: Pour tester

Exécuter le script et vérifier que l'état (`status`) des différentes participations est correcte.
