### PR TITLE
[BUGFIX] Problème de contraste sur le bouton de texte alternatif d'une épreuve (PIX-3490).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -240,8 +240,10 @@
     background-color: transparent;
     cursor: pointer;
 
-    &:hover {
-      color: $dark-blue-pro;
+    &:hover,
+    &:focus,
+    &:active {
+      color: $white;
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Le bouton pour afficher l'alternative textuel n'est plus visible (passage PixButton).

## :robot: Solution
Remettre une bonne couleur

## :rainbow: Remarques

## :100: Pour tester
Une épreuve : `rec2ON5ChJ8PgHclr`