### PR TITLE
 [FEATURE] Scoring des certifications démarrées (PIX-2982)

### DIFF
--- a/admin/app/components/certification/certification-details-answer.js
+++ b/admin/app/components/certification/certification-details-answer.js
@@ -9,8 +9,9 @@ const options = [
   { value: 'partially', label: 'Succès partiel' },
   { value: 'timedout', label: 'Temps écoulé' },
   { value: 'focusedOut', label: 'Focus échoué' },
-  { value: 'aband', label: 'Abandon' },
+  { value: 'aband', label: 'Passée' },
   { value: 'skip', label: 'Neutralisée' },
+  { value: 'skippedAutomatically', label: 'Abandon' },
 ];
 
 export default class CertificationDetailsAnswer extends Component {
@@ -54,8 +55,10 @@ export default class CertificationDetailsAnswer extends Component {
   _answerResultValue() {
     if (this.args.answer.isNeutralized) {
       return this.getOption('skip');
-    } else {
-      return this.getOption(this.args.answer.result);
     }
+    if (this.args.answer.hasBeenSkippedAutomatically) {
+      return this.getOption('skippedAutomatically');
+    }
+    return this.getOption(this.args.answer.result);
   }
 }

--- a/admin/tests/integration/components/certification/certification-details-answer_test.js
+++ b/admin/tests/integration/components/certification/certification-details-answer_test.js
@@ -64,6 +64,30 @@ module('Integration | Component | Certification | CertificationDetailsAnswer', f
     assert.contains('Succès partiel');
   });
 
