### PR TITLE
[BUGFIX] L'affichage du code d'une campagne se fait sur deux lignes (PIX-2858).

### DIFF
--- a/orga/app/components/campaign/header/title.hbs
+++ b/orga/app/components/campaign/header/title.hbs
@@ -13,7 +13,7 @@
       <dt class="label-text">
         {{t 'pages.campaign.created-on'}}
       </dt>
-      <dd class="content-text">
+      <dd>
         {{moment-format @campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}
       </dd>
     </div>
@@ -22,7 +22,7 @@
       <dt class="label-text">
         {{t 'pages.campaign.created-by'}}
       </dt>
-      <dd class="content-text">
+      <dd>
         {{@campaign.creatorFullName}}
       </dd>
     </div>
@@ -31,7 +31,7 @@
       <dt class="label-text">
         {{t 'pages.campaign.code'}}
       </dt>
-      <dd class="content-text campaign-header-title__campaign-code">
+      <dd class="campaign-header-title__campaign-code">
         <span>{{@campaign.code}}</span>
         <Campaign::CopyPasteButton
           @clipBoardtext={{@campaign.code}}

--- a/orga/app/styles/components/campaign/header/title.scss
+++ b/orga/app/styles/components/campaign/header/title.scss
@@ -29,6 +29,10 @@
   }
 
   &__info-item {
+    color: $grey-60;
+    font-family: $roboto;
+    font-size: 1rem;
+
     & > dt {
       display: block;
       margin-bottom: 8px;
@@ -54,7 +58,7 @@
       justify-content: center;
       width: 100%;
     }
-  
+
     &__infos {
       justify-content: center;
     }


### PR DESCRIPTION
## :unicorn: Problème
L'affichage du code d'une campagne se fait sur deux lignes en cas de copier/coller on peut rater des caractères.

## :robot: Solution
Mettre le code campagne sur une seule ligne

## :rainbow: Remarques
La date de création, le  nom du créateur ont aussi ce problème.

## :100: Pour tester
Aller sur PixOrga
Afficher un campagne
Réduire la taille de l'écran et constater que la date et le code sont sur une seule ligne et que le nom et prénom sont sur deux lignes