### PR TITLE
[FEATURE] Envoyer un code de vérification par mail lors d'un changement d'adresse e-mail (PIX-3453).

### DIFF
--- a/mon-pix/app/adapters/email-verification-code.js
+++ b/mon-pix/app/adapters/email-verification-code.js
@@ -1,0 +1,22 @@
+import ApplicationAdapter from './application';
+
+export default class EmailVerificationCodeAdapter extends ApplicationAdapter {
+
+  createRecord(store, type, { adapterOptions }) {
+    const { userId, password, newEmail } = adapterOptions;
+    const url = `${this.host}/${this.namespace}/users/${userId}/email/verification-code`;
+    const payload = {
+      data: {
+        data: {
+          type: 'email-verification-code',
+          attributes: {
+            password,
+            newEmail,
+          },
+        },
+      },
+    };
+
+    return this.ajax(url, 'PUT', payload);
+  }
+}

--- a/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
+++ b/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
@@ -31,6 +31,11 @@
         autocomplete="off"
       />
     </div>
+    {{#if this.errorMessage}}
+      <PixMessage @type='alert' class="user-account-update-email-with-validation__error-message">
+        {{this.errorMessage}}
+      </PixMessage>
+    {{/if}}
     <div class="user-account-update-email-with-validation__confirm-button">
       <PixButton
         class="user-account-update-email-with-validation-actions__confirm-button"

--- a/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
+++ b/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
@@ -35,6 +35,7 @@
       <PixButton
         class="user-account-update-email-with-validation-actions__confirm-button"
         @type="submit"
+        @isDisabled={{not this.isFormValid}}
       >
         {{t 'pages.user-account.account-update-email-with-validation.save-button'}}
       </PixButton>

--- a/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
+++ b/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
@@ -17,6 +17,7 @@
         @errorMessage={{this.newEmailValidationMessage}}
         {{on "focusout" this.validateNewEmail}}
         autocomplete="off"
+        required
       />
     </div>
     <div class="user-account-update-email-with-validation__informations">
@@ -27,8 +28,9 @@
         @id="password"
         @label={{t 'pages.user-account.account-update-email-with-validation.fields.password.label'}}
         @errorMessage={{this.passwordValidationMessage}}
-        {{on "focusout" this.validatePassword}}
+        {{on "input" this.validatePassword}}
         autocomplete="off"
+        required
       />
     </div>
     {{#if this.errorMessage}}

--- a/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
+++ b/mon-pix/app/components/user-account/user-account-update-email-with-validation.hbs
@@ -23,11 +23,12 @@
       <p>{{t 'pages.user-account.account-update-email-with-validation.fields.password.security-information'}}</p>
     </div>
     <div class="user-account-update-email-with-validation__password-input">
-      <FormTextfield
-        @label={{t 'pages.user-account.account-update-email-with-validation.fields.password.label'}} @textfieldName="password"
-        @inputBindingValue={{this.password}} @onValidate={{this.validatePassword}}
-        @validationMessage={{this.passwordValidation.message}} @validationStatus={{this.passwordValidation.status}}
-        @autocomplete="off"
+      <PixInputPassword
+        @id="password"
+        @label={{t 'pages.user-account.account-update-email-with-validation.fields.password.label'}}
+        @errorMessage={{this.passwordValidationMessage}}
+        {{on "focusout" this.validatePassword}}
+        autocomplete="off"
       />
     </div>
     <div class="user-account-update-email-with-validation__confirm-button">

--- a/mon-pix/app/components/user-account/user-account-update-email-with-validation.js
+++ b/mon-pix/app/components/user-account/user-account-update-email-with-validation.js
@@ -18,6 +18,10 @@ export default class UserAccountUpdateEmailWithValidation extends Component {
   @tracked newEmailValidationMessage = null;
   @tracked passwordValidationMessage = null;
 
+  get isFormValid() {
+    return isEmailValid(this.newEmail) && !isEmpty(this.password);
+  }
+
   @action
   validateNewEmail(event) {
     this.newEmail = event.target.value;
@@ -31,13 +35,29 @@ export default class UserAccountUpdateEmailWithValidation extends Component {
   }
 
   @action
-  validatePassword() {
+  validatePassword(event) {
+    this.password = event.target.value;
     const isInvalidInput = isEmpty(this.password);
 
     this.passwordValidationMessage = null;
 
     if (isInvalidInput) {
       this.passwordValidationMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
+    }
+  }
+
+  @action
+  async onSubmit(event) {
+    event && event.preventDefault();
+    if (this.isFormValid) {
+      try {
+        await this.args.sendVerificationCode({
+          newEmail: this.newEmail,
+          password: this.password,
+        });
+      } catch (response) {
+        console.log(response);
+      }
     }
   }
 }

--- a/mon-pix/app/components/user-account/user-account-update-email-with-validation.js
+++ b/mon-pix/app/components/user-account/user-account-update-email-with-validation.js
@@ -5,20 +5,10 @@ import { tracked } from '@glimmer/tracking';
 import isEmailValid from '../../utils/email-validator';
 import isEmpty from 'lodash/isEmpty';
 
-const STATUS_MAP = {
-  defaultStatus: 'default',
-  errorStatus: 'error',
-};
-
 const ERROR_INPUT_MESSAGE_MAP = {
   invalidEmail: 'pages.user-account.account-update-email-with-validation.fields.errors.invalid-email',
   emptyPassword: 'pages.user-account.account-update-email-with-validation.fields.errors.empty-password',
 };
-
-class PasswordValidation {
-  @tracked status = STATUS_MAP['defaultStatus'];
-  @tracked message = null;
-}
 
 export default class UserAccountUpdateEmailWithValidation extends Component {
 
@@ -26,8 +16,7 @@ export default class UserAccountUpdateEmailWithValidation extends Component {
   @tracked newEmail = '';
   @tracked password = '';
   @tracked newEmailValidationMessage = null;
-
-  @tracked passwordValidation = new PasswordValidation();
+  @tracked passwordValidationMessage = null;
 
   @action
   validateNewEmail(event) {
@@ -45,12 +34,10 @@ export default class UserAccountUpdateEmailWithValidation extends Component {
   validatePassword() {
     const isInvalidInput = isEmpty(this.password);
 
-    this.passwordValidation.status = STATUS_MAP['defaultStatus'];
-    this.passwordValidation.message = null;
+    this.passwordValidationMessage = null;
 
     if (isInvalidInput) {
-      this.passwordValidation.status = STATUS_MAP['errorStatus'];
-      this.passwordValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
+      this.passwordValidationMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
     }
   }
 }

--- a/mon-pix/app/controllers/user-account/connection-methods.js
+++ b/mon-pix/app/controllers/user-account/connection-methods.js
@@ -1,9 +1,11 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class ConnectionMethodsController extends Controller {
 
+  @service currentUser;
   @tracked isEmailEditionMode = false;
   @tracked isEmailWithValidationEditionMode = false;
 
@@ -34,5 +36,15 @@ export default class ConnectionMethodsController extends Controller {
     await this.model.save({ adapterOptions: { updateEmail: true } });
     this.model.password = null;
     this.disableEmailEditionMode();
+  }
+
+  @action
+  async sendVerificationCode({ newEmail, password }) {
+    const emailVerificationCode = this.store.createRecord('email-verification-code');
+    await emailVerificationCode.save({ adapterOptions: {
+      password,
+      newEmail: newEmail.trim().toLowerCase(),
+      userId: this.currentUser.user.id,
+    } });
   }
 }

--- a/mon-pix/app/models/email-verification-code.js
+++ b/mon-pix/app/models/email-verification-code.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class EmailVerificationCode extends Model {
+  @attr('string') newEmail;
+  @attr('string') password;
+}

--- a/mon-pix/app/styles/components/_user-account-update-email-with-validation.scss
+++ b/mon-pix/app/styles/components/_user-account-update-email-with-validation.scss
@@ -50,55 +50,9 @@
       padding-bottom: 40px;
     }
 
-    .form-textfield label {
-      color: $grey-70;
-      font-weight: 400;
-      font-size: 0.875rem;
-      letter-spacing: 0;
-    }
-
-    .form-textfield__input-field-container {
-      margin-top: 4px;
-      border: 1px solid $grey-40;
-      border-radius: 4px;
-      height: 37px;
-
-      &:hover {
-        box-shadow: inset 0 0 0 0.6px $grey-40;
-      }
-
-      &:focus {
-        box-shadow: inset 0 0 0 0.6px $blue;
-      }
-
-      input {
-        height: auto;
-        color: $grey-90;
-        font-size: 0.875rem;
-        margin-left: 1px;
-        padding-left: 16px;
-        width: 100%;
-      }
-
-      div {
-        margin: 0;
-
-        button {
-          margin: 0 10px;
-        }
-      }
-    }
-
-    .form-textfield__input-container--error {
-      border-color: $red;
-      box-shadow: inset 0 0 0 0.6px $red;
-    }
-
-    .form-textfield__message--error {
-      position: absolute;
-      font-size: 0.75rem;
-      color: $red;
-      margin-top: 4px;
+    .pix-input-password > svg {
+      width: 18px;
+      height: 18px;
     }
   }
 

--- a/mon-pix/app/styles/components/_user-account-update-email-with-validation.scss
+++ b/mon-pix/app/styles/components/_user-account-update-email-with-validation.scss
@@ -47,7 +47,7 @@
 
   &__password-input {
     @include device-is('desktop') {
-      padding-bottom: 40px;
+      padding-bottom: 20px;
     }
 
     .pix-input-password > svg {
@@ -77,12 +77,19 @@
     }
   }
 
+  &__error-message {
+    @include device-is('tablet') {
+      max-width: 520px;
+      margin-bottom: 10px;
+    }
+  }
+
   &__confirm-button {
     display: flex;
     padding-top: 10px;
 
     @include device-is('tablet') {
-      padding-top: 0;
+      padding-top: 20px;
     }
   }
 }

--- a/mon-pix/app/templates/user-account/connection-methods.hbs
+++ b/mon-pix/app/templates/user-account/connection-methods.hbs
@@ -4,14 +4,17 @@
   </div>
 {{else if this.isEmailWithValidationEditionMode}}
   <div class="user-account__update-email-with-validation">
-    <UserAccount::UserAccountUpdateEmailWithValidation @disableEmailWithValidationEditionMode={{this.disableEmailWithValidationEditionMode}} />
+    <UserAccount::UserAccountUpdateEmailWithValidation
+      @disableEmailWithValidationEditionMode={{this.disableEmailWithValidationEditionMode}}
+      @sendVerificationCode={{this.sendVerificationCode}}
+    />
   </div>
 {{else}}
   <div class="user-account__connection-methods">
     <UserAccountConnexionMethods
-            @user={{@model}}
-            @enableEmailEditionMode={{this.enableEmailEditionMode}}
-            @enableEmailWithValidationEditionMode={{this.enableEmailWithValidationEditionMode}}
+      @user={{@model}}
+      @enableEmailEditionMode={{this.enableEmailEditionMode}}
+      @enableEmailWithValidationEditionMode={{this.enableEmailWithValidationEditionMode}}
     />
   </div>
 {{/if}}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -35118,8 +35118,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#7995bad08b49a0abf7abdcbad72e1f861e4e6f91",
-      "from": "git://github.com/1024pix/pix-ui.git#v8.0.1",
+      "version": "git://github.com/1024pix/pix-ui.git#d37152577026188de646d4eca2b4f876593dc64e",
+      "from": "git://github.com/1024pix/pix-ui.git#v8.1.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -113,7 +113,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v8.0.1",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v8.1.0",
     "sass": "^1.38.0",
     "showdown": "^1.9.1",
     "stylelint": "^13.13.1",

--- a/mon-pix/tests/integration/components/user-account-update-email-with-validation-test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email-with-validation-test.js
@@ -82,4 +82,27 @@ describe('Integration | Component | user-account-update-email-with-validation', 
       });
     });
   });
+
+  context('when the user submit new email and password', function() {
+
+    it('should call send verification code method', async function() {
+      // given
+      const newEmail = 'newEmail@example.net';
+      const password = 'password';
+
+      const sendVerificationCode = sinon.stub();
+      this.set('sendVerificationCode', sendVerificationCode);
+
+      await render(hbs`<UserAccount::UserAccountUpdateEmailWithValidation @sendVerificationCode={{this.sendVerificationCode}} />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
+      await triggerEvent('#password', 'focusout');
+      await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
+
+      // then
+      sinon.assert.calledWith(sendVerificationCode, { newEmail, password });
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/user-account-update-email-with-validation-test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email-with-validation-test.js
@@ -70,7 +70,6 @@ describe('Integration | Component | user-account-update-email-with-validation', 
           // when
           await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
           await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), emptyPassword);
-          await triggerEvent('#password', 'focusout');
 
           // then
           expect(contains(this.intl.t('pages.user-account.account-update-email-with-validation.fields.errors.empty-password'))).to.exist;
@@ -92,7 +91,6 @@ describe('Integration | Component | user-account-update-email-with-validation', 
       // when
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
-      await triggerEvent('#password', 'focusout');
       await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
       // then
@@ -112,7 +110,6 @@ describe('Integration | Component | user-account-update-email-with-validation', 
       // when
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), emailAlreadyExist);
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
-      await triggerEvent('#password', 'focusout');
       await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
       // then
@@ -132,7 +129,6 @@ describe('Integration | Component | user-account-update-email-with-validation', 
       // when
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
-      await triggerEvent('#password', 'focusout');
       await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
       // then
@@ -152,7 +148,6 @@ describe('Integration | Component | user-account-update-email-with-validation', 
       // when
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
-      await triggerEvent('#password', 'focusout');
       await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
       // then
@@ -172,7 +167,6 @@ describe('Integration | Component | user-account-update-email-with-validation', 
       // when
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
-      await triggerEvent('#password', 'focusout');
       await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
       // then

--- a/mon-pix/tests/integration/components/user-account-update-email-with-validation-test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email-with-validation-test.js
@@ -1,11 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import {
-  find,
-  render,
-  triggerEvent,
-} from '@ember/test-helpers';
+import { find, render, triggerEvent } from '@ember/test-helpers';
 import { fillInByLabel } from '../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { contains } from '../../helpers/contains';
@@ -83,15 +79,13 @@ describe('Integration | Component | user-account-update-email-with-validation', 
     });
   });
 
-  context('when the user submit new email and password', function() {
+  context('when the user submits new email and password', function() {
 
-    it('should call send verification code method', async function() {
+    it('should call the send verification code method', async function() {
       // given
       const newEmail = 'newEmail@example.net';
       const password = 'password';
-
-      const sendVerificationCode = sinon.stub();
-      this.set('sendVerificationCode', sendVerificationCode);
+      this.set('sendVerificationCode', sinon.stub());
 
       await render(hbs`<UserAccount::UserAccountUpdateEmailWithValidation @sendVerificationCode={{this.sendVerificationCode}} />`);
 
@@ -102,7 +96,87 @@ describe('Integration | Component | user-account-update-email-with-validation', 
       await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
       // then
-      sinon.assert.calledWith(sendVerificationCode, { newEmail, password });
+      sinon.assert.calledWith(this.sendVerificationCode, { newEmail, password });
+    });
+
+    it('should display email already exists error if response status is 400', async function() {
+      // given
+      const emailAlreadyExist = 'email@example.net';
+      const password = 'password';
+
+      this.set('sendVerificationCode', sinon.stub());
+      this.sendVerificationCode.rejects({ errors: [{ status: '400', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS' }] });
+
+      await render(hbs `<UserAccount::UserAccountUpdateEmailWithValidation @sendVerificationCode={{this.sendVerificationCode}} />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), emailAlreadyExist);
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
+      await triggerEvent('#password', 'focusout');
+      await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
+
+      // then
+      expect(contains(this.intl.t('pages.user-account.account-update-email-with-validation.fields.errors.new-email-already-exist'))).to.exist;
+    });
+
+    it('should display error message from server if response status is 400 or 403', async function() {
+      // given
+      const newEmail = 'newEmail@example.net';
+      const password = 'password';
+
+      this.set('sendVerificationCode', sinon.stub());
+      this.sendVerificationCode.rejects({ errors: [{ status: '400' }] });
+
+      await render(hbs `<UserAccount::UserAccountUpdateEmailWithValidation @sendVerificationCode={{this.sendVerificationCode}} />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
+      await triggerEvent('#password', 'focusout');
+      await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
+
+      // then
+      expect(contains(this.intl.t('pages.user-account.account-update-email-with-validation.fields.errors.invalid-password'))).to.exist;
+    });
+
+    it('should display invalid email format error if response status is 422', async function() {
+      // given
+      const newEmail = 'newEmail@example.net';
+      const password = 'password';
+
+      this.set('sendVerificationCode', sinon.stub());
+      this.sendVerificationCode.rejects({ errors: [{ status: '422', source: { pointer: 'attributes/email' } }] });
+
+      await render(hbs `<UserAccount::UserAccountUpdateEmailWithValidation @sendVerificationCode={{this.sendVerificationCode}} />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
+      await triggerEvent('#password', 'focusout');
+      await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
+
+      // then
+      expect(contains(this.intl.t('pages.user-account.account-update-email-with-validation.fields.errors.invalid-email'))).to.exist;
+    });
+
+    it('should display empty password error if response status is 422', async function() {
+      // given
+      const newEmail = 'newEmail@example.net';
+      const password = 'password';
+
+      this.set('sendVerificationCode', sinon.stub());
+      this.sendVerificationCode.rejects({ errors: [{ status: '422', source: { pointer: 'attributes/password' } }] });
+
+      await render(hbs `<UserAccount::UserAccountUpdateEmailWithValidation @sendVerificationCode={{this.sendVerificationCode}} />`);
+
+      // when
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
+      await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
+      await triggerEvent('#password', 'focusout');
+      await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
+
+      // then
+      expect(contains(this.intl.t('pages.user-account.account-update-email-with-validation.fields.errors.empty-password'))).to.exist;
     });
   });
 });

