### PR TITLE
[BUGFIX] Supprimer le double appel à getNextChallenge (PIX-2760).

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -19,9 +19,9 @@ export default class ChallengeRoute extends Route {
       const challengeId = answers[currentChallengeNumber].challenge.get('id');
       challenge = await this.store.findRecord('challenge', challengeId);
     } else {
-      if (assessment.isPreview) {
+      if (assessment.isPreview && params.challengeId) {
         challenge = await this.store.findRecord('challenge', params.challengeId);
-      } else {
+      } else if (!assessment.isPreview) {
         challenge = await this.store.queryRecord('challenge', { assessmentId: assessment.id });
       }
     }

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -26,6 +26,13 @@ export default class ChallengeRoute extends Route {
       }
     }
 
+    if (!challenge) {
+      return RSVP.hash({
+        assessment,
+        challenge,
+      });
+    }
+
     return RSVP.hash({
       assessment,
       challenge,
@@ -37,7 +44,12 @@ export default class ChallengeRoute extends Route {
         return this.transitionTo('index');
       }
     });
+  }
 
+  async redirect(model) {
+    if (!model.challenge) {
+      return this.replaceWith('assessments.resume', model.assessment.id, { queryParams: { assessmentHasNoMoreQuestions: true } });
+    }
   }
 
   serialize(model) {

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -91,7 +91,7 @@ export default class ChallengeRoute extends Route {
         };
       }
 
-      return this.transitionTo('assessments.resume', assessment.get('id'), queryParams);
+      this.transitionTo('assessments.resume', assessment.get('id'), queryParams);
     }
     catch (error) {
       answer.rollbackAttributes();

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -20,11 +20,12 @@ export default class ResumeRoute extends Route {
       return this._routeToResults(assessment);
     }
     const nextChallenge = await this.store.queryRecord('challenge', { assessmentId: assessment.id });
+    const assessmentHasNoMoreQuestions = nextChallenge == null;
 
     if (assessment.hasCheckpoints) {
-      return this._resumeAssessmentWithCheckpoint(assessment, nextChallenge);
+      return this._resumeAssessmentWithCheckpoint(assessment, assessmentHasNoMoreQuestions);
     } else {
-      return this._resumeAssessmentWithoutCheckpoint(assessment, nextChallenge);
+      return this._resumeAssessmentWithoutCheckpoint(assessment, assessmentHasNoMoreQuestions);
     }
   }
 
@@ -34,11 +35,10 @@ export default class ResumeRoute extends Route {
     return originRoute._router.currentRouteName !== 'assessments.challenge';
   }
 
