### PR TITLE
[TECH] Séparer les différentes logiques d'accès à une campagne (PIX-3181)

### DIFF
--- a/high-level-tests/e2e/cypress/support/index.js
+++ b/high-level-tests/e2e/cypress/support/index.js
@@ -22,4 +22,8 @@ import 'cypress-axe'
 
 beforeEach(() => {
   cy.exec('npm run db:empty');
+
+  cy.window().then((win) => {
+    win.sessionStorage.clear();
+  });
 });

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
@@ -28,7 +28,7 @@
         {{/if}}
       </div>
       <LinkTo class="link campaign-participation-overview-card-content__see-more campaign-participation-overview-card-content__action"
-              @route="campaigns.start-or-resume"
+              @route="campaigns.entry-point"
               @model={{@model.campaignCode}}>
           <FaIcon @icon='arrow-right' aria-hidden="true"></FaIcon>
         {{t 'pages.campaign-participation-overview.card.see-more'}}

--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
@@ -14,7 +14,7 @@
   </header>
   <section class="campaign-participation-overview-card-content">
     <LinkTo class="button button--link campaign-participation-overview-card-content__action"
-            @route="campaigns.start-or-resume"
+            @route="campaigns.entry-point"
             @model={{@model.campaignCode}}>
       {{t 'pages.campaign-participation-overview.card.resume'}}
     </LinkTo>

--- a/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
@@ -14,7 +14,7 @@
   </header>
   <section class="campaign-participation-overview-card-content">
     <LinkTo class="button button--link button--yellow campaign-participation-overview-card-content__action"
-            @route="campaigns.start-or-resume"
+            @route="campaigns.entry-point"
             @model={{@model.campaignCode}}>
       {{t 'pages.campaign-participation-overview.card.send'}}
     </LinkTo>

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -54,7 +54,7 @@
                           @textColorClass="new-information--black-text"
                           @linkDisplayType="button"
                           @linkText="{{t 'pages.dashboard.campaigns.resume.action' }}"
