### PR TITLE
[BUGFIX] Pouvoir ajouter un élève qui est lié à un compte déjà lié à un élève de mon établissement (PIX-3447)

### DIFF
--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -149,9 +149,10 @@ module.exports = {
       ...schoolingRegistrationData,
       organizationId,
     }));
-    const currentSchoolingRegistrations = await this.findByOrganizationId({ organizationId });
+    const existingSchoolingRegistrations = await this.findByOrganizationId({ organizationId });
 
-    const [schoolingRegistrationsToUpdate, schoolingRegistrationsToCreate] = await this._getStudentsListToUpdateOrCreate(schoolingRegistrationsFromFile, currentSchoolingRegistrations);
+    const reconciledSchoolingRegistrationsToImport = await this._reconcileSchoolingRegistrations(schoolingRegistrationsFromFile, existingSchoolingRegistrations);
+    const [schoolingRegistrationsToUpdate, schoolingRegistrationsToCreate] = await this._getStudentsListToUpdateOrCreate(reconciledSchoolingRegistrationsToImport, existingSchoolingRegistrations);
 
     try {
       await Promise.all([
@@ -180,22 +181,31 @@ module.exports = {
     }
   },
 
-  async _getStudentsListToUpdateOrCreate(schoolingRegistrationStudent, currentSchoolingRegistrations) {
-    const nationalStudentIdsFromFile = schoolingRegistrationStudent.map((schoolingRegistrationData) => schoolingRegistrationData.nationalStudentId);
+  async _reconcileSchoolingRegistrations(schoolingRegistrationsToImport, existingSchoolingRegistrations) {
+    const nationalStudentIdsFromFile = schoolingRegistrationsToImport.map((schoolingRegistrationData) => schoolingRegistrationData.nationalStudentId);
     const students = await studentRepository.findReconciledStudentsByNationalStudentId(_.compact(nationalStudentIdsFromFile));
 
-    return _.partition(schoolingRegistrationStudent, (schoolingRegistration) => {
-
-      const currentSchoolingRegistration = currentSchoolingRegistrations.find((currentSchoolingRegistration) => {
+    return _.map(schoolingRegistrationsToImport, (schoolingRegistration) => {
+      const currentSchoolingRegistration = existingSchoolingRegistrations.find((currentSchoolingRegistration) => {
         return currentSchoolingRegistration.nationalStudentId === schoolingRegistration.nationalStudentId;
       });
 
       if (!currentSchoolingRegistration || !_isReconciled(currentSchoolingRegistration)) {
-        const student = students.find((student) => student.nationalStudentId === schoolingRegistration.nationalStudentId && !currentSchoolingRegistrations.some(({ userId }) => userId === student.account.userId));
+        const student = students.find((student) => student.nationalStudentId === schoolingRegistration.nationalStudentId && !existingSchoolingRegistrations.some(({ userId }) => userId === student.account.userId));
         if (student) {
           schoolingRegistration.userId = student.account.userId;
         }
       }
+      return schoolingRegistration;
+    });
+  },
+
+  async _getStudentsListToUpdateOrCreate(schoolingRegistrationsToImport, existingSchoolingRegistrations) {
+    return _.partition(schoolingRegistrationsToImport, (schoolingRegistration) => {
+
+      const currentSchoolingRegistration = existingSchoolingRegistrations.find((currentSchoolingRegistration) => {
+        return currentSchoolingRegistration.nationalStudentId === schoolingRegistration.nationalStudentId;
+      });
 
       return !!currentSchoolingRegistration;
     });

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -191,7 +191,7 @@ module.exports = {
       });
 
       if (!currentSchoolingRegistration || !_isReconciled(currentSchoolingRegistration)) {
-        const student = students.find((student) => student.nationalStudentId === schoolingRegistration.nationalStudentId);
+        const student = students.find((student) => student.nationalStudentId === schoolingRegistration.nationalStudentId && !currentSchoolingRegistrations.some(({ userId }) => userId === student.account.userId));
         if (student) {
           schoolingRegistration.userId = student.account.userId;
         }


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un élève est importé via un fichier SIECLE et qu'il est réconcilié avec un compte déjà associé à un élève de l'établissement l'import échoue.

Exemple : Cela arrive dans les fratries à cheval entre le collège et le lycée. Lorsque le plus jeune arrive au lycée et qu'ils se sont réconcilié avec le même compte par mégarde (ordinateur familial).

## :robot: Solution
On enregistre l'élève dans l'établissement sans réconcilier son inscription.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Étape 1
  - Se connecter à PixOrga avec sco.admin
  - Importer dans Collège The Night Watch ce [fichier](https://github.com/1024pix/pix/files/7144962/import-college.xml.txt)
  - Importer dans Lycée The Night Watch ce [fichier](https://github.com/1024pix/pix/files/7144963/import-lycee.xml.txt)

- Étape  2
  - Se connecter à PixApp avec userpix1
  - Participer à une campagne BADGES123 en se réconciliant en tant que : BB | BB | 01/01/2001
  - Participer à une campagne BADGES456 en se réconciliant en tant que : AA | AA | 01/01/2001

- Étape 3
  - Se connecter à PixOrga avec sco.admin
  - Importer dans Lycée The Night Watch ce [fichier](https://github.com/1024pix/pix/files/7144964/import-lycee-2.xml.txt)
  - L'import ne doit pas planter

Pour re-tester lancer sur la RA : `npm run db:empty && npm run db:seed` 