### PR TITLE
[BUGFIX] Correction de tests qui tombent en erreur le 12 et le 30 du mois.

### DIFF
--- a/orga/tests/integration/components/participant/profile/header_test.js
+++ b/orga/tests/integration/components/participant/profile/header_test.js
@@ -172,27 +172,27 @@ module('Integration | Component | Participant::Profile::Header', function (hooks
 
       test('it does not display the total number of competence', async function (assert) {
         this.campaignProfile = {
-          competencesCount: 12,
+          competencesCount: 32,
           isShared: false,
         };
         this.campaign = {};
 
         await render(hbs`<Participant::Profile::Header @campaignProfile={{campaignProfile}} @campaign={{campaign}} />`);
 
-        assert.notContains('12');
+        assert.notContains('32');
         assert.notContains('COMP. CERTIFIABLE');
       });
 
       test('it does not display the total number of certifiable competence', async function (assert) {
         this.campaignProfile = {
-          certifiableCompetencesCount: 30,
+          certifiableCompetencesCount: 33,
           isShared: false,
         };
         this.campaign = {};
 
         await render(hbs`<Participant::Profile::Header @campaignProfile={{campaignProfile}} @campaign={{campaign}} />`);
 
-        assert.notContains('30');
+        assert.notContains('33');
       });
 
       test('it does not display certifiable badge', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Nous sommes le 30 septembre, et un test semble être en erreur sur toutes les RA.

## :robot: Solution
On a fait une correction rapide de 2 tests qui voulaient respectivement vérifier que "12" ou "30" n'apparaissaient pas sur la page en tant que nombre total de compétences. Mais quand on est le 12 ou 30 du mois, cette valeur apparait bien.

## :rainbow: Remarques
C'est un quickfix, le test devrait être réécrit avec une vérification plus précise

