### PR TITLE
[BUGFIX] Gérer un cas d'erreur lors d'un accès à une campagne SCO sur Pix App (PIX-3191).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -291,6 +291,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SchoolingRegistrationAlreadyLinkedToUserError) {
     return new HttpErrors.ConflictError(error.message, error.code, error.meta);
   }
+  if (error instanceof DomainErrors.SchoolingRegistrationAlreadyLinkedToInvalidUserError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
   if (error instanceof DomainErrors.MatchingReconciledStudentNotFoundError) {
     return new HttpErrors.BadRequestError(error.message, error.code);
   }

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -54,7 +54,6 @@ module.exports = {
         username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
         samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
         anotherStudentIsAlreadyReconciled: { shortCode: 'R70', code: 'USER_ALREADY_RECONCILED_IN_THIS_ORGANIZATION' },
-
       },
     },
     LOGIN_OR_REGISTER: {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -613,6 +613,12 @@ class SchoolingRegistrationAlreadyLinkedToUserError extends DomainError {
   }
 }
 
+class SchoolingRegistrationAlreadyLinkedToInvalidUserError extends DomainError {
+  constructor(message = 'Élève rattaché avec un compte invalide.') {
+    super(message);
+  }
+}
+
 class UserAlreadyExistsWithAuthenticationMethodError extends DomainError {
   constructor(message = 'Il existe déjà un compte qui possède cette méthode d‘authentification.') {
     super(message);
@@ -970,6 +976,7 @@ module.exports = {
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
   SchoolingRegistrationAlreadyLinkedToUserError,
+  SchoolingRegistrationAlreadyLinkedToInvalidUserError,
   SchoolingRegistrationDisabledError,
   SchoolingRegistrationNotFound,
   SchoolingRegistrationsCouldNotBeSavedError,

--- a/api/lib/domain/services/obfuscation-service.js
+++ b/api/lib/domain/services/obfuscation-service.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const authenticationMethodRepository = require('../../infrastructure/repositories/authentication-method-repository');
 const AuthenticationMethod = require('../models/AuthenticationMethod');
+const { NotFoundError } = require('../errors');
 
 const CONNEXION_TYPES = {
   username: 'username',
@@ -24,6 +25,9 @@ async function getUserAuthenticationMethodWithObfuscation(user) {
   if (user.email) {
     const email = emailObfuscation(user.email);
     return { authenticatedBy: CONNEXION_TYPES.email, value: email };
+  }
+  else {
+    throw new NotFoundError('La méthode d\'autentification trouvé n\'est ni GAR ni PIX.');
   }
 }
 

--- a/api/lib/domain/services/obfuscation-service.js
+++ b/api/lib/domain/services/obfuscation-service.js
@@ -27,7 +27,7 @@ async function getUserAuthenticationMethodWithObfuscation(user) {
     return { authenticatedBy: CONNEXION_TYPES.email, value: email };
   }
   else {
-    throw new NotFoundError('La méthode d\'autentification trouvé n\'est ni GAR ni PIX.');
+    throw new NotFoundError('Aucune méthode d\'authentification trouvée dont le fournisseur d\'identité est GAR ou PIX.');
   }
 }
 

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -2,9 +2,10 @@ const _ = require('lodash');
 const { pipe } = require('lodash/fp');
 const randomString = require('randomstring');
 const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
-
 const {
-  NotFoundError, SchoolingRegistrationAlreadyLinkedToUserError, AlreadyRegisteredUsernameError,
+  NotFoundError,
+  SchoolingRegistrationAlreadyLinkedToUserError,
+  AlreadyRegisteredUsernameError,
 } = require('../errors');
 const { areTwoStringsCloseEnough, isOneStringCloseEnoughFromMultipleStrings } = require('./string-comparison-service');
 const { normalizeAndRemoveAccents, removeSpecialCharacters } = require('./validation-treatments');

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -17,6 +17,7 @@ const {
   UserShouldChangePasswordError,
   MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError,
   UserHasAlreadyLeftSCO,
+  SchoolingRegistrationAlreadyLinkedToInvalidUserError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -292,6 +293,19 @@ describe('Unit | Application | ErrorManager', function() {
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate BadRequestError when SchoolingRegistrationAlreadyLinkedToInvalidUserError', async function() {
+      // given
+      const error = new SchoolingRegistrationAlreadyLinkedToInvalidUserError();
+      sinon.stub(HttpErrors, 'BadRequestError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
     });
   });
 

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -1,8 +1,14 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const {
+  expect,
+  sinon,
+  domainBuilder,
+  catchErr,
+} = require('../../../test-helper');
 const obfuscationService = require('../../../../lib/domain/services/obfuscation-service');
 const authenticationMethodRepository = require('../../../../lib/infrastructure/repositories/authentication-method-repository');
 const User = require('../../../../lib/domain/models/User');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Service | user-authentication-method-obfuscation-service', function() {
 
@@ -146,6 +152,18 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
         value: 'j***@example.net',
       };
       expect(value).to.be.deep.equal(expectedResult);
+    });
+
+    it('should throw NotFoundError when user authentication is neither username, email nor samlId', async function() {
+      // given
+      const user = domainBuilder.buildUser({ username: null, email: null, authenticationMethods: [] });
+
+      // when
+      const error = await catchErr(obfuscationService.getUserAuthenticationMethodWithObfuscation)(user);
+
+      // then
+      expect(error).to.be.instanceof(NotFoundError);
+      expect(error.message).to.equal('La méthode d\'autentification trouvé n\'est ni GAR ni PIX.');
     });
   });
 });

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -17,11 +17,13 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
   describe('#emailObfuscation', function() {
 
     it('should return obfuscated email', function() {
-      // Given
+      // given
       const email = 'johnHarry@example.net';
-      // When
+
+      // when
       const value = obfuscationService.emailObfuscation(email);
-      //Then
+
+      // then
       expect(value).to.be.equal('j***@example.net');
     });
 
@@ -30,11 +32,13 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
   describe('#usernameObfuscation', function() {
 
     it('should return obfuscated username', function() {
-      // Given
+      // given
       const username = 'john.harry0702';
-      // When
+
+      // when
       const value = obfuscationService.usernameObfuscation(username);
-      //Then
+
+      // then
       expect(value).to.be.equal('j***.h***2');
     });
 
@@ -43,15 +47,15 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
   describe('#getUserAuthenticationMethodWithObfuscation', function() {
 
     it('should return authenticated with samlId when user is authenticated with samlId only', async function() {
-      // Given
+      // given
       const user = domainBuilder.buildUser();
       const authenticationMethod = domainBuilder.buildAuthenticationMethod({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 
-      // When
+      // when
       const value = await obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
-      //Then
+      // then
       const expectedResult = {
         authenticatedBy: 'samlId',
         value: null,
@@ -60,16 +64,16 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     });
 
     it('should return authenticated with samlId when user is authenticated with samlId and username', async function() {
-      // Given
+      // given
       const username = 'john.harry.0702';
       const user = new User({ username });
       const authenticationMethod = domainBuilder.buildAuthenticationMethod({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 
-      // When
+      // when
       const value = await obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
-      //Then
+      // then
       const expectedResult = {
         authenticatedBy: 'samlId',
         value: null,
@@ -78,17 +82,17 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     });
 
     it('should return authenticated with samlId when user is authenticated with samlId, username and email', async function() {
-      // Given
+      // given
       const username = 'john.harry.0702';
       const email = 'john.harry@example.net';
       const user = new User({ username, email });
       const authenticationMethod = domainBuilder.buildAuthenticationMethod({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 
-      // When
+      // when
       const value = await obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
-      //Then
+      // then
       const expectedResult = {
         authenticatedBy: 'samlId',
         value: null,
@@ -97,13 +101,13 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     });
 
     it('should return authenticated with username when user is authenticated with username only', async function() {
-      // Given
+      // given
       const username = 'john.harry0702';
       const user = new User({ username });
 
-      // When
+      // when
       const value = await obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
-      //Then
+      // then
       const expectedResult = {
         authenticatedBy: 'username',
         value: 'j***.h***2',
@@ -112,15 +116,15 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     });
 
     it('should return authenticated with username when user is authenticated with username and email', async function() {
-      // Given
+      // given
       const username = 'john.harry0702';
       const email = 'john.harry@example.net';
       const user = new User({ username, email });
 
-      // When
+      // when
       const value = await obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
-      //Then
+      // then
       const expectedResult = {
         authenticatedBy: 'username',
         value: 'j***.h***2',
@@ -129,14 +133,14 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     });
 
     it('should return authenticated with username when user is authenticated with email only', async function() {
-      // Given
+      // given
       const email = 'john.harry@example.net';
       const user = new User({ email });
 
-      // When
+      // when
       const value = await obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
-      //Then
+      // then
       const expectedResult = {
         authenticatedBy: 'email',
         value: 'j***@example.net',

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -163,7 +163,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
 
       // then
       expect(error).to.be.instanceof(NotFoundError);
-      expect(error.message).to.equal('La méthode d\'autentification trouvé n\'est ni GAR ni PIX.');
+      expect(error.message).to.equal('Aucune méthode d\'authentification trouvée dont le fournisseur d\'identité est GAR ou PIX.');
     });
   });
 });

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -1,7 +1,14 @@
-const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const {
+  expect,
+  sinon,
+  domainBuilder,
+  catchErr,
+} = require('../../../test-helper');
 const userReconciliationService = require('../../../../lib/domain/services/user-reconciliation-service');
 const {
-  NotFoundError, SchoolingRegistrationAlreadyLinkedToUserError, AlreadyRegisteredUsernameError,
+  NotFoundError,
+  SchoolingRegistrationAlreadyLinkedToUserError,
+  AlreadyRegisteredUsernameError,
 } = require('../../../../lib/domain/errors');
 
 describe('Unit | Service | user-reconciliation-service', function() {
@@ -584,9 +591,15 @@ describe('Unit | Service | user-reconciliation-service', function() {
     let studentRepositoryStub;
 
     beforeEach(function() {
-      userRepositoryStub = { getForObfuscation: sinon.stub() };
-      obfuscationServiceStub = { getUserAuthenticationMethodWithObfuscation: sinon.stub() };
-      studentRepositoryStub = { getReconciledStudentByNationalStudentId: sinon.stub() };
+      userRepositoryStub = {
+        getForObfuscation: sinon.stub(),
+      };
+      obfuscationServiceStub = {
+        getUserAuthenticationMethodWithObfuscation: sinon.stub(),
+      };
+      studentRepositoryStub = {
+        getReconciledStudentByNationalStudentId: sinon.stub(),
+      };
     });
 
     context('When student is already reconciled in the same organization', function() {
@@ -608,6 +621,7 @@ describe('Unit | Service | user-reconciliation-service', function() {
           // when
           const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(schoolingRegistration, userRepositoryStub, obfuscationServiceStub, studentRepositoryStub);
 
+          // then
           expect(error).to.be.instanceof(SchoolingRegistrationAlreadyLinkedToUserError);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
           expect(error.code).to.equal('ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION');
@@ -634,6 +648,7 @@ describe('Unit | Service | user-reconciliation-service', function() {
           // when
           const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(schoolingRegistration, userRepositoryStub, obfuscationServiceStub, studentRepositoryStub);
 
+          // then
           expect(error).to.be.instanceof(SchoolingRegistrationAlreadyLinkedToUserError);
           expect(userRepositoryStub.getForObfuscation).to.have.been.calledWith(user.id);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
@@ -661,6 +676,7 @@ describe('Unit | Service | user-reconciliation-service', function() {
           // when
           const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(schoolingRegistration, userRepositoryStub, obfuscationServiceStub, studentRepositoryStub);
 
+          // then
           expect(error).to.be.instanceof(SchoolingRegistrationAlreadyLinkedToUserError);
           expect(userRepositoryStub.getForObfuscation).to.have.been.calledWith(user.id);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
@@ -692,6 +708,7 @@ describe('Unit | Service | user-reconciliation-service', function() {
           // when
           const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(schoolingRegistration, userRepositoryStub, obfuscationServiceStub, studentRepositoryStub);
 
+          // then
           expect(error).to.be.instanceof(SchoolingRegistrationAlreadyLinkedToUserError);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans un autre établissement.');
           expect(error.code).to.equal('ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION');
@@ -719,6 +736,7 @@ describe('Unit | Service | user-reconciliation-service', function() {
           // when
           const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(schoolingRegistration, userRepositoryStub, obfuscationServiceStub, studentRepositoryStub);
 
+          // then
           expect(error).to.be.instanceof(SchoolingRegistrationAlreadyLinkedToUserError);
           expect(userRepositoryStub.getForObfuscation).to.have.been.calledWith(user.id);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans un autre établissement.');
@@ -747,6 +765,7 @@ describe('Unit | Service | user-reconciliation-service', function() {
           // when
           const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(schoolingRegistration, userRepositoryStub, obfuscationServiceStub, studentRepositoryStub);
 
+          // then
           expect(error).to.be.instanceof(SchoolingRegistrationAlreadyLinkedToUserError);
           expect(userRepositoryStub.getForObfuscation).to.have.been.calledWith(user.id);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans un autre établissement.');

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -1,18 +1,18 @@
-{{!-- template-lint-disable require-input-label no-triple-curlies no-unknown-arguments-for-builtin-components --}}
-<div class="join-restricted-campaign__title">{{t 'pages.join.sco.first-title' organizationName=@organizationName}}</div>
+{{!-- template-lint-disable require-input-label --}}
+<h1 class="join-restricted-campaign__sco-title">{{t 'pages.join.sco.first-title' organizationName=@organizationName}}</h1>
 <div class="join-restricted-campaign__subtitle">{{t 'pages.join.sco.subtitle'}}</div>
 <form onSubmit={{this.submit}}>
   <div class="join-restricted-campaign__row">
-    <label class="join-restricted-campaign__label">{{t 'pages.join.fields.firstname.label'}}</label>
+    <label for="firstName" class="join-restricted-campaign__label">{{t 'pages.join.fields.firstname.label'}}</label>
     <Input
-            @id="firstName"
-            @type="text"
-            @value={{this.firstName}}
-            placeholder={{t 'pages.join.fields.firstname.label'}}
-            @readonly={{this.isDisabled}}
-            @disabled={{this.isDisabled}}
-            class={{if this.validation.firstName "input--error"}}
-            @focusOut={{ fn this.triggerInputStringValidation "firstName" this.firstName }}
+      id="firstName"
+      @type="text"
+      @value={{this.firstName}}
+      placeholder={{t 'pages.join.fields.firstname.label'}}
+      readonly={{this.isDisabled}}
+      disabled={{this.isDisabled}}
+      class={{if this.validation.firstName "input--error"}}
+      {{on "focusout" (fn this.triggerInputStringValidation "firstName" this.firstName)}}
     />
     <div class={{if this.validation.firstName "join-restricted-campaign__field-error"}} role="alert">
       {{this.validation.firstName}}
@@ -20,16 +20,16 @@
   </div>
 
   <div class="join-restricted-campaign__row">
-    <label class="join-restricted-campaign__label">{{t 'pages.join.fields.lastname.label'}}</label>
+    <label for="lastName" class="join-restricted-campaign__label">{{t 'pages.join.fields.lastname.label'}}</label>
     <Input
-            @id="lastName"
-            @type="text"
-            @value={{this.lastName}}
-            placeholder={{t 'pages.join.fields.lastname.label'}}
-            @readonly={{this.isDisabled}}
-            @disabled={{this.isDisabled}}
-            class={{if this.validation.lastName "input--error"}}
-            @focusOut={{ fn this.triggerInputStringValidation "lastName" this.lastName }}
+      id="lastName"
+      @type="text"
+      @value={{this.lastName}}
+      placeholder={{t 'pages.join.fields.lastname.label'}}
+      readonly={{this.isDisabled}}
+      disabled={{this.isDisabled}}
+      class={{if this.validation.lastName "input--error"}}
+      {{on "focusout" (fn this.triggerInputStringValidation "lastName" this.lastName)}}
     />
     <div class={{if this.validation.lastName "join-restricted-campaign__field-error"}} role="alert">
       {{this.validation.lastName}}
@@ -37,11 +37,35 @@
   </div>
 
   <div class="join-restricted-campaign__row">
-    <label class="join-restricted-campaign__label">{{t 'pages.join.fields.birthdate.label'}}</label>
+    <p class="join-restricted-campaign__label">{{t 'pages.join.fields.birthdate.label'}}</p>
     <div class="join-restricted-campaign__birthdate">
-      <Input @id="dayOfBirth" @type="text" @value={{this.dayOfBirth}} placeholder={{t 'pages.join.fields.birthdate.day-format'}} class={{if this.validation.dayOfBirth "input--error"}} @focusOut={{ fn this.triggerInputDayValidation "dayOfBirth" this.dayOfBirth }} />
-      <Input @id="monthOfBirth" @type="text" @value={{this.monthOfBirth}} placeholder={{t 'pages.join.fields.birthdate.month-format'}} class={{if this.validation.monthOfBirth "input--error"}} @focusOut={{ fn this.triggerInputMonthValidation "monthOfBirth" this.monthOfBirth }} />
-      <Input @id="yearOfBirth" @type="text" @value={{this.yearOfBirth}} placeholder={{t 'pages.join.fields.birthdate.year-format'}} class={{if this.validation.yearOfBirth "input--error"}} @focusOut={{ fn this.triggerInputYearValidation "yearOfBirth" this.yearOfBirth }} />
+      <Input
+        id="dayOfBirth"
+        @type="text"
+        @value={{this.dayOfBirth}}
+        placeholder={{t 'pages.join.fields.birthdate.day-format'}}
+        class={{if this.validation.dayOfBirth "input--error"}}
+        aria-label={{t 'pages.join.fields.birthdate.day-label'}}
+        {{on "focusout" (fn this.triggerInputDayValidation "dayOfBirth" this.dayOfBirth)}}
+      />
+      <Input
+        id="monthOfBirth"
+        @type="text"
+        @value={{this.monthOfBirth}}
+        placeholder={{t 'pages.join.fields.birthdate.month-format'}}
+        class={{if this.validation.monthOfBirth "input--error"}}
+        {{on "focusout" (fn this.triggerInputMonthValidation "monthOfBirth" this.monthOfBirth)}}
+        aria-label={{t 'pages.join.fields.birthdate.month-label'}}
+      />
+      <Input
+        id="yearOfBirth"
+        @type="text"
+        @value={{this.yearOfBirth}}
+        placeholder={{t 'pages.join.fields.birthdate.year-format'}}
+        class={{if this.validation.yearOfBirth "input--error"}}
+        {{on "focusout" (fn this.triggerInputYearValidation "yearOfBirth" this.yearOfBirth)}}
+        aria-label={{t 'pages.join.fields.birthdate.year-label'}}
+      />
     </div>
     <div class={{if this.validation.dayOfBirth "join-restricted-campaign__field-error"}} role="alert">
       {{this.validation.dayOfBirth}}
@@ -55,7 +79,7 @@
   </div>
 
   {{#if this.errorMessage}}
-    <div class="join-restricted-campaign__error" aria-live="polite">{{{this.errorMessage}}}</div>
+    <div class="join-restricted-campaign__error" aria-live="polite">{{this.errorMessage}}</div>
   {{/if}}
   <div class="join-restricted-campaign__actions">
     <PixButton @type="submit">{{t 'pages.join.button'}}</PixButton>
@@ -63,10 +87,10 @@
 </form>
 {{#if this.displayInformationModal}}
   <Routes::Campaigns::Restricted::JoinScoInformationModal
-          @campaignCode={{@campaignCode}}
-          @reconciliationError={{this.reconciliationError}}
-          @reconciliationWarning={{this.reconciliationWarning}}
-          @closeModal={{this.closeModal}}
-          @associate={{this.associate}}
+    @campaignCode={{@campaignCode}}
+    @reconciliationError={{this.reconciliationError}}
+    @reconciliationWarning={{this.reconciliationWarning}}
+    @closeModal={{this.closeModal}}
+    @associate={{this.associate}}
   />
 {{/if}}

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -218,6 +218,8 @@ export default class JoinSco extends Component {
         }
       } else if (error.status === '404') {
         this.errorMessage = this.intl.t('pages.join.sco.error-not-found', { htmlSafe: true });
+      } else if (error.status === '400') {
+        this.errorMessage = this.intl.t('pages.join.sco.invalid-reconciliation-error', { htmlSafe: true });
       } else {
         this.errorMessage = error.detail;
       }

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -35,13 +35,27 @@
     text-align: right;
   }
 
-  &__title {
+  &__title,
+  &__sco-title {
     color: $grey-100;
     font-family: $font-open-sans;
-    font-size: 2.625rem;
     font-weight: $font-light;
     text-align: center;
+  }
+
+  &__title {
+    font-size: 2.625rem;
     margin-bottom: 12px;
+  }
+
+  &__sco-title {
+    font-size: 1.5625rem;
+    margin: 30px 0 12px 0;
+
+    @include device-is('tablet') {
+      font-size: 2.625rem;
+      margin: 0 0 12px 0;
+    }
   }
 
   &__subtitle {
@@ -57,16 +71,17 @@
     font-family: $font-roboto;
     font-size: 0.938rem;
     font-weight: $font-medium;
+    margin: 0;
   }
 
   &__field-error {
-    color: $pure-orange;
+    color: $red;
     font-size: 0.875rem;
   }
 
   &__error {
     text-align: center;
-    color: $pure-orange;
+    color: $red;
     font-size: 0.938rem;
     padding: 4px 10px;
     margin: 8px 0;

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco_test.js
@@ -639,6 +639,23 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           expect(component.reconciliationError).to.be.null;
         });
       });
+
+      describe('When user has an invalid reconciliation', () => {
+
+        it('should return a bad request error and display the invalid reconciliation error message', async function() {
+          // given
+          const expectedErrorMessage = this.intl.t('pages.join.sco.invalid-reconciliation-error');
+          const error = { status: '400' };
+
+          onSubmitToReconcileStub.rejects({ errors: [error] });
+
+          // when
+          await component.actions.submit.call(component, eventStub);
+
+          // then
+          expect(component.errorMessage.string).to.equal(expectedErrorMessage);
+        });
+      });
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -754,6 +754,7 @@
         "associate": "Link",
         "continue-with-pix": "Continue with my Pix account",
         "error-not-found": "If you're a pupil '<br>' Check your information (first name, last name and date of birth) or contact a teacher.'<br><br>' If you're a teacher '<br>' Access to this customised test is not available at the moment.",
+        "invalid-reconciliation-error": "An error has occured. <br> Please contact the support.",
         "first-title": "{ organizationName }",
         "login-information-message": "The Pix account  '<b>'{ connectionMethod }'</b>' will be linked with the pupil:  '<b>'{ firstName }  { lastName }'</b>'.'<b>'If this is you, click on \"Link\". Otherwise, log out.",
         "login-information-title": "Pix account information",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -754,6 +754,7 @@
         "associate": "Associer",
         "continue-with-pix": "Continuer avec mon compte Pix",
         "error-not-found": "Vous êtes un élève ? '<br>' Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.'<br><br>' Vous êtes un enseignant ? '<br>' L‘accès à un parcours n‘est pas disponible pour le moment.",
+        "invalid-reconciliation-error": "Une erreur est survenue. <br> Veuillez contacter le support.",
         "first-title": "Rejoignez l'organisation { organizationName }",
         "login-information-message": "Le compte Pix '<b>'{ connectionMethod }'</b>' va être associé à l'élève: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'S’il s’agit bien de vous, cliquez sur \"Associer\", sinon déconnectez-vous.",
         "login-information-title": "Information de connexion",


### PR DESCRIPTION
## :unicorn: Problème
Le 14 septembre 2020, les captains nous remontent des 500 causées par des tentatives d'accès à une campagne SCO sur Pix App.
https://1024pix.slack.com/archives/C01RL0T8J7R/p1632218164000300
Après avoir rempli sa date de naissance et validé, l'élève obtenait un message d'erreur `[Object object]`.

 
<img width="539" alt="Capture d’écran 2021-09-21 à 11 50 31" src="https://user-images.githubusercontent.com/58915422/134312550-24c508a4-b56d-409c-9465-fdc84eca06c3.png">

L'élève était rattaché à un compte ne disposant pas de méthode de connexion. Nous n'avions pas géré ce cas de figure, causant une erreur 500.

## :robot: Solution
Renvoyer une erreur 400, en indiquant de contacter le support.

## 🖐👁👂 Accessibilité

Ajout d'un h1 sur la page, d'aria-label pour les champs et changement de la couleur des messages d'erreur ( problème de contraste ).

## :100: Pour tester
En local : 
- Sur Pix App, passer la campagne "SIMPLIFIE", vous obtiendrez dans la table users une entrée d'un compte "anonyme"
- Choisir un seed ayant un `schooling-registration` (ex : user gar 07 01 2002 ) et lui rattacher le userId du compte "anonyme".
- Lancer le faux GAR `http://localhost:7000/`
- Mettre un samlID au hasard puis nom et prénom 
<img width="629" alt="Capture d’écran 2021-09-23 à 14 33 14" src="https://user-images.githubusercontent.com/58915422/134507336-79f60519-0de3-4177-bc3c-ec225aa88d60.png">

- campagne `BADGES123`
- mettre la date de naissance et obtenir le message d'erreur suivant : `Une erreur est survenue. Veuillez contacter le support.`


