### PR TITLE
[BUGFIX] Ne pas afficher le warning d'écran de fin test si pas de certification terminée (PIX-3449)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -2,7 +2,7 @@
 
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 import sumBy from 'lodash/sumBy';
@@ -29,10 +29,9 @@ export default class SessionsFinalizeController extends Controller {
     return this.featureToggles.featureToggles.isManageUncompletedCertifEnabled;
   }
 
-  @computed('session.certificationReports.@each.hasSeenEndTestScreen')
   get uncheckedHasSeenEndTestScreenCount() {
     return sumBy(
-      this.session.certificationReports.toArray(),
+      this.session.completedCertificationReports.toArray(),
       (reports) => Number(!reports.hasSeenEndTestScreen),
     );
   }

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -141,7 +141,23 @@ module('Acceptance | Session Finalization', function(hooks) {
         });
       });
 
-      module('when there is no completed report', function() {
+      module('when there are no completed report', function() {
+
+        test('it should not display end test screen warning', async function(assert) {
+          // given
+          const certificationReport = server.create('certification-report', { isCompleted: false, abortReason: 'technical' });
+
+          session.update({ certificationReports: [certificationReport] });
+
+          // when
+          await visit(`/sessions/${session.id}/finalisation`);
+          await clickByLabel('Finaliser');
+
+          // then
+          assert.contains(CONFIRMATION_TEXT);
+          assert.notContains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
+        });
+
         test('it should not show the completed reports table', async function(assert) {
           // given
           const certificationReport = server.create('certification-report', { isCompleted: false, abortReason: null });

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import ArrayProxy from '@ember/array/proxy';
+import { run } from '@ember/runloop';
+import Service from '@ember/service';
 import sinon from 'sinon';
 
 const FINALIZE_PATH = 'authenticated/sessions/finalize';
@@ -12,11 +13,17 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
 
     test('it should count no unchecked box if no report', function(assert) {
       // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = {
+          isManageUncompletedCertifEnabled: false,
+        };
+      }
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const session = ArrayProxy.create({
+      controller.model = run(() => store.createRecord('session', {
         certificationReports: [],
-      });
-      controller.model = session;
+      }));
 
       // when
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
@@ -26,59 +33,57 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     });
 
     test('it should count unchecked boxes', function(assert) {
-
       // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = {
+          isManageUncompletedCertifEnabled: false,
+        };
+      }
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const session = ArrayProxy.create({
-        certificationReports: [
-          { hasSeenEndTestScreen: true },
-          { hasSeenEndTestScreen: false },
-          { hasSeenEndTestScreen: false },
-          { hasSeenEndTestScreen: false },
-          { hasSeenEndTestScreen: true },
-        ],
-      });
-      controller.model = session;
+      const certificationReportA = run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: true,
+      }));
+      const certificationReportB = run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: false,
+      }));
+      const certificationReportC = run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: false,
+      }));
+      controller.model = run(() => store.createRecord('session', {
+        certificationReports: [certificationReportA, certificationReportB, certificationReportC],
+      }));
 
       // when
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
 
       // then
-      assert.equal(uncheckedHasSeenEndTestScreenCount, 3);
-    });
-
-    test('it should count 1 unchecked box if only one box (unchecked)', function(assert) {
-
-      // given
-      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const session = ArrayProxy.create({
-        certificationReports: [
-          { hasSeenEndTestScreen: false },
-        ],
-      });
-      controller.model = session;
-
-      // when
-      const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
-
-      // then
-      assert.strictEqual(uncheckedHasSeenEndTestScreenCount, 1);
+      assert.equal(uncheckedHasSeenEndTestScreenCount, 2);
     });
   });
 
   module('#computed hasUncheckedHasSeenEndTestScreen', function() {
 
     test('it should be false if no unchecked certification reports', function(assert) {
-
       // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = {
+          isManageUncompletedCertifEnabled: false,
+        };
+      }
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const session = ArrayProxy.create({
-        certificationReports: [
-          { hasSeenEndTestScreen: true },
-          { hasSeenEndTestScreen: true },
-        ],
-      });
-      controller.model = session;
+      const certificationReportA = run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: true,
+      }));
+      const certificationReportB = run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: true,
+      }));
+      controller.model = run(() => store.createRecord('session', {
+        certificationReports: [certificationReportA, certificationReportB],
+      }));
 
       // when
       const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
@@ -88,16 +93,24 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     });
 
     test('it should be true if at least one unchecked certification reports', function(assert) {
-
       // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = {
+          isManageUncompletedCertifEnabled: false,
+        };
+      }
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const session = ArrayProxy.create({
-        certificationReports: [
-          { hasSeenEndTestScreen: false },
-          { hasSeenEndTestScreen: true },
-        ],
-      });
-      controller.model = session;
+      const certificationReportA = run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: true,
+      }));
+      const certificationReportB = run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: false,
+      }));
+      controller.model = run(() => store.createRecord('session', {
+        certificationReports: [certificationReportA, certificationReportB],
+      }));
 
       // when
       const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;


### PR DESCRIPTION
## :unicorn: Problème
Avec la mise en place l'épix "Gestion des certifications démarrée", lorsqu'une session ne contient que des sessions non-terminées, on affiche quand même qu'il y'a des écrans de fin de test non vu, hors cette case à cocher n’apparaît pas dans le tableau pour les certifications démarrées. Le test n'étant pas terminé, l'ecran de fin de test ne peut pas avoir été coché.

## :robot: Solution
Ajouter une condition pour afficher ou non cet avertissement sur la modale de confirmation de finalisation.

## :100: Pour tester
- Créer une session
- Créer une certification
- Démarrer une certification (ne pas la terminer)
- Aller sur la page de finalisation de session de pix-certif
- Sélectionner une raison d'abandon
- Cliquer sur la finalisation
- Constater que l'avertissement lié aux écran de fin de test non coché n'apparait pas

![image](https://user-images.githubusercontent.com/37305474/133100384-6642be43-1ca7-465c-861d-85889c8a041f.png)


![image](https://user-images.githubusercontent.com/37305474/133100422-85cb9310-85f8-4550-8224-a50a498141f9.png)
