### PR TITLE
[BUGFIX] Le bloc d'alerte de sorti d'épreuve focus ne doit pas bloquer l'utilisation de certains boutons (PIX-3179).

### DIFF
--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -54,28 +54,31 @@
 
   &__info-alert {
     z-index: 1;
-    position: sticky;
     display: flex;
     flex-direction: column;
     align-items: center;
-    bottom: 10px;
-    margin: 20px auto 0 auto;
-    padding: 24px 32px;
     border-radius: 51px;
     box-shadow: 0 10px 20px 0 rgba($blue, 0.06);
     background-color: rgba($blue-10, 0.9);
     color: $blue-60;
-    opacity: 0;
-    height: 0;
 
-    @include device-is('tablet') {
-      padding: 24px 98px;
+    &.challenge__info-alert--hide {
+      opacity: 0;
+      height: 0;
     }
 
     &.challenge__info-alert--show,
     &:focus.challenge__info-alert--could-show {
       opacity: 1;
       height: auto;
+      bottom: 10px;
+      margin: 20px auto 0 auto;
+      padding: 24px 32px;
+      position: sticky;
+
+      @include device-is('tablet') {
+        padding: 24px 98px;
+      }
     }
   }
 }

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -46,7 +46,7 @@
   </div>
     {{#if @model.challenge.focused}}
       <div
-          class="challenge__info-alert
+          class="challenge__info-alert challenge__info-alert--hide
           {{if this.displayInfoAlertForFocusOut 'challenge__info-alert--show'}}
           {{if this.couldDisplayInfoAlert 'challenge__info-alert--could-show'}}"
         tabindex="0"

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -44,21 +44,23 @@
   <div class="challenge__feedback" role="complementary">
     <FeedbackPanel @assessment={{@model.assessment}} @challenge={{@model.challenge}}/>
   </div>
-    <div
-      class="challenge__info-alert
-        {{if this.displayInfoAlertForFocusOut 'challenge__info-alert--show'}}
-        {{if this.couldDisplayInfoAlert 'challenge__info-alert--could-show'}}"
-      tabindex="0"
-      role="alert"
-      aria-live="assertive">
-      <div class="challenge-info-alert__icon" />
-      <p class="challenge-info-alert__title">
-        {{t 'pages.challenge.is-focused-challenge.info-alert.title'}}
-      </p>
-      <p class="challenge-info-alert__subtitle">
-        {{t 'pages.challenge.is-focused-challenge.info-alert.subtitle'}}
-      </p>
-    </div>
+    {{#if @model.challenge.focused}}
+      <div
+          class="challenge__info-alert
+          {{if this.displayInfoAlertForFocusOut 'challenge__info-alert--show'}}
+          {{if this.couldDisplayInfoAlert 'challenge__info-alert--could-show'}}"
+        tabindex="0"
+        role="alert"
+        aria-live="assertive">
+        <div class="challenge-info-alert__icon" />
+        <p class="challenge-info-alert__title">
+          {{t 'pages.challenge.is-focused-challenge.info-alert.title'}}
+        </p>
+        <p class="challenge-info-alert__subtitle">
+          {{t 'pages.challenge.is-focused-challenge.info-alert.subtitle'}}
+        </p>
+      </div>
+    {{/if}}
 </div>
 
 {{#if this.showLevelup}}

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -278,6 +278,18 @@ describe('Acceptance | Displaying a challenge of any type', () => {
         expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
       });
 
+      it('should not display warning block', async function() {
+        // given
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+        server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+
+        // when
+        await visit(`/assessments/${assessment.id}/challenges/0`);
+
+        // then
+        expect(find('.challenge__info-alert')).to.not.exist;
+      });
+
       describe('when user has focused out of document', function() {
         beforeEach(async function() {
           // given


### PR DESCRIPTION
## :unicorn: Problème
Le bloc du message warning bleu est invisible, mais sans le  `display:none` pour être accessible au clavier.
Le fait qu'il garde une épaisseur pouvait bloquer l'utilisation du reste de la page, le bloc étant sticky, invisible mais présent.

## :robot: Solution
- N'avoir ce bloc que pour les focus
- Retirer les marges et padding du bloc quand il n'est pas visible

## :rainbow: Remarques

## :100: Pour tester
Passer un test avec des focus : [recBCwxarnE8QntZr](https://app-pr3475.review.pix.fr/courses/recBCwxarnE8QntZr/)
- Le warning bleu s'affiche toujours à la sortie avec la souris
- De même avec le clavier
- Sur les non-focus, il n'existe pas
- Sur les focus, il ne bloque pas les boutons