### PR TITLE
[FEATURE] Mettre à jour les informations d'un centre de certifications depuis Pix Admin (PIX-3478) 

### DIFF
--- a/admin/app/adapters/certification-center.js
+++ b/admin/app/adapters/certification-center.js
@@ -1,0 +1,18 @@
+import ApplicationAdapter from './application';
+
+export default class CertificationCenterAdapter extends ApplicationAdapter {
+  updateRecord(store, type, snapshot) {
+    const model = snapshot.record;
+    const serializer = store.serializerFor(type.modelName);
+    const data = {};
+    serializer.serializeIntoHash(data, type, snapshot, { includeId: true });
+    data.data.included = model.accreditations.map((accreditation) => {
+      return {
+        type: 'accreditations',
+        id: accreditation.get('id'),
+        attributes: { ...accreditation.toJSON() },
+      };
+    });
+    return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PATCH', { data });
+  }
+}

--- a/admin/app/components/certification-center-form.hbs
+++ b/admin/app/components/certification-center-form.hbs
@@ -23,20 +23,21 @@
     <div class="form-field form-group">
       <label class="form-field__label" for="certificationCenterType">Type : </label>
       <div
-        id="certificationCenterTypeSelector"
         class="form-field__select
           {{if @certificationCenter.errors.type "is-invalid" ""}}
           certification-center-form__select-type"
       >
-        <PowerSelect
+        <PixSelect
+          id="certificationCenterTypeSelector"
           @options={{this.certificationCenterTypes}}
-          @searchEnabled={{false}}
-          @selected={{this.selectedCertificationCenterType}}
+          @isSearchable={{false}}
+          @emptyOptionNotSelectable={{true}}
+          @emptyOptionLabel={{"-- Choisissez --"}}
           @onChange={{this.selectCertificationCenterType}}
           as |certificationCenterType|
         >
           {{certificationCenterType.label}}
-        </PowerSelect>
+        </PixSelect>
       </div>
       {{#each @certificationCenter.errors.type as |error|}}
         <div class="form-field__error">

--- a/admin/app/components/certification-center-form.js
+++ b/admin/app/components/certification-center-form.js
@@ -1,19 +1,12 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { types } from '../models/certification-center';
 
 export default class CertificationCenterForm extends Component {
-  certificationCenterTypes = [
-    { value: 'PRO', label: 'Organisation professionnelle' },
-    { value: 'SCO', label: 'Établissement scolaire' },
-    { value: 'SUP', label: 'Établissement supérieur' },
-  ];
-
-  @tracked selectedCertificationCenterType;
+  certificationCenterTypes = types;
 
   @action
-  selectCertificationCenterType(certificationCenterType) {
-    this.selectedCertificationCenterType = certificationCenterType;
-    this.args.certificationCenter.type = certificationCenterType.value;
+  selectCertificationCenterType(event) {
+    this.args.certificationCenter.type = event.target.value;
   }
 }

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -26,6 +26,8 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
   @tracked isEditMode = false;
   @tracked selectedCertificationCenterType;
 
+  @tracked isEditMode = false;
+
   get isDisabled() {
     return !this.userEmailToAdd || !!this.errorMessage;
   }

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -48,6 +48,16 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
     }
   }
 
+  @action
+  updateGrantedAccreditation(accreditation) {
+    const accreditations = this.model.certificationCenter.accreditations;
+    if (accreditations.includes(accreditation)) {
+      accreditations.removeObject(accreditation);
+    } else {
+      accreditations.addObject(accreditation);
+    }
+  }
+
   _getEmailErrorMessage(email) {
     return email && !isEmailValid(email) ? this.EMAIL_INVALID_ERROR_MESSAGE : null;
   }

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -26,8 +26,6 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
   @tracked isEditMode = false;
   @tracked selectedCertificationCenterType;
 
-  @tracked isEditMode = false;
-
   get isDisabled() {
     return !this.userEmailToAdd || !!this.errorMessage;
   }

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -21,6 +21,8 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
   @tracked userEmailToAdd;
   @tracked errorMessage;
 
+  @tracked isEditMode = false;
+
   get isDisabled() {
     return !this.userEmailToAdd || !!this.errorMessage;
   }
@@ -33,7 +35,6 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
   @action
   async addCertificationCenterMembership(event) {
     event && event.preventDefault();
-
     this.errorMessage = this._getEmailErrorMessage(this.userEmailToAdd);
     if (!this.userEmailToAdd) {
       this.errorMessage = this.EMAIL_REQUIRED_ERROR_MESSAGE;
@@ -49,6 +50,11 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
   }
 
   @action
+  toggleEditMode() {
+    this.isEditMode = !this.isEditMode;
+  }
+
+  @action
   updateGrantedAccreditation(accreditation) {
     const accreditations = this.model.certificationCenter.accreditations;
     if (accreditations.includes(accreditation)) {
@@ -58,13 +64,25 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
     }
   }
 
+  @action
+  async submitForm(event) {
+    event.preventDefault();
+    try {
+      await this.model.certificationCenter.save();
+      this.notifications.success('Centre de certification mis à jour avec succès.');
+    } catch (e) {
+      this.notifications.error("Une erreur est survenue, le centre de certification n'a pas été mis à jour.");
+    }
+
+    this.toggleEditMode();
+  }
+
   _getEmailErrorMessage(email) {
     return email && !isEmailValid(email) ? this.EMAIL_INVALID_ERROR_MESSAGE : null;
   }
 
   async _createCertificationCenterMembership() {
     const { certificationCenter } = this.model;
-
     await this.store.createRecord('certification-center-membership').save({
       adapterOptions: {
         createByEmail: true,

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { types } from '../../../models/certification-center';
 
 import isEmailValid from '../../../utils/email-validator';
 
@@ -16,15 +17,22 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
     STATUS_412: 'Ce membre est déjà rattaché.',
   };
 
+  certificationCenterTypes = types;
+
   @service notifications;
 
   @tracked userEmailToAdd;
   @tracked errorMessage;
-
   @tracked isEditMode = false;
+  @tracked selectedCertificationCenterType;
 
   get isDisabled() {
     return !this.userEmailToAdd || !!this.errorMessage;
+  }
+
+  @action
+  selectCertificationCenterType(event) {
+    this.model.certificationCenter.type = event.target.value;
   }
 
   @action

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -1,5 +1,11 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
+export const types = [
+  { value: 'PRO', label: 'Organisation professionnelle' },
+  { value: 'SCO', label: 'Établissement scolaire' },
+  { value: 'SUP', label: 'Établissement supérieur' },
+];
+
 export default class CertificationCenter extends Model {
   @attr() name;
   @attr() type;

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -16,6 +16,38 @@
       font-size: 1.2rem;
       font-weight: 600;
     }
+
+    .accreditations-list {
+      background-color: #F4F5F7;
+      border-radius: 16px;
+      display: flex;
+      padding: 8px;
+
+      li {
+        float: left;
+        width: 200px;
+      }
+
+      .granted-accreditation-icon {
+        color: $green;
+      }
+
+      .not-granted-accreditation-icon {
+        color: $grey-35;
+      }
+    }
+
+    button {
+      margin: 16px 0;
+    }
+  }
+
+  .accreditations-checkbox-list {
+    display: flex;
+
+    ul {
+      list-style-type: none;
+    }
   }
 
   .certification-center {
@@ -29,6 +61,10 @@
         width: 310px;
       }
     }
+
+    &__edit-form {
+      width: 500px;
+    }
   }
 
   .error {
@@ -38,21 +74,12 @@
   }
 
   ul {
-    padding: 0;
-    margin: 0;
     list-style-type: none;
+    margin: 8px;
+    padding: 0px;
   }
 
-  li {
-    float: left;
-    width: 200px;
-  }
-
-  .granted-accreditation-icon {
-    color: $green;
-  }
-
-  .not-granted-accreditation-icon {
-    color: $grey-35;
+  .accreditation-entry {
+    display: block;
   }
 }

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -42,14 +42,6 @@
     }
   }
 
