### PR TITLE
[FEATURE] Minimiser le nombre d'appels lors de la recherche dans les composants Pix Admin (PIX-3116).

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -83,7 +83,7 @@ module.exports = function(environment) {
     },
 
     pagination: {
-      debounce: 250,
+      debounce: _getEnvironmentVariableAsNumber({ environmentVariableName: 'RESEARCH_DEBOUNCE_TIMEOUT', defaultValue: 500, minValue: 250 }),
     },
 
   };


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, on utilise des composants qui offrent un système de recherche qui lance un appel API à chaque caractère saisi ou supprimé. Exemple pour chercher un utilisateur avec le prénom (Philippe),  8 appels seront déclenchés si l'utilisateur saisi le prénom avec une cadence de 250ms par caractère, un peu moins s'il saisi plus de caractère par interval de 250ms.
Vu les temps constatés en production, ce mécanisme peut rapidement dégrader l'expérience avec notre base de donnée de plus de 4 millions d'utilisateurs.

![image](https://user-images.githubusercontent.com/10045497/132670869-b6f8dbb6-b3c3-4b49-9cc0-ca5e4f301582.png)


## :robot: Solution
Externaliser le temps d’attente avant le lancement de la recherche dans les pages de Pix Admin.  Augmenter cette valeur qui pourra être ré-ajuster par l'équipe de Support en se basant sur l'expérience de Pix Admin en production.

La valeur a été mise à 5 seconde pour voir l'application de timeout. On peut la modifié dans la variable d'env de la RA si besoin

## :100: Pour tester
Ouvrir les page de Pix Admin qui utilise le composant avec ce filtre de recherche. 

 https://admin-pr3472.review.pix.fr/users/list|https://admin.pix.fr/users/list
 https://admin-pr3472.review.pix.fr/certification-centers/list
 https://admin-pr3472.review.pix.fr/certification-centers/list

Saisir des données de recherche et vérifier que l'API n'est appelé qu'après que le timeout ne soit écoulé.
