### PR TITLE
[FEATURE] Modification du fichier d'import Fregata (PIX-3140)

### DIFF
--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -7,6 +7,8 @@ const { getI18n } = require('../../../../tooling/i18n/i18n');
 const i18n = getI18n();
 
 const schoolingRegistrationCsvColumns = new SchoolingRegistrationColumns(i18n).columns.map((column) => column.label).join(';');
+const COL_TO_REMOVE = 'Code sexe*';
+const schoolingRegistrationCsvColumnsWithoutSexCode = new SchoolingRegistrationColumns(i18n).columns.map((column) => column.label).filter((col) => col !== COL_TO_REMOVE).join(';');
 
 describe('Unit | Infrastructure | SchoolingRegistrationParser', function() {
   context('when the header is not correctly formed', function() {
@@ -119,11 +121,6 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', function() {
         });
 
         context('when csv does not have \'Sex code\' column', function() {
-
-          const COL_TO_REMOVE = 'Sexe*';
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          const schoolingRegistrationCsvColumnsWithoutSexCode = new SchoolingRegistrationColumns(i18n).columns.map((column) => column.label).filter((col) => col !== COL_TO_REMOVE).join(';');
 
           it('returns a schooling registration for each line', function() {
             const input = `${schoolingRegistrationCsvColumnsWithoutSexCode}

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -73,7 +73,7 @@
       "division": "Class*",
       "first-name": "First name*",
       "last-name": "Last name*",
-      "sex": "Sex*",
+      "sex": "Sex code*",
       "mef-code": "MEF code*",
       "middle-name": "Middle name #1",
       "national-identifier": "Unique identifier*",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -85,7 +85,7 @@
       "division": "Division*",
       "first-name": "Premier prénom*",
       "last-name": "Nom de famille*",
-			"sex": "Sexe*",
+			"sex": "Code sexe*",
       "mef-code": "Code MEF*",
       "middle-name": "Deuxième prénom",
       "national-identifier": "Identifiant unique*",


### PR DESCRIPTION
## :unicorn: Problème
Pour le renseignement du genre de l'élève, le sco agri utilise une colonne "Code sexe" et non plus "Sexe".

## :robot: Solution
Modifier le nom de la colonne dans l'import d'élèves


## :100: Pour tester
Dans pix-orga

- Dans une organisation agri
- Importer des élèves à l'aide du csv suivant

```Nom de famille*;Nom d'usage;Premier prénom*;Deuxième prénom;Troisième prénom;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code pays naissance*;Code département naissance*;Code MEF*;Division*;Statut*;Identifiant unique*;Code sexe*```



- Constater que les élèves sont bien importés