### PR TITLE
[BUGFIX] Force une valeur pour eviter un flaky test (PIX-3471)

### DIFF
--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -145,7 +145,8 @@ module('Acceptance | Session Finalization', function(hooks) {
 
         test('it should not display end test screen warning', async function(assert) {
           // given
-          const certificationReport = server.create('certification-report', { isCompleted: false, abortReason: 'technical' });
+          const certificationReport = server.create('certification-report', { hasSeenEndTestScreen: false, isCompleted: false, abortReason: 'technical' });
+          server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
 
           session.update({ certificationReports: [certificationReport] });
 


### PR DESCRIPTION
## :unicorn: Problème
Mirage positionne les champs via faker. La valeur de certification-report.hasSeenEndTestScreen est donc aléatoire. On obtient un test flaky pour _Acceptance | Session Finalization_ _it should not display end test screen warning_

## :robot: Solution
Forcer la valeur. 

## :rainbow: Remarques
On set aussi la valeur du toggle qui est manquante _isManageUncompletedCertifEnabled_ cette feature

## :100: Pour tester
Correction dans les tests uniquement
