### PR TITLE
[FEATURE] Créer une route permettant de lister les habilitations et mettre à jour l'affichage des habilitations d'un centre de certification dans Pix Admin (PIX-3174).

### DIFF
--- a/admin/app/helpers/contains.js
+++ b/admin/app/helpers/contains.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function contains([value, array]) {
+  return array.includes(value);
+}
+
+export default helper(contains);

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -12,10 +12,12 @@ export default class CertificationCentersGetRoute extends Route {
         certificationCenterId: certificationCenter.id,
       },
     });
+    const accreditations = await this.store.findAll('accreditation');
 
     return RSVP.hash({
       certificationCenterMemberships,
       certificationCenter,
+      accreditations,
     });
   }
 

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -11,6 +11,11 @@
       font-weight: 600;
       margin-bottom: 20px;
     }
+
+    .certification-center__subtitle {
+      font-size: 1.2rem;
+      font-waight: 600;
+    }
   }
 
   .certification-center {
@@ -31,4 +36,24 @@
     color: $error;
     font-size: .85rem;
   }
+
+  ul {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+  }
+
+  li {
+    float: left;
+    width: 200px;
+  }
+
+  .granted-accreditation-icon {
+    color: $green;
+  }
+
+  .not-granted-accreditation-icon {
+    color: $grey-35;
+  }
 }
+

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -15,11 +15,20 @@
         Type : <span>{{@model.certificationCenter.type}}</span><br>
         Identifiant externe : <span>{{@model.certificationCenter.externalId}}</span><br>
       </p>
+      <h3 class="certification-center__subtitle">Habilitations aux certifications complémentaires</h3>
       <ul>
