### PR TITLE
[BUGFIX] Sauvegarde l'état de la question focus seulement en cas de sortie de la fenêtre

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -69,16 +69,14 @@ export default class ChallengeController extends Controller {
   }
 
   @action
-  async setFocusedOutOfChallenge(value) {
+  setFocusedOutOfChallenge(value) {
     this.hasFocusedOutOfChallenge = value;
-    if (this.hasFocusedOutOfChallenge) {
-      await this.model.assessment.save({ adapterOptions: { updateLastQuestionsState: true, state: 'focusedout' } });
-    }
   }
 
   @action
-  focusedOutOfWindow() {
+  async focusedOutOfWindow() {
     this.hasFocusedOutOfWindow = true;
+    await this.model.assessment.save({ adapterOptions: { updateLastQuestionsState: true, state: 'focusedout' } });
   }
 
   @action

--- a/mon-pix/mirage/routes/assessments/index.js
+++ b/mon-pix/mirage/routes/assessments/index.js
@@ -3,6 +3,7 @@ import findAssessments from './find-assessments';
 import getAssessment from './get-assessment';
 import getNextChallenge from './get-next-challenge';
 import postAssessments from './post-assessments';
+import setFocusedOutState from './set-focusedout-state';
 
 export default function index(config) {
   config.get('/assessments', findAssessments);
@@ -13,4 +14,5 @@ export default function index(config) {
   config.get('/assessments/:id/next', getNextChallenge);
 
   config.patch('/assessments/:id/complete-assessment', completeAssessment);
+  config.patch('/assessments/:id/last-challenge-state/focusedout', setFocusedOutState);
 }

--- a/mon-pix/mirage/routes/assessments/set-focusedout-state.js
+++ b/mon-pix/mirage/routes/assessments/set-focusedout-state.js
@@ -1,0 +1,6 @@
+export default function(schema, request) {
+  const assessmentId = request.params.id;
+  const assessment = schema.assessments.find(assessmentId);
+  assessment.update({ lastQuestionState: 'focusedout' });
+  return assessment;
+}


### PR DESCRIPTION
## :unicorn: Problème
L'état `focusedout` de la question focus est actuellement sauvegardé lorsqu'on déplace la souris en dehors de la div du challenge. Mais ce qui nos intéresse c'est la sortie de la fenêtre.

## :robot: Solution
Déplacer la sauvegarde au moment de la sortie de la fenêtre.

## :100: Pour tester
1. Aller sur une épreuve focus `rec1Y3cL4enp1lZ97`
2. Sortir de la div
3. Recharger la page
4. Constater que l'état initial n'est pas "vous êtes sorti de la page"
5. Sortir de la fenêtre
6. Recharger
7. Constater que l'état initial est "changement de fenêtre détecté"
