### PR TITLE
[TECH] Ajout d'une étape dans la github action déclenchée lors du merge afin de vérifier si le fichier de config a été modifié.

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -31,3 +31,22 @@ jobs:
       with:
         issue: ${{ steps.find.outputs.issue }}
         transition: "Move to 'Deployed in Integration'"
+
+  notify-if-config-file-change:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Check config file change
+        run: |
+          echo "DIFF_RESULT=$(git diff HEAD~  HEAD --shortstat api/lib/config.js)" >> $GITHUB_ENV
+
+      - name: Send notification
+        uses: slackapi/slack-github-action@v1.14.0
+        with:
+          payload: "{\"environment\":\"INTÉGRATION\",\"scalingo_url\":\"https://dashboard.scalingo.com/apps/osc-fr1/pix-api-integration/environment\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: env.DIFF_RESULT


### PR DESCRIPTION
## :unicorn: Problème
Lors du merge d'une PR sur la branche dev, il arrive parfois que des variables d'environnement soient ajoutées/modifiées/supprimées. Cela implique de devoir mettre à jour les variables d'environnement de Scalingo sur l'environnement d'Intégration. Cependant, il arrive parfois que cette étape soit oubliée.

## :robot: Solution
Afin de limiter les oublis de mise à jour des variables d'environnement, une étape a été ajouté dans la github action qui se déclenche lors du merge d'une PR afin d'envoyer un message Slack dans le canal "tech-releases" afin d'avertir d'aller modifier les variables de Scalingo Intégration lorsque de config a été modifié. 

## :100: Pour tester
La procédure n'est pas testable en l'état car elle nécessite un merge sur la branche dev. Cependant, elle a été testée sur un repo de test.