+  module('when chalenge has been skipped automatically', function() {
+    test('info are correctly displayed ', async function(assert) {
+      // given
+      const skippedAnswerData = {
+        ...answerData,
+        hasBeenSkippedAutomatically: true,
+      };
+      this.setProperties({
+        answer: skippedAnswerData,
+        onUpdateRate: () => {},
+      });
+
+      // when
+      await render(hbs`<Certification::CertificationDetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`);
+
+      // then
+      assert.contains('5');
+      assert.contains('@skill6');
+      assert.contains('rec1234');
+      assert.contains('coucou');
+      assert.contains('Abandon');
+    });
+  });
+
   test('jury class is set when answer is modified', async function(assert) {
     // given
     this.setProperties({

--- a/api/db/database-builder/factory/build-certification-challenge.js
+++ b/api/db/database-builder/factory/build-certification-challenge.js
@@ -12,6 +12,7 @@ module.exports = function buildCertificationChallenge({
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
   isNeutralized = false,
+  isSkipped = false,
   certifiableBadgeKey = null,
 } = {}) {
 
@@ -27,6 +28,7 @@ module.exports = function buildCertificationChallenge({
     createdAt,
     updatedAt,
     isNeutralized,
+    isSkipped,
     certifiableBadgeKey,
   };
   return databaseBuffer.pushInsertable({

--- a/api/db/database-builder/factory/build-certification-challenge.js
+++ b/api/db/database-builder/factory/build-certification-challenge.js
@@ -12,7 +12,7 @@ module.exports = function buildCertificationChallenge({
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
   isNeutralized = false,
-  isSkipped = false,
+  hasBeenSkippedAutomatically = false,
   certifiableBadgeKey = null,
 } = {}) {
 
@@ -28,7 +28,7 @@ module.exports = function buildCertificationChallenge({
     createdAt,
     updatedAt,
     isNeutralized,
-    isSkipped,
+    hasBeenSkippedAutomatically,
     certifiableBadgeKey,
   };
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20210917121620_add-hasBeenSkippedAutomatically-in-certification-chalenge-table.js
+++ b/api/db/migrations/20210917121620_add-hasBeenSkippedAutomatically-in-certification-chalenge-table.js
@@ -1,5 +1,5 @@
 const TABLE_NAME = 'certification-challenges';
-const COLUMN_NAME = 'isSkipped';
+const COLUMN_NAME = 'hasBeenSkippedAutomatically';
 
 exports.up = function(knex) {
   return knex.schema.table(TABLE_NAME, (table) => {

--- a/api/db/migrations/20210917121620_add-isSkipped-in-certification-chalenge-table.js
+++ b/api/db/migrations/20210917121620_add-isSkipped-in-certification-chalenge-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-challenges';
+const COLUMN_NAME = 'isSkipped';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -81,6 +81,10 @@ async function _autoCompleteUnfinishedTest({
     certificationAssessment.skipUnansweredChallenges();
   }
 
+  if (certificationCourse.isAbortReasonTechnical()) {
+    certificationAssessment.neutralizeUnpassedChallenges();
+  }
+
   await certificationAssessmentRepository.save(certificationAssessment);
 
   return true;

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -30,7 +30,10 @@ async function handleAutoJury({
 
     const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId: certificationCourse.getId() });
 
-    const hasAutoCompleteAnEffectOnScoring = await _autoCompleteUnfinishedTest();
+    const hasAutoCompleteAnEffectOnScoring = await _autoCompleteUnfinishedTest({
+      certificationCourse,
+      certificationAssessment,
+    });
 
     const hasAutoResolutionAnEffectOnScoring = await _autoResolveCertificationIssueReport({
       certificationCourse,
@@ -63,8 +66,18 @@ async function handleAutoJury({
   ];
 }
 
-function _autoCompleteUnfinishedTest() {
-  return false;
+function _autoCompleteUnfinishedTest({
+  certificationCourse,
+  certificationAssessment,
+}) {
+
+  if (certificationCourse.isCompleted()) {
+    return false;
+  }
+
+  certificationAssessment.skipUnansweredChallenges();
+
+  return true;
 }
 
 async function _autoResolveCertificationIssueReport({

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -33,6 +33,7 @@ async function handleAutoJury({
     const hasAutoCompleteAnEffectOnScoring = await _autoCompleteUnfinishedTest({
       certificationCourse,
       certificationAssessment,
+      certificationAssessmentRepository,
     });
 
     const hasAutoResolutionAnEffectOnScoring = await _autoResolveCertificationIssueReport({
@@ -66,9 +67,10 @@ async function handleAutoJury({
   ];
 }
 
-function _autoCompleteUnfinishedTest({
+async function _autoCompleteUnfinishedTest({
   certificationCourse,
   certificationAssessment,
+  certificationAssessmentRepository,
 }) {
 
   if (certificationCourse.isCompleted()) {
@@ -76,6 +78,8 @@ function _autoCompleteUnfinishedTest({
   }
 
   certificationAssessment.skipUnansweredChallenges();
+
+  await certificationAssessmentRepository.save(certificationAssessment);
 
   return true;
 }

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -77,12 +77,12 @@ async function _autoCompleteUnfinishedTest({
     return false;
   }
 
-  if (certificationCourse.isAbortReasonCandidate()) {
+  if (certificationCourse.isAbortReasonCandidateRelated()) {
     certificationAssessment.skipUnansweredChallenges();
   }
 
-  if (certificationCourse.isAbortReasonTechnical()) {
-    certificationAssessment.neutralizeUnpassedChallenges();
+  if (certificationCourse.isAbortReasonCandidateUnrelated()) {
+    certificationAssessment.neutralizeUnansweredChallenges();
   }
 
   await certificationAssessmentRepository.save(certificationAssessment);

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -77,7 +77,9 @@ async function _autoCompleteUnfinishedTest({
     return false;
   }
 
-  certificationAssessment.skipUnansweredChallenges();
+  if (certificationCourse.isAbortReasonCandidate()) {
+    certificationAssessment.skipUnansweredChallenges();
+  }
 
   await certificationAssessmentRepository.save(certificationAssessment);
 

--- a/api/lib/domain/models/AnswerCollectionForScoring.js
+++ b/api/lib/domain/models/AnswerCollectionForScoring.js
@@ -36,7 +36,7 @@ module.exports = class AnswerCollectionForScoring {
     let numberOfNonNeutralizedChallenges = 0;
     this.challengesWithAnswers.forEach((challengeWithAnswer) => {
 
-      if (!challengeWithAnswer.isNeutralized() && !challengeWithAnswer.isEmpty()) {
+      if (!challengeWithAnswer.isNeutralized() && challengeWithAnswer.isAnswered()) {
         numberOfNonNeutralizedChallenges++;
       }
     });
@@ -96,6 +96,10 @@ class ChallengeWithAnswer {
     this._challenge = challenge;
   }
 
+  isAnswered() {
+    return this._answer || this._challenge.hasBeenSkippedAutomatically;
+  }
+
   isQROCMdep() {
     const challengeType = this._challenge ? this._challenge.type : '';
     return challengeType === qrocmDepChallenge;
@@ -103,10 +107,6 @@ class ChallengeWithAnswer {
 
   isCorrect() {
     return Boolean(this._answer?.isOk());
-  }
-
-  isEmpty() {
-    return !this._answer;
   }
 
   isAFullyCorrectQROCMdep() {

--- a/api/lib/domain/models/AnswerCollectionForScoring.js
+++ b/api/lib/domain/models/AnswerCollectionForScoring.js
@@ -2,28 +2,29 @@ const _ = require('lodash');
 const qrocmDepChallenge = 'QROCM-dep';
 
 module.exports = class AnswerCollectionForScoring {
-  constructor(answers, challenges) {
-    this.answers = answers;
-    this.challenges = challenges;
+  constructor(challengesWithAnswers) {
+    this.challengesWithAnswers = challengesWithAnswers;
   }
 
   static from({ answers, challenges }) {
-    const answersForScoring = answers.map((answer) => {
-      const challenge = challenges.find((challenge) => answer.challengeId === challenge.challengeId);
-      return new AnswerForScoring(answer, challenge);
+
+    const challengesWithAnswers = challenges.map((challenge) => {
+      const answer = answers.find((answer) => answer.challengeId === challenge.challengeId);
+
+      return new ChallengeWithAnswer(answer, challenge);
     });
-    const challengesForScoring = challenges.map((challenge) => new ChallengeForScoring(challenge));
-    return new AnswerCollectionForScoring(answersForScoring, challengesForScoring);
+
+    return new AnswerCollectionForScoring(challengesWithAnswers);
   }
 
   numberOfChallenges() {
-    return this.challenges.length;
+    return this.challengesWithAnswers.length;
   }
 
   numberOfCorrectAnswers() {
     let nbOfCorrectAnswers = 0;
-    this.answers.forEach((answer) => {
-      if (!answer.isNeutralized() && answer.isCorrect()) {
+    this.challengesWithAnswers.forEach((challengeWithAnswer) => {
+      if (!challengeWithAnswer.isNeutralized() && challengeWithAnswer.isCorrect()) {
         nbOfCorrectAnswers++;
       }
     });
@@ -33,8 +34,9 @@ module.exports = class AnswerCollectionForScoring {
 
   numberOfNonNeutralizedChallenges() {
     let numberOfNonNeutralizedChallenges = 0;
-    this.answers.forEach((answer) => {
-      if (!answer.isNeutralized()) {
+    this.challengesWithAnswers.forEach((challengeWithAnswer) => {
+
+      if (!challengeWithAnswer.isNeutralized() && !challengeWithAnswer.isEmpty()) {
         numberOfNonNeutralizedChallenges++;
       }
     });
@@ -43,7 +45,7 @@ module.exports = class AnswerCollectionForScoring {
   }
 
   numberOfChallengesForCompetence(competenceId) {
-    const challengesForCompetence = this.challenges.filter((challenge) => challenge.competenceId() === competenceId);
+    const challengesForCompetence = this.challengesWithAnswers.filter((challengeWithAnswer) => challengeWithAnswer.competenceId() === competenceId);
     const numberOfChallenges = _(challengesForCompetence).map((challenge) => {
       if (challengesForCompetence.length < 3 && challenge.isQROCMdep()) {
         return 2;
@@ -55,15 +57,15 @@ module.exports = class AnswerCollectionForScoring {
   }
 
   numberOfCorrectAnswersForCompetence(competenceId) {
-    const answersForCompetence = this.answers.filter((answer) => answer.competenceId() === competenceId);
+    const challengesWithAnswersForCompetence = this.challengesWithAnswers.filter((challengeWithAnswer) => challengeWithAnswer.competenceId() === competenceId);
     let nbOfCorrectAnswers = 0;
-    answersForCompetence.forEach((answer) => {
-      if (!answer.challenge.isNeutralized) {
-        if (answersForCompetence.length < 3 && answer.isAFullyCorrectQROCMdep()) {
+    challengesWithAnswersForCompetence.forEach((challengeWithAnswer) => {
+      if (!challengeWithAnswer.isNeutralized()) {
+        if (challengesWithAnswersForCompetence.length < 3 && challengeWithAnswer.isAFullyCorrectQROCMdep()) {
           nbOfCorrectAnswers += 2;
-        } else if (answersForCompetence.length < 3 && answer.isAPartiallyCorrectQROCMdep()) {
+        } else if (challengesWithAnswersForCompetence.length < 3 && challengeWithAnswer.isAPartiallyCorrectQROCMdep()) {
           nbOfCorrectAnswers += 1;
-        } else if (answer.isCorrect()) {
+        } else if (challengeWithAnswer.isCorrect()) {
           nbOfCorrectAnswers += 1;
         }
       }
@@ -73,7 +75,7 @@ module.exports = class AnswerCollectionForScoring {
   }
 
   numberOfNeutralizedChallengesForCompetence(competenceId) {
-    const answersForCompetence = this.answers.filter((answer) => answer.competenceId() === competenceId);
+    const answersForCompetence = this.challengesWithAnswers.filter((challengeWithAnswer) => challengeWithAnswer.competenceId() === competenceId);
     return _(answersForCompetence).map((answer) => {
       if (answer.isNeutralized()) {
         if (answersForCompetence.length < 3 && answer.isQROCMdep()) {
@@ -88,19 +90,23 @@ module.exports = class AnswerCollectionForScoring {
   }
 };
 
-class AnswerForScoring {
+class ChallengeWithAnswer {
   constructor(answer, challenge) {
-    this.answer = answer;
-    this.challenge = challenge;
+    this._answer = answer;
+    this._challenge = challenge;
   }
 
   isQROCMdep() {
-    const challengeType = this.challenge ? this.challenge.type : '';
+    const challengeType = this._challenge ? this._challenge.type : '';
     return challengeType === qrocmDepChallenge;
   }
 
   isCorrect() {
-    return Boolean(this.answer?.isOk());
+    return Boolean(this._answer?.isOk());
+  }
+
+  isEmpty() {
+    return !this._answer;
   }
 
   isAFullyCorrectQROCMdep() {
@@ -109,33 +115,14 @@ class AnswerForScoring {
 
   isAPartiallyCorrectQROCMdep() {
     return this.isQROCMdep()
-      && Boolean(this.answer) && this.answer.isPartially();
+      && Boolean(this._answer) && this._answer.isPartially();
   }
 
   isNeutralized() {
-    return this.challenge.isNeutralized;
+    return this._challenge.isNeutralized;
   }
 
   competenceId() {
-    return this.challenge.competenceId;
-  }
-}
-
-class ChallengeForScoring {
-  constructor(challenge) {
-    this.challenge = challenge;
-  }
-
-  isQROCMdep() {
-    const challengeType = this.challenge ? this.challenge.type : '';
-    return challengeType === qrocmDepChallenge;
-  }
-
-  isNeutralized() {
-    return this.challenge.isNeutralized;
-  }
-
-  competenceId() {
-    return this.challenge.competenceId;
+    return this._challenge.competenceId;
   }
 }

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -115,13 +115,13 @@ class CertificationAssessment {
   skipUnansweredChallenges() {
     this.certificationChallenges.forEach((certificationChallenge) => {
       if (!this.certificationAnswersByDate.some((certificationAnswer) => certificationChallenge.challengeId === certificationAnswer.challengeId)) {
-        certificationChallenge.skip();
+        certificationChallenge.skipAutomatically();
       }
     });
   }
 
   neutralizeUnansweredChallenges() {
-    this.certificationChallenges.forEach((certificationChallenge) => {
+    this.certificationChallenges.map((certificationChallenge) => {
       if (!this.certificationAnswersByDate.some((certificationAnswer) => certificationChallenge.challengeId === certificationAnswer.challengeId)) {
         certificationChallenge.neutralize();
       }

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -111,6 +111,14 @@ class CertificationAssessment {
   getChallengeRecIdByQuestionNumber(questionNumber) {
     return this.certificationAnswersByDate[questionNumber - 1]?.challengeId || null;
   }
+
+  skipUnansweredChallenges() {
+    this.certificationChallenges.forEach((certificationChallenge) => {
+      if (!this.certificationAnswersByDate.some((certificationAnswer) => certificationChallenge.challengeId === certificationAnswer.challengeId)) {
+        certificationChallenge.skip();
+      }
+    });
+  }
 }
 
 function _isAnswerKoOrSkippedOrPartially(answerStatus) {

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -119,6 +119,14 @@ class CertificationAssessment {
       }
     });
   }
+
+  neutralizeUnansweredChallenges() {
+    this.certificationChallenges.forEach((certificationChallenge) => {
+      if (!this.certificationAnswersByDate.some((certificationAnswer) => certificationChallenge.challengeId === certificationAnswer.challengeId)) {
+        certificationChallenge.neutralize();
+      }
+    });
+  }
 }
 
 function _isAnswerKoOrSkippedOrPartially(answerStatus) {

--- a/api/lib/domain/models/CertificationChallengeWithType.js
+++ b/api/lib/domain/models/CertificationChallengeWithType.js
@@ -8,6 +8,7 @@ class CertificationChallengeWithType {
     type,
     competenceId,
     isNeutralized,
+    isSkipped,
     certifiableBadgeKey,
   } = {}) {
     this.id = id;
@@ -19,6 +20,7 @@ class CertificationChallengeWithType {
       : 'EmptyType';
     this.competenceId = competenceId;
     this.isNeutralized = isNeutralized;
+    this.isSkipped = isSkipped;
     this.certifiableBadgeKey = certifiableBadgeKey;
   }
 
@@ -32,6 +34,10 @@ class CertificationChallengeWithType {
 
   isPixPlus() {
     return Boolean(this.certifiableBadgeKey);
+  }
+
+  skip() {
+    this.isSkipped = true;
   }
 }
 

--- a/api/lib/domain/models/CertificationChallengeWithType.js
+++ b/api/lib/domain/models/CertificationChallengeWithType.js
@@ -8,7 +8,7 @@ class CertificationChallengeWithType {
     type,
     competenceId,
     isNeutralized,
-    isSkipped,
+    hasBeenSkippedAutomatically,
     certifiableBadgeKey,
   } = {}) {
     this.id = id;
@@ -20,7 +20,7 @@ class CertificationChallengeWithType {
       : 'EmptyType';
     this.competenceId = competenceId;
     this.isNeutralized = isNeutralized;
-    this.isSkipped = isSkipped;
+    this.hasBeenSkippedAutomatically = hasBeenSkippedAutomatically;
     this.certifiableBadgeKey = certifiableBadgeKey;
   }
 
@@ -36,8 +36,8 @@ class CertificationChallengeWithType {
     return Boolean(this.certifiableBadgeKey);
   }
 
-  skip() {
-    this.isSkipped = true;
+  skipAutomatically() {
+    this.hasBeenSkippedAutomatically = true;
   }
 }
 

--- a/api/lib/domain/models/CertificationContract.js
+++ b/api/lib/domain/models/CertificationContract.js
@@ -23,12 +23,6 @@ class CertificationContract {
     }
   }
 
-  static assertThatCompetenceHasAtLeastOneAnswer(answerForCompetence, competenceIndex) {
-    if (answerForCompetence.length === 0) {
-      throw new CertificationComputeError('Pas assez de réponses pour la compétence ' + competenceIndex);
-    }
-  }
-
   static assertThatScoreIsCoherentWithReproducibilityRate(scoreAfterRating, reproducibilityRate) {
     if (scoreAfterRating < 1 && reproducibilityRate > 50) {
       throw new CertificationComputeError('Rejeté avec un taux de reproductibilité supérieur à 50');

--- a/api/lib/domain/models/CertificationContract.js
+++ b/api/lib/domain/models/CertificationContract.js
@@ -5,7 +5,14 @@ class CertificationContract {
 
   /* PUBLIC INTERFACE */
   static assertThatWeHaveEnoughAnswers(listAnswers, listChallenges) {
-    if (listAnswers.length < listChallenges.length) {
+    const someUnansweredChallenges = _.some(listChallenges,
+      (challenge) => {
+        return !challenge.hasBeenSkippedAutomatically
+        && !challenge.isNeutralized
+        && !listAnswers.find((answer) => answer.challengeId === challenge.challengeId);
+      });
+
+    if (someUnansweredChallenges) {
       throw new CertificationComputeError('L’utilisateur n’a pas répondu à toutes les questions');
     }
   }

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -176,11 +176,11 @@ class CertificationCourse {
     return Boolean(this._completedAt);
   }
 
-  isAbortReasonCandidate() {
+  isAbortReasonCandidateRelated() {
     return this._abortReason === 'candidate';
   }
 
-  isAbortReasonTechnical() {
+  isAbortReasonCandidateUnrelated() {
     return this._abortReason === 'technical';
   }
 

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -176,6 +176,10 @@ class CertificationCourse {
     return Boolean(this._completedAt);
   }
 
+  isAbortReasonCandidate() {
+    return this._abortReason === 'candidate';
+  }
+
   isPublished() {
     return this._isPublished;
   }

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -172,6 +172,10 @@ class CertificationCourse {
     this._birthdate = modifiedBirthdate;
   }
 
+  isCompleted() {
+    return Boolean(this._completedAt);
+  }
+
   isPublished() {
     return this._isPublished;
   }

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -180,6 +180,10 @@ class CertificationCourse {
     return this._abortReason === 'candidate';
   }
 
+  isAbortReasonTechnical() {
+    return this._abortReason === 'technical';
+  }
+
   isPublished() {
     return this._isPublished;
   }

--- a/api/lib/domain/read-models/CertificationDetails.js
+++ b/api/lib/domain/read-models/CertificationDetails.js
@@ -149,6 +149,7 @@ function _buildListChallengesAndAnswers({
       };
     })
     .compact()
+    .sortBy('competence')
     .value();
 
   return answeredChallengesAndAnswers.concat(unansweredChallengesAndAnswers);

--- a/api/lib/domain/read-models/CertificationDetails.js
+++ b/api/lib/domain/read-models/CertificationDetails.js
@@ -116,7 +116,7 @@ function _buildListChallengesAndAnswers({
   certificationAssessment,
   competencesWithMark,
 }) {
-  return _.map(certificationAssessment.certificationAnswersByDate, (certificationAnswer) => {
+  const answeredChallengesAndAnswers = _.map(certificationAssessment.certificationAnswersByDate, (certificationAnswer) => {
     const challengeForAnswer = certificationAssessment.getCertificationChallenge(certificationAnswer.challengeId);
     const competenceIndex = _getCompetenceIndexForChallenge(challengeForAnswer, competencesWithMark);
 
@@ -124,11 +124,34 @@ function _buildListChallengesAndAnswers({
       challengeId: challengeForAnswer.challengeId,
       competence: competenceIndex,
       isNeutralized: challengeForAnswer.isNeutralized,
+      hasBeenSkippedAutomatically: false,
       result: certificationAnswer.result.status,
       skill: challengeForAnswer.associatedSkillName,
       value: certificationAnswer.value,
     };
   });
+
+  const unansweredChallengesAndAnswers = _(certificationAssessment.certificationChallenges)
+    .map((challenge) => {
+      const answer = certificationAssessment.certificationAnswersByDate.find((answer) => answer.challengeId === challenge.challengeId);
+      if (answer) {
+        return null;
+      }
+      const competenceIndex = _getCompetenceIndexForChallenge(challenge, competencesWithMark);
+      return {
+        challengeId: challenge.challengeId,
+        competence: competenceIndex,
+        isNeutralized: challenge.isNeutralized,
+        hasBeenSkippedAutomatically: challenge.hasBeenSkippedAutomatically,
+        result: undefined,
+        skill: challenge.associatedSkillName,
+        value: undefined,
+      };
+    })
+    .compact()
+    .value();
+
+  return answeredChallengesAndAnswers.concat(unansweredChallengesAndAnswers);
 }
 
 function _getCompetenceIndexForChallenge(certificationChallenge, competencesWithMark) {

--- a/api/lib/domain/services/scoring/scoring-certification-service.js
+++ b/api/lib/domain/services/scoring/scoring-certification-service.js
@@ -32,7 +32,6 @@ function _getCompetenceMarksWithCertifiedLevelAndScore(answers, listCompetences,
 
     if (!continueOnError) {
       CertificationContract.assertThatCompetenceHasAtLeastOneChallenge(challengesForCompetence, competence.index);
-      CertificationContract.assertThatCompetenceHasAtLeastOneAnswer(answersForCompetence, competence.index);
       CertificationContract.assertThatEveryAnswerHasMatchingChallenge(answersForCompetence, challengesForCompetence);
       CertificationContract.assertThatNoChallengeHasMoreThanOneAnswer(answersForCompetence, challengesForCompetence);
     }

--- a/api/lib/domain/usecases/get-certification-details.js
+++ b/api/lib/domain/usecases/get-certification-details.js
@@ -8,16 +8,17 @@ module.exports = async function getCertificationDetails({
   scoringCertificationService,
 }) {
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({ certificationCourseId });
-  if (certificationAssessment.isCompleted()) {
+
+  const competenceMarks = await competenceMarkRepository.findByCertificationCourseId(certificationCourseId);
+
+  if (competenceMarks.length) {
     return _retrievePersistedCertificationDetails(
-      certificationCourseId,
+      competenceMarks,
       certificationAssessment,
-      competenceMarkRepository,
       placementProfileService,
     );
   } else {
     return _computeCertificationDetailsOnTheFly(
-      certificationCourseId,
       certificationAssessment,
       placementProfileService,
       scoringCertificationService,
@@ -25,7 +26,7 @@ module.exports = async function getCertificationDetails({
   }
 };
 
-async function _computeCertificationDetailsOnTheFly(certificationCourseId, certificationAssessment, placementProfileService, scoringCertificationService) {
+async function _computeCertificationDetailsOnTheFly(certificationAssessment, placementProfileService, scoringCertificationService) {
   const certificationAssessmentScore = await scoringCertificationService.calculateCertificationAssessmentScore({
     certificationAssessment,
     continueOnError: true,
@@ -43,8 +44,7 @@ async function _computeCertificationDetailsOnTheFly(certificationCourseId, certi
   });
 }
 
-async function _retrievePersistedCertificationDetails(certificationCourseId, certificationAssessment, competenceMarkRepository, placementProfileService) {
-  const competenceMarks = await competenceMarkRepository.findByCertificationCourseId(certificationCourseId);
+async function _retrievePersistedCertificationDetails(competenceMarks, certificationAssessment, placementProfileService) {
 
   const placementProfile = await placementProfileService.getPlacementProfile({
     userId: certificationAssessment.userId,

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -96,7 +96,7 @@ module.exports = {
     for (const challenge of certificationAssessment.certificationChallenges) {
       await knex('certification-challenges')
         .where({ id: challenge.id })
-        .update(_.pick(challenge, ['isNeutralized', 'isSkipped']));
+        .update(_.pick(challenge, ['isNeutralized', 'hasBeenSkippedAutomatically']));
     }
   },
 

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -96,7 +96,7 @@ module.exports = {
     for (const challenge of certificationAssessment.certificationChallenges) {
       await knex('certification-challenges')
         .where({ id: challenge.id })
-        .update(_.pick(challenge, ['isNeutralized']));
+        .update(_.pick(challenge, ['isNeutralized', 'isSkipped']));
     }
   },
 

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -115,8 +115,6 @@ describe('Acceptance | API | Certification Course', function() {
           state: CertificationAssessment.states.STARTED,
           userId: user.id,
         }).id;
-        const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
-        databaseBuilder.factory.buildCompetenceMark({ assessmentResultId, competenceId: 'competence_id' });
 
         challenges.forEach(({ id: challengeId }) => {
           databaseBuilder.factory.buildCertificationChallenge({

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -284,15 +284,15 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       // when
       certificationAssessmentToBeSaved.certificationChallenges.map((certificationChallenge) => {
         if (certificationChallenge.challengeId === 'rec567') {
-          certificationChallenge.isSkipped = true;
+          certificationChallenge.hasBeenSkippedAutomatically = true;
         }
       });
       await certificationAssessmentRepository.save(certificationAssessmentToBeSaved);
 
       // then
       const persistedCertificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
-      expect(persistedCertificationAssessment.certificationChallenges[0].isSkipped).to.be.false;
-      expect(persistedCertificationAssessment.certificationChallenges[1].isSkipped).to.be.true;
+      expect(persistedCertificationAssessment.certificationChallenges[0].hasBeenSkippedAutomatically).to.be.false;
+      expect(persistedCertificationAssessment.certificationChallenges[1].hasBeenSkippedAutomatically).to.be.true;
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -260,5 +260,39 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       expect(persistedCertificationAssessment.certificationChallenges[1].isNeutralized).to.be.true;
       expect(persistedCertificationAssessment.certificationChallenges[2].isNeutralized).to.be.false;
     });
+
+    it('persists the mutation of skipped certification challenges', async function() {
+      // given
+      const dbf = databaseBuilder.factory;
+      const userId = dbf.buildUser().id;
+      const certificationCourseId = dbf.buildCertificationCourse({ userId }).id;
+      const certificationAssessmentId = dbf.buildAssessment({
+        userId,
+        certificationCourseId,
+      }).id;
+      dbf.buildAnswer({ assessmentId: certificationAssessmentId, challengeId: 'rec1234' });
+      dbf.buildAnswer({ assessmentId: certificationAssessmentId });
+
+      const certificationChallenge1RecId = 'rec1234';
+      const certificationChallenge2RecId = 'rec567' ;
+      dbf.buildCertificationChallenge({ challengeId: certificationChallenge1RecId, courseId: certificationCourseId, isSkipped: false });
+      dbf.buildCertificationChallenge({ challengeId: certificationChallenge2RecId, courseId: certificationCourseId, isSkipped: false });
+
+      await databaseBuilder.commit();
+      const certificationAssessmentToBeSaved = await certificationAssessmentRepository.get(certificationAssessmentId);
+
+      // when
+      certificationAssessmentToBeSaved.certificationChallenges.map((certificationChallenge) => {
+        if (certificationChallenge.challengeId === 'rec567') {
+          certificationChallenge.isSkipped = true;
+        }
+      });
+      await certificationAssessmentRepository.save(certificationAssessmentToBeSaved);
+
+      // then
+      const persistedCertificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
+      expect(persistedCertificationAssessment.certificationChallenges[0].isSkipped).to.be.false;
+      expect(persistedCertificationAssessment.certificationChallenges[1].isSkipped).to.be.true;
+    });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge-with-type.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge-with-type.js
@@ -8,7 +8,7 @@ module.exports = function buildCertificationChallengeWithType({
   type = Challenge.Type.QCU,
   associatedSkillName = 'cueillir des fleurs',
   isNeutralized = false,
-  isSkipped = false,
+  hasBeenSkippedAutomatically = false,
   certifiableBadgeKey = null,
 } = {}) {
 
@@ -19,7 +19,7 @@ module.exports = function buildCertificationChallengeWithType({
     associatedSkillName,
     type,
     isNeutralized,
-    isSkipped,
+    hasBeenSkippedAutomatically,
     certifiableBadgeKey,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge-with-type.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge-with-type.js
@@ -8,6 +8,7 @@ module.exports = function buildCertificationChallengeWithType({
   type = Challenge.Type.QCU,
   associatedSkillName = 'cueillir des fleurs',
   isNeutralized = false,
+  isSkipped = false,
   certifiableBadgeKey = null,
 } = {}) {
 
@@ -18,6 +19,7 @@ module.exports = function buildCertificationChallengeWithType({
     associatedSkillName,
     type,
     isNeutralized,
+    isSkipped,
     certifiableBadgeKey,
   });
 };

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -209,51 +209,50 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
       }));
     });
 
-    it('should skip unpassed challenges', async function() {
-      // given
-      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false, isSkipped: false });
-      const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false, isSkipped: false });
-      const answeredChallenge = domainBuilder.buildAnswer({
-        challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
-      });
-      const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationCourseId: 4567,
-        certificationAnswersByDate: [answeredChallenge],
-        certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
-      });
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        sessionId: 1234,
-        id: 4567,
-        completedAt: null,
-        abortReason: 'candidate',
-      });
-      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
-      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
-      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
-      certificationAssessmentRepository.save.resolves();
-      const event = new SessionFinalized({
-        sessionId: 1234,
-        finalizedAt: new Date(),
-        hasExaminerGlobalComment: false,
-        certificationCenterName: 'A certification center name',
-        sessionDate: '2021-01-29',
-        sessionTime: '14:00',
-      });
+    context('when abort reason is candidate', function() {
+      it('should skip unpassed challenges', async function() {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false, isSkipped: false });
+        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false, isSkipped: false });
+        const answeredChallenge = domainBuilder.buildAnswer({
+          challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
+        });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationAnswersByDate: [answeredChallenge],
+          certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          completedAt: null,
+          abortReason: 'candidate',
+        });
+        certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+        certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+        certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+        certificationAssessmentRepository.save.resolves();
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
 
-      // when
-      await handleAutoJury({
-        event,
-        certificationIssueReportRepository,
-        certificationAssessmentRepository,
-        certificationCourseRepository,
-      });
+        // when
+        await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
 
-      // then
-      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal123').isSkipped).to.be.true;
-      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal456').isSkipped).to.be.false;
+        // then
+        expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal123').isSkipped).to.be.true;
+        expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal456').isSkipped).to.be.false;
+      });
     });
 
     it('should save certification assessment', async function() {

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -255,6 +255,53 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
       });
     });
 
+    context('when abort reason is technical', function() {
+      it('should neutralize unpassed challenges', async function() {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false, isSkipped: false });
+        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false, isSkipped: false });
+        const answeredChallenge = domainBuilder.buildAnswer({
+          challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
+        });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationAnswersByDate: [answeredChallenge],
+          certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          completedAt: null,
+          abortReason: 'technical',
+        });
+        certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+        certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+        certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+        certificationAssessmentRepository.save.resolves();
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(certificationAssessment.certificationChallenges[0].isNeutralized).to.be.true;
+        expect(certificationAssessment.certificationChallenges[0].challengeId).to.equal('recChal123');
+        expect(certificationAssessment.certificationChallenges[1].isNeutralized).to.be.false;
+      });
+    });
+
     it('should save certification assessment', async function() {
       // given
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -169,6 +169,137 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
     }));
   });
 
+  context('when the certification is not completed', function() {
+    it('returns a CertificationJuryDone event first in returned collection', async function() {
+      // given
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({ certificationCourseId: 4567 });
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        sessionId: 1234,
+        id: 4567,
+        completedAt: null,
+        abortReason: 'candidate',
+      });
+      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+      certificationAssessmentRepository.save.resolves();
+      const event = new SessionFinalized({
+        sessionId: 1234,
+        finalizedAt: new Date(),
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-29',
+        sessionTime: '14:00',
+      });
+
+      // when
+      const events = await handleAutoJury({
+        event,
+        certificationIssueReportRepository,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(events[0]).to.deepEqualInstance(new CertificationJuryDone({
+        certificationCourseId: certificationCourse.getId(),
+      }));
+    });
+
+    it('should skip unpassed challenges', async function() {
+      // given
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false, isSkipped: false });
+      const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false, isSkipped: false });
+      const answeredChallenge = domainBuilder.buildAnswer({
+        challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
+      });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 4567,
+        certificationAnswersByDate: [answeredChallenge],
+        certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
+      });
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        sessionId: 1234,
+        id: 4567,
+        completedAt: null,
+        abortReason: 'candidate',
+      });
+      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+      certificationAssessmentRepository.save.resolves();
+      const event = new SessionFinalized({
+        sessionId: 1234,
+        finalizedAt: new Date(),
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-29',
+        sessionTime: '14:00',
+      });
+
+      // when
+      await handleAutoJury({
+        event,
+        certificationIssueReportRepository,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal123').isSkipped).to.be.true;
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal456').isSkipped).to.be.false;
+    });
+
+  });
+  context('when certificationCourse is completed', function() {
+
+    it('should not return a CertificationJuryDone', async function() {
+      // given
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 4567,
+      });
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        id: 4567,
+        sessionId: 1234,
+        completedAt: '2010-01-01',
+        abortReason: null,
+      });
+      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
+      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+      certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
+      certificationAssessmentRepository.save.resolves();
+      const event = new SessionFinalized({
+        sessionId: 1234,
+        finalizedAt: new Date(),
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-29',
+        sessionTime: '14:00',
+      });
+
+      // when
+      const events = await handleAutoJury({
+        event,
+        certificationIssueReportRepository,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(events[0]).not.to.be.an.instanceof(CertificationJuryDone);
+      expect(events.length).to.equal(1);
+    });
+  });
+
   context('when there is no certification issue report', function() {
     it('does not return a CertificationJuryDone event', async function() {
       // given
@@ -176,6 +307,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
       const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 4567,
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
           domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
@@ -188,7 +320,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
         ],
       });
 
-      const certificationCourse = domainBuilder.buildCertificationCourse();
+      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
       certificationAssessmentRepository.getByCertificationCourseId.withArgs({ certificationCourseId: certificationCourse.getId() }).resolves(certificationAssessment);
       certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
       certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
@@ -224,6 +356,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
       const challenge = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 4567,
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.OK }),
         ],
@@ -231,7 +364,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
           challenge,
         ],
       });
-      const certificationCourse = domainBuilder.buildCertificationCourse();
+      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
       const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.FRAUD, subcategory: null, questionNumber: 1 });
       certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 1234 }).resolves([ certificationCourse ]);
       certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([ certificationIssueReport1 ]);
@@ -270,6 +403,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
       const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false });
       const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789', isNeutralized: false });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId: 4567,
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
           domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
@@ -281,7 +415,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
           challengeNotToBeNeutralized,
         ],
       });
-      const certificationCourse = domainBuilder.buildCertificationCourse();
+      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
       const certificationIssueReport = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING, questionNumber: 1 });
       const certificationIssueReport2 = domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.IN_CHALLENGE, subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED, questionNumber: 1 });
       const challengeRepository = {

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -215,8 +215,8 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
         const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
         const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
         const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false, isSkipped: false });
-        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false, isSkipped: false });
+        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false, hasBeenSkippedAutomatically: false });
+        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false, hasBeenSkippedAutomatically: false });
         const answeredChallenge = domainBuilder.buildAnswer({
           challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
         });
@@ -250,8 +250,8 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
         });
 
         // then
-        expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal123').isSkipped).to.be.true;
-        expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal456').isSkipped).to.be.false;
+        expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal123').hasBeenSkippedAutomatically).to.be.true;
+        expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'recChal456').hasBeenSkippedAutomatically).to.be.false;
       });
     });
 
@@ -261,8 +261,8 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
         const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
         const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
         const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false, isSkipped: false });
-        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false, isSkipped: false });
+        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123', isNeutralized: false, hasBeenSkippedAutomatically: false });
+        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456', isNeutralized: false, hasBeenSkippedAutomatically: false });
         const answeredChallenge = domainBuilder.buildAnswer({
           challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
         });
@@ -314,7 +314,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
         type: 'QCU',
         competenceId: 'recCOMP',
         isNeutralized: false,
-        isSkipped: true,
+        hasBeenSkippedAutomatically: true,
         certifiableBadgeKey: null,
       });
       const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
@@ -324,7 +324,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
         type: 'QCU',
         competenceId: 'recCOMP',
         isNeutralized: false,
-        isSkipped: false,
+        hasBeenSkippedAutomatically: false,
         certifiableBadgeKey: null,
       });
       const answeredChallenge = domainBuilder.buildAnswer({
@@ -370,7 +370,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function() {
         certificationChallenges: [
           domainBuilder.buildCertificationChallengeWithType({
             ...challengeToBeConsideredAsSkipped,
-            isSkipped: true,
+            hasBeenSkippedAutomatically: true,
           }),
           challengeNotToBeConsideredAsSkipped,
         ],

--- a/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
@@ -95,6 +95,27 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
       // then
       expect(numberOfChallenges).to.equal(0);
     });
+
+    it('counts automatically skipped challenges as wrong answers', function() {
+      // given
+      const challenge1 = _buildDecoratedCertificationChallenge({ isNeutralized: true, challengeId: 'chal1', type: 'QCM' });
+      const challenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', type: 'QCM' });
+      const challenge3 = _buildDecoratedCertificationChallenge({ challengeId: 'chal3', type: 'QCM' });
+      const challenge4 = _buildDecoratedCertificationChallenge({ challengeId: 'chal4', type: 'QCM', hasBeenSkippedAutomatically: true });
+      const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.challengeId });
+      const answer2 = domainBuilder.buildAnswer({ challengeId: challenge2.challengeId });
+      const answer3 = domainBuilder.buildAnswer({ challengeId: challenge3.challengeId });
+      const answerCollection = AnswerCollectionForScoring.from({
+        answers: [answer1, answer2, answer3],
+        challenges: [challenge1, challenge2, challenge3, challenge4],
+      });
+
+      // when
+      const numberOfChallenges = answerCollection.numberOfNonNeutralizedChallenges();
+
+      // then
+      expect(numberOfChallenges).to.equal(3);
+    });
   });
 
   context('#numberOfCorrectAnswers', function() {

--- a/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
@@ -628,6 +628,6 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function() {
   });
 });
 
-function _buildDecoratedCertificationChallenge({ challengeId, type, isNeutralized, competenceId }) {
-  return domainBuilder.buildCertificationChallengeWithType({ type, challengeId, isNeutralized, competenceId });
+function _buildDecoratedCertificationChallenge({ challengeId, type, isNeutralized, competenceId, hasBeenSkippedAutomatically }) {
+  return domainBuilder.buildCertificationChallengeWithType({ type, challengeId, isNeutralized, competenceId, hasBeenSkippedAutomatically });
 }

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -536,4 +536,29 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
       expect(recId).to.equal(null);
     });
   });
+
+  describe('#skipUnansweredChallenges', function() {
+    it('should skip unanswered challenges', function() {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1234', isSkipped: false });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', isSkipped: false });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', isSkipped: false });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1, certificationChallenge2, certificationChallenge3],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: certificationChallenge1.challengeId, result: AnswerStatus.KO.status }),
+          domainBuilder.buildAnswer({ challengeId: certificationChallenge3.challengeId, result: AnswerStatus.KO.status }),
+        ],
+      });
+
+      // when
+      certificationAssessment.skipUnansweredChallenges();
+
+      // then
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec456').isSkipped).to.be.true;
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec1234').isSkipped).to.be.false;
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec789').isSkipped).to.be.false;
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -540,9 +540,9 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
   describe('#skipUnansweredChallenges', function() {
     it('should skip unanswered challenges', function() {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1234', isSkipped: false });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', isSkipped: false });
-      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', isSkipped: false });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1234', hasBeenSkippedAutomatically: false });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', hasBeenSkippedAutomatically: false });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', hasBeenSkippedAutomatically: false });
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge1, certificationChallenge2, certificationChallenge3],

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -556,9 +556,9 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
       certificationAssessment.skipUnansweredChallenges();
 
       // then
-      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec456').isSkipped).to.be.true;
-      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec1234').isSkipped).to.be.false;
-      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec789').isSkipped).to.be.false;
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec456').hasBeenSkippedAutomatically).to.be.true;
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec1234').hasBeenSkippedAutomatically).to.be.false;
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec789').hasBeenSkippedAutomatically).to.be.false;
     });
   });
 

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -561,4 +561,29 @@ describe('Unit | Domain | Models | CertificationAssessment', function() {
       expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec789').isSkipped).to.be.false;
     });
   });
+
+  describe('#neutralizeUnansweredChallenges', function() {
+    it('should neutralize unanswered challenges', function() {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec1234', isNeutralized: false });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', isNeutralized: false });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', isNeutralized: false });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1, certificationChallenge2, certificationChallenge3],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: certificationChallenge1.challengeId, result: AnswerStatus.KO.status }),
+          domainBuilder.buildAnswer({ challengeId: certificationChallenge3.challengeId, result: AnswerStatus.KO.status }),
+        ],
+      });
+
+      // when
+      certificationAssessment.neutralizeUnansweredChallenges();
+
+      // then
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec456').isNeutralized).to.be.true;
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec1234').isNeutralized).to.be.false;
+      expect(certificationAssessment.certificationChallenges.find((certificationChallenge) => certificationChallenge.challengeId === 'rec789').isNeutralized).to.be.false;
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CertificationContract_test.js
+++ b/api/tests/unit/domain/models/CertificationContract_test.js
@@ -78,26 +78,6 @@ describe('Unit | Domain | Models | CertificationContract', function() {
     });
   });
 
