### PR TITLE
[FEATURE] Enregistrer la dernière date de connexion dans le cas du GAR ou de Pôle Emploi (PIX-3510).

### DIFF
--- a/api/lib/application/pole-emplois/pole-emploi-controller.js
+++ b/api/lib/application/pole-emplois/pole-emploi-controller.js
@@ -1,5 +1,6 @@
 const usecases = require('../../domain/usecases');
 const tokenService = require('../../domain/services/token-service');
+const userRepository = require('../../infrastructure/repositories/user-repository');
 
 module.exports = {
 
@@ -9,6 +10,7 @@ module.exports = {
     const { userId, idToken } = await usecases.createUserFromPoleEmploi({ authenticationKey });
 
     const accessToken = tokenService.createAccessTokenFromUser(userId, 'pole_emploi_connect');
+    await userRepository.updateLastLoggedAt({ userId });
 
     const response = {
       access_token: accessToken,

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -1,9 +1,7 @@
 const usecases = require('../../domain/usecases');
 const schoolingRegistrationDependentUser = require('../../infrastructure/serializers/jsonapi/schooling-registration-dependent-user-serializer');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
-const tokenService = require('../../domain/services/token-service');
 const studentInformationForAccountRecoverySerializer = require('../../infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer');
-const userRepository = require('../../infrastructure/repositories/user-repository');
 
 module.exports = {
 
@@ -36,15 +34,11 @@ module.exports = {
       'external-user-token': token,
     } = request.payload.data.attributes;
 
-    const createdUser = await usecases.createUserAndReconcileToSchoolingRegistrationFromExternalUser({
+    const accessToken = await usecases.createUserAndReconcileToSchoolingRegistrationFromExternalUser({
       birthdate,
       campaignCode,
       token,
     });
-
-    // todo : refacto, should not call tokenService and userRepository from here
-    const accessToken = tokenService.createAccessTokenFromExternalUser(createdUser.id);
-    await userRepository.updateLastLoggedAt({ userId: createdUser.id });
 
     const response = {
       data: {

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -3,6 +3,7 @@ const schoolingRegistrationDependentUser = require('../../infrastructure/seriali
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 const tokenService = require('../../domain/services/token-service');
 const studentInformationForAccountRecoverySerializer = require('../../infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer');
+const userRepository = require('../../infrastructure/repositories/user-repository');
 
 module.exports = {
 
@@ -41,7 +42,9 @@ module.exports = {
       token,
     });
 
+    // todo : refacto, should not call tokenService and userRepository from here
     const accessToken = tokenService.createAccessTokenFromExternalUser(createdUser.id);
+    await userRepository.updateLastLoggedAt({ userId: createdUser.id });
 
     const response = {
       data: {

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -54,8 +54,9 @@ async function authenticateExternalUser({
       throw new UserShouldChangePasswordError();
     }
 
+    const token = tokenService.createAccessTokenFromExternalUser(userFromCredentials.id);
     await userRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
-    return tokenService.createAccessTokenFromExternalUser(userFromCredentials.id);
+    return token;
 
   } catch (error) {
     if ((error instanceof UserNotFoundError) || (error instanceof PasswordNotMatching)) {

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -54,6 +54,7 @@ async function authenticateExternalUser({
       throw new UserShouldChangePasswordError();
     }
 
+    await userRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
     return tokenService.createAccessTokenFromExternalUser(userFromCredentials.id);
 
   } catch (error) {

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -38,31 +38,26 @@ module.exports = async function authenticatePoleEmploiUser({
   let pixAccessToken;
 
   if (authenticatedUserId) {
-    const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId: authenticatedUserId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI });
-
-    if (authenticationMethod) {
-      if (authenticationMethod.externalIdentifier !== userInfo.externalIdentityId) {
-        throw new UnexpectedUserAccountError({ message: 'Le compte Pix connecté n\'est pas celui qui est attendu.' });
-      }
-
-      await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: authenticatedUserId });
-
-    } else {
-      const authenticationMethod = _buildPoleEmploiAuthenticationMethod({ userInfo, authenticationComplement, userId: authenticatedUserId });
-      await authenticationMethodRepository.create({ authenticationMethod });
-    }
-
-    pixAccessToken = tokenService.createAccessTokenFromUser(authenticatedUserId, 'pole_emploi_connect');
-
+    pixAccessToken = await _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
+      userInfo,
+      authenticatedUserId,
+      authenticationComplement,
+      authenticationMethodRepository,
+      tokenService,
+    });
   } else {
     const user = await userRepository.findByPoleEmploiExternalIdentifier(userInfo.externalIdentityId);
 
     if (!user) {
       const authenticationKey = await poleEmploiTokensRepository.save(poleEmploiTokens);
-      return { authenticationKey };
+      return { authenticationKey }; // todo : refacto, should not return differents objects
     } else {
-      await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: user.id });
-      pixAccessToken = tokenService.createAccessTokenFromUser(user.id, 'pole_emploi_connect');
+      pixAccessToken = await _getPixAccessTokenFromPoleEmploiUser({
+        user,
+        authenticationComplement,
+        authenticationMethodRepository,
+        tokenService,
+      });
     }
   }
 
@@ -79,4 +74,40 @@ function _buildPoleEmploiAuthenticationMethod({ userInfo, authenticationCompleme
     externalIdentifier: userInfo.externalIdentityId,
     authenticationComplement,
   });
+}
+
+async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
+  userInfo,
+  authenticatedUserId,
+  authenticationComplement,
+  authenticationMethodRepository,
+  tokenService,
+}) {
+  const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId: authenticatedUserId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI });
+
+  if (authenticationMethod) {
+    if (authenticationMethod.externalIdentifier !== userInfo.externalIdentityId) {
+      throw new UnexpectedUserAccountError({ message: 'Le compte Pix connecté n\'est pas celui qui est attendu.' });
+    }
+
+    await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: authenticatedUserId });
+
+  } else {
+    const authenticationMethod = _buildPoleEmploiAuthenticationMethod({ userInfo, authenticationComplement, userId: authenticatedUserId });
+    await authenticationMethodRepository.create({ authenticationMethod });
+  }
+  const pixAccessToken = tokenService.createAccessTokenFromUser(authenticatedUserId, 'pole_emploi_connect');
+
+  return pixAccessToken;
+}
+
+async function _getPixAccessTokenFromPoleEmploiUser({
+  user,
+  authenticationComplement,
+  authenticationMethodRepository,
+  tokenService,
+}) {
+  await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: user.id });
+  const pixAccessToken = tokenService.createAccessTokenFromUser(user.id, 'pole_emploi_connect');
+  return pixAccessToken;
 }

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -42,8 +42,9 @@ module.exports = async function authenticateUser({
 
     if (!shouldChangePassword) {
       _checkUserAccessScope(scope, foundUser);
+      const token = tokenService.createAccessTokenFromUser(foundUser.id, source);
       await userRepository.updateLastLoggedAt({ userId: foundUser.id });
-      return tokenService.createAccessTokenFromUser(foundUser.id, source);
+      return token;
     } else {
       throw new UserShouldChangePasswordError();
     }

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -89,11 +89,12 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
   }
 
   if (userWithSamlId) {
+    const token = tokenService.createAccessTokenFromExternalUser(userWithSamlId.id);
     await userRepository.updateLastLoggedAt({ userId: userWithSamlId.id });
-    return tokenService.createAccessTokenFromExternalUser(userWithSamlId.id);
+    return token;
   } else {
-    const user = await userRepository.get(userId);
+    const token = tokenService.createAccessTokenFromExternalUser(userId);
     await userRepository.updateLastLoggedAt({ userId });
-    return tokenService.createAccessTokenFromExternalUser(user.id);
+    return token;
   }
 };

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -88,5 +88,12 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
     }
   }
 
