### PR TITLE
[FEATURE] Modifier le message d'erreur pour les imports SCO (PIX-3515)

### DIFF
--- a/api/lib/infrastructure/utils/xml/siecle-file-streamer.js
+++ b/api/lib/infrastructure/utils/xml/siecle-file-streamer.js
@@ -21,9 +21,6 @@ const logger = require('../../logger');
 const ERRORS = {
   INVALID_FILE: 'INVALID_FILE',
   ENCODING_NOT_SUPPORTED: 'ENCODING_NOT_SUPPORTED',
-  PARSING_ERROR: 'PARSING_ERROR',
-  UNZIP_ERROR: 'UNZIP_ERROR',
-  NO_VALID_FILE_TO_EXTRACT: 'NO_VALID_FILE_TO_EXTRACT',
 };
 const DEFAULT_FILE_ENCODING = 'UTF-8';
 const ZIP = 'application/zip';
@@ -83,7 +80,7 @@ async function _unzipFile(directory, path) {
     await zip.extract(fileName, extractedFileName);
   } catch (error) {
     await zip.close();
-    throw new FileValidationError(ERRORS.UNZIP_ERROR);
+    throw new FileValidationError(ERRORS.INVALID_FILE);
   }
   await zip.close();
   return extractedFileName;
@@ -95,8 +92,8 @@ async function _getFileToExtractName(zipStream) {
   const validFiles = fileNames.filter((name) => VALID_FILE_NAME_REGEX.test(name));
   if (validFiles.length != 1) {
     zipStream.close();
-    logger.error({ ERROR: ERRORS.NO_VALID_FILE_TO_EXTRACT, entries });
-    throw new FileValidationError(ERRORS.NO_VALID_FILE_TO_EXTRACT);
+    logger.error({ ERROR: ERRORS.INVALID_FILE, entries });
+    throw new FileValidationError(ERRORS.INVALID_FILE);
   }
   return validFiles[0];
 }
@@ -145,7 +142,7 @@ function _getSaxStream(path, encoding, reject) {
   const saxParser = sax.createStream(true);
   saxParser.on('error', (err) => {
     logger.error(err);
-    reject(new FileValidationError(ERRORS.PARSING_ERROR));
+    reject(new FileValidationError(ERRORS.INVALID_FILE));
   });
 
   return inputStream.pipe(decodeStream).pipe(saxParser);

--- a/api/tests/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
+++ b/api/tests/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
@@ -28,7 +28,7 @@ describe('SiecleFileStreamer', function() {
             });
 
           expect(error).to.be.an.instanceof(FileValidationError);
-          expect(error.code).to.equal('PARSING_ERROR');
+          expect(error.code).to.equal('INVALID_FILE');
         });
       });
 
@@ -83,7 +83,7 @@ describe('SiecleFileStreamer', function() {
           const error = await catchErr(SiecleFileStreamer.create)(path);
 
           expect(error).to.be.an.instanceof(FileValidationError);
-          expect(error.code).to.equal('UNZIP_ERROR');
+          expect(error.code).to.equal('INVALID_FILE');
         });
       });
 
@@ -94,7 +94,7 @@ describe('SiecleFileStreamer', function() {
           const error = await catchErr(SiecleFileStreamer.create)(path);
 
           expect(error).to.be.an.instanceof(FileValidationError);
-          expect(error.code).to.equal('NO_VALID_FILE_TO_EXTRACT');
+          expect(error.code).to.equal('INVALID_FILE');
         });
       });
 

--- a/orga/tests/unit/controllers/authenticated/sco-students/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-students/list_test.js
@@ -70,7 +70,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
         assert.equal(
           notificationMessage,
-          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre fichier et l’importer à nouveau.</div>'
+          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'
         );
       });
 
@@ -84,7 +84,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
         assert.equal(
           notificationMessage,
-          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre fichier et l’importer à nouveau.</div>'
+          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'
         );
       });
 
@@ -98,7 +98,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
         assert.equal(
           notificationMessage,
-          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre fichier et l’importer à nouveau.</div>'
+          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'
         );
       });
     });

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -574,7 +574,7 @@
         "none": "Aucune"
       },
       "import": {
-        "error-wrapper": "<div>Aucun élève n’a été importé.<br/><strong>{message}</strong><br/> Veuillez vérifier ou modifier votre fichier et l’importer à nouveau.</div>",
+        "error-wrapper": "<div>Aucun élève n’a été importé.<br/><strong>{message}</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>",
         "global-error": "<div>Aucun élève n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">le formulaire du centre d’aide</a>.</div>",
         "global-success": "La liste a été importée avec succès."
       },


### PR DESCRIPTION
## :unicorn: Problème
Le texte ne convenait pas lorsqu'une erreur était remonté

## :robot: Solution
Retravailler le wording du message d'erreur.

## :rainbow: Remarques

## :100: Pour tester
Importer un fichier SIECLE en erreur et vérifier la présence du message `Veuillez vérifier ou modifier votre base élèves et importer à nouveau.`