### PR TITLE
[FEATURE] Afficher le statut d'un profil cible dans la liste des profils cibles dans Pix Admin (Pix-3475).

### DIFF
--- a/admin/app/components/target-profiles/list-items.hbs
+++ b/admin/app/components/target-profiles/list-items.hbs
@@ -5,6 +5,7 @@
         <tr>
           <th>ID</th>
           <th>Nom</th>
+          <th class="col-status">Statut</th>
         </tr>
         <tr>
           <th>
@@ -15,6 +16,7 @@
             <input id="name" type="text" value={{@name}} oninput={{perform @triggerFiltering 'name' }}
               class="table-admin-input" />
           </th>
+          <th></th>
         </tr>
       </thead>
 
@@ -25,6 +27,9 @@
           class="tr--clickable">
           <td>{{targetProfile.id}}</td>
           <td>{{targetProfile.name}}</td>
+          <td class="target-profile-table-column__status">
+            {{if targetProfile.outdated "Obsolète" "Actif"}}
+          </td>
         </tr>
         {{/each}}
       </tbody>

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -62,7 +62,7 @@
 @import 'components/target-profiles/create-target-profile-form';
 @import 'components/target-profiles/details';
 @import 'components/target-profiles/insight';
+@import 'components/target-profiles/list-items';
 @import 'components/target-profiles/organizations';
 @import 'components/target-profiles/stages';
 @import 'components/badges/badge';
-

--- a/admin/app/styles/components/target-profiles/list-items.scss
+++ b/admin/app/styles/components/target-profiles/list-items.scss
@@ -1,0 +1,5 @@
+.target-profile-table-column__status {
+  p {
+    display: inline;
+  }
+}

--- a/admin/app/styles/components/user-detail-personal-information-section.scss
+++ b/admin/app/styles/components/user-detail-personal-information-section.scss
@@ -30,7 +30,7 @@
   }
 
   &--isDisabled {
-    color: $error;
+    color: $grey-30;
   }
 }
 

--- a/admin/app/styles/globals/table-admin.scss
+++ b/admin/app/styles/globals/table-admin.scss
@@ -29,6 +29,10 @@
       }
     }
   }
+
+  .col-status{
+    width: 10%;
+  }
 }
 
 .table-admin__wrapper {

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-items_test.js
@@ -14,16 +14,17 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
     this.goToTargetProfilePage = goToTargetProfilePage;
   });
 
-  test('it should display header with name and id', async function(assert) {
+  test('it should display header with name, id and status', async function(assert) {
     // when
     await render(hbs`<TargetProfiles::ListItems @triggerFiltering={{this.triggerFiltering}} @goToTargetProfilePage={{this.goToTargetProfilePage}}/>`);
 
     // then
     assert.contains('ID');
     assert.contains('Nom');
+    assert.contains('Statut');
   });
 
-  test('if should display search inputs', async function(assert) {
+  test('it should display search inputs', async function(assert) {
     // when
     await render(hbs`<TargetProfiles::ListItems @triggerFiltering={{this.triggerFiltering}} @goToTargetProfilePage={{this.goToTargetProfilePage}}/>`);
 
@@ -65,5 +66,35 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
     // then
     assert.dom('[aria-label="Profil cible"]').containsText(123);
     assert.dom('[aria-label="Profil cible"]').containsText('Profile Cible 1');
+  });
+
+  test('it should display target profile status as "Obsolète" when target profile is outdated', async function(assert) {
+    // given
+    const targetProfiles = [{ id: 123, name: 'Profile Cible - outdated', outdated: true }];
+    targetProfiles.meta = {
+      rowCount: 2,
+    };
+    this.targetProfiles = targetProfiles;
+
+    // when
+    await render(hbs`<TargetProfiles::ListItems @targetProfiles={{this.targetProfiles}} @triggerFiltering={{this.triggerFiltering}} @goToTargetProfilePage={{this.goToTargetProfilePage}}/>`);
+
+    // then
+    assert.contains('Obsolète');
+  });
+
+  test('it should display target profile status as "Actif" when target profile is not outdated', async function(assert) {
+    // given
+    const targetProfiles = [{ id: 123, name: 'Profile Cible - active', outdated: false }];
+    targetProfiles.meta = {
+      rowCount: 2,
+    };
+    this.targetProfiles = targetProfiles;
+
+    // when
+    await render(hbs`<TargetProfiles::ListItems @targetProfiles={{this.targetProfiles}} @triggerFiltering={{this.triggerFiltering}} @goToTargetProfilePage={{this.goToTargetProfilePage}}/>`);
+
+    // then
+    assert.contains('Actif');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans la liste des profils cibles de pix admin, seuls les colonnes id et nom sont visibles. Sauf que pour chercher les utilisateurs, on aurait besoin d'autres éléments.

## :robot: Solution
Ajouter une nouvelle colonne appelé  "Statut" et si un profil cible a été archivé (isOutaded) mettre dans la colonne "Obsolète" sinon ne rien mettre.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Admin -> profile cible
- Constatez que la colonne 'statut' exist 
- Constatez que un icon de croix gris avec un status 'Obsolète' sont attribués aux profiles cible avec `outdated = true`