-  .accreditations-checkbox-list {
-    display: flex;
-
-    ul {
-      list-style-type: none;
-    }
-  }
-
   .certification-center {
 
     &__section {
@@ -76,10 +68,18 @@
   ul {
     list-style-type: none;
     margin: 8px;
-    padding: 0px;
+    padding: 0;
   }
 
   .accreditation-entry {
     display: block;
+  }
+
+  .accreditations-checkbox-list {
+    display: flex;
+
+    ul {
+      list-style-type: none;
+    }
   }
 }

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -11,122 +11,122 @@
 
 <main class="page-body" id="certification-center-get-page">
   <section class="page-section mb_10">
-    <div class="certification-center__data">
-      <h1 class="certification-center__name">{{@model.certificationCenter.name}}</h1>
+    <div class="certification-center__information">
 
       {{#if this.isEditMode}}
         <div class="certification-center__edit-form">
-          <form class="form" {{on "submit" this.updateCertificationCenter}}>
+          <form class="form" onsubmit={{this.submitForm}}>
 
             <div class="form-field">
-              <label for="type" class="form-field__label">Nom du centre</label>
-              {{#if (v-get this.form 'name' 'isInvalid')}}
-                <div class="form-field__error" aria-label="Message d'erreur du champ nom">
-                  {{v-get this.form 'name' 'message'}}
+              <label for="certification-center-name" class="form-field__label">Nom du centre</label>
+              <Input
+                id="certification-center-name"
+                name="certification-center-name"
+                @type="text"
+                maxlength="255"
+                class="form-control"
+                @value={{@model.certificationCenter.name}}
+              />
+              {{#each this.certificationCenter.errors.name as |error|}}
+                <div class="session-form__error error-message">
+                  {{error.message}}
                 </div>
-              {{/if}}
-              <Input id="name"
-                     @type="text"
-                     class={{if (v-get this.form 'name' 'isInvalid') "form-control is-invalid" "form-control"}}
-                     @value={{this.form.name}}
-                     required={{true}} />
+              {{/each}}
             </div>
+
             <div class="form-field">
-              <label for="type" class="form-field__label">Type</label>
-              {{#if (v-get this.form 'type' 'isInvalid')}}
-                <div class="form-field__error" aria-label="Message d'erreur du champ type">
-                  {{v-get this.form 'type' 'message'}}
+              <label for="certification-center-type" class="form-field__label">Type</label>
+              <Input
+                id="certification-center-@type"
+                name="certification-center-type"
+                @type="text"
+                maxlength="255"
+                class="form-control"
+                @value={{@model.certificationCenter.type}}
+              />
+              {{#each this.certificationCenter.errors.type as |error|}}
+                <div class="session-form__error error-message">
+                  {{error.message}}
                 </div>
-              {{/if}}
-              <Input id="type"
-                     @type="text"
-                     class={{if (v-get this.form 'type' 'isInvalid') "form-control is-invalid" "form-control"}}
-                     @value={{this.form.type}} />
+              {{/each}}
             </div>
+
             <div class="form-field">
-              <label for="externalId" class="form-field__label">Identifiant externe</label>
-              {{#if (v-get this.form 'externalId' 'isInvalid')}}
-                <div class="form-field__error" aria-label="Message d'erreur du champ identifiant externe">
-                  {{v-get this.form 'externalId' 'message'}}
+              <label for="certification-center-external-id" class="form-field__label">Identifiant externe</label>
+              <Input
+                id="certification-center-external-id"
+                name="certification-center-external-id"
+                @type="text"
+                maxlength="255"
+                class="form-control"
+                @value={{@model.certificationCenter.externalId}}
+              />
+              {{#each this.certificationCenter.errors.externalId as |error|}}
+                <div class="session-form__error error-message">
+                  {{error.message}}
                 </div>
-              {{/if}}
-              <Input id="externalId"
-                     @type="text"
-                     class={{if (v-get this.form 'externalId' 'isInvalid') "form-control is-invalid" "form-control"}}
-                     @value={{this.form.externalId}} />
+              {{/each}}
             </div>
-            <div>
+            <div class="form-field accreditations-checkbox-list">
               <ul>
                 {{#each @model.accreditations as |accreditation|}}
                   <li>
-                    <label for="accreditation-checkbox">{{accreditation.name}}</label>
-                    <Input
-                      @type="checkbox"
-                      @checked={{contains accreditation @model.certificationCenter.accreditations}}
-                      {{on "input" (fn this.updateGrantedAccreditation accreditation)}}
-                    />
+                    <div class="accreditation-entry">
+                      <Input
+                        @type="checkbox"
+                        @checked={{contains accreditation @model.certificationCenter.accreditations}}
+                        {{on "input" (fn this.updateGrantedAccreditation accreditation)}}
+                      />
+                      <label for="accreditation-checkbox">{{accreditation.name}}</label>
+                    </div>
                   </li>
                 {{/each}}
               </ul>
             </div>
             <div class="form-actions">
               <PixButton
-                      @size="small"
-                      @backgroundColor="transparent-light"
-                      @isBorderVisible={{true}}
-                      @triggerAction={{this.cancel}}>Annuler</PixButton>
-              <PixButton
-                      @type="submit"
-                      @size="small"
-                      @backgroundColor="green"
-                      @triggerAction={{this.toggleEditMode}}>Ajouter</PixButton>
+                @size="small"
+                @backgroundColor="transparent-light"
+                @isBorderVisible={{true}}
+                @triggerAction={{this.toggleEditMode}}
+              >Annuler</PixButton>
+              <PixButton @type="submit" @size="small" @backgroundColor="green">Enregistrer</PixButton>
             </div>
           </form>
         </div>
       {{else}}
-        <p>
-          Type : <span>{{@model.certificationCenter.type}}</span><br>
-          Identifiant externe : <span>{{@model.certificationCenter.externalId}}</span><br>
-        </p>
-        <h3 class="certification-center__subtitle">Habilitations aux certifications complémentaires</h3>
-        <ul>
-          {{#each @model.accreditations as |accreditation|}}
-            <li>
-              {{#if (contains accreditation @model.certificationCenter.accreditations)}}
-                <FaIcon class="granted-accreditation-icon" @icon="check-circle" />
-              {{else}}
-                <FaIcon class="not-granted-accreditation-icon" @icon="times-circle" />
-              {{/if}}
-              {{accreditation.name}}
-            </li>
-          {{/each}}
-        </ul>
-        <PixButton
-                @backgroundColor="transparent-light"
-                @isBorderVisible={{true}}
-                @size="small"
-                @triggerAction={{this.toggleEditMode}}
-                aria-label="Editer">Editer</PixButton>
+        <div class="certification-center__data">
+          <h1 class="certification-center__name">{{@model.certificationCenter.name}}</h1>
+          <p>
+            Type :
+            <span>{{@model.certificationCenter.type}}</span><br />
+            Identifiant externe :
+            <span>{{@model.certificationCenter.externalId}}</span><br />
+          </p>
+          <h3 class="certification-center__subtitle">Habilitations aux certifications complémentaires</h3>
+          <div class="accreditations-list">
+            <ul>
+              {{#each @model.accreditations as |accreditation|}}
+                <li>
+                  {{#if (contains accreditation @model.certificationCenter.accreditations)}}
+                    <FaIcon class="granted-accreditation-icon" @icon="check-circle" />
+                  {{else}}
+                    <FaIcon class="not-granted-accreditation-icon" @icon="times-circle" />
+                  {{/if}}
+                  {{accreditation.name}}
+                </li>
+              {{/each}}
+            </ul>
+          </div>
+          <PixButton
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @size="small"
+            @triggerAction={{this.toggleEditMode}}
+            aria-label="Editer"
+          >Editer</PixButton>
+        </div>
       {{/if}}
-      <p>
-        Type :
-        <span>{{@model.certificationCenter.type}}</span><br />
-        Identifiant externe :
-        <span>{{@model.certificationCenter.externalId}}</span><br />
-      </p>
-      <h3 class="certification-center__subtitle">Habilitations aux certifications complémentaires</h3>
-      <ul>
-        {{#each @model.accreditations as |accreditation|}}
-          <li>
-            {{#if (contains accreditation @model.certificationCenter.accreditations)}}
-              <FaIcon class="granted-accreditation-icon" @icon="check-circle" />
-            {{else}}
-              <FaIcon class="not-granted-accreditation-icon" @icon="times-circle" />
-            {{/if}}
-            {{accreditation.name}}
-          </li>
-        {{/each}}
-      </ul>
 
     </div>
   </section>

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -37,7 +37,7 @@
             <div class="form-field">
               <label for="certification-center-type" class="form-field__label">Type</label>
               <PixSelect
-                id="certificationCenterTypeSelector"
+                id="certification-center-type"
                 @options={{this.certificationCenterTypes}}
                 @isSearchable={{false}}
                 @emptyOptionNotSelectable={{true}}

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -13,6 +13,101 @@
   <section class="page-section mb_10">
     <div class="certification-center__data">
       <h1 class="certification-center__name">{{@model.certificationCenter.name}}</h1>
+
+      {{#if this.isEditMode}}
+        <div class="certification-center__edit-form">
+          <form class="form" {{on "submit" this.updateCertificationCenter}}>
+
+            <div class="form-field">
+              <label for="type" class="form-field__label">Nom du centre</label>
+              {{#if (v-get this.form 'name' 'isInvalid')}}
+                <div class="form-field__error" aria-label="Message d'erreur du champ nom">
+                  {{v-get this.form 'name' 'message'}}
+                </div>
+              {{/if}}
+              <Input id="name"
+                     @type="text"
+                     class={{if (v-get this.form 'name' 'isInvalid') "form-control is-invalid" "form-control"}}
+                     @value={{this.form.name}}
+                     required={{true}} />
+            </div>
+            <div class="form-field">
+              <label for="type" class="form-field__label">Type</label>
+              {{#if (v-get this.form 'type' 'isInvalid')}}
+                <div class="form-field__error" aria-label="Message d'erreur du champ type">
+                  {{v-get this.form 'type' 'message'}}
+                </div>
+              {{/if}}
+              <Input id="type"
+                     @type="text"
+                     class={{if (v-get this.form 'type' 'isInvalid') "form-control is-invalid" "form-control"}}
+                     @value={{this.form.type}} />
+            </div>
+            <div class="form-field">
+              <label for="externalId" class="form-field__label">Identifiant externe</label>
+              {{#if (v-get this.form 'externalId' 'isInvalid')}}
+                <div class="form-field__error" aria-label="Message d'erreur du champ identifiant externe">
+                  {{v-get this.form 'externalId' 'message'}}
+                </div>
+              {{/if}}
+              <Input id="externalId"
+                     @type="text"
+                     class={{if (v-get this.form 'externalId' 'isInvalid') "form-control is-invalid" "form-control"}}
+                     @value={{this.form.externalId}} />
+            </div>
+            <div>
+              <ul>
+                {{#each @model.accreditations as |accreditation|}}
+                  <li>
+                    <label for="accreditation-checkbox">{{accreditation.name}}</label>
+                    <Input
+                      @type="checkbox"
+                      @checked={{contains accreditation @model.certificationCenter.accreditations}}
+                      {{on "input" (fn this.updateGrantedAccreditation accreditation)}}
+                    />
+                  </li>
+                {{/each}}
+              </ul>
+            </div>
+            <div class="form-actions">
+              <PixButton
+                      @size="small"
+                      @backgroundColor="transparent-light"
+                      @isBorderVisible={{true}}
+                      @triggerAction={{this.cancel}}>Annuler</PixButton>
+              <PixButton
+                      @type="submit"
+                      @size="small"
+                      @backgroundColor="green"
+                      @triggerAction={{this.toggleEditMode}}>Ajouter</PixButton>
+            </div>
+          </form>
+        </div>
+      {{else}}
+        <p>
+          Type : <span>{{@model.certificationCenter.type}}</span><br>
+          Identifiant externe : <span>{{@model.certificationCenter.externalId}}</span><br>
+        </p>
+        <h3 class="certification-center__subtitle">Habilitations aux certifications complémentaires</h3>
+        <ul>
+          {{#each @model.accreditations as |accreditation|}}
+            <li>
+              {{#if (contains accreditation @model.certificationCenter.accreditations)}}
+                <FaIcon class="granted-accreditation-icon" @icon="check-circle" />
+              {{else}}
+                <FaIcon class="not-granted-accreditation-icon" @icon="times-circle" />
+              {{/if}}
+              {{accreditation.name}}
+            </li>
+          {{/each}}
+        </ul>
+        <PixButton
+                @backgroundColor="transparent-light"
+                @isBorderVisible={{true}}
+                @size="small"
+                @triggerAction={{this.toggleEditMode}}
+                aria-label="Editer">Editer</PixButton>
+      {{/if}}
       <p>
         Type :
         <span>{{@model.certificationCenter.type}}</span><br />

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -36,14 +36,18 @@
 
             <div class="form-field">
               <label for="certification-center-type" class="form-field__label">Type</label>
-              <Input
-                id="certification-center-@type"
-                name="certification-center-type"
-                @type="text"
-                maxlength="255"
-                class="form-control"
-                @value={{@model.certificationCenter.type}}
-              />
+              <PixSelect
+                id="certificationCenterTypeSelector"
+                @options={{this.certificationCenterTypes}}
+                @isSearchable={{false}}
+                @emptyOptionNotSelectable={{true}}
+                @emptyOptionLabel={{"-- Choisissez --"}}
+                @selectedOption={{this.model.certificationCenter.type}}
+                @onChange={{this.selectCertificationCenterType}}
+                as |certificationCenterType|
+              >
+                {{certificationCenterType.label}}
+              </PixSelect>
               {{#each this.certificationCenter.errors.type as |error|}}
                 <div class="session-form__error error-message">
                   {{error.message}}

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -82,7 +82,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
     await visit(`/certification-centers/${certificationCenter.id}`);
 
     // then
-    const grantedAccreditations = findAll('.certification-center__data > ul > li > svg[data-icon="check-circle"]');
+    const grantedAccreditations = findAll('.accreditations-list > ul > li > svg[data-icon="check-circle"]');
     assert.equal(grantedAccreditations.length, 2);
   });
 
@@ -112,7 +112,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       // then
       assert.contains('Ajouter un membre');
       assert.dom('[aria-label="Adresse e-mail du nouveau membre"]').exists();
-      assert.dom('button').hasText('Valider');
+      assert.contains('Valider');
       assert.dom('.error').notExists;
     });
 

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -6,6 +6,8 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 import { createAuthenticateSession } from '../../../helpers/test-init';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
+import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 
 module('Acceptance | authenticated/certification-centers/get', function (hooks) {
   setupApplicationTest(hooks);
@@ -168,6 +170,39 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       // then
       const foundElement = findAll('td[data-test-user-email]').find((element) => element.innerText.includes(email));
       assert.ok(foundElement);
+    });
+  });
+
+  module('Update certification center', function () {
+    test('should display a form after clicking on "Editer"', async function (assert) {
+      // given
+      await visit(`/certification-centers/${certificationCenter.id}`);
+
+      // when
+      await clickByLabel('Editer');
+
+      // then
+      assert.contains('Annuler');
+      assert.contains('Enregistrer');
+    });
+
+    test('should send edited certification center to the API', async function (assert) {
+      // given
+      await visit(`/certification-centers/${certificationCenter.id}`);
+      await clickByLabel('Editer');
+
+      // when
+      this.server.patch(`/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
+      await fillInByLabel('Nom du centre', 'nouveau nom');
+      await fillInByLabel('Type', 'SUP');
+      await fillInByLabel('Identifiant externe', 'nouvel identifiant externe');
+      await clickByLabel('Enregistrer');
+
+      // then
+      assert.contains('Habilitations aux certifications complémentaires');
+      assert.contains('nouveau nom');
+      assert.contains('SUP');
+      assert.contains('nouvel identifiant externe');
     });
   });
 });

--- a/admin/tests/acceptance/certification-center-form-_test.js
+++ b/admin/tests/acceptance/certification-center-form-_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
-import { selectChoose } from 'ember-power-select/test-support/helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -23,9 +22,8 @@ module('Acceptance | Certification-center Form', function (hooks) {
 
     // when
     await visit('/certification-centers/new');
-
     await fillIn('#certificationCenterName', name);
-    await selectChoose('#certificationCenterTypeSelector', type.label);
+    await fillIn('#certificationCenterTypeSelector', type.value);
     await fillIn('#certificationCenterExternalId', externalId);
     await click('button[type=submit]');
 

--- a/admin/tests/integration/components/certification-center-form_test.js
+++ b/admin/tests/integration/components/certification-center-form_test.js
@@ -1,9 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
-import { selectChoose } from 'ember-power-select/test-support/helpers';
 
 module('Integration | Component | certification-center-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -36,11 +35,10 @@ module('Integration | Component | certification-center-form', function (hooks) {
       );
 
       // when
-      await selectChoose('#certificationCenterTypeSelector', 'Établissement scolaire');
+      await fillIn('#certificationCenterTypeSelector', 'SCO');
 
       // then
       assert.equal(this.certificationCenter.type, 'SCO');
-      assert.dom('.ember-power-select-selected-item').hasText('Établissement scolaire');
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get_test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get_test.js
@@ -25,7 +25,13 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
       save: saveStub,
     });
 
-    certificationCenter = { id: 1 };
+    const store = this.owner.lookup('service:store');
+    certificationCenter = store.createRecord('certification-center', {
+      id: 1,
+      name: 'Centre des Anne-Etoiles',
+      type: 'PRO',
+      externalId: 'ex123',
+    });
 
     controller.store = Service.create({
       createRecord: createRecordStub,

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get_test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get_test.js
@@ -26,11 +26,14 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
     });
 
     const store = this.owner.lookup('service:store');
+    const testAccreditation = store.createRecord('accreditation', { name: 'Accreditation test' });
+
     certificationCenter = store.createRecord('certification-center', {
       id: 1,
       name: 'Centre des Anne-Etoiles',
       type: 'PRO',
       externalId: 'ex123',
+      accreditations: [testAccreditation],
     });
 
     controller.store = Service.create({
@@ -201,6 +204,44 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
           assert.ok(true);
         });
       });
+    });
+  });
+
+  module('#updateGrantedAccreditation', function () {
+    test('it should add the accreditation to the certification center', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const cleaAccreditation = store.createRecord('accreditation', { name: 'Pix+clea' });
+
+      // when
+      controller.updateGrantedAccreditation(cleaAccreditation);
+
+      // then
+      assert.true(controller.model.certificationCenter.accreditations.includes(cleaAccreditation));
+    });
+
+    test('it should remove the accreditation from the certification center', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const pixSurfAccreditation = store.createRecord('accreditation', { name: 'Pix+Surf' });
+
+      certificationCenter = store.createRecord('certification-center', {
+        id: 2,
+        name: 'Centre des Anne-surfeuses',
+        type: 'PRO',
+        externalId: 'ex313',
+        accreditations: [pixSurfAccreditation],
+      });
+
+      controller.model = {
+        certificationCenter,
+      };
+
+      // when
+      controller.updateGrantedAccreditation(pixSurfAccreditation);
+
+      // then
+      assert.false(controller.model.certificationCenter.accreditations.includes(pixSurfAccreditation));
     });
   });
 });

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -1,5 +1,6 @@
 const usecases = require('../../domain/usecases');
 
+const accreditationSerializer = require('../../infrastructure/serializers/jsonapi/accreditation-serializer');
 const certificationCenterSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-serializer');
 const certificationCenterMembershipSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-membership-serializer');
 const divisionSerializer = require('../../infrastructure/serializers/jsonapi/division-serializer');
@@ -12,7 +13,12 @@ module.exports = {
 
   async save(request) {
     const certificationCenter = certificationCenterSerializer.deserialize(request.payload);
-    const savedCertificationCenter = await usecases.saveCertificationCenter({ certificationCenter });
+    const accreditations = await Promise.all(
+      (request.payload.data.included || [])
+        .filter((data) => data.type === 'accreditations')
+        .map((data) => accreditationSerializer.deserialize({ data })),
+    );
+    const savedCertificationCenter = await usecases.saveCertificationCenter({ certificationCenter, accreditations });
     return certificationCenterSerializer.serialize(savedCertificationCenter);
   },
 

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -24,6 +24,23 @@ exports.register = async function(server) {
       },
     },
     {
+      method: 'PATCH',
+      path: '/api/certification-centers/{id}',
+      config: {
+        handler: certificationCenterController.save,
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs Pix Master authentifiés**\n' +
+          '- Création d‘un nouveau centre de certification\n' +
+          '- L‘utilisateur doit avoir les droits d‘accès en tant que Pix Master',
+        ],
+        tags: ['api', 'certification-center'],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/certification-centers',
       config: {

--- a/api/lib/domain/models/GrantedAccreditation.js
+++ b/api/lib/domain/models/GrantedAccreditation.js
@@ -1,0 +1,14 @@
+class GrantedAccreditation {
+
+  constructor({
+    id,
+    accreditationId,
+    certificationCenterId,
+  }) {
+    this.id = id;
+    this.accreditationId = accreditationId;
+    this.certificationCenterId = certificationCenterId;
+  }
+}
+
+module.exports = GrantedAccreditation;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -61,6 +61,7 @@ const dependencies = {
   divisionRepository: require('../../infrastructure/repositories/division-repository'),
   encryptionService: require('../../domain/services/encryption-service'),
   getCompetenceLevel: require('../../domain/services/get-competence-level'),
+  grantedAccreditationRepository: require('../../infrastructure/repositories/granted-accreditation-repository'),
   finalizedSessionRepository: require('../../infrastructure/repositories/finalized-session-repository'),
   higherSchoolingRegistrationRepository: require('../../infrastructure/repositories/higher-schooling-registration-repository'),
   improvementService: require('../../domain/services/improvement-service'),

--- a/api/lib/domain/usecases/save-certification-center.js
+++ b/api/lib/domain/usecases/save-certification-center.js
@@ -1,6 +1,20 @@
 const certificationCenterCreationValidator = require('../validators/certification-center-creation-validator');
+const GrantedAccreditation = require('../../domain/models/GrantedAccreditation');
 
-module.exports = function saveCertificationCenter({ certificationCenter, certificationCenterRepository }) {
+module.exports = async function saveCertificationCenter({ certificationCenter, accreditations, certificationCenterRepository, grantedAccreditationRepository }) {
   certificationCenterCreationValidator.validate(certificationCenter);
+  if (certificationCenter.id) {
+    await grantedAccreditationRepository.deleteByCertificationCenterId(certificationCenter.id);
+  }
+  if (accreditations) {
+    await Promise.all(accreditations.map((accreditation) => {
+      const grantedAccreditationModel = new GrantedAccreditation({
+        accreditationId: accreditation.id,
+        certificationCenterId: certificationCenter.id,
+      });
+      return grantedAccreditationRepository.save(grantedAccreditationModel);
+    }));
+  }
+
   return certificationCenterRepository.save(certificationCenter);
 };

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -79,6 +79,7 @@ module.exports = {
     const cleanedCertificationCenter = _.omit(certificationCenter, ['createdAt', 'accreditations']);
     const certificationCenterBookshelf = await new BookshelfCertificationCenter(cleanedCertificationCenter)
       .save();
+    await certificationCenterBookshelf.related('accreditations').fetch();
     return _toDomain(certificationCenterBookshelf);
   },
 

--- a/api/lib/infrastructure/repositories/granted-accreditation-repository.js
+++ b/api/lib/infrastructure/repositories/granted-accreditation-repository.js
@@ -1,0 +1,20 @@
+const { knex } = require('../bookshelf');
+
+module.exports = {
+  async save(grantedAccreditation) {
+    const columnsToSave = {
+      accreditationId: grantedAccreditation.accreditationId,
+      certificationCenterId: grantedAccreditation.certificationCenterId,
+    };
+    return await knex('granted-accreditations')
+      .insert(columnsToSave)
+      .returning('id');
+  },
+
+  async deleteByCertificationCenterId(certificationCenterId) {
+    return await knex('granted-accreditations')
+      .delete()
+      .where({ certificationCenterId })
+      .returning('id');
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/accreditation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/accreditation-serializer.js
@@ -1,10 +1,19 @@
 const { Serializer } = require('jsonapi-serializer');
 
+const Accreditation = require('../../../domain/models/Accreditation');
+
 module.exports = {
 
   serialize(accreditation) {
     return new Serializer('accreditation', {
       attributes: ['name'],
     }).serialize(accreditation);
+  },
+
+  deserialize(jsonAPI) {
+    return new Accreditation({
+      id: jsonAPI.data.id,
+      name: jsonAPI.data.attributes.name,
+    });
   },
 };

--- a/api/tests/integration/infrastructure/repositories/granted-accreditation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/granted-accreditation-repository_test.js
@@ -1,0 +1,74 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const grantedAccreditationRepository = require('../../../../lib/infrastructure/repositories/granted-accreditation-repository');
+const { knex } = require('../../../../lib/infrastructure/bookshelf');
+
+describe('Integration | Infrastructure | Repository | granted-accreditation-repository', function() {
+
+  context('#save', function() {
+
+    afterEach(function() {
+      return knex('granted-accreditations').delete();
+    });
+
+    it('should create the granted accreditation', async function() {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const accreditationId = databaseBuilder.factory.buildAccreditation().id;
+      await databaseBuilder.commit();
+
+      // when
+      await grantedAccreditationRepository.save({
+        certificationCenterId,
+        accreditationId,
+      });
+
+      // then
+      const grantedAccreditation = await knex
+        .select('*')
+        .from('granted-accreditations')
+        .where({ certificationCenterId, accreditationId })
+        .first();
+      expect(grantedAccreditation).to.not.be.null;
+    });
+  });
+
+  context('#deleteByCertificationCenterId', function() {
+    it('should delete all granted accreditations for a given certification center id', async function() {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const otherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const accreditation1Id = databaseBuilder.factory.buildAccreditation().id;
+      const accreditation2Id = databaseBuilder.factory.buildAccreditation().id;
+      const otherAccreditationId = databaseBuilder.factory.buildAccreditation().id;
+      databaseBuilder.factory.buildGrantedAccreditation({
+        certificationCenterId,
+        accreditationId: accreditation1Id,
+      });
+      databaseBuilder.factory.buildGrantedAccreditation({
+        certificationCenterId,
+        accreditationId: accreditation2Id,
+      });
+      databaseBuilder.factory.buildGrantedAccreditation({
+        certificationCenterId: otherCertificationCenterId,
+        accreditationId: otherAccreditationId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await grantedAccreditationRepository.deleteByCertificationCenterId(certificationCenterId);
+
+      // then
+      const grantedAccreditationsForCertificationCenterId = await knex
+        .select('*')
+        .from('granted-accreditations')
+        .where({ certificationCenterId });
+      expect(grantedAccreditationsForCertificationCenterId.length).to.equal(0);
+      const grantedAccreditationThatShouldHaveBeenDeleted = await knex
+        .select('*')
+        .from('granted-accreditations')
+        .where({ certificationCenterId: otherCertificationCenterId });
+      expect(grantedAccreditationThatShouldHaveBeenDeleted.length).to.equal(1);
+    });
+  });
+
+});

--- a/api/tests/tooling/domain-builder/factory/build-granted-accreditation.js
+++ b/api/tests/tooling/domain-builder/factory/build-granted-accreditation.js
@@ -1,0 +1,13 @@
+const GrantedAccreditation = require('../../../../lib/domain/models/GrantedAccreditation');
+
+module.exports = function buildGrantedAccreditation({
+  id = 123,
+  accreditationId = 456,
+  certificationCenterId = 789,
+} = {}) {
+  return new GrantedAccreditation({
+    id,
+    accreditationId,
+    certificationCenterId,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -59,6 +59,7 @@ module.exports = {
   buildCompetenceResult: require('./build-competence-result'),
   buildCompetenceTree: require('./build-competence-tree'),
   buildCourse: require('./build-course'),
+  buildGrantedAccreditation: require('./build-granted-accreditation'),
   buildFinalizedSession: require('./build-finalized-session'),
   buildHint: require('./build-hint'),
   buildHigherSchoolingRegistration: require('./build-higher-schooling-registration'),

--- a/api/tests/unit/domain/models/GrantedAccreditation_test.js
+++ b/api/tests/unit/domain/models/GrantedAccreditation_test.js
@@ -1,0 +1,42 @@
+const GrantedAccreditation = require('../../../../lib/domain/models/GrantedAccreditation');
+const { expect, domainBuilder } = require('../../../test-helper');
+const _ = require('lodash');
+
+const GRANTED_ACCREDITATION_PROPS = [
+  'id',
+  'accreditationId',
+  'certificationCenterId',
+];
+
+describe('Unit | Domain | Models | GrantedAccreditation', function() {
+  let grantedAccreditations;
+
+  beforeEach(function() {
+    grantedAccreditations = domainBuilder.buildGrantedAccreditation({
+      accreditationId: 456,
+      certificationCenterId: 789,
+    });
+  });
+
+  it('should create an object of the GrantedAccreditation type', function() {
+    expect(grantedAccreditations).to.be.instanceOf(GrantedAccreditation);
+  });
+
+  it('should create an object with all the requires properties', function() {
+    expect(_.keys(grantedAccreditations)).to.have.deep.members(GRANTED_ACCREDITATION_PROPS);
+  });
+
+  it('should create an object with correct properties using a domain builder', function() {
+    // when
+    const domainBuiltGrantedAccreditations = domainBuilder.buildGrantedAccreditation({
+      id: 123,
+      accreditationId: 456,
+      certificationCenterId: 789,
+    });
+
+    // then
+    expect(domainBuiltGrantedAccreditations.id).to.equal(123);
+    expect(domainBuiltGrantedAccreditations.accreditationId).to.equal(456);
+    expect(domainBuiltGrantedAccreditations.certificationCenterId).to.equal(789);
+  });
+});

--- a/api/tests/unit/domain/usecases/save-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/save-certification-center_test.js
@@ -1,0 +1,70 @@
+const { expect, domainBuilder, sinon } = require('../../../test-helper');
+const saveCertificationCenter = require('../../../../lib/domain/usecases/save-certification-center');
+const certificationCenterCreationValidator = require('../../../../lib/domain/validators/certification-center-creation-validator');
+
+describe('Unit | UseCase | save-certification-center', function() {
+
+  describe('#saveCertificationCenter', function() {
+
+    context('when there are no associated accreditation', function() {
+      it('should save the certification center', async function() {
+        // given
+        const certificationCenter = domainBuilder.buildCertificationCenter();
+        const validatorStub = sinon.stub(certificationCenterCreationValidator, 'validate');
+        const certificationCenterRepository = { save: sinon.stub().returns(certificationCenter) };
+        const grantedAccreditationRepository = { deleteByCertificationCenterId: sinon.stub(), save: sinon.stub().returns(certificationCenter) };
+
+        // when
+        const savedCertificationCenter = await saveCertificationCenter({
+          certificationCenter,
+          certificationCenterRepository,
+          grantedAccreditationRepository,
+        });
+
+        // then
+        expect(validatorStub).to.be.calledOnceWith(certificationCenter);
+        expect(certificationCenterRepository.save).to.be.calledOnceWith(certificationCenter);
+        expect(savedCertificationCenter).to.equal(certificationCenter);
+      });
+    });
+
+    context('when there are associated accreditations', function() {
+      it('should reset existing granted accreditation and create new ones', async function() {
+        // given
+        const certificationCenter = domainBuilder.buildCertificationCenter();
+        const accreditation1 = domainBuilder.buildAccreditation();
+        const accreditation2 = domainBuilder.buildAccreditation();
+        const grantedAccreditation1 = domainBuilder.buildGrantedAccreditation({
+          accreditationId: accreditation1.id,
+          certificationCenterId: certificationCenter.id,
+        });
+        const grantedAccreditation2 = domainBuilder.buildGrantedAccreditation({
+          accreditationId: accreditation2.id,
+          certificationCenterId: certificationCenter.id,
+        });
+        grantedAccreditation1.id = undefined;
+        grantedAccreditation2.id = undefined;
+        const validatorStub = sinon.stub(certificationCenterCreationValidator, 'validate');
+        const certificationCenterRepository = { save: sinon.stub().returns(certificationCenter) };
+        const grantedAccreditationRepository = { deleteByCertificationCenterId: sinon.stub(), save: sinon.stub() };
+
+        // when
+        const savedCertificationCenter = await saveCertificationCenter({
+          certificationCenter,
+          accreditations: [accreditation1, accreditation2],
+          certificationCenterRepository,
+          grantedAccreditationRepository,
+        });
+
+        // then
+        expect(validatorStub).to.be.calledOnceWith(certificationCenter);
+        expect(certificationCenterRepository.save).to.be.calledOnceWith(certificationCenter);
+        expect(grantedAccreditationRepository.deleteByCertificationCenterId).to.be.calledOnceWith(certificationCenter.id);
+        expect(grantedAccreditationRepository.save).to.be.calledWith(grantedAccreditation1);
+        expect(grantedAccreditationRepository.save).to.be.calledWith(grantedAccreditation2);
+        expect(savedCertificationCenter).to.equal(certificationCenter);
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on consulte le détail d'un centre de certification depuis Pix Admin, il n'est pas possible de modifier les informations du centre (Nom, type, id externe, habilitations).

## :robot: Solution
On profite de cette épix autour des habilitations pour permettre de mettre à jour les informations d'un centre de certifications dont font partie les habilitations. 

## :rainbow: Remarques
Refacto sur liste déroulante dans "Création centre de certif"
- utilisation Pi UI au lieu de PowerSelect

## :100: Pour tester

- Se connecter à Pix Admin en tant que Pix Master
- Se rendre sur la liste des centres de certifications 
- Ouvrir un centre de certification depuis la liste
- Cliquer sur Editer pour modifier les informations du centre de certification
- identifiant externe, nom, habilitation

Pré-premplissage
- Constater le pré-remplissage des champs avec les informations actuelles du centre et les habilitations
- Modifier des informations du centre 
- Sauvegarder 


Mise à jour avec informations valides
- message de confirmation affiché pdt x secondes "Centre de certification mis à jour avec succès."
- liste mise à jour 
- au rechargemeent de la page, liste toujours à jour (info transmises à l'API)

Mise à jour avec informations invalides:
- champ non renseigné: identifiant externe, nom
- message d'erreur affiché en pop-up pendant 5 secondes: "Une erreur est survenue, le centre de certification n'a pas été mis à jour.'
- liste mise à jour
- au rechargement, la modification n'apparait plus

Création centre de certif (non-régression)
