### PR TITLE
[FEATURE] Permettre la création de résultat thématique depuis Pix Admin 1/2 (PIX-3480).

### DIFF
--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -217,6 +217,40 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'POST',
+      path: '/api/admin/target-profiles/{id}/badges',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.targetProfileId,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                key: Joi.string().required(),
+                'alt-message': Joi.string().required(),
+                'image-url': Joi.string().required(),
+                message: Joi.string().required(),
+                title: Joi.string().required(),
+                'is-certifiable': Joi.boolean().required(),
+                'is-always-visible': Joi.boolean().required(),
+              }).required(),
+            }).required(),
+          }).required(),
+        },
+        handler: targetProfileController.createBadge,
+        tags: ['api', 'badges'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de créer un résultat thématique rattaché au profil cible.',
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/admin/target-profiles/{id}/badges',
       config: {

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -5,6 +5,7 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils'
 const organizationSerializer = require('../../infrastructure/serializers/jsonapi/organization-serializer');
 const badgeSerializer = require('../../infrastructure/serializers/jsonapi/badge-serializer');
 const stageSerializer = require('../../infrastructure/serializers/jsonapi/stage-serializer');
+
 module.exports = {
 
   async findPaginatedFilteredTargetProfiles(request) {
@@ -76,5 +77,14 @@ module.exports = {
 
     const stages = await usecases.findTargetProfileStages({ targetProfileId });
     return stageSerializer.serialize(stages);
+  },
+
+  async createBadge(request, h) {
+    const targetProfileId = request.params.id;
+    const badge = badgeSerializer.deserialize(request.payload);
+
+    const createdBadge = await usecases.createBadge({ targetProfileId, badge });
+
+    return h.response(badgeSerializer.serialize(createdBadge)).created();
   },
 };

--- a/api/lib/domain/usecases/create-badge.js
+++ b/api/lib/domain/usecases/create-badge.js
@@ -1,0 +1,6 @@
+module.exports = async function createBadge({ targetProfileId, badge, badgeRepository, targetProfileRepository }) {
+  await targetProfileRepository.get(targetProfileId);
+  await badgeRepository.isKeyAvailable(badge.key);
+
+  return badgeRepository.save(badge);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -157,6 +157,7 @@ module.exports = injectDependencies({
   correctAnswerThenUpdateAssessment: require('./correct-answer-then-update-assessment'),
   correctCandidateIdentityInCertificationCourse: require('./correct-candidate-identity-in-certification-course'),
   createAndReconcileUserToSchoolingRegistration: require('./create-and-reconcile-user-to-schooling-registration'),
+  createBadge: require('./create-badge'),
   createCampaign: require('./create-campaign'),
   createCertificationCenterMembership: require('./create-certification-center-membership'),
   createCertificationCenterMembershipByEmail: require('./create-certification-center-membership-by-email'),

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -1,5 +1,10 @@
+const { knex } = require('../bookshelf');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const BookshelfBadge = require('../orm-models/Badge');
+const Badge = require('../../domain/models/Badge');
+const omit = require('lodash/omit');
+const bookshelfUtils = require('../utils/knex-utils');
+const { AlreadyExistingEntityError } = require('../../domain/errors');
 
 module.exports = {
 
@@ -60,4 +65,23 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfBadge, bookshelfBadge);
   },
 
+  async save(badge) {
+    try {
+      const [savedBadge] = await knex('badges').insert(_adaptModelToDb(badge)).returning('*');
+      return new Badge(savedBadge);
+    } catch (err) {
+      if (bookshelfUtils.isUniqConstraintViolated(err)) {
+        throw new AlreadyExistingEntityError(`The badge key ${badge.key} already exists`);
+      }
+      throw err;
+    }
+  },
 };
+
+function _adaptModelToDb(badge) {
+  return omit(badge, [
+    'id',
+    'badgeCriteria',
+    'badgePartnerCompetences',
+  ]);
+}

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -6,6 +6,8 @@ const omit = require('lodash/omit');
 const bookshelfUtils = require('../utils/knex-utils');
 const { AlreadyExistingEntityError } = require('../../domain/errors');
 
+const TABLE_NAME = 'badges';
+
 module.exports = {
 
   findByTargetProfileId(targetProfileId) {
@@ -67,7 +69,7 @@ module.exports = {
 
   async save(badge) {
     try {
-      const [savedBadge] = await knex('badges').insert(_adaptModelToDb(badge)).returning('*');
+      const [savedBadge] = await knex(TABLE_NAME).insert(_adaptModelToDb(badge)).returning('*');
       return new Badge(savedBadge);
     } catch (err) {
       if (bookshelfUtils.isUniqConstraintViolated(err)) {
@@ -75,6 +77,14 @@ module.exports = {
       }
       throw err;
     }
+  },
+
+  async isKeyAvailable(key) {
+    const result = await knex(TABLE_NAME).select('key').where('key', key);
+    if (result.length) {
+      throw new AlreadyExistingEntityError(`The badge key ${key} already exists`);
+    }
+    return true;
   },
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -7,4 +7,16 @@ module.exports = {
       attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable', 'isAlwaysVisible'],
     }).serialize(badge);
   },
+
+  deserialize(json) {
+    return {
+      key: json.data.attributes['key'],
+      altMessage: json.data.attributes['alt-message'],
+      imageUrl: json.data.attributes['image-url'],
+      message: json.data.attributes['message'],
+      title: json.data.attributes['title'],
+      isCertifiable: json.data.attributes['is-certifiable'],
+      isAlwaysVisible: json.data.attributes['is-always-visible'],
+    };
+  },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize(badge = {}) {
     return new Serializer('badge', {
       ref: 'id',
-      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable'],
+      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable', 'isAlwaysVisible'],
     }).serialize(badge);
   },
 };

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -340,6 +340,7 @@ describe('Acceptance | Controller | target-profile-controller', function() {
         attributes: {
           'alt-message': badge.altMessage,
           'is-certifiable': false,
+          'is-always-visible': false,
           'image-url': badge.imageUrl,
           'key': badge.key,
           'message': badge.message,

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -425,4 +425,32 @@ describe('Integration | Repository | Badge', function() {
       });
     });
   });
+
+  describe('#isKeyAvailable', function() {
+    it('should return true', async function() {
+      // given
+      const key = 'NOT_EXISTING_KEY';
+
+      // when
+      const result = await badgeRepository.isKeyAvailable(key);
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    describe('when key is already exists', function() {
+      it('should return AlreadyExistEntityError', async function() {
+        // given
+        const key = 'AN_EXISTING_KEY';
+        databaseBuilder.factory.buildBadge({ key });
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(badgeRepository.isKeyAvailable)(key);
+
+        // then
+        expect(error).to.instanceOf(AlreadyExistingEntityError);
+      });
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -3,6 +3,7 @@ const badgeRepository = require('../../../../lib/infrastructure/repositories/bad
 const Badge = require('../../../../lib/domain/models/Badge');
 const BadgeCriterion = require('../../../../lib/domain/models/BadgeCriterion');
 const BadgePartnerCompetence = require('../../../../lib/domain/models/BadgePartnerCompetence');
+const omit = require('lodash/omit');
 
 describe('Integration | Repository | Badge', function() {
 
@@ -31,7 +32,6 @@ describe('Integration | Repository | Badge', function() {
     targetProfileWithPartnerCompetences = databaseBuilder.factory.buildTargetProfile();
 
     badgeWithBadgePartnerCompetences = databaseBuilder.factory.buildBadge({
-      id: 2,
       altMessage: 'You won the Toto badge!',
       imageUrl: '/img/toto.svg',
       message: 'Congrats, you won the Toto badge!',
@@ -67,7 +67,6 @@ describe('Integration | Repository | Badge', function() {
     targetProfileWithSeveralBadges = databaseBuilder.factory.buildTargetProfile();
 
     badgeWithSameTargetProfile_1 = databaseBuilder.factory.buildBadge({
-      id: 3,
       altMessage: 'You won the YELLOW badge!',
       imageUrl: '/img/toto.svg',
       message: 'Congrats, you won the yellow badge!',
@@ -83,7 +82,6 @@ describe('Integration | Repository | Badge', function() {
     databaseBuilder.factory.buildBadgeCriterion({ ...badgeCriterionForBadgeWithSameTargetProfile_1, badgeId: badgeWithSameTargetProfile_1.id });
 
     badgeWithSameTargetProfile_2 = databaseBuilder.factory.buildBadge({
-      id: 4,
       altMessage: 'You won the GREEN badge!',
       imageUrl: '/img/toto.svg',
       message: 'Congrats, you won the green badge!',
@@ -99,10 +97,10 @@ describe('Integration | Repository | Badge', function() {
     databaseBuilder.factory.buildBadgeCriterion({ ...badgeCriterionForBadgeWithSameTargetProfile_2, badgeId: badgeWithSameTargetProfile_2.id });
   }
 
-  afterEach(function() {
-    knex('badges').delete();
-    knex('badge-criteria').delete();
-    return knex('badge-partner-competences').delete();
+  afterEach(async function() {
+    await knex('badge-partner-competences').delete();
+    await knex('badge-criteria').delete();
+    await knex('badges').delete();
   });
 
   describe('#findByTargetProfileId', function() {
@@ -117,19 +115,19 @@ describe('Integration | Repository | Badge', function() {
       expect(badges.length).to.equal(2);
 
       const firstBadge = badges.find(({ id }) => id === badgeWithSameTargetProfile_1.id);
-      expect(firstBadge).deep.equal({
+      expect(omit(firstBadge, 'id')).deep.equal(omit({
         ...badgeWithSameTargetProfile_1,
         badgeCriteria: [badgeCriterionForBadgeWithSameTargetProfile_1],
         badgePartnerCompetences: [],
-      });
+      }, 'id'));
 
       const secondBadge = badges.find(({ id }) => id === badgeWithSameTargetProfile_2.id);
-      expect(secondBadge).deep.equal(
+      expect(omit(secondBadge, 'id')).deep.equal(omit(
         {
           ...badgeWithSameTargetProfile_2,
           badgeCriteria: [badgeCriterionForBadgeWithSameTargetProfile_2],
           badgePartnerCompetences: [],
-        });
+        }, 'id'));
 
     });
 
@@ -375,5 +373,4 @@ describe('Integration | Repository | Badge', function() {
       expect(myBadge.badgePartnerCompetences.length).to.equal(1);
     });
   });
-
 });

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -561,4 +561,85 @@ describe('Integration | Application | Target Profiles | Routes', function() {
 
   });
 
+  describe('POST /api/target-profiles/{id}/badges', function() {
+    it('should return 201 HTTP response', async function() {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(targetProfileController, 'createBadge').callsFake((request, h) => h.response('ok').code(201));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'POST';
+      const payload = {
+        data: {
+          attributes: {
+            key: 'KEY',
+            'alt-message': 'alt-message',
+            'image-url': 'https://example.net/image.svg',
+            message: 'message',
+            title: 'title',
+            'is-certifiable': false,
+            'is-always-visible': true,
+          },
+        },
+      };
+      const url = '/api/admin/target-profiles/123/badges';
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+
+    describe('when user does not have a Pix Master role', function() {
+      it('should return a 403 HTTP response', async function() {
+        // given
+        sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'POST';
+        const payload = {
+          data: {
+            attributes: {
+              key: 'KEY',
+              'alt-message': 'alt-message',
+              'image-url': 'https://example.net/image.svg',
+              message: 'message',
+              title: 'title',
+              'is-certifiable': false,
+              'is-always-visible': true,
+            },
+          },
+        };
+        const url = '/api/admin/target-profiles/123/badges';
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('when request payload has wrong format', function() {
+      it('should return a 400 HTTP response', async function() {
+        // given
+        sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'POST';
+        const payload = { data: { attributes: { } } };
+        const url = '/api/admin/target-profiles/123/badges';
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/create-badge_test.js
+++ b/api/tests/unit/domain/usecases/create-badge_test.js
@@ -1,0 +1,54 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const createBadge = require('../../../../lib/domain/usecases/create-badge');
+const { AlreadyExistingEntityError, NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | create-badge', function() {
+
+  it('should call the badge repository to persist badge', async function() {
+    // given
+    const targetProfileId = 1;
+    const badgeCreated = Symbol('created-badge');
+    const targetProfileRepository = { get: sinon.stub().resolves({ id: targetProfileId }) };
+    const badgeRepository = { isKeyAvailable: sinon.stub().resolves(true), save: sinon.stub().resolves(badgeCreated) };
+    const badge = { title: 'My badge' };
+
+    // when
+    const result = await createBadge({ targetProfileId, badge, badgeRepository, targetProfileRepository });
+
+    // then
+    expect(badgeRepository.save).to.have.been.calledWith(badge);
+    expect(result).to.equal(badgeCreated);
+  });
+
+  describe('when targetProfile not exist', function() {
+    it('should throw an error', async function() {
+      // given
+      const targetProfileId = 1;
+      const badge = {};
+      const targetProfileRepository = { get: sinon.stub().throws(new NotFoundError()) };
+      const badgeRepository = { save: sinon.stub() };
+
+      // when
+      const error = await catchErr(createBadge)({ targetProfileId, badge, badgeRepository, targetProfileRepository });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  describe('when badge key is already used', function() {
+    it('should throw an AlreadyExistingEntityError', async function() {
+      // given
+      const targetProfileId = 1;
+      const badge = {};
+      const targetProfileRepository = { get: sinon.stub().resolves({ id: 1 }) };
+      const badgeRepository = { isKeyAvailable: sinon.stub().throws(new AlreadyExistingEntityError()) };
+
+      // when
+      const error = await catchErr(createBadge)({ targetProfileId, badge, badgeRepository, targetProfileRepository });
+
+      // then
+      expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -129,4 +129,38 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
     });
   });
 
+  describe('#deserialize', function() {
+    it('should convert JSON API data into a Badge model object', function() {
+      // given
+      const jsonBadge = {
+        data: {
+          type: 'badges',
+          attributes: {
+            key: 'BADGE_KEY',
+            'alt-message': 'alt-message',
+            'image-url': 'https://example.net/image.svg',
+            message: 'message',
+            title: 'title',
+            'is-certifiable': false,
+            'is-always-visible': true,
+          },
+        },
+      };
+
+      // when
+      const badge = serializer.deserialize(jsonBadge);
+
+      // then
+      const expectedBadge = {
+        key: 'BADGE_KEY',
+        altMessage: 'alt-message',
+        imageUrl: 'https://example.net/image.svg',
+        message: 'message',
+        title: 'title',
+        isCertifiable: false,
+        isAlwaysVisible: true,
+      };
+      expect(badge).to.deep.equal(expectedBadge);
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
         title: 'Banana',
         targetProfileId: '1',
         isCertifiable: false,
+        isAlwaysVisible: true,
         badgeCriteria: [
           domainBuilder.buildBadgeCriterion({ partnerCompetenceIds: null }),
         ],
@@ -29,6 +30,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
             'alt-message': 'You won a banana badge',
             'image-url': '/img/banana.svg',
             'is-certifiable': false,
+            'is-always-visible': true,
             message: 'Congrats, you won a banana badge',
             title: 'Banana',
             key: 'BANANA',
@@ -56,6 +58,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
         title: 'Banana',
         targetProfileId: '1',
         isCertifiable: false,
+        isAlwaysVisible: true,
       });
 
       const expectedSerializedBadge = {
@@ -64,6 +67,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
             'alt-message': 'You won a banana badge',
             'image-url': '/img/banana.svg',
             'is-certifiable': false,
+            'is-always-visible': true,
             message: 'Congrats, you won a banana badge',
             title: 'Banana',
             key: 'BANANA',
@@ -91,6 +95,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
         title: 'Banana',
         targetProfileId: '1',
         isCertifiable: false,
+        isAlwaysVisible: true,
         badgeCriteria: [
           domainBuilder.buildBadgeCriterion({
             scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
@@ -106,6 +111,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
             'alt-message': 'You won a banana badge',
             'image-url': '/img/banana.svg',
             'is-certifiable': false,
+            'is-always-visible': true,
             message: 'Congrats, you won a banana badge',
             title: 'Banana',
             key: 'BANANA',


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le processus de création de badges est fastidieux pour les équipes de Pix. 
En effet, un ticket sur un board Trello est créé avec les informations du badge puis le PO de la team expérience d'évaluation fait des manipulations sur la base de données. 
Cela pose plusieurs problèmes, car on touche directement à la base de données et c'est sujet aux erreurs. 

## :robot: Solution
Permettre de créer un badge depuis un profil cible directement depuis Pix Admin. 
Ce ticket est le premier d'une série, il ajoute un endpoint : `POST /api/admin/target-profiles/{id}/badges`, permettant de créer un badge avec les informations de base. 

## :rainbow: Remarques
Les nouvelles méthodes de repository ont été écrites en utilisant directement `knex` comme nous souhaitons retirer notre ORM (cf: [ADR Remplacer ORM Bookshelf](https://github.com/1024pix/pix/blob/dev/docs/adr/0028-remplacer-orm-bookshelfjs-par-query-builder-knexjs.md)) 

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