-  context('#assertThatCompetenceHasAtLeastOneAnswer', function() {
-
-    context('when there is not enough answers for one competence', function() {
-
-      it('should throw', async function() {
-        // given
-        const competenceIndex = '1.1';
-
-        const competenceChallenges = [];
-
-        // when
-        const error = await catchErr(CertificationContract.assertThatCompetenceHasAtLeastOneAnswer)(competenceChallenges, competenceIndex);
-
-        // then
-        expect(error).to.be.instanceOf(CertificationComputeError);
-        expect(error.message).to.equal('Pas assez de réponses pour la compétence 1.1');
-      });
-    });
-  });
-
   context('#assertThatScoreIsCoherentWithReproducibilityRate', function() {
 
     context('when score is < 1 and reproductibility rate is > 50%', function() {

--- a/api/tests/unit/domain/models/CertificationContract_test.js
+++ b/api/tests/unit/domain/models/CertificationContract_test.js
@@ -7,7 +7,7 @@ describe('Unit | Domain | Models | CertificationContract', function() {
 
   context('#assertThatWeHaveEnoughAnswers', function() {
 
-    context('when there is less answers than challenges', function() {
+    context('when there are unanswered challenges', function() {
 
       it('should throw', async function() {
         // given
@@ -32,6 +32,28 @@ describe('Unit | Domain | Models | CertificationContract', function() {
         // then
         expect(error).to.be.instanceOf(CertificationComputeError);
         expect(error.message).to.equal('L’utilisateur n’a pas répondu à toutes les questions');
+      });
+
+      it('should not throw', async function() {
+        // given
+        const answers = _.map([
+          { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
+          { challengeId: 'challenge_D_for_competence_2', result: 'ok' },
+          { challengeId: 'challenge_E_for_competence_2', result: 'ok' },
+        ], domainBuilder.buildAnswer);
+
+        const challenges = _.map([
+          { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1', type: 'QCM' },
+          { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeB_1', type: 'QCM' },
+          { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeC_1', type: 'QCM', hasBeenSkippedAutomatically: true },
+          { challengeId: 'challenge_D_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeD_2', type: 'QCM' },
+          { challengeId: 'challenge_E_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeE_2', type: 'QCM' },
+        ], domainBuilder.buildCertificationChallengeWithType);
+
+        // when
+        // then
+        expect(()=> CertificationContract.assertThatWeHaveEnoughAnswers(answers, challenges)).not.to.throw();
       });
     });
   });

--- a/api/tests/unit/domain/read-models/CertificationDetails_test.js
+++ b/api/tests/unit/domain/read-models/CertificationDetails_test.js
@@ -66,6 +66,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
           challengeId: 'rec123',
           competence: '1.1',
           isNeutralized: false,
+          hasBeenSkippedAutomatically: false,
           result: 'ok',
           skill: 'manger une mangue',
           value: 'prout',
@@ -73,6 +74,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
           challengeId: 'rec456',
           competence: '2.2',
           isNeutralized: false,
+          hasBeenSkippedAutomatically: false,
           result: 'ko',
           skill: 'faire son lit',
           value: 'bidule',
@@ -101,24 +103,68 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
       expect(certificationDetails.toDTO().percentageCorrectAnswers).to.equal(0);
     });
 
-    it('should ignore challenges that do not have answer', function() {
+    it('should have the "challenges and answers" list ordered by answer date with unanswered challenges at the end', function() {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123' });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123', competenceId: 'recComp1', isNeutralized: true });
       const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', competenceId: 'recComp1' });
+      const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456' });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', competenceId: 'recComp1', isNeutralized: true });
+      const certificationChallenge4 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recABC', competenceId: 'recComp1', hasBeenSkippedAutomatically: true });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationChallenges: [certificationChallenge1, certificationChallenge2],
-        certificationAnswersByDate: [answer1],
+        certificationChallenges: [certificationChallenge3, certificationChallenge1, certificationChallenge4, certificationChallenge2],
+        certificationAnswersByDate: [answer1, answer2],
       });
-      const competenceMarks = [];
-      const placementProfile = null;
+      const competenceMark1 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
+      const competenceMarks = [competenceMark1];
+      const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
+        competencesData: [
+          { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
+        ],
+      });
 
       // when
       const certificationDetails = CertificationDetails.from({ certificationAssessment, placementProfile, competenceMarks });
 
       // then
-      expect(certificationDetails.toDTO().listChallengesAndAnswers).to.have.length(1);
-      expect(certificationDetails.toDTO().listChallengesAndAnswers[0].challengeId).to.equal('rec123');
+      expect(certificationDetails.toDTO().listChallengesAndAnswers).to.deep.equal([
+        {
+          challengeId: 'rec123',
+          competence: '1.1',
+          isNeutralized: true,
+          hasBeenSkippedAutomatically: false,
+          result: 'ok',
+          skill: 'cueillir des fleurs',
+          value: '1',
+        },
+        {
+          challengeId: 'rec456',
+          competence: '1.1',
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: false,
+          result: 'ko',
+          skill: 'cueillir des fleurs',
+          value: '1',
+        },
+        {
+          challengeId: 'rec789',
+          competence: '1.1',
+          isNeutralized: true,
+          hasBeenSkippedAutomatically: false,
+          result: undefined,
+          skill: 'cueillir des fleurs',
+          value: undefined,
+        },
+        {
+          challengeId: 'recABC',
+          competence: '1.1',
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: true,
+          result: undefined,
+          skill: 'cueillir des fleurs',
+          value: undefined,
+        },
+      ]);
     });
   });
 
@@ -191,6 +237,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
           challengeId: 'rec123',
           competence: '1.1',
           isNeutralized: false,
+          hasBeenSkippedAutomatically: false,
           result: 'ok',
           skill: 'manger une mangue',
           value: 'prout',
@@ -198,6 +245,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
           challengeId: 'rec456',
           competence: '2.2',
           isNeutralized: false,
+          hasBeenSkippedAutomatically: false,
           result: 'ko',
           skill: 'faire son lit',
           value: 'bidule',
@@ -206,37 +254,72 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
       expect(certificationDetails.toDTO()).to.deep.equal(expectedCertificationDetails.toDTO());
     });
 
-    it('should ignore challenges that do not have answer', function() {
+    it('should have the "challenges and answers" list ordered by answer date with unanswered challenges at the end', function() {
       // given
-      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: true });
-      const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
-      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit', isNeutralized: true });
+      const certificationChallenge1 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123', competenceId: 'recComp1', isNeutralized: true });
+      const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', competenceId: 'recComp1' });
+      const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456' });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', competenceId: 'recComp1', isNeutralized: true });
+      const certificationChallenge4 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recABC', competenceId: 'recComp1', hasBeenSkippedAutomatically: true });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationChallenges: [certificationChallenge1, certificationChallenge2],
-        certificationAnswersByDate: [answer1],
+        certificationChallenges: [certificationChallenge3, certificationChallenge1, certificationChallenge4, certificationChallenge2],
+        certificationAnswersByDate: [answer1, answer2],
       });
       const competenceMark1 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
-      const competenceMark2 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp2', score: 17, level: 2, competence_code: '2.2', area_code: '2' });
+      const competenceMarks = [competenceMark1];
       const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
-        competenceMarks: [competenceMark1, competenceMark2],
+        competenceMarks,
+        percentageCorrectAnswers: 50,
       });
       const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
         competencesData: [
           { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
-          { id: 'recComp2', index: '2.2', name: 'Ranger sa chambre', level: 2, score: 18 },
         ],
       });
 
       // when