-      {{#each @model.certificationCenter.accreditations as |accreditation|}}
-        <li>{{accreditation.name}}</li>
-      {{/each}}
+        {{#each @model.accreditations as |accreditation|}}
+          <li>
+            {{#if (contains accreditation @model.certificationCenter.accreditations)}}
+              <FaIcon class="granted-accreditation-icon" @icon="check-circle" />
+            {{else}}
+              <FaIcon class="not-granted-accreditation-icon" @icon="times-circle" />
+            {{/if}}
+            {{accreditation.name}}
+          </li>
+        {{/each}}
       </ul>
+
     </div>
   </section>
 

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -245,4 +245,8 @@ export default function() {
   this.get('/countries', (schema, _) => {
     return schema.countries.all();
   });
+
+  this.get('/accreditations', (schema, _) => {
+    return schema.accreditations.all();
+  });
 }

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -79,6 +79,21 @@ module('Acceptance | authenticated/certification-centers/get', function(hooks) {
     assert.contains('Pix+Surf');
   });
 
+  test('should highlight the accreditations of the current certification center', async function(assert) {
+    // given
+    const accreditation1 = server.create('accreditation', { name: 'Pix+Edu' });
+    const accreditation2 = server.create('accreditation', { name: 'Pix+Surf' });
+    server.create('accreditation', { name: 'Pix+Autre' });
+    certificationCenter.update({ accreditations: [accreditation1, accreditation2] });
+
+    // when
+    await visit(`/certification-centers/${certificationCenter.id}`);
+
+    // then
+    const grantedAccreditations = findAll('.certification-center__data > ul > li > svg[data-icon="check-circle"]');
+    assert.equal(grantedAccreditations.length, 2);
+  });
+
   test('should display Certification center memberships', async function(assert) {
     // given
     const expectedDate1 = moment(certificationCenterMembership1.createdAt).format('DD-MM-YYYY - HH:mm:ss');

--- a/admin/tests/unit/helpers/contains_test.js
+++ b/admin/tests/unit/helpers/contains_test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { contains } from 'pix-admin/helpers/contains';
+
+module('Unit | Helpers | contains', function() {
+
+  test('it should return true when a value is included in an array', function(assert) {
+    // given
+    const value = 2;
+    const array = [1, 2, 3];
+
+    // when
+    const result = contains([value, array]);
+
+    // then
+    assert.true(result);
+  });
+
+  test('it should return false when a value is not included in an array', function(assert) {
+    // given
+    const value = 4;
+    const array = [1, 2, 3];
+
+    // when
+    const result = contains([value, array]);
+
+    // then
+    assert.false(result);
+  });
+});

--- a/api/lib/application/accreditations/accreditation-controller.js
+++ b/api/lib/application/accreditations/accreditation-controller.js
@@ -1,0 +1,9 @@
+const usecases = require('../../domain/usecases');
+const accreditationSerializer = require('../../infrastructure/serializers/jsonapi/accreditation-serializer');
+
+module.exports = {
+  async findAccreditations() {
+    const accreditations = await usecases.findAccreditations();
+    return accreditationSerializer.serialize(accreditations);
+  },
+};

--- a/api/lib/application/accreditations/index.js
+++ b/api/lib/application/accreditations/index.js
@@ -1,0 +1,26 @@
+const accreditationController = require('./accreditation-controller');
+const securityPreHandlers = require('../security-pre-handlers');
+
+exports.register = async function(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/accreditations',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: accreditationController.findAccreditations,
+        tags: ['api'],
+        notes: [
+          'Cette route est utilisée par Pix Admin',
+          'Elle renvoie la liste des accreditations à des certifications complémentaires existantes.',
+        ],
+      },
+    },
+
+  ]);
+};
+
+exports.name = 'accreditations';

--- a/api/lib/domain/usecases/find-accreditations.js
+++ b/api/lib/domain/usecases/find-accreditations.js
@@ -1,0 +1,3 @@
+module.exports = function findAccreditations({ accreditationRepository }) {
+  return accreditationRepository.findAll();
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,5 +1,6 @@
 const dependencies = {
   accountRecoveryDemandRepository: require('../../infrastructure/repositories/account-recovery-demand-repository'),
+  accreditationRepository: require('../../infrastructure/repositories/accreditation-repository'),
   answerRepository: require('../../infrastructure/repositories/answer-repository'),
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -176,6 +176,7 @@ module.exports = injectDependencies({
   dissociateSchoolingRegistrations: require('./dissociate-schooling-registrations'),
   enrollStudentsToSession: require('./enroll-students-to-session'),
   finalizeSession: require('./finalize-session'),
+  findAccreditations: require('./find-accreditations'),
   findAllTags: require('./find-all-tags'),
   findAnswerByAssessment: require('./find-answer-by-assessment'),
   findAnswerByChallengeAndAssessment: require('./find-answer-by-challenge-and-assessment'),

--- a/api/lib/infrastructure/repositories/accreditation-repository.js
+++ b/api/lib/infrastructure/repositories/accreditation-repository.js
@@ -1,0 +1,19 @@
+const Accreditation = require('../../domain/models/Accreditation');
+const { knex } = require('../bookshelf');
+
+function _toDomain(row) {
+  return new Accreditation({
+    ...row,
+  });
+}
+
+module.exports = {
+  async findAll() {
+    const result = await knex
+      .from('accreditations')
+      .select('id', 'name')
+      .orderBy('id', 'asc');
+
+    return result.map(_toDomain);
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/accreditation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/accreditation-serializer.js
@@ -1,0 +1,10 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(accreditation) {
+    return new Serializer('accreditation', {
+      attributes: ['name'],
+    }).serialize(accreditation);
+  },
+};

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -1,5 +1,6 @@
 module.exports = [
   require('./application/account-recovery'),
+  require('./application/accreditations'),
   require('./application/answers'),
   require('./application/assessment-results'),
   require('./application/assessments'),

--- a/api/tests/acceptance/application/accreditations/accreditations-controller_test.js
+++ b/api/tests/acceptance/application/accreditations/accreditations-controller_test.js
@@ -1,0 +1,59 @@
+const { expect, databaseBuilder, insertUserWithRolePixMaster, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | API | accreditations-controller', function() {
+
+  let server;
+
+  beforeEach(async function() {
+    server = await createServer();
+  });
+
+  describe('GET /api/accreditations/', function() {
+
+    it('should return 200 HTTP status code', async function() {
+      // given
+      const pixMaster = await insertUserWithRolePixMaster();
+      const options = {
+        method: 'GET',
+        url: '/api/accreditations',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(pixMaster.id),
+        },
+      };
+      databaseBuilder.factory.buildAccreditation({
+        id: 1,
+        name: 'Pix+Edu',
+      });
+      databaseBuilder.factory.buildAccreditation({
+        id: 2,
+        name: 'Cléa Numérique',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        'data': [
+          {
+            'type': 'accreditations',
+            'id': '1',
+            'attributes': {
+              'name': 'Pix+Edu',
+            },
+          },
+          {
+            'type': 'accreditations',
+            'id': '2',
+            'attributes': {
+              'name': 'Cléa Numérique',
+            },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/accreditation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/accreditation-repository_test.js
@@ -1,0 +1,61 @@
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
+const accreditationRepository = require('../../../../lib/infrastructure/repositories/accreditation-repository');
+
+describe('Integration | Repository | accreditation-repository', function() {
+
+  describe('#findAll', function() {
+
+    describe('when there are accreditations', function() {
+
+      it('should return all accreditations ordered by id', async function() {
+        // given
+        databaseBuilder.factory.buildAccreditation({
+          id: 1,
+          name: 'Pix+Edu',
+        });
+        databaseBuilder.factory.buildAccreditation({
+          id: 2,
+          name: 'Pix+Droit',
+        });
+        databaseBuilder.factory.buildAccreditation({
+          id: 3,
+          name: 'CléA Numérique',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const accreditations = await accreditationRepository.findAll();
+
+        // then
+        const expectedAccreditations = [
+          domainBuilder.buildAccreditation({
+            id: 1,
+            name: 'Pix+Edu',
+          }),
+          domainBuilder.buildAccreditation({
+            id: 2,
+            name: 'Pix+Droit',
+          }),
+          domainBuilder.buildAccreditation({
+            id: 3,
+            name: 'CléA Numérique',
+          }),
+        ];
+
+        expect(accreditations).to.deepEqualArray(expectedAccreditations);
+      });
+    });
+
+    describe('when there are no accreditations', function() {
+
+      it('should return an empty array', async function() {
+        // given when
+        const accreditations = await accreditationRepository.findAll();
+
+        // then
+        expect(accreditations).to.be.empty;
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/accreditations/index_test.js
+++ b/api/tests/unit/application/accreditations/index_test.js
@@ -1,0 +1,29 @@
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+const moduleUnderTest = require('../../../../lib/application/accreditations');
+const accreditationController = require('../../../../lib/application/accreditations/accreditation-controller');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+describe('Unit | Application | Router | accreditations-router', function() {
+
+  describe('GET /api/accreditations', function() {
+
+    it('should return 403 HTTP status code when the user authenticated is not PixMaster', async function() {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(accreditationController, 'findAccreditations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/accreditations');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(accreditationController.findAccreditations);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-accreditations_test.js
+++ b/api/tests/unit/domain/usecases/find-accreditations_test.js
@@ -1,0 +1,37 @@
+const { expect, domainBuilder, sinon } = require('../../../test-helper');
+const findAccreditations = require('../../../../lib/domain/usecases/find-accreditations');
+
+describe('Unit | UseCase | find-accreditations', function() {
+
+  let accreditationRepository;
+
+  beforeEach(function() {
+
+    accreditationRepository = {
+      findAll: sinon.stub(),
+    };
+  });
+
+  it('should find the accreditations', async function() {
+    // given
+    const accreditations = [
+      domainBuilder.buildAccreditation({
+        id: 11,
+        name: 'Pix+Edu',
+      }),
+      domainBuilder.buildAccreditation({
+        id: 22,
+        name: 'Cléa Numérique',
+      }),
+    ];
+    accreditationRepository.findAll.resolves(accreditations);
+
+    // when
+    const result = await findAccreditations({
+      accreditationRepository,
+    });
+
+    // then
+    expect(result).to.deep.equal(accreditations);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/accreditation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/accreditation-serializer_test.js
@@ -1,0 +1,45 @@
+const { domainBuilder, expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/accreditation-serializer');
+
+describe('Unit | Serializer | JSONAPI | accreditation-serializer', function() {
+
+  describe('#serialize', function() {
+
+    it('should convert an accreditation model object into JSON API data', function() {
+      // given
+      const accreditations = [
+        domainBuilder.buildAccreditation({
+          id: 11,
+          name: 'Pix+Edu',
+        }),
+        domainBuilder.buildAccreditation({
+          id: 22,
+          name: 'Cléa Numérique',
+        }),
+      ];
+
+      // when
+      const json = serializer.serialize(accreditations);
+
+      // then
+      expect(json).to.deep.equal({
+        data: [
+          {
+            id: '11',
+            type: 'accreditations',
+            attributes: {
+              name: 'Pix+Edu',
+            },
+          },
+          {
+            id: '22',
+            type: 'accreditations',
+            attributes: {
+              name: 'Cléa Numérique',
+            },
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
L'affichage des habilitations d'un centre de certification dans la page de détail de Pix Admin nécessite d'avoir toutes les habilitations.

## :robot: Solution
- Créer un endpoint permettant de lister les habilitations existantes.
- Utiliser ce endpoint dans Pix Admin.
- Mettre à jour l'affichage des habilitations d'un centre de certification.

## :100: Pour tester
- Se connecter sur Pix-Admin
- Aller sur la page de détail du centre de certification “Centre SUP des Anne-étoiles” (id 3)
     - Constater que toutes les habilitations sont mise en avant.
- Aller sur la de détail du centre de certification "Centre PRO des Anne-Étoiles" (id 2)
    - Constater que l’habilitation “Clea Numérique ” est la seule mise en avant
- Aller sur la de détail du centre de certification "Centre SCO des Anne-Étoiles" (id 1)
    - Constater que toutes les habilitations sont grisées