### PR TITLE
[FEATURE] Ajout d'un pied de page (footer) dans Pix Orga (PIX-3487).

### DIFF
--- a/orga/app/components/layout/footer.hbs
+++ b/orga/app/components/layout/footer.hbs
@@ -1,0 +1,25 @@
+<footer class="footer">
+  <nav class="footer__navigation">
+    <ul class="footer__navigation-list">
+      <li>
+        <a href="{{this.legalNoticeUrl}}"
+          target="_blank"
+          class="footer-navigation__item" rel="noopener noreferrer">
+        {{t 'navigation.footer.legal-notice'}}
+        </a>
+      </li>
+
+      <li>
+        <a href="{{this.accessibilityUrl}}"
+          target="_blank"
+          class="footer-navigation__item" rel="noopener noreferrer">
+        {{t 'navigation.footer.a11y'}}
+        </a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="footer__copyrights">
+    <span>{{t 'navigation.footer.copyrights'}} {{ this.currentYear }} {{t 'navigation.footer.pix'}}</span>
+  </div>
+</footer>

--- a/orga/app/components/layout/footer.js
+++ b/orga/app/components/layout/footer.js
@@ -1,0 +1,19 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class Footer extends Component {
+  @service url;
+
+  get currentYear() {
+    const date = new Date();
+    return date.getFullYear().toString();
+  }
+
+  get legalNoticeUrl() {
+    return this.url.legalNoticeUrl;
+  }
+
+  get accessibilityUrl() {
+    return this.url.accessibilityUrl;
+  }
+}

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -29,4 +29,11 @@ export default class Url extends Service {
     return `${this.definedHomeUrl}?lang=${currentLanguage}`;
   }
 
+  get legalNoticeUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    if (currentLanguage === 'en') {
+      return 'https://pix.org/en-gb/legal-notice';
+    }
+    return `https://pix.${this.currentDomain.getExtension()}/mentions-legales`;
+  }
 }

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -36,4 +36,12 @@ export default class Url extends Service {
     }
     return `https://pix.${this.currentDomain.getExtension()}/mentions-legales`;
   }
+
+  get accessibilityUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    if (currentLanguage === 'en') {
+      return 'https://pix.org/en-gb/accessibility-pix-orga';
+    }
+    return `https://pix.${this.currentDomain.getExtension()}/accessibilite-pix-orga`;
+  }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -27,6 +27,7 @@
 @import "components/dropdown";
 @import "components/indicator-card";
 @import "components/join-request-form";
+@import "components/layout/footer";
 @import "components/layout/organization-credit-info";
 @import "components/layout/sidebar";
 @import "components/layout/topbar";

--- a/orga/app/styles/components/layout/footer.scss
+++ b/orga/app/styles/components/layout/footer.scss
@@ -1,0 +1,70 @@
+.footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  margin: 0 35px;
+  border-top: 1px solid $grey-20;
+
+  @include device-is('desktop') {
+    flex-direction: row;
+  }
+
+  &__navigation {
+    display: flex;
+    flex-direction: column;
+
+    @include device-is('desktop') {
+      flex-direction: row;
+    }
+
+    &-list {
+      list-style: none;
+      display: flex;
+      padding: 0;
+
+      li {
+        align-self: center;
+        display: inline;
+        padding: 0;
+      }
+    }
+  }
+
+  &__copyrights {
+    color: $grey-50;
+    cursor: default;
+    font-size: 0.75rem;
+    font-family: $roboto;
+    padding: 16px 0;
+  }
+}
+
+.footer-navigation {
+  &__item {
+    margin-right: 3px;
+    color: $grey-60;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    font-family: $roboto;
+    text-decoration: none;
+
+    @include device-is('desktop') {
+      margin-right: 12px;
+    }
+
+    &.active {
+      color: $blue;
+    }
+
+    &:focus {
+      color: $grey-50;
+    }
+
+    &:hover {
+      cursor: pointer;
+      color: $blue;
+    }
+  }
+}

--- a/orga/app/styles/components/layout/topbar.scss
+++ b/orga/app/styles/components/layout/topbar.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  flex-shrink: 0;
   background-color: $white;
   min-height: 60px;
 

--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -13,7 +13,7 @@
   overflow: auto;
 
   &__body {
-    height: 100%;
+    flex: 1 0 auto;
   }
 }
 

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -9,6 +9,8 @@
     <main class="main-content__body page">
       {{outlet}}
     </main>
+
+    <Layout::Footer />
   </div>
 
   <NotificationContainer @position="bottom-right" />

