### PR TITLE
[TECH]  Refacto des requetes avec JSON_AGG (PIX-3452)

### DIFF
--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -57,7 +57,7 @@ class CertificationResult {
     } else {
       certificationStatus = certificationResultDTO?.assessmentResultStatus ?? status.STARTED;
     }
-    const competenceMarkDTOs = JSON.parse(certificationResultDTO.competenceMarksJson);
+    const competenceMarkDTOs = _.compact(certificationResultDTO.competenceMarks);
     const competencesWithMark = _.map(competenceMarkDTOs, (competenceMarkDTO) => new CompetenceMark({
       ...competenceMarkDTO,
       area_code: competenceMarkDTO.area_code.toString(),

--- a/api/lib/domain/read-models/livret-scolaire/Certificate.js
+++ b/api/lib/domain/read-models/livret-scolaire/Certificate.js
@@ -1,5 +1,4 @@
 const { VALIDATED, PENDING } = require('./CertificateStatus');
-const sortBy = require('lodash/sortBy');
 
 class Certificate {
 
@@ -50,13 +49,13 @@ class Certificate {
     date,
     deliveredAt,
     certificationCenter,
-    competenceResultsJson,
+    competenceResults,
   } = {}) {
     const isValidated = _isValidated(status);
     const displayScore = _displayScore({ isPublished, isValidated });
     const updatedStatus = (isPublished) ? status : PENDING;
     const updatedScore = displayScore ? pixScore : 0;
-    const competenceResults = displayScore ? _getExtractValidatedCompetenceResults(competenceResultsJson) : [];
+    const updatedCompetenceResults = displayScore ? competenceResults : [];
 
     return new Certificate({ id,
       firstName,
@@ -72,7 +71,7 @@ class Certificate {
       date,
       deliveredAt,
       certificationCenter,
-      competenceResults,
+      competenceResults: updatedCompetenceResults,
     });
   }
 }
@@ -81,12 +80,6 @@ module.exports = Certificate;
 
 function _isValidated(status) {
   return status === VALIDATED;
-}
-
-function _getExtractValidatedCompetenceResults(competenceResultsJson) {
-  const competenceResults = JSON
-    .parse(competenceResultsJson);
-  return sortBy(competenceResults, 'competenceId');
 }
 
 function _displayScore({ isPublished, isValidated }) {

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -20,9 +20,14 @@ module.exports = {
         isPublished: 'certification-courses.isPublished',
         status: 'assessment-results.status',
         pixScore: 'assessment-results.pixScore',
+        competenceResults: knex.raw(`
+        json_agg(
+          json_build_object('level', "competence-marks".level, 'competenceId', "competence-marks"."competence_code")
+          ORDER BY "competence-marks"."competence_code" asc
+        )`,
+        ),
       },
     )
-      .select(knex.raw('\'[\' || (string_agg(\'{ "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\')) || \']\' as "competenceResultsJson"'))
       .from('certification-courses')
       .innerJoin('schooling-registrations', 'schooling-registrations.userId', 'certification-courses.userId')
       .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')

--- a/api/lib/infrastructure/repositories/certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/certification-result-repository.js
@@ -45,7 +45,9 @@ function _selectCertificationResults() {
       assessmentResultStatus: 'assessment-results.status',
       commentForOrganization: 'assessment-results.commentForOrganization',
     })
-    .select(knex.raw('\'[\' || (string_agg(\'{ "id":\' || "competence-marks"."id"::VARCHAR || \', "score":\' || "competence-marks".score::VARCHAR || \', "level":\' || "competence-marks".level::VARCHAR || \', "area_code":\' || "competence-marks"."area_code"::VARCHAR || \', "competence_code":\' || "competence-marks"."competence_code"::VARCHAR || \', "assessmentResultId":\' || "competence-marks"."assessmentResultId"::VARCHAR || \', "competenceId":"\' || "competence-marks"."competenceId" || \'"}\', \',\')) || \']\' as "competenceMarksJson"'))
+    .select(knex.raw(`
+        json_agg("competence-marks".* ORDER BY "competence-marks"."competence_code" asc)  as "competenceMarks"`,
+    ))
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
     .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -75,8 +75,13 @@ function _selectPrivateCertificates() {
       commentForCandidate: 'assessment-results.commentForCandidate',
       assessmentResultStatus: 'assessment-results.status',
       assessmentResultId: 'assessment-results.id',
+      competenceMarks: knex.raw(`
+        json_agg(
+          json_build_object('score', "competence-marks".score, 'level', "competence-marks".level, 'competence_code', "competence-marks"."competence_code")
+          ORDER BY "competence-marks"."competence_code" asc
+        )`,
+      ),
     })
-    .select(knex.raw('\'[\' || (string_agg(\'{ "score":\' || "competence-marks".score::VARCHAR || \', "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\')) || \']\' as "competenceResultsJson"'))
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
     .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
@@ -129,13 +134,8 @@ function _toDomain({ certificationCourseDTO, competenceTree, cleaCertificationRe
 
   if (competenceTree) {
 
-    const competenceResults = JSON .parse(certificationCourseDTO.competenceResultsJson);
-
-    const competenceMarks = _.map(competenceResults, (competenceMark) => new CompetenceMark({
-      score: competenceMark.score,
-      level: competenceMark.level,
-      competence_code: competenceMark.competenceId,
-    }));
+    const competenceMarks = _.compact(certificationCourseDTO.competenceMarks)
+      .map((competenceMark) => new CompetenceMark({ ...competenceMark }));
 
     const resultCompetenceTree = ResultCompetenceTree.generateTreeFromCompetenceMarks({
       competenceTree,

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -294,8 +294,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
       // then
       const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation(certificationAttestation);
-      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
-      expect(certificationAttestation).to.deep.equal(expectedCertificationAttestation);
+      expect(certificationAttestation).to.deepEqualInstance(expectedCertificationAttestation);
     });
 
     it('should get the clea certification result if badge V1 taken', async function() {

--- a/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -270,10 +270,10 @@ describe('Integration | Repository | Certification-ls ', function() {
       buildValidatedPublishedCertificationData(
         {
           user, schoolingRegistration, verificationCode, pixScore, competenceMarks: [{
-            code: '1.1', level: 0,
-          }, {
             code: '5.2', level: -1,
-          }],
+          }, {
+            code: '1.1', level: 0,
+          } ],
         },
       );
 

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -96,8 +96,7 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
           })],
         });
         expect(juryCertificationSummaries).to.have.length(3);
-        expect(juryCertificationSummaries[0]).to.be.instanceOf(JuryCertificationSummary);
-        expect(juryCertificationSummaries[0]).to.deep.equal(expectedJuryCertificationSummary);
+        expect(juryCertificationSummaries[0]).to.deepEqualInstance(expectedJuryCertificationSummary);
         expect(juryCertificationSummaries[1].id).to.equal(startedCertification.id);
       });
 

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -1,7 +1,6 @@
 const { expect, databaseBuilder, domainBuilder, catchErr, learningContentBuilder, mockLearningContent } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const shareableCertificateRepository = require('../../../../lib/infrastructure/repositories/shareable-certificate-repository');
