### PR TITLE
[TECH] Logger le dispatch de Domain Events (PIX-3175)

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -43,22 +43,21 @@ try {
 const knexConfig = knexConfigs[environment];
 const knex = require('knex')(knexConfig);
 
-const queries = new Map();
-
 knex.on('query', function(data) {
   if (logging.enableLogKnexQueriesWithCorrelationId && doesStoreContainsRequest()) {
+    const store = asyncLocalStorage.getStore();
     const queryStartedTime = performance.now();
-    queries.set(data.__knexQueryUid, queryStartedTime);
+    store.knexQueriesUUIDs[data.__knexQueryUid] = queryStartedTime;
   }
 });
 
 knex.on('query-response', function(response, obj) {
   if (logging.enableLogKnexQueriesWithCorrelationId && doesStoreContainsRequest()) {
-    const queryStartedTime = queries.get(obj.__knexQueryUid);
+    const store = asyncLocalStorage.getStore();
+    const queryStartedTime = store.knexQueriesUUIDs[obj.__knexQueryUid];
     const duration = performance.now() - queryStartedTime;
     obj.duration = duration;
     addKnexMetricsToRequestContext(obj);
-    queries.delete(obj.__knexQueryUid);
   }
 });
 

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -1,6 +1,7 @@
 const types = require('pg').types;
 const { addPositionToQuerieAndIncrementQueriesCounter, logKnexQueriesWithCorrelationId } = require('../lib/infrastructure/monitoring-tools');
 const { logging } = require('../lib/config');
+const { performance } = require('perf_hooks');
 /*
 By default, node-postgres casts a DATE value (PostgreSQL type) as a Date Object (JS type).
 But, when dealing with dates with no time (such as birthdate for example), we want to
@@ -46,7 +47,7 @@ const queries = new Map();
 
 knex.on('query', function(data) {
   if (logging.enableLogKnexQueriesWithCorrelationId) {
-    const queryStartedTime = new Date();
+    const queryStartedTime = performance.now();
     queries.set(data.__knexQueryUid, queryStartedTime);
     addPositionToQuerieAndIncrementQueriesCounter(data.__knexQueryUid);
   }
@@ -55,7 +56,7 @@ knex.on('query', function(data) {
 knex.on('query-response', function(response, obj) {
   if (logging.enableLogKnexQueriesWithCorrelationId) {
     const queryStartedTime = queries.get(obj.__knexQueryUid);
-    const duration = new Date() - queryStartedTime;
+    const duration = performance.now() - queryStartedTime;
     obj.duration = duration;
     logKnexQueriesWithCorrelationId(obj, 'Knex Query');
     queries.delete(obj.__knexQueryUid);

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -66,6 +66,7 @@ module.exports = (function() {
       colorEnabled: false,
       logLevel: (process.env.LOG_LEVEL || 'info'),
       enableLogKnexQueriesWithCorrelationId: isFeatureEnabled(process.env.LOG_KNEX_QUERIES_WITH_CORRELATION_ID),
+      logEventDispatchWithCorrelationId: isFeatureEnabled(process.env.LOG_EVENT_DISPATCH_WITH_CORRELATION_ID),
       emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,
     },
 
@@ -259,6 +260,7 @@ module.exports = (function() {
 
     config.logging.enabled = false;
     config.logging.enableLogKnexQueriesWithCorrelationId = false;
+    config.logging.logEventDispatchWithCorrelationId = false;
 
     config.caching.redisUrl = null;
     config.caching.redisCacheKeyLockTTL = 0;

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -56,16 +56,26 @@ const handlersToBeInjected = {
 
 function buildEventDispatcher(handlersStubs) {
   const eventDispatcher = new EventDispatcher();
+
+  const handlersNames = _.map(handlersToBeInjected, (handler) => handler.name);
+
+  if (_.some(handlersNames, (name) => _.isEmpty(name))) {
+    throw new Error('All handlers must have a name. Handlers : ' + handlersNames.join(', '));
+  }
+  if (_.uniq(handlersNames).length !== handlersNames.length) {
+    throw new Error('All handlers must have a unique name. Handlers : ' + handlersNames.join(', '));
+  }
+
   const handlers = { ...handlersToBeInjected, ...handlersStubs };
 
   for (const key in handlers) {
     const inject = _.partial(injectDefaults, dependencies);
     const injectedHandler = inject(handlers[key]);
+    injectedHandler.handlerName = handlers[key].name;
     for (const eventType of handlersToBeInjected[key].eventTypes) {
       eventDispatcher.subscribe(eventType, injectedHandler);
     }
   }
-
   return eventDispatcher;
 }
 

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -69,13 +69,13 @@ function addKnexMetricsToRequestContext(data) {
 }
 
 function addEventDispatchLogToRequestContext(data) {
-  const request = asyncLocalStorage.getStore();
-  if (logging.logEventDispatchWithCorrelationId && request) {
-    request.eventsDispatch = request.eventsDispatch || [];
+  const store = asyncLocalStorage.getStore();
+  if (logging.logEventDispatchWithCorrelationId && store.metrics) { // TODO : & store.request ??
+    store.metrics.eventsDispatch = store.metrics.eventsDispatch || [];
     const errorMessage = get(data, 'error.message') ?
       (data.error.message + ' (see dedicated error log entry for more information)')
       : '-';
-    request.eventsDispatch.push({
+    store.metrics.eventsDispatch.push({
       message: data.message,
       event_name: data.eventName,
       event_content: data.eventContent,

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -68,6 +68,24 @@ function addKnexMetricsToRequestContext(data) {
   }
 }
 
+function addEventDispatchLogToRequestContext(data) {
+  const request = asyncLocalStorage.getStore();
+  if (logging.logEventDispatchWithCorrelationId && request) {
+    request.eventsDispatch = request.eventsDispatch || [];
+    const errorMessage = get(data, 'error.message') ?
+      (data.error.message + ' (see dedicated error log entry for more information)')
+      : '-';
+    request.eventsDispatch.push({
+      message: data.message,
+      event_name: data.eventName,
+      event_content: data.eventContent,
+      event_handler: data.eventHandler,
+      error_message: errorMessage,
+      duration: data.duration,
+    });
+  }
+}
+
 function extractUserIdFromRequest(request) {
   let userId = get(request, 'auth.credentials.userId');
   if (!userId && get(request, 'headers.authorization')) userId = requestUtils.extractUserIdFromRequest(request);
@@ -86,4 +104,5 @@ module.exports = {
   logKnexQueriesWithCorrelationId,
   logErrorWithCorrelationIds,
   logInfoWithCorrelationIds,
+  addEventDispatchLogToRequestContext,
 };

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -56,18 +56,13 @@ function logKnexQueriesWithCorrelationId(data, msg) {
 }
 
 function addKnexMetricsToRequestContext(data) {
-  const request = asyncLocalStorage.getStore();
-  if (request) {
-    request.knexQueryPosition = request.knexQueryPosition || [];
-    request.knexQueries = request.knexQueries || [];
-    request.queriesCounter = request.queriesCounter || 0;
-    request.queriesCounter++;
-    request.knexQueryPosition[data.__knexQueryUid] = request.queriesCounter;
-    request.knexQueries.push({
-      knex_query_id: data.__knexQueryUid,
-      knex_query_position: request.queriesCounter,
-      knex_query_sql: data.sql,
-      knex_query_params: [(data.bindings) ? data.bindings.join(',') : ''],
+  const store = asyncLocalStorage.getStore();
+  if (store && store.request && store.metrics) {
+    store.metrics.queriesCounter++;
+    store.metrics.knexQueries.push({
+      id: data.__knexQueryUid,
+      sql: data.sql,
+      params: [(data.bindings) ? data.bindings.join(',') : ''],
       duration: get(data, 'duration', '-'),
     });
   }

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -12,6 +12,7 @@ function logObjectSerializer(obj) {
     ...obj,
     user_id: get(store, 'request') ? extractUserIdFromRequest(store.request) : '-',
     knexQueries: get(store, 'metrics.knexQueries', '-'),
+    eventsDispatch: get(store, 'metrics.eventsDispatch', '-'),
   };
 }
 

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -7,11 +7,11 @@ const { get } = require('lodash');
 const { asyncLocalStorage, extractUserIdFromRequest } = require('./infrastructure/monitoring-tools');
 
 function logObjectSerializer(obj) {
-  const request = asyncLocalStorage.getStore();
+  const store = asyncLocalStorage.getStore();
   return {
     ...obj,
-    user_id: extractUserIdFromRequest(request),
-    knexQueries: get(request, 'knexQueries', '-'),
+    user_id: get(store, 'request') ? extractUserIdFromRequest(store.request) : '-',
+    knexQueries: get(store, 'metrics.knexQueries', '-'),
   };
 }
 

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -3,6 +3,7 @@ const settings = require('./config');
 const Blipp = require('blipp');
 const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
+const { get } = require('lodash');
 const { asyncLocalStorage, extractUserIdFromRequest } = require('./infrastructure/monitoring-tools');
 
 function logObjectSerializer(obj) {
@@ -10,6 +11,7 @@ function logObjectSerializer(obj) {
   return {
     ...obj,
     user_id: extractUserIdFromRequest(request),
+    knexQueries: get(request, 'knexQueries', '-'),
   };
 }
 

--- a/api/server.js
+++ b/api/server.js
@@ -18,7 +18,7 @@ const originalMethod = Request.prototype._execute;
 
 Request.prototype._execute = function(...args) {
   const request = this;
-  const store = { request, metrics: { knexQueries: [], queriesCounter: 0 }, knexQueriesUUIDs: {} };
+  const store = { request, metrics: { knexQueries: [], queriesCounter: 0, eventsDispatch: [] }, knexQueriesUUIDs: {} };
   return asyncLocalStorage.run(store, () => originalMethod.call(request, args));
 };
 

--- a/api/server.js
+++ b/api/server.js
@@ -18,7 +18,8 @@ const originalMethod = Request.prototype._execute;
 
 Request.prototype._execute = function(...args) {
   const request = this;
-  return asyncLocalStorage.run(request, () => originalMethod.call(request, args));
+  const store = { request, metrics: { knexQueries: [], queriesCounter: 0 }, knexQueriesUUIDs: {} };
+  return asyncLocalStorage.run(store, () => originalMethod.call(request, args));
 };
 
 let config;


### PR DESCRIPTION
## :unicorn: Problème
Le suivi du dispatch de Domain Events depuis les logs n'est pas simple.

## :robot: Solution
Logger le dispatch de Domain Events et, en particulier : 
- Type d'event dispatché
- Contenu de l'event
- Le nom de l'eventHandler a qui on a dispatché l'event
- La durée de traitement de l'event
- Une indication de succès/échec
- Le message d'erreur (si le dispatch a échoué)

**Example :** 
```json
"eventsDispatch": [
        {
          "message": "EventDispatcher : dispatched event successfully",
          "event_name": "AssessmentCompleted",
          "event_content": {
            "assessmentId": 10000011,
            "userId": 106,
            "campaignParticipationId": null,
            "certificationCourseId": 10000011
          },
          "event_handler": "handleBadgeAcquisition",
          "error_message": "-",
          "duration": 27067.51647377014
        },
        {
          "message": "EventDispatcher : an error occurred while dispatching an event",
          "event_name": "AssessmentCompleted",
          "event_content": {
            "assessmentId": 10000011,
            "userId": 106,
            "campaignParticipationId": null,
            "certificationCourseId": 10000011
          },
          "event_handler": "handleCertificationScoring",
          "error_message": "A fake error (see dedicated error log entry for more information)",
          "duration": 0.9003920555114746
        },
        {
          "message": "EventDispatcher : dispatched event successfully",
          "event_name": "AssessmentCompleted",
          "event_content": {
            "assessmentId": 10000011,
            "userId": 106,
            "campaignParticipationId": null,
            "certificationCourseId": 10000011
          },
          "event_handler": "handlePoleEmploiParticipationFinished",
          "error_message": "-",
          "duration": 0.1621723175048828
        }
      ]
```

## :rainbow: Remarques

Imaginons une chorégraphie d'event comme ceci

```
EventA -> HandlerA1 -> EventB -> HandlerB1
	\
	 \ -> HandlerA2 -> EventC -> HandlerC1
```
	 
Les handlers étant exécutés séquentiellement, s'exécuteront dans cet ordre : 
- `Handler A1`
- `Handler B1`
- `Handler A2`
- `Handler C1`

Imaginons maintenant qu'une exception soit lancée depuis le `Handler A1`
 	 
```
EventA -> HandlerA1💥 -> EventB -> HandlerB1
	\
	 \ -> HandlerA2   -> EventC -> HandlerC1
```

L'`Event B` ne sera jamais dispatché et donc le `Handler B1` ne sera pas exécuté (normal).
Par contre nous voudrions que le `Handler A2`, puis `C1` soient éxécutés.

Aussi il a été décidé de mettre un `try/catch` autour de l'éxécution des `Handlers` pour pouvoir logger cette erreur...
```json
{
  "message": "EventDispatcher : an error occurred while dispatching an event",
  "event_name": "A",
  "event_content": {},
  "event_handler": "A1",
  "error_message": "An error occured",
  "duration": 0.9003920555114746
}
```
... sans interrompre le reste de la chorégraphie.

Comme les exceptions se produisant lors de l'execution des handlers sont catchées, elles ne remontent pas "normalement" jusqu'à être logguées automatiquement pas les mécanismes actuels (erreur `500`) aussi celle-ci sont explicitement logguées dans le `catch`. Il est possible de faire le lien entre les logs d'event (i.e. le log de la requête) et les logs d'erreur dédiés via le `request_id`.    

## :100: Pour tester
- Mettre la variable d'envirionnement `LOG_EVENT_DISPATCH_WITH_CORRELATION_ID` à `true`
- Inscrire une session de certification
- Inscrire un candidat
- Aller jusqu'au bout de la certification 
- Consulter les logs
- Constater que les différents events de scoring / acquisition de badges ont été loggué
