### PR TITLE
[FEATURE] Ajout d'un filtre sur la colonne "groupe" sur la page "Étudiants". (PIX-3537)

### DIFF
--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -53,6 +53,7 @@ function organizationsSupBuilder({ databaseBuilder }) {
     organizationId: SUP_UNIVERSITY_ID,
     userId: null,
     studentNumber: 'JAIMELESFRUITS123',
+    group: 'L1',
   });
 
   // student associated
@@ -70,6 +71,7 @@ function organizationsSupBuilder({ databaseBuilder }) {
     organizationId: SUP_UNIVERSITY_ID,
     userId: aryaStark.id,
     studentNumber: 'JAIMELESLEGUMES123',
+    group: 'L1',
   });
 
   // with student number
@@ -88,6 +90,7 @@ function organizationsSupBuilder({ databaseBuilder }) {
     organizationId: SUP_UNIVERSITY_ID,
     userId: sansaStark.id,
     studentNumber: 'JAIMELECHOCOLAT',
+    group: 'L2',
   });
 
   // disabled student

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -29,7 +29,7 @@ function _toUserWithSchoolingRegistrationDTO(BookshelfSchoolingRegistration) {
   });
 }
 
-function _setSchoolingRegistrationFilters(qb, { lastName, firstName, studentNumber, division, connexionType } = {}) {
+function _setSchoolingRegistrationFilters(qb, { lastName, firstName, studentNumber, division, group, connexionType } = {}) {
   if (lastName) {
     qb.whereRaw('LOWER("schooling-registrations"."lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
   }
@@ -41,6 +41,9 @@ function _setSchoolingRegistrationFilters(qb, { lastName, firstName, studentNumb
   }
   if (division) {
     qb.whereRaw('LOWER("schooling-registrations"."division") LIKE ?', `%${division.toLowerCase()}%`);
+  }
+  if (group) {
+    qb.whereRaw('LOWER("schooling-registrations"."group") LIKE ?', `%${group.toLowerCase()}%`);
   }
   if (connexionType === 'none') {
     qb.whereRaw('"users"."username" IS NULL');

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1605,7 +1605,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         expect(_.map(data, 'lastName')).to.deep.equal(['Avatar', 'UvAtur']);
       });
 
-      it('should return school registrations filtered by firstname', async function() {
+      it('should return schooling registrations filtered by firstname', async function() {
         // given
         const organization = databaseBuilder.factory.buildOrganization();
 
@@ -1624,7 +1624,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         expect(_.map(data, 'firstName')).to.deep.equal(['Bar', 'Baz']);
       });
 
-      it('should return school registrations filtered by student number', async function() {
+      it('should return schooling registrations filtered by student number', async function() {
         // given
         const organization = databaseBuilder.factory.buildOrganization();
 
@@ -1643,7 +1643,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         expect(_.map(data, 'studentNumber')).to.deep.equal(['BAR123', 'BAZ123']);
       });
 
-      it('should return school registrations filtered by division', async function() {
+      it('should return schooling registrations filtered by division', async function() {
         // given
         const organization = databaseBuilder.factory.buildOrganization();
 
@@ -1662,7 +1662,26 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         expect(_.map(data, 'division')).to.deep.equal(['3B', '3A']);
       });
 
-      it('should return school registrations filtered by firstname AND lastname', async function() {
+      it('should return schooling registrations filtered by group', async function() {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: '1', group: '4A' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: '2', group: '3B' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: '3', group: '3A' });
+        await databaseBuilder.commit();
+
+        // when
+        const { data } = await schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations({
+          organizationId: organization.id,
+          filter: { group: '3' },
+        });
+
+        // then
+        expect(_.map(data, 'group')).to.deep.equal(['3B', '3A']);
+      });
+
+      it('should return schooling registrations filtered by firstname AND lastname', async function() {
         // given
         const organization = databaseBuilder.factory.buildOrganization();
 
@@ -1696,7 +1715,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           await databaseBuilder.commit();
         });
 
-        it('should return school registrations filtered by "none" user connexion', async function() {
+        it('should return schooling registrations filtered by "none" user connexion', async function() {
           // when
           const { data } = await schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations({
             organizationId,
@@ -1707,7 +1726,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           expect(_.map(data, 'lastName')).to.deep.equal(['Lee']);
         });
 
-        it('should return school registrations filtered by "identifiant" user connexion', async function() {
+        it('should return schooling registrations filtered by "identifiant" user connexion', async function() {
           // when
           const { data } = await schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations({
             organizationId,
@@ -1718,7 +1737,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           expect(_.map(data, 'lastName')).to.deep.equal(['Willis']);
         });
 
-        it('should return school registrations filtered by "email" user connexion', async function() {
+        it('should return schooling registrations filtered by "email" user connexion', async function() {
           // when
           const { data } = await schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations({
             organizationId,
@@ -1729,7 +1748,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           expect(_.map(data, 'lastName')).to.deep.equal(['Rambo']);
         });
 
-        it('should return school registrations filtered by "mediacentre" user connexion', async function() {
+        it('should return schooling registrations filtered by "mediacentre" user connexion', async function() {
           // when
           const { data } = await schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations({
             organizationId,
@@ -1741,7 +1760,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         });
       });
 
-      it('should return school registrations paginated', async function() {
+      it('should return schooling registrations paginated', async function() {
         // given
         const organization = databaseBuilder.factory.buildOrganization();
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -631,7 +631,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
     it('should call the usecase to find students with users infos related to filters', async function() {
       // given
-      request = { ...request, query: { 'filter[lastName]': 'Bob', 'filter[firstName]': 'Tom', 'filter[connexionType]': 'email' } };
+      request = { ...request, query: { 'filter[lastName]': 'Bob', 'filter[firstName]': 'Tom', 'filter[connexionType]': 'email', 'filter[group]': 'L1' } };
       usecases.findPaginatedFilteredSchoolingRegistrations.resolves({});
 
       // when
@@ -640,7 +640,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       // then
       expect(usecases.findPaginatedFilteredSchoolingRegistrations).to.have.been.calledWith({
         organizationId,
-        filter: { lastName: 'Bob', firstName: 'Tom', connexionType: 'email' },
+        filter: { lastName: 'Bob', firstName: 'Tom', connexionType: 'email', group: 'L1' },
         page: {},
       });
     });

--- a/api/tests/unit/domain/usecases/find-paginated-filtered-schooling-registrations_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-filtered-schooling-registrations_test.js
@@ -29,14 +29,14 @@ describe('Unit | UseCase | findPaginatedFilteredSchoolingRegistrations', functio
   it('should fetch students matching organization', async function() {
     foundOrganizationSchoolingRegistrations = await findPaginatedFilteredSchoolingRegistrations({
       organizationId,
-      filter: { lastName: 'A' },
+      filter: { lastName: 'A', group: 'L1' },
       page: { size: 10, number: 1 },
       schoolingRegistrationRepository,
     });
 
     expect(schoolingRegistrationRepository.findPaginatedFilteredSchoolingRegistrations).to.have.been.calledWithExactly({
       organizationId,
-      filter: { lastName: 'A' },
+      filter: { lastName: 'A', group: 'L1' },
       page: { size: 10, number: 1 },
     });
     expect(foundOrganizationSchoolingRegistrations).to.deep.equal(expectedSchoolingRegistrations);

--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -32,7 +32,13 @@
           @triggerFiltering={{@onFilter}}
         />
         <Table::Header />
-        <Table::Header />
+        <Table::HeaderFilterInput
+          @field="group"
+          @value={{@groupFilter}}
+          @placeholder={{t "pages.students-sup.table.filter.group.label"}}
+          @ariaLabel={{t "pages.students-sup.table.filter.group.aria-label"}}
+          @triggerFiltering={{@onFilter}}
+        />
         <Table::Header />
       </tr>
     </thead>

--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -15,21 +15,21 @@
           @value={{@studentNumberFilter}}
           @placeholder={{t "pages.students-sup.table.filter.student-number.label"}}
           @ariaLabel={{t "pages.students-sup.table.filter.student-number.aria-label"}}
-          @triggerFiltering={{@onFilter}}
+          @triggerFiltering={{this.onFilter}}
         />
         <Table::HeaderFilterInput
           @field="lastName"
           @value={{@lastNameFilter}}
           @placeholder={{t "pages.students-sup.table.filter.last-name.label"}}
           @ariaLabel={{t "pages.students-sup.table.filter.last-name.aria-label"}}
-          @triggerFiltering={{@onFilter}}
+          @triggerFiltering={{this.onFilter}}
         />
         <Table::HeaderFilterInput
           @field="firstName"
           @value={{@firstNameFilter}}
           @placeholder={{t "pages.students-sup.table.filter.first-name.label"}}
           @ariaLabel={{t "pages.students-sup.table.filter.first-name.aria-label"}}
-          @triggerFiltering={{@onFilter}}
+          @triggerFiltering={{this.onFilter}}
         />
         <Table::Header />
         <Table::HeaderFilterInput
@@ -37,7 +37,7 @@
           @value={{@groupFilter}}
           @placeholder={{t "pages.students-sup.table.filter.group.label"}}
           @ariaLabel={{t "pages.students-sup.table.filter.group.aria-label"}}
-          @triggerFiltering={{@onFilter}}
+          @triggerFiltering={{this.onFilter}}
         />
         <Table::Header />
       </tr>

--- a/orga/app/components/student/sup/list.js
+++ b/orga/app/components/student/sup/list.js
@@ -22,6 +22,11 @@ export default class ListItems extends Component {
   }
 
   @action
+  onFilter(fieldName, debounced, e) {
+    this.args.onFilter(fieldName, debounced, e.target.value);
+  }
+
+  @action
   openEditStudentNumberModal(student) {
     this.selectedStudent = student;
     this.isShowingEditStudentNumberModal = true;

--- a/orga/app/controllers/authenticated/sup-students/list.js
+++ b/orga/app/controllers/authenticated/sup-students/list.js
@@ -20,11 +20,11 @@ export default class ListController extends Controller {
   debouncedUpdateFilters = debounce(this.updateFilters, ENV.pagination.debounce);
 
   @action
-  triggerFiltering(fieldName, debounced, event) {
+  triggerFiltering(fieldName, debounced, value) {
     if (debounced) {
-      this.debouncedUpdateFilters({ [fieldName]: event.target.value });
+      this.debouncedUpdateFilters({ [fieldName]: value });
     } else {
-      this.updateFilters({ [fieldName]: event.target.value });
+      this.updateFilters({ [fieldName]: value });
     }
   }
 }

--- a/orga/app/controllers/authenticated/sup-students/list.js
+++ b/orga/app/controllers/authenticated/sup-students/list.js
@@ -8,6 +8,7 @@ export default class ListController extends Controller {
   @tracked lastName = null;
   @tracked firstName = null;
   @tracked studentNumber = null;
+  @tracked group = null;
   @tracked pageNumber = null;
   @tracked pageSize = null;
 

--- a/orga/app/routes/authenticated/sup-students/list.js
+++ b/orga/app/routes/authenticated/sup-students/list.js
@@ -8,6 +8,7 @@ export default class ListRoute extends Route {
     lastName: { refreshModel: true },
     firstName: { refreshModel: true },
     studentNumber: { refreshModel: true },
+    group: { refreshModel: true },
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
   };
@@ -21,6 +22,7 @@ export default class ListRoute extends Route {
         lastName: params.lastName,
         firstName: params.firstName,
         studentNumber: params.studentNumber,
+        group: params.group,
       },
       page: {
         number: params.pageNumber,
@@ -34,6 +36,7 @@ export default class ListRoute extends Route {
       controller.lastName = null;
       controller.firstName = null;
       controller.studentNumber = null;
+      controller.group = null;
       controller.pageNumber = null;
       controller.pageSize = null;
     }

--- a/orga/app/templates/authenticated/sup-students/list.hbs
+++ b/orga/app/templates/authenticated/sup-students/list.hbs
@@ -7,6 +7,7 @@
     @lastNameFilter={{this.lastName}}
     @firstNameFilter={{this.firstName}}
     @studentNumberFilter={{this.studentNumber}}
+    @groupFilter={{this.group}}
     @onFilter={{this.triggerFiltering}}
   />
 </div>

--- a/orga/mirage/handlers/find-filtered-paginated-students.js
+++ b/orga/mirage/handlers/find-filtered-paginated-students.js
@@ -31,6 +31,11 @@ function _filtersFromQueryParams(schema, organizationId, queryParams) {
     return schema.students.where(({ firstName }) => firstName.includes(firstNameFilter));
   }
 
+  const groupFilter = queryParams['filter[group]'];
+  if (groupFilter) {
+    return schema.students.where(({ group }) => group.includes(groupFilter));
+  }
+
   const connexionTypeFilter = queryParams['filter[connexionType]'];
   if (connexionTypeFilter) {
     return schema.students.where((student) => {

--- a/orga/tests/acceptance/sup-student-list_test.js
+++ b/orga/tests/acceptance/sup-student-list_test.js
@@ -26,25 +26,39 @@ module('Acceptance | Sup Student List', function (hooks) {
       createPrescriberByUser(user);
 
       await authenticateSession(user.id);
+
+      const { organizationId } = user.memberships.models.firstObject;
+      server.create('student', {
+        studentNumber: '123',
+        firstName: 'toto',
+        lastName: 'banana',
+        group: 'L2',
+        organizationId,
+      });
+      server.create('student', {
+        studentNumber: '321',
+        firstName: 'tata',
+        lastName: 'banana',
+        group: 'L1',
+        organizationId,
+      });
     });
 
-    module('And edit the student number', function (hooks) {
-      hooks.beforeEach(() => {
-        const { organizationId } = user.memberships.models.firstObject;
-        server.create('student', {
-          studentNumber: '123',
-          firstName: 'toto',
-          lastName: 'banana',
-          organizationId,
-        });
-        server.create('student', {
-          studentNumber: '321',
-          firstName: 'toto',
-          lastName: 'banana',
-          organizationId,
-        });
-      });
+    module('filters', function () {
+      test('it should filter students by group', async function (assert) {
+        // given
+        await visit('/etudiants');
 
+        // when
+        await fillInByLabel('Entrer un groupe', 'L1');
+
+        // then
+        assert.notContains('toto');
+        assert.contains('tata');
+      });
+    });
+
+    module('And edit the student number', function () {
       test('it should update the student number', async function (assert) {
         // given
         await visit('/etudiants');

--- a/orga/tests/integration/components/students/sup/list_test.js
+++ b/orga/tests/integration/components/students/sup/list_test.js
@@ -80,10 +80,8 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       await fillInByLabel('Entrer un nom', 'bob');
 
       // then
-      const call = triggerFiltering.getCall(0);
-      assert.equal(call.args[0], 'lastName');
-      assert.true(call.args[1]);
-      assert.equal(call.args[2].target.value, 'bob');
+      sinon.assert.calledWithExactly(triggerFiltering, 'lastName', true, 'bob');
+      assert.ok(true);
     });
 
     test('it should trigger filtering with firstname', async function (assert) {
@@ -97,10 +95,8 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       await fillInByLabel('Entrer un prénom', 'bob');
 
       // then
-      const call = triggerFiltering.getCall(0);
-      assert.equal(call.args[0], 'firstName');
-      assert.true(call.args[1]);
-      assert.equal(call.args[2].target.value, 'bob');
+      sinon.assert.calledWithExactly(triggerFiltering, 'firstName', true, 'bob');
+      assert.ok(true);
     });
 
     test('it should trigger filtering with student number', async function (assert) {
@@ -114,10 +110,8 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       await fillInByLabel('Entrer un numéro étudiant', 'LATERREURGIGI123');
 
       // then
-      const call = triggerFiltering.getCall(0);
-      assert.equal(call.args[0], 'studentNumber');
-      assert.true(call.args[1]);
-      assert.equal(call.args[2].target.value, 'LATERREURGIGI123');
+      sinon.assert.calledWithExactly(triggerFiltering, 'studentNumber', true, 'LATERREURGIGI123');
+      assert.ok(true);
     });
 
     test('it should trigger filtering with group', async function (assert) {
@@ -131,10 +125,8 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       await fillInByLabel('Entrer un groupe', 'L1');
 
       // then
-      const call = triggerFiltering.getCall(0);
-      assert.equal(call.args[0], 'group');
-      assert.true(call.args[1]);
-      assert.equal(call.args[2].target.value, 'L1');
+      sinon.assert.calledWithExactly(triggerFiltering, 'group', true, 'L1');
+      assert.ok(true);
     });
   });
 });

--- a/orga/tests/integration/components/students/sup/list_test.js
+++ b/orga/tests/integration/components/students/sup/list_test.js
@@ -119,5 +119,22 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       assert.true(call.args[1]);
       assert.equal(call.args[2].target.value, 'LATERREURGIGI123');
     });
+
+    test('it should trigger filtering with group', async function (assert) {
+      const triggerFiltering = sinon.spy();
+      this.set('triggerFiltering', triggerFiltering);
+      this.set('students', []);
+
+      // when
+      await render(hbs`<Student::Sup::List @students={{students}} @onFilter={{triggerFiltering}}/>`);
+
+      await fillInByLabel('Entrer un groupe', 'L1');
+
+      // then
+      const call = triggerFiltering.getCall(0);
+      assert.equal(call.args[0], 'group');
+      assert.true(call.args[1]);
+      assert.equal(call.args[2].target.value, 'L1');
+    });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -679,6 +679,10 @@
             "aria-label": "Enter a first name",
             "label": "Search by first name"
           },
+          "group": {
+            "aria-label": "Enter a group",
+            "label": "Search by group"
+          },
           "last-name": {
             "aria-label": "Enter a last name",
             "label": "Search by last name"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -679,6 +679,10 @@
             "aria-label": "Entrer un prénom",
             "label": "Rechercher par prénom"
           },
+          "group": {
+            "aria-label": "Entrer un groupe",
+            "label": "Rechercher par groupe"
+          },
           "last-name": {
             "aria-label": "Entrer un nom",
             "label": "Rechercher par nom"


### PR DESCRIPTION
## :unicorn: Problème
La colonne "groupe" est affiché sur la liste des étudiants. Cependant, il n'est pas possible de filtrer les étudiants par leur groupe.

## :robot: Solution
Ajout d'un champ libre pour filtrer les étudiants par leur groupe.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur Pix Orga avec sup.admin@example.net
Aller sur la page "Étudiants" https://orga-pr3543.review.pix.fr/etudiants
Constater la présence d'un filtre sur la colonne "Groupe"
Tappez "L1" dans le filtre et constater que la liste est filtrée