-      const certificationDetails = CertificationDetails.fromCertificationAssessmentScore({
-        certificationAssessmentScore,
-        certificationAssessment,
-        placementProfile,
-      });
+      const certificationDetails = CertificationDetails.fromCertificationAssessmentScore({ certificationAssessment, placementProfile, certificationAssessmentScore });
 
       // then
-      expect(certificationDetails.toDTO().listChallengesAndAnswers).to.have.length(1);
-      expect(certificationDetails.toDTO().listChallengesAndAnswers[0].challengeId).to.equal('rec123');
+      expect(certificationDetails.toDTO().listChallengesAndAnswers).to.deep.equal([
+        {
+          challengeId: 'rec123',
+          competence: '1.1',
+          isNeutralized: true,
+          hasBeenSkippedAutomatically: false,
+          result: 'ok',
+          skill: 'cueillir des fleurs',
+          value: '1',
+        },
+        {
+          challengeId: 'rec456',
+          competence: '1.1',
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: false,
+          result: 'ko',
+          skill: 'cueillir des fleurs',
+          value: '1',
+        },
+        {
+          challengeId: 'rec789',
+          competence: '1.1',
+          isNeutralized: true,
+          hasBeenSkippedAutomatically: false,
+          result: undefined,
+          skill: 'cueillir des fleurs',
+          value: undefined,
+        },
+        {
+          challengeId: 'recABC',
+          competence: '1.1',
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: true,
+          result: undefined,
+          skill: 'cueillir des fleurs',
+          value: undefined,
+        },
+      ]);
     });
   });
 

