### PR TITLE
[FEATURE] Enregistrer la nouvelle adresse e-mail lorsque l'utilisateur entre le code de vérification - API (PIX-3448).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -330,6 +330,12 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SessionNotAccessible) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.InvalidVerificationCodeError) {
+    return new HttpErrors.ForbiddenError(error.message, error.code);
+  }
+  if (error instanceof DomainErrors.EmailModificationDemandNotFoundOrExpiredError) {
+    return new HttpErrors.ForbiddenError(error.message, error.code);
+  }
 
   if (error instanceof DomainErrors.TargetProfileCannotBeCreated) {
     return new HttpErrors.UnprocessableEntityError(error.message);

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -75,10 +75,11 @@ class PasswordShouldChangeError extends BaseHttpError {
 }
 
 class ForbiddenError extends BaseHttpError {
-  constructor(message) {
+  constructor(message, code) {
     super(message);
     this.title = 'Forbidden';
     this.status = 403;
+    this.code = code;
   }
 }
 

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -263,6 +263,44 @@ exports.register = async function(server) {
       },
     },
     {
+      method: 'POST',
+      path: '/api/users/{id}/update-email',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+          {
+            method: featureToggles.checkIfEmailValidationIsEnabled,
+            assign: 'isEmailValidationEnabled',
+          },
+        ],
+        handler: userController.updateUserEmailWithValidation,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            data: {
+              type: Joi.string().valid('email-verification-codes').required(),
+              attributes: {
+                code: Joi.string().regex(/^[1-9]{6}$/).required(),
+              },
+            },
+          }),
+          failAction: (request, h, error) => {
+            return EntityValidationError.fromJoiErrors(error.details);
+          },
+        },
+        notes: ['- Suite à une demande de changement d\'adresse e-mail, met à jour cette dernière pour l\'utilisateur identifié par son id.'],
+        tags: ['api', 'user', 'update-email'],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/users/{id}/password-update',
       config: {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -683,7 +683,7 @@ exports.register = async function(server) {
           }),
           payload: Joi.object({
             data: {
-              type: Joi.string().valid('email-verification-code').required(),
+              type: Joi.string().valid('email-verification-codes').required(),
               attributes: {
                 'new-email': Joi.string().email().required(),
                 password: Joi.string().required(),

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -9,6 +9,7 @@ const sharedProfileForCampaignSerializer = require('../../infrastructure/seriali
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 const emailVerificationSerializer = require('../../infrastructure/serializers/jsonapi/email-verification-serializer');
 const userDetailsForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
+const updateEmailSerializer = require('../../infrastructure/serializers/jsonapi/update-email-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
@@ -277,4 +278,15 @@ module.exports = {
     return h.response().code(204);
   },
 
+  async updateUserEmailWithValidation(request) {
+    const userId = request.params.id;
+    const code = request.payload.data.attributes.code;
+
+    const updatedUserAttributes = await usecases.updateUserEmailWithValidation({
+      userId,
+      code,
+    });
+
+    return updateEmailSerializer.serialize(updatedUserAttributes);
+  },
 };

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -269,10 +269,11 @@ module.exports = {
 
   async sendVerificationCode(request, h) {
     const locale = extractLocaleFromRequest(request);
+    const i18n = request.i18n;
     const userId = request.params.id;
     const { newEmail, password } = await emailVerificationSerializer.deserialize(request.payload);
 
-    await usecases.sendVerificationCode({ locale, newEmail, password, userId });
+    await usecases.sendVerificationCode({ i18n, locale, newEmail, password, userId });
     return h.response().code(204);
   },
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -889,6 +889,18 @@ class NoOrganizationToAttach extends DomainError {
   }
 }
 
+class InvalidVerificationCodeError extends DomainError {
+  constructor(message = 'Le code de vérification renseigné ne correspond pas à celui enregistré.', code = 'INVALID_VERIFICATION_CODE') {
+    super(message, code);
+  }
+}
+
+class EmailModificationDemandNotFoundOrExpiredError extends DomainError {
+  constructor(message = 'La demande de modification d\'adresse e-mail n\'existe pas ou est expirée.', code = 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND') {
+    super(message, code);
+  }
+}
+
 module.exports = {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryDemandExpired,
@@ -938,6 +950,7 @@ module.exports = {
   CsvParsingError,
   DeprecatedCertificationIssueReportSubcategory,
   DomainError,
+  EmailModificationDemandNotFoundOrExpiredError,
   EntityValidationError,
   FileValidationError,
   ForbiddenAccess,
@@ -953,6 +966,7 @@ module.exports = {
   InvalidResultRecipientTokenError,
   InvalidSessionResultError,
   InvalidTemporaryKeyError,
+  InvalidVerificationCodeError,
   ManyOrganizationsFoundError,
   MatchingReconciledStudentNotFoundError,
   MembershipCreationError,

--- a/api/lib/domain/models/EmailModificationDemand.js
+++ b/api/lib/domain/models/EmailModificationDemand.js
@@ -1,0 +1,12 @@
+class EmailModificationDemand {
+
+  constructor({
+    code,
+    newEmail,
+  } = {}) {
+    this.code = code;
+    this.newEmail = newEmail;
+  }
+}
+
+module.exports = EmailModificationDemand;

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -342,7 +342,7 @@ function sendAccountRecoveryEmail({
   });
 }
 
-function sendVerificationCodeEmail({ code, email, locale }) {
+function sendVerificationCodeEmail({ code, email, locale, translate }) {
 
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
@@ -353,7 +353,7 @@ function sendVerificationCodeEmail({ code, email, locale }) {
   };
 
   if (locale === FRENCH_SPOKEN) {
-    options.subject = frTranslations['verification-code-email'].subject;
+    options.subject = translate(frTranslations['verification-code-email'].subject, { code });
 
     options.variables = {
       code,
@@ -365,7 +365,7 @@ function sendVerificationCodeEmail({ code, email, locale }) {
 
   }
   else if (locale === FRENCH_FRANCE) {
-    options.subject = frTranslations['verification-code-email'].subject;
+    options.subject = translate(frTranslations['verification-code-email'].subject, { code });
 
     options.variables = {
       code,
@@ -377,7 +377,7 @@ function sendVerificationCodeEmail({ code, email, locale }) {
 
   }
   else if (locale === ENGLISH_SPOKEN) {
-    options.subject = enTranslations['verification-code-email'].subject;
+    options.subject = translate(enTranslations['verification-code-email'].subject, { code });
 
     options.variables = {
       code,

--- a/api/lib/domain/services/sco-account-recovery-service.js
+++ b/api/lib/domain/services/sco-account-recovery-service.js
@@ -46,7 +46,7 @@ async function retrieveAndValidateAccountRecoveryDemand({
   accountRecoveryDemandRepository,
 }) {
   const { id, userId, newEmail, schoolingRegistrationId, createdAt } = await accountRecoveryDemandRepository.findByTemporaryKey(temporaryKey);
-  await userRepository.isEmailAvailable(newEmail);
+  await userRepository.checkIfEmailIsAvailable(newEmail);
 
   const accountRecoveryDemands = await accountRecoveryDemandRepository.findByUserId(userId);
 

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-schooling-registration.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-schooling-registration.js
@@ -92,7 +92,7 @@ async function _validateData({
     }
   } else {
     try {
-      await userRepository.isEmailAvailable(userAttributes.email);
+      await userRepository.checkIfEmailIsAvailable(userAttributes.email);
     } catch (err) {
       validationErrors.push(_manageEmailAvailabilityError(err));
     }

--- a/api/lib/domain/usecases/create-user.js
+++ b/api/lib/domain/usecases/create-user.js
@@ -47,7 +47,7 @@ async function _validateData({
 
   const validationErrors = [];
   if (user.email) {
-    validationErrors.push(await userRepository.isEmailAvailable(user.email).catch(_manageEmailAvailabilityError));
+    validationErrors.push(await userRepository.checkIfEmailIsAvailable(user.email).catch(_manageEmailAvailabilityError));
   }
   validationErrors.push(userValidatorError);
   validationErrors.push(passwordValidatorError);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -327,5 +327,6 @@ module.exports = injectDependencies({
   updateUserAccount: require('./account-recovery/update-user-account'),
   updateUserDetailsForAdministration: require('./update-user-details-for-administration'),
   updateUserEmail: require('./update-user-email'),
+  updateUserEmailWithValidation: require('./update-user-email-with-validation'),
   updateUserPassword: require('./update-user-password'),
 }, dependencies);

--- a/api/lib/domain/usecases/send-email-for-account-recovery.js
+++ b/api/lib/domain/usecases/send-email-for-account-recovery.js
@@ -22,7 +22,7 @@ module.exports = async function sendEmailForAccountRecovery({
     userReconciliationService,
   });
 
-  await userRepository.isEmailAvailable(newEmail);
+  await userRepository.checkIfEmailIsAvailable(newEmail);
 
   const accountRecoveryDemand = new AccountRecoveryDemand({
     userId,

--- a/api/lib/domain/usecases/send-verification-code.js
+++ b/api/lib/domain/usecases/send-verification-code.js
@@ -21,7 +21,7 @@ module.exports = async function sendVerificationCode({
     throw new UserNotAuthorizedToUpdateEmailError();
   }
 
-  await userRepository.isEmailAvailable(newEmail);
+  await userRepository.checkIfEmailIsAvailable(newEmail);
 
   const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
     userId,

--- a/api/lib/domain/usecases/send-verification-code.js
+++ b/api/lib/domain/usecases/send-verification-code.js
@@ -4,6 +4,7 @@ const { InvalidPasswordForUpdateEmailError, UserNotAuthorizedToUpdateEmailError 
 const get = require('lodash/get');
 
 module.exports = async function sendVerificationCode({
+  i18n,
   locale,
   newEmail,
   password,
@@ -41,5 +42,5 @@ module.exports = async function sendVerificationCode({
   const code = codeUtils.generateNumericalString(6);
 
   await userEmailRepository.saveEmailModificationDemand({ userId, code, newEmail });
-  await mailService.sendVerificationCodeEmail({ code, locale, email: newEmail });
+  await mailService.sendVerificationCodeEmail({ code, locale, translate: i18n.__, email: newEmail });
 };

--- a/api/lib/domain/usecases/update-user-email-with-validation.js
+++ b/api/lib/domain/usecases/update-user-email-with-validation.js
@@ -1,0 +1,39 @@
+const {
+  UserNotAuthorizedToUpdateEmailError,
+  InvalidVerificationCodeError,
+  EmailModificationDemandNotFoundOrExpiredError,
+} = require('../errors');
+
+module.exports = async function updateUserEmailWithValidation({
+  code,
+  userId,
+  userEmailRepository,
+  userRepository,
+}) {
+
+  const user = await userRepository.get(userId);
+  if (!user.email) {
+    throw new UserNotAuthorizedToUpdateEmailError();
+  }
+
+  const emailModificationDemand = await userEmailRepository.getEmailModificationDemandByUserId(userId);
+  if (!emailModificationDemand) {
+    throw new EmailModificationDemandNotFoundOrExpiredError();
+  }
+
+  if (code !== emailModificationDemand.code) {
+    throw new InvalidVerificationCodeError();
+  }
+
+  await userRepository.checkIfEmailIsAvailable(emailModificationDemand.newEmail);
+
+  await userRepository.updateWithEmailConfirmed({
+    id: userId,
+    userAttributes: {
+      email: emailModificationDemand.newEmail,
+      emailConfirmedAt: new Date(),
+    },
+  });
+
+  return { email: emailModificationDemand.newEmail };
+};

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -37,7 +37,7 @@ module.exports = async function updateUserEmail({
     throw new InvalidPasswordForUpdateEmailError();
   }
 
-  await userRepository.isEmailAvailable(email);
+  await userRepository.checkIfEmailIsAvailable(email);
   await userRepository.updateEmail({ id: userId, email: email.toLowerCase() });
   await mailService.notifyEmailChange({ email, locale });
 };

--- a/api/lib/infrastructure/repositories/user-email-repository.js
+++ b/api/lib/infrastructure/repositories/user-email-repository.js
@@ -1,6 +1,7 @@
 const settings = require('../../config');
 const temporaryStorage = require('../temporary-storage');
 const EXPIRATION_DELAY_SECONDS = settings.temporaryStorage.expirationDelaySeconds;
+const EmailModificationDemand = require('../../domain/models/EmailModificationDemand');
 
 module.exports = {
 
@@ -11,6 +12,18 @@ module.exports = {
       key,
       value: { code, newEmail },
       expirationDelaySeconds: EXPIRATION_DELAY_SECONDS,
+    });
+  },
+
+  async getEmailModificationDemandByUserId(userId) {
+    const key = 'VERIFY-EMAIL-' + userId;
+    const emailModificationDemand = await temporaryStorage.get(key);
+
+    if (!emailModificationDemand) return;
+
+    return new EmailModificationDemand({
+      newEmail: emailModificationDemand.newEmail,
+      code: emailModificationDemand.code,
     });
   },
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -190,7 +190,7 @@ module.exports = {
       .update(userAttributes);
   },
 
-  isEmailAvailable(email) {
+  checkIfEmailIsAvailable(email) {
     return BookshelfUser
       .query((qb) => qb.whereRaw('LOWER("email") = ?', email.toLowerCase()))
       .fetch({ require: false })

--- a/api/lib/infrastructure/serializers/jsonapi/email-verification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/email-verification-serializer.js
@@ -2,12 +2,12 @@ const { Deserializer } = require('jsonapi-serializer');
 
 module.exports = {
 
-  async deserialize(payload) {
+  deserialize(payload) {
     return new Deserializer()
       .deserialize(payload)
       .then((record) => {
         return {
-          newEmail: record['new-email'],
+          newEmail: record['new-email'].toLowerCase(),
           password: record['password'],
         };
       });

--- a/api/lib/infrastructure/serializers/jsonapi/update-email-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/update-email-serializer.js
@@ -1,0 +1,10 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(newEmail) {
+    return new Serializer('email-verification-codes', {
+      attributes: ['email'],
+    }).serialize(newEmail);
+  },
+};

--- a/api/tests/acceptance/application/users/send-verification-code-route-put_test.js
+++ b/api/tests/acceptance/application/users/send-verification-code-route-put_test.js
@@ -27,7 +27,7 @@ describe('Acceptance | Route | Users', function() {
 
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': newEmail,
             password: rawPassword,
@@ -69,7 +69,7 @@ describe('Acceptance | Route | Users', function() {
 
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': newEmail,
             password: rawPassword,
@@ -111,7 +111,7 @@ describe('Acceptance | Route | Users', function() {
 
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': user.email,
             password: rawPassword,
@@ -154,7 +154,7 @@ describe('Acceptance | Route | Users', function() {
 
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': user.email,
             password: rawPassword,
@@ -196,7 +196,7 @@ describe('Acceptance | Route | Users', function() {
 
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': newEmail,
             password: 'WRONG-PASSWORD',

--- a/api/tests/acceptance/application/users/update-user-email-with-validation-route-post_test.js
+++ b/api/tests/acceptance/application/users/update-user-email-with-validation-route-post_test.js
@@ -1,0 +1,53 @@
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+const { featureToggles } = require('../../../../lib/config');
+const userEmailRepository = require('../../../../lib/infrastructure/repositories/user-email-repository');
+
+describe('Acceptance | Route | Users', function() {
+
+  describe('POST /api/users/{id}/update-email', function() {
+
+    it('should return 200 HTTP status code', async function() {
+      // given
+      const server = await createServer();
+      featureToggles.isEmailValidationEnabled = true;
+
+      const code = '999999';
+      const newEmail = 'judy.new_email@example.net';
+      const user = databaseBuilder.factory.buildUser.withRawPassword({
+        email: 'judy.howl@example.net',
+      });
+      await databaseBuilder.commit();
+
+      await userEmailRepository.saveEmailModificationDemand({ userId: user.id, code, newEmail });
+
+      const payload = {
+        data: {
+          type: 'email-verification-codes',
+          attributes: {
+            code,
+          },
+        },
+      };
+
+      const options = {
+        method: 'POST',
+        url: `/api/users/${user.id}/update-email`,
+        payload,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(user.id),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/user-email-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-email-repository_test.js
@@ -1,6 +1,6 @@
 const { expect, databaseBuilder } = require('../../../test-helper');
-
 const userEmailRepository = require('../../../../lib/infrastructure/repositories/user-email-repository');
+const EmailModificationDemand = require('../../../../lib/domain/models/EmailModificationDemand');
 
 describe('Integration | Repository | UserEmailRepository', function() {
 
@@ -18,6 +18,25 @@ describe('Integration | Repository | UserEmailRepository', function() {
 
       // then
       expect(key).to.equal(expectedKey);
+    });
+  });
+
+  describe('#getEmailModificationDemandByUserId', function() {
+
+    it('should retrieve the email modification demand if it exists', async function() {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const newEmail = 'user@example.net';
+      const code = '999999';
+
+      await userEmailRepository.saveEmailModificationDemand({ userId, code, newEmail });
+
+      // when
+      const result = await userEmailRepository.getEmailModificationDemandByUserId(userId);
+
+      // then
+      expect(result).to.deep.equal({ code, newEmail });
+      expect(result).to.be.instanceOf(EmailModificationDemand);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -712,7 +712,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function(
     });
   });
 
-  describe('#isEmailAvailable', function() {
+  describe('#checkIfEmailIsAvailable', function() {
 
     let userInDb;
 
@@ -723,7 +723,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function(
 
     it('should return the email when the email is not registered', async function() {
       // when
-      const email = await userRepository.isEmailAvailable('email@example.net');
+      const email = await userRepository.checkIfEmailIsAvailable('email@example.net');
 
       // then
       expect(email).to.equal('email@example.net');
@@ -731,7 +731,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function(
 
     it('should reject an AlreadyRegisteredEmailError when it already exists', async function() {
       // when
-      const result = await catchErr(userRepository.isEmailAvailable)(userInDb.email);
+      const result = await catchErr(userRepository.checkIfEmailIsAvailable)(userInDb.email);
 
       // then
       expect(result).to.be.instanceOf(AlreadyRegisteredEmailError);
@@ -745,7 +745,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function(
       await databaseBuilder.commit();
 
       // when
-      const result = await catchErr(userRepository.isEmailAvailable)(lowerCaseEmail);
+      const result = await catchErr(userRepository.checkIfEmailIsAvailable)(lowerCaseEmail);
 
       // then
       expect(result).to.be.instanceOf(AlreadyRegisteredEmailError);

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -18,6 +18,8 @@ const {
   MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError,
   UserHasAlreadyLeftSCO,
   SchoolingRegistrationAlreadyLinkedToInvalidUserError,
+  InvalidVerificationCodeError,
+  EmailModificationDemandNotFoundOrExpiredError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -293,6 +295,32 @@ describe('Unit | Application | ErrorManager', function() {
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate ForbiddenError when InvalidVerificationCodeError', async function() {
+      // given
+      const error = new InvalidVerificationCodeError();
+      sinon.stub(HttpErrors, 'ForbiddenError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
+    });
+
+    it('should instantiate ForbiddenError when EmailModificationDemandNotFoundOrExpiredError', async function() {
+      // given
+      const error = new EmailModificationDemandNotFoundOrExpiredError();
+      sinon.stub(HttpErrors, 'ForbiddenError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
     });
 
     it('should instantiate BadRequestError when SchoolingRegistrationAlreadyLinkedToInvalidUserError', async function() {

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -590,7 +590,7 @@ describe('Unit | Router | user-router', function() {
       const url = '/api/users/1/email/verification-code';
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': 'user@example.net',
             password: 'Password123',
@@ -614,7 +614,7 @@ describe('Unit | Router | user-router', function() {
 
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': 'user@example.net',
             password: 'Password123',
@@ -652,7 +652,7 @@ describe('Unit | Router | user-router', function() {
 
       // then
       expect(result.statusCode).to.equal(422);
-      expect(result.result.errors[0].detail).to.equal('"data.type" must be [email-verification-code]');
+      expect(result.result.errors[0].detail).to.equal('"data.type" must be [email-verification-codes]');
     });
 
     it('should return 422 when email is not valid', async function() {
@@ -664,7 +664,7 @@ describe('Unit | Router | user-router', function() {
 
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': 'newEmail',
             password: 'Password123',
@@ -689,7 +689,7 @@ describe('Unit | Router | user-router', function() {
 
       const payload = {
         data: {
-          type: 'email-verification-code',
+          type: 'email-verification-codes',
           attributes: {
             'new-email': 'user@example.net',
           },

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -704,4 +704,81 @@ describe('Unit | Router | user-router', function() {
       expect(result.result.errors[0].detail).to.equal('"data.attributes.password" is required');
     });
   });
+
+  describe('POST /api/users/{id}/update-email', function() {
+
+    it('should return 403 if requested user is not the same as authenticated user', async function() {
+      // given
+      sinon.stub(featureToggles, 'checkIfEmailValidationIsEnabled').resolves(true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const url = '/api/users/1/update-email';
+
+      const payload = {
+        data: {
+          type: 'email-verification-codes',
+          attributes: {
+            code: '999999',
+          },
+        },
+      };
+
+      // when
+      const result = await httpTestServer.request('POST', url, payload);
+
+      // then
+      expect(result.statusCode).to.equal(403);
+      expect(result.result.errors[0].detail).to.equal('Missing or insufficient permissions.');
+    });
+
+    it('should return 404 if FT_VALIDATE_EMAIL is not enabled', async function() {
+      // given
+      sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const url = '/api/users/1/update-email';
+
+      const payload = {
+        data: {
+          type: 'email-verification-codes',
+          attributes: {
+            code: '999999',
+          },
+        },
+      };
+
+      // when
+      const result = await httpTestServer.request('POST', url, payload);
+
+      // then
+      expect(result.statusCode).to.equal(404);
+      expect(result.result.errors[0].detail).to.equal('Cette route est désactivée');
+    });
+
+    it('should return 422 when code is not valid', async function() {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const url = '/api/users/1/update-email';
+
+      const payload = {
+        data: {
+          type: 'email-verification-codes',
+          attributes: {
+            code: '9',
+          },
+        },
+      };
+
+      // when
+      const result = await httpTestServer.request('POST', url, payload);
+
+      // then
+      expect(result.statusCode).to.equal(422);
+      expect(result.result.errors[0].detail).to.equal('"data.attributes.code" with value "9" fails to match the required pattern: /^[1-9]{6}$/');
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -1,12 +1,11 @@
 const { sinon, expect, domainBuilder, hFake } = require('../../../test-helper');
 
 const User = require('../../../../lib/domain/models/User');
-
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
-
 const encryptionService = require('../../../../lib/domain/services/encryption-service');
 const mailService = require('../../../../lib/domain/services/mail-service');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 const usecases = require('../../../../lib/domain/usecases');
 
@@ -896,13 +895,11 @@ describe('Unit | Controller | user-controller', function() {
 
   describe('#sendVerificationCode', function() {
 
-    beforeEach(function() {
-      sinon.stub(usecases, 'sendVerificationCode');
-    });
-
     it('should call the usecase to send verification code with code, email and locale', async function() {
       // given
+      sinon.stub(usecases, 'sendVerificationCode');
       usecases.sendVerificationCode.resolves();
+      const i18n = getI18n();
       const userId = 1;
       const locale = 'fr';
       const newEmail = 'user@example.net';
@@ -910,6 +907,7 @@ describe('Unit | Controller | user-controller', function() {
 
       const request = {
         headers: { 'accept-language': locale },
+        i18n,
         auth: {
           credentials: {
             userId,
@@ -934,6 +932,7 @@ describe('Unit | Controller | user-controller', function() {
 
       // then
       expect(usecases.sendVerificationCode).to.have.been.calledWith({
+        i18n,
         locale,
         newEmail,
         password,
@@ -941,5 +940,4 @@ describe('Unit | Controller | user-controller', function() {
       });
     });
   });
-
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -17,6 +17,7 @@ const profileSerializer = require('../../../../lib/infrastructure/serializers/js
 const userSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
 const userDetailsForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
 const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
+const updateEmailSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/update-email-serializer');
 
 const userController = require('../../../../lib/application/users/user-controller');
 
@@ -938,6 +939,52 @@ describe('Unit | Controller | user-controller', function() {
         password,
         userId,
       });
+    });
+  });
+
+  describe('#updateUserEmailWithValidation', function() {
+
+    it('should call the usecase to update user email', async function() {
+      // given
+      const userId = 1;
+      const updatedEmail = 'new-email@example.net';
+      const code = '999999';
+
+      const responseSerialized = Symbol('an response serialized');
+      sinon.stub(usecases, 'updateUserEmailWithValidation');
+      sinon.stub(updateEmailSerializer, 'serialize');
+
+      usecases.updateUserEmailWithValidation.withArgs({ code, userId }).resolves(updatedEmail);
+      updateEmailSerializer.serialize.withArgs(updatedEmail).returns(responseSerialized);
+
+      const request = {
+        auth: {
+          credentials: {
+            userId,
+          },
+        },
+        params: {
+          id: userId,
+        },
+        payload: {
+          data: {
+            type: 'users',
+            attributes: {
+              code,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await userController.updateUserEmailWithValidation(request);
+
+      // then
+      expect(usecases.updateUserEmailWithValidation).to.have.been.calledWith({
+        code,
+        userId,
+      });
+      expect(response).to.deep.equal(responseSerialized);
     });
   });
 });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -468,4 +468,12 @@ describe('Unit | Domain | Errors', function() {
   it('should export a SchoolingRegistrationsCouldNotBeSavedError', function() {
     expect(errors.SchoolingRegistrationsCouldNotBeSavedError).to.exist;
   });
+
+  it('should export an InvalidVerificationCodeError', function() {
+    expect(errors.InvalidVerificationCodeError).to.exist;
+  });
+
+  it('should export an EmailModificationDemandNotFoundOrExpiredError', function() {
+    expect(errors.EmailModificationDemandNotFoundOrExpiredError).to.exist;
+  });
 });

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -4,6 +4,7 @@ const mailService = require('../../../../lib/domain/services/mail-service');
 const mailer = require('../../../../lib/infrastructure/mailers/mailer');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const settings = require('../../../../lib/config');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 const mainTranslationsMapping = {
   fr: require('../../../../translations/fr'),
@@ -716,8 +717,10 @@ describe('Unit | Service | MailService', function() {
     let testCases;
     let code;
     let userEmail;
+    let translate;
 
     before(function() {
+      translate = getI18n().__;
       userEmail = 'user@example.net';
       code = '999999';
 
@@ -732,7 +735,7 @@ describe('Unit | Service | MailService', function() {
           expected: {
             from: 'ne-pas-repondre@pix.fr',
             to: userEmail,
-            subject: translationsMapping.fr.subject,
+            subject: translate(translationsMapping.fr.subject, { code }),
             template: 'test-email-verification-code-template-id',
             tags: ['EMAIL_VERIFICATION_CODE'],
             variables: {
@@ -749,7 +752,7 @@ describe('Unit | Service | MailService', function() {
           expected: {
             from: 'ne-pas-repondre@pix.fr',
             to: userEmail,
-            subject: translationsMapping.fr.subject,
+            subject: translate(translationsMapping.fr.subject, { code }),
             template: 'test-email-verification-code-template-id',
             tags: ['EMAIL_VERIFICATION_CODE'],
             variables: {
@@ -766,7 +769,7 @@ describe('Unit | Service | MailService', function() {
           expected: {
             from: 'ne-pas-repondre@pix.fr',
             to: userEmail,
-            subject: translationsMapping.en.subject,
+            subject: translate(translationsMapping.en.subject, { code }),
             tags: ['EMAIL_VERIFICATION_CODE'],
             template: 'test-email-verification-code-template-id',
             variables: {
@@ -786,7 +789,12 @@ describe('Unit | Service | MailService', function() {
       const testCase = testCases[0];
 
       // when
-      await mailService.sendVerificationCodeEmail({ code, email: userEmail, locale: testCase.locale });
+      await mailService.sendVerificationCodeEmail({
+        code,
+        email: userEmail,
+        locale: testCase.locale,
+        translate,
+      });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
@@ -799,7 +807,12 @@ describe('Unit | Service | MailService', function() {
       const testCase = testCases[1];
 
       // when
-      await mailService.sendVerificationCodeEmail({ code, email: userEmail, locale: testCase.locale });
+      await mailService.sendVerificationCodeEmail({
+        code,
+        email: userEmail,
+        locale: testCase.locale,
+        translate,
+      });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
@@ -812,7 +825,12 @@ describe('Unit | Service | MailService', function() {
       const testCase = testCases[2];
 
       // when
-      await mailService.sendVerificationCodeEmail({ code, email: userEmail, locale: testCase.locale });
+      await mailService.sendVerificationCodeEmail({
+        code,
+        email: userEmail,
+        locale: testCase.locale,
+        translate,
+      });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];

--- a/api/tests/unit/domain/services/sco-account-recovery-service_test.js
+++ b/api/tests/unit/domain/services/sco-account-recovery-service_test.js
@@ -458,7 +458,7 @@ describe('Unit | Service | sco-account-recovery-service', function() {
 
     beforeEach(function() {
       userRepository = {
-        isEmailAvailable: sinon.stub(),
+        checkIfEmailIsAvailable: sinon.stub(),
       };
       accountRecoveryDemandRepository = {
         findByUserId: sinon.stub(),
@@ -481,7 +481,7 @@ describe('Unit | Service | sco-account-recovery-service', function() {
       };
 
       accountRecoveryDemandRepository.findByTemporaryKey.resolves({ ...expectedResult, createdAt });
-      userRepository.isEmailAvailable.withArgs(newEmail).resolves();
+      userRepository.checkIfEmailIsAvailable.withArgs(newEmail).resolves();
       accountRecoveryDemandRepository.findByUserId.withArgs(userId).resolves([{ used: false }]);
 
       // when
@@ -496,7 +496,7 @@ describe('Unit | Service | sco-account-recovery-service', function() {
       const newEmail = 'philippe@example.net';
 
       accountRecoveryDemandRepository.findByTemporaryKey.resolves({ newEmail });
-      userRepository.isEmailAvailable.withArgs(newEmail).rejects(new AlreadyRegisteredEmailError());
+      userRepository.checkIfEmailIsAvailable.withArgs(newEmail).rejects(new AlreadyRegisteredEmailError());
 
       // when
       const error = await catchErr(retrieveAndValidateAccountRecoveryDemand)({ userRepository, accountRecoveryDemandRepository });
@@ -512,7 +512,7 @@ describe('Unit | Service | sco-account-recovery-service', function() {
       const userId = '1234';
 
       accountRecoveryDemandRepository.findByTemporaryKey.resolves({ userId });
-      userRepository.isEmailAvailable.resolves();
+      userRepository.checkIfEmailIsAvailable.resolves();
       accountRecoveryDemandRepository.findByUserId.withArgs(userId).resolves([{ used: true }]);
 
       // when
@@ -531,7 +531,7 @@ describe('Unit | Service | sco-account-recovery-service', function() {
       createdAt.setDate(createdAt.getDate() - createdTenDaysAgo);
 
       accountRecoveryDemandRepository.findByTemporaryKey.resolves({ userId, createdAt });
-      userRepository.isEmailAvailable.resolves();
+      userRepository.checkIfEmailIsAvailable.resolves();
       accountRecoveryDemandRepository.findByUserId.withArgs(userId).resolves([{ used: false }]);
 
       // when

--- a/api/tests/unit/domain/usecases/account-recovery/send-email-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/send-email-for-account-recovery_test.js
@@ -14,7 +14,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
 
   beforeEach(function() {
     userRepository = {
-      isEmailAvailable: sinon.stub(),
+      checkIfEmailIsAvailable: sinon.stub(),
       get: sinon.stub(),
     };
     schoolingRegistrationRepository = {
@@ -35,7 +35,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
 
     it('should throw AlreadyRegisteredEmailError', async function() {
       // given
-      userRepository.isEmailAvailable.rejects(new AlreadyRegisteredEmailError());
+      userRepository.checkIfEmailIsAvailable.rejects(new AlreadyRegisteredEmailError());
       const newEmail = 'new_email@example.net';
 
       const studentInformation = {
@@ -78,7 +78,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
       const newEmail = 'NEW_EMAIL@example.net';
       const temporaryKey = '1234ADC';
 
-      userRepository.isEmailAvailable.resolves(true);
+      userRepository.checkIfEmailIsAvailable.resolves(true);
       accountRecoveryDemandRepository.save.resolves();
       mailService.sendAccountRecoveryEmail.resolves();
 
@@ -127,7 +127,7 @@ describe('Unit | UseCase | Account-recovery | send-email-for-account-recovery', 
       const oldEmail = 'old_email@example.net';
       const newEmail = 'NEW_EMAIL@example.net';
       const temporaryKey = '1234ADC';
-      userRepository.isEmailAvailable.resolves(true);
+      userRepository.checkIfEmailIsAvailable.resolves(true);
       accountRecoveryDemandRepository.save.resolves();
 
       const studentInformation = {

--- a/api/tests/unit/domain/usecases/create-and-reconcile-user-to-schooling-registration_test.js
+++ b/api/tests/unit/domain/usecases/create-and-reconcile-user-to-schooling-registration_test.js
@@ -54,7 +54,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-schooling-registration',
     };
     userRepository = {
       create: sinon.stub(),
-      isEmailAvailable: sinon.stub(),
+      checkIfEmailIsAvailable: sinon.stub(),
       isUsernameAvailable: sinon.stub(),
       get: sinon.stub(),
     };
@@ -79,7 +79,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-schooling-registration',
       .withArgs(campaignCode)
       .resolves(domainBuilder.buildCampaign({ organization: { id: organizationId } }));
     userRepository.isUsernameAvailable.resolves();
-    userRepository.isEmailAvailable.resolves();
+    userRepository.checkIfEmailIsAvailable.resolves();
 
     mailService.sendAccountCreationEmail.resolves();
 
@@ -220,7 +220,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-schooling-registration',
 
         it('should throw EntityValidationError', async function() {
           // given
-          userRepository.isEmailAvailable.rejects(new AlreadyRegisteredEmailError());
+          userRepository.checkIfEmailIsAvailable.rejects(new AlreadyRegisteredEmailError());
 
           // when
           const error = await catchErr(usecases.createAndReconcileUserToSchoolingRegistration)({

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -35,7 +35,7 @@ describe('Unit | UseCase | create-user', function() {
 
     };
     userRepository = {
-      isEmailAvailable: sinon.stub(),
+      checkIfEmailIsAvailable: sinon.stub(),
       create: sinon.stub(),
     };
     campaignRepository = {
@@ -55,7 +55,7 @@ describe('Unit | UseCase | create-user', function() {
     sinon.stub(userValidator, 'validate');
     sinon.stub(passwordValidator, 'validate');
 
-    userRepository.isEmailAvailable.resolves();
+    userRepository.checkIfEmailIsAvailable.resolves();
     userRepository.create.resolves(savedUser);
 
     userValidator.validate.returns();
@@ -72,7 +72,7 @@ describe('Unit | UseCase | create-user', function() {
 
     it('should check the non existence of email in UserRepository', async function() {
       // given
-      userRepository.isEmailAvailable.resolves();
+      userRepository.checkIfEmailIsAvailable.resolves();
 
       // when
       await createUser({
@@ -87,7 +87,7 @@ describe('Unit | UseCase | create-user', function() {
       });
 
       // then
-      expect(userRepository.isEmailAvailable).to.have.been.calledWith(userEmail);
+      expect(userRepository.checkIfEmailIsAvailable).to.have.been.calledWith(userEmail);
     });
 
     it('should validate the user', async function() {
@@ -136,7 +136,7 @@ describe('Unit | UseCase | create-user', function() {
           }],
         });
 
-        userRepository.isEmailAvailable.rejects(emailExistError);
+        userRepository.checkIfEmailIsAvailable.rejects(emailExistError);
 
         // when
         const error = await catchErr(createUser)({
@@ -213,7 +213,7 @@ describe('Unit | UseCase | create-user', function() {
 
       it('should reject with an error EntityValidationError containing the entityValidationError and the AlreadyRegisteredEmailError', async function() {
         // given
-        userRepository.isEmailAvailable.rejects(emailExistError);
+        userRepository.checkIfEmailIsAvailable.rejects(emailExistError);
         userValidator.validate.throws(entityValidationError);
 
         // when
@@ -254,7 +254,7 @@ describe('Unit | UseCase | create-user', function() {
       });
 
       // then
-      expect(userRepository.isEmailAvailable).to.not.have.been.called;
+      expect(userRepository.checkIfEmailIsAvailable).to.not.have.been.called;
     });
   });
 

--- a/api/tests/unit/domain/usecases/send-verification-code_test.js
+++ b/api/tests/unit/domain/usecases/send-verification-code_test.js
@@ -28,7 +28,7 @@ describe('Unit | UseCase | send-verification-code', function() {
       saveEmailModificationDemand: sinon.stub(),
     };
     userRepository = {
-      isEmailAvailable: sinon.stub(),
+      checkIfEmailIsAvailable: sinon.stub(),
       get: sinon.stub(),
     };
     encryptionService = {
@@ -55,7 +55,7 @@ describe('Unit | UseCase | send-verification-code', function() {
     const i18n = getI18n();
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
-    userRepository.isEmailAvailable.withArgs(newEmail).resolves(newEmail);
+    userRepository.checkIfEmailIsAvailable.withArgs(newEmail).resolves(newEmail);
     authenticationMethodRepository.findOneByUserIdAndIdentityProvider
       .withArgs({
         userId,
@@ -95,7 +95,7 @@ describe('Unit | UseCase | send-verification-code', function() {
     const translate = getI18n().__;
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
-    userRepository.isEmailAvailable.withArgs(newEmail).resolves(newEmail);
+    userRepository.checkIfEmailIsAvailable.withArgs(newEmail).resolves(newEmail);
     authenticationMethodRepository.findOneByUserIdAndIdentityProvider
       .withArgs({
         userId,
@@ -136,7 +136,7 @@ describe('Unit | UseCase | send-verification-code', function() {
     const locale = 'fr';
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
-    userRepository.isEmailAvailable.rejects(new AlreadyRegisteredEmailError());
+    userRepository.checkIfEmailIsAvailable.rejects(new AlreadyRegisteredEmailError());
 
     // when
     const error = await catchErr(usecases.sendVerificationCode)({
@@ -164,7 +164,7 @@ describe('Unit | UseCase | send-verification-code', function() {
     const locale = 'fr';
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
-    userRepository.isEmailAvailable.withArgs(newEmail).resolves(newEmail);
+    userRepository.checkIfEmailIsAvailable.withArgs(newEmail).resolves(newEmail);
     authenticationMethodRepository.findOneByUserIdAndIdentityProvider
       .withArgs({
         userId,

--- a/api/tests/unit/domain/usecases/send-verification-code_test.js
+++ b/api/tests/unit/domain/usecases/send-verification-code_test.js
@@ -4,13 +4,14 @@ const {
   catchErr,
   domainBuilder,
 } = require('../../../test-helper');
-const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
-const codeUtils = require('../../../../lib/infrastructure/utils/code-utils');
 const {
   AlreadyRegisteredEmailError,
   InvalidPasswordForUpdateEmailError,
   UserNotAuthorizedToUpdateEmailError,
 } = require('../../../../lib/domain/errors');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+const codeUtils = require('../../../../lib/infrastructure/utils/code-utils');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 const usecases = require('../../../../lib/domain/usecases');
 
@@ -51,6 +52,7 @@ describe('Unit | UseCase | send-verification-code', function() {
     const password = 'pix123';
     const passwordHash = 'ABCD';
     const locale = 'fr';
+    const i18n = getI18n();
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
     userRepository.isEmailAvailable.withArgs(newEmail).resolves(newEmail);
@@ -65,6 +67,7 @@ describe('Unit | UseCase | send-verification-code', function() {
 
     // when
     await usecases.sendVerificationCode({
+      i18n,
       locale,
       newEmail,
       password,
@@ -88,6 +91,8 @@ describe('Unit | UseCase | send-verification-code', function() {
     const passwordHash = 'ABCD';
     const code = '999999';
     const locale = 'fr';
+    const i18n = getI18n();
+    const translate = getI18n().__;
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
     userRepository.isEmailAvailable.withArgs(newEmail).resolves(newEmail);
@@ -102,6 +107,7 @@ describe('Unit | UseCase | send-verification-code', function() {
 
     // when
     await usecases.sendVerificationCode({
+      i18n,
       locale,
       newEmail,
       password,
@@ -118,6 +124,7 @@ describe('Unit | UseCase | send-verification-code', function() {
       code,
       locale,
       email: newEmail,
+      translate,
     });
   });
 

--- a/api/tests/unit/domain/usecases/update-user-email-with-validation_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email-with-validation_test.js
@@ -1,0 +1,187 @@
+const {
+  expect,
+  sinon,
+  catchErr,
+  domainBuilder,
+} = require('../../../test-helper');
+const {
+  AlreadyRegisteredEmailError,
+  InvalidVerificationCodeError,
+  UserNotAuthorizedToUpdateEmailError,
+  EmailModificationDemandNotFoundOrExpiredError,
+} = require('../../../../lib/domain/errors');
+
+const EmailModificationDemand = require('../../../../lib/domain/models/EmailModificationDemand');
+const updateUserEmailWithValidation = require('../../../../lib/domain/usecases/update-user-email-with-validation');
+
+describe('Unit | UseCase | update-user-email-with-validation', function() {
+
+  let userEmailRepository;
+  let userRepository;
+  let clock;
+
+  beforeEach(function() {
+    userEmailRepository = {
+      getEmailModificationDemandByUserId: sinon.stub(),
+    };
+    userRepository = {
+      checkIfEmailIsAvailable: sinon.stub(),
+      get: sinon.stub(),
+      updateWithEmailConfirmed: sinon.stub(),
+    };
+  });
+
+  it('should update email and set date for confirmed email', async function() {
+    // given
+    const userId = domainBuilder.buildUser().id;
+    const email = 'oldEmail@example.net';
+    const newEmail = 'new_email@example.net';
+    const code = '999999';
+    const emailModificationDemand = new EmailModificationDemand({
+      code,
+      newEmail,
+    });
+
+    const now = new Date();
+    clock = sinon.useFakeTimers(now);
+
+    userRepository.get.withArgs(userId).resolves({ email });
+    userEmailRepository.getEmailModificationDemandByUserId.withArgs(userId).resolves(emailModificationDemand);
+    userRepository.checkIfEmailIsAvailable.withArgs(newEmail).resolves();
+
+    // when
+    await updateUserEmailWithValidation({
+      userId,
+      code,
+      userEmailRepository,
+      userRepository,
+    });
+
+    // then
+    expect(userRepository.updateWithEmailConfirmed).to.have.been.calledWith({
+      id: userId,
+      userAttributes: { email: newEmail, emailConfirmedAt: now },
+    });
+    clock.restore();
+  });
+
+  it('should get email modification demand in temporary storage', async function() {
+    // given
+    const userId = domainBuilder.buildUser().id;
+    const email = 'oldEmail@example.net';
+    const newEmail = 'new_email@example.net';
+    const code = '999999';
+    const emailModificationDemand = new EmailModificationDemand({
+      code,
+      newEmail,
+    });
+
+    userRepository.get.withArgs(userId).resolves({ email });
+    userEmailRepository.getEmailModificationDemandByUserId.withArgs(userId).resolves(emailModificationDemand);
+
+    // when
+    await updateUserEmailWithValidation({
+      userId,
+      code,
+      userEmailRepository,
+      userRepository,
+    });
+
+    // then
+    expect(userEmailRepository.getEmailModificationDemandByUserId).to.have.been.calledWithExactly(userId);
+  });
+
+  it('should throw UserNotAuthorizedToUpdateEmailError if user does not have an email', async function() {
+    // given
+    userRepository.get.resolves({});
+    const userId = 1;
+    const code = '999999';
+
+    // when
+    const error = await catchErr(updateUserEmailWithValidation)({
+      userId,
+      code,
+      userRepository,
+      userEmailRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(UserNotAuthorizedToUpdateEmailError);
+  });
+
+  it('should throw AlreadyRegisteredEmailError if email already exists', async function() {
+    // given
+    const userId = domainBuilder.buildUser().id;
+    const email = 'oldEmail@example.net';
+    const newEmail = 'new_email@example.net';
+    const code = '999999';
+    const emailModificationDemand = new EmailModificationDemand({
+      code,
+      newEmail,
+    });
+
+    userRepository.get.withArgs(userId).resolves({ email });
+    userEmailRepository.getEmailModificationDemandByUserId.withArgs(userId).resolves(emailModificationDemand);
+    userRepository.checkIfEmailIsAvailable.withArgs(newEmail).rejects(new AlreadyRegisteredEmailError());
+
+    // when
+    const error = await catchErr(updateUserEmailWithValidation)({
+      userId,
+      code,
+      userEmailRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(AlreadyRegisteredEmailError);
+  });
+
+  it('should throw InvalidVerificationCodeError if the code send does not match with then code saved in temporary storage', async function() {
+    // given
+    const userId = domainBuilder.buildUser().id;
+    const email = 'oldEmail@example.net';
+    const newEmail = 'new_email@example.net';
+    const code = '999999';
+    const anotherCode = '444444';
+    const emailModificationDemand = new EmailModificationDemand({
+      code: anotherCode,
+      newEmail,
+    });
+
+    userRepository.get.withArgs(userId).resolves({ email });
+    userEmailRepository.getEmailModificationDemandByUserId.withArgs(userId).resolves(emailModificationDemand);
+
+    // when
+    const error = await catchErr(updateUserEmailWithValidation)({
+      userId,
+      code,
+      userEmailRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(InvalidVerificationCodeError);
+  });
+
+  it('should throw EmailModificationDemandNotFoundOrExpiredError if no email modification demand match or is expired', async function() {
+    // given
+    const userId = domainBuilder.buildUser().id;
+    const anotherUserId = domainBuilder.buildUser().id;
+    const email = 'oldEmail@example.net';
+    const code = '999999';
+
+    userRepository.get.withArgs(userId).resolves({ email });
+    userEmailRepository.getEmailModificationDemandByUserId.withArgs(anotherUserId).resolves(null);
+
+    // when
+    const error = await catchErr(updateUserEmailWithValidation)({
+      userId,
+      code,
+      userEmailRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(EmailModificationDemandNotFoundOrExpiredError);
+  });
+});

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -20,7 +20,7 @@ describe('Unit | UseCase | update-user-email', function() {
   beforeEach(function() {
     userRepository = {
       updateEmail: sinon.stub(),
-      isEmailAvailable: sinon.stub(),
+      checkIfEmailIsAvailable: sinon.stub(),
       get: sinon.stub().resolves({ email: 'old_email@example.net' }),
     };
 
@@ -118,7 +118,7 @@ describe('Unit | UseCase | update-user-email', function() {
 
   it('should throw AlreadyRegisteredEmailError if email already exists', async function() {
     // given
-    userRepository.isEmailAvailable.rejects(new AlreadyRegisteredEmailError());
+    userRepository.checkIfEmailIsAvailable.rejects(new AlreadyRegisteredEmailError());
     const userId = 1;
     const authenticatedUserId = 1;
     const newEmail = 'new_email@example.net';

--- a/api/tests/unit/infrastructure/serializers/jsonapi/email-verification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/email-verification-serializer_test.js
@@ -2,6 +2,7 @@ const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/email-verification-serializer');
 
 describe('Unit | Serializer | JSONAPI | email-verification-serializer', function() {
+
   describe('#deserialize()', function() {
 
     it('should convert the payload json to email information', async function() {
@@ -10,7 +11,7 @@ describe('Unit | Serializer | JSONAPI | email-verification-serializer', function
         data: {
           type: 'email-verification-code',
           attributes: {
-            'new-email': 'email@example.net',
+            'new-email': 'EMAIL@example.net',
             password: 'myPassword',
           },
         },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/update-email-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/update-email-serializer_test.js
@@ -1,0 +1,29 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/update-email-serializer');
+
+describe('Unit | Serializer | JSONAPI | update-email-serializer', function() {
+
+  describe('#serialize()', function() {
+
+    it('should convert user new email into JSON API data', function() {
+      //given
+      const updatedUserAttributes = {
+        email: 'new-email@example.net',
+      };
+
+      // when
+      const json = serializer.serialize(updatedUserAttributes);
+
+      // then
+      const expectedJsonApi = {
+        data: {
+          type: 'email-verification-codes',
+          attributes: {
+            'email': updatedUserAttributes.email,
+          },
+        },
+      };
+      expect(json).to.deep.equal(expectedJsonApi);
+    });
+  });
+});

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -128,7 +128,7 @@
     "subject": "Email change confirmation"
   },
   "verification-code-email": {
-    "subject": "You’ve recently changed your email address",
+    "subject": "Your Pix code is {{ code }}",
     "body": {
       "doNotAnswer": "This is an automated email message, please do not reply.",
       "context": "You’ve requested to change the email address linked to your account. To continue, enter the following verification code on Pix:",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -140,7 +140,7 @@
     "subject": "Vous avez changé votre adresse e-mail"
   },
   "verification-code-email": {
-    "subject": "Vous avez changé votre adresse e-mail",
+    "subject": "Votre code Pix est {{ code }}",
     "body": {
       "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre",
       "context": "Vous souhaitez faire une modification de votre adresse e-mail sur votre compte. Pour continuer, entrez le code suivant sur Pix :",


### PR DESCRIPTION
## :unicorn: Problème
Dans Mon Compte sur Pix App, lorsque l'utilisateur rempli la nouvelle adresse e-mail et son mot de passe, il reçoit un code de vérification par mail.
Lorsqu'il entre ce code, sa nouvelle adresse e-mail doit être enregistré.

Sous feature toggle donc non visible en prod. `FT_VALIDATE_EMAIL`

## :robot: Solution
Partie API uniquement.
Mettre à jour le compte de l'utilisateur avec la nouvelle adresse-email et enregistrer celle ci comme confirmée.

## :rainbow: Remarques
- Dans la table `users`, le champ `emailConfirmedAt` est mis à jour également, prouvant que sa nouvelle adresse est valide.

Ajouts supplémentaires : 
- Changement du titre du mail pour "Votre code Pix est 000 000".
- Changement du nom de la méthode de repo `isEmailAvailable` > `CheckIfEmailAvailable`
- Enregistrer temporairement la nouvelle adresse e-mail en minuscule ( `toLowerCase` )

## :100: Pour tester
**Cas valide :**

Aller sur Mon Compte > Méthodes de connexion > Modifier
Entrer votre adresse e-mail et le mot de passe.

Puis lancer la commande curl en ajoutant un token valide, le userId du seed connecté et le code reçu par mail.

`curl 'https://app-pr3530.review.pix.fr/api/users/???/update-email' -X 'POST' -H 'authorization: Bearer ???' -H 'content-type: application/vnd.api+json' -H 'accept: application/vnd.api+json' --data-raw '{"data":{"attributes":{"code":"???"},"type":"email-verification-codes"}}'`

En réponse le user est renvoyé.
Vérifier que l'adresse e-mail et le `emailConfirmedAt` ont été mis à jour.

**Cas d'erreurs :**

_Adresse e-mail déjà utilisée_ : Relancez la même commande du cas valide

`{"errors":[{"status":"400","code":"ACCOUNT_WITH_EMAIL_ALREADY_EXISTS","title":"Bad Request","detail":"Cette adresse e-mail est déjà utilisée."}]}%`

---
Si le feature toggle FT_VALIDATE_EMAIL est à false (changé à true dans la RA, à changer au besoin) :

`{"errors":[{"status":"404","title":"Not Found","detail":"Cette route est désactivée"}]}%`

---
_Code erroné_ : Fournissez un code invalide. 

`{"errors":[{"status":"403","title":"Forbidden","detail":"Le code de vérification renseigné ne correspond pas à celui enregistré."}]}%`

Fonctionne aussi lorsque l'utilisateur à fait le process une fois, puis lors de la seconde fois, il remet le tout premier code reçu.
L'ancienne entrée a été remplacée par la nouvelle, donc l'ancien code fonctionne une fois.

---
_Mauvais format de code_ : Mettez le code suivant "7777777777777" ou "77"

`{"errors":[{"status":"422","title":"Invalid data attribute \"code\"","detail":"\"data.attributes.code\" with value \"299\" fails to match the required pattern: /^[1-9]{6}$/","source":{"pointer":"/data/attributes/code"}}]}%`

---
_Demande de changement qui n'existe pas_ : lancer la commande sans avoir fait la première étape.

`{"errors":[{"status":"403","title":"Forbidden","detail":"La demande de modification d'adresse e-mail n'existe pas ou est expirée."}]}%`

---

_Demande de changement d'adresse périmée_ : attendre 10 minutes après avoir fait la demande et lancer la commande curl.

`{"errors":[{"status":"403","title":"Forbidden","detail":"La demande de modification d'adresse e-mail n'existe pas ou est expirée."}]}%`

**Pour tester la durée de la demande :** 

Se connecter au CLI : `scalingo --region osc-fr1 --app=pix-api-review-pr3530  redis-console`

Faire la demande de changement d'adresse

`KEYS VERIFY-EMAIL-*` -> Liste toutes les clés
`TTL VERIFY-EMAIL-104` indique le temps d'expiration de cette clé 
Exemple : `(integer) 311 `