--- a/mon-pix/tests/unit/adapters/email-verification-code-test.js
+++ b/mon-pix/tests/unit/adapters/email-verification-code-test.js
@@ -1,0 +1,46 @@
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapter | Email-Verification-Code', function() {
+  setupTest();
+
+  describe('#createRecord', () => {
+    it('should call API to send email verification code', async function() {
+      // given
+      const adapter = this.owner.lookup('adapter:email-verification-code');
+      adapter.ajax = sinon.stub().resolves();
+
+      const userId = '123';
+      const newEmail = 'hello@example.net';
+      const password = 'pix123';
+      const snapshot = {
+        adapterOptions: {
+          userId,
+          password,
+          newEmail,
+        },
+      };
+
+      const expectedUrl = `http://localhost:3000/api/users/${userId}/email/verification-code`;
+      const expectedMethod = 'PUT';
+      const expectedPayload = {
+        data: {
+          data: {
+            type: 'email-verification-code',
+            attributes: {
+              password,
+              newEmail,
+            },
+          },
+        },
+      };
+
+      // when
+      await adapter.createRecord(null, 'email-verification-code', snapshot);
+
+      // then
+      sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedPayload);
+    });
+  });
+});

--- a/mon-pix/tests/unit/models/email-verification-code-test.js
+++ b/mon-pix/tests/unit/models/email-verification-code-test.js
@@ -1,0 +1,16 @@
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import { expect } from 'chai';
+
+describe('Unit | Model | Email-Verification-Code', function() {
+  setupTest();
+
+  it('exists', function() {
+    // given
+    const store = this.owner.lookup('service:store');
+    const emailVerificationCode = store.createRecord('email-verification-code');
+
+    // when & then
+    expect(emailVerificationCode).to.be.ok;
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1323,7 +1323,9 @@
         "fields": {
           "errors": {
             "empty-password": "Your password can't be empty.",
-            "invalid-email": "Your email address is invalid."
+            "invalid-email": "Your email address is invalid.",
+            "new-email-already-exist": "This email address is already in use.",
+            "invalid-password": "There was an error in the password entered."
           },
           "new-email": {
             "label": "New email address"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1323,7 +1323,9 @@
         "fields": {
           "errors": {
             "empty-password": "Votre mot de passe ne peut pas être vide.",
-            "invalid-email": "Votre adresse e-mail n’est pas valide."
+            "invalid-email": "Votre adresse e-mail n’est pas valide.",
+            "new-email-already-exist": "Cette adresse e-mail est déjà utilisée.",
+            "invalid-password": "Le mot de passe que vous avez saisi est invalide."
           },
           "new-email": {
             "label": "Nouvelle adresse e-mail"


### PR DESCRIPTION
## :unicorn: Problème
Dans Mon Compte sur Pix App, lorsque l'utilisateur rempli la nouvelle adresse e-mail et son mot de passe, on doit pouvoir valider ce changement d'adresse.

Sous feature toggle donc non visible en prod. `FT_VALIDATE_EMAIL`

## :robot: Solution
Suite de la PR https://github.com/1024pix/pix/pull/3482

## :rainbow: Remarques

Modifier le POST par un PUT et changer le type (anciennement 'users' => 'email-verification-code-demand')

## :100: Pour tester