--- a/api/tests/unit/domain/read-models/CertificationDetails_test.js
+++ b/api/tests/unit/domain/read-models/CertificationDetails_test.js
@@ -109,17 +109,19 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
       const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123' });
       const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', competenceId: 'recComp1' });
       const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456' });
-      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', competenceId: 'recComp1', isNeutralized: true });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', competenceId: 'recComp2', isNeutralized: true });
       const certificationChallenge4 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recABC', competenceId: 'recComp1', hasBeenSkippedAutomatically: true });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge3, certificationChallenge1, certificationChallenge4, certificationChallenge2],
         certificationAnswersByDate: [answer1, answer2],
       });
       const competenceMark1 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
-      const competenceMarks = [competenceMark1];
+      const competenceMark2 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp2', score: 5, level: 1, competence_code: '1.2', area_code: '1' });
+      const competenceMarks = [competenceMark1, competenceMark2];
       const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
         competencesData: [
           { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
+          { id: 'recComp2', index: '1.2', name: 'Manger des legumes', level: 3, score: 45 },
         ],
       });
 
@@ -147,19 +149,19 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
           value: '1',
         },
         {
-          challengeId: 'rec789',
+          challengeId: 'recABC',
           competence: '1.1',
-          isNeutralized: true,
-          hasBeenSkippedAutomatically: false,
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: true,
           result: undefined,
           skill: 'cueillir des fleurs',
           value: undefined,
         },
         {
-          challengeId: 'recABC',
-          competence: '1.1',
-          isNeutralized: false,
-          hasBeenSkippedAutomatically: true,
+          challengeId: 'rec789',
+          competence: '1.2',
+          isNeutralized: true,
+          hasBeenSkippedAutomatically: false,
           result: undefined,
           skill: 'cueillir des fleurs',
           value: undefined,
@@ -260,14 +262,15 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
       const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123' });
       const certificationChallenge2 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec456', competenceId: 'recComp1' });
       const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456' });
-      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', competenceId: 'recComp1', isNeutralized: true });
+      const certificationChallenge3 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec789', competenceId: 'recComp2', isNeutralized: true });
       const certificationChallenge4 = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recABC', competenceId: 'recComp1', hasBeenSkippedAutomatically: true });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationChallenges: [certificationChallenge3, certificationChallenge1, certificationChallenge4, certificationChallenge2],
         certificationAnswersByDate: [answer1, answer2],
       });
       const competenceMark1 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
