### PR TITLE
[FEATURE] Simplifier la visibilité de l'épreuve et des tooltips (PIX-3483).

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import isInteger from 'lodash/isInteger';
-import ENV from 'mon-pix/config/environment';
 
 export default class ChallengeItemGeneric extends Component {
 
@@ -20,20 +19,7 @@ export default class ChallengeItemGeneric extends Component {
   }
 
   get isAnswerFieldDisabled() {
-    if (ENV.APP.FT_FOCUS_CHALLENGE_ENABLED) {
-      if (this.args.isFocusedChallenge && this._hasUserNotSeenFocusedChallengeTooltip()
-        || !this.args.isFocusedChallenge && this._hasUserNotSeenOtherChallengesTooltip()) {
-        return this.args.answer || !this.args.isTooltipClosed;
-      }
-    }
     return this.args.answer;
-  }
-
-  _hasUserNotSeenFocusedChallengeTooltip() {
-    return this.args.isFocusedChallenge && this.currentUser.user && !this.currentUser.user.hasSeenFocusedChallengeTooltip;
-  }
-  _hasUserNotSeenOtherChallengesTooltip() {
-    return !this.args.isFocusedChallenge && this.currentUser.user && !this.currentUser.user.hasSeenOtherChallengesTooltip;
   }
 
   get isTimedChallengeWithoutAnswer() {

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -17,7 +17,6 @@
                 hasFocusedOutOfWindow=this.hasFocusedOutOfWindow
                 answerValidated=@answerValidated
                 resumeAssessment=@resumeAssessment
-                isTooltipClosed=this.isTooltipClosed
                 isFocusedChallenge=this.isFocusedChallenge
     }}
   </div>

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -9,11 +9,17 @@ export default class Item extends Component {
   @service currentUser;
   @tracked hasFocusedOutOfWindow = false;
   @tracked hasFocusedOutOfChallenge = false;
-  @tracked isTooltipClosed = false;
+
+  constructor() {
+    super(...arguments);
+    if (this.isFocusedChallenge) {
+      this._setOnBlurEventToWindow();
+    }
+  }
 
   @action
   hideOutOfFocusBorder() {
-    if (this.isFocusedChallenge && this.isTooltipClosed) {
+    if (this.isFocusedChallenge) {
       this.args.onFocusIntoChallenge();
       this.hasFocusedOutOfChallenge = false;
     }
@@ -21,7 +27,7 @@ export default class Item extends Component {
 
   @action
   showOutOfFocusBorder() {
-    if (this.isFocusedChallenge && this.isTooltipClosed && !this.args.answer) {
+    if (this.isFocusedChallenge && !this.args.answer) {
       this.args.onFocusOutOfChallenge();
       this.hasFocusedOutOfChallenge = true;
     }
@@ -30,9 +36,6 @@ export default class Item extends Component {
   @action
   enableFocusedChallenge() {
     this.isTooltipClosed = true;
-    if (this.isFocusedChallenge) {
-      this._setOnBlurEventToWindow();
-    }
     this.args.onTooltipClose();
   }
 

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -7,7 +7,6 @@ const defaultPageTitle = 'pages.challenge.title.default';
 const timedOutPageTitle = 'pages.challenge.title.timed-out';
 const focusedPageTitle = 'pages.challenge.title.focused';
 const focusedOutPageTitle = 'pages.challenge.title.focused-out';
-import ENV from 'mon-pix/config/environment';
 import isInteger from 'lodash/isInteger';
 
 export default class ChallengeController extends Controller {
@@ -59,18 +58,6 @@ export default class ChallengeController extends Controller {
 
   get displayInfoAlertForFocusOut() {
     return this.hasFocusedOutOfChallenge && this.couldDisplayInfoAlert;
-  }
-
-  get isTooltipWithConfirmationButtonDisplayed() {
-    if (ENV.APP.FT_FOCUS_CHALLENGE_ENABLED) {
-      if (this.model.challenge.focused) {
-        return this.isTooltipOverlayDisplayed && this.currentUser.user && !this.currentUser.user.hasSeenFocusedChallengeTooltip;
-      }
-      else if (!this.model.challenge.focused) {
-        return this.isTooltipOverlayDisplayed && this.currentUser.user && !this.currentUser.user.hasSeenOtherChallengesTooltip;
-      }
-    }
-    return false;
   }
 
   @action

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -19,14 +19,6 @@ export default class ChallengeController extends Controller {
   @tracked hasFocusedOutOfChallenge = false;
   @tracked hasFocusedOutOfWindow = false;
   @tracked hasUserConfirmedWarning = false;
-  @tracked shouldRemoveTooltipOverlay = false;
-
-  get isTooltipOverlayDisplayed() {
-    if (this.model.challenge) {
-      return !this.shouldRemoveTooltipOverlay;
-    }
-    return false;
-  }
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;
@@ -73,7 +65,6 @@ export default class ChallengeController extends Controller {
 
   async _updateUserAndTriggerOverlayRemoval(tooltipChallengeType) {
     await this.currentUser.user.save({ adapterOptions: tooltipChallengeType });
-    this.shouldRemoveTooltipOverlay = true;
   }
 
   @action

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -2,6 +2,10 @@
   color: $grey-60;
   font-size: 0.938rem;
   margin-top: 16px;
+  z-index: 1;
+  background-color: white;
+  border-radius: 10px;
+  padding: 5px 15px;
 }
 
 /* "Link" view

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -15,18 +15,6 @@
     margin-bottom: 30px;
   }
 
-  &__overlay {
-    position: fixed;
-    display: block;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-  }
-
   &__focused-out-overlay {
     position: fixed;
     display: block;

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -36,7 +36,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: rgba(0, 0, 0, 0.15);
+    background-color: rgba(0, 0, 0, 0.5);
   }
 
   &__feedback {

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -1,9 +1,6 @@
 {{page-title this.pageTitle}}
 
 <div class="background-banner-wrapper challenge">
-  {{#if this.isTooltipWithConfirmationButtonDisplayed}}
-    <div class="challenge__overlay"></div>
-  {{/if}}
   {{#if this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
     <div class="challenge__focused-out-overlay"></div>
   {{/if}}

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -5,7 +5,7 @@ import { getPageTitle } from 'ember-page-title/test-support';
 import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { expect } from 'chai';
-import { click, find, findAll, triggerEvent } from '@ember/test-helpers';
+import { click, find, triggerEvent } from '@ember/test-helpers';
 
 describe('Acceptance | Displaying a challenge of any type', () => {
   setupApplicationTest();
@@ -53,16 +53,6 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           it('should display a tooltip', async () => {
             // then
             expect(find('.tooltip-tag__information')).to.exist;
-          });
-
-          it('should disable input and buttons', async () => {
-            // then
-            expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.exist;
-            expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.exist;
-
-            const responseFields = findAll('[data-test="challenge-response-proposal-selector"]');
-            expect(responseFields).to.have.lengthOf.at.least(1);
-            responseFields.forEach((input) => expect(input.disabled).to.equal(true));
           });
 
           it('should not display an info alert with dashed border and overlay', async function() {
@@ -290,16 +280,6 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           it('should display a tooltip', async () => {
             // then
             expect(find('.tooltip-tag__information')).to.exist;
-          });
-
-          it('should disable input and buttons', async () => {
-            // then
-            expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.exist;
-            expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.exist;
-
-            const responseFields = findAll('[data-test="challenge-response-proposal-selector"]');
-            expect(responseFields).to.have.lengthOf.at.least(1);
-            responseFields.forEach((input) => expect(input.disabled).to.equal(true));
           });
 
           describe('when user closes tooltip', () => {

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -55,15 +55,15 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             expect(find('.tooltip-tag__information')).to.exist;
           });
 
-          it('should not display an info alert with dashed border and overlay', async function() {
+          it('should display an info alert with dashed border and overlay', async function() {
             // when
             const challengeItem = find('.challenge-item');
             await triggerEvent(challengeItem, 'mouseleave');
 
             // then
-            expect(find('.challenge__info-alert--show')).to.not.exist;
-            expect(find('.challenge-item__container--focused')).to.not.exist;
-            expect(find('.challenge__focused-out-overlay')).to.not.exist;
+            expect(find('.challenge__info-alert--show')).to.exist;
+            expect(find('.challenge-item__container--focused')).to.exist;
+            expect(find('.challenge__focused-out-overlay')).to.exist;
           });
 
           describe('when user closes tooltip', () => {

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -50,9 +50,8 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             await visit(`/assessments/${assessment.id}/challenges/0`);
           });
 
-          it('should display an overlay and tooltip', async () => {
+          it('should display a tooltip', async () => {
             // then
-            expect(find('.challenge__overlay')).to.exist;
             expect(find('.tooltip-tag__information')).to.exist;
           });
 
@@ -88,9 +87,8 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await click('.tooltip-tag-information__button');
             });
 
-            it('should hide an overlay and tooltip', async () => {
+            it('should hide a tooltip', async () => {
               // then
-              expect(find('.challenge__overlay')).to.not.exist;
               expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
             });
 
@@ -154,9 +152,8 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             await visit(`/assessments/${assessment.id}/challenges/0`);
           });
 
-          it('should hide the overlay and tooltip', async function() {
+          it('should hide the tooltip', async function() {
             // then
-            expect(find('.challenge__overlay')).to.not.exist;
             expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
           });
 
@@ -290,9 +287,8 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             await visit(`/assessments/${assessment.id}/challenges/0`);
           });
 
-          it('should display an overlay and tooltip', async () => {
+          it('should display a tooltip', async () => {
             // then
-            expect(find('.challenge__overlay')).to.exist;
             expect(find('.tooltip-tag__information')).to.exist;
           });
 
@@ -317,9 +313,8 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await click('.tooltip-tag-information__button');
             });
 
-            it('should hide an overlay and tooltip', async () => {
+            it('should hide a tooltip', async () => {
               // then
-              expect(find('.challenge__overlay')).to.not.exist;
               expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
             });
 


### PR DESCRIPTION
## :unicorn: Problème
Des utilisateurs ont remontés des soucis sur les épreuves focus : l'overlay leur donnait l'impression de ne pas pouvoir répondre, il sortait sans s'en rendre compte, etc..

## :robot: Solution
- Ne plus bloquer le champs réponse quand on a une tooltip avec J'ai Compris
- Ne plus mettre l'overlay quand la tooltip avec J'ai compris est présent
- Mettre la partie "Signaler un probleme" dans un bloc blanc, avec contour arrondi et un peu de padding, visible quand on sort en focus
- Quand on sort au focus, le grisé doit être de 0.5

## :rainbow: Remarques
Cette PR est basé actuellement sur celle ajoutant les tooltips pour toutes les épreuves.
Commencer à ce commit : https://github.com/1024pix/pix/pull/3501/commits/3a068e2e97e579c0cb6532b3fd01014d9113f5c2

## :100: Pour tester
Etre un nouvel utilisateur et passer des compétences.