### PR TITLE
[FEATURE] Arrondir à l'entier supérieur la règle de scoring globale d'une certification (PIX-3527).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Pix Changelog
 
+## v3.109.0 (01/10/2021)
+
+
 ## v3.108.0 (01/10/2021)
 
 - [#3535](https://github.com/1024pix/pix/pull/3535) [FEATURE] Cacher les élèves désactivés de la liste des élèves pouvant être inscrits à une session de certification (PIX-3163).

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "private": false,
   "description": "Interface d'administration pour les Pix Masters.",
   "license": "AGPL-3.0",

--- a/api/lib/domain/models/CertificationContract.js
+++ b/api/lib/domain/models/CertificationContract.js
@@ -49,7 +49,7 @@ class CertificationContract {
   }
 
   static hasEnoughNonNeutralizedChallengesToBeTrusted(numberOfChallenges, numberOfNonNeutralizedChallenges) {
-    const minimalNumberOfNonNeutralizedChallengesToBeTrusted = Math.floor(numberOfChallenges * 0.66);
+    const minimalNumberOfNonNeutralizedChallengesToBeTrusted = Math.ceil(numberOfChallenges * 0.66);
     return numberOfNonNeutralizedChallenges >= minimalNumberOfNonNeutralizedChallengesToBeTrusted;
   }
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-api",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-api",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/api/tests/unit/domain/models/CertificationContract_test.js
+++ b/api/tests/unit/domain/models/CertificationContract_test.js
@@ -160,8 +160,8 @@ describe('Unit | Domain | Models | CertificationContract', function() {
 
       it('should return true', function() {
         // given
-        const numberOfChallenges = 6;
-        const numberOfNonNeutralizedChallenges = 4;
+        const numberOfChallenges = 15;
+        const numberOfNonNeutralizedChallenges = 10;
 
         // when
         const hasEnoughNonNeutralizedChallengeToBeTrusted = CertificationContract.hasEnoughNonNeutralizedChallengesToBeTrusted(numberOfChallenges, numberOfNonNeutralizedChallenges);
@@ -175,8 +175,8 @@ describe('Unit | Domain | Models | CertificationContract', function() {
 
       it('should return false', function() {
         // given
-        const numberOfChallenges = 6;
-        const numberOfNonNeutralizedChallenges = 2;
+        const numberOfChallenges = 15;
+        const numberOfNonNeutralizedChallenges = 9;
 
         // when
         const hasEnoughNonNeutralizedChallengeToBeTrusted = CertificationContract.hasEnoughNonNeutralizedChallengesToBeTrusted(numberOfChallenges, numberOfNonNeutralizedChallenges);

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-certif",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-certif",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "private": false,
   "description": "Plateforme en ligne de gestion des sessions de certification",
   "license": "AGPL-3.0",

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-e2e",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-e2e",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "description": "Permet d'exécuter des tests de bout en bout sur la plateforme Pix",
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-load-testing",
-  "version": "1.214.0",
+  "version": "1.215.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-load-testing",
-  "version": "1.214.0",
+  "version": "1.215.0",
   "description": "Permet d'exécuter des tests de charge sur l'API de la plateforme Pix.",
   "homepage": "https://github.com/1024pix/pix/tree/dev/high-level-tests/load-testing#readme",
   "author": "GIP Pix",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mon-pix",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mon-pix",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-orga",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-orga",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "private": false,
   "description": "Plateforme en ligne de gestion de campagne d'évaluation",
   "license": "AGPL-3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix",
-  "version": "3.108.0",
+  "version": "3.109.0",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## :unicorn: Problème
Une règle de scoring globale a été implémentée, permettant d’annuler automatiquement une certification dont le taux de neutralisation dépasse un certain pourcentage (33%). Tel qu’implémentée aujourd’hui, cette règle de scoring permet de rendre scorable une certification avec trop de questions neutralisées, et donc ne garantit pas suffisamment la bonne qualité de la certification délivrée. En effet pour le moment, une certification avec 15 questions par exemple sera considérée comme scorable s’il y a eu 9 questions non neutralisées. 

## :robot: Solution
Arrondir à l'entier supérieur la règle de neutralisation d'une certification.

## :100: Pour tester
- créer une session de certif avec 2 candidats : 
    - anne success
    - certif 1
- passer le test de certif avec certif1@example.net
    - réussir toutes les questions
- passer le test de certif avec certifsuccess@example.net
    - répondre à OK à 32/48 questions puis NE PAS terminer le test
- finaliser la session de certification
- sélectionner comme “raison de l’abandon” = “pb technique” pour le candidat anne success
- dans pix admin, afficher la page de détails : 
    - de certif1 : 
        - neutraliser 5 questions : la certif doit être automatiquement “Annulée”
        - déneutraliser 1 question : la certif doit repasser au statut “Validée”
    - anne success : 
        - la certif doit avoir été scorée automatiquement au statut “Validée”
        - neutraliser une question : la certif doit être automatiquement “Annulée”