### PR TITLE
[ADMIN] Ne plus bloquer l'enregistrement d'une liste d'organisations si certains sont déjà rattachées à un profil cible (PIX-3456)

### DIFF
--- a/admin/app/components/target-profiles/organizations.js
+++ b/admin/app/components/target-profiles/organizations.js
@@ -17,9 +17,31 @@ export default class Organizations extends Component {
     e.preventDefault();
     const targetProfile = this.args.targetProfile;
     try {
-      await targetProfile.attachOrganizations({ 'organization-ids': this._getUniqueOrganizations() });
+      const response = await targetProfile.attachOrganizations({ 'organization-ids': this._getUniqueOrganizations() });
+
+      const { 'attached-ids': attachedIds, 'duplicated-ids': duplicatedIds } = response.data.attributes;
+
       this.organizationsToAttach = null;
-      await this.notifications.success('Organisation(s) rattaché(es) avec succès.');
+      const hasInsertedOrganizations = attachedIds.length > 0;
+      const hasDuplicatedOrgnizations = duplicatedIds.length > 0;
+      const message = [];
+
+      if (hasInsertedOrganizations) {
+        message.push('Organisation(s) rattaché(es) avec succès.');
+      }
+
+      if (hasInsertedOrganizations && hasDuplicatedOrgnizations) {
+        message.push('<br/>');
+      }
+
+      if (hasDuplicatedOrgnizations) {
+        message.push(
+          `Le(s) organisation(s) suivantes étai(en)t déjà rattachée(s) à ce profil cible : ${duplicatedIds.join(', ')}`
+        );
+      }
+
+      await this.notifications.success(message.join(''), { htmlContent: true });
+
       return this.router.replaceWith('authenticated.target-profiles.target-profile.organizations');
     } catch (responseError) {
       this._handleResponseError(responseError);

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -18,7 +18,8 @@ function attachTargetProfileToOrganizations(schema, request) {
   organizationsToAttach.forEach((organizationId) =>
     schema.organizations.create({ id: organizationId, name: `Organization ${organizationId}` })
   );
-  return new Response(204);
+
+  return { data: { attributes: { 'duplicated-ids': [], 'attached-ids': organizationsToAttach } } };
 }
 
 function attachOrganizationsFromExistingTargetProfile(schema, request) {

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -5,6 +5,7 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils'
 const organizationSerializer = require('../../infrastructure/serializers/jsonapi/organization-serializer');
 const badgeSerializer = require('../../infrastructure/serializers/jsonapi/badge-serializer');
 const stageSerializer = require('../../infrastructure/serializers/jsonapi/stage-serializer');
+const targetProfileAttachOrganizationSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer');
 
 module.exports = {
 
@@ -39,8 +40,9 @@ module.exports = {
   async attachOrganizations(request, h) {
     const organizationIds = request.payload['organization-ids'];
     const targetProfileId = request.params.id;
-    await usecases.attachOrganizationsToTargetProfile({ targetProfileId, organizationIds });
-    return h.response({}).code(204);
+    const results = await usecases.attachOrganizationsToTargetProfile({ targetProfileId, organizationIds });
+
+    return h.response(targetProfileAttachOrganizationSerializer.serialize({ ...results, targetProfileId })).code(200);
   },
 
   async attachOrganizationsFromExistingTargetProfile(request, h) {

--- a/api/lib/domain/usecases/attach-organizations-to-target-profile.js
+++ b/api/lib/domain/usecases/attach-organizations-to-target-profile.js
@@ -7,5 +7,5 @@ module.exports = async function attachOrganizationsToTargetProfile({
   const targetProfile = await targetProfileRepository.get(targetProfileId);
   targetProfile.addOrganizations(organizationIds);
 
-  await targetProfileRepository.attachOrganizations(targetProfile);
+  return targetProfileRepository.attachOrganizations(targetProfile);
 };

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js
@@ -1,0 +1,13 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(model) {
+    return new Serializer('target-profile-attach-organization', {
+      id: 'targetProfileId',
+      attributes: [
+        'duplicatedIds',
+        'attachedIds',
+      ],
+    }).serialize(model);
+  },
+};

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -164,8 +164,8 @@ describe('Acceptance | Controller | target-profile-controller', function() {
       return knex('target-profile-shares').delete();
     });
 
-    it('should return 204', async function() {
-      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+    it('should return 200', async function() {
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const user = databaseBuilder.factory.buildUser.withPixRolePixMaster();
       const organization1 = databaseBuilder.factory.buildOrganization();
       const organization2 = databaseBuilder.factory.buildOrganization();
@@ -173,7 +173,7 @@ describe('Acceptance | Controller | target-profile-controller', function() {
 
       const options = {
         method: 'POST',
-        url: `/api/admin/target-profiles/${targetProfile.id}/attach-organizations`,
+        url: `/api/admin/target-profiles/${targetProfileId}/attach-organizations`,
         headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
         payload: {
           'organization-ids': [organization1.id, organization2.id],
@@ -185,10 +185,10 @@ describe('Acceptance | Controller | target-profile-controller', function() {
 
       const rows = await knex('target-profile-shares')
         .select('organizationId')
-        .where({ targetProfileId: targetProfile.id });
+        .where({ targetProfileId: targetProfileId });
       const organizationIds = rows.map(({ organizationId }) => organizationId);
       // then
-      expect(response.statusCode).to.equal(204);
+      expect(response.statusCode).to.equal(200);
       expect(organizationIds).to.exactlyContain([organization1.id, organization2.id]);
     });
   });

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -443,10 +443,12 @@ describe('Integration | Repository | Target-profile', function() {
     });
 
     context('when there are filters that should be ignored', function() {
+      let targetProfileId1;
+      let targetProfileId2;
 
       beforeEach(function() {
-        databaseBuilder.factory.buildTargetProfile({ id: 1 });
-        databaseBuilder.factory.buildTargetProfile({ id: 2 });
+        targetProfileId1 = databaseBuilder.factory.buildTargetProfile().id;
+        targetProfileId2 = databaseBuilder.factory.buildTargetProfile().id;
 
         return databaseBuilder.commit();
       });
@@ -460,7 +462,7 @@ describe('Integration | Repository | Target-profile', function() {
         const { models: matchingTargetProfiles } = await targetProfileRepository.findPaginatedFiltered({ filter, page });
 
         // then
-        expect(_.map(matchingTargetProfiles, 'id')).to.have.members([1, 2]);
+        expect(_.map(matchingTargetProfiles, 'id')).to.have.members([targetProfileId1, targetProfileId2]);
       });
     });
   });
@@ -472,13 +474,13 @@ describe('Integration | Repository | Target-profile', function() {
     });
 
     it('should return attachedIds', async function() {
-      databaseBuilder.factory.buildTargetProfile({ id: 12 });
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const organization1 = databaseBuilder.factory.buildOrganization();
       const organization2 = databaseBuilder.factory.buildOrganization();
 
       await databaseBuilder.commit();
 
-      const targetProfile = domainBuilder.buildTargetProfile({ id: 12 });
+      const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId });
 
       targetProfile.addOrganizations([organization1.id, organization2.id]);
 
@@ -488,13 +490,13 @@ describe('Integration | Repository | Target-profile', function() {
     });
 
     it('add organization to the target profile', async function() {
-      databaseBuilder.factory.buildTargetProfile({ id: 12 });
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const organization1 = databaseBuilder.factory.buildOrganization();
       const organization2 = databaseBuilder.factory.buildOrganization();
 
       await databaseBuilder.commit();
 
-      const targetProfile = domainBuilder.buildTargetProfile({ id: 12 });
+      const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId });
 
       targetProfile.addOrganizations([organization1.id, organization2.id]);
 
@@ -510,13 +512,13 @@ describe('Integration | Repository | Target-profile', function() {
 
     context('when the organization does not exist', function() {
       it('throws an error', async function() {
-        databaseBuilder.factory.buildTargetProfile({ id: 12 });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const unknownOrganizationId = 99999;
 
         await databaseBuilder.commit();
 
-        const targetProfile = domainBuilder.buildTargetProfile({ id: 12 });
+        const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId });
 
         targetProfile.addOrganizations([unknownOrganizationId, organizationId]);
 
@@ -529,15 +531,15 @@ describe('Integration | Repository | Target-profile', function() {
 
     context('when the organization is already attached', function() {
       it('should return inserted organizationId', async function() {
-        databaseBuilder.factory.buildTargetProfile({ id: 12 });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
         const firstOrganization = databaseBuilder.factory.buildOrganization();
         const secondOrganization = databaseBuilder.factory.buildOrganization();
 
-        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: 12, organizationId: firstOrganization.id });
+        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileId, organizationId: firstOrganization.id });
 
         await databaseBuilder.commit();
 
-        const targetProfile = domainBuilder.buildTargetProfile({ id: 12 });
+        const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId });
 
         targetProfile.addOrganizations([firstOrganization.id, secondOrganization.id]);
 
@@ -588,19 +590,19 @@ describe('Integration | Repository | Target-profile', function() {
 
     context('when the organization is already attached', function() {
       it('should return inserted organization', async function() {
-        const targetProfile = databaseBuilder.factory.buildTargetProfile({ id: 12 });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
         const firstOrganization = databaseBuilder.factory.buildOrganization();
         const secondOrganization = databaseBuilder.factory.buildOrganization();
 
-        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: 12, organizationId: firstOrganization.id });
+        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: firstOrganization.id });
 
         await databaseBuilder.commit();
 
-        await targetProfileRepository.attachOrganizationIds({ targetProfileId: targetProfile.id, organizationIds: [firstOrganization.id, secondOrganization.id] });
+        await targetProfileRepository.attachOrganizationIds({ targetProfileId, organizationIds: [firstOrganization.id, secondOrganization.id] });
 
         const rows = await knex('target-profile-shares')
           .select('organizationId')
-          .where({ targetProfileId: targetProfile.id });
+          .where({ targetProfileId });
         const result = rows.map(({ organizationId }) => organizationId);
 
         expect(result).to.deep.equal([firstOrganization.id, secondOrganization.id]);
@@ -612,13 +614,13 @@ describe('Integration | Repository | Target-profile', function() {
 
     context('when none of given organizations is attached to the targetProfile', function() {
       it('return true', async function() {
-        databaseBuilder.factory.buildTargetProfile({ id: 12 });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
         const organization1 = databaseBuilder.factory.buildOrganization();
         const organization2 = databaseBuilder.factory.buildOrganization();
 
         await databaseBuilder.commit();
 
-        const targetProfile = domainBuilder.buildTargetProfile({ id: 12 });
+        const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId });
 
         targetProfile.addOrganizations([organization1.id, organization2.id]);
 
@@ -630,15 +632,15 @@ describe('Integration | Repository | Target-profile', function() {
 
     context('when one of given organizations is attached to the targetProfile', function() {
       it('return true', async function() {
-        databaseBuilder.factory.buildTargetProfile({ id: 12 });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
         const organization1 = databaseBuilder.factory.buildOrganization();
         const organization2 = databaseBuilder.factory.buildOrganization();
 
-        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: 12, organizationId: organization1.id });
+        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: organization1.id });
 
         await databaseBuilder.commit();
 
-        const targetProfile = domainBuilder.buildTargetProfile({ id: 12 });
+        const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId });
 
         targetProfile.addOrganizations([organization1.id, organization2.id]);
 

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon, hFake } = require('../../../test-helper');
 const targetProfileController = require('../../../../lib/application/target-profiles/target-profile-controller');
 const usecases = require('../../../../lib/domain/usecases');
+const targetProfileAttachOrganizationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer');
 
 describe('Unit | Controller | target-profile-controller', function() {
 
@@ -9,7 +10,6 @@ describe('Unit | Controller | target-profile-controller', function() {
     let request;
 
     beforeEach(function() {
-
       sinon.stub(usecases, 'updateTargetProfileName');
 
       request = {
@@ -52,6 +52,7 @@ describe('Unit | Controller | target-profile-controller', function() {
 
     beforeEach(function() {
       sinon.stub(usecases, 'attachOrganizationsToTargetProfile');
+      sinon.stub(targetProfileAttachOrganizationSerializer, 'serialize');
 
       request = {
         params: {
@@ -67,10 +68,15 @@ describe('Unit | Controller | target-profile-controller', function() {
 
       it('should succeed', async function() {
         // when
-        const response = await targetProfileController.attachOrganizations(request, hFake);
+        const serializer = Symbol('targetProfileAttachOrganizationsSerializer');
+        usecases.attachOrganizationsToTargetProfile.resolves();
+        targetProfileAttachOrganizationSerializer.serialize.returns(serializer);
 
+        const response = await targetProfileController.attachOrganizations(request, hFake);
         // then
-        expect(response.statusCode).to.equal(204);
+        expect(targetProfileAttachOrganizationSerializer.serialize).to.have.been.called;
+        expect(response.statusCode).to.equal(200);
+        expect(response.source).to.equal(serializer);
       });
 
       it('should call usecase', async function() {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer_test.js
@@ -1,0 +1,26 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer');
+
+describe('Unit | Serializer | JSONAPI | target-profile-attach-organization-serializer', function() {
+
+  describe('#serialize', function() {
+    it('should convert a target profile attach organization object to JSON API data', function() {
+      const json = serializer.serialize({
+        targetProfileId: 1,
+        attachedIds: [1, 5],
+        duplicatedIds: [8, 9],
+      });
+
+      expect(json).to.deep.equal({
+        data: {
+          type: 'target-profile-attach-organizations',
+          id: '1',
+          attributes: {
+            'attached-ids': [1, 5],
+            'duplicated-ids': [8, 9],
+          },
+        },
+      });
+    });
+  });
+});

--- a/orga/tests/integration/components/participant/profile/header_test.js
+++ b/orga/tests/integration/components/participant/profile/header_test.js
@@ -91,6 +91,7 @@ module('Integration | Component | Participant::Profile::Header', function (hooks
       test('it displays the pix score', async function (assert) {
         this.campaignProfile = {
           pixScore: '124',
+          createdAt: '01-01-1990',
           isShared: true,
         };
         this.campaign = {};
@@ -103,6 +104,7 @@ module('Integration | Component | Participant::Profile::Header', function (hooks
       test('it displays the total number of competence', async function (assert) {
         this.campaignProfile = {
           competencesCount: 12,
+          createdAt: '01-01-1990',
           isShared: true,
         };
         this.campaign = {};
@@ -114,6 +116,7 @@ module('Integration | Component | Participant::Profile::Header', function (hooks
       test('it displays the total number of certifiable competence', async function (assert) {
         this.campaignProfile = {
           certifiableCompetencesCount: 2,
+          createdAt: '01-01-1990',
           isShared: true,
         };
         this.campaign = {};
@@ -173,6 +176,7 @@ module('Integration | Component | Participant::Profile::Header', function (hooks
       test('it does not display the total number of competence', async function (assert) {
         this.campaignProfile = {
           competencesCount: 32,
+          createdAt: '01-01-1990',
           isShared: false,
         };
         this.campaign = {};
@@ -186,6 +190,7 @@ module('Integration | Component | Participant::Profile::Header', function (hooks
       test('it does not display the total number of certifiable competence', async function (assert) {
         this.campaignProfile = {
           certifiableCompetencesCount: 33,
+          createdAt: '01-01-1990',
           isShared: false,
         };
         this.campaign = {};


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'ajout d'une liste d'organisations à un profil cible, si dans cette liste certains était déjà rattaché, nous affichions un message d'erreur. Ce qui est une gêne pour l'utilisateur à devoir nettoyer sa liste.

## :robot: Solution
Ne plus empêcher l'insertion de la liste ET remonter un message pour notifier quelles organisations étaient déjà présentes.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur Pix Admin et ajouter des organisations déjà rattachées