### PR TITLE
[TECH] Supprimer la gestion des erreurs sur les doublons d'INE dans la base de données (Pix-3189).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -228,9 +228,6 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SchoolingRegistrationsCouldNotBeSavedError) {
     return new HttpErrors.BadRequestError(error.message);
   }
-  if (error instanceof DomainErrors.SameNationalStudentIdInOrganizationError) {
-    return new HttpErrors.ConflictError(error.message);
-  }
   if (error instanceof DomainErrors.AssessmentNotCompletedError) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -169,24 +169,8 @@ class AccountRecoveryUserAlreadyConfirmEmail extends DomainError {
 }
 
 class SchoolingRegistrationsCouldNotBeSavedError extends DomainError {
-  constructor() {
-    super('An error occurred during process');
-  }
-}
-
-class SameNationalStudentIdInOrganizationError extends DomainError {
-  constructor(errorDetail) {
-    let message = 'INE already in use for this organization.';
-    let nationalStudentId;
-    const regex = /([a-zA-Z0-9]+)\)/;
-    if (errorDetail) {
-      const regexMatches = errorDetail.match(regex);
-      nationalStudentId = regexMatches[1];
-      message = `The INE ${nationalStudentId} is already in use for this organization.`;
-    }
-
+  constructor(message = 'An error occurred during process') {
     super(message);
-    this.nationalStudentId = errorDetail ? nationalStudentId : null;
   }
 }
 