-const ShareableCertificate = require('../../../../lib/domain/models/ShareableCertificate');
 const { badgeKeyV1: cleaBadgeKeyV1, badgeKeyV2: cleaBadgeKeyV2 } = require('../../../../lib/domain/models/CleaCertificationResult');
 const { badgeKey: pixPlusDroitMaitreBadgeKey } = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 const { badgeKey: pixPlusDroitExpertBadgeKey } = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
@@ -312,8 +311,6 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         ...shareableCertificateData,
         resultCompetenceTree,
       });
-      expect(shareableCertificate).to.be.instanceOf(ShareableCertificate);
-      expect(shareableCertificate).to.deep.equal(expectedShareableCertificate);
       expect(shareableCertificate).to.deepEqualInstance(expectedShareableCertificate);
     });
 

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Models | CertificationResult', function() {
         commentForJury: 'Un commentaire jury 1',
         commentForOrganization: 'Un commentaire orga 1',
         juryId: 159,
-        competenceMarksJson: '[{ "id":123, "score":10, "level":4, "area_code":2, "competence_code":2.3, "assessmentResultId":753, "competenceId":"recComp23"}]',
+        competenceMarks: [{ 'id': 123, 'score': 10, 'level': 4, 'area_code': 2, 'competence_code': '2.3', 'assessmentResultId': 753, 'competenceId': 'recComp23' }],
       };
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Plusieurs requêtes PG utilisent la fonction `string_agg` qui construit un "tableau json" via une chaine de caractère. Ce code est peu lisible et donc difficilement maintenable.

## :robot: Solution
Utiliser `json_agg` qui créé automatiquement le tableau en json (pas besoin de construire le tableau et knex retourne directement du js/json).

## :100: Pour tester
Les tests sont autosuffisants
