### PR TITLE
[TECH] Savoir si la personne a bien répondu mais est quand même sortie (PIX-3079).

### DIFF
--- a/api/db/migrations/20210920153452_add-column-focusedout-to-answers.js
+++ b/api/db/migrations/20210920153452_add-column-focusedout-to-answers.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'answers';
+const COLUMN_NAME = 'isFocusedOut';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/Answer.js
+++ b/api/lib/domain/models/Answer.js
@@ -8,7 +8,7 @@ class Answer {
     result,
     resultDetails,
     timeout,
-    focusedOut,
+    isFocusedOut,
     value,
     levelup,
     assessmentId,
@@ -20,7 +20,7 @@ class Answer {
     this.result = AnswerStatus.from(result);
     this.resultDetails = resultDetails;
     this.timeout = timeout;
-    this.focusedOut = focusedOut || this.result.isFOCUSEDOUT();
+    this.isFocusedOut = isFocusedOut || this.result.isFOCUSEDOUT();
     this.value = value;
     this.levelup = levelup;
     this.assessmentId = assessmentId;

--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -33,7 +33,7 @@ class Examiner {
       correctedAnswer.result = AnswerStatus.TIMEDOUT;
     }
 
-    if (isCorrectAnswer && answer.focusedOut && isCertificationEvaluation) {
+    if (isCorrectAnswer && answer.isFocusedOut && isCertificationEvaluation) {
       correctedAnswer.result = AnswerStatus.FOCUSEDOUT;
     }
 

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -7,7 +7,7 @@ const answerStatusDatabaseAdapter = require('../adapters/answer-status-database-
 
 function _adaptAnswerToDb(answer) {
   return {
-    ...(_.pick(answer, ['value', 'timeout', 'challengeId', 'assessmentId', 'timeSpent'])),
+    ...(_.pick(answer, ['value', 'timeout', 'challengeId', 'assessmentId', 'timeSpent', 'isFocusedOut'])),
     result: answerStatusDatabaseAdapter.toSQLString(answer.result),
     resultDetails: jsYaml.dump(answer.resultDetails),
   };

--- a/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -48,7 +48,7 @@ module.exports = {
       result: null,
       resultDetails: null,
       timeout: payload.data.attributes.timeout,
-      focusedOut: payload.data.attributes['focused-out'],
+      isFocusedOut: payload.data.attributes['focused-out'],
       assessmentId: payload.data.relationships.assessment.data.id,
       challengeId: payload.data.relationships.challenge.data.id,
     });

--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -464,6 +464,7 @@ describe('Integration | Repository | answerRepository', function() {
         assessmentId: 123,
         challengeId: 'recChallenge123',
         timeSpent: 20,
+        isFocusedOut: true,
       });
       databaseBuilder.factory.buildAssessment({ id: 123 });
       await databaseBuilder.commit();

--- a/api/tests/tooling/domain-builder/factory/build-answer.js
+++ b/api/tests/tooling/domain-builder/factory/build-answer.js
@@ -10,7 +10,7 @@ function buildAnswer({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 20,
-  focusedOut = false,
+  isFocusedOut = false,
 } = {}) {
   return new Answer({
     id,
@@ -21,7 +21,7 @@ function buildAnswer({
     assessmentId,
     challengeId,
     timeSpent,
-    focusedOut,
+    isFocusedOut,
   });
 }
 
@@ -31,7 +31,7 @@ buildAnswer.uncorrected = function({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 10,
-  focusedOut = false,
+  isFocusedOut = false,
 } = {}) {
   return new Answer({
     timeout,
@@ -39,7 +39,7 @@ buildAnswer.uncorrected = function({
     assessmentId,
     challengeId,
     timeSpent,
-    focusedOut,
+    isFocusedOut,
   });
 };
 
@@ -51,7 +51,7 @@ buildAnswer.ok = function({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 20,
-  focusedOut = false,
+  isFocusedOut = false,
 } = {}) {
 
   return buildAnswer({
@@ -63,7 +63,7 @@ buildAnswer.ok = function({
     assessmentId,
     challengeId,
     timeSpent,
-    focusedOut,
+    isFocusedOut,
   });
 };
 
@@ -75,7 +75,7 @@ buildAnswer.ko = function({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 20,
-  focusedOut = false,
+  isFocusedOut = false,
 } = {}) {
 
   return buildAnswer({
@@ -87,7 +87,7 @@ buildAnswer.ko = function({
     assessmentId,
     challengeId,
     timeSpent,
-    focusedOut,
+    isFocusedOut,
   });
 };
 
@@ -99,7 +99,7 @@ buildAnswer.skipped = function({
   assessmentId = 456,
   challengeId = 'recChallenge123',
   timeSpent = 20,
-  focusedOut = false,
+  isFocusedOut = false,
 } = {}) {
 
   return buildAnswer({
@@ -111,7 +111,7 @@ buildAnswer.skipped = function({
     assessmentId,
     challengeId,
     timeSpent,
-    focusedOut,
+    isFocusedOut,
   });
 };
 

--- a/api/tests/unit/domain/models/Answer_test.js
+++ b/api/tests/unit/domain/models/Answer_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Models | Answer', function() {
         assessmentId: 82,
         levelup: {},
         timeSpent: 30,
-        focusedOut: false,
+        isFocusedOut: false,
       };
 
       const expectedAnswer = {
@@ -31,7 +31,7 @@ describe('Unit | Domain | Models | Answer', function() {
         assessmentId: 82,
         levelup: {},
         timeSpent: 30,
-        focusedOut: false,
+        isFocusedOut: false,
       };
 
       // when

--- a/api/tests/unit/domain/models/Examiner_test.js
+++ b/api/tests/unit/domain/models/Examiner_test.js
@@ -91,7 +91,7 @@ describe('Unit | Domain | Models | Examiner', function() {
         // given
         validation = domainBuilder.buildValidation({ result: AnswerStatus.OK });
         validator.assess.returns(validation);
-        uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected({ focusedOut: true });
+        uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected({ isFocusedOut: true });
         examiner = new Examiner({ validator });
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -115,7 +115,7 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function() {
       expect(answer.result).to.deep.equal(AnswerStatus.from(null));
       expect(answer.resultDetails).to.equal(null);
       expect(answer.timeout).to.equal(null);
-      expect(answer.focusedOut).to.equal(true);
+      expect(answer.isFocusedOut).to.equal(true);
       expect(answer.assessmentId).to.equal(assessmentId);
       expect(answer.challengeId).to.equal(challengeId);
     });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre d'un positionnement, les épreuves focus n'ont pas d'impact sur le résultat (qui sera OK ou KO).
Nous avons besoin (pour des statistiques, de l'analyse, et plus tard un affichage spécifique) de savoir si l'utilisateur est quand même sorti ou non.

## :robot: Solution
- Ajout d'une colonne `isFocusedOut`,
- Remplir cette colonne avec l'info `isFocusedOut` déjà présente

## :rainbow: Remarques
- Nous n'avons pas l'info pour les anciennes réponses
- Ajout d'une nouvelle colonne sur answers : normalement pas de soucis.

## :100: Pour tester
Passer une épreuve Focus, bien répondre mais sortir.
- On doit voir la réponse en OK
- On doit avoir `isFocusedOut` à `true` en base de données
