### PR TITLE
[BUGFIX] Corriger l'affichage du centre de certification courant dans Pix Certif (PIX-3560).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -10,7 +10,6 @@ export default class SessionsDetailsController extends Controller {
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
-  @alias('model.shouldDisplayPrescriptionScoStudentRegistrationFeature') shouldDisplayPrescriptionScoStudentRegistrationFeature;
 
   get pageTitle() {
     return `Détails | Session ${this.session.id} | Pix Certif`;
@@ -36,5 +35,9 @@ export default class SessionsDetailsController extends Controller {
   @computed('shouldDisplayPrescriptionScoStudentRegistrationFeature')
   get shouldDisplayResultRecipientInfoMessage() {
     return !this.shouldDisplayPrescriptionScoStudentRegistrationFeature;
+  }
+
+  get shouldDisplayPrescriptionScoStudentRegistrationFeature() {
+    return this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -10,11 +10,11 @@ import { inject as service } from '@ember/service';
 export default class CertificationCandidatesController extends Controller {
 
   @service featureToggles;
+  @service currentUser;
 
   @alias('model.session') currentSession;
   @alias('model.certificationCandidates') certificationCandidates;
   @alias('model.reloadCertificationCandidate') reloadCertificationCandidate;
-  @alias('model.shouldDisplayPrescriptionScoStudentRegistrationFeature') shouldDisplayPrescriptionScoStudentRegistrationFeature;
   @alias('model.countries') countries;
 
   get pageTitle() {
@@ -32,6 +32,10 @@ export default class CertificationCandidatesController extends Controller {
   get hasOneOrMoreCandidates() {
     const certificationCandidatesCount = this.model.certificationCandidates.length;
     return certificationCandidatesCount > 0;
+  }
+
+  get shouldDisplayPrescriptionScoStudentRegistrationFeature() {
+    return this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
   }
 
   @action

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -53,6 +53,10 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
     };
   }
 
+  afterModel(model) {
+    this.currentUser.updateCurrentCertificationCenter(model.session.certificationCenterId);
+  }
+
   setupController(controller, model) {
     super.setupController(controller, model);
 

--- a/certif/app/routes/authenticated/sessions/details.js
+++ b/certif/app/routes/authenticated/sessions/details.js
@@ -27,4 +27,8 @@ export default class SessionsDetailsRoute extends Route {
       },
     });
   }
+
+  afterModel(model) {
+    this.currentUser.updateCurrentCertificationCenter(model.session.certificationCenterId);
+  }
 }

--- a/certif/app/routes/authenticated/sessions/details.js
+++ b/certif/app/routes/authenticated/sessions/details.js
@@ -17,12 +17,10 @@ export default class SessionsDetailsRoute extends Route {
       sessionId: params.session_id,
     });
     const certificationCandidates = await loadCertificationCandidates();
-    const shouldDisplayPrescriptionScoStudentRegistrationFeature = this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
 
     return EmberObject.create({
       session,
       certificationCandidates,
-      shouldDisplayPrescriptionScoStudentRegistrationFeature,
       async reloadCertificationCandidate() {
         const certificationCandidates = await loadCertificationCandidates();
         this.set('certificationCandidates', certificationCandidates);

--- a/certif/app/routes/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/routes/authenticated/sessions/details/certification-candidates.js
@@ -15,4 +15,8 @@ export default class CertificationCandidatesRoute extends Route {
     details.set('countries', countries);
     return details;
   }
+
+  afterModel(model) {
+    this.currentUser.updateCurrentCertificationCenter(model.session.certificationCenterId);
+  }
 }

--- a/certif/app/routes/authenticated/sessions/finalize.js
+++ b/certif/app/routes/authenticated/sessions/finalize.js
@@ -22,5 +22,6 @@ export default class SessionsFinalizeRoute extends Route {
 
       transition.abort();
     }
+    this.currentUser.updateCurrentCertificationCenter(model.certificationCenterId);
   }
 }

--- a/certif/app/routes/authenticated/sessions/update.js
+++ b/certif/app/routes/authenticated/sessions/update.js
@@ -17,6 +17,10 @@ export default class SessionsUpdateRoute extends Route {
     return session;
   }
 
+  afterModel(model) {
+    this.currentUser.updateCurrentCertificationCenter(model.certificationCenterId);
+  }
+
   deactivate() {
     this.controller.model.rollbackAttributes();
   }

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -27,4 +27,11 @@ export default class CurrentUserService extends Service {
       return this.router.replaceWith('authenticated.restricted-access');
     }
   }
