### PR TITLE
[FEATURE] Distinguer les Schooling registration désactivées sur PixAdmin en utilisant la colonne 'isDisabled' (PIX-3098).

### DIFF
--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -240,7 +240,6 @@
         <th>DDN</th>
         <th class="table__column--small">Classe</th>
         <th class="table__column--small">Orga ID</th>
-        <th>UAI</th>
         <th class="table__column--wide">Nom de l'orga</th>
         <th>Date d'import</th>
         <th>Dernière MAJ</th>
@@ -256,8 +255,7 @@
           <td>{{format-date schoolingRegistration.birthdate}}</td>
           <td>{{schoolingRegistration.division}}</td>
           <td><LinkTo @route="authenticated.organizations.get" @model={{schoolingRegistration.organizationId}}>{{schoolingRegistration.organizationId}}</LinkTo></td>
-          <td>{{schoolingRegistration.organizationExternalId}}</td>
-          <td title="{{schoolingRegistration.organizationName}}">{{schoolingRegistration.organizationName}}</td>
+          <td>{{schoolingRegistration.organizationName}}</td>
           <td>{{format-date schoolingRegistration.createdAt}}</td>
           <td>{{format-date schoolingRegistration.updatedAt}}</td>
           <td class="table-admin-schooling-registrations-status">
@@ -280,7 +278,7 @@
         </tr>
       {{else}}
         <tr>
-          <td colspan="11" class="table-admin-empty">Aucun résultat</td>
+          <td colspan="10" class="table-admin-empty">Aucun résultat</td>
         </tr>
       {{/each}}
       </tbody>

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -244,6 +244,7 @@
         <th class="table__column--wide">Nom de l'orga</th>
         <th>Date d'import</th>
         <th>Dernière MAJ</th>
+        <th>Actif</th>
         <th>Actions</th>
       </tr>
       </thead>
@@ -259,6 +260,13 @@
           <td title="{{schoolingRegistration.organizationName}}">{{schoolingRegistration.organizationName}}</td>
           <td>{{format-date schoolingRegistration.createdAt}}</td>
           <td>{{format-date schoolingRegistration.updatedAt}}</td>
