### PR TITLE
[FEATURE] Envoyer le code de vérification une fois le champ de code rempli pour le changement d'adresse e-mail sur Pix App (PIX-3534).

### DIFF
--- a/mon-pix/app/components/user-account/email-verification-code.hbs
+++ b/mon-pix/app/components/user-account/email-verification-code.hbs
@@ -16,14 +16,14 @@
     </PixMessage>
   {{/if}}
 
-  {{#if this.wasButtonClicked}}
+  {{#if this.isEmailSent}}
     <PixMessage @type="success" class="email-verification-code__resend-confirmation-message">
       {{t "pages.user-account.email-verification.confirmation-message"}}
     </PixMessage>
   {{else}}
     <div class="email-verification-code__resend {{if this.showResendCode "visible"}}">
       <p>{{t "pages.user-account.email-verification.did-not-receive"}}</p>
-      <button type="button" {{on "click" this.resendVerificationCodeByEmail}}>
+      <button type="button" disabled={{this.isResending}} {{on "click" this.resendVerificationCodeByEmail}}>
         {{t "pages.user-account.email-verification.send-back-the-code"}}
       </button>
     </div>

--- a/mon-pix/app/components/user-account/email-verification-code.hbs
+++ b/mon-pix/app/components/user-account/email-verification-code.hbs
@@ -10,6 +10,12 @@
     />
   </div>
 
+  {{#if this.errorMessage}}
+    <PixMessage @type="error" class="email-verification-code__error">
+      {{this.errorMessage}}
+    </PixMessage>
+  {{/if}}
+
   {{#if this.wasButtonClicked}}
     <PixMessage @type="success" class="email-verification-code__resend-confirmation-message">
       {{t "pages.user-account.email-verification.confirmation-message"}}

--- a/mon-pix/app/components/user-account/email-verification-code.hbs
+++ b/mon-pix/app/components/user-account/email-verification-code.hbs
@@ -1,24 +1,24 @@
-<h2 class="user-account__validation-title">{{t "pages.email-verification.title"}}</h2>
+<h2 class="user-account__validation-title">{{t "pages.user-account.email-verification.title"}}</h2>
 <div class="email-verification-code">
-  <p class="email-verification-code__description">{{t "pages.email-verification.description"}}</p>
+  <p class="email-verification-code__description">{{t "pages.user-account.email-verification.description"}}</p>
   <p class="email-verification-code__email">{{@email}}</p>
   <div class="email-verification-code__input-code">
     <PixInputCode
-      @ariaLabel="Champ du code de vérification"
+      @ariaLabel={{t "pages.user-account.email-verification.code-label"}}
       @numInputs={{6}}
-      @onAllInputsFilled={{this.submitInputCode}}
+      @onAllInputsFilled={{this.onSubmitCode}}
     />
   </div>
 
   {{#if this.wasButtonClicked}}
     <PixMessage @type="success" class="email-verification-code__resend-confirmation-message">
-      {{t "pages.email-verification.confirmation-message"}}
+      {{t "pages.user-account.email-verification.confirmation-message"}}
     </PixMessage>
   {{else}}
     <div class="email-verification-code__resend {{if this.showResendCode "visible"}}">
-      <p>{{t "pages.email-verification.did-not-receive"}}</p>
+      <p>{{t "pages.user-account.email-verification.did-not-receive"}}</p>
       <button type="button" {{on "click" this.resendVerificationCodeByEmail}}>
-        {{t "pages.email-verification.send-back-the-code"}}
+        {{t "pages.user-account.email-verification.send-back-the-code"}}
       </button>
     </div>
   {{/if}}

--- a/mon-pix/app/components/user-account/email-verification-code.js
+++ b/mon-pix/app/components/user-account/email-verification-code.js
@@ -44,5 +44,6 @@ export default class EmailVerificationCode extends Component {
     if (email) {
       this.currentUser.user.email = email;
     }
+    this.args.disableEmailEditionMode();
   }
 }

--- a/mon-pix/app/components/user-account/email-verification-code.js
+++ b/mon-pix/app/components/user-account/email-verification-code.js
@@ -10,7 +10,8 @@ export default class EmailVerificationCode extends Component {
   @service store;
   @service intl;
   @tracked showResendCode = false;
-  @tracked wasButtonClicked = false;
+  @tracked isResending = false;
+  @tracked isEmailSent = false;
   @tracked errorMessage = null;
 
   constructor() {
@@ -23,18 +24,18 @@ export default class EmailVerificationCode extends Component {
 
   @action
   async resendVerificationCodeByEmail() {
+    this.isResending = true;
     try {
-      if (!this.wasButtonClicked) {
-        this.wasButtonClicked = true;
-        const emailVerificationCode = this.store.createRecord('email-verification-code', {
-          password: this.args.password,
-          newEmail: this.args.email.trim().toLowerCase(),
-        });
-        await emailVerificationCode.sendNewEmail();
-      }
+      const emailVerificationCode = this.store.createRecord('email-verification-code', {
+        password: this.args.password,
+        newEmail: this.args.email.trim().toLowerCase(),
+      });
+      await emailVerificationCode.sendNewEmail();
+      this.isEmailSent = true;
     } finally {
+      this.isResending = false;
       setTimeout(() => {
-        this.wasButtonClicked = false;
+        this.isEmailSent = false;
       }, ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
     }
   }

--- a/mon-pix/app/components/user-account/email-verification-code.js
+++ b/mon-pix/app/components/user-account/email-verification-code.js
@@ -5,9 +5,9 @@ import { tracked } from '@glimmer/tracking';
 import ENV from 'mon-pix/config/environment';
 
 export default class EmailVerificationCode extends Component {
-
-  @service intl;
+  @service currentUser;
   @service store;
+  @service intl;
   @tracked showResendCode = false;
   @tracked wasButtonClicked = false;
 
@@ -38,7 +38,11 @@ export default class EmailVerificationCode extends Component {
   }
 
   @action
-  submitInputCode() {
-    // todo
+  async onSubmitCode(code) {
+    const emailVerificationCode = this.store.createRecord('email-verification-code', { code });
+    const email = await emailVerificationCode.verifyCode();
+    if (email) {
+      this.currentUser.user.email = email;
+    }
   }
 }

--- a/mon-pix/app/components/user-account/email-verification-code.js
+++ b/mon-pix/app/components/user-account/email-verification-code.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'mon-pix/config/environment';
+import get from 'lodash/get';
 
 export default class EmailVerificationCode extends Component {
   @service currentUser;
@@ -10,6 +11,7 @@ export default class EmailVerificationCode extends Component {
   @service intl;
   @tracked showResendCode = false;
   @tracked wasButtonClicked = false;
+  @tracked errorMessage = null;
 
   constructor() {
     super(...arguments);
@@ -40,11 +42,29 @@ export default class EmailVerificationCode extends Component {
   @action
   async onSubmitCode(code) {
     const emailVerificationCode = this.store.createRecord('email-verification-code', { code });
-    const email = await emailVerificationCode.verifyCode();
-    if (email) {
-      this.currentUser.user.email = email;
+    try {
+      const email = await emailVerificationCode.verifyCode();
+      if (email) {
+        this.currentUser.user.email = email;
+      }
+      this.args.disableEmailEditionMode();
+      this.args.displayEmailUpdateMessage();
+    } catch (response) {
+      const status = get(response, 'errors[0].status');
+
+      if (status === '403') {
+        const code = get(response, 'errors[0].code');
+
+        if (code === 'INVALID_VERIFICATION_CODE') {
+          this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.incorrect-code');
+        } else if (code === 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND') {
+          this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.email-modification-demand-expired');
+        }
+      } else if (status === '400') {
+        this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.new-email-already-exist');
+      } else {
+        this.errorMessage = this.intl.t('pages.user-account.email-verification.errors.unknown-error');
+      }
     }
-    this.args.disableEmailEditionMode();
-    this.args.displayEmailUpdateMessage();
   }
 }

--- a/mon-pix/app/components/user-account/email-verification-code.js
+++ b/mon-pix/app/components/user-account/email-verification-code.js
@@ -45,5 +45,6 @@ export default class EmailVerificationCode extends Component {
       this.currentUser.user.email = email;
     }
     this.args.disableEmailEditionMode();
+    this.args.displayEmailUpdateMessage();
   }
 }

--- a/mon-pix/app/components/user-account/update-email-with-validation.hbs
+++ b/mon-pix/app/components/user-account/update-email-with-validation.hbs
@@ -7,6 +7,7 @@
   {{else}}
     <UserAccount::EmailVerificationCode
       @disableEmailEditionMode={{@disableEmailEditionMode}}
+      @displayEmailUpdateMessage={{@displayEmailUpdateMessage}}
       @email={{this.newEmail}}
       @password={{this.password}}
     />

--- a/mon-pix/app/controllers/user-account/connection-methods.js
+++ b/mon-pix/app/controllers/user-account/connection-methods.js
@@ -7,6 +7,7 @@ export default class ConnectionMethodsController extends Controller {
   @service featureToggles;
 
   @tracked isEmailEditionMode = false;
+  @tracked showEmailUpdatedMessage = false;
 
   get shouldShowEmail() {
     return !!this.model.email;
@@ -24,6 +25,11 @@ export default class ConnectionMethodsController extends Controller {
   @action
   disableEmailEditionMode() {
     this.isEmailEditionMode = false;
+  }
+
+  @action
+  displayEmailUpdateMessage() {
+    this.showEmailUpdatedMessage = true;
   }
 
   @action

--- a/mon-pix/app/models/email-verification-code.js
+++ b/mon-pix/app/models/email-verification-code.js
@@ -4,13 +4,30 @@ import { memberAction } from 'ember-api-actions';
 export default class EmailVerificationCode extends Model {
   @attr('string') newEmail;
   @attr('string') password;
+  @attr('string') code;
 
   sendNewEmail = memberAction({
     path: 'email/verification-code',
     type: 'PUT',
-    urlType: 'email-verification-code',
     before() {
-      return this.serialize();
+      const payload = this.serialize();
+      delete payload.data.attributes.code;
+      return payload;
+    },
+  });
+
+  verifyCode = memberAction({
+    path: 'update-email',
+    type: 'POST',
+    before() {
+      const payload = this.serialize();
+      delete payload.data.attributes['new-email'];
+      delete payload.data.attributes.password;
+      return payload;
+    },
+    after(response) {
+      const { data: { attributes: { email } = {} } = {} } = response;
+      return email;
     },
   });
 }

--- a/mon-pix/app/models/email-verification-code.js
+++ b/mon-pix/app/models/email-verification-code.js
@@ -26,8 +26,7 @@ export default class EmailVerificationCode extends Model {
       return payload;
     },
     after(response) {
-      const { data: { attributes: { email } = {} } = {} } = response;
-      return email;
+      return response?.data?.attributes?.email;
     },
   });
 }

--- a/mon-pix/app/routes/user-account/connection-methods.js
+++ b/mon-pix/app/routes/user-account/connection-methods.js
@@ -9,5 +9,6 @@ export default class ConnectionMethodsRoute extends Route {
   setupController(controller, model) {
     super.setupController(controller, model);
     controller.isEmailEditionMode = false;
+    controller.showEmailUpdatedMessage = false;
   }
 }

--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -105,9 +105,7 @@
     }
   }
 
-  &__connection-methods,
-  &__update-email,
-  &__update-email-with-validation {
+  &__connection-methods {
     margin: 0 auto;
     max-width: 980px;
     padding: 0 20px;

--- a/mon-pix/app/styles/components/user-account/_email-verification-code.scss
+++ b/mon-pix/app/styles/components/user-account/_email-verification-code.scss
@@ -14,6 +14,11 @@
     margin: 24px 0;
   }
 
+  &__error {
+    max-width: 520px;
+    margin-bottom: 20px;
+  }
+
   &__resend {
     display: flex;
     opacity: 0;

--- a/mon-pix/app/styles/components/user-account/_update-email-with-validation.scss
+++ b/mon-pix/app/styles/components/user-account/_update-email-with-validation.scss
@@ -24,9 +24,13 @@
     }
   }
 
-  &__password-input .pix-input-password > svg {
-    width: 18px;
-    height: 18px;
+  &__password-input {
+    padding-bottom: 20px;
+
+    .pix-input-password > svg {
+      width: 18px;
+      height: 18px;
+    }
   }
 
   &__informations {

--- a/mon-pix/app/styles/pages/_connexion-methods.scss
+++ b/mon-pix/app/styles/pages/_connexion-methods.scss
@@ -1,14 +1,25 @@
 .user-account-panel__item {
-  margin: 20px 0;
+  margin: 20px 0 0 0;
   display: flex;
   align-content: flex-start;
   border-bottom: $grey-15 1px solid;
-  padding-bottom: 1rem;
+  padding-bottom: 20px;
+
+  &.with-success-message {
+    border-bottom: none;
+    margin: 20px 0 0 0;
+  }
 
   &:last-child {
     border-bottom: none;
     padding-bottom: 0;
+    margin: 20px 0;
   }
+}
+
+.success-message {
+  padding-bottom: 20px;
+  border-bottom: $grey-15 1px solid;
 }
 
 .user-account-panel-item__text {

--- a/mon-pix/app/templates/user-account/connection-methods.hbs
+++ b/mon-pix/app/templates/user-account/connection-methods.hbs
@@ -1,18 +1,14 @@
-{{#if this.isEmailEditionMode}}
-  {{#if this.featureToggles.featureToggles.isEmailValidationEnabled}}
-    <div class="user-account__update-email-with-validation">
+<div class="user-account__connection-methods">
+  {{#if this.isEmailEditionMode}}
+    {{#if this.featureToggles.featureToggles.isEmailValidationEnabled}}
       <UserAccount::UpdateEmailWithValidation @disableEmailEditionMode={{this.disableEmailEditionMode}} />
-    </div>
-  {{else}}
-    <div class="user-account__update-email">
+    {{else}}
       <UserAccount::UpdateEmail
         @saveNewEmail={{this.saveNewEmail}}
         @disableEmailEditionMode={{this.disableEmailEditionMode}}
       />
-    </div>
-  {{/if}}
-{{else}}
-  <div class="user-account__connection-methods">
+    {{/if}}
+  {{else}}
     {{#if this.shouldShowEmail}}
       <div class="user-account-panel__item">
         <div class="user-account-panel-item__text">
@@ -26,7 +22,6 @@
         </PixButton>
       </div>
     {{/if}}
-
     {{#if this.shouldShowUsername}}
       <div class="user-account-panel__item">
         <div class="user-account-panel-item__text">
@@ -37,5 +32,5 @@
         </div>
       </div>
     {{/if}}
-  </div>
-{{/if}}
+  {{/if}}
+</div>

--- a/mon-pix/app/templates/user-account/connection-methods.hbs
+++ b/mon-pix/app/templates/user-account/connection-methods.hbs
@@ -1,7 +1,10 @@
 <div class="user-account__connection-methods">
   {{#if this.isEmailEditionMode}}
     {{#if this.featureToggles.featureToggles.isEmailValidationEnabled}}
-      <UserAccount::UpdateEmailWithValidation @disableEmailEditionMode={{this.disableEmailEditionMode}} />
+      <UserAccount::UpdateEmailWithValidation
+        @disableEmailEditionMode={{this.disableEmailEditionMode}}
+        @displayEmailUpdateMessage={{this.displayEmailUpdateMessage}}
+      />
     {{else}}
       <UserAccount::UpdateEmail
         @saveNewEmail={{this.saveNewEmail}}
@@ -10,7 +13,7 @@
     {{/if}}
   {{else}}
     {{#if this.shouldShowEmail}}
-      <div class="user-account-panel__item">
+      <div class="user-account-panel__item{{if this.showEmailUpdatedMessage " with-success-message"}}">
         <div class="user-account-panel-item__text">
           <p class="form-textfield__label user-account-panel-item__label">{{t
               "pages.user-account.connexion-methods.email"
@@ -21,6 +24,14 @@
           {{t "pages.user-account.connexion-methods.edit-button"}}
         </PixButton>
       </div>
+
+      {{#if this.showEmailUpdatedMessage}}
+        <div class="success-message">
+          <PixMessage @type="success" @withIcon={{true}}>
+            {{t "pages.user-account.email-verification.update-successful"}}
+          </PixMessage>
+        </div>
+      {{/if}}
     {{/if}}
     {{#if this.shouldShowUsername}}
       <div class="user-account-panel__item">

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -68,6 +68,19 @@ export default function() {
     return new Response(204);
   });
 
+  this.post('/users/:id/update-email', () => {
+    const response = {
+      'data': {
+        'type': 'email-verification-codes',
+        'attributes': {
+          'email': 'new-email@example.net',
+        },
+      },
+    };
+
+    return response;
+  });
+
   this.patch('/users/:id/pix-terms-of-service-acceptance', (schema, request) => {
     const userId = request.params.id;
     const user = schema.users.find(userId);

--- a/mon-pix/tests/acceptance/user-account/connection-methods_test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods_test.js
@@ -129,7 +129,7 @@ describe('Acceptance | user-account | connection-methods', function() {
         await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
         // then
-        expect(contains(this.intl.t('pages.email-verification.description'))).to.exist;
+        expect(contains(this.intl.t('pages.user-account.email-verification.description'))).to.exist;
         expect(contains(newEmail)).to.exist;
       });
 

--- a/mon-pix/tests/acceptance/user-account/connection-methods_test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods_test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import visit from '../../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { triggerEvent } from '@ember/test-helpers';
 import { contains } from '../../helpers/contains';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { fillInByLabel } from '../../helpers/fill-in-by-label';
@@ -114,7 +115,7 @@ describe('Acceptance | user-account | connection-methods', function() {
 
     context('email validation is toggled on', function() {
 
-      it('should be able to edit the email using the new form and see the verification code page', async function() {
+      it('should be able to edit the email, enter the code received, and be successfully redirected to account page', async function() {
         // given
         const user = server.create('user', 'withEmail');
         server.create('feature-toggle', { id: 0, isEmailValidationEnabled: true });
@@ -127,10 +128,10 @@ describe('Acceptance | user-account | connection-methods', function() {
         await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
         await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), user.password);
         await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
+        await triggerEvent('#code-input-1', 'paste', { clipboardData: { getData: () => '123456' } });
 
         // then
-        expect(contains(this.intl.t('pages.user-account.email-verification.description'))).to.exist;
-        expect(contains(newEmail)).to.exist;
+        expect(contains(this.intl.t('pages.user-account.connexion-methods.email'))).to.exist;
       });
 
     });

--- a/mon-pix/tests/acceptance/user-account/connection-methods_test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods_test.js
@@ -132,6 +132,8 @@ describe('Acceptance | user-account | connection-methods', function() {
 
         // then
         expect(contains(this.intl.t('pages.user-account.connexion-methods.email'))).to.exist;
+        expect(contains(this.intl.t('pages.user-account.email-verification.update-successful'))).to.exist;
+        expect(contains(newEmail)).to.exist;
       });
 
     });

--- a/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import findByLabel from '../../../helpers/find-by-label';
 import { contains } from '../../../helpers/contains';
@@ -12,66 +12,176 @@ import { clickByLabel } from '../../../helpers/click-by-label';
 describe('Integration | Component | user-account | email-verification-code', function() {
   setupIntlRenderingTest();
 
-  it('should not display resend code message at the beginning', async function() {
-    // given
-    this.set('email', 'toto@example.net');
+  context('resend code message', function() {
 
-    // when
-    await render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} />`);
+    it('should not display resend code message at the beginning', async function() {
+      // given
+      this.set('email', 'toto@example.net');
 
-    // then
-    expect(findByLabel(this.intl.t('pages.user-account.email-verification.did-not-receive'))).not.to.have.class('visible');
-  });
-
-  it(`should display a resend code message after ${ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND} milliseconds`, function() {
-    // given
-    const email = 'toto@example.net';
-    const password = 'pix123';
-    this.set('email', email);
-    this.set('password', password);
-
-    const clock = sinon.useFakeTimers();
-
-    // when
-    const promise = render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} @password={{this.password}} />`);
-    clock.tick(ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
-
-    const result = promise.then(async () => {
-      expect(contains(this.intl.t('pages.user-account.email-verification.did-not-receive'))).to.exist;
-      expect(contains(this.intl.t('pages.user-account.email-verification.send-back-the-code'))).to.exist;
-    });
-    clock.restore();
-    return result;
-  });
-
-  it('should show confirmation message when resending code message', function() {
-    // given
-    const email = 'toto@example.net';
-    const password = 'pix123';
-    this.set('email', email);
-    this.set('password', password);
-
-    const store = this.owner.lookup('service:store');
-    const sendNewEmailStub = sinon.stub();
-    store.createRecord = sinon.stub();
-    store.createRecord
-      .withArgs('email-verification-code', { password, newEmail: email })
-      .returns({ sendNewEmail: sendNewEmailStub });
-
-    const clock = sinon.useFakeTimers();
-
-    // when
-    const promise = render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} @password={{this.password}} />`);
-    clock.tick(ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
-
-    const result = promise.then(async () => {
-      await clickByLabel(this.intl.t('pages.user-account.email-verification.send-back-the-code'));
+      // when
+      await render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} />`);
 
       // then
-      expect(contains(this.intl.t('pages.user-account.email-verification.confirmation-message'))).to.exist;
-      expect(contains(this.intl.t('pages.user-account.email-verification.send-back-the-code'))).to.not.exist;
+      expect(findByLabel(this.intl.t('pages.user-account.email-verification.did-not-receive'))).not.to.have.class('visible');
     });
-    clock.restore();
-    return result;
+
+    it(`should display a resend code message after ${ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND} milliseconds`, function() {
+    // given
+      const email = 'toto@example.net';
+      const password = 'pix123';
+      this.set('email', email);
+      this.set('password', password);
+
+      const clock = sinon.useFakeTimers();
+
+      // when
+      const promise = render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} @password={{this.password}} />`);
+      clock.tick(ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
+
+      const result = promise.then(async () => {
+        expect(contains(this.intl.t('pages.user-account.email-verification.did-not-receive'))).to.exist;
+        expect(contains(this.intl.t('pages.user-account.email-verification.send-back-the-code'))).to.exist;
+      });
+      clock.restore();
+      return result;
+    });
+
+    it('should show confirmation message when resending code message', function() {
+    // given
+      const email = 'toto@example.net';
+      const password = 'pix123';
+      this.set('email', email);
+      this.set('password', password);
+
+      const store = this.owner.lookup('service:store');
+      const sendNewEmailStub = sinon.stub();
+      store.createRecord = sinon.stub();
+      store.createRecord
+        .withArgs('email-verification-code', { password, newEmail: email })
+        .returns({ sendNewEmail: sendNewEmailStub });
+
+      const clock = sinon.useFakeTimers();
+
+      // when
+      const promise = render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} @password={{this.password}} />`);
+      clock.tick(ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
+
+      const result = promise.then(async () => {
+        await clickByLabel(this.intl.t('pages.user-account.email-verification.send-back-the-code'));
+
+        // then
+        expect(contains(this.intl.t('pages.user-account.email-verification.confirmation-message'))).to.exist;
+        expect(contains(this.intl.t('pages.user-account.email-verification.send-back-the-code'))).to.not.exist;
+      });
+      clock.restore();
+      return result;
+    });
+  });
+
+  context('after entering code', function() {
+
+    it('should show invalid code message when receiving 403', async function() {
+      // given
+      const store = this.owner.lookup('service:store');
+      const disableEmailEditionMode = sinon.stub();
+      const displayEmailUpdateMessage = sinon.stub();
+      this.set('disableEmailEditionMode', disableEmailEditionMode);
+      this.set('displayEmailUpdateMessage', displayEmailUpdateMessage);
+      this.set('email', 'toto@example.net');
+      const verifyCode = sinon.stub().throws({ errors: [{ status: '403', code: 'INVALID_VERIFICATION_CODE' }] });
+      store.createRecord = () => ({ verifyCode });
+
+      await render(hbs`<UserAccount::EmailVerificationCode
+        @email={{this.email}}
+        @disableEmailEditionMode={{this.disableEmailEditionMode}}
+        @displayEmailUpdateMessage={{this.displayEmailUpdateMessage}}
+      />`);
+
+      // when
+      await triggerEvent('#code-input-1', 'paste', { clipboardData: { getData: () => '123456' } });
+
+      // then
+      sinon.assert.notCalled(disableEmailEditionMode);
+      sinon.assert.notCalled(displayEmailUpdateMessage);
+      expect(contains(this.intl.t('pages.user-account.email-verification.errors.incorrect-code'))).to.exist;
+    });
+
+    it('should show demand expired message when receiving 403', async function() {
+      // given
+      const store = this.owner.lookup('service:store');
+      const disableEmailEditionMode = sinon.stub();
+      const displayEmailUpdateMessage = sinon.stub();
+      this.set('disableEmailEditionMode', disableEmailEditionMode);
+      this.set('displayEmailUpdateMessage', displayEmailUpdateMessage);
+      this.set('email', 'toto@example.net');
+      const verifyCode = sinon.stub().throws({ errors: [{ status: '403', code: 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND' }] });
+      store.createRecord = () => ({ verifyCode });
+
+      await render(hbs`<UserAccount::EmailVerificationCode
+        @email={{this.email}}
+        @disableEmailEditionMode={{this.disableEmailEditionMode}}
+        @displayEmailUpdateMessage={{this.displayEmailUpdateMessage}}
+      />`);
+
+      // when
+      await triggerEvent('#code-input-1', 'paste', { clipboardData: { getData: () => '123456' } });
+
+      // then
+      sinon.assert.notCalled(disableEmailEditionMode);
+      sinon.assert.notCalled(displayEmailUpdateMessage);
+      expect(contains(this.intl.t('pages.user-account.email-verification.errors.email-modification-demand-expired'))).to.exist;
+    });
+
+    it('should show email already exists message when receiving 400', async function() {
+      // given
+      const store = this.owner.lookup('service:store');
+      const disableEmailEditionMode = sinon.stub();
+      const displayEmailUpdateMessage = sinon.stub();
+      this.set('disableEmailEditionMode', disableEmailEditionMode);
+      this.set('displayEmailUpdateMessage', displayEmailUpdateMessage);
+      this.set('email', 'toto@example.net');
+      const verifyCode = sinon.stub().throws({ errors: [{ status: '400', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS' }] });
+      store.createRecord = () => ({ verifyCode });
+
+      await render(hbs`<UserAccount::EmailVerificationCode
+        @email={{this.email}}
+        @disableEmailEditionMode={{this.disableEmailEditionMode}}
+        @displayEmailUpdateMessage={{this.displayEmailUpdateMessage}}
+      />`);
+
+      // when
+      await triggerEvent('#code-input-1', 'paste', { clipboardData: { getData: () => '123456' } });
+
+      // then
+      sinon.assert.notCalled(disableEmailEditionMode);
+      sinon.assert.notCalled(displayEmailUpdateMessage);
+      expect(contains(this.intl.t('pages.user-account.email-verification.errors.new-email-already-exist'))).to.exist;
+    });
+
+    it('should show error message when receiving 500', async function() {
+      // given
+      const store = this.owner.lookup('service:store');
+      const disableEmailEditionMode = sinon.stub();
+      const displayEmailUpdateMessage = sinon.stub();
+      this.set('disableEmailEditionMode', disableEmailEditionMode);
+      this.set('displayEmailUpdateMessage', displayEmailUpdateMessage);
+      this.set('email', 'toto@example.net');
+      const verifyCode = sinon.stub().throws({ errors: [{ status: '500' }] });
+      store.createRecord = () => ({ verifyCode });
+
+      await render(hbs`<UserAccount::EmailVerificationCode
+        @email={{this.email}}
+        @disableEmailEditionMode={{this.disableEmailEditionMode}}
+        @displayEmailUpdateMessage={{this.displayEmailUpdateMessage}}
+      />`);
+
+      // when
+      await triggerEvent('#code-input-1', 'paste', { clipboardData: { getData: () => '123456' } });
+
+      // then
+      sinon.assert.notCalled(disableEmailEditionMode);
+      sinon.assert.notCalled(displayEmailUpdateMessage);
+      expect(contains(this.intl.t('pages.user-account.email-verification.errors.unknown-error'))).to.exist;
+    });
   });
 });

--- a/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
@@ -20,7 +20,7 @@ describe('Integration | Component | user-account | email-verification-code', fun
     await render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} />`);
 
     // then
-    expect(findByLabel(this.intl.t('pages.email-verification.did-not-receive'))).not.to.have.class('visible');
+    expect(findByLabel(this.intl.t('pages.user-account.email-verification.did-not-receive'))).not.to.have.class('visible');
   });
 
   it(`should display a resend code message after ${ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND} milliseconds`, function() {
@@ -37,8 +37,8 @@ describe('Integration | Component | user-account | email-verification-code', fun
     clock.tick(ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
 
     const result = promise.then(async () => {
-      expect(contains(this.intl.t('pages.email-verification.did-not-receive'))).to.exist;
-      expect(contains(this.intl.t('pages.email-verification.send-back-the-code'))).to.exist;
+      expect(contains(this.intl.t('pages.user-account.email-verification.did-not-receive'))).to.exist;
+      expect(contains(this.intl.t('pages.user-account.email-verification.send-back-the-code'))).to.exist;
     });
     clock.restore();
     return result;
@@ -65,11 +65,11 @@ describe('Integration | Component | user-account | email-verification-code', fun
     clock.tick(ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
 
     const result = promise.then(async () => {
-      await clickByLabel(this.intl.t('pages.email-verification.send-back-the-code'));
+      await clickByLabel(this.intl.t('pages.user-account.email-verification.send-back-the-code'));
 
       // then
-      expect(contains(this.intl.t('pages.email-verification.confirmation-message'))).to.exist;
-      expect(contains(this.intl.t('pages.email-verification.send-back-the-code'))).to.not.exist;
+      expect(contains(this.intl.t('pages.user-account.email-verification.confirmation-message'))).to.exist;
+      expect(contains(this.intl.t('pages.user-account.email-verification.send-back-the-code'))).to.not.exist;
     });
     clock.restore();
     return result;

--- a/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
@@ -26,7 +26,7 @@ describe('Integration | Component | user-account | email-verification-code', fun
     });
 
     it(`should display a resend code message after ${ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND} milliseconds`, function() {
-    // given
+      // given
       const email = 'toto@example.net';
       const password = 'pix123';
       this.set('email', email);
@@ -46,8 +46,37 @@ describe('Integration | Component | user-account | email-verification-code', fun
       return result;
     });
 
+    it('should prevent multiple requests to resend verification code', function() {
+      // given
+      const email = 'toto@example.net';
+      const password = 'pix123';
+      this.set('email', email);
+      this.set('password', password);
+
+      const store = this.owner.lookup('service:store');
+      store.createRecord = sinon.stub();
+      store.createRecord
+        .withArgs('email-verification-code', { password, newEmail: email })
+        .returns({ sendNewEmail: () => new Promise(() => {}) });
+
+      const clock = sinon.useFakeTimers();
+
+      // when
+      const promise = render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} @password={{this.password}} />`);
+      clock.tick(ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
+
+      const result = promise.then(async () => {
+        await clickByLabel(this.intl.t('pages.user-account.email-verification.send-back-the-code'));
+
+        // then
+        expect(findByLabel(this.intl.t('pages.user-account.email-verification.send-back-the-code')).disabled).to.be.true;
+      });
+      clock.restore();
+      return result;
+    });
+
     it('should show confirmation message when resending code message', function() {
-    // given
+      // given
       const email = 'toto@example.net';
       const password = 'pix123';
       this.set('email', email);
@@ -114,7 +143,12 @@ describe('Integration | Component | user-account | email-verification-code', fun
       this.set('disableEmailEditionMode', disableEmailEditionMode);
       this.set('displayEmailUpdateMessage', displayEmailUpdateMessage);
       this.set('email', 'toto@example.net');
-      const verifyCode = sinon.stub().throws({ errors: [{ status: '403', code: 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND' }] });
+      const verifyCode = sinon.stub().throws({
+        errors: [{
+          status: '403',
+          code: 'EXPIRED_OR_NULL_EMAIL_MODIFICATION_DEMAND',
+        }],
+      });
       store.createRecord = () => ({ verifyCode });
 
       await render(hbs`<UserAccount::EmailVerificationCode
@@ -140,7 +174,12 @@ describe('Integration | Component | user-account | email-verification-code', fun
       this.set('disableEmailEditionMode', disableEmailEditionMode);
       this.set('displayEmailUpdateMessage', displayEmailUpdateMessage);
       this.set('email', 'toto@example.net');
-      const verifyCode = sinon.stub().throws({ errors: [{ status: '400', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS' }] });
+      const verifyCode = sinon.stub().throws({
+        errors: [{
+          status: '400',
+          code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS',
+        }],
+      });
       store.createRecord = () => ({ verifyCode });
 
       await render(hbs`<UserAccount::EmailVerificationCode

--- a/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
@@ -9,12 +9,13 @@ describe('Unit | Component | user-account | email-verification-code', function()
 
   context('#onSubmitCode', function() {
 
-    it('should send entered code for verification', async function() {
+    it('should send entered code for verification and redirect to account page', async function() {
       // given
       const component = createGlimmerComponent('component:user-account/email-verification-code');
       const code = '918435';
       const verifyCode = sinon.stub();
       component.store = { createRecord: () => ({ verifyCode }) };
+      component.args.disableEmailEditionMode = sinon.stub();
       sinon.spy(component.store, 'createRecord');
 
       // when
@@ -23,6 +24,7 @@ describe('Unit | Component | user-account | email-verification-code', function()
       // then
       sinon.assert.calledWith(component.store.createRecord, 'email-verification-code', { code });
       sinon.assert.calledOnce(verifyCode);
+      sinon.assert.calledOnce(component.args.disableEmailEditionMode);
     });
 
     it('should update the user email when code verification is successful', async function() {

--- a/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
@@ -26,7 +26,7 @@ describe('Unit | Component | user-account | email-verification-code', function()
       sinon.assert.calledWith(component.store.createRecord, 'email-verification-code', { code });
       sinon.assert.calledOnce(verifyCode);
       sinon.assert.calledOnce(component.args.disableEmailEditionMode);
-      sinon.assert.calledWith(component.args.displayEmailUpdateMessage, 'pages.user-account.email-verification.update-successful');
+      sinon.assert.calledOnce(component.args.displayEmailUpdateMessage);
     });
 
     it('should update the user email when code verification is successful', async function() {
@@ -52,24 +52,40 @@ describe('Unit | Component | user-account | email-verification-code', function()
 
   context('#resendVerificationCodeByEmail', function() {
 
-    it('should prevent to double click on resend verification code', async function() {
+    it('should be loading while resending email', function() {
       // given
       const component = createGlimmerComponent('component:user-account/email-verification-code');
       const newEmail = 'toto@example.net';
       const password = 'pix123';
-      const sendNewEmail = sinon.stub();
-      component.store = { createRecord: () => ({ sendNewEmail }) };
+      component.isResending = false;
       component.args.email = newEmail;
       component.args.password = password;
-      sinon.spy(component.store, 'createRecord');
+      component.store = { createRecord: () => ({ sendNewEmail: () => new Promise(() => {}) }) };
+
+      // when
+      component.resendVerificationCodeByEmail();
+
+      // then
+      expect(component.isResending).to.be.true;
+    });
+
+    it('should show success message after resending', async function() {
+      // given
+      const component = createGlimmerComponent('component:user-account/email-verification-code');
+      const newEmail = 'toto@example.net';
+      const password = 'pix123';
+      component.isEmailSent = false;
+      component.args.email = newEmail;
+      component.args.password = password;
+      component.store = { createRecord: () => ({ sendNewEmail: sinon.stub() }) };
 
       // when
       await component.resendVerificationCodeByEmail();
-      await component.resendVerificationCodeByEmail();
 
       // then
-      expect(component.wasButtonClicked).to.be.true;
-      sinon.assert.calledOnce(sendNewEmail);
+      expect(component.isEmailSent).to.be.true;
+      expect(component.isResending).to.be.false;
     });
+
   });
 });

--- a/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
@@ -7,6 +7,45 @@ import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-compone
 describe('Unit | Component | user-account | email-verification-code', function() {
   setupTest();
 
+  context('#onSubmitCode', function() {
+
+    it('should send entered code for verification', async function() {
+      // given
+      const component = createGlimmerComponent('component:user-account/email-verification-code');
+      const code = '918435';
+      const verifyCode = sinon.stub();
+      component.store = { createRecord: () => ({ verifyCode }) };
+      sinon.spy(component.store, 'createRecord');
+
+      // when
+      await component.onSubmitCode(code);
+
+      // then
+      sinon.assert.calledWith(component.store.createRecord, 'email-verification-code', { code });
+      sinon.assert.calledOnce(verifyCode);
+    });
+
+    it('should update the user email when code verification is successful', async function() {
+      // given
+      const component = createGlimmerComponent('component:user-account/email-verification-code');
+      const code = '918435';
+      const newEmail = 'new-email@example.net';
+      const verifyCode = sinon.stub().returns(newEmail);
+      component.store = { createRecord: () => ({ verifyCode }) };
+      component.currentUser = { user: { email: 'old-email@example.net' } };
+      component.args.disableEmailEditionMode = sinon.stub();
+      component.args.showSuccessMessageTemporarily = sinon.stub();
+      sinon.spy(component.store, 'createRecord');
+
+      // when
+      await component.onSubmitCode(code);
+
+      // then
+      expect(component.currentUser.user.email).to.equal(newEmail);
+    });
+
+  });
+
   context('#resendVerificationCodeByEmail', function() {
 
     it('should prevent to double click on resend verification code', async function() {

--- a/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
@@ -9,13 +9,14 @@ describe('Unit | Component | user-account | email-verification-code', function()
 
   context('#onSubmitCode', function() {
 
-    it('should send entered code for verification and redirect to account page', async function() {
+    it('should send entered code for verification and redirect to account page with successful message', async function() {
       // given
       const component = createGlimmerComponent('component:user-account/email-verification-code');
       const code = '918435';
       const verifyCode = sinon.stub();
       component.store = { createRecord: () => ({ verifyCode }) };
       component.args.disableEmailEditionMode = sinon.stub();
+      component.args.displayEmailUpdateMessage = sinon.stub();
       sinon.spy(component.store, 'createRecord');
 
       // when
@@ -25,6 +26,7 @@ describe('Unit | Component | user-account | email-verification-code', function()
       sinon.assert.calledWith(component.store.createRecord, 'email-verification-code', { code });
       sinon.assert.calledOnce(verifyCode);
       sinon.assert.calledOnce(component.args.disableEmailEditionMode);
+      sinon.assert.calledWith(component.args.displayEmailUpdateMessage, 'pages.user-account.email-verification.update-successful');
     });
 
     it('should update the user email when code verification is successful', async function() {
@@ -36,7 +38,7 @@ describe('Unit | Component | user-account | email-verification-code', function()
       component.store = { createRecord: () => ({ verifyCode }) };
       component.currentUser = { user: { email: 'old-email@example.net' } };
       component.args.disableEmailEditionMode = sinon.stub();
-      component.args.showSuccessMessageTemporarily = sinon.stub();
+      component.args.displayEmailUpdateMessage = sinon.stub();
       sinon.spy(component.store, 'createRecord');
 
       // when

--- a/mon-pix/tests/unit/controllers/user-account/connection-methods_test.js
+++ b/mon-pix/tests/unit/controllers/user-account/connection-methods_test.js
@@ -32,4 +32,18 @@ describe('Unit | Controller | user-account | connection-methods', function() {
       expect(controller.isEmailEditionMode).to.be.false;
     });
   });
+
+  context('#displayEmailUpdateMessage', function() {
+    it('should display email update message', function() {
+      // given
+      const controller = this.owner.lookup('controller:user-account/connection-methods');
+      controller.set('showEmailUpdatedMessage', false);
+
+      // when
+      controller.displayEmailUpdateMessage();
+
+      // then
+      expect(controller.showEmailUpdatedMessage).to.be.true;
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1357,7 +1357,10 @@
         "code-label": "Field to enter your verification code",
         "update-successful": "Your email address has been changed!",
         "errors": {
-          "incorrect-code": "The code entered is incorrect."
+          "incorrect-code": "The code entered is incorrect.",
+          "email-modification-demand-expired": "This code has expired. Please renew your request.",
+          "new-email-already-exist": "This email address is already in use.",
+          "unknown-error": "An error has occurred. Please try again or contact the support."
         }
       },
       "language": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -673,14 +673,6 @@
         "subtitle": "Resume testing your skills, find your most recent tests here."
       }
     },
-    "email-verification": {
-      "title": "Verify your email address",
-      "description": "Enter the verification code you received at the following email address:",
-      "did-not-receive": "You haven’t received anything?",
-      "send-back-the-code": "Send the code again",
-      "confirmation-message": "Email sent!",
-      "incorrect-code": "The code entered is incorrect"
-    },
     "error": {
       "content-text": "'<p>'Please refresh the page or '<LinkTo @route=\"login\">'return to homepage'</LinkTo>'.'</p><p>'You can also contact us via '<a href=\"https://pix.org/en-gb/contact-form\">'the help centre form'</a>'specifying the error code below in the description.'</p><p>'Please excuse any inconvenience caused.'</p><p>'The Pix team.'</p>'",
       "first-title": "Oops, an error occurred!"
@@ -1355,6 +1347,18 @@
         "email": "Email address",
         "menu-link-title": "Log in methods",
         "username": "Username"
+      },
+      "email-verification": {
+        "title": "Verify your email address",
+        "description": "Enter the verification code you received at the following email address:",
+        "did-not-receive": "You haven’t received anything?",
+        "send-back-the-code": "Send the code again",
+        "confirmation-message": "Email sent!",
+        "code-label": "Field to enter your verification code",
+        "update-successful": "Your email address has been changed!",
+        "errors": {
+          "incorrect-code": "The code entered is incorrect."
+        }
       },
       "language": {
         "fields": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1357,7 +1357,10 @@
         "code-label": "Champ du code de vérification",
         "update-successful": "Votre adresse e-mail a été changé !",
         "errors": {
-          "incorrect-code": "Le code saisi est incorrect."
+          "incorrect-code": "Le code saisi est incorrect.",
+          "email-modification-demand-expired": "Ce code a expiré. Veuillez renouveler la demande.",
+          "new-email-already-exist": "Cette adresse e-mail est déjà utilisée.",
+          "unknown-error": "Une erreur est survenue. Veuillez recommencer ou contacter le support."
         }
       },
       "language": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -673,14 +673,6 @@
         "subtitle": "Continuez vos tests de compétences, retrouvez les plus récents ici."
       }
     },
-    "email-verification": {
-      "title": "Vérification de votre adresse e-mail",
-      "description": "Saisissez le code de vérification reçu à l'adresse e-mail :",
-      "did-not-receive": "Je n'ai rien reçu,",
-      "send-back-the-code": "me renvoyer le code",
-      "confirmation-message": "E-mail envoyé !",
-      "incorrect-code": "Le code saisi est incorrect"
-    },
     "error": {
       "content-text": "'<p>'Nous vous invitons à recharger cette page ou '<LinkTo @route=\"login\">'revenir à la page d’accueil'</LinkTo>'.'</p><p>'Vous pouvez aussi nous contacter via '<a href=\"https://support.pix.fr/support/tickets/new\">'le formulaire du centre d'aide'</a>' en nous précisant le code d’erreur ci-dessous dans la description.'</p><p>'Nous vous prions de nous excuser pour la gêne occasionnée.'</p><p>'L’équipe Pix.'</p>'",
       "first-title": "Oups, une erreur est survenue !"
@@ -1355,6 +1347,18 @@
         "email": "Adresse e-mail",
         "menu-link-title": "Mes méthodes de connexion",
         "username": "Identifiant"
+      },
+      "email-verification": {
+        "title": "Vérification de votre adresse e-mail",
+        "description": "Saisissez le code de vérification reçu à l'adresse e-mail :",
+        "did-not-receive": "Je n'ai rien reçu,",
+        "send-back-the-code": "me renvoyer le code",
+        "confirmation-message": "E-mail envoyé !",
+        "code-label": "Champ du code de vérification",
+        "update-successful": "Votre adresse e-mail a été changé !",
+        "errors": {
+          "incorrect-code": "Le code saisi est incorrect."
+        }
       },
       "language": {
         "fields": {


### PR DESCRIPTION
## :unicorn: Problème
Cela concerne le changement d'adresse e-mail avec validation sur Pix App. Non visible en prod (Feature toggle)

La [PR coté API](https://github.com/1024pix/pix/pull/3530) ayant été mis en production, il faut maintenant finaliser le front pour terminer cette procédure de changement d'adresse e-mail.

## :robot: Solution
Lancer l'appel API lorsque l'utilisateur entre le dernier chiffre du code de vérification, fermer la fenêtre et informer celui-ci que le changement a été effectué.

## :rainbow: Remarques
- modification du type de l'appel précédent. 
- déplacement des clés de traduction dans l'objet `user-account`.

## 🗒️ TODO

- [x] Traduction de la phrase en attente : `Ce code a expiré. Veuillez renouveler la demande.`

## :100: Pour tester
**Cas valide :** 

Mon compte > Méthodes de connexion > modifier l'adresse e-mail

Entrer une nouvelle adresse valide et le mot de passe + entrer le code de vérification reçue. 

**Résultat attendu** : l'utilisateur est renvoyé vers les méthodes de connexions avec un message de validation s'affichant temporairement.

Le message de succès reste affiché jusqu'a ce que l'utilisateur change de page.

---

**Cas d'erreur :** 

Code invalide : Entrer un code au hasard.

**Message attendu :** "Votre code est invalide." apparaît.

---

Demande expirée : Pour ne pas attendre 10 minutes, coté Scalingo j'ai ajouté la variable en RA `TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS`, à changer pour quelques secondes. 

**Message attendu :** "Ce code a expiré. Veuillez renouveler la demande."

---

Adresse déjà existante : Pour se protéger des cas tordus, coté API on vérifie à nouveau que l'adresse e-mail n'existe toujours pas en base. En effet elle pourrait être utilisé entre la demande de changement et la validation de cette nouvelle adresse.

Faites une demande > avant de mettre le code, ajouter la nouvelle adresse dans un user existant par exemple, puis finaliser la demande.

**Message attendu :** "Cette adresse existe déjà."