### PR TITLE
[TECH] Ajour des variables CSS de Pix-ui (PIX-3186)

### DIFF
--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -3,8 +3,9 @@
 @import "ember-modal-dialog/ember-modal-structure";
 @import "ember-modal-dialog/ember-modal-appearance";
 
+@import 'colors';
+
 @import "globals/breakpoints";
-@import "globals/colors";
 @import "globals/errors";
 @import "globals/fonts";
 @import "globals/forms";

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -111,7 +111,7 @@
         svg {
           width: 14px;
           height: 16px;
-          color: $blue-zodia;
+          color: $blue-zodiac;
           font-size: 16px;
           font-weight: normal;
           letter-spacing: 0;
@@ -147,7 +147,7 @@
         input[id|="input-for-category-in-challenge-question-number"] {
           box-sizing: border-box;
           margin-left: 8px;
-          border: 1.2px solid $blue-zodia;
+          border: 1.2px solid $blue-zodiac;
           border-radius: 4px;
           padding: 2px  8px;
 

--- a/certif/app/styles/components/add-student-list.scss
+++ b/certif/app/styles/components/add-student-list.scss
@@ -5,7 +5,7 @@
 
   &__filters {
     background-color: $white;
-    color: $blue-zodia;
+    color: $blue-zodiac;
     padding: 18px 24px;
 
     label {
@@ -17,7 +17,7 @@
 
       &__list-button {
         display: flex;
-        color: $blue-zodia;
+        color: $blue-zodiac;
       }
     }
   }
@@ -90,7 +90,7 @@
     bottom: 0;
     box-shadow: -2px 2px 9px 0 rgba(0, 0, 0, 0.22);
     background-color: $white;
-    color: $blue-zodia;
+    color: $blue-zodiac;
     font-family: $roboto;
 
     .bottom-action-bar__informations {

--- a/certif/app/styles/components/certification-candidate-details-modal.scss
+++ b/certif/app/styles/components/certification-candidate-details-modal.scss
@@ -48,7 +48,7 @@
 
     &__value {
       font-weight: 400;
-      color: $blue-zodia;
+      color: $blue-zodiac;
     }
   }
 

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -37,7 +37,7 @@
     }
 
     .required-field-indicator {
-      color: $pix-red;
+      color: $red;
     }
 
     &__field {

--- a/certif/app/styles/globals/colors.scss
+++ b/certif/app/styles/globals/colors.scss
@@ -1,52 +1,8 @@
 // See https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a
 
-// primary
-$blue: #3D68FF;
-$blue-zodia: #505F79;
-$yellow: #FFBE00;
-$white: #FFFFFF;
-$black: #07142E;
-// secondary
-$pix-orga: #00DDFF;
-$pix-purplie: #6B20DC;
-$pix-purple: #8A49FF;
-$pix-certif-banner: #C4E8FF;
-$pix-certif-banner-text: #0069AB;
-$pix-red: #D63F00;
+// pix-ui _colors.scss
+@import 'styles/colors';
+
 // gradients
+
 $pix-green-gradient: linear-gradient(-45deg, #52D987 0%, #1A8C89 100%);
-// light
-$grey-5: #FAFBFC;
-$grey-10: #F4F5F7;
-$grey-15: #EAECF0;
-$grey-20: #DFE1E6;
-$grey-22: #C1C7D0;
-$grey-25: #A5ADBA;
-// medium
-$grey-30: #97A0AF;
-$grey-35: #8993A4;
-$grey-40: #7A869A;
-$grey-45: #6B778C;
-$grey-50: #5E6C84;
-$grey-60: #505F79;
-// dark
-$grey-70: #344563;
-$grey-80: #253858;
-$grey-90: #172B4D;
-$grey-100: #091E42;
-// gradients domain
-// solids
-$environment-dark: #5E2563;
-$environment-light: #564DA6;
-$communication-dark: #3D68FF;
-$communication-light: #12A3FF;
-$content-dark: #1A8C89;
-$content-light: #52D987;
-$information-dark: #F24645;
-$information-light: #F1A141;
-$security-dark: #AC008D;
-$security-light: #FF3F94;
-// status
-$error: #FF4B00;
-$success: #57C884;
-$warning: #FFBE00;

--- a/certif/app/styles/globals/colors.scss
+++ b/certif/app/styles/globals/colors.scss
@@ -3,6 +3,3 @@
 // pix-ui _colors.scss
 @import 'styles/colors';
 
-// gradients
-
-$pix-green-gradient: linear-gradient(-45deg, #52D987 0%, #1A8C89 100%);

--- a/certif/app/styles/globals/colors.scss
+++ b/certif/app/styles/globals/colors.scss
@@ -1,5 +1,0 @@
-// See https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a
-
-// pix-ui _colors.scss
-@import 'styles/colors';
-

--- a/certif/app/styles/globals/forms.scss
+++ b/certif/app/styles/globals/forms.scss
@@ -81,7 +81,7 @@ input[type=number] {
     background: none;
     font-family: $roboto;
     font-size: 0.875rem;
-    color: $blue-zodia;
+    color: $blue-zodiac;
 
     &:hover {
       cursor: pointer;

--- a/certif/app/styles/pages/authenticated/sessions/add-student.scss
+++ b/certif/app/styles/pages/authenticated/sessions/add-student.scss
@@ -1,7 +1,7 @@
 .add-student {
   margin-bottom: 68px;
   &__return-to span {
-    color: $blue-zodia;
+    color: $blue-zodiac;
   }
 
   &__title {

--- a/certif/app/styles/pages/authenticated/terms-of-service.scss
+++ b/certif/app/styles/pages/authenticated/terms-of-service.scss
@@ -4,7 +4,7 @@
   width: 100%;
   min-height: 100%;
   min-height: 100vh;
-  background: $pix-green-gradient;
+  background: $pix-certif-gradient;
   align-items: center;
 }
 

--- a/certif/app/styles/pages/login.scss
+++ b/certif/app/styles/pages/login.scss
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100px;
   min-height: 100vh;
-  background: $pix-green-gradient;
+  background: $pix-certif-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
   align-items: center;
 }

--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -24,7 +24,7 @@ module.exports = function(defaults) {
     },
     sassOptions: {
       includePaths: [
-        'node_modules/pix-ui/addon',
+        'node_modules/pix-ui/addon/styles',
       ],
     },
   });

--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -16,13 +16,16 @@ module.exports = function(defaults) {
     addons: {
       blacklist: pluginsToBlacklist,
     },
-
     flatpickr: {
       locales: ['fr'],
     },
-
     'ember-cli-template-lint': {
       testGenerator: 'qunit',
+    },
+    sassOptions: {
+      includePaths: [
+        'node_modules/pix-ui/addon',
+      ],
     },
   });
 


### PR DESCRIPTION
## :unicorn: Problème
La web-app certif n'utilise pas les variables CSS de pix-ui

## :robot: Solution
Importer les variables CSS de pix-ui, supprimer les variables dupliquées et adapter le code aux potentiels changement de noms

## :rainbow: Remarques
L'orientation du dégradé sur le page de login est différent

## :100: Pour tester
Pas de regression sur le visuel sur certif
