### PR TITLE
[TECH] Remplace le userId par me dans l'url certification-point-of-contacts (pix-3495)

### DIFF
--- a/api/lib/application/certification-point-of-contacts/index.js
+++ b/api/lib/application/certification-point-of-contacts/index.js
@@ -1,29 +1,15 @@
-const Joi = require('joi');
-
-const securityPreHandlers = require('../security-pre-handlers');
 const certificationPointOfContactController = require('./certification-point-of-contact-controller');
-const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/certification-point-of-contacts/{userId}',
+      path: '/api/certification-point-of-contacts/me',
       config: {
-        validate: {
-          params: Joi.object({
-            userId: identifiersType.certificationCenterMembershipId,
-          }),
-        },
-        pre: [{
-          method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-          assign: 'requestedUserIsAuthenticatedUser',
-        }],
         handler: certificationPointOfContactController.get,
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Récupération d’un référent de certification.\n' +
-          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+          '- **Cette route est restreinte aux utilisateurs authentifiés*' * '\n' +
+          '- Récupération d’un référent de certification.',
         ],
         tags: ['api', 'user', 'certification', 'certification-point-of-contact'],
       },

--- a/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
+++ b/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
@@ -9,7 +9,7 @@ describe('Acceptance | Route | CertificationPointOfContact', function() {
     server = await createServer();
   });
 
-  describe('GET /api/certification-point-of-contacts/:userId', function() {
+  describe('GET /api/certification-point-of-contacts/me', function() {
 
     it('should 200 HTTP status code', async function() {
       // given
@@ -22,7 +22,7 @@ describe('Acceptance | Route | CertificationPointOfContact', function() {
       await databaseBuilder.commit();
       const options = {
         method: 'GET',
-        url: `/api/certification-point-of-contacts/${userId}`,
+        url: '/api/certification-point-of-contacts/me',
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
 

--- a/api/tests/unit/application/certification-point-of-contacts/index_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/index_test.js
@@ -6,38 +6,22 @@ const {
 
 const moduleUnderTest = require('../../../../lib/application/certification-point-of-contacts');
 const certificationPointOfContactController = require('../../../../lib/application/certification-point-of-contacts/certification-point-of-contact-controller');
-const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 
 describe('Unit | Router | certification-point-of-contact-router', function() {
 
-  describe('GET /api/certification-point-of-contacts/{userId}', function() {
+  describe('GET /api/certification-point-of-contacts/me', function() {
 
     it('should exist', async function() {
       // given
-      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').returns('ok');
       sinon.stub(certificationPointOfContactController, 'get').callsFake((request, h) => h.response().code(200));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const result = await httpTestServer.request('GET', '/api/certification-point-of-contacts/123');
+      const result = await httpTestServer.request('GET', '/api/certification-point-of-contacts/me');
 
       // then
       expect(result.statusCode).to.equal(200);
-    });
-
-    it('should call pre-handler', async function() {
-      // given
-      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').returns('ok');
-      sinon.stub(certificationPointOfContactController, 'get').callsFake((request, h) => h.response().code(200));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      await httpTestServer.request('GET', '/api/certification-point-of-contacts/123');
-
-      // then
-      expect(securityPreHandlers.checkRequestedUserIsAuthenticatedUser).to.have.been.called;
     });
   });
 });

--- a/certif/app/adapters/certification-point-of-contact.js
+++ b/certif/app/adapters/certification-point-of-contact.js
@@ -12,4 +12,8 @@ export default class CertificationPointOfContactAdapter extends ApplicationAdapt
 
     return url;
   }
+
+  urlForQueryRecord() {
+    return `${this.host}/${this.namespace}/certification-point-of-contacts/me`;
+  }
 }

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -12,7 +12,7 @@ export default class CurrentUserService extends Service {
   async load() {
     if (this.session.isAuthenticated) {
       try {
-        this.certificationPointOfContact = await this.store.findRecord('certification-point-of-contact', this.session.data.authenticated.user_id);
+        this.certificationPointOfContact = await this.store.queryRecord('certification-point-of-contact', {});
         this.currentAllowedCertificationCenterAccess = this.certificationPointOfContact.hasMany('allowedCertificationCenterAccesses').value().firstObject;
       } catch (error) {
         this.certificationPointOfContact = null;

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -151,15 +151,10 @@ export default function() {
     return session;
   });
 
-  this.get('/certification-point-of-contacts/:id', (schema, request) => {
-    const certificationPointOfContactId = request.params.id;
+  this.get('/certification-point-of-contacts/me', (schema, request) => {
     const userToken = request.requestHeaders['Authorization'].replace('Bearer ', '');
     const userId = JSON.parse(atob(userToken.split('.')[1])).user_id;
-    if (parseInt(certificationPointOfContactId) !== parseInt(userId)) {
-      return new Response(403, { some: 'header' }, { errors: [{ status: '403', title: 'Forbidden', detail: 'Authenticated user different from the one asked' }] });
-    }
-
-    return schema.certificationPointOfContacts.find(certificationPointOfContactId);
+    return schema.certificationPointOfContacts.find(userId);
   });
 
   this.patch('/users/:id/pix-certif-terms-of-service-acceptance', (schema, request) => {

--- a/certif/tests/unit/services/current-user_test.js
+++ b/certif/tests/unit/services/current-user_test.js
@@ -25,7 +25,7 @@ module('Unit | Service | current-user', function(hooks) {
           allowedCertificationCenterAccesseA, allowedCertificationCenterAccesseB,
         ],
       });
-      sinon.stub(store, 'findRecord').resolves(certificationPointOfContact);
+      sinon.stub(store, 'queryRecord').resolves(certificationPointOfContact);
 
       class SessionStub extends Service {
         isAuthenticated = true;

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -44,7 +44,7 @@ Cypress.Commands.add('loginOrga', (username, password) => {
 
 Cypress.Commands.add('loginCertif', (username, password) => {
   cy.server();
-  cy.route('/api/certification-point-of-contacts/**').as('getCurrentUser');
+  cy.route('/api/certification-point-of-contacts/me').as('getCurrentUser');
   cy.request({
     url: `${Cypress.env('API_URL')}/api/token`,
     method: 'POST',


### PR DESCRIPTION
## :unicorn: Problème
L'appel à l'url `/api/certification-point-of-contacts` ne peut être accéder que par l'utilisateur connecté mais permet d'en faire la demande avec n'importe quel userId

## :robot: Solution
Remplacer l'url par `/api/certification-point-of-contacts/me`


## :rainbow: Remarques
https://github.com/1024pix/pix/pull/3469#issuecomment-918220290

## :100: Pour tester
Se connecter sur pix-certif. Verifier que les centre de certifications s'affichent correctement dans le header
