### PR TITLE
[CLEAN]  Corrige des typos

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -80,7 +80,7 @@ exports.register = async function(server) {
         handler: certificationCenterController.getStudents,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Récupération d\'une liste d\'élèves SCO à partir d\' un identifiant de centre de certification',
+          '- Récupération d\'une liste d\'élèves SCO à partir d\'un identifiant de centre de certification',
         ],
         tags: ['api', 'certification-center', 'students', 'session'],
       },
@@ -97,7 +97,7 @@ exports.register = async function(server) {
         handler: certificationCenterController.getDivisions,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Récupération d\'une liste de classes à partir d\' un identifiant de centre de certification',
+          '- Récupération d\'une liste de classes à partir d\'un identifiant de centre de certification',
         ],
         tags: ['api', 'certification-center', 'students', 'session'],
       },


### PR DESCRIPTION
## :unicorn: Problème
Des espaces inutiles sont présent dans les commentaires des routes.

##  :robot: Solution
Supprimer l'espace

## :100: Pour tester
Relire