-  _resumeAssessmentWithoutCheckpoint(assessment, nextChallenge) {
+  _resumeAssessmentWithoutCheckpoint(assessment, assessmentHasNoMoreQuestions) {
     const {
-      assessmentHasNoMoreQuestions,
       assessmentIsCompleted,
-    } = this._parseState(assessment, nextChallenge);
+    } = this._parseState(assessment);
 
     if (assessmentHasNoMoreQuestions || assessmentIsCompleted) {
       return this._rateAssessment(assessment);
@@ -46,13 +46,12 @@ export default class ResumeRoute extends Route {
     return this._routeToNextChallenge(assessment);
   }
 
-  _resumeAssessmentWithCheckpoint(assessment, nextChallenge) {
+  _resumeAssessmentWithCheckpoint(assessment, assessmentHasNoMoreQuestions) {
     const {
-      assessmentHasNoMoreQuestions,
       assessmentIsCompleted,
       userHasSeenCheckpoint,
       userHasReachedCheckpoint,
-    } = this._parseState(assessment, nextChallenge);
+    } = this._parseState(assessment);
 
     if (assessmentIsCompleted) {
       return this._rateAssessment(assessment);
@@ -72,8 +71,7 @@ export default class ResumeRoute extends Route {
     return this._routeToNextChallenge(assessment);
   }
 
-  _parseState(assessment, nextChallenge) {
-    const assessmentHasNoMoreQuestions = !nextChallenge;
+  _parseState(assessment) {
     const userHasSeenCheckpoint = this.hasSeenCheckpoint;
 
     const quantityOfAnswersInAssessment = assessment.get('answers.length');
@@ -82,10 +80,8 @@ export default class ResumeRoute extends Route {
     const assessmentIsCompleted = assessment.isCompleted;
 
     return {
-      assessmentHasNoMoreQuestions,
       userHasSeenCheckpoint,
       userHasReachedCheckpoint,
-      nextChallenge,
       assessmentIsCompleted,
     };
   }

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -86,7 +86,7 @@ export default class ResumeRoute extends Route {
   }
 
   _routeToNextChallenge(assessment) {
-    return this.replaceWith('assessments.challenge', assessment.id, assessment.currentChallengeNumber, { queryParams: { newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
+    this.replaceWith('assessments.challenge', assessment.id, assessment.currentChallengeNumber, { queryParams: { newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
   }
 
   async _rateAssessment(assessment) {
@@ -97,22 +97,24 @@ export default class ResumeRoute extends Route {
 
   _routeToResults(assessment) {
     if (assessment.isCertification) {
-      return this.replaceWith('certifications.results', assessment.certificationNumber);
+      this.replaceWith('certifications.results', assessment.certificationNumber);
     }
-    if (assessment.isForCampaign) {
-      return this.replaceWith('campaigns.assessment.skill-review', assessment.codeCampaign);
+    else if (assessment.isForCampaign) {
+      this.replaceWith('campaigns.assessment.skill-review', assessment.codeCampaign);
     }
-    if (assessment.isCompetenceEvaluation) {
-      return this.replaceWith('competences.results', assessment.competenceId, assessment.id);
+    else if (assessment.isCompetenceEvaluation) {
+      this.replaceWith('competences.results', assessment.competenceId, assessment.id);
     }
-    return this.replaceWith('assessments.results', assessment.id);
+    else {
+      this.replaceWith('assessments.results', assessment.id);
+    }
   }
 
   _routeToCheckpoint(assessment) {
-    return this.replaceWith('assessments.checkpoint', assessment.id, { queryParams: { newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
+    this.replaceWith('assessments.checkpoint', assessment.id, { queryParams: { newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
   }
 
   _routeToFinalCheckpoint(assessment) {
-    return this.replaceWith('assessments.checkpoint', assessment.id, { queryParams: { finalCheckpoint: true, newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
+    this.replaceWith('assessments.checkpoint', assessment.id, { queryParams: { finalCheckpoint: true, newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
   }
 }

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -82,7 +82,6 @@ describe('Unit | Route | Assessments | Challenge', function() {
           isPreview: true,
         };
         route.modelFor.returns(assessmentForPreview);
-        storeStub.findRecord.resolves({ id: 'recId' });
       });
 
       it('should call findRecord to find the asked challenge', async function() {
@@ -91,12 +90,27 @@ describe('Unit | Route | Assessments | Challenge', function() {
           challengeId: 'recId',
           challenge_number: 0,
         };
+        storeStub.findRecord.resolves({ id: 'recId' });
 
         // when
         await route.model(params);
 
         // then
         sinon.assert.calledWith(findRecordStub, 'challenge', 'recId');
+      });
+
+      it('should not call for next challenge', async function() {
+        // given
+        const params = {
+          challengeId: null,
+          challenge_number: 0,
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.notCalled(findRecordStub);
       });
     });
 

--- a/mon-pix/tests/unit/routes/assessments/resume_test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume_test.js
@@ -35,28 +35,6 @@ describe('Unit | Route | Assessments | Resume', function() {
       assessment.save = sinon.stub().resolves();
     });
 
-    it('should not query next challenge if assessment is completed', function() {
-      assessment.isCompleted = true;
-
-      route.redirect(assessment);
-
-      sinon.assert.notCalled(queryRecordStub);
-    });
-
-    it('should get the next challenge of the assessment', function() {
-      // given
-      queryRecordStub.resolves();
-
-      // when
-      const promise = route.redirect(assessment);
-
-      // then
-      return promise.then(() => {
-        sinon.assert.calledOnce(queryRecordStub);
-        sinon.assert.calledWith(queryRecordStub, 'challenge', { assessmentId: 123 });
-      });
-    });
-
     context('when the next challenge exists', function() {
 
       let nextChallenge;
@@ -64,6 +42,7 @@ describe('Unit | Route | Assessments | Resume', function() {
       beforeEach(function() {
         nextChallenge = EmberObject.create({ id: 456 });
         queryRecordStub.resolves(nextChallenge);
+        route.assessmentHasNoMoreQuestions = false;
       });
 
       context('when assessment is a CAMPAIGN', function() {
@@ -153,6 +132,7 @@ describe('Unit | Route | Assessments | Resume', function() {
 
       beforeEach(function() {
         queryRecordStub.resolves(null);
+        route.assessmentHasNoMoreQuestions = true;
       });
 
       context('when assessment is a CAMPAIGN', function() {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on arrive sur une nouvelle épreuve via les bouton je passe / je valide ou via la page de compétence, on remarque que deux appels à l'api sont faits pour récupérer la prochaine épreuve:
- un appel depuis `assessments.resume` pour savoir si une prochaine épreuve existe (pour pouvoir ensuite rediriger sur le checkpoint final si ce n'est pas le cas)
- un appel depuis `assessments.challenge` pour récupérer le contenu de l'épreuve

## :robot: Solution
1. Supprimer l'appel fait dans `assessments.resume` --> on arrive alors toujours sur une épreuve
2. Si l'épreuve est null, alors on redirige sur `assessments.resume` qui fait son routage vers le checkpoint final

## :rainbow: Remarques
Petit problème sur le transition.to: il ne faut pas lui mettre de `return` devant !
Cela ne posait pas de problème avant la PR car l'appel à getNextChallenge de `assessments.resume` prenait du temps et ça laissait le temps à transitionTo de finir.

## :100: Pour tester
Passer des épreuves et voir qu'un seul appel à /next est fait.