@@ -985,7 +969,6 @@ module.exports = {
   OrganizationWithoutEmailError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
-  SameNationalStudentIdInOrganizationError,
   SchoolingRegistrationAlreadyLinkedToUserError,
   SchoolingRegistrationDisabledError,
   SchoolingRegistrationNotFound,

--- a/api/lib/domain/usecases/import-schooling-registrations-from-siecle.js
+++ b/api/lib/domain/usecases/import-schooling-registrations-from-siecle.js
@@ -7,7 +7,6 @@ const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 const ERRORS = {
   EMPTY: 'EMPTY',
-  INE_UNIQUE: 'INE_UNIQUE',
   INVALID_FILE_EXTENSION: 'INVALID_FILE_EXTENSION',
 };
 
@@ -22,7 +21,7 @@ module.exports = async function importSchoolingRegistrationsFromSIECLEFormat({ o
   } else if (format === 'csv') {
     schoolingRegistrationData = await schoolingRegistrationsCsvService.extractSchoolingRegistrationsInformation(path, organization, i18n);
   } else {
-    throw new FileValidationError('INVALID_FILE_EXTENSION', { fileExtension: format });
+    throw new FileValidationError(ERRORS.INVALID_FILE_EXTENSION, { fileExtension: format });
   }
 
   fs.unlink(payload.path);

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -3,7 +3,6 @@ const bluebird = require('bluebird');
 
 const {
   NotFoundError,
-  SameNationalStudentIdInOrganizationError,
   SchoolingRegistrationNotFound,
   SchoolingRegistrationsCouldNotBeSavedError,
   UserCouldNotBeReconciledError,
@@ -20,7 +19,6 @@ const { knex } = require('../../../db/knex-database-connection');
 const BookshelfSchoolingRegistration = require('../orm-models/SchoolingRegistration');
 
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
-const bookshelfUtils = require('../utils/knex-utils');
 const DomainTransaction = require('../DomainTransaction');
 
 function _toUserWithSchoolingRegistrationDTO(BookshelfSchoolingRegistration) {
@@ -174,9 +172,6 @@ module.exports = {
         knexConn.batchInsert('schooling-registrations', schoolingRegistrationsToCreate),
       ]);
     } catch (err) {
-      if (bookshelfUtils.isUniqConstraintViolated(err)) {
-        throw new SameNationalStudentIdInOrganizationError(err.detail);
-      }
       throw new SchoolingRegistrationsCouldNotBeSavedError();
     }
   },

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -257,14 +257,6 @@ describe('Integration | API | Controller Error', function() {
       expect(responseDetail(response)).to.equal('L\'élève est déjà rattaché à un compte utilisateur.');
     });
 
-    it('responds Conflict when a SameNationalStudentIdInOrganizationError error occurs', async function() {
-      routeHandler.throws(new DomainErrors.SameNationalStudentIdInOrganizationError('(ABC123)'));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(CONFLICT_ERROR);
-      expect(responseDetail(response)).to.equal('The INE ABC123 is already in use for this organization.');
-    });
-
     it('responds Conflict when a AccountRecoveryUserAlreadyConfirmEmail error occurs', async function() {
       routeHandler.throws(new DomainErrors.AccountRecoveryUserAlreadyConfirmEmail());
       const response = await server.requestObject(request);

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -8,7 +8,7 @@ const AuthenticationMethod = require('../../../../lib/domain/models/Authenticati
 
 const {
   NotFoundError,
-  SameNationalStudentIdInOrganizationError,
+  SchoolingRegistrationsCouldNotBeSavedError,
   SchoolingRegistrationNotFound,
   UserCouldNotBeReconciledError,
   UserNotFoundError,
@@ -889,7 +889,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       });
     });
 
-    context('when the same nationalStudentId is twice in schoolingRegistrations to create', function() {
+    context('when an error occurs', function() {
 
       let schoolingRegistrations;
       let organizationId;
@@ -923,7 +923,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         return knex('schooling-registrations').delete();
       });
 
-      it('should return a SameNationalStudentIdInOrganizationError', async function() {
+      it('should return a SchoolingRegistrationsCouldNotBeSavedError', async function() {
         // when
         let error;
         await DomainTransaction.execute(async (domainTransaction) => {
@@ -931,7 +931,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         });
 
         // then
-        expect(error).to.be.instanceof(SameNationalStudentIdInOrganizationError);
+        expect(error).to.be.instanceof(SchoolingRegistrationsCouldNotBeSavedError);
       });
     });
 

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -79,49 +79,6 @@ describe('Unit | Domain | Errors', function() {
     expect(errors.SessionNotAccessible).to.exist;
   });
 
-  describe('#SameNationalStudentIdInOrganizationError', function() {
-
-    context('When errorDetail is provided', function() {
-
-      it('should return a message with given nationalStudentId', function() {
-        // given
-        const expectedErrorMessage = 'The INE 123INE456 is already in use for this organization.';
-        const errorMessage = 'Key ("organizationId", "nationalStudentId")=(ORGAID, 123INE456) already exists.';
-
-        // when
-        const sameNationalStudentIdInOrganizationError = new errors.SameNationalStudentIdInOrganizationError(errorMessage);
-
-        // then
-        expect(sameNationalStudentIdInOrganizationError.message).to.equal(expectedErrorMessage);
-      });
-
-      it('should set a nationalStudentId property', function() {
-        // given
-        const errorMessage = 'Key ("organizationId", "nationalStudentId")=(ORGAID, 123INE456) already exists.';
-
-        // when
-        const sameNationalStudentIdInOrganizationError = new errors.SameNationalStudentIdInOrganizationError(errorMessage);
-
-        // then
-        expect(sameNationalStudentIdInOrganizationError.nationalStudentId).to.equal('123INE456');
-      });
-    });
-
-    context('When errorDetail is not provided', function() {
-
-      it('should return a generic message', function() {
-        // given
-        const expectedErrorMessage = 'INE already in use for this organization.';
-
-        // when
-        const sameNationalStudentIdInOrganizationError = new errors.SameNationalStudentIdInOrganizationError();
-
-        // then
-        expect(sameNationalStudentIdInOrganizationError.message).to.equal(expectedErrorMessage);
-      });
-    });
-  });
-
   describe('#UserNotFoundError', function() {
     it('should export a UserNotFoundError', function() {
       expect(errors.UserNotFoundError).to.exist;


### PR DESCRIPTION
## :unicorn: Problème
Les problèmes de doublons d'INE ressortent déjà comme erreur dans le fichier. Cette erreur ne va donc plus jamais jusqu'en base de données.

## :robot: Solution
Supprimer cette erreur, qui était de surcroit complexe (gestion de regex, etc) et non traduite.

## :rainbow: Remarques
Rien à signaler

## :100: Pour tester
Non régression sur l'import et la mise à jour d'élèves avec le même INE.
