### PR TITLE
[FEATURE]  Ajout de la colonne groupe dans le fichier d'export CSV au sein d'une campaign de collecte de profil  (Pix-3540).

### DIFF
--- a/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -23,6 +23,7 @@ class CampaignProfilesCollectionResultLine {
       this.campaign.name,
       this.campaignParticipationResult.participantLastName,
       this.campaignParticipationResult.participantFirstName,
+      ...(this._getGroupColumn()),
       ...(this._getDivisionColumn()),
       ...(this._getStudentNumberColumn()),
       ...(this._getIdPixLabelColumn()),
@@ -95,6 +96,14 @@ class CampaignProfilesCollectionResultLine {
     });
 
     return columns;
+  }
+
+  _getGroupColumn() {
+    if (this.organization.isSup && this.organization.isManagingStudents) {
+      return [this.campaignParticipationResult.group || ''];
+    }
+
+    return EMPTY_ARRAY;
   }
 }
 

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -112,6 +112,7 @@ module.exports = {
           'campaign-participations.*',
           'schooling-registrations.studentNumber',
           'schooling-registrations.division',
+          'schooling-registrations.group',
           knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
           knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
         ])
@@ -349,6 +350,7 @@ function _rowToResult(row) {
     participantLastName: row.lastName,
     division: row.division,
     pixScore: row.pixScore,
+    group: row.group,
   };
 }
 

--- a/api/lib/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/lib/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -33,6 +33,7 @@ class CampaignProfilesCollectionExport {
 
   _buildHeader() {
     const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
+    const displayGroup = this.organization.isSup && this.organization.isManagingStudents;
     const displayDivision = this.organization.isSco && this.organization.isManagingStudents;
 
     const header = [
@@ -41,6 +42,7 @@ class CampaignProfilesCollectionExport {
       this.translate('campaign-export.common.campaign-name'),
       this.translate('campaign-export.common.participant-lastname'),
       this.translate('campaign-export.common.participant-firstname'),
+      displayGroup && this.translate('campaign-export.common.participant-group'),
       displayDivision && this.translate('campaign-export.common.participant-division'),
       displayStudentNumber && this.translate('campaign-export.common.participant-student-number'),
       this.idPixLabel,

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -274,7 +274,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         organization = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
         databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
 
-        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: participant.id, studentNumber: '12345A', firstName: '@Jean', lastName: '=Bono', organizationId: organization.id });
+        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: participant.id, studentNumber: '12345A', firstName: '@Jean', lastName: '=Bono', group: '=AB1', organizationId: organization.id });
 
         campaign = databaseBuilder.factory.buildCampaign({
           name: '@Campagne de Test N°2',
@@ -299,7 +299,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         await databaseBuilder.commit();
       });
 