+          <td class="table-admin-schooling-registrations-status">
+            {{#if schoolingRegistration.isDisabled}}
+              <FaIcon @icon="times-circle" class="schooling-registrations-table__status--isDisabled" aria-label="Inscription désactivée"/>
+            {{else}}
+              <FaIcon @icon="check-circle" class="schooling-registrations-table__status--isEnabled" aria-label="Inscription activée"/>
+            {{/if}}
+          </td>
           <td>
             <PixButton
               @triggerAction={{fn this.toggleDisplayDissociateModal schoolingRegistration}}
@@ -272,7 +280,7 @@
         </tr>
       {{else}}
         <tr>
-          <td colspan="10" class="table-admin-empty">Aucun résultat</td>
+          <td colspan="11" class="table-admin-empty">Aucun résultat</td>
         </tr>
       {{/each}}
       </tbody>

--- a/admin/app/models/schooling-registration.js
+++ b/admin/app/models/schooling-registration.js
@@ -11,6 +11,7 @@ export default class SchoolingRegistration extends Model {
   @attr() organizationName;
   @attr() createdAt;
   @attr() updatedAt;
+  @attr() isDisabled;
 
   @belongsTo('user') user;
 }

--- a/admin/app/styles/components/user-detail-personal-information-section.scss
+++ b/admin/app/styles/components/user-detail-personal-information-section.scss
@@ -20,6 +20,20 @@
   margin-top: 20px;
 }
 
+.schooling-registrations-table__status {
+  p {
+    margin: 0;
+  }
+
+  &--isEnabled {
+    color: $success;
+  }
+
+  &--isDisabled {
+    color: $error;
+  }
+}
+
 .user-authentication-method {
 
   &__item {

--- a/admin/app/styles/globals/table-admin.scss
+++ b/admin/app/styles/globals/table-admin.scss
@@ -1,5 +1,4 @@
 .table-admin {
-
   a:not(.pix-button) {
     color: $blue;
   }
@@ -12,14 +11,16 @@
     background-color: rgba(0, 0, 0, 0.03);
   }
 
-  tbody > tr, thead > tr {
+  tbody > tr,
+  thead > tr {
     border-bottom: 1px solid $grey-22;
 
     &:first-child {
       border-top: 1px solid $grey-22;
     }
 
-    td, th {
+    td,
+    th {
       padding: 6px 18px;
       border-left: 1px solid $grey-22;
 
@@ -47,4 +48,3 @@
   margin: 48px auto 36px auto;
   text-align: center;
 }
-

--- a/admin/tests/integration/components/user-detail-personal-information_test.js
+++ b/admin/tests/integration/components/user-detail-personal-information_test.js
@@ -177,6 +177,34 @@ module('Integration | Component | user-detail-personal-information', function(ho
           // then
           assert.dom('tr[aria-label="Inscription"]').exists({ count: 2 });
         });
+
+        module('Display the schooling registrations status', function() {
+
+          test('Should display a green tick mark on the table when "isDisabled = false"', async function(assert) {
+            // given
+            this.set('user', { schoolingRegistrations: [{ id: 1, isDisabled: false }] });
+
+            // when
+            await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+            // then
+            assert.dom('[aria-label="Inscription activée"]').exists();
+
+          });
+
+          test('Should display a red cross on the table when "isDisabled= true"', async function(assert) {
+            // given
+            this.set('user', { schoolingRegistrations: [{ id: 1, isDisabled: true }] });
+
+            // when
+            await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+            // then
+            assert.dom('[aria-label="Inscription désactivée"]').exists();
+
+          });
+
+        });
       });
     });
 

--- a/api/lib/domain/read-models/SchoolingRegistrationForAdmin.js
+++ b/api/lib/domain/read-models/SchoolingRegistrationForAdmin.js
@@ -13,6 +13,7 @@ const validationSchema = Joi.object({
   organizationName: Joi.string().required(),
   createdAt: Joi.date().required(),
   updatedAt: Joi.date().required(),
+  isDisabled: Joi.boolean().required(),
 });
 
 class SchoolingRegistrationForAdmin {
@@ -28,6 +29,7 @@ class SchoolingRegistrationForAdmin {
     organizationName,
     createdAt,
     updatedAt,
+    isDisabled,
   }) {
     this.id = id;
     this.firstName = firstName;
@@ -39,10 +41,10 @@ class SchoolingRegistrationForAdmin {
     this.organizationName = organizationName;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.isDisabled = isDisabled;
 
     validateEntity(validationSchema, this);
   }
 }
 
 module.exports = SchoolingRegistrationForAdmin;
-

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -443,6 +443,7 @@ function _toSchoolingRegistrationsForAdmin(schoolingRegistrations) {
       organizationName: schoolingRegistration.organization.name,
       createdAt: schoolingRegistration.createdAt,
       updatedAt: schoolingRegistration.updatedAt,
+      isDisabled: schoolingRegistration.isDisabled,
     });
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -14,7 +14,7 @@ module.exports = {
         ref: 'id',
         includes: true,
         attributes: ['firstName', 'lastName', 'birthdate', 'division', 'organizationId', 'organizationExternalId',
-          'organizationName', 'createdAt', 'updatedAt'],
+          'organizationName', 'createdAt', 'updatedAt', 'isDisabled'],
       },
       authenticationMethods: {
         ref: 'id',

--- a/api/tests/tooling/domain-builder/factory/build-schooling-registration-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-schooling-registration-for-admin.js
@@ -11,6 +11,7 @@ module.exports = function buildSchoolingRegistrationForAdmin({
   organizationName = 'name',
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-01'),
+  isDisabled = false,
 } = {}) {
   return new SchoolingRegistrationForAdmin({
     id,
@@ -23,5 +24,6 @@ module.exports = function buildSchoolingRegistrationForAdmin({
     organizationName,
     createdAt,
     updatedAt,
+    isDisabled,
   });
 };

--- a/api/tests/unit/domain/read-models/SchoolingRegistrationForAdmin_test.js
+++ b/api/tests/unit/domain/read-models/SchoolingRegistrationForAdmin_test.js
@@ -18,6 +18,7 @@ describe('Unit | Domain | Read-models | SchoolingRegistrationForAdmin', function
         organizationName: 'School',
         createdAt: new Date('2020-09-05'),
         updatedAt: new Date('2020-09-08'),
+        isDisabled: false,
       };
     });
 
@@ -104,6 +105,14 @@ describe('Unit | Domain | Read-models | SchoolingRegistrationForAdmin', function
       expect(() => new SchoolingRegistrationForAdmin({ ...validArguments, updatedAt: 'not_valid' }))
         .to.throw(ObjectValidationError);
       expect(() => new SchoolingRegistrationForAdmin({ ...validArguments, updatedAt: undefined }))
+        .to.throw(ObjectValidationError);
+    });
+
+    it('should throw an ObjectValidationError when isDisabled is not valid', function() {
+      // when
+      expect(() => new SchoolingRegistrationForAdmin({ ...validArguments, isDisabled: 'not_valid' }))
+        .to.throw(ObjectValidationError);
+      expect(() => new SchoolingRegistrationForAdmin({ ...validArguments, isDisabled: undefined }))
         .to.throw(ObjectValidationError);
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -55,6 +55,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
             'organization-name': modelObject.schoolingRegistrations[0].organizationName,
             'created-at': modelObject.schoolingRegistrations[0].createdAt,
             'updated-at': modelObject.schoolingRegistrations[0].updatedAt,
+            'is-disabled': modelObject.schoolingRegistrations[0].isDisabled,
           },
           'id': `${modelObject.schoolingRegistrations[0].id}`,
           'type': 'schoolingRegistrations',


### PR DESCRIPTION
## :unicorn: Problème
La team prescription a ajouté une feature/flag dans la table schooling registration isDisabled qui désactive les SR mais dans Pix admin on ne peux pas distinguer les SR actives et désactivées

## :robot: Solution
Dans Pix admin/users/xxxxx ; dans le tableau Informations élèves SCO, ajouter dans la liste des schooling registration d'un user SCO une colonne supplémentaire “désactivée” a fin de pouvoir visualiser le status d'un SR pour un utilisateur donné.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur Pix Admin, allez dans la page Utilisateurs 
**Cas isDisabled = false**
- filtrez la liste des utilisateurs par le nom  " De Cambridge " puis sélectionnez l’utilisateur filtré , dans le tableau d'Informations sur les SA en bas de la page, constatez que la colonne 'Actif' existe avec une coche verte.

**Cas isDisabled = true**
- filtrez la liste des utilisateurs par le nom  " disabled " puis sélectionnez l’utilisateur filtré , dans le tableau d'Informations sur les SA en bas de la page, constatez que la colonne 'Actif' existe avec un croix rouge.