### PR TITLE
[BUGFIX] Le reload de la page ne doit pas faire oublié qu'on a défocus (PIX-3506).

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -131,7 +131,7 @@ async function _getChallenge(assessment, request) {
   const challenge = await _getChallengeByAssessmentType({ assessment, request });
 
   if (challenge) {
-    if (challenge.id !== assessment.currentChallengeId) {
+    if (challenge.id !== assessment.lastChallengeId) {
       await assessmentRepository.updateWhenNewChallengeIsAsked({ id: assessment.id, lastChallengeId: challenge.id });
     }
   }


### PR DESCRIPTION
## :unicorn: Problème
Si on rechargeait plusieurs fois une page d'une épreuve focus alors qu'on a perdu le focus, ça pouvait revenir à zéro.
Cela venait d'une erreur de typo.

## :robot: Solution
- Corriger l'erreur
- Ajouter des tests

## :rainbow: Remarques

## :100: Pour tester
Passer une épreuve focus, dans la démo recBCwxarnE8QntZr