### PR TITLE
[BUGFIX] Retirer la vérification de la ville de naissance lors de l'ajout d'un candidat SCO à une session de certification (PIX-3500)

### DIFF
--- a/api/lib/domain/models/SCOCertificationCandidate.js
+++ b/api/lib/domain/models/SCOCertificationCandidate.js
@@ -8,7 +8,7 @@ const scoCertificationCandidateValidationJoiSchema = Joi.object({
   birthdate: Joi.date().format('YYYY-MM-DD').greater('1900-01-01').required().empty(null),
   birthINSEECode: Joi.string().allow(null).optional(),
   birthCountry: Joi.string().allow(null).optional(),
-  birthCity: Joi.string().allow(null).optional(),
+  birthCity: Joi.string().allow(null, '').optional(),
   sex: Joi.string().allow(null).optional(),
   sessionId: Joi.number().required().empty(null),
   schoolingRegistrationId: Joi.number().required().empty(null),

--- a/api/tests/unit/domain/models/SCOCertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/SCOCertificationCandidate_test.js
@@ -103,6 +103,17 @@ describe('Unit | Domain | Models | SCO Certification Candidate', function() {
       });
     });
 
+    it('should validate when birthCity is an empty string', async function() {
+      try {
+        buildSCOCertificationCandidate({
+          ...validAttributes,
+          birthCity: '',
+        });
+      } catch (e) {
+        expect.fail('scoCertificationCandidate is valid when all required fields are present');
+      }
+    });
+
     it('should throw an error when birthdate is not a date', async function() {
       const error = await catchErr(buildSCOCertificationCandidate)({ ...validAttributes, birthdate: 'je mange des fruits' });
 


### PR DESCRIPTION
## :unicorn: Problème

Aujourd'hui, si on ajoute un candidat SCO à une session de certification pour lequel la ville de naissance n'est pas renseignée, cela provoque une erreur "Candidat de certification invalide". Or nous n'avons pas besoin de cette information si le code INSEE est renseigné.

## :robot: Solution

Retirer la vérification de cette information lors de l'ajout de candidat SCO.

## :rainbow: Remarques

On ne vérifie pas la bonne présence des infos CPF de naissance car on considère que les fichiers SIÈCLE sont censés être corrects.

## :100: Pour tester

- Se connecter à Pix Certif avec un compte SCO
- Ajouter à une session un candidat pour lequel le champ birthCity n'est pas renseigné
- Constater que l'ajout réussit sans message d'erreur
