### PR TITLE
[CLEANUP] Choix des épreuves de certification : clarifie la sélection des épreuves déjà répondues

### DIFF
--- a/api/lib/domain/models/PlacementProfile.js
+++ b/api/lib/domain/models/PlacementProfile.js
@@ -36,6 +36,10 @@ class PlacementProfile {
   getUserCompetence(competenceId) {
     return _.find(this.userCompetences, { id: competenceId }) || null;
   }
+
+  getCertifiableUserCompetences() {
+    return this.userCompetences.filter((uc) => uc.isCertifiable());
+  }
 }
 
 module.exports = PlacementProfile;

--- a/api/lib/domain/models/UserCompetence.js
+++ b/api/lib/domain/models/UserCompetence.js
@@ -37,11 +37,8 @@ class UserCompetence {
     return this.estimatedLevel >= MINIMUM_COMPETENCE_LEVEL_FOR_CERTIFIABILITY;
   }
 
-  static orderSkillsOfCompetenceByDifficulty(userCompetences) {
-    return _.map(userCompetences, (userCompetence) => {
-      userCompetence.skills = Skill.sortByDecreasingDifficulty(userCompetence.skills);
-      return userCompetence;
-    });
+  sortSkillsByDecreasingDifficulty() {
+    this.skills = Skill.sortByDecreasingDifficulty(this.skills);
   }
 }
 

--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -7,7 +7,6 @@ const {
 } = require('../constants');
 
 const KnowledgeElement = require('../models/KnowledgeElement');
-const UserCompetence = require('../models/UserCompetence');
 const Challenge = require('../models/Challenge');
 const challengeRepository = require('../../infrastructure/repositories/challenge-repository');
 const answerRepository = require('../../infrastructure/repositories/answer-repository');
@@ -18,9 +17,10 @@ const certifiableProfileForLearningContentRepository = require('../../infrastruc
 module.exports = {
 
   async pickCertificationChallenges(placementProfile, locale) {
-    const certifiableUserCompetencesWithOrderedSkills =
-      UserCompetence.orderSkillsOfCompetenceByDifficulty(placementProfile.userCompetences)
-        .filter((uc) => uc.isCertifiable());
+    const certifiableUserCompetencesWithOrderedSkills = placementProfile.getCertifiableUserCompetences();
+    for (const uc of certifiableUserCompetencesWithOrderedSkills) {
+      uc.sortSkillsByDecreasingDifficulty();
+    }
 
     const allOperativeChallenges = await challengeRepository.findOperativeHavingLocale(locale);
 

--- a/api/tests/tooling/domain-builder/factory/build-user-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-competence.js
@@ -8,6 +8,7 @@ module.exports = function buildUserCompetence({
   area = buildArea(),
   pixScore = 42,
   estimatedLevel = 1,
+  skills = [],
 } = {}) {
   return new UserCompetence({
     id,
@@ -16,5 +17,6 @@ module.exports = function buildUserCompetence({
     area,
     pixScore,
     estimatedLevel,
+    skills,
   });
 };

--- a/api/tests/unit/domain/models/PlacementProfile_test.js
+++ b/api/tests/unit/domain/models/PlacementProfile_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const PlacementProfile = require('../../../../lib/domain/models/PlacementProfile');
 const UserCompetence = require('../../../../lib/domain/models/UserCompetence');
 
@@ -157,4 +157,19 @@ describe('Unit | Domain | Models | PlacementProfile', function() {
     });
   });
 
+  describe('#getCertifiableUserCompetences', function() {
+    it('filters certifiable user competences', function() {
+      const uc1 = domainBuilder.buildUserCompetence({ estimatedLevel: 1 });
+      const uc2 = domainBuilder.buildUserCompetence({ estimatedLevel: 0 });
+      const uc3 = domainBuilder.buildUserCompetence({ estimatedLevel: 1 });
+      const uc4 = domainBuilder.buildUserCompetence({ estimatedLevel: 0 });
+      const placementProfile = domainBuilder.buildPlacementProfile({
+        userCompetences: [uc1, uc2, uc3, uc4],
+      });
+
+      const result = placementProfile.getCertifiableUserCompetences();
+
+      expect(result).to.deep.equal([uc1, uc3]);
+    });
+  });
 });

--- a/api/tests/unit/domain/models/UserCompetence_test.js
+++ b/api/tests/unit/domain/models/UserCompetence_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const UserCompetence = require('../../../../lib/domain/models/UserCompetence');
 
 describe('Unit | Domain | Models | UserCompetence', function() {
@@ -50,6 +50,19 @@ describe('Unit | Domain | Models | UserCompetence', function() {
       expect(result).to.be.true;
     });
 
+  });
+
+  describe('#sortSkillsByDecreasingDifficulty', function() {
+    it('sorts skills, most difficult first', function() {
+      const skill1 = domainBuilder.buildSkill({ difficulty: 2 });
+      const skill2 = domainBuilder.buildSkill({ difficulty: 8 });
+      const skill3 = domainBuilder.buildSkill({ difficulty: 4 });
+      const uc = domainBuilder.buildUserCompetence({ skills: [skill1, skill2, skill3] });
+
+      uc.sortSkillsByDecreasingDifficulty();
+
+      expect(uc.skills).to.deep.equal([skill2, skill3, skill1]);
+    });
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème

Dans le code de la sélection des épreuves de certification, le processus de sélection des épreuves déjà répondues est un peu confu et mélangé avec la sélection et le tri des compétences certifiables.

## :robot: Solution

Séparer ces opérations de manière plus évidente dans le code.

## Remarque

Il y a deux commits, je trouve que les deux sont intéressants mais le premier me semble le plus utile.

## :100: Pour tester

Générer un test de certification, vérifier que les épreuves choisies sont les bonnes.

Note : j'ai généré les stats (niveau des questions par compétences) et comparé avant / après pour 1000 tests de certifications, pas de différence.