### PR TITLE
[TECH] Ajouter une Github action qui notifie les équipes sur Slack lorsque le fichier de config est modifié.

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -31,3 +31,10 @@ jobs:
       with:
         issue: ${{ steps.find.outputs.issue }}
         transition: "Move to 'Deployed in Integration'"
+
+    - name: Notify team on config file change
+      uses: 1024pix/notify-team-on-config-file-change@v1.0.0
+      with:
+        GITHUB_TOKEN: ${{ github.token }}
+        SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}
+        INTEGRATION_ENV_URL: ${{ secrets.INTEGRATION_ENV_URL }}


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le fichier de config est modifié, il faut penser à changer le variables d'environnement. 

## :robot: Solution
Surveiller les changements dans le fichier de config au merge et notifier les équipes à l'origine de la PR.

## :rainbow: Remarques
Pour plus d'info : https://github.com/1024pix/notify-team-on-config-file-change.
