### PR TITLE
[INFRA] Ajouter des helpers de tests getByLabel et queryByLabel à Pix Admin

### DIFF
--- a/admin/tests/acceptance/organization-information-management_test.js
+++ b/admin/tests/acceptance/organization-information-management_test.js
@@ -25,7 +25,7 @@ module('Acceptance | organization information management', function(hooks) {
 
       // when
       await fillInByLabel('Nom', 'newOrganizationName');
-      await clickByLabel('Ajouter');
+      await clickByLabel('Ajouter', { exact: true });
 
       // then
       assert.contains('newOrganizationName');

--- a/admin/tests/helpers/extended-ember-test-helpers/click-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/click-by-label.js
@@ -1,35 +1,8 @@
-import { click, findAll } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import getByLabel from './get-by-label';
 
 export default function clickByLabel(labelText) {
-  const clickableElement = _findClickableElementForLabel(labelText);
-
-  if (!clickableElement) {
-    throw new Error(`Cannot find clickable element labelled "${labelText}".`);
-  }
+  const clickableElement = getByLabel(labelText);
 
   return click(clickableElement);
-}
-
-function _findClickableElementForLabel(labelText) {
-  const clickableSelectors = ['button', 'a[href]', '[role="button"]', 'input[type="radio"]', 'input[type="checkbox"]', 'label[for]'];
-  return findAll(clickableSelectors.join(',')).find(_matchesLabel(labelText));
-}
-
-function _matchesLabel(labelText) {
-  return (element) => _matchesInnerText(element, labelText) ||
-                      _matchesTitle(element, labelText) ||
-                      _matchesAriaLabel(element, labelText);
-}
-
-function _matchesInnerText(element, labelText) {
-  return element.innerText.includes(labelText);
-}
-
-function _matchesTitle(element, labelText) {
-  return element.title && element.title.includes(labelText);
-}
-
-function _matchesAriaLabel(element, labelText) {
-  const ariaLabel = element.getAttribute('aria-label');
-  return ariaLabel && ariaLabel.includes(labelText);
 }

--- a/admin/tests/helpers/extended-ember-test-helpers/click-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/click-by-label.js
@@ -1,8 +1,8 @@
 import { click } from '@ember/test-helpers';
 import getByLabel from './get-by-label';
 
-export default function clickByLabel(labelText) {
-  const clickableElement = getByLabel(labelText);
+export default function clickByLabel(labelText, options) {
+  const clickableElement = getByLabel(labelText, options);
 
   return click(clickableElement);
 }

--- a/admin/tests/helpers/extended-ember-test-helpers/fill-in-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/fill-in-by-label.js
@@ -1,36 +1,8 @@
-import { fillIn, findAll, find } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
+import getByLabel from './get-by-label';
 
 export default function fillInByLabel(labelText, value) {
-  const control = _findControlForLabel(labelText);
+  const control = getByLabel(labelText);
 
   return fillIn(control, value);
-}
-
-function _findControlForLabel(labelText) {
-  const label = _findLabel(labelText);
-  if (label && label.control) return label.control;
-
-  const control = _findControl(labelText);
-  if (control) return control;
-
-  if (label && !label.control) {
-    throw new Error(`Found label "${labelText}" but no associated form control.`);
-  }
-  throw new Error(`Cannot find form control labelled "${labelText}".`);
-}
-
-function _findLabel(labelText) {
-  return findAll('label').find((label) => label.innerText.includes(labelText));
-}
-
-function _findControl(labelText) {
-  const selectors = [];
-
-  for (const tag of ['input', 'textarea', 'select']) {
-    for (const attr of ['aria-label', 'title']) {
-      selectors.push(`${tag}[${attr}="${labelText}"]`);
-    }
-  }
-
-  return find(selectors.join(','));
 }

--- a/admin/tests/helpers/extended-ember-test-helpers/get-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/get-by-label.js
@@ -1,0 +1,10 @@
+import queryByLabel from './query-by-label';
+
+export default function getByLabel(labelText) {
+  const labelledElement = queryByLabel(labelText);
+  if (!labelledElement) {
+    throw new Error(`Cannot find any element labelled "${labelText}".`);
+  }
+
+  return labelledElement;
+}

--- a/admin/tests/helpers/extended-ember-test-helpers/get-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/get-by-label.js
@@ -1,7 +1,7 @@
 import queryByLabel from './query-by-label';
 
-export default function getByLabel(labelText) {
-  const labelledElement = queryByLabel(labelText);
+export default function getByLabel(labelText, options) {
+  const labelledElement = queryByLabel(labelText, options);
   if (!labelledElement) {
     throw new Error(`Cannot find any element labelled "${labelText}".`);
   }

--- a/admin/tests/helpers/extended-ember-test-helpers/query-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/query-by-label.js
@@ -1,0 +1,56 @@
+import { findAll } from '@ember/test-helpers';
+
+export default function queryByLabel(labelText) {
+  const labelElement = _findLabelElement(labelText);
+  if (labelElement) {
+    return _getElementControlledByLabel(labelElement, labelText);
+  }
+
+  const labelledElement = _findElementWithLabel(labelText);
+  if (!labelledElement) {
+    return null;
+  }
+
+  return labelledElement;
+}
+
+function _findLabelElement(labelText) {
+  return findAll('label').find((label) => label.innerText.includes(labelText));
+}
+
+function _getElementControlledByLabel(label, labelText) {
+  if (!label.control) {
+    throw new Error(`Found label "${labelText}" but no associated form control.`);
+  }
+
+  return label.control;
+}
+
+function _findElementWithLabel(labelText) {
+  const labellableElementSelectors = ['button', 'a[href]', '[role="button"]', 'input', 'textarea', 'select', 'label[for]', 'img'];
+  return findAll(labellableElementSelectors.join(',')).find(_matchesLabel(labelText));
+}
+
+function _matchesLabel(labelText) {
+  return (element) => _matchesInnerText(element, labelText)
+    || _matchesTitle(element, labelText)
+    || _matchesAriaLabel(element, labelText)
+    || _matchesAltAttribute(element, labelText);
+}
+
+function _matchesInnerText(element, labelText) {
+  return element.innerText.includes(labelText);
+}
+
+function _matchesTitle(element, labelText) {
+  return element.title?.includes(labelText);
+}
+
+function _matchesAltAttribute(element, labelText) {
+  return element.alt?.includes(labelText);
+}
+
+function _matchesAriaLabel(element, labelText) {
+  const ariaLabel = element.getAttribute('aria-label');
+  return ariaLabel?.includes(labelText);
+}

--- a/admin/tests/helpers/extended-ember-test-helpers/query-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/query-by-label.js
@@ -1,7 +1,10 @@
 import { findAll } from '@ember/test-helpers';
 
-export default function queryByLabel(labelText) {
-  const labelElement = _findLabelElement(labelText);
+export default function queryByLabel(labelText, options = {}) {
+
+  options.exact = options.exact ?? false;
+
+  const labelElement = _findLabelElement(labelText, options);
   if (labelElement) {
     return _getElementControlledByLabel(labelElement, labelText);
   }
@@ -14,8 +17,14 @@ export default function queryByLabel(labelText) {
   return labelledElement;
 }
 
-function _findLabelElement(labelText) {
-  return findAll('label').find((label) => label.innerText.includes(labelText));
+function _findLabelElement(labelText, options) {
+  return findAll('label').find((label) => {
+    if (options.exact) {
+      return label.innerText === labelText;
+    }
+
+    return label.innerText.includes(labelText);
+  });
 }
 
 function _getElementControlledByLabel(label, labelText) {


### PR DESCRIPTION
## :unicorn: Problème

Il existe aujourd'hui des helpers de test très pratiques `clickByLabel` ou `fillInByLabel` qui permettent de sélectionner un élément HTML via son label puis de cliquer dessus ou de le remplir (dans le cas d'un champ de formulaire).
Mais on a parfois besoin de sélectionner un élément pour faire une autre opération ou simplement vérifier son existence (ou sa non existence).

## :robot: Solution

Cette PR ajoute deux helpers déjà présent dans Pix Certif :
- `queryByLabel(label: string)` qui retourne l'élément correspondant au label ou `null` s'il n'existe pas (utile pour vérifier qu'un élément n'est pas présent)
- `getByLabel(label: string)` qui retourne l'élément correspondant au label ou lève une exception s'il n'existe pas

C'est particulièrement utile pour les champs de formulaire car utiliser `assert.dom(getByLabel('Prénom')).exists()` plutôt que `assert.dom('#first-name').exists()` permet en une assertion de vérifier à la fois :
- que l'élément `input` est présent
- que l'élement `label` est présent
- que les deux sont bien reliés ensemble

## :rainbow: Remarques

- L'API s'inspire de l'excellente [Testing Library](https://testing-library.com/docs/queries/about#types-of-queries) qui n'est malheureusement pas compatible avec Ember.
- Une option `exact` a été ajoutée sur le modèle de celle de Testing Library. Elle permet de préciser si on matche le texte exact du label ou une sous-chaîne du label. 
Par exemple, un élément ayant pour label "Ajouter un membre" sera sélectionné si on appelle `getByLabel('Ajouter', { exact: false })` tandis que seul un élément ayant exactement le label "Ajouter" sera sélectionné si on appelle `getByLabel('Ajouter', { exact: true })`.
L'option `exact` vaut `false` par défaut, ce qui est le comportement inverse de la Testing Library. Ce choix a été fait pour ne pas casser le comportement des helpers déjà existant.

## :100: Pour tester

Lancer les tests de Pix Admin