-      const competenceMarks = [competenceMark1];
+      const competenceMark2 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp2', score: 5, level: 1, competence_code: '1.2', area_code: '1' });
+      const competenceMarks = [competenceMark1, competenceMark2];
       const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
         competenceMarks,
         percentageCorrectAnswers: 50,
@@ -275,6 +278,7 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
       const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
         competencesData: [
           { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
+          { id: 'recComp2', index: '1.2', name: 'Manger des legumes', level: 3, score: 45 },
         ],
       });
 
@@ -302,19 +306,19 @@ describe('Unit | Domain | Read-models | CertificationDetails', function() {
           value: '1',
         },
         {
-          challengeId: 'rec789',
+          challengeId: 'recABC',
           competence: '1.1',
-          isNeutralized: true,
-          hasBeenSkippedAutomatically: false,
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: true,
           result: undefined,
           skill: 'cueillir des fleurs',
           value: undefined,
         },
         {
-          challengeId: 'recABC',
-          competence: '1.1',
-          isNeutralized: false,
-          hasBeenSkippedAutomatically: true,
+          challengeId: 'rec789',
+          competence: '1.2',
+          isNeutralized: true,
+          hasBeenSkippedAutomatically: false,
           result: undefined,
           skill: 'cueillir des fleurs',
           value: undefined,

--- a/api/tests/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-details_test.js
@@ -107,6 +107,7 @@ describe('Unit | UseCase | get-certification-details', function() {
           {
             challengeId: 'rec123',
             competence: '1.1',
+            hasBeenSkippedAutomatically: false,
             isNeutralized: false,
             result: 'ok',
             skill: 'manger une mangue',
@@ -206,6 +207,7 @@ describe('Unit | UseCase | get-certification-details', function() {
           {
             challengeId: 'rec123',
             competence: '1.1',
+            hasBeenSkippedAutomatically: false,
             isNeutralized: false,
             result: 'ok',
             skill: 'manger une mangue',

--- a/api/tests/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-details_test.js
@@ -5,34 +5,26 @@ const CertificationAssessmentStates = require('../../../../lib/domain/models/Cer
 
 describe('Unit | UseCase | get-certification-details', function() {
 
-  const certificationAssessmentRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    getByCertificationCourseId: sinon.stub(),
-  };
-
-  const placementProfileService = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    getPlacementProfile: sinon.stub(),
-  };
-
-  const competenceMarkRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    findByCertificationCourseId: sinon.stub(),
-  };
-
-  const scoringCertificationService = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    calculateCertificationAssessmentScore: sinon.stub(),
-  };
-
   context('the certification assessment has not been completed', function() {
 
     it('should compute the certification details on the fly', async function() {
       // given
+      const certificationAssessmentRepository = {
+        getByCertificationCourseId: sinon.stub(),
+      };
+
+      const placementProfileService = {
+        getPlacementProfile: sinon.stub(),
+      };
+
+      const competenceMarkRepository = {
+        findByCertificationCourseId: sinon.stub(),
+      };
+
+      const scoringCertificationService = {
+        calculateCertificationAssessmentScore: sinon.stub(),
+      };
+
       const certificationCourseId = 1234;
       const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({
         challengeId: 'rec123',
@@ -71,6 +63,7 @@ describe('Unit | UseCase | get-certification-details', function() {
         ],
       });
 
+      competenceMarkRepository.findByCertificationCourseId.resolves([]);
       scoringCertificationService.calculateCertificationAssessmentScore
         .withArgs({ certificationAssessment, continueOnError: true })
         .resolves(certificationAssessmentScore);
@@ -131,6 +124,22 @@ describe('Unit | UseCase | get-certification-details', function() {
   context('the certification assessment has been completed', function() {
     it('should return the certification details', async function() {
       // given
+      const certificationAssessmentRepository = {
+        getByCertificationCourseId: sinon.stub(),
+      };
+
+      const placementProfileService = {
+        getPlacementProfile: sinon.stub(),
+      };
+
+      const competenceMarkRepository = {
+        findByCertificationCourseId: sinon.stub(),
+      };
+
+      const scoringCertificationService = {
+        calculateCertificationAssessmentScore: sinon.stub(),
+      };
+
       const certificationCourseId = 1234;
       const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue', isNeutralized: false });
       const answer = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix “Gestion des certif démarrées”, nous allons permettre à un utilisateur Pix Certif finalisant une session de donner la raison de l’abandon d’une certif par un candidat. En fonction de cette raison (liée au candidat ou non), des règles ont été définies pour le scoring mais ne sont pas encore implémentées.

## :robot: Solution
Implémenter les règles de scoring des certif démarrées. Lorsqu’une session est finalisée, si il y a une (ou plusieurs) certif démarrées, appliquer les règles suivantes : 

- SI la raison est liée au candidat : on considère que les questions non répondues sont "abandonnées", ce qui signifie que le calcul du taux de repro sera le suivant : nbre de réponses OK / nbre de question prévues pour le test

- SINON SI la raison n’est PAS liée au candidat : on considère les questions non répondues comme "neutralisées" de façon à ce qu'elles ne soient pas prises en compte dans le calcul du taux de repro : nbre de réponses OK / nbre de questions répondues

## :100: Pour tester
- Démarrer une session de certification avec deux candidats
- Répondre à quelques questions
- Ne pas aller jusqu'au bout des tests de certification

Dans pix-certif: 
- Finaliser les session en choisissant comme motif d'abandon 'candidat' pour un candidat et 'technique' pour le deuxième

Dans pix-admin:

- Constater que pour le candidat concerné par l'abandon 'candidat', les dernières questions sont en statut 'Abandon'
![image](https://user-images.githubusercontent.com/37305474/134314548-4992f55f-d976-43d9-b142-a50acd5bddc8.png)

- Constater que pour le candidat concerné par l'abandon 'technique', les dernières questions sont en statut 'Neutralisée' sans réponse affichée
![image](https://user-images.githubusercontent.com/37305474/134314932-5b485dc0-a83e-45f5-93b9-b527353e06b4.png)


