### PR TITLE
[FEATURE] Ajoute la colonne "groupe" sur la page "Étudiants" pour les orgas SUP isManagingStudent. (PIX-3536)

### DIFF
--- a/api/lib/domain/models/UserWithSchoolingRegistration.js
+++ b/api/lib/domain/models/UserWithSchoolingRegistration.js
@@ -12,6 +12,7 @@ class UserWithSchoolingRegistration {
     isAuthenticatedFromGAR,
     studentNumber,
     division,
+    group,
   } = {}) {
     this.id = id;
     this.lastName = lastName;
@@ -24,6 +25,7 @@ class UserWithSchoolingRegistration {
     this.isAuthenticatedFromGAR = isAuthenticatedFromGAR;
     this.studentNumber = studentNumber;
     this.division = division;
+    this.group = group;
   }
 }
 

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -287,6 +287,7 @@ module.exports = {
           'schooling-registrations.lastName',
           'schooling-registrations.birthdate',
           'schooling-registrations.division',
+          'schooling-registrations.group',
           'schooling-registrations.studentNumber',
           'schooling-registrations.userId',
           'schooling-registrations.organizationId',

--- a/api/lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize(students, meta) {
     return new Serializer('students', {
       attributes: [
-        'lastName', 'firstName', 'birthdate', 'username', 'userId', 'email', 'isAuthenticatedFromGAR', 'studentNumber', 'division',
+        'lastName', 'firstName', 'birthdate', 'username', 'userId', 'email', 'isAuthenticatedFromGAR', 'studentNumber', 'division', 'group',
       ],
       meta,
     }).serialize(students);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -919,6 +919,7 @@ describe('Acceptance | Application | organization-controller', function() {
                 'is-authenticated-from-gar': true,
                 'student-number': schoolingRegistration.studentNumber,
                 'division': schoolingRegistration.division,
+                'group': schoolingRegistration.group,
               },
               'id': schoolingRegistration.id.toString(),
               'type': 'students',

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1757,6 +1757,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           isAuthenticatedFromGAR: false,
           studentNumber: schoolingRegistration.studentNumber,
           division: schoolingRegistration.division,
+          group: schoolingRegistration.group,
         });
         await databaseBuilder.commit();
 
@@ -1798,6 +1799,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           isAuthenticatedFromGAR: true,
           studentNumber: schoolingRegistration.studentNumber,
           division: schoolingRegistration.division,
+          group: schoolingRegistration.group,
         });
         await databaseBuilder.commit();
 
@@ -1831,6 +1833,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           isAuthenticatedFromGAR: false,
           studentNumber: schoolingRegistration.studentNumber,
           division: schoolingRegistration.division,
+          group: schoolingRegistration.group,
         });
         await databaseBuilder.commit();
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer_test.js
@@ -19,6 +19,7 @@ describe('Unit | Serializer | JSONAPI | UserWithSchoolingRegistration-serializer
         isAuthenticatedFromGAR: false,
         studentNumber: '123456789',
         division: '3A',
+        group: 'AB1',
       });
 
       const expectedSerializedUserWithSchoolingRegistration = {
@@ -35,6 +36,7 @@ describe('Unit | Serializer | JSONAPI | UserWithSchoolingRegistration-serializer
             'is-authenticated-from-gar': false,
             'student-number': userWithSchoolingRegistration.studentNumber,
             'division': userWithSchoolingRegistration.division,
+            'group': userWithSchoolingRegistration.group,
           },
         },
       };

--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -6,6 +6,7 @@
         <Table::Header>{{t "pages.students-sup.table.column.last-name"}}</Table::Header>
         <Table::Header>{{t "pages.students-sup.table.column.first-name"}}</Table::Header>
         <Table::Header>{{t "pages.students-sup.table.column.date-of-birth"}}</Table::Header>
+        <Table::Header>{{t "pages.students-sup.table.column.group"}}</Table::Header>
         <Table::Header class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
@@ -32,6 +33,7 @@
         />
         <Table::Header />
         <Table::Header />
+        <Table::Header />
       </tr>
     </thead>
 
@@ -43,6 +45,7 @@
             <td>{{student.lastName}}</td>
             <td>{{student.firstName}}</td>
             <td>{{moment-format student.birthdate "DD/MM/YYYY"}}</td>
+            <td>{{student.group}}</td>
             <td class="list-students-page__actions hide-on-mobile">
               {{#if this.currentUser.isAdminInOrganization}}
                 <Dropdown::IconTrigger

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -16,6 +16,7 @@ export default class Student extends Model {
   @attr('string') email;
   @attr('string') studentNumber;
   @attr('string') division;
+  @attr('string') group;
   @attr('boolean') isAuthenticatedFromGar;
   @belongsTo('organization') organization;
 

--- a/orga/tests/integration/components/students/sup/list_test.js
+++ b/orga/tests/integration/components/students/sup/list_test.js
@@ -24,6 +24,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
     assert.contains('Nom');
     assert.contains('Prénom');
     assert.contains('Date de naissance');
+    assert.contains('Groupe');
   });
 
   test('it should display a list of students', async function (assert) {
@@ -50,6 +51,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
         lastName: 'La Terreur',
         firstName: 'Gigi',
         birthdate: new Date('2010-02-01'),
+        group: 'AB1',
       },
     ];
 
@@ -63,6 +65,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
     assert.contains('La Terreur');
     assert.contains('Gigi');
     assert.contains('01/02/2010');
+    assert.contains('AB1');
   });
 
   module('when user is filtering some users', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -669,6 +669,7 @@
         "column": {
           "date-of-birth": "Date of birth",
           "first-name": "First name",
+          "group": "Group",
           "last-name": "Last name",
           "student-number": "Student number"
         },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -669,6 +669,7 @@
         "column": {
           "date-of-birth": "Date de naissance",
           "first-name": "Prénom",
+          "group": "Groupe",
           "last-name": "Nom",
           "student-number": "Numéro étudiant"
         },


### PR DESCRIPTION
## :unicorn: Problème
Les universités accueille de nombreux étudiants, il souhaitent pouvoir vérifier les effectifs de chaque "groupe" (ex: L1).

## :robot: Solution
La colonne "group" est déjà présente en base de donnée et rempli par l'import. On va exposer ce champ sur le endpoint "students" et l'afficher dans la page "Étudiants" de Pix Orga.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Orga avec sup.admin@example.net
- Aller sur la page "Étudiants" https://orga-pr3543.review.pix.fr/etudiants
- Constater la présence de la colonne "Groupe"