-      it('should return the complete line with student number', async function() {
+      it('should return the complete line for a SUP organisation that manages students', async function() {
         // given
         const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
         const expectedCsvSecondLine = `"${organization.name}";` +
@@ -307,6 +307,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           `"'${campaign.name}";` +
           `"'${schoolingRegistration.lastName}";` +
           `"'${schoolingRegistration.firstName}";` +
+          `"'${schoolingRegistration.group}";` +
           `"${schoolingRegistration.studentNumber}";` +
           `"'${campaignParticipation.participantExternalId}";` +
           '"Oui";' +

--- a/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
+++ b/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
@@ -452,7 +452,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
       });
 
       context('when the participant does not have a student number', function() {
-        it('should return the csv with empty student number', function() {
+        it('should return the csv with empty student number and group', function() {
           //given
           sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(false);
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
@@ -472,6 +472,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             participantLastName: 'Carlitos',
             studentNumber: null,
             pixScore: 13,
+            group: '',
           };
 
           const csvExcpectedLine = `"${organization.name}";` +
@@ -479,6 +480,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +
+            `"${campaignParticipationResultData.group}";` +
             '"";' +
             '"Oui";' +
             '2019-03-01;' +
@@ -520,6 +522,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             participantLastName: 'Carlitos',
             studentNumber: 'HELLO123',
             pixScore: 13,
+            group: 'NA',
           };
 
           const csvExcpectedLine = `"${organization.name}";` +
@@ -527,6 +530,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +
+            `"${campaignParticipationResultData.group}";` +
             `"${campaignParticipationResultData.studentNumber}";` +
             '"Oui";' +
             '2019-03-01;' +
@@ -546,6 +550,57 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
         });
       });
+
+      context('when the participant has a group', function() {
+        it('should return the csv with group information', function() {
+          //given
+          sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(false);
+          sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
+
+          campaign.id = 123;
+          campaign.name = 'test';
+          organization.name = 'Umbrella';
+
+          const campaignParticipationResultData = {
+            id: 1,
+            isShared: true,
+            isCompleted: true,
+            createdAt: new Date('2019-02-25T10:00:00Z'),
+            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            userId: 123,
+            participantFirstName: 'Juan',
+            participantLastName: 'Carlitos',
+            studentNumber: 'HELLO123',
+            pixScore: 13,
+            group: 'groupix',
+          };
+
+          const csvExcpectedLine = `"${organization.name}";` +
+            `${campaign.id};` +
+            `"${campaign.name}";` +
+            `"${campaignParticipationResultData.participantLastName}";` +
+            `"${campaignParticipationResultData.participantFirstName}";` +
+            `"${campaignParticipationResultData.group}";` +
+            `"${campaignParticipationResultData.studentNumber}";` +
+            '"Oui";' +
+            '2019-03-01;' +
+            '13;' +
+            '"Non";' +
+            '0;' +
+            '1;' +
+            '9;' +
+            '0;' +
+            '4' +
+            '\n';
+
+          //when
+          const line = new CampaignProfilesCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
+
+          //then
+          expect(line.toCsvLine()).to.equal(csvExcpectedLine);
+        });
+      });
+
     });
 
     context('When organization is SUP and not managing students', function() {

--- a/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
@@ -106,7 +106,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
       expect(csv).to.equal(expectedHeader);
     });
 
-    it('should display student number header when organization is SUP and managing students', async function() {
+    it('It displays all headers for SUP organization that manages students', async function() {
       //given
       organization.isSup = true;
       organization.isManagingStudents = true;
@@ -118,6 +118,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
           '"Nom de la campagne";' +
           '"Nom du Participant";' +
           '"Prénom du Participant";' +
+          '"Groupe du Participant";' +
           '"Numéro Étudiant";' +
           '"Envoi (O/N)";' +
           '"Date de l\'envoi";' +

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -34,6 +34,7 @@
       "organization-name": "Organisation’s name",
       "participant-division": "Class",
       "participant-firstname": "Participant's first name",
+      "participant-group": "Participant's group",
       "participant-lastname": "Participant's last name",
       "participant-student-number": "Student number",
       "yes": "Yes"

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -46,6 +46,7 @@
       "organization-name": "Nom de l'organisation",
       "participant-division": "Classe",
       "participant-firstname": "Prénom du Participant",
+      "participant-group": "Groupe du Participant",
       "participant-lastname": "Nom du Participant",
       "participant-student-number": "Numéro Étudiant",
       "yes": "Oui"


### PR DESCRIPTION
## :unicorn: Problème
Dans le contexte de l'ouverture de l'import pour les orga SUP IsmanagingStudent, nous avons pu expérimenté et voir les axes d'améliorations à réaliser pour compléter et apporter plus de valeurs à l'utilisateur. 

## :robot: Solution
Ajouter la colonne “groupe” au sein de l’export des résultats d’une campagne de collecte de profil.

## :rainbow: Remarques
N/A

## :100: Pour tester
- Se connecter sur pix orga avec `sup.admin@example.net`
- Allez dans la page campagnes --> sélectionnez une campagne de collect de profile 
- Exported le fichier des résultats  puis constatez que la colonne groupe existe dans le fichier, soit avec un nom du groupe ou  une chaine de caractere vide.