### PR TITLE
[FEATURE] Réutiliser le champ résultat pour les exports CSV des deux campagnes (PIX-3066).

### DIFF
--- a/api/lib/domain/read-models/CampaignParticipationInfo.js
+++ b/api/lib/domain/read-models/CampaignParticipationInfo.js
@@ -13,6 +13,7 @@ const validationSchema = Joi.object({
   createdAt: Joi.date().required(),
   sharedAt: Joi.date().required().allow(null),
   division: Joi.string().allow(null).optional(),
+  masteryPercentage: Joi.number().required().allow(null),
 });
 
 class CampaignParticipationInfo {
@@ -28,6 +29,7 @@ class CampaignParticipationInfo {
     createdAt,
     sharedAt,
     division,
+    masteryPercentage,
   } = {}) {
     this.participantFirstName = participantFirstName;
     this.participantLastName = participantLastName;
@@ -39,6 +41,7 @@ class CampaignParticipationInfo {
     this.createdAt = createdAt;
     this.sharedAt = sharedAt;
     this.division = division;
+    this.masteryPercentage = Number(masteryPercentage);
 
     validateEntity(validationSchema, this);
   }

--- a/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -72,10 +72,7 @@ class CampaignProfilesCollectionResultLine {
   _getTotalEarnedPixColumn() {
     let totalEarnedPix = this.notShared;
     if (this.campaignParticipationResult.isShared) {
-      totalEarnedPix = 0;
-      this.placementProfile.userCompetences.forEach(({ pixScore }) => {
-        totalEarnedPix += pixScore;
-      });
+      totalEarnedPix = this.campaignParticipationResult.pixScore;
     }
 
     return totalEarnedPix;

--- a/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
@@ -48,5 +48,6 @@ function _rowToCampaignParticipationInfo(row) {
     createdAt: new Date(row.createdAt),
     sharedAt: row.sharedAt ? new Date(row.sharedAt) : null,
     division: row.division,
+    masteryPercentage: row.masteryPercentage,
   });
 }

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -348,6 +348,7 @@ function _rowToResult(row) {
     participantFirstName: row.firstName,
     participantLastName: row.lastName,
     division: row.division,
+    pixScore: row.pixScore,
   };
 }
 

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -99,7 +99,7 @@ class CampaignAssessmentCsvLine {
       this.campaignParticipationInfo.isShared ? moment.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD') : this.emptyContent,
       ...(this.targetProfileWithLearningContent.hasReachableStages() ? [this._getReachedStage()] : []),
       ...(this.campaignParticipationInfo.isShared ? this._makeBadgesColumns() : this._makeEmptyColumns(this.targetProfileWithLearningContent.badges.length)),
-      this.campaignParticipationInfo.isShared ? this._percentageSkillsValidated() : this.emptyContent,
+      this.campaignParticipationInfo.isShared ? this.campaignParticipationInfo.masteryPercentage : this.emptyContent,
     ];
   }
 
@@ -143,25 +143,14 @@ class CampaignAssessmentCsvLine {
       .length;
   }
 
-  _countValidatedKnowledgeElements() {
-    return _.sum(_.map(this.targetedKnowledgeElementsByCompetence, (knowledgeElements) => {
-      return knowledgeElements.filter((knowledgeElement) => knowledgeElement.isValidated)
-        .length;
-    }));
-  }
-
-  _percentageSkillsValidated() {
-    return _.round(this._countValidatedKnowledgeElements() / this.targetProfileWithLearningContent.skills.length, 2);
-  }
-
   _getReachedStage() {
     if (!this.campaignParticipationInfo.isShared) {
       return this.emptyContent;
     }
 
-    const percentageSkillsValidated = this._percentageSkillsValidated() * 100;
+    const masteryPercentage = this.campaignParticipationInfo.masteryPercentage * 100;
 
-    return this.targetProfileWithLearningContent.reachableStages.filter((stage) => percentageSkillsValidated >= stage.threshold).length;
+    return this.targetProfileWithLearningContent.reachableStages.filter((stage) => masteryPercentage >= stage.threshold).length;
   }
 
   get _studentNumber() {

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -95,6 +95,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         campaignId: campaign.id,
         isShared: true,
         userId: participant.id,
+        masteryPercentage: 0.67,
       });
       databaseBuilder.factory.buildAssessment({
         campaignParticipationId: campaignParticipation.id,

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -144,6 +144,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           campaignId: campaign.id,
           isShared: true,
           userId: participant.id,
+          pixScore: 52,
         });
 
         await databaseBuilder.commit();
@@ -217,6 +218,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           campaignId: campaign.id,
           isShared: true,
           userId: participant.id,
+          pixScore: 52,
         });
 
         await databaseBuilder.commit();
@@ -291,6 +293,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           campaignId: campaign.id,
           isShared: true,
           userId: participant.id,
+          pixScore: 52,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -59,6 +59,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
             userId: campaignParticipation1.userId,
             campaignParticipationId: campaignParticipation1.id,
             isCompleted: false,
+            masteryPercentage: 0,
             participantFirstName: 'First',
             participantLastName: 'Last',
             studentNumber: null,
@@ -69,7 +70,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
       });
     });
 
