### PR TITLE
[BUGFIX] Afficher les détails d'un badge dans pix-admin (PIX-3552).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer.js
@@ -1,4 +1,5 @@
 const { Serializer } = require('jsonapi-serializer');
+const _ = require('lodash');
 
 const mapType = {
   badgeCriteria: 'badge-criteria',
@@ -46,9 +47,10 @@ module.exports = {
           });
         });
         badge.badgePartnerCompetences.forEach((badgePartnerCompetence) => {
-          badgePartnerCompetence.skills = badgePartnerCompetence.skillIds.map((skillId) => {
+          const skills = badgePartnerCompetence.skillIds.map((skillId) => {
             return record.skills.find(({ id }) => skillId === id);
           });
+          badgePartnerCompetence.skills = _.compact(skills);
           badgePartnerCompetence.skills.forEach((skill) => {
             skill.tube = { ...record.tubes.find(({ id }) => id === skill.tubeId) };
           });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-with-learning-content-serializer_test.js
@@ -247,6 +247,163 @@ describe('Unit | Serializer | JSONAPI | badge-with-learning-content-serializer',
       // then
       expect(json).to.deep.equal(expectedSerializedBadge);
     });
+
+    it('should only consider badge\'s skills', function() {
+      // given
+      const badge = domainBuilder.buildBadge({
+        id: '1',
+        altMessage: 'You won a banana badge',
+        imageUrl: '/img/banana.svg',
+        message: 'Congrats, you won a banana badge',
+        key: 'BANANA',
+        title: 'Banana',
+        targetProfileId: '1',
+        isCertifiable: false,
+      });
+
+      const skills = [
+        domainBuilder.buildSkill({ id: 'recABC', name: '@sau6', tubeId: 'recTUB123' }),
+      ];
+
+      const tubes = [
+        domainBuilder.buildTube({ id: 'recTUB123', name: '@sau', skills }),
+      ];
+
+      const badgeWithLearningContent = domainBuilder.buildBadgeWithLearningContent({ badge, skills, tubes });
+
+      const expectedSerializedBadge = {
+        data: {
+          attributes: {
+            'alt-message': 'You won a banana badge',
+            'image-url': '/img/banana.svg',
+            'is-certifiable': false,
+            message: 'Congrats, you won a banana badge',
+            title: 'Banana',
+            key: 'BANANA',
+          },
+          id: '1',
+          type: 'badges',
+          relationships: {
+            'badge-criteria': {
+              'data': [{
+                id: '1',
+                type: 'badge-criteria',
+              }, {
+                id: '2',
+                type: 'badge-criteria',
+              }],
+            },
+            'badge-partner-competences': {
+              'data': [{
+                id: '1',
+                type: 'badge-partner-competences',
+              }, {
+                id: '2',
+                type: 'badge-partner-competences',
+              }],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              scope: 'CampaignParticipation',
+              threshold: 40,
+            },
+            relationships: {
+              'partner-competences': {
+                data: [],
+              },
+            },
+            id: '1',
+            type: 'badge-criteria',
+          },
+          {
+            attributes: {
+              scope: 'CampaignParticipation',
+              threshold: 40,
+            },
+            relationships: {
+              'partner-competences': {
+                data: [{
+                  id: '1',
+                  type: 'badge-partner-competences',
+                }, {
+                  id: '2',
+                  type: 'badge-partner-competences',
+                }],
+              },
+            },
+            id: '2',
+            type: 'badge-criteria',
+          },
+          {
+            type: 'tubes',
+            id: 'recTUB123',
+            attributes: {
+              'practical-title': 'titre pratique',
+            },
+            relationships: {},
+          },
+          {
+            attributes: {
+              name: '@sau6',
+              difficulty: 6,
+            },
+            id: 'recABC',
+            relationships: {
+              tube: {
+                data: {
+                  id: 'recTUB123',
+                  type: 'tubes',
+                },
+              },
+            },
+            type: 'skills',
+          },
+          {
+            attributes: {
+              name: 'name',
+            },
+            id: '1',
+            type: 'badge-partner-competences',
+            relationships: {
+              'skills': {
+                data: [
+                  {
+                    id: 'recABC',
+                    type: 'skills',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            attributes: {
+              name: 'name',
+            },
+            id: '2',
+            type: 'badge-partner-competences',
+            relationships: {
+              'skills': {
+                data: [
+                  {
+                    id: 'recABC',
+                    type: 'skills',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      };
+
+      // when
+      const json = serializer.serialize(badgeWithLearningContent);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedBadge);
+    });
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas accéder aux détails de certains badges (ex: https://admin.pix.fr/badges/142).

Cause:
Dans le serializer, à partir de chaque skillId, on récupère le skill via une liste de skills `operative` (operative = `actif` ou `archivé`). Or le skillId recherché peut être celui d'un skill `périmé`! Le skill n'est alors pas retrouvé dans la liste de skills `operative`(il est`undefined`).
Puisque l'on accède ensuite aux propriétés du skill, l'api plante parce que le skill est `undefined`.

## :robot: Solution
Ne pas considérer les skills qui ne sont pas `operative` d'un badge-partner-competences.

## :rainbow: Remarques
Cette PR ignore les skills `périmés`. Il s'agit d'un quickfix pour corriger l'affichage de la page de détail d'un badge.
D'autres PR suivront pour mettre en avant sur pix-admin les PR périmés d'un badge.

## :100: Pour tester
J'ai reproduis sur la RA le cas en prod (même badgePartnerCompetences).
Vérifier que https://admin-pr3540.review.pix.fr/badges/10000001 s'affiche.