-  return userWithSamlId ? userWithSamlId : userRepository.get(userId);
+  if (userWithSamlId) {
+    await userRepository.updateLastLoggedAt({ userId: userWithSamlId.id });
+    return tokenService.createAccessTokenFromExternalUser(userWithSamlId.id);
+  } else {
+    const user = await userRepository.get(userId);
+    await userRepository.updateLastLoggedAt({ userId });
+    return tokenService.createAccessTokenFromExternalUser(user.id);
+  }
 };

--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -16,11 +16,12 @@ module.exports = async function getExternalAuthenticationRedirectionUrl({
 
   if (user) {
     const token = tokenService.createAccessTokenFromExternalUser(user.id);
-
+    await userRepository.updateLastLoggedAt({ userId: user.id });
     return `/?token=${encodeURIComponent(token)}&user-id=${user.id}`;
   } else {
     const externalUserToken = tokenService.createIdTokenForUserReconciliation(externalUser);
 
     return `/campagnes?externalUser=${encodeURIComponent(externalUserToken)}`;
   }
+
 };

--- a/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
@@ -100,55 +100,6 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
     });
   });
 
-  describe('#createUserAndReconcileToSchoolingRegistrationFromExternalUser', function() {
-
-    const payload = { data: { attributes: {} } };
-
-    beforeEach(function() {
-      sandbox.stub(usecases, 'createUserAndReconcileToSchoolingRegistrationFromExternalUser').rejects();
-      payload.data.attributes = {
-        'campaign-code': 'RESTRICTD',
-        'external-user-token': 'external-user-token',
-        'birthdate': '1948-12-21',
-        'access-token': null,
-      };
-    });
-
-    context('Success cases', function() {
-
-      it('should return an HTTP response with status code 200 and access-token in payload', async function() {
-        // given
-        const createdUser = domainBuilder.buildUser();
-        usecases.createUserAndReconcileToSchoolingRegistrationFromExternalUser.resolves(createdUser);
-
-        // when
-        const response = await httpTestServer.request('POST', '/api/schooling-registration-dependent-users/external-user-token', payload);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.data.attributes['access-token']).to.not.be.empty;
-      });
-
-    });
-
-    context('Error cases', function() {
-
-      context('when a NotFoundError is thrown', function() {
-
-        it('should resolve a 404 HTTP response', async function() {
-          // given
-          usecases.createUserAndReconcileToSchoolingRegistrationFromExternalUser.rejects(new NotFoundError());
-
-          // when
-          const response = await httpTestServer.request('POST', '/api/schooling-registration-dependent-users/external-usertoken', payload);
-
-          // then
-          expect(response.statusCode).to.equal(404);
-        });
-      });
-    });
-  });
-
   describe('#generateUsernameWithTemporaryPassword', function() {
 
     const payload = { data: { attributes: {} } };

--- a/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
@@ -43,14 +43,11 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
 
     context('Success cases', function() {
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      const createdUser = domainBuilder.buildUser();
-
       context('When email is used', function() {
 
         it('should return an HTTP response with status code 204', async function() {
           // given
+          const createdUser = domainBuilder.buildUser();
           payload.data.attributes.email = 'toto@example.net';
           delete payload.data.attributes.username;
           payload.data.attributes['with-username'] = false;
@@ -68,6 +65,7 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
 
         it('should return an HTTP response with status code 204', async function() {
           // given
+          const createdUser = domainBuilder.buildUser();
           delete payload.data.attributes.email;
           payload.data.attributes.username = 'robert.smith1212';
           payload.data.attributes['with-username'] = true;
@@ -118,12 +116,9 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
 
     context('Success cases', function() {
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      const createdUser = domainBuilder.buildUser();
-
       it('should return an HTTP response with status code 200 and access-token in payload', async function() {
         // given
+        const createdUser = domainBuilder.buildUser();
         usecases.createUserAndReconcileToSchoolingRegistrationFromExternalUser.resolves(createdUser);
 
         // when

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -2,6 +2,8 @@ const { expect, sinon, hFake } = require('../../../test-helper');
 
 const poleEmploiController = require('../../../../lib/application/pole-emplois/pole-emploi-controller');
 const usecases = require('../../../../lib/domain/usecases');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const tokenService = require('../../../../lib/domain/services/token-service');
 
 describe('Unit | Controller | pole-emplois-controller', function() {
 
@@ -49,6 +51,24 @@ describe('Unit | Controller | pole-emplois-controller', function() {
           expect(usecases.getPoleEmploiSendings).have.been.calledWith({ cursor: 'azefvbjljhgrEDJNH', filters: { isSuccessful: false } });
         });
       });
+    });
+  });
+
+  describe('#createUser', function() {
+
+    it('should save the last logged at date', async function() {
+      // given
+      const request = { query: { 'authentication-key': 'abcde' } };
+      const userId = 7;
+      sinon.stub(usecases, 'createUserFromPoleEmploi').resolves({ userId, idToken: 1 });
+      sinon.stub(tokenService, 'createAccessTokenFromUser').resolves('an access token');
+      sinon.stub(userRepository, 'updateLastLoggedAt');
+
+      // when
+      await poleEmploiController.createUser(request, hFake);
+
+      //then
+      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 7 });
     });
   });
 });

--- a/api/tests/unit/application/schooling-registration-dependent-user/schooling-registration-dependant-user-controller_test.js
+++ b/api/tests/unit/application/schooling-registration-dependent-user/schooling-registration-dependant-user-controller_test.js
@@ -1,10 +1,8 @@
-const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
+const { expect, sinon, hFake } = require('../../../test-helper');
 
 const usecases = require('../../../../lib/domain/usecases');
-const tokenService = require('../../../../lib/domain/services/token-service');
 const studentInformationForAccountRecoverySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js');
 const schoolingRegistrationDependantUserController = require('../../../../lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | Application | Controller | schooling-registration-user-associations', function() {
 
@@ -53,24 +51,23 @@ describe('Unit | Application | Controller | schooling-registration-user-associat
 
   describe('#createUserAndReconcileToSchoolingRegistrationFromExternalUser', function() {
 
-    it('should save last logged at date', async function() {
+    it('should return 200 response with an access token', async function() {
       // given
       const request = { payload: { data: { attributes: {
         birthdate: '01-01-2000',
         'campaign-code': 'BADGES123',
         'external-user-token': '123SamlId',
       } } } };
-      const user = domainBuilder.buildUser({ id: 7 });
+      const token = Symbol('token');
 
-      sinon.stub(usecases, 'createUserAndReconcileToSchoolingRegistrationFromExternalUser').resolves(user);
-      sinon.stub(tokenService, 'createAccessTokenFromExternalUser').returns('accessToken');
-      sinon.stub(userRepository, 'updateLastLoggedAt');
+      sinon.stub(usecases, 'createUserAndReconcileToSchoolingRegistrationFromExternalUser').resolves(token);
 
       // when
-      await schoolingRegistrationDependantUserController.createUserAndReconcileToSchoolingRegistrationFromExternalUser(request, hFake);
+      const response = await schoolingRegistrationDependantUserController.createUserAndReconcileToSchoolingRegistrationFromExternalUser(request, hFake);
 
       // then
-      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 7 });
+      expect(response.source.data.attributes['access-token']).to.deep.equal(token);
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/unit/application/schooling-registration-dependent-user/schooling-registration-dependant-user-controller_test.js
+++ b/api/tests/unit/application/schooling-registration-dependent-user/schooling-registration-dependant-user-controller_test.js
@@ -1,8 +1,10 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
 
 const usecases = require('../../../../lib/domain/usecases');
+const tokenService = require('../../../../lib/domain/services/token-service');
 const studentInformationForAccountRecoverySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js');
 const schoolingRegistrationDependantUserController = require('../../../../lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | Application | Controller | schooling-registration-user-associations', function() {
 
@@ -49,4 +51,26 @@ describe('Unit | Application | Controller | schooling-registration-user-associat
     });
   });
 
+  describe('#createUserAndReconcileToSchoolingRegistrationFromExternalUser', function() {
+
+    it('should save last logged at date', async function() {
+      // given
+      const request = { payload: { data: { attributes: {
+        birthdate: '01-01-2000',
+        'campaign-code': 'BADGES123',
+        'external-user-token': '123SamlId',
+      } } } };
+      const user = domainBuilder.buildUser({ id: 7 });
+
+      sinon.stub(usecases, 'createUserAndReconcileToSchoolingRegistrationFromExternalUser').resolves(user);
+      sinon.stub(tokenService, 'createAccessTokenFromExternalUser').returns('accessToken');
+      sinon.stub(userRepository, 'updateLastLoggedAt');
+
+      // when
+      await schoolingRegistrationDependantUserController.createUserAndReconcileToSchoolingRegistrationFromExternalUser(request, hFake);
+
+      // then
+      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 7 });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -17,33 +17,6 @@ const authenticatePoleEmploiUser = require('../../../../lib/domain/usecases/auth
 
 describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
 
-  const code = 'code';
-  const redirectUri = 'redirectUri';
-  const clientId = 'clientId';
-  const state = 'state';
-
-  const pixAccessToken = 'pixAccessToken';
-
-  const poleEmploiAccessToken = 'poleEmploiAccessToken';
-  const idToken = 'idToken';
-  const expiresIn = 60;
-  const refreshToken = 'refreshToken';
-  const poleEmploiTokens = new PoleEmploiTokens({
-    accessToken: poleEmploiAccessToken,
-    expiresIn,
-    idToken,
-    refreshToken,
-  });
-
-  const firstName = 'firstname';
-  const lastName = 'lastname';
-  const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
-
-  const userId = 1;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const domainTransaction = Symbol();
-
   let authenticationService;
   let tokenService;
 
@@ -51,21 +24,14 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
   let poleEmploiTokensRepository;
   let userRepository;
 
-  let userInfo;
   let clock;
 
   beforeEach(function() {
     clock = sinon.useFakeTimers(Date.now());
 
-    userInfo = {
-      family_name: lastName,
-      given_name: firstName,
-      externalIdentityId,
-    };
-
     authenticationService = {
-      generatePoleEmploiTokens: sinon.stub().resolves(poleEmploiTokens),
-      getPoleEmploiUserInfo: sinon.stub().resolves(userInfo),
+      generatePoleEmploiTokens: sinon.stub(),
+      getPoleEmploiUserInfo: sinon.stub(),
     };
 
     tokenService = {
@@ -86,6 +52,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
       findByPoleEmploiExternalIdentifier: sinon.stub().resolves({}),
     };
 
+    const domainTransaction = Symbol();
     DomainTransaction.execute = (lambda) => { return lambda(domainTransaction); };
   });
 
@@ -103,10 +70,10 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
 
       // when
       const error = await catchErr(authenticatePoleEmploiUser)({
-        authenticatedUserId: userId,
-        clientId,
-        code,
-        redirectUri,
+        authenticatedUserId: 1,
+        clientId: 'clientId',
+        code: 'code',
+        redirectUri: 'redirectUri',
         stateReceived,
         stateSent,
         authenticationService,
@@ -125,14 +92,30 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
   context('When user has an account', function() {
 
     it('should call authenticate pole emploi user with code, redirectUri and clientId parameters', async function() {
+      // given
+      const poleEmploiTokens = new PoleEmploiTokens({
+        accessToken: 'poleEmploiAccessToken',
+        expiresIn: 60,
+        idToken: 'idToken',
+        refreshToken: 'refreshToken',
+      });
+      const userInfo = {
+        family_name: 'Morris',
+        given_name: 'Tuck',
+        externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+      };
+
+      authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+      authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
+
       // when
       await authenticatePoleEmploiUser({
-        authenticatedUserId: userId,
-        clientId,
-        code,
-        redirectUri,
-        stateReceived: state,
-        stateSent: state,
+        authenticatedUserId: 1,
+        clientId: 'clientId',
+        code: 'code',
+        redirectUri: 'redirectUri',
+        stateReceived: 'state',
+        stateSent: 'state',
         authenticationService,
         tokenService,
         authenticationMethodRepository,
@@ -142,19 +125,35 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
 
       // then
       expect(authenticationService.generatePoleEmploiTokens).to.have.been.calledWith({
-        code, redirectUri, clientId,
+        code: 'code', redirectUri: 'redirectUri', clientId: 'clientId',
       });
     });
 
     it('should call get pole emploi user info with id token parameter', async function() {
+      // given
+      const poleEmploiTokens = new PoleEmploiTokens({
+        accessToken: 'poleEmploiAccessToken',
+        expiresIn: 60,
+        idToken: 'idToken',
+        refreshToken: 'refreshToken',
+      });
+      const userInfo = {
+        family_name: 'Morris',
+        given_name: 'Tuck',
+        externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+      };
+
+      authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+      authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
+
       // when
       await authenticatePoleEmploiUser({
-        authenticatedUserId: userId,
-        clientId,
-        code,
-        redirectUri,
-        stateReceived: state,
-        stateSent: state,
+        authenticatedUserId: 1,
+        clientId: 'clientId',
+        code: 'code',
+        redirectUri: 'redirectUri',
+        stateReceived: 'state',
+        stateSent: 'state',
         authenticationService,
         tokenService,
         authenticationMethodRepository,
@@ -163,24 +162,37 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
       });
 
       // then
-      expect(authenticationService.getPoleEmploiUserInfo).to.have.been.calledWith(idToken);
+      expect(authenticationService.getPoleEmploiUserInfo).to.have.been.calledWith('idToken');
     });
 
     it('should call tokenService createAccessTokenFromUser function with external source and user parameters', async function() {
       // given
-      const user = new User({ id: userId, firstName, lastName });
-      user.externalIdentityId = externalIdentityId;
+      const user = new User({ id: 1, firstName: 'Tuck', lastName: 'Morris' });
+      user.externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
+      const poleEmploiTokens = new PoleEmploiTokens({
+        accessToken: 'poleEmploiAccessToken',
+        expiresIn: 60,
+        idToken: 'idToken',
+        refreshToken: 'refreshToken',
+      });
+      const userInfo = {
+        family_name: 'Morris',
+        given_name: 'Tuck',
+        externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+      };
 
-      userRepository.findByPoleEmploiExternalIdentifier.resolves({ id: userId });
+      authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+      authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
+      userRepository.findByPoleEmploiExternalIdentifier.resolves({ id: 1 });
 
       // when
       await authenticatePoleEmploiUser({
-        authenticatedUserId: userId,
-        clientId,
-        code,
-        redirectUri,
-        stateReceived: state,
-        stateSent: state,
+        authenticatedUserId: 1,
+        clientId: 'clientId',
+        code: 'code',
+        redirectUri: 'redirectUri',
+        stateReceived: 'state',
+        stateSent: 'state',
         authenticationService,
         tokenService,
         authenticationMethodRepository,
@@ -189,26 +201,40 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
       });
 
       // then
-      expect(tokenService.createAccessTokenFromUser).to.have.been.calledWith(userId, 'pole_emploi_connect');
+      expect(tokenService.createAccessTokenFromUser).to.have.been.calledWith(1, 'pole_emploi_connect');
     });
 
     it('should return accessToken and idToken', async function() {
       // given
+      const pixAccessToken = 'pixAccessToken';
+      const poleEmploiTokens = new PoleEmploiTokens({
+        accessToken: 'poleEmploiAccessToken',
+        expiresIn: 60,
+        idToken: 'idToken',
+        refreshToken: 'refreshToken',
+      });
       const expectedResult = {
         pixAccessToken,
         poleEmploiTokens,
       };
+      const userInfo = {
+        family_name: 'Morris',
+        given_name: 'Tuck',
+        externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+      };
 
+      authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+      authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
       tokenService.createAccessTokenFromUser.returns(pixAccessToken);
 
       // when
       const result = await authenticatePoleEmploiUser({
-        authenticatedUserId: userId,
-        clientId,
-        code,
-        redirectUri,
-        stateReceived: state,
-        stateSent: state,
+        authenticatedUserId: 1,
+        clientId: 'clientId',
+        code: 'code',
+        redirectUri: 'redirectUri',
+        stateReceived: 'state',
+        stateSent: 'state',
         authenticationService,
         tokenService,
         authenticationMethodRepository,
@@ -224,21 +250,35 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
 
       it('should call authentication repository updatePoleEmploiAuthenticationComplementByUserId function', async function() {
         // given
-        userRepository.findByPoleEmploiExternalIdentifier.resolves({ id: userId });
+        userRepository.findByPoleEmploiExternalIdentifier.resolves({ id: 1 });
+        const poleEmploiTokens = new PoleEmploiTokens({
+          accessToken: 'poleEmploiAccessToken',
+          expiresIn: 60,
+          idToken: 'idToken',
+          refreshToken: 'refreshToken',
+        });
         const expectedAuthenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
           accessToken: poleEmploiTokens.accessToken,
           refreshToken: poleEmploiTokens.refreshToken,
           expiredDate: moment().add(poleEmploiTokens.expiresIn, 's').toDate(),
         });
+        const userInfo = {
+          family_name: 'Morris',
+          given_name: 'Tuck',
+          externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+        };
+
+        authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+        authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
 
         // when
         await authenticatePoleEmploiUser({
           authenticatedUserId: undefined,
-          clientId,
-          code,
-          redirectUri,
-          stateReceived: state,
-          stateSent: state,
+          clientId: 'clientId',
+          code: 'code',
+          redirectUri: 'redirectUri',
+          stateReceived: 'state',
+          stateSent: 'state',
           authenticationService,
           tokenService,
           authenticationMethodRepository,
@@ -249,7 +289,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
         // then
         expect(authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId).to.have.been.calledWith({
           authenticationComplement: expectedAuthenticationComplement,
-          userId,
+          userId: 1,
         });
       });
     });
@@ -261,30 +301,40 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
         it('should call authentication method repository create function with pole emploi authentication method in domain transaction', async function() {
           // given
           const userInfo = {
-            firstName, lastName, externalIdentityId,
+            firstName: 'Tuck',
+            lastName: 'Morris',
+            externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
           };
 
-          authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
-          userRepository.findByPoleEmploiExternalIdentifier.resolves(null);
+          const poleEmploiTokens = new PoleEmploiTokens({
+            accessToken: 'poleEmploiAccessToken',
+            expiresIn: 60,
+            idToken: 'idToken',
+            refreshToken: 'refreshToken',
+          });
           const expectedAuthenticationMethod = new AuthenticationMethod({
             identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
-            externalIdentifier: externalIdentityId,
+            externalIdentifier: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
             authenticationComplement: new AuthenticationMethod.PoleEmploiAuthenticationComplement({
               accessToken: poleEmploiTokens.accessToken,
               refreshToken: poleEmploiTokens.refreshToken,
               expiredDate: moment().add(poleEmploiTokens.expiresIn, 's').toDate(),
             }),
-            userId,
+            userId: 1,
           });
+
+          userRepository.findByPoleEmploiExternalIdentifier.resolves(null);
+          authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+          authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
 
           // when
           await authenticatePoleEmploiUser({
-            authenticatedUserId: userId,
-            clientId,
-            code,
-            redirectUri,
-            stateReceived: state,
-            stateSent: state,
+            authenticatedUserId: 1,
+            clientId: 'clientId',
+            code: 'code',
+            redirectUri: 'redirectUri',
+            stateReceived: 'state',
+            stateSent: 'state',
             authenticationService,
             tokenService,
             authenticationMethodRepository,
@@ -304,22 +354,36 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
         it('should call authentication repository updatePoleEmploiAuthenticationComplementByUserId function', async function() {
           // given
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
-            externalIdentifier: userInfo.externalIdentityId,
+            externalIdentifier: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
           }));
+          const poleEmploiTokens = new PoleEmploiTokens({
+            accessToken: 'poleEmploiAccessToken',
+            expiresIn: 60,
+            idToken: 'idToken',
+            refreshToken: 'refreshToken',
+          });
           const expectedAuthenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
             accessToken: poleEmploiTokens.accessToken,
             refreshToken: poleEmploiTokens.refreshToken,
             expiredDate: moment().add(poleEmploiTokens.expiresIn, 's').toDate(),
           });
+          const userInfo = {
+            family_name: 'Morris',
+            given_name: 'Tuck',
+            externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+          };
+
+          authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+          authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
 
           // when
           await authenticatePoleEmploiUser({
-            authenticatedUserId: userId,
-            clientId,
-            code,
-            redirectUri,
-            stateReceived: state,
-            stateSent: state,
+            authenticatedUserId: 1,
+            clientId: 'clientId',
+            code: 'code',
+            redirectUri: 'redirectUri',
+            stateReceived: 'state',
+            stateSent: 'state',
             authenticationService,
             tokenService,
             authenticationMethodRepository,
@@ -331,24 +395,38 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
           expect(authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId)
             .to.have.been.calledWith({
               authenticationComplement: expectedAuthenticationComplement,
-              userId,
+              userId: 1,
             });
         });
 
         it('should throw an UnexpectedUserAccountError error if the external identifier does not match the one in the pole emploi id token', async function() {
           // given
+          const poleEmploiTokens = new PoleEmploiTokens({
+            accessToken: 'poleEmploiAccessToken',
+            expiresIn: 60,
+            idToken: 'idToken',
+            refreshToken: 'refreshToken',
+          });
+          const userInfo = {
+            family_name: 'Morris',
+            given_name: 'Tuck',
+            externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+          };
+
+          authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
             externalIdentifier: 'other_external_identifier',
           }));
+          authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
 
           // when
           const error = await catchErr(authenticatePoleEmploiUser)({
-            authenticatedUserId: userId,
-            clientId,
-            code,
-            redirectUri,
-            stateReceived: state,
-            stateSent: state,
+            authenticatedUserId: 1,
+            clientId: 'clientId',
+            code: 'code',
+            redirectUri: 'redirectUri',
+            stateReceived: 'state',
+            stateSent: 'state',
             authenticationService,
             tokenService,
             authenticationMethodRepository,
@@ -370,15 +448,29 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
       const key = 'aaa-bbb-ccc';
       poleEmploiTokensRepository.save.resolves(key);
       userRepository.findByPoleEmploiExternalIdentifier.resolves(null);
+      const poleEmploiTokens = new PoleEmploiTokens({
+        accessToken: 'poleEmploiAccessToken',
+        expiresIn: 60,
+        idToken: 'idToken',
+        refreshToken: 'refreshToken',
+      });
+      const userInfo = {
+        family_name: 'Morris',
+        given_name: 'Tuck',
+        externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+      };
+
+      authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+      authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
 
       // when
       await authenticatePoleEmploiUser({
         authenticatedUserId: undefined,
-        clientId,
-        code,
-        redirectUri,
-        stateReceived: state,
-        stateSent: state,
+        clientId: 'clientId',
+        code: 'code',
+        redirectUri: 'redirectUri',
+        stateReceived: 'state',
+        stateSent: 'state',
         authenticationService,
         tokenService,
         authenticationMethodRepository,
@@ -393,17 +485,31 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function() {
     it('should return an authenticationKey', async function() {
       // given
       const key = 'aaa-bbb-ccc';
+      const poleEmploiTokens = new PoleEmploiTokens({
+        accessToken: 'poleEmploiAccessToken',
+        expiresIn: 60,
+        idToken: 'idToken',
+        refreshToken: 'refreshToken',
+      });
+      const userInfo = {
+        family_name: 'Morris',
+        given_name: 'Tuck',
+        externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+      };
+
       poleEmploiTokensRepository.save.resolves(key);
       userRepository.findByPoleEmploiExternalIdentifier.resolves(null);
+      authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
+      authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
 
       // when
       const result = await authenticatePoleEmploiUser({
         authenticatedUserId: undefined,
-        clientId,
-        code,
-        redirectUri,
-        stateReceived: state,
-        stateSent: state,
+        clientId: 'clientId',
+        code: 'code',
+        redirectUri: 'redirectUri',
+        stateReceived: 'state',
+        stateSent: 'state',
         authenticationService,
         tokenService,
         authenticationMethodRepository,

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
@@ -27,7 +27,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-schooling-registration-f
     };
     userRepository = {
       getBySamlId: sinon.stub(),
-      get: sinon.stub(),
       updateLastLoggedAt: sinon.stub(),
     };
     userService = {
@@ -115,7 +114,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-schooling-registration-f
       userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
       userRepository.getBySamlId.resolves(null);
       userService.createAndReconcileUserToSchoolingRegistration.resolves(user.id);
-      userRepository.get.resolves(user);
 
       // when
       await createUserAndReconcileToSchoolingRegistrationFromExternalUser({
@@ -149,7 +147,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-schooling-registration-f
       userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
       userRepository.getBySamlId.resolves(null);
       userService.createAndReconcileUserToSchoolingRegistration.resolves(user.id);
-      userRepository.get.resolves(user);
       tokenService.createAccessTokenFromExternalUser.withArgs(user.id).resolves(token);
 
       // when

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
@@ -1,0 +1,175 @@
+const { domainBuilder, expect, sinon } = require('../../../test-helper');
+const createUserAndReconcileToSchoolingRegistrationFromExternalUser = require('../../../../lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user');
+
+describe('Unit | UseCase | create-user-and-reconcile-to-schooling-registration-from-external-user', function() {
+
+  let obfuscationService;
+  let tokenService;
+  let userReconciliationService;
+  let userService;
+  let authenticationMethodRepository;
+  let campaignRepository;
+  let userRepository;
+  let schoolingRegistrationRepository;
+  let studentRepository;
+
+  beforeEach(function() {
+    campaignRepository = {
+      getByCode: sinon.stub(),
+    };
+    tokenService = {
+      extractExternalUserFromIdToken: sinon.stub(),
+      createAccessTokenFromExternalUser: sinon.stub(),
+    };
+    userReconciliationService = {
+      findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser: sinon.stub(),
+      checkIfStudentHasAnAlreadyReconciledAccount: sinon.stub(),
+    };
+    userRepository = {
+      getBySamlId: sinon.stub(),
+      get: sinon.stub(),
+      updateLastLoggedAt: sinon.stub(),
+    };
+    userService = {
+      createAndReconcileUserToSchoolingRegistration: sinon.stub(),
+    };
+  });
+
+  context('when user has saml id', function() {
+
+    it('should save last login date', async function() {
+      // given
+      const user = domainBuilder.buildUser();
+      const schoolingRegistration = domainBuilder.buildSchoolingRegistration(user);
+      const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
+
+      campaignRepository.getByCode.resolves('ABCDE');
+      tokenService.extractExternalUserFromIdToken.resolves(externalUser);
+      userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
+      userRepository.getBySamlId.resolves(user);
+
+      // when
+      await createUserAndReconcileToSchoolingRegistrationFromExternalUser({
+        birthdate: user.birthdate,
+        campaignCode: 'ABCDE',
+        token: 'a token',
+        obfuscationService,
+        tokenService,
+        userReconciliationService,
+        userService,
+        authenticationMethodRepository,
+        campaignRepository,
+        userRepository,
+        schoolingRegistrationRepository,
+        studentRepository,
+      });
+
+      // then
+      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
+    });
+
+    it('should return an access token', async function() {
+      // given
+      const user = domainBuilder.buildUser();
+      const schoolingRegistration = domainBuilder.buildSchoolingRegistration(user);
+      const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
+      const token = Symbol('token');
+
+      campaignRepository.getByCode.resolves('ABCDE');
+      tokenService.extractExternalUserFromIdToken.resolves(externalUser);
+      userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
+      userRepository.getBySamlId.resolves(user);
+      tokenService.createAccessTokenFromExternalUser.withArgs(user.id).resolves(token);
+
+      // when
+      const result = await createUserAndReconcileToSchoolingRegistrationFromExternalUser({
+        birthdate: user.birthdate,
+        campaignCode: 'ABCDE',
+        token: 'a token',
+        obfuscationService,
+        tokenService,
+        userReconciliationService,
+        userService,
+        authenticationMethodRepository,
+        campaignRepository,
+        userRepository,
+        schoolingRegistrationRepository,
+        studentRepository,
+      });
+
+      // then
+      expect(result).to.equal(token);
+    });
+  });
+
+  context('when user does not have saml id', function() {
+
+    it('should save last login date', async function() {
+      // given
+      const user = domainBuilder.buildUser();
+      const schoolingRegistration = domainBuilder.buildSchoolingRegistration(user);
+      const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
+
+      campaignRepository.getByCode.resolves('ABCDE');
+      tokenService.extractExternalUserFromIdToken.resolves(externalUser);
+      userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
+      userRepository.getBySamlId.resolves(null);
+      userService.createAndReconcileUserToSchoolingRegistration.resolves(user.id);
+      userRepository.get.resolves(user);
+
+      // when
+      await createUserAndReconcileToSchoolingRegistrationFromExternalUser({
+        birthdate: user.birthdate,
+        campaignCode: 'ABCDE',
+        token: 'a token',
+        obfuscationService,
+        tokenService,
+        userReconciliationService,
+        userService,
+        authenticationMethodRepository,
+        campaignRepository,
+        userRepository,
+        schoolingRegistrationRepository,
+        studentRepository,
+      });
+
+      // then
+      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
+    });
+
+    it('should return an access token', async function() {
+      // given
+      const user = domainBuilder.buildUser();
+      const schoolingRegistration = domainBuilder.buildSchoolingRegistration(user);
+      const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
+      const token = Symbol('token');
+
+      campaignRepository.getByCode.resolves('ABCDE');
+      tokenService.extractExternalUserFromIdToken.resolves(externalUser);
+      userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
+      userRepository.getBySamlId.resolves(null);
+      userService.createAndReconcileUserToSchoolingRegistration.resolves(user.id);
+      userRepository.get.resolves(user);
+      tokenService.createAccessTokenFromExternalUser.withArgs(user.id).resolves(token);
+
+      // when
+      const result = await createUserAndReconcileToSchoolingRegistrationFromExternalUser({
+        birthdate: user.birthdate,
+        campaignCode: 'ABCDE',
+        token: 'a token',
+        obfuscationService,
+        tokenService,
+        userReconciliationService,
+        userService,
+        authenticationMethodRepository,
+        campaignRepository,
+        userRepository,
+        schoolingRegistrationRepository,
+        studentRepository,
+      });
+
+      // then
+      expect(result).to.equal(token);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -4,79 +4,85 @@ const getExternalAuthenticationRedirectionUrl = require('../../../../lib/domain/
 
 describe('Unit | UseCase | get-external-authentication-redirection-url', function() {
 
-  const userAttributes = {
-    'IDO': 'saml-id-for-adele',
-    'NOM': 'Lopez',
-    'PRE': 'Adèle',
-  };
-
   let userRepository;
   let tokenService;
 
   beforeEach(function() {
     userRepository = {
-      create: () => {},
-      getBySamlId: () => {},
+      getBySamlId: sinon.stub(),
     };
 
     tokenService = {
-      createIdTokenForUserReconciliation: () => { return 'external-user-token'; },
-      createAccessTokenFromExternalUser: () => { return 'access-token'; },
+      createIdTokenForUserReconciliation: sinon.stub(),
+      createAccessTokenFromExternalUser: sinon.stub(),
     };
   });
 
-  const expectedUser = new User({
-    id: 1,
-    firstName: 'Adèle',
-    lastName: 'Lopez',
-    samlId: 'saml-id-for-adele',
-  });
-
-  const settings = {
-    saml: {
-      attributeMapping: {
-        samlId: 'IDO',
-        firstName: 'PRE',
-        lastName: 'NOM',
-      },
-    },
-  };
-
   context('when user does not exist in database yet', function() {
-
-    beforeEach(function() {
-      sinon.stub(userRepository, 'getBySamlId').resolves(null);
-      sinon.stub(userRepository, 'create').callsFake((user) => Promise.resolve(user));
-    });
 
     it('should return campaign url with external user token', async function() {
       // given
-      const expectedUrl = '/campagnes?externalUser=external-user-token';
+      const userAttributes = {
+        'IDO': 'saml-id-for-adele',
+        'NOM': 'Lopez',
+        'PRE': 'Adèle',
+      };
+      const settings = {
+        saml: {
+          attributeMapping: {
+            samlId: 'IDO',
+            firstName: 'PRE',
+            lastName: 'NOM',
+          },
+        },
+      };
+
+      tokenService.createIdTokenForUserReconciliation.returns('external-user-token');
+      userRepository.getBySamlId.resolves(null);
 
       // when
       const result = await getExternalAuthenticationRedirectionUrl({ userAttributes, userRepository, tokenService, settings });
 
       // then
-      expect(result).to.deep.equal(expectedUrl);
+      expect(result).to.deep.equal('/campagnes?externalUser=external-user-token');
     });
   });
 
   context('when user already exists in database', function() {
 
-    beforeEach(function() {
-      sinon.stub(userRepository, 'getBySamlId')
-        .withArgs('saml-id-for-adele')
-        .resolves(expectedUser);
-    });
-
     it('should return access token url', async function() {
       // given
-      const expectedUrl = '/?token=access-token&user-id=1';
+      const userAttributes = {
+        'IDO': 'saml-id-for-adele',
+        'NOM': 'Lopez',
+        'PRE': 'Adèle',
+      };
+      const settings = {
+        saml: {
+          attributeMapping: {
+            samlId: 'IDO',
+            firstName: 'PRE',
+            lastName: 'NOM',
+          },
+        },
+      };
+      const expectedUser = new User({
+        id: 1,
+        firstName: 'Adèle',
+        lastName: 'Lopez',
+        samlId: 'saml-id-for-adele',
+      });
+
+      userRepository.getBySamlId
+        .withArgs('saml-id-for-adele')
+        .resolves(expectedUser);
+      tokenService.createAccessTokenFromExternalUser.returns('access-token');
 
       // when
       const result = await getExternalAuthenticationRedirectionUrl({ userAttributes, userRepository, tokenService, settings });
 
       // then
+      const expectedUrl = '/?token=access-token&user-id=1';
       expect(result).to.deep.equal(expectedUrl);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la PR https://github.com/1024pix/pix/pull/3424 , la dernière date de connexion est sauvegardé dans la table "users".
Cependant, ceci n'était valable que pour les utilisateurs Pix se connectant de manière classique via notre interface.

Les utilisateurs de pôle emploi et ceux venant du GAR se connectent via des interfaces externes à Pix mais il nous faut aussi tracer leur dernière date de connexion simplement.

## :robot: Solution
Sauvegarder la dernière date de connexion pour les utilisateurs Pôle emploi et GAR dès qu'on leur génère un token Pix.

## :rainbow: Remarques
Pour la lecture de la PR je recommande de faire commit par commit pour plus de simplicité.

Quelques refactos ont été effectués :
- suppression d'un setup de test placé en dehors d'un `it`
- découpage en fonctions de l'authentification des users pôle emploi
- remplacement d'un early exit par un seul exit

## :100: Pour tester en local
**Pour tester avec Pôle emploi :** 

_Si vous rencontrez des problèmes lors des étapes suivantes vérifiez votre configuration. Pour cela faites les premières étapes de : https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1949663259/Int+gration+P+le+Emploi+-+Pix._
- lancer `mon-pix` comme décrit dans la doc précédente
- aller sur http://localhost.fr:8080/connexion
- cliquer sur "Se connecter avec pôle emploi"
- se connecter avec un identifiant de l'environnement de recette de pôle emploi : https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1961295916/Environnements+P+le+emploi
- todo

**Pour tester avec le GAR :**
Dans un autre dossier : 
- `git clone git@github.com:1024pix/pix-saml-idp.git && cd pix-saml-idp`
- npm ci
- rajouter un `.env` (voir `sample.env` comme modèle)
- rajouter dans le `.env` AUTH_SECRET=pix123
- npm start
- aller sur localhost:7000
- Remplir l'URL de destination avec `http://localhost:4200`
- Cliquer sur "Générer les env"
Dans notre api : 
- Rajouter les variables dans le fichier `.env`: `SAML_IDP_CONFIG=...` et `SAML_SP_CONFIG=...` en remplaçant `...` par les valeurs précédemment obtenues
- Démarrer l'api

Retourner dans l'app saml : 
- Remplir les champs "Saml ID" par n'importe quelle valeur , "Prénom" par `George` et "Nom" par `De Cambridge` 
- Puis lors de la réconcialitation l'anniversaire est : `22/07/2013`
- Rentrer un code campagne d'une orga SCO , par exemple : `BADGES123`
- Se connecter avec `george.de cambridge2339213@example.net` et `pix123` 

- Constater en BDD que l'utilisateur George De Cambridge bien une date dans la colonne `lastLoggedAt` 
```sql
select email, "lastLoggedAt" from "users" u where u."firstName" ILIKE '%georg%';
```