--- a/orga/tests/integration/components/layout/footer_test.js
+++ b/orga/tests/integration/components/layout/footer_test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | Layout::Footer', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display copyright', async function(assert) {
+    //given
+    const date = new Date();
+    const expectedYear = date.getFullYear().toString();
+
+    // when
+    await render(hbs`<Layout::Footer />}`);
+
+    // then
+    assert.contains(`© ${expectedYear} Pix`);
+  });
+
+  test('should display legal notice link', async function(assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+    // when
+    await render(hbs`<Layout::Footer />}`);
+
+    // then
+    assert.contains('Mentions légales');
+    assert.dom('a[href="https://pix.fr/mentions-legales"]').exists();
+  });
+
+  test('should display accessibility link', async function(assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+    // when
+    await render(hbs`<Layout::Footer />}`);
+
+    // then
+    assert.contains('Accessibilité : non conforme');
+    assert.dom('a[href="https://pix.fr/accessibilite-pix-orga"]').exists();
+  });
+});

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -137,4 +137,48 @@ module('Unit | Service | url', function(hooks) {
       assert.equal(url, expectedUrl);
     });
   });
+
+  module('#accessibilityUrl', function() {
+
+    test('should get "pix.fr" when current domain contains pix.fr', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedUrl = 'https://pix.fr/accessibilite-pix-orga';
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+      // when
+      const url = service.accessibilityUrl;
+
+      // then
+      assert.equal(url, expectedUrl);
+    });
+
+    test('should get "pix.org" in english when current language is en', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedUrl = 'https://pix.org/en-gb/accessibility-pix-orga';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('en') };
+
+      // when
+      const url = service.accessibilityUrl;
+
+      // then
+      assert.equal(url, expectedUrl);
+    });
+
+    test('should get "pix.org" in french when current language is fr', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedUrl = 'https://pix.org/accessibilite-pix-orga';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('fr') };
+
+      // when
+      const url = service.accessibilityUrl;
+
+      // then
+      assert.equal(url, expectedUrl);
+    });
+  });
 });

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -93,4 +93,48 @@ module('Unit | Service | url', function(hooks) {
       assert.equal(homeUrl, expectedHomeUrl);
     });
   });
+
+  module('#legalNoticeUrl', function() {
+
+    test('should get "pix.fr" url when current domain contains pix.fr', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedUrl = 'https://pix.fr/mentions-legales';
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+      // when
+      const url = service.legalNoticeUrl;
+
+      // then
+      assert.equal(url, expectedUrl);
+    });
+
+    test('should get "pix.org" english url when current language is en', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedUrl = 'https://pix.org/en-gb/legal-notice';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('en') };
+
+      // when
+      const url = service.legalNoticeUrl;
+
+      // then
+      assert.equal(url, expectedUrl);
+    });
+
+    test('should get "pix.org" french url when current language is fr', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedUrl = 'https://pix.org/mentions-legales';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('fr') };
+
+      // when
+      const url = service.legalNoticeUrl;
+
+      // then
+      assert.equal(url, expectedUrl);
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -160,6 +160,12 @@
       "number": "{count, plural, =0 {0 credits} =1 {1 credit} other {{count, number} credits}}",
       "tooltip-text": "The number of credits displayed is the number of credits acquired by the organisation and currently valid (regardless of their activation). For more information, please contact us at the following address: <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
     },
+    "footer": {
+      "a11y": "Accessibility",
+      "copyrights": "©",
+      "legal-notice": "Legal notice",
+      "pix": "Pix"
+    },
     "main": {
       "campaigns": "Campaigns",
       "certifications": "Certifications",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -160,6 +160,12 @@
       "number": "{count, plural, =0 {0 crédit} =1 {1 crédit} other {{count, number} crédits}}",
       "tooltip-text": "Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation). Pour plus d’information contactez-nous à l’adresse <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
     },
+    "footer": {
+      "a11y": "Accessibilité : non conforme",
+      "copyrights": "©",
+      "legal-notice": "Mentions légales",
+      "pix": "Pix"
+    },
     "main": {
       "campaigns": "Campagnes",
       "certifications": "Certifications",


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui aucun pied de page n'existe. Or on a besoin d'ajouter quelque part les mentions légales, les CGUs, une page accessibilité etc.

## :robot: Solution
Ajouter un footer avec les pages prêtes.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à Pix Orga, vérifier que le footer s'affiche bien sur différentes pages, en mode mobile et desktop et que les liens sont fonctionnels en FR et EN.
