### PR TITLE
Revert "[RELEASE] A minor is being released to 3.109.0."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Pix Changelog
 
-## v3.109.0 (01/10/2021)
-
-
 ## v3.108.0 (01/10/2021)
 
 - [#3535](https://github.com/1024pix/pix/pull/3535) [FEATURE] Cacher les élèves désactivés de la liste des élèves pouvant être inscrits à une session de certification (PIX-3163).

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "private": false,
   "description": "Interface d'administration pour les Pix Masters.",
   "license": "AGPL-3.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-api",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-api",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-certif",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-certif",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "private": false,
   "description": "Plateforme en ligne de gestion des sessions de certification",
   "license": "AGPL-3.0",

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-e2e",
-  "version": "0.216.0",
+  "version": "0.215.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-e2e",
-  "version": "0.216.0",
+  "version": "0.215.0",
   "description": "Permet d'exécuter des tests de bout en bout sur la plateforme Pix",
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-load-testing",
-  "version": "1.215.0",
+  "version": "1.214.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-load-testing",
-  "version": "1.215.0",
+  "version": "1.214.0",
   "description": "Permet d'exécuter des tests de charge sur l'API de la plateforme Pix.",
   "homepage": "https://github.com/1024pix/pix/tree/dev/high-level-tests/load-testing#readme",
   "author": "GIP Pix",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mon-pix",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mon-pix",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-orga",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-orga",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "private": false,
   "description": "Plateforme en ligne de gestion de campagne d'évaluation",
   "license": "AGPL-3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix",
-  "version": "3.109.0",
+  "version": "3.108.0",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",


### PR DESCRIPTION
This reverts commit 374b02242dcfd203f5fc14226fd223ab1a69bba8.

## :unicorn: Problème
Une double release a été effectuée par erreur et une PR mergée après la correction incluait la modification des package.json et du CHANGELOG.md