### PR TITLE
[CLEANUP] Uniformiser les url des badges (PIX-3479). 

### DIFF
--- a/api/db/migrations/20210916120235_update-badges-imageUrl-to-url-with-pix-domain.js
+++ b/api/db/migrations/20210916120235_update-badges-imageUrl-to-url-with-pix-domain.js
@@ -1,0 +1,12 @@
+const TABLE_NAME = 'badges';
+const COLUMN_NAME = 'imageUrl';
+const OVH_URL = 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-images';
+const PIX_URL = 'https://images.pix.fr';
+
+exports.up = function(knex) {
+  return knex.raw(`UPDATE ${TABLE_NAME} SET "${COLUMN_NAME}" = REPLACE("${COLUMN_NAME}", '${OVH_URL}', '${PIX_URL}') WHERE "${COLUMN_NAME}" LIKE '${OVH_URL}%';`);
+};
+
+exports.down = function() {
+
+};


### PR DESCRIPTION
## :unicorn: Problème
Les nouveaux badges sont créés à la main avec des urls avec le format `https://images.pix.fr`, depuis la PR https://github.com/1024pix/pix/pull/3204
Avant de permettre la création de badges via Pix Admin, nous souhaitons uniformisés les url présentes en base sous le nouveau format.	 

## :robot: Solution
Ajouter un migration permettant de passer sous le nouveau format. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Cloner la branche en local 
- Ajouter un badge avec une url sous l'ancien format 
```sql
INSERT INTO badges ("imageUrl","altMessage") VALUES('https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-images/badges/test.svg', 'alt')
```
- Lancer la migration 
```shell
npm run db:migrate
```
- Constater que la nouvelle url est sous le nouveau format. 
