### PR TITLE
[FEATURE] Marquer la participation "STARTED" au moment du "retenter". (PIX-3155)

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -14,6 +14,7 @@ module.exports = function buildCampaignParticipation({
   validatedSkillsCount,
   masteryPercentage,
   pixScore,
+  status,
   isImproved = false,
 } = {}) {
 
@@ -32,6 +33,7 @@ module.exports = function buildCampaignParticipation({
     validatedSkillsCount,
     masteryPercentage,
     pixScore,
+    status,
     isImproved,
   };
   return databaseBuffer.pushInsertable({

--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -50,11 +50,14 @@ module.exports = {
     const userId = request.auth.credentials.userId;
     const campaignParticipationId = request.params.id;
 
-    await usecases.beginCampaignParticipationImprovement({
-      campaignParticipationId,
-      userId,
+    return DomainTransaction.execute(async (domainTransaction) => {
+      await usecases.beginCampaignParticipationImprovement({
+        campaignParticipationId,
+        userId,
+        domainTransaction,
+      });
+      return null;
     });
-    return null;
   },
 
   async getAnalysis(request) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -133,6 +133,12 @@ class AlreadySharedCampaignParticipationError extends DomainError {
   }
 }
 
+class CantImproveCampaignParticipationError extends DomainError {
+  constructor(message = 'Une campagne de collecte de profils ne peut pas être retentée.') {
+    super(message);
+  }
+}
+
 class NoCampaignParticipationForUserAndCampaign extends DomainError {
   constructor(message = 'L\'utilisateur n\'a pas encore participé à la campagne') {
     super(message);
@@ -965,6 +971,7 @@ module.exports = {
   MissingOrInvalidCredentialsError,
   MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError,
   NoCampaignParticipationForUserAndCampaign,
+  CantImproveCampaignParticipationError,
   NoCertificationResultForDivision,
   NoStagesForCampaign,
   NoOrganizationToAttach,

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { ArchivedCampaignError, AssessmentNotCompletedError, AlreadySharedCampaignParticipationError } = require('../errors');
+const { ArchivedCampaignError, AssessmentNotCompletedError, AlreadySharedCampaignParticipationError, CantImproveCampaignParticipationError } = require('../errors');
 
 const statuses = {
   STARTED: 'STARTED',
@@ -53,6 +53,18 @@ class CampaignParticipation {
     this.isShared = true;
     this.sharedAt = new Date();
     this.status = statuses.SHARED;
+  }
+
+  improve() {
+    this._canBeImproved();
+
+    this.status = statuses.STARTED;
+  }
+
+  _canBeImproved() {
+    if (this.campaign.isProfilesCollection()) {
+      throw new CantImproveCampaignParticipationError();
+    }
   }
 
   _canBeShared() {

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -83,14 +83,14 @@ module.exports = {
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 
-  getLatestByCampaignParticipationId(campaignParticipationId) {
+  getLatestByCampaignParticipationId(campaignParticipationId, domainTransaction = DomainTransaction.emptyTransaction()) {
     return BookshelfAssessment
       .where({ 'campaign-participations.id': campaignParticipationId, 'assessments.type': 'CAMPAIGN' })
       .query((qb) => {
         qb.innerJoin('campaign-participations', 'campaign-participations.id', 'assessments.campaignParticipationId');
       })
       .orderBy('assessments.createdAt', 'DESC')
-      .fetch({ withRelated: ['campaignParticipation.campaign'] })
+      .fetch({ withRelated: ['campaignParticipation.campaign'], transacting: domainTransaction.knexTransaction })
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 

--- a/api/tests/integration/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/tests/integration/domain/usecases/begin-campaign-participation-improvement.js
@@ -1,0 +1,20 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const beginCampaignParticipationImprovement = require('../../../../lib/domain/usecases/begin-campaign-participation-improvement');
+const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
+const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
+
+describe('Integration | UseCase | begin-campaign-participation-improvement', function() {
+  it('should change campaignParticipation status to STARTED', async function() {
+    const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: 'TO_SHARE', isShared: false, sharedAt: null });
+    databaseBuilder.factory.buildAssessment({ userId: campaignParticipation.userId, campaignParticipationId: campaignParticipation.id, type: 'CAMPAIGN' });
+    await databaseBuilder.commit();
+
+    await beginCampaignParticipationImprovement({ campaignParticipationRepository, assessmentRepository, campaignParticipationId: campaignParticipation.id, userId: campaignParticipation.userId });
+
+    const [campaignParticipationFound] = await knex('campaign-participations')
+      .where({ id: campaignParticipation.id });
+
+    expect(campaignParticipationFound.status).to.equal('STARTED');
+  });
+});
+

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -239,7 +239,10 @@ describe('Unit | Application | Controller | Campaign-Participation', function() 
         params: { id: campaignParticipationId },
         auth: { credentials: { userId } },
       };
+      const domainTransaction = Symbol();
+
       sinon.stub(usecases, 'beginCampaignParticipationImprovement');
+      DomainTransaction.execute = (lambda) => { return lambda(domainTransaction); };
       usecases.beginCampaignParticipationImprovement
         .resolves();
 
@@ -247,7 +250,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function() 
       await campaignParticipationController.beginImprovement(request);
 
       // then
-      expect(usecases.beginCampaignParticipationImprovement).to.have.been.calledOnceWith({ campaignParticipationId, userId });
+      expect(usecases.beginCampaignParticipationImprovement).to.have.been.calledOnceWith({ campaignParticipationId, userId, domainTransaction });
     });
   });
 

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -5,24 +5,21 @@ const { beginCampaignParticipationImprovement } = require('../../../../lib/domai
 const { AlreadySharedCampaignParticipationError, UserNotAuthorizedToAccessEntityError, CantImproveCampaignParticipationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Usecase | begin-campaign-participation-improvement', function() {
+  let dependencies;
+  let campaignParticipationRepository;
+  let assessmentRepository;
 
-  const campaignParticipationRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    get: sinon.stub(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    update: sinon.stub(),
-  };
-  const assessmentRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    save: sinon.stub(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    getLatestByCampaignParticipationId: sinon.stub(),
-  };
-  const dependencies = { campaignParticipationRepository, assessmentRepository };
+  beforeEach(function() {
+    campaignParticipationRepository = {
+      get: sinon.stub(),
+      update: sinon.stub(),
+    };
+    assessmentRepository = {
+      save: sinon.stub(),
+      getLatestByCampaignParticipationId: sinon.stub(),
+    };
+    dependencies = { campaignParticipationRepository, assessmentRepository };
+  });
 
   it('should throw an error if the campaign participation is not linked to user', async function() {
     // given

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -2,7 +2,7 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const { beginCampaignParticipationImprovement } = require('../../../../lib/domain/usecases');
-const { AlreadySharedCampaignParticipationError, UserNotAuthorizedToAccessEntityError, CantImproveCampaignParticipationError } = require('../../../../lib/domain/errors');
+const { AlreadySharedCampaignParticipationError, UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Usecase | begin-campaign-participation-improvement', function() {
   let dependencies;
@@ -51,28 +51,6 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function()
 
     // then
     expect(error).to.be.instanceOf(AlreadySharedCampaignParticipationError);
-  });
-
-  it('should throw an error if the campaign is of type profiles collection', async function() {
-    // given
-    const userId = 1;
-    const campaignParticipationId = 2;
-    const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId, id: campaignParticipationId, isShared: false, campaign: domainBuilder.buildCampaign({ type: 'PROFILES_COLLECTION' }) });
-    campaignParticipationRepository.get
-      .withArgs(campaignParticipationId, {})
-      .resolves(campaignParticipation);
-    const latestAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
-    latestAssessment.state = Assessment.states.COMPLETED;
-    assessmentRepository.getLatestByCampaignParticipationId
-      .withArgs(campaignParticipationId)
-      .resolves(latestAssessment);
-    assessmentRepository.save.resolves({});
-
-    // when
-    const error = await catchErr(beginCampaignParticipationImprovement)({ campaignParticipationId, userId, ...dependencies });
-
-    // then
-    expect(error).to.be.instanceOf(CantImproveCampaignParticipationError);
   });
 
   it('should not start another assessment when the current assessment of the campaign is of improving type and still ongoing', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons le besoin de filtrer par status dans l'onglet d'activité de Pix orga. Le calcul du status d'une participation à une campagne est couteux.

## :robot: Solution
Le status est donc stocké dans une campagne participation en base de donnée. Lorsque l'utilisateur veut retenter sa participation à une campagne on repasse le status de celle-ci à STARTED.

## :rainbow: Remarques
Il n'est pas possible de retenter une campagne de type collecte de profils. On a ajouté une transaction pour s'assurer que les opérations sur assessment et campaign-participations soient bien cohérentes.

## :100: Pour tester
Se connecter à Pix App avec le compte userpix1
Passer la campagne AZERTY123
Créer une campagne avec le profil cible "Résoudre des problèmes techniques (compétence 5.1)"
Passer cette nouvelle campagne
Cliquer sur "Je retente"
Vérifier en BDD que la propriété status de la participation à la campagne a bien pour valeur STARTED
