### PR TITLE
[TECH] Suppression des parseInt autour de request.auth.credentials.userId

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -31,9 +31,7 @@ module.exports = {
 
   async findPaginatedSessionSummaries(request) {
     const certificationCenterId = request.params.id;
-    // As route is authenticated, token always contains an userId, so parseInt in useless
-    // eslint-disable-next-line no-restricted-syntax
-    const userId = parseInt(request.auth.credentials.userId);
+    const userId = request.auth.credentials.userId;
     const options = queryParamsUtils.extractParameters(request.query);
 
     const { models: sessionSummaries, meta } = await usecases.findPaginatedCertificationCenterSessionSummaries({

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -57,8 +57,7 @@ module.exports = {
 
   async updatePassword(request, h) {
     const payload = request.payload.data.attributes;
-    // eslint-disable-next-line no-restricted-syntax
-    const userId = parseInt(request.auth.credentials.userId);
+    const userId = request.auth.credentials.userId;
     const organizationId = payload['organization-id'];
     const schoolingRegistrationId = payload['schooling-registration-id'];
 


### PR DESCRIPTION
## :unicorn: Problème
Le parseInt est inutile autour de `request.auth.credentials.userId`. En plus on désactive eslint pour ça et il y a même un commentaire sur le sujet :/

##  :robot: Solution
Supprimer le parseInt (et les commentaires)

## :rainbow: Remarques
:grimacing: 

## :100: Pour tester
Tests au vert