### PR TITLE
[TECH] Monter les BDD de développement en version majeure 13.3 depuis la 12.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
   api_build_and_test:
     docker:
       - image: circleci/node:14.17.0
-      - image: postgres:12.7-alpine
+      - image: postgres:13.3-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -229,7 +229,7 @@ jobs:
   e2e_test:
     docker:
       - image: cypress/browsers:node14.17.0-chrome91-ff89
-      - image: postgres:12.7-alpine
+      - image: postgres:13.3-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:12.7-alpine
+    image: postgres:13.3-alpine
     container_name: pix-api-postgres
     ports:
       - "${PIX_DATABASE_PORT:-5432}:5432"

--- a/high-level-tests/e2e/docker-compose.yml
+++ b/high-level-tests/e2e/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:12.5-alpine
+    image: postgres:13.3-alpine
     container_name: pix-e2e-postgres
     environment:
       POSTGRES_DB: pix


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle version majeure de PostgreSQL (13.3) est disponible sur Scalingo.
Elle est utilisée automatiquement en review app.

Les BDD de développement n'utilisent pas cette version et des comportements inexpliqués peuvent apparaître:
- local;
- CI.

## :robot: Solution
Aligner les BDD de développement avec la version majeure.

## :rainbow: Remarques
Changelogs:
- [13](https://www.postgresql.org/docs/13/release-13.html)
- [13.1](https://www.postgresql.org/docs/release/13.1/)
- [13.2](https://www.postgresql.org/docs/release/13.2/)
- [13.3](https://www.postgresql.org/docs/release/13.3/)

Après merge, effectuer la montée de version manuelle des applications Scalingo 
- intégration
- recette
- replication ( + mise à jour var env, voir [Wiki](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1549434939/Mises+jour+hors+npm) )

Pour la production, un créneau de maintenance doit être planifiée

## :100: Pour tester
Vérifier que la suite de test passe en CI et en local