+
+  updateCurrentCertificationCenter(certificationCenterId) {
+    if (this.currentAllowedCertificationCenterAccess.id !== String(certificationCenterId)) {
+      this.currentAllowedCertificationCenterAccess = this.certificationPointOfContact.allowedCertificationCenterAccesses
+        .findBy('id', String(certificationCenterId));
+    }
+  }
 }

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -20,7 +20,7 @@ module('Acceptance | authenticated', function(hooks) {
     test('it should redirect to the sessions list page', async function(assert) {
       // given
       const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      const session = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+      const session = server.create('session', { certificationCenterId: parseInt(certificationPointOfContact.allowedCertificationCenterAccessIds[0]) });
       await authenticateSession(certificationPointOfContact.id);
 
       // when
@@ -37,7 +37,7 @@ module('Acceptance | authenticated', function(hooks) {
     test('it should also redirect to the sessions list page', async function(assert) {
       // given
       const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      const session = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+      const session = server.create('session', { certificationCenterId: parseInt(certificationPointOfContact.allowedCertificationCenterAccessIds[0]) });
       await authenticateSession(certificationPointOfContact.id);
 
       // when

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -234,7 +234,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
 
         hooks.beforeEach(async () => {
           // given
-          sessionWithEnrolledStudent = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+          sessionWithEnrolledStudent = server.create('session', { certificationCenterId: allowedCertificationCenterAccess.id });
           server.create('student', { isSelected: false, isEnrolled: false });
           const enrolledStudent = server.create('student', { isSelected: false, isEnrolled: true });
           server.create('certification-candidate', { schoolingRegistrationId: enrolledStudent.id, sessionId: sessionWithEnrolledStudent.id });

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -98,7 +98,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
       let candidates;
 
       hooks.beforeEach(function() {
-        sessionWithCandidates = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+        sessionWithCandidates = server.create('session', { certificationCenterId: allowedCertificationCenterAccess.id });
         candidates = server.createList('certification-candidate', 3, { sessionId: sessionWithCandidates.id, isLinked: false, resultRecipientEmail: 'recipient@example.com' });
       });
 
@@ -238,7 +238,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
     module('when the addCandidate button is clicked', function() {
       test('it should open the new Certification Candidate Modal', async function(assert) {
         // given
-        const sessionWithoutCandidates = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+        const sessionWithoutCandidates = server.create('session', { certificationCenterId: allowedCertificationCenterAccess.id });
         server.create('country', []);
 
         // when
@@ -253,7 +253,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
         test('it should display the error message when the submitted form data is incorrect', async function(assert) {
           // given
-          const session = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+          const session = server.create('session', { certificationCenterId: allowedCertificationCenterAccess.id });
           server.createList('country', 2, { code: '99100' });
 
           this.server.post('/sessions/:id/certification-candidates', () => ({
@@ -277,7 +277,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
           hooks.beforeEach(async function() {
             server.createList('country', 2, { code: '99100' });
-            session = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+            session = server.create('session', { certificationCenterId: allowedCertificationCenterAccess.id });
             await visit(`/sessions/${session.id}/candidats`);
           });
 

--- a/certif/tests/unit/controllers/authenticated/sessions/details_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details_test.js
@@ -98,11 +98,11 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
   module('#shouldDisplayResultRecipientInfoMessage', function() {
 
     module('when the current user certification center does manage students', function() {
-      test('should also return false', function(assert) {
+      test('should return false', function(assert) {
         // given
         const controller = this.owner.lookup('controller:authenticated/sessions/details');
-        controller.model = {
-          shouldDisplayPrescriptionScoStudentRegistrationFeature: true,
+        controller.currentUser = {
+          currentAllowedCertificationCenterAccess: { isScoManagingStudents: true },
         };
 
         // when
@@ -113,12 +113,12 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
       });
     });
 
-    module('when current user is if of type Sco and does not managing students', function() {
+    module('when current user does not manage students', function() {
       test('should return true', function(assert) {
         // given
         const controller = this.owner.lookup('controller:authenticated/sessions/details');
         controller.currentUser = {
-          currentCertificationCenter: { isScoManagingStudents: false },
+          currentAllowedCertificationCenterAccess: { isScoManagingStudents: false },
         };
 
         // when

--- a/certif/tests/unit/routes/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/finalize_test.js
@@ -1,13 +1,19 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Route | authenticated/sessions/finalize', function(hooks) {
   setupTest(hooks);
   let route;
 
   hooks.beforeEach(function() {
+    class CurrentUserServiceStub extends Service {
+      updateCurrentCertificationCenter = sinon.stub();
+    }
+    this.owner.register('service:currentUser', CurrentUserServiceStub);
     route = this.owner.lookup('route:authenticated/sessions/finalize');
+
   });
 
   module('#model', function(hooks) {

--- a/certif/tests/unit/services/current-user_test.js
+++ b/certif/tests/unit/services/current-user_test.js
@@ -134,5 +134,31 @@ module('Unit | Service | current-user', function(hooks) {
       assert.true(true);
     });
   });
+
+  module('#updateCurrentCertificationCenter', function() {
+
+    test('should modify the current allowed certification center access', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', { id: 111 });
+      const newAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', { id: 222 });
+      const certificationPointOfContact = store.createRecord('certification-point-of-contact', {
+        id: 124,
+        allowedCertificationCenterAccesses: [
+          currentAllowedCertificationCenterAccess, newAllowedCertificationCenterAccess,
+        ],
+      });
+
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.certificationPointOfContact = certificationPointOfContact;
+      currentUser.currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+
+      // when
+      currentUser.updateCurrentCertificationCenter(222);
+
+      // then
+      assert.equal(currentUser.currentAllowedCertificationCenterAccess, newAllowedCertificationCenterAccess);
+    });
+  });
 });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur de Pix Certif possède plusieurs centres de certification, nous choisissons de le "connecter" à son premier centre par défaut. Cela pose parfois problème, notamment lors du rechargement de la page lorsque l'utilisateur se trouve sur une page associée à une session spécifique. En effet, dans ce cas, la session affichée peut ne pas appartenir au centre de certification affiché dans le bandeau (en haut à droite) si celle-ci n'appartient pas au premier centre de certification. 

## :robot: Solution
Corriger l'affichage du centre de certification courant suite à un rafraîchissement sur les pages suivantes:
- La page de mise à jour d'une session
- La page de détail
- La page listant les candidats
- La page de finalisation d'une session
- La page d'ajout de candidats SCO

## :rainbow: Remarques
Le rafraîchissement de page n'est pas testable avec Ember.
 
## :100: Pour tester
Se connecter à Pix Certif avec le compte certifsco@example.net et tester le rafraîchissement de ces routes.