-                          @linkTo="campaigns.start-or-resume"
+                          @linkTo="campaigns.entry-point"
                           @code={{this.profileCollectionCampaignParticipationCode}}
           />
         {{/if}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -52,7 +52,7 @@
               <div class="skill-review-share-error__message" aria-live="polite">
                 {{t 'pages.skill-review.not-finished'}}
               </div>
-              <LinkTo @route="campaigns.start-or-resume" @model={{@model.campaign.code}}
+              <LinkTo @route="campaigns.entry-point" @model={{@model.campaign.code}}
                       class="skill-review-share-error__resume-button button button--big button--link"><span class="sr-only">{{t
                       'pages.profile.resume-campaign-banner.accessibility.resume'}}</span>{{t
                       'pages.profile.resume-campaign-banner.actions.resume'}}</LinkTo>
@@ -78,7 +78,7 @@
     {{#if @model.campaignParticipationResult.canRetry }}
       <div class="skill-review__retry">
         <p class="skill-review-retry__message">{{t 'pages.skill-review.retry.message' organizationName=@model.campaign.organizationName}}</p>
-        <LinkTo @route="campaigns.start-or-resume"
+        <LinkTo @route="campaigns.entry-point"
                 @model={{@model.campaign.code}}
                 @query={{hash retry=true}}
                 class="skill-review-retry__button button button--big button--link">{{t 'pages.skill-review.retry.button'}}</LinkTo>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -158,7 +158,7 @@ export default class SkillReview extends Component {
     const campaignParticipationResult = this.args.model.campaignParticipationResult;
     const adapter = this.store.adapterFor('campaign-participation-result');
     await adapter.beginImprovement(campaignParticipationResult.id);
-    return this.router.transitionTo('campaigns.start-or-resume', this.args.model.campaign.code);
+    return this.router.transitionTo('campaigns.entry-point', this.args.model.campaign.code);
   }
 
   @action

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.js
@@ -13,6 +13,7 @@ export default class JoinScoInformationModal extends Component {
   @service router;
   @service url;
   @service intl;
+  @service campaignStorage;
 
   @tracked message = null;
   @tracked displayContinueButton = true;
@@ -41,6 +42,7 @@ export default class JoinScoInformationModal extends Component {
   @action
   async goToCampaignConnectionForm() {
     await this.session.invalidate();
-    return this.router.replaceWith('campaigns.start-or-resume', this.args.campaignCode, { queryParams: { hasUserSeenJoinPage: true } });
+    this.campaignStorage.set(this.args.campaignCode, 'hasUserSeenJoinPage', true);
+    return this.router.replaceWith('campaigns.start-or-resume', this.args.campaignCode);
   }
 }

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -1,12 +1,14 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default class CampaignLandingPageController extends Controller {
+  @service campaignStorage
+  @service router;
 
   @action
   startCampaignParticipation() {
-    return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
-      queryParams: { hasUserSeenLandingPage: true },
-    });
+    this.campaignStorage.set(this.model.code, 'landingPageShown', true);
+    return this.router.transitionTo('campaigns.start-or-resume', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/fill-in-participant-external-id.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-participant-external-id.js
@@ -1,16 +1,21 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default class FillInParticipantExternalId extends Controller {
+  @service campaignStorage;
+  @service router;
+
   @action
   onSubmitParticipantExternalId(participantExternalId) {
-    return this.transitionToRoute('campaigns.start-or-resume', this.model, { queryParams: { participantExternalId } });
+
+    this.campaignStorage.set(this.model.code, 'participantExternalId', participantExternalId);
+    return this.router.transitionTo('campaigns.start-or-resume', this.model);
   }
 
   @action
   onCancel() {
-    return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
-      queryParams: { hasUserSeenLandingPage: false },
-    });
+    this.campaignStorage.set(this.model.code, 'landingPageShown', false);
+    return this.router.transitionTo('campaigns.start-or-resume', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -3,13 +3,12 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class JoinRestrictedCampaignController extends Controller {
-  queryParams = ['participantExternalId'];
-  participantExternalId = null;
-
   @service session;
   @service store;
   @service intl;
   @service currentUser;
+  @service campaignStorage;
+  @service router;
 
   @action
   async reconcile(schoolingRegistration, adapterOptions) {
@@ -20,9 +19,8 @@ export default class JoinRestrictedCampaignController extends Controller {
       return;
     }
 
-    return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
-      queryParams: { associationDone: true, participantExternalId: this.participantExternalId },
-    });
+    this.campaignStorage.set(this.model.code, 'associationDone', true);
+    return this.router.transitionTo('campaigns.start-or-resume', this.model.code);
   }
 
   @action
@@ -38,8 +36,7 @@ export default class JoinRestrictedCampaignController extends Controller {
     await this.session.authenticate('authenticator:oauth2', { token: response.accessToken });
     await this.currentUser.load();
 
-    return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
-      queryParams: { associationDone: true, participantExternalId: this.participantExternalId },
-    });
+    this.campaignStorage.set(this.model.code, 'associationDone', true);
+    return this.router.transitionTo('campaigns.start-or-resume', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/restricted/login-or-register-to-access.js
+++ b/mon-pix/app/controllers/campaigns/restricted/login-or-register-to-access.js
@@ -6,8 +6,10 @@ import { action } from '@ember/object';
 export default class LoginOrRegisterToAccessRoute extends Controller {
 
   @service currentUser;
+  @service campaignStorage;
   @service session;
   @service store;
+  @service router;
 
   @tracked displayRegisterForm = true;
 
@@ -31,9 +33,8 @@ export default class LoginOrRegisterToAccessRoute extends Controller {
     await this.currentUser.load();
     await this._reconcileUser();
 
-    this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
-      queryParams: { associationDone: true, participantExternalId: this.participantExternalId },
-    });
+    this.campaignStorage.set(this.model.code, 'associationDone', true);
+    this.router.transitionTo('campaigns.start-or-resume', this.model.code);
   }
 
   _reconcileUser() {

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -7,6 +7,7 @@ export default class FillInCampaignCodeController extends Controller {
 
   @service store;
   @service intl;
+  @service router;
   @service session;
   @service currentUser;
 
@@ -52,7 +53,7 @@ export default class FillInCampaignCodeController extends Controller {
       const campaign = await this.store.queryRecord('campaign', {
         filter: { code: campaignCode },
       });
-      this.transitionToRoute('campaigns.start-or-resume', campaign);
+      this.router.transitionTo('campaigns.entry-point', campaign);
     } catch (error) {
       this.onStartCampaignError(error);
     }

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -69,7 +69,9 @@ Router.map(function() {
   this.route('fill-in-campaign-code', { path: '/campagnes' });
 
   this.route('campaigns', { path: '/campagnes/:code' }, function() {
-    this.route('start-or-resume', { path: '/' });
+    this.route('entry-point', { path: '/' });
+    this.route('campaign-not-found', { path: '/oups' });
+    this.route('start-or-resume', { path: '/startOrResume' });
     this.route('campaign-landing-page', { path: '/presentation' });
     this.route('fill-in-participant-external-id', { path: '/identifiant' });
     this.route('restricted', { path: '/privee' }, function() {

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -39,8 +39,7 @@ export default Route.extend(ApplicationRouteMixin, {
   },
 
   async _checkAnonymousAccess(transition) {
-
-    const allowedRoutesForAnonymousAccess = ['fill-in-campaign-code', 'campaigns.assessment.tutorial', 'campaigns.start-or-resume', 'campaigns.campaign-landing-page', 'assessments.challenge', 'campaigns.assessment.skill-review', 'assessments.checkpoint'];
+    const allowedRoutesForAnonymousAccess = ['fill-in-campaign-code', 'campaigns.assessment.tutorial', 'campaigns.start-or-resume', 'campaigns.entry-point', 'campaigns.campaign-landing-page', 'assessments.challenge', 'campaigns.assessment.skill-review', 'assessments.checkpoint', 'campaigns.campaign-not-found'];
     const isUserAnonymous = get(this.session, 'data.authenticated.authenticator') === 'authenticator:anonymous';
     const isRouteAccessNotAllowedForAnonymousUser = !allowedRoutesForAnonymousAccess.includes(get(transition, 'to.name'));
 

--- a/mon-pix/app/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/routes/campaigns/assessment/skill-review.js
@@ -13,7 +13,7 @@ export default class SkillReviewRoute extends Route.extend(SecuredRouteMixin) {
       return { campaign, campaignParticipationResult };
     } catch (error) {
       if (error.errors?.[0]?.status === '412') {
-        return this.transitionTo('campaigns.start-or-resume', campaign.code);
+        return this.transitionTo('campaigns.entry-point', campaign.code);
       } else throw error;
     }
   }

--- a/mon-pix/app/routes/campaigns/campaign-not-found.js
+++ b/mon-pix/app/routes/campaigns/campaign-not-found.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class CampaignNotFound extends Route {}

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -11,9 +11,12 @@ export default class EntryPoint extends Route {
   }
 
   async redirect(campaign, transition) {
-    const participantExternalId = transition.to.queryParams.participantExternalId;
-    if (participantExternalId) {
+    const queryParams = transition.to.queryParams;
+    if (queryParams.participantExternalId) {
       this.campaignStorage.set(campaign.code, 'participantExternalId', transition.to.queryParams.participantExternalId);
+    }
+    if (queryParams.retry) {
+      this.campaignStorage.set(campaign.code, 'retry', transition.to.queryParams.retry);
     }
 
     const currentUserId = get(this.currentUser, 'user.id', null);

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -1,0 +1,35 @@
+import get from 'lodash/get';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class EntryPoint extends Route {
+  @service currentUser;
+  @service campaignStorage;
+
+  async model() {
+    return this.modelFor('campaigns');
+  }
+
+  async redirect(campaign, transition) {
+    const participantExternalId = transition.to.queryParams.participantExternalId;
+    if (participantExternalId) {
+      this.campaignStorage.set(campaign.code, 'participantExternalId', transition.to.queryParams.participantExternalId);
+    }
+
+    const currentUserId = get(this.currentUser, 'user.id', null);
+    let ongoingCampaignParticipation = null;
+
+    if (currentUserId) {
+      ongoingCampaignParticipation = await this.store.queryRecord('campaignParticipation', {
+        campaignId: campaign.id,
+        userId: currentUserId,
+      });
+    }
+
+    if (campaign.isArchived && !ongoingCampaignParticipation) {
+      return this.replaceWith('campaigns.campaign-not-found', campaign);
+    }
+
+    return this.replaceWith('campaigns.start-or-resume', campaign);
+  }
+}

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -6,8 +6,12 @@ export default class EntryPoint extends Route {
   @service currentUser;
   @service campaignStorage;
 
-  async model() {
+  model() {
     return this.modelFor('campaigns');
+  }
+
+  afterModel(campaign) {
+    this.campaignStorage.clear(campaign.code);
   }
 
   async redirect(campaign, transition) {

--- a/mon-pix/app/routes/campaigns/profiles-collection/profile-already-shared.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/profile-already-shared.js
@@ -17,7 +17,7 @@ export default class ProfileAlreadySharedRoute extends Route.extend(SecuredRoute
       };
     } catch (error) {
       if (error.errors?.[0]?.status === '412') {
-        return this.transitionTo('campaigns.start-or-resume', campaign.code);
+        return this.transitionTo('campaigns.entry-point', campaign.code);
       } else throw error;
     }
   }

--- a/mon-pix/app/routes/campaigns/restricted/join.js
+++ b/mon-pix/app/routes/campaigns/restricted/join.js
@@ -9,6 +9,7 @@ const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_
 export default class JoinRoute extends Route {
   @service currentUser;
   @service session;
+  @service campaignStorage;
 
   model() {
     return this.modelFor('campaigns');
@@ -30,9 +31,8 @@ export default class JoinRoute extends Route {
       }
 
       if (!isEmpty(schoolingRegistration)) {
-        this.replaceWith('campaigns.start-or-resume', campaign.code, {
-          queryParams: { associationDone: true },
-        });
+        this.campaignStorage.set(campaign.code, 'associationDone', true);
+        this.replaceWith('campaigns.start-or-resume', campaign.code);
       }
     }
   }

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -72,7 +72,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     return this.modelFor('campaigns');
   }
 
-  async afterModel(campaign, transition) {
+  async afterModel(campaign) {
     await this._findOngoingCampaignParticipationAndUpdateState(campaign);
 
     if (this._shouldVisitLandingPageAsLoggedUser && !campaign.isForAbsoluteNovice) {
@@ -83,7 +83,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       return this.replaceWith('campaigns.fill-in-participant-external-id', campaign);
     }
 
-    if (this._shouldStartCampaignParticipation(campaign, transition.to.queryParams)) {
+    if (this._shouldStartCampaignParticipation(campaign)) {
       await this._createCampaignParticipation(campaign);
     }
   }
@@ -238,8 +238,9 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       && !this.state.doesUserHaveOngoingParticipation;
   }
 
-  _shouldStartCampaignParticipation(campaign, queryParams) {
-    return !this.state.doesUserHaveOngoingParticipation || (campaign.multipleSendings && queryParams.retry);
+  _shouldStartCampaignParticipation(campaign) {
+    const retry = this.campaignStorage.get(campaign.code, 'retry');
+    return !this.state.doesUserHaveOngoingParticipation || (campaign.multipleSendings && retry);
   }
 
   _handleQueryParamBoolean(value, defaultValue) {

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -10,6 +10,7 @@ const AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI = ENV.APP.AUTHENTICATED_SOURCE_FROM_
 export default class LogoutRoute extends Route {
   @service session;
   @service url;
+  @service campaignStorage;
 
   beforeModel() {
     const session = this.session;
@@ -21,6 +22,7 @@ export default class LogoutRoute extends Route {
         return session.singleLogout(id_token);
       }
 
+      this.campaignStorage.clear();
       return session.invalidate();
     }
   }

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -16,13 +16,14 @@ export default class LogoutRoute extends Route {
     const session = this.session;
     this.source = session.data.authenticated.source;
     delete session.data.externalUser;
+    this.campaignStorage.clearAll();
+
     if (session.isAuthenticated) {
       if (get(session, 'data.authenticated.id_token')) {
         const { id_token } = session.data.authenticated;
         return session.singleLogout(id_token);
       }
 
-      this.campaignStorage.clear();
       return session.invalidate();
     }
   }

--- a/mon-pix/app/services/campaign-storage.js
+++ b/mon-pix/app/services/campaign-storage.js
@@ -15,6 +15,10 @@ export default class CampaignStorage extends Service {
   clear(campaignCode) {
     _setCampaignData(campaignCode, {});
   }
+
+  clearAll() {
+    sessionStorage.setItem('campaigns', JSON.stringify({}));
+  }
 }
 
 function _getCampaignData(campaignCode) {

--- a/mon-pix/app/services/campaign-storage.js
+++ b/mon-pix/app/services/campaign-storage.js
@@ -1,0 +1,35 @@
+import Service from '@ember/service';
+
+export default class CampaignStorage extends Service {
+  set(campaignCode, key, value) {
+    const campaignData = _getCampaignData(campaignCode);
+    campaignData[key] = value;
+    _setCampaignData(campaignCode, campaignData);
+  }
+
+  get(campaignCode, key) {
+    const campaignData = _getCampaignData(campaignCode);
+    return campaignData[key];
+  }
+
+  clear(campaignCode) {
+    _setCampaignData(campaignCode, {});
+  }
+}
+
+function _getCampaignData(campaignCode) {
+  const value = sessionStorage.getItem('campaigns');
+
+  const json = value ? JSON.parse(value) : {};
+
+  return json[campaignCode] || {};
+}
+
+function _setCampaignData(campaignCode, campaignData) {
+  const allCampaignsData = sessionStorage.getItem('campaigns');
+
+  const allCampaignsDataParsed = allCampaignsData ? JSON.parse(allCampaignsData) : {};
+
+  allCampaignsDataParsed[campaignCode] = campaignData;
+  sessionStorage.setItem('campaigns', JSON.stringify(allCampaignsDataParsed));
+}

--- a/mon-pix/app/templates/campaigns/campaign-not-found.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-not-found.hbs
@@ -1,0 +1,3 @@
+<InaccessibleCampaign>
+  {{t "pages.campaign.errors.no-longer-accessible"}}
+</InaccessibleCampaign>

--- a/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
@@ -18,7 +18,7 @@
     {{#if this.model.sharedProfile.canRetry}}
       <div class="profile-already-shared-retry">
         <p class="profile-already-shared-retry__message">{{t 'pages.profile-already-shared.retry.message' organization=this.model.campaign.organizationName}}</p>
-        <LinkTo @route="campaigns.start-or-resume"
+        <LinkTo @route="campaigns.entry-point"
                 @model={{@model.campaign.code}}
                 @query={{hash retry=true}}
                 class="button button--link profile-already-shared-retry__button">{{t 'pages.profile-already-shared.retry.button'}}</LinkTo>

--- a/mon-pix/app/templates/campaigns/start-or-resume.hbs
+++ b/mon-pix/app/templates/campaigns/start-or-resume.hbs
@@ -4,11 +4,5 @@
       <img src="/images/interwind.gif" alt={{t "common.loading"}} />
     </p>
   </div>
-{{else}}
-  {{#if @model.isArchived }}
-    <InaccessibleCampaign>
-      {{t "pages.campaign.errors.no-longer-accessible"}}
-    </InaccessibleCampaign>
-  {{/if}}
 {{/if}}
 

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
 import { resumeCampaignOfTypeProfilesCollectionByCode, completeCampaignOfTypeProfilesCollectionByCode } from '../helpers/campaign';
 import visit from '../helpers/visit';
-import { invalidateSession } from 'ember-simple-auth/test-support';
+import { invalidateSession } from '../helpers/invalidate-session';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { contains } from '../helpers/contains';

--- a/mon-pix/tests/acceptance/user-dashboard_test.js
+++ b/mon-pix/tests/acceptance/user-dashboard_test.js
@@ -1,6 +1,6 @@
 import { currentURL, click, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { invalidateSession } from 'ember-simple-auth/test-support';
+import { invalidateSession } from '../helpers/invalidate-session';
 import { setupApplicationTest } from 'ember-mocha';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
@@ -53,11 +53,9 @@ describe('Acceptance | User dashboard page', function() {
     describe('when user is doing a campaign of type assessment', function() {
 
       context('when user has not completed the campaign', () => {
-        let uncompletedCampaign;
-        let uncompletedCampaignParticipationOverview;
 
         beforeEach(async function() {
-          uncompletedCampaign = server.create('campaign', {
+          const uncompletedCampaign = server.create('campaign', {
             idPixLabel: 'email',
             type: ASSESSMENT,
             isArchived: false,
@@ -65,7 +63,7 @@ describe('Acceptance | User dashboard page', function() {
             code: '123',
           }, 'withThreeChallenges');
 
-          uncompletedCampaignParticipationOverview = server.create('campaign-participation-overview', {
+          server.create('campaign-participation-overview', {
             assessmentState: 'started',
             campaignCode: uncompletedCampaign.code,
             campaignTitle: uncompletedCampaign.title,
@@ -87,30 +85,19 @@ describe('Acceptance | User dashboard page', function() {
           expect(resumeButton).to.exist;
           expect(resumeButton.textContent.trim()).to.equal('Reprendre');
         });
-
-        it('should redirect to the unfinished campaign where it stopped when clicking on resume button ', async function() {
-        // when
-          await visit('/accueil');
-          await click('.campaign-participation-overview-card-content__action');
-
-          // then
-          expect(currentURL()).to.equal(`/campagnes/${uncompletedCampaignParticipationOverview.campaignCode}/presentation`);
-        });
       });
 
       context('when user has completed the campaign but not shared his/her results', () => {
-        let unsharedCampaign;
-        let unsharedCampaignParticipationOverview;
 
         beforeEach(async function() {
-          unsharedCampaign = server.create('campaign', {
+          const unsharedCampaign = server.create('campaign', {
             idPixLabel: 'email',
             type: ASSESSMENT,
             isArchived: false,
             code: '123',
           }, 'withThreeChallenges');
 
-          unsharedCampaignParticipationOverview = server.create('campaign-participation-overview', {
+          server.create('campaign-participation-overview', {
             assessmentState: 'completed',
             campaignCode: unsharedCampaign.code,
             createdAt: new Date('2020-04-20T04:05:06Z'),
@@ -132,15 +119,6 @@ describe('Acceptance | User dashboard page', function() {
           const shareButton = find('.campaign-participation-overview-card-content__action');
           expect(shareButton).to.exist;
           expect(shareButton.textContent.trim()).to.equal('Envoyer mes résultats');
-        });
-
-        it('should redirect to the unshared campaign results page when clicking on share button', async function() {
-        // when
-          await visit('/accueil');
-          await click('.campaign-participation-overview-card-content__action');
-
-          // then
-          expect(currentURL()).to.equal(`/campagnes/${unsharedCampaignParticipationOverview.campaignCode}/presentation`);
         });
       });
     });

--- a/mon-pix/tests/helpers/invalidate-session.js
+++ b/mon-pix/tests/helpers/invalidate-session.js
@@ -1,0 +1,6 @@
+import testSupport from 'ember-simple-auth/test-support';
+
+export async function invalidateSession() {
+  sessionStorage.clear();
+  await testSupport.invalidateSession();
+}

--- a/mon-pix/tests/test-helper.js
+++ b/mon-pix/tests/test-helper.js
@@ -22,3 +22,7 @@ mocha.setup({
 
 setApplication(Application.create(config.APP));
 start();
+
+afterEach(() => {
+  sessionStorage.clear();
+});

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
@@ -84,12 +84,12 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
       sinon.assert.calledWithExactly(adapter.beginImprovement, 12345);
     });
 
-    it('should redirect to campaigns.start-or-resume', async function() {
+    it('should redirect to campaigns.entry-point', async function() {
       // when
       await component.actions.improve.call(component);
 
       // then
-      sinon.assert.calledWith(component.router.transitionTo, 'campaigns.start-or-resume');
+      sinon.assert.calledWith(component.router.transitionTo, 'campaigns.entry-point');
     });
   });
 

--- a/mon-pix/tests/unit/controllers/campaigns/campaign-landing-page_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/campaign-landing-page_test.js
@@ -10,7 +10,7 @@ describe('Unit | Controller | Campaigns | Landing Page', function() {
 
   beforeEach(function() {
     controller = this.owner.lookup('controller:campaigns/campaign-landing-page');
-    controller.transitionToRoute = sinon.stub();
+    controller.router = { transitionTo: sinon.stub() };
   });
 
   describe('#startCampaignParticipation', () => {
@@ -23,11 +23,7 @@ describe('Unit | Controller | Campaigns | Landing Page', function() {
       controller.actions.startCampaignParticipation.call(controller);
 
       // then
-      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume', 'konami', {
-        queryParams: {
-          hasUserSeenLandingPage: true,
-        },
-      });
+      sinon.assert.calledWith(controller.router.transitionTo, 'campaigns.start-or-resume', 'konami');
     });
   });
 });

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-participant-external-id_test.js
@@ -16,7 +16,7 @@ describe('Unit | Controller | Campaigns | FillInParticipantExternalId', function
   beforeEach(function() {
     controller = this.owner.lookup('controller:campaigns/fill-in-participant-external-id');
     controller.set('model', model);
-    controller.transitionToRoute = sinon.stub();
+    controller.router = { transitionTo: sinon.stub() };
   });
 
   describe('#onSubmitParticipantExternalId', () => {
@@ -25,7 +25,7 @@ describe('Unit | Controller | Campaigns | FillInParticipantExternalId', function
       controller.actions.onSubmitParticipantExternalId.call(controller, participantExternalId);
 
       // then
-      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume', controller.model, { queryParams: { participantExternalId } });
+      sinon.assert.calledWith(controller.router.transitionTo, 'campaigns.start-or-resume', controller.model);
     });
   });
 
@@ -35,7 +35,7 @@ describe('Unit | Controller | Campaigns | FillInParticipantExternalId', function
       controller.actions.onCancel.call(controller);
 
       // then
-      sinon.assert.calledWithExactly(controller.transitionToRoute, 'campaigns.start-or-resume', controller.get('model.code'), { queryParams: { hasUserSeenLandingPage: false } });
+      sinon.assert.calledWithExactly(controller.router.transitionTo, 'campaigns.start-or-resume', controller.get('model.code'));
     });
   });
 });

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/join_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/join_test.js
@@ -9,7 +9,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
   beforeEach(function() {
     controller = this.owner.lookup('controller:campaigns.restricted.join');
-    controller.transitionToRoute = sinon.stub();
+    controller.router = { transitionTo: sinon.stub() };
     controller.set('model', 'AZERTY999');
   });
 
@@ -33,7 +33,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
         // then
         sinon.assert.calledOnce(schoolingRegistration.save);
-        sinon.assert.notCalled(controller.transitionToRoute);
+        sinon.assert.notCalled(controller.router.transitionTo);
       });
     });
 
@@ -49,7 +49,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
         // then
         sinon.assert.calledOnce(schoolingRegistration.save);
-        sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
+        sinon.assert.calledWith(controller.router.transitionTo, 'campaigns.start-or-resume');
       });
     });
   });
@@ -86,7 +86,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
       sinon.assert.calledOnce(externalUser.save);
       sinon.assert.calledWith(sessionStub.set, 'data.externalUser', null);
       sinon.assert.calledWith(sessionStub.authenticate, 'authenticator:oauth2', { token: accessToken });
-      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
+      sinon.assert.calledWith(controller.router.transitionTo, 'campaigns.start-or-resume');
     });
   });
 });

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/login-or-register-to-access_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/login-or-register-to-access_test.js
@@ -31,7 +31,7 @@ describe('Unit | Controller | campaigns/restricted/login-or-register-to-access',
     controller.set('session', sessionStub);
     controller.set('currentUser', currentUserStub);
 
-    controller.transitionToRoute = sinon.stub();
+    controller.router = { transitionTo: sinon.stub() };
   });
 
   describe('#addGarAuthenticationMethodToUser', () => {
@@ -50,7 +50,7 @@ describe('Unit | Controller | campaigns/restricted/login-or-register-to-access',
       await controller.actions.addGarAuthenticationMethodToUser.call(controller, externallUserAuthenticationRequest);
 
       // then
-      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
+      sinon.assert.calledWith(controller.router.transitionTo, 'campaigns.start-or-resume');
 
     });
 

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
@@ -16,10 +16,11 @@ describe('Unit | Controller | Fill in Campaign Code', function() {
 
   beforeEach(function() {
     controller = this.owner.lookup('controller:fill-in-campaign-code');
-    controller.transitionToRoute = sinon.stub();
+    const routerStub = { transitionTo: sinon.stub() };
     sessionStub = { invalidate: sinon.stub() };
     eventStub = { preventDefault: sinon.stub() };
     currentUserStub = { user: { firstName: 'John', lastname: 'Doe' } };
+    controller.set('router', routerStub);
     controller.set('session', sessionStub);
     controller.set('currentUser', currentUserStub);
     controller.set('errorMessage', null);
@@ -40,7 +41,7 @@ describe('Unit | Controller | Fill in Campaign Code', function() {
       await controller.actions.startCampaign.call(controller, eventStub);
 
       // then
-      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume', campaign);
+      sinon.assert.calledWith(controller.router.transitionTo, 'campaigns.entry-point', campaign);
     });
 
     it('should set error when campaign code is empty', async () => {

--- a/mon-pix/tests/unit/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/skill-review_test.js
@@ -29,7 +29,7 @@ describe('Unit | Route | Campaign | Assessment | Skill review', function() {
       it('should redirect to start or resume', async function() {
         await route.model();
 
-        sinon.assert.calledWith(route.transitionTo, 'campaigns.start-or-resume', 'NEW_CODE');
+        sinon.assert.calledWith(route.transitionTo, 'campaigns.entry-point', 'NEW_CODE');
       });
     });
 

--- a/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
@@ -19,7 +19,7 @@ describe('Unit | Route | Entry Point', function() {
     route.store = { queryRecord: sinon.stub() };
     route.replaceWith = sinon.stub();
     route.modelFor = sinon.stub();
-    route.campaignStorage = { set: sinon.stub() };
+    route.campaignStorage = { set: sinon.stub(), clear: sinon.stub() };
   });
 
   describe('#model', function() {
@@ -29,6 +29,16 @@ describe('Unit | Route | Entry Point', function() {
 
       //then
       sinon.assert.calledWith(route.modelFor, 'campaigns');
+    });
+  });
+
+  describe('#afterModel', function() {
+    it('should erase campaign storage', async function() {
+      //given/when
+      await route.afterModel({ code: 'CODE' });
+
+      //then
+      sinon.assert.calledWith(route.campaignStorage.clear, 'CODE');
     });
   });
 

--- a/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
@@ -1,0 +1,188 @@
+import EmberObject from '@ember/object';
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Route | Entry Point', function() {
+  setupTest();
+
+  let route;
+
+  const campaign = EmberObject.create({
+    id: 3,
+    code: 'NEW_CODE',
+  });
+
+  beforeEach(function() {
+    route = this.owner.lookup('route:campaigns.entry-point');
+
+    route.store = { queryRecord: sinon.stub() };
+    route.replaceWith = sinon.stub();
+    route.modelFor = sinon.stub();
+    route.campaignStorage = { set: sinon.stub() };
+  });
+
+  describe('#model', function() {
+    it('should load model', async function() {
+      //given/when
+      await route.model();
+
+      //then
+      sinon.assert.calledWith(route.modelFor, 'campaigns');
+    });
+  });
+
+  describe('#redirect', function() {
+    describe('user not connected', function() {
+      it('should not call queryRecord to retrieve campaignParticipation', async function() {
+        //given
+        const transition = { to: { queryParams: {} } };
+        route.currentUser = undefined;
+
+        //when
+        await route.redirect(campaign, transition);
+
+        //then
+        sinon.assert.notCalled(route.store.queryRecord);
+      });
+
+      it('should redirect to start-or-resume', async function() {
+        //given
+        const transition = { to: { queryParams: {} } };
+        route.currentUser = undefined;
+        campaign.isArchived = false;
+
+        //when
+        await route.redirect(campaign, transition);
+
+        //then
+        sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume');
+      });
+
+      describe('archived campaign', function() {
+        it('should redirect to not-found page', async function() {
+          //given
+          const transition = { to: { queryParams: {} } };
+          route.currentUser = undefined;
+          campaign.isArchived = true;
+
+          //when
+          await route.redirect(campaign, transition);
+
+          //then
+          sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-not-found');
+        });
+      });
+    });
+
+    describe('user connected', function() {
+      it('should call queryRecord to retrieve campaignParticipation', async function() {
+        //given
+        const transition = { to: { queryParams: {} } };
+        route.currentUser = { user: {
+          id: 12,
+        } };
+
+        //when
+        await route.redirect(campaign, transition);
+
+        //then
+        sinon.assert.calledWith(route.store.queryRecord, 'campaignParticipation', {
+          campaignId: 3,
+          userId: 12,
+        });
+      });
+
+      it('should redirect to start-or-resume', async function() {
+        //given
+        const transition = { to: { queryParams: {} } };
+        route.currentUser = { user: {
+          id: 12,
+        } };
+        campaign.isArchived = false;
+
+        //when
+        await route.redirect(campaign, transition);
+
+        //then
+        sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume');
+      });
+
+      describe('archived campaign', function() {
+        it('should redirect to not-found page with no participation', async function() {
+          //given
+          const transition = { to: { queryParams: {} } };
+          route.currentUser = { user: {
+            id: 12,
+          } };
+          campaign.isArchived = true;
+
+          route.store.queryRecord.withArgs('campaignParticipation', {
+            campaignId: 3,
+            userId: 12,
+          }).resolves(null);
+
+          //when
+          await route.redirect(campaign, transition);
+
+          //then
+          sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-not-found');
+        });
+
+        it('should redirect to start or resume page with participation', async function() {
+          //given
+          const transition = { to: { queryParams: {} } };
+          route.currentUser = { user: {
+            id: 12,
+          } };
+          campaign.isArchived = true;
+
+          route.store.queryRecord.withArgs('campaignParticipation', {
+            campaignId: 3,
+            userId: 12,
+          }).resolves('Ma Participation');
+
+          //when
+          await route.redirect(campaign, transition);
+
+          //then
+          sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume');
+        });
+      });
+    });
+
+    describe('participantExternalId', function() {
+      describe('when there are participantExternalId', function() {
+        it('sets the current participantExternalId', async function() {
+          //given
+          const transition = { to: { queryParams: { participantExternalId: 'externalId' } } };
+          route.currentUser = { user: {
+            id: 12,
+          } };
+
+          //when
+          await route.redirect(campaign, transition);
+
+          //then
+          sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', 'externalId');
+        });
+      });
+
+      describe('when there is no participantExternalId', function() {
+        it('does not set the participantExternalId', async function() {
+          //given
+          const transition = { to: { queryParams: { } } };
+          route.currentUser = { user: {
+            id: 12,
+          } };
+
+          //when
+          await route.redirect(campaign, transition);
+
+          //then
+          sinon.assert.notCalled(route.campaignStorage.set);
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
@@ -184,5 +184,39 @@ describe('Unit | Route | Entry Point', function() {
         });
       });
     });
+
+    describe('retry', function() {
+      describe('when there are retry', function() {
+        it('sets the current retry', async function() {
+          //given
+          const transition = { to: { queryParams: { retry: 'true' } } };
+          route.currentUser = { user: {
+            id: 12,
+          } };
+
+          //when
+          await route.redirect(campaign, transition);
+
+          //then
+          sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'retry', 'true');
+        });
+      });
+
+      describe('when there is no retry', function() {
+        it('does not set the retry', async function() {
+          //given
+          const transition = { to: { queryParams: { } } };
+          route.currentUser = { user: {
+            id: 12,
+          } };
+
+          //when
+          await route.redirect(campaign, transition);
+
+          //then
+          sinon.assert.notCalled(route.campaignStorage.set);
+        });
+      });
+    });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/profiles-collection/profile-already-shared_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/profiles-collection/profile-already-shared_test.js
@@ -30,7 +30,7 @@ describe('Unit | Route | Campaign | Profiles Collection | Profile already shared
       it('should redirect to start or resume', async function() {
         await route.model();
 
-        sinon.assert.calledWith(route.transitionTo, 'campaigns.start-or-resume', 'NEW_CODE');
+        sinon.assert.calledWith(route.transitionTo, 'campaigns.entry-point', 'NEW_CODE');
       });
     });
 

--- a/mon-pix/tests/unit/routes/campaigns/restricted/join_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/restricted/join_test.js
@@ -30,7 +30,7 @@ describe('Unit | Route | campaigns/restricted/join', function() {
       await route.afterModel(campaign);
 
       // then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume', campaign.code, { queryParams: { associationDone: true } });
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume', campaign.code);
     });
   });
 

--- a/mon-pix/tests/unit/routes/logout_test.js
+++ b/mon-pix/tests/unit/routes/logout_test.js
@@ -10,6 +10,11 @@ describe('Unit | Route | logout', () => {
   setupTest();
 
   let sessionStub;
+  let campaignStorageStub;
+
+  beforeEach(function() {
+    campaignStorageStub = { clearAll: sinon.stub() };
+  });
 
   it('should disconnect the user', function() {
     // Given
@@ -23,6 +28,7 @@ describe('Unit | Route | logout', () => {
 
     const route = this.owner.lookup('route:logout');
     route.set('session', sessionStub);
+    route.set('campaignStorage', campaignStorageStub);
 
     // When
     route.beforeModel();
@@ -39,6 +45,7 @@ describe('Unit | Route | logout', () => {
 
     const route = this.owner.lookup('route:logout');
     route.set('session', sessionStub);
+    route.set('campaignStorage', campaignStorageStub);
     route._redirectToHome = sinon.stub();
     route.source = 'pix';
 
@@ -57,6 +64,7 @@ describe('Unit | Route | logout', () => {
 
     const route = this.owner.lookup('route:logout');
     route.set('session', sessionStub);
+    route.set('campaignStorage', campaignStorageStub);
     route._redirectToDisconnectedPage = sinon.stub();
     route.source = AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
@@ -67,4 +75,23 @@ describe('Unit | Route | logout', () => {
     sinon.assert.calledOnce(route._redirectToDisconnectedPage);
   });
 
+  it('should erase campaign storage', function() {
+    // Given
+    const invalidateStub = sinon.stub();
+    sessionStub = Service.create({ invalidate: invalidateStub, data: {
+      authenticated: {},
+    },
+    });
+
+    const route = this.owner.lookup('route:logout');
+    route.set('campaignStorage', campaignStorageStub);
+    route.set('session', sessionStub);
+    route.set('campaignStorage', campaignStorageStub);
+
+    // When
+    route.beforeModel();
+
+    // Then
+    sinon.assert.calledOnce(campaignStorageStub.clearAll);
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le `start-or-resume` n'est pas évident à appréhender, à maintenir, à corriger/ajouter du fonctionnel car il contient TOUT.

## :robot: Solution
Séparer la logique d'accès à une campagne en plusieurs brique (disponible sur le miro prescription/accès (Archive)

## :rainbow: Remarques

## :100: Pour tester
Faire des parcours

Collecte de profil
Campagne  (retenter/repasser)  avec association/ (avec @ajoanny , on a pas su tester une connexion GAR si ça existe en mode dev)

