### PR TITLE
[BUGFIX] Ne plus avoir l'écran grisé sur des épreuves focus (PIX-3167).

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -61,13 +61,13 @@ export default class ChallengeItemGeneric extends Component {
 
     return this.args.answerValidated(this.args.challenge, this.args.assessment, this._getAnswerValue(), this._getTimeout(), this.args.hasFocusedOutOfWindow)
       .finally(() => {
-        this.args.finishChallenge();
+        this.args.resetChallengeInfo();
       });
   }
 
   @action
   resumeAssessment() {
-    this.args.finishChallenge();
+    this.args.resetChallengeInfo();
     return this.args.resumeAssessment(this.args.assessment);
   }
 
@@ -76,7 +76,7 @@ export default class ChallengeItemGeneric extends Component {
     this.errorMessage = null;
     return this.args.answerValidated(this.args.challenge, this.args.assessment, '#ABAND#', this._getTimeout(), this.args.hasFocusedOutOfWindow)
       .finally(() => {
-        this.args.finishChallenge();
+        this.args.resetChallengeInfo();
       });
   }
 }

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -67,6 +67,7 @@ export default class ChallengeItemGeneric extends Component {
 
   @action
   resumeAssessment() {
+    this.args.finishChallenge();
     return this.args.resumeAssessment(this.args.assessment);
   }
 

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -13,7 +13,7 @@
                 answer=@answer
                 assessment=@assessment
                 timeoutChallenge=@timeoutChallenge
-                finishChallenge=@finishChallenge
+                resetChallengeInfo=@resetChallengeInfo
                 hasFocusedOutOfWindow=this.hasFocusedOutOfWindow
                 answerValidated=@answerValidated
                 resumeAssessment=@resumeAssessment

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -76,7 +76,7 @@ export default class ChallengeController extends Controller {
   }
 
   @action
-  finishChallenge() {
+  resetChallengeInfo() {
     this.challengeTitle = defaultPageTitle;
     this.hasUserConfirmedWarning = false;
     this.hasFocusedOutOfChallenge = false;

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -15,7 +15,7 @@ export default class ChallengeController extends Controller {
   @service currentUser;
   @tracked newLevel = null;
   @tracked competenceLeveled = null;
-  @tracked challengeTitle = this.model.challenge.focused ? focusedPageTitle : defaultPageTitle;
+  @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOutOfChallenge = false;
   @tracked hasFocusedOutOfWindow = false;
   @tracked isTooltipOverlayDisplayed = !(this.currentUser.user && this.currentUser.user.hasSeenFocusedChallengeTooltip)
@@ -28,8 +28,9 @@ export default class ChallengeController extends Controller {
   get pageTitle() {
     const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, this.model.currentChallengeNumber);
     const totalChallengeNumber = progressInAssessment.getMaxStepsNumber(this.model.assessment);
+    const title = this.model.challenge.focused ? focusedPageTitle : this.challengeTitle;
 
-    return this.intl.t(this.challengeTitle, { stepNumber, totalChallengeNumber });
+    return this.intl.t(title, { stepNumber, totalChallengeNumber });
   }
 
   get isFocusedChallengeAndUserHasFocusedOutOfChallenge() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -78,6 +78,8 @@ export default class ChallengeController extends Controller {
   finishChallenge() {
     this.challengeTitle = defaultPageTitle;
     this.hasUserConfirmedWarning = false;
+    this.hasFocusedOutOfChallenge = false;
+    this.hasFocusedOutOfWindow = false;
   }
 
   get displayHomeLink() {

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -29,7 +29,7 @@
         @assessment={{@model.assessment}}
         @answer={{@model.answer}}
         @timeoutChallenge={{this.timeoutChallenge}}
-        @finishChallenge={{this.finishChallenge}}
+        @resetChallengeInfo={{this.resetChallengeInfo}}
         @answerValidated={{route-action "saveAnswerAndNavigate"}}
         @resumeAssessment={{route-action "resumeAssessment"}}
         @onFocusIntoChallenge={{fn this.setFocusedOutOfChallenge false}}


### PR DESCRIPTION
## :unicorn: Problème
Quand on a une épreuve focus considéré comme sorti, l'épreuve d'après peut être déjà grisé.

## :robot: Solution
- Mettre à jour les attributs quand on passe à l'épreuve suivante

## :rainbow: Remarques
Proposition du bugfix aussi sur le titre

## :100: Pour tester
Passer des compétences avec des Focus
Vérifier les titres
Vérifier qu'on n'ait pas d'écran grisé.
Test avec Focus : recBCwxarnE8QntZr
Pour le test avec Focus (à faire sur recette et sur la RA) : 
- Répondre à la première question
- Répondre à la deuxieme qui n'est pas focus 
- Sur celle focus, sortir de la zone d'épreuve et revenir en arrière
- Cliquer sur Poursuivre 
- Voir en recette que l'écran est grisé sur l'épreuve, et pas sur la RA
Tests Timer : recVhpqHADC8KxyvG