### PR TITLE
[BUGFIX] Améliorer le style de la tooltip d'explication du score Pix (PIX-3482).

### DIFF
--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -1,12 +1,8 @@
-import { action } from '@ember/object';
 import { isNone } from '@ember/utils';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import ENV from 'mon-pix/config/environment';
 
 export default class HexagonScore extends Component {
-  @tracked displayHelp = false;
-
   get score() {
     const score = this.args.pixScore;
     return (isNone(score) || score === 0) ? '–' : Math.floor(score);
@@ -18,20 +14,5 @@ export default class HexagonScore extends Component {
 
   get maxReachableLevel() {
     return ENV.APP.MAX_REACHABLE_LEVEL;
-  }
-
-  @action
-  hideHelp() {
-    this.displayHelp = false;
-  }
-
-  @action
-  showHelp() {
-    this.displayHelp = true;
-  }
-
-  @action
-  toggleTooltip() {
-    this.displayHelp = !this.displayHelp;
   }
 }

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -71,15 +71,11 @@
   border-radius: 3px;
   z-index: 300;
   width: 300px;
-  padding: 20px 36px;
+  padding: 32px;
   margin: 150px 0 0 -80px;
-  letter-spacing: 0.12rem;
-  word-spacing: 0.16rem;
 
   @include device-is('large-screen') {
-    height: 270px;
     width: 587px;
-    padding: 20px 36px;
     margin: 135px 0 0 -520px;
   }
 
@@ -102,7 +98,7 @@
 
   p {
     margin-top: 0;
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
 
     &:last-child {
       margin-bottom: 0;
@@ -113,7 +109,7 @@
 .hexagon-score-information__text {
   font-family: $font-open-sans;
   font-size: 1rem;
-  line-height: 1.5rem;
+  line-height: 1.6rem;
   display: block;
 
   &--strong {

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -65,36 +65,7 @@
 }
 
 .hexagon-score__information {
-  position: absolute;
-  background-color: $white;
-  box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.2);
-  border-radius: 3px;
-  z-index: 300;
-  width: 300px;
-  padding: 32px;
-  margin: 150px 0 0 -80px;
-
-  @include device-is('large-screen') {
-    width: 587px;
-    margin: 135px 0 0 -520px;
-  }
-
-  &::before {
-    content: '';
-    position: absolute;
-    width: 0;
-    height: 0;
-    top: -17px;
-    right: 130px;
-    border-bottom: 20px solid white;
-    border-left: 20px solid transparent;
-    border-right: 20px solid transparent;
-
-    @include device-is('large-screen') {
-      right: 0;
-      border-right: none;
-    }
-  }
+  padding: 24px 16px;
 
   p {
     margin-top: 0;
@@ -128,11 +99,6 @@
   }
 }
 
-.pix-button.hexagon-score-content-pix-total__button {
+hexagon-score-content-pix-total__icon {
   padding: 0 0 0 4px;
-  border: none;
-
-  &:hover {
-    background-color: transparent;
-  }
 }

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -1,31 +1,26 @@
-<div class="hexagon-score"
-  {{on 'mouseenter' this.showHelp}}
-  {{on 'mouseleave' this.hideHelp}}>
-  <div class="hexagon-score__content">
-    <div class="hexagon-score-content__title">{{t 'common.pix'}}</div>
-    <div class="hexagon-score-content__pix-score">{{this.score}}</div>
-    <div class="hexagon-score-content__pix-total">
-      1024
-      <PixButton
-        aria-label={{t 'pages.profile.total-score-helper.title'}}
-        @backgroundColor="transparent-light"
-        @triggerAction={{this.toggleTooltip}}
-        {{on 'focusout' this.hideHelp}}
-        aria-describedby="hexagon-score-tooltip"
-        class="hexagon-score-content-pix-total__button"
-      >
-        <FaIcon @icon="info-circle"/>
-      </PixButton>
+<PixTooltip
+  @text="<div class='hexagon-score__information hexagon-score-information__text'>
+          <p class='hexagon-score-information__text--strong'>
+            {{t 'pages.profile.total-score-helper.title'}}
+          </p>
+          {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}
+         </div>
+        "
+  @isLight={{true}}
+  @isWide={{true}}
+  @position="bottom"
+  @unescapeHtml={{true}}
+>
+  <div class="hexagon-score" tabindex="0">
+    <div class="hexagon-score__content">
+      <div class="hexagon-score-content__title">{{t 'common.pix'}}</div>
+      <div class="hexagon-score-content__pix-score">{{this.score}}</div>
+      <div class="hexagon-score-content__pix-total">
+        1024
+          <div class="hexagon-score-content-pix-total__icon">
+            <FaIcon @icon="info-circle"/>
+          </div>
+      </div>
     </div>
   </div>
-
-  {{#if this.displayHelp}}
-    <div role="tooltip"
-         id="hexagon-score-tooltip"
-         class="hexagon-score__information hexagon-score-information__text"
-         {{on-key 'Escape' this.hideHelp event='keyup'}}>
-      <p class="hexagon-score-information__text--strong">{{t 'pages.profile.total-score-helper.title'}}</p>
-      {{t 'pages.profile.total-score-helper.explanation' maxReachablePixCount=this.maxReachablePixCount maxReachableLevel=this.maxReachableLevel htmlSafe=true}}
-    </div>
-  {{/if}}
-</div>
+</PixTooltip>

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -1,13 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, find, render, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | hexagon-score', function() {
   setupIntlRenderingTest();
-
-  const buttonClass = '.hexagon-score-content-pix-total__button';
 
   describe('Component rendering', function() {
 
@@ -35,84 +33,6 @@ describe('Integration | Component | hexagon-score', function() {
       await render(hbs`<HexagonScore @pixScore={{this.pixScore}} />`);
       // then
       expect(this.element.querySelector('.hexagon-score-content__pix-score').innerHTML).to.equal(pixScore);
-    });
-  });
-
-  describe('Tooltip behaviour', () => {
-    const tooltip = '.hexagon-score__information';
-
-    beforeEach(async () => {
-      await render(hbs`<HexagonScore />`);
-      expect(find(tooltip)).not.to.exist;
-    });
-
-    describe('on click', () => {
-      it('should display tooltip on click when tooltip is hidden', async function() {
-        // when
-        await click(buttonClass);
-
-        // then
-        expect(find(tooltip)).to.exist;
-      });
-
-      it('should hide tooltip on click when tooltip is displayed', async function() {
-        // when
-        await click(buttonClass);
-        await click(buttonClass);
-
-        // then
-        expect(find(tooltip)).not.to.exist;
-      });
-    });
-
-    describe('on hover', () => {
-
-      it('should display tooltip when mouse enters the score hexagon', async function() {
-        // when
-        await triggerEvent('.hexagon-score', 'mouseenter');
-
-        // then
-        expect(find(tooltip)).to.exist;
-      });
-
-      it('should hide tooltip when mouse leaves the score hexagon', async function() {
-        // when
-        await triggerEvent('.hexagon-score', 'mouseenter');
-        await triggerEvent('.hexagon-score', 'mouseleave');
-
-        // then
-        expect(find(tooltip)).to.not.exist;
-      });
-    });
-
-    describe('on ‘Escape‘ key pressed', () => {
-      it('should hide tooltip', async () => {
-        // given
-        await triggerEvent('.hexagon-score', 'mouseenter');
-        expect(find(tooltip)).to.exist;
-
-        // when
-        const escapeKeyCode = 27;
-        await triggerKeyEvent('.hexagon-score__information', 'keyup', escapeKeyCode);
-
-        // then
-        expect(find(tooltip)).not.to.exist;
-      });
-    });
-
-    describe('on button focusout', () => {
-      it('should hide tooltip', async () => {
-        // given
-        const button = find(buttonClass);
-        await click(button);
-        expect(find(tooltip)).to.exist;
-
-        // when
-        await triggerEvent(button, 'focusout');
-
-        // then
-        expect(find(tooltip)).not.to.exist;
-      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le texte de la tooltip d'explication du score Pix n'est pas en adéquation avec le reste des textes présents sur Pix. 

## :robot: Solution
- Mettre en adéquation le texte avec ce qui se fait déjà. 
- Améliorer le padding 
- Utiliser la tooltip de Pix UI 

## :rainbow: Remarques
Les tests ont été supprimés car pour l'instant la tooltip de Pix U, ne permet pas d'enlever le focus avec la touche échap et tester le comportement de la tooltip revient à tester du html, car c'est seulement le `role=tooltip` qui conditionne l'affichage au survol.

## :100: Pour tester
- Vérifier l'affichage de la tooltip et du format de son contenu. 
