### PR TITLE
[FEATURE] Changement de titre de page pour les épreuves focus (PIX-3484).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/page-title.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/page-title.feature
@@ -25,4 +25,4 @@ Fonctionnalité: Titre des pages
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la compétence "recH9MjIzN54zXlwr"
     Lorsque je clique sur "Commencer"
-    Alors je vois le titre de la page "Épreuve 1 sur 5 | Mathématiques | Pix"
+    Alors je vois le titre de la page "Question 1 sur 5 | Mathématiques | Pix"

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -30,7 +30,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // then
-        expect(getPageTitle()).to.contain('Épreuve de savoir');
+        expect(getPageTitle()).to.contain('Mode focus');
       });
 
       describe('when user has not answered the question', function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -317,8 +317,8 @@
       "title": {
         "default": "Question {stepNumber} of {totalChallengeNumber}",
         "timed-out": "Timed out - Question {stepNumber} of {totalChallengeNumber}",
-        "focused": "Knowledge Question - Question {stepNumber} of {totalChallengeNumber}",
-        "focused-out": "Challenge failed - Knowledge Question - Question {stepNumber} of {totalChallengeNumber}"
+        "focused": "Focus Mode - Question {stepNumber} of {totalChallengeNumber}",
+        "focused-out": "Failed - Focus Mode - Question {stepNumber} of {totalChallengeNumber}"
       },
       "actions": {
         "continue": "Continue",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -315,10 +315,10 @@
     },
     "challenge": {
       "title": {
-        "default": "Épreuve {stepNumber} sur {totalChallengeNumber}",
-        "timed-out": "Temps écoulé - Épreuve {stepNumber} sur {totalChallengeNumber}",
-        "focused": "Épreuve de savoir - Épreuve {stepNumber} sur {totalChallengeNumber}",
-        "focused-out": "Échoué - Épreuve de savoir - Épreuve {stepNumber} sur {totalChallengeNumber}"
+        "default": "Question {stepNumber} sur {totalChallengeNumber}",
+        "timed-out": "Temps écoulé - Question {stepNumber} sur {totalChallengeNumber}",
+        "focused": "Mode focus - Question {stepNumber} sur {totalChallengeNumber}",
+        "focused-out": "Échoué - Mode focus - Question {stepNumber} sur {totalChallengeNumber}"
       },
       "actions": {
         "continue": "Poursuivre",


### PR DESCRIPTION
## :unicorn: Problème
Problème de nom sur les titres des épreuves

## :robot: Solution
Passer de "Epreuve de savoir" à "Mode focus", et de "Epreuve" à "Questions".

## :rainbow: Remarques

## :100: Pour tester
Répondre à des questions et voir que les titres s'affichent toujours correctement.