-    context('when there are several participant', function() {
+    context('when there are several participants', function() {
       let campaign;
       let campaignParticipation1;
       let campaignParticipation2;
@@ -122,6 +123,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           userId: campaignParticipation1.userId,
           campaignParticipationId: campaignParticipation1.id,
           isCompleted: false,
+          masteryPercentage: 0,
           participantFirstName: 'The',
           participantLastName: 'Narrator',
           studentNumber: null,
@@ -136,6 +138,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           userId: campaignParticipation2.userId,
           campaignParticipationId: campaignParticipation2.id,
           isCompleted: true,
+          masteryPercentage: 0,
           participantFirstName: 'Tyler',
           participantLastName: 'Durden',
           studentNumber: null,
@@ -189,6 +192,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           userId: campaignParticipation.userId,
           campaignParticipationId: campaignParticipation.id,
           isCompleted: true,
+          masteryPercentage: 0,
           participantFirstName: 'The',
           participantLastName: 'Narrator',
           studentNumber: null,
@@ -251,6 +255,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           userId: campaignParticipation2.userId,
           campaignParticipationId: campaignParticipation2.id,
           isCompleted: true,
+          masteryPercentage: 0,
           participantFirstName: 'The',
           participantLastName: 'Narrator',
           studentNumber: null,

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-info.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-info.js
@@ -11,6 +11,7 @@ function buildCampaignParticipationInfo({
   createdAt = new Date('2020-01-01'),
   sharedAt = new Date('2020-02-02'),
   division,
+  masteryPercentage = 1,
 } = {}) {
   return new CampaignParticipationInfo({
     participantFirstName,
@@ -23,6 +24,7 @@ function buildCampaignParticipationInfo({
     createdAt,
     sharedAt,
     division,
+    masteryPercentage,
   });
 }
 

--- a/api/tests/unit/domain/read-models/CampaignParticipationInfo_test.js
+++ b/api/tests/unit/domain/read-models/CampaignParticipationInfo_test.js
@@ -17,6 +17,7 @@ describe('Unit | Domain | Read-models | CampaignParticipationInfo', function() {
         isCompleted: true,
         createdAt: new Date('2019-04-01'),
         sharedAt: new Date('2019-05-01'),
+        masteryPercentage: 1,
       };
     });
 
@@ -131,6 +132,7 @@ describe('Unit | Domain | Read-models | CampaignParticipationInfo', function() {
         campaignParticipationId: 999,
         isCompleted: true,
         createdAt: new Date('2019-04-01'),
+        masteryPercentage: 1,
       };
     });
 

--- a/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
+++ b/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
@@ -65,6 +65,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           userId: 123,
           participantFirstName: 'Juan',
           participantLastName: 'Carlitos',
+          pixScore: 13,
         };
 
         const csvExcpectedLine = `"${organization.name}";` +
@@ -108,6 +109,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           userId: 123,
           participantFirstName: 'Juan',
           participantLastName: 'Carlitos',
+          pixScore: 13,
         };
 
         const csvExcpectedLine = `"${organization.name}";` +
@@ -257,6 +259,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           participantLastName: 'Carlitos',
           division: '5me',
           studentNumber: 'studentNumber',
+          pixScore: 13,
         };
 
         const csvExcpectedLine = `"${organization.name}";` +
@@ -309,6 +312,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
             division: null,
+            pixScore: 13,
           };
 
           const csvExcpectedLine = `"${organization.name}";` +
@@ -356,6 +360,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
             division: '3eme',
+            pixScore: 13,
           };
 
           const csvExcpectedLine = `"${organization.name}";` +
@@ -466,6 +471,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
             studentNumber: null,
+            pixScore: 13,
           };
 
           const csvExcpectedLine = `"${organization.name}";` +
@@ -513,6 +519,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             participantFirstName: 'Juan',
             participantLastName: 'Carlitos',
             studentNumber: 'HELLO123',
+            pixScore: 13,
           };
 
           const csvExcpectedLine = `"${organization.name}";` +
@@ -597,4 +604,3 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
   });
 
 });
-

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -771,7 +771,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function()
             // given
             const organization = domainBuilder.buildOrganization();
             const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
-            const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
+            const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01'), masteryPercentage: 0.7 });
             const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
             const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
             const skill3 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_3', tubeId: 'recTube1' });
@@ -795,20 +795,8 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function()
               skillId: skill1.id,
               competenceId: competence.id,
             });
-            const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
-              status: KnowledgeElement.StatusType.VALIDATED,
-              earnedPix: 2,
-              skillId: skill2.id,
-              competenceId: competence.id,
-            });
-            const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
-              status: KnowledgeElement.StatusType.INVALIDATED,
-              earnedPix: 4,
-              skillId: skill3.id,
-              competenceId: competence.id,
-            });
             const participantKnowledgeElementsByCompetenceId = {
-              'recCompetence1': [knowledgeElement1, knowledgeElement2, knowledgeElement3],
+              'recCompetence1': [knowledgeElement1],
             };
             const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
               organization,


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que nous avons pré-calculé et stocker le score nous pouvons le remplacer dans tous les écrans de pix orga. 

## :robot: Solution
Changer le PixScore et MasteryRate pour les deux exports csv (se baser sur les nouvelles colonnes)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
