### PR TITLE
[FEATURE] Permettre le ré-envoie de code de vérification lors d'un changement d'email (PIX-3497)

### DIFF
--- a/mon-pix/app/components/user-account/email-verification-code.hbs
+++ b/mon-pix/app/components/user-account/email-verification-code.hbs
@@ -12,7 +12,9 @@
 
   <div class="email-verification-code__resend {{if this.showResendCode "visible"}}">
     <p>{{t "pages.email-verification.did-not-receive"}}</p>
-    <p>{{t "pages.email-verification.send-back-the-code"}}</p>
+    <button type="button" {{on "click" this.resendVerificationCodeByEmail}}>{{t
+        "pages.email-verification.send-back-the-code"
+      }}</button>
   </div>
   <PixButton @isBorderVisible={{true}} @triggerAction={{@disableEmailEditionMode}} @backgroundColor="transparent-light">
     {{t "common.actions.cancel"}}

--- a/mon-pix/app/components/user-account/email-verification-code.hbs
+++ b/mon-pix/app/components/user-account/email-verification-code.hbs
@@ -12,9 +12,9 @@
 
   <div class="email-verification-code__resend {{if this.showResendCode "visible"}}">
     <p>{{t "pages.email-verification.did-not-receive"}}</p>
-    <button type="button" {{on "click" this.resendVerificationCodeByEmail}}>{{t
-        "pages.email-verification.send-back-the-code"
-      }}</button>
+    <button type="button" {{on "click" this.resendVerificationCodeByEmail}} disabled={{this.wasButtonClicked}}>
+      {{t "pages.email-verification.send-back-the-code"}}
+    </button>
   </div>
   <PixButton @isBorderVisible={{true}} @triggerAction={{@disableEmailEditionMode}} @backgroundColor="transparent-light">
     {{t "common.actions.cancel"}}

--- a/mon-pix/app/components/user-account/email-verification-code.hbs
+++ b/mon-pix/app/components/user-account/email-verification-code.hbs
@@ -10,12 +10,18 @@
     />
   </div>
 
-  <div class="email-verification-code__resend {{if this.showResendCode "visible"}}">
-    <p>{{t "pages.email-verification.did-not-receive"}}</p>
-    <button type="button" {{on "click" this.resendVerificationCodeByEmail}} disabled={{this.wasButtonClicked}}>
-      {{t "pages.email-verification.send-back-the-code"}}
-    </button>
-  </div>
+  {{#if this.wasButtonClicked}}
+    <PixMessage @type="success" class="email-verification-code__resend-confirmation-message">
+      {{t "pages.email-verification.confirmation-message"}}
+    </PixMessage>
+  {{else}}
+    <div class="email-verification-code__resend {{if this.showResendCode "visible"}}">
+      <p>{{t "pages.email-verification.did-not-receive"}}</p>
+      <button type="button" {{on "click" this.resendVerificationCodeByEmail}}>
+        {{t "pages.email-verification.send-back-the-code"}}
+      </button>
+    </div>
+  {{/if}}
   <PixButton @isBorderVisible={{true}} @triggerAction={{@disableEmailEditionMode}} @backgroundColor="transparent-light">
     {{t "common.actions.cancel"}}
   </PixButton>

--- a/mon-pix/app/components/user-account/email-verification-code.js
+++ b/mon-pix/app/components/user-account/email-verification-code.js
@@ -7,6 +7,7 @@ import ENV from 'mon-pix/config/environment';
 export default class EmailVerificationCode extends Component {
 
   @service intl;
+  @service store;
   @tracked showResendCode = false
 
   constructor() {
@@ -15,6 +16,15 @@ export default class EmailVerificationCode extends Component {
     setTimeout(() => {
       this.showResendCode = true;
     }, ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
+  }
+
+  @action
+  async resendVerificationCodeByEmail() {
+    const emailVerificationCode = this.store.createRecord('email-verification-code', {
+      password: this.args.password,
+      newEmail: this.args.email.trim().toLowerCase(),
+    });
+    await emailVerificationCode.sendNewEmail();
   }
 
   @action

--- a/mon-pix/app/components/user-account/email-verification-code.js
+++ b/mon-pix/app/components/user-account/email-verification-code.js
@@ -8,7 +8,8 @@ export default class EmailVerificationCode extends Component {
 
   @service intl;
   @service store;
-  @tracked showResendCode = false
+  @tracked showResendCode = false;
+  @tracked wasButtonClicked = false;
 
   constructor() {
     super(...arguments);
@@ -20,11 +21,20 @@ export default class EmailVerificationCode extends Component {
 
   @action
   async resendVerificationCodeByEmail() {
-    const emailVerificationCode = this.store.createRecord('email-verification-code', {
-      password: this.args.password,
-      newEmail: this.args.email.trim().toLowerCase(),
-    });
-    await emailVerificationCode.sendNewEmail();
+    try {
+      if (!this.wasButtonClicked) {
+        this.wasButtonClicked = true;
+        const emailVerificationCode = this.store.createRecord('email-verification-code', {
+          password: this.args.password,
+          newEmail: this.args.email.trim().toLowerCase(),
+        });
+        await emailVerificationCode.sendNewEmail();
+      }
+    } finally {
+      setTimeout(() => {
+        this.wasButtonClicked = false;
+      }, ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
+    }
   }
 
   @action

--- a/mon-pix/app/components/user-account/email-with-validation-form.hbs
+++ b/mon-pix/app/components/user-account/email-with-validation-form.hbs
@@ -5,6 +5,7 @@
       @id="newEmail"
       @label={{t "pages.user-account.account-update-email-with-validation.fields.new-email.label"}}
       @errorMessage={{this.newEmailValidationMessage}}
+      type="email"
       {{on "focusout" this.validateNewEmail}}
       autocomplete="off"
       required
@@ -39,7 +40,7 @@
     <PixButton
       class="update-email-with-validation-actions__confirm-button"
       @type="submit"
-      @isDisabled={{not this.isFormValid}}
+      @isDisabled={{this.wasButtonClicked}}
     >
       {{t "pages.user-account.account-update-email-with-validation.save-button"}}
     </PixButton>

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -69,7 +69,7 @@ export default class EmailWithValidationForm extends Component {
           });
           await emailVerificationCode.sendNewEmail();
 
-          this.args.showVerificationCode(this.newEmail);
+          this.args.showVerificationCode({ newEmail: this.newEmail, password: this.password });
         }
       } catch (response) {
         this.handleSubmitError(response);

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -11,6 +11,7 @@ const ERROR_INPUT_MESSAGE_MAP = {
   emptyPassword: 'pages.user-account.account-update-email-with-validation.fields.errors.empty-password',
   emailAlreadyExist: 'pages.user-account.account-update-email-with-validation.fields.errors.new-email-already-exist',
   invalidPassword: 'pages.user-account.account-update-email-with-validation.fields.errors.invalid-password',
+  unknownError: 'pages.user-account.account-update-email.fields.errors.unknown-error',
 };
 
 export default class EmailWithValidationForm extends Component {
@@ -94,6 +95,8 @@ export default class EmailWithValidationForm extends Component {
       if (code === 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS') {
         this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emailAlreadyExist']);
       }
+    } else {
+      this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']);
     }
   }
 }

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import isEmailValid from '../../utils/email-validator';
 import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
-import ENV from 'mon-pix/config/environment';
 
 const ERROR_INPUT_MESSAGE_MAP = {
   invalidEmail: 'pages.user-account.account-update-email-with-validation.fields.errors.invalid-email',
@@ -74,9 +73,7 @@ export default class EmailWithValidationForm extends Component {
       } catch (response) {
         this.handleSubmitError(response);
       } finally {
-        setTimeout(() => {
-          this.wasButtonClicked = false;
-        }, ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
+        this.wasButtonClicked = false;
       }
     }
   }

--- a/mon-pix/app/components/user-account/update-email-with-validation.hbs
+++ b/mon-pix/app/components/user-account/update-email-with-validation.hbs
@@ -8,6 +8,7 @@
     <UserAccount::EmailVerificationCode
       @disableEmailEditionMode={{@disableEmailEditionMode}}
       @email={{this.newEmail}}
+      @password={{this.password}}
     />
   {{/if}}
 </div>

--- a/mon-pix/app/components/user-account/update-email-with-validation.js
+++ b/mon-pix/app/components/user-account/update-email-with-validation.js
@@ -7,11 +7,13 @@ export default class UpdateEmailWithValidation extends Component {
   @service store;
 
   @tracked newEmail = '';
+  @tracked password = '';
   @tracked showEmailForm = true;
 
   @action
-  showVerificationCode(newEmail) {
+  showVerificationCode({ newEmail, password }) {
     this.newEmail = newEmail.trim();
+    this.password = password;
     this.showEmailForm = false;
   }
 }

--- a/mon-pix/app/styles/components/user-account/_email-verification-code.scss
+++ b/mon-pix/app/styles/components/user-account/_email-verification-code.scss
@@ -39,4 +39,8 @@
       cursor: pointer;
     }
   }
+
+  &__resend-confirmation-message {
+    margin-bottom: 12px;
+  }
 }

--- a/mon-pix/app/styles/components/user-account/_email-verification-code.scss
+++ b/mon-pix/app/styles/components/user-account/_email-verification-code.scss
@@ -18,13 +18,25 @@
     display: flex;
     opacity: 0;
     transition: opacity 0.2s ease-in;
+    margin-bottom: 12px;
 
-    p:last-child {
-      margin-left: 4px;
+    p {
+      margin: 0;
     }
 
     &.visible {
       opacity: 1;
+    }
+
+    button {
+      padding: 0;
+      margin-left: 2px;
+      background-color: transparent;
+      border: none;
+      font-family: $font-roboto;
+      font-size: 1rem;
+      color: $blue;
+      cursor: pointer;
     }
   }
 }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -62,7 +62,7 @@ module.exports = function(environment) {
       LOAD_EXTERNAL_SCRIPT: true,
       NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS: 5,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
-      MILLISECONDS_BEFORE_MAIL_RESEND: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MILLISECONDS_BEFORE_MAIL_RESEND', defaultValue: 5000, minValue: 0 }),
+      MILLISECONDS_BEFORE_MAIL_RESEND: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MILLISECONDS_BEFORE_MAIL_RESEND', defaultValue: 7000, minValue: 0 }),
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       FRENCH_NEW_LEVEL_MESSAGE: process.env.FRENCH_NEW_LEVEL_MESSAGE || '',

--- a/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-verification-code-test.js
@@ -23,7 +23,28 @@ describe('Integration | Component | user-account | email-verification-code', fun
     expect(findByLabel(this.intl.t('pages.email-verification.did-not-receive'))).not.to.have.class('visible');
   });
 
-  it(`should be possible to resend code message after ${ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND} milliseconds`, function() {
+  it(`should display a resend code message after ${ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND} milliseconds`, function() {
+    // given
+    const email = 'toto@example.net';
+    const password = 'pix123';
+    this.set('email', email);
+    this.set('password', password);
+
+    const clock = sinon.useFakeTimers();
+
+    // when
+    const promise = render(hbs`<UserAccount::EmailVerificationCode @email={{this.email}} @password={{this.password}} />`);
+    clock.tick(ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
+
+    const result = promise.then(async () => {
+      expect(contains(this.intl.t('pages.email-verification.did-not-receive'))).to.exist;
+      expect(contains(this.intl.t('pages.email-verification.send-back-the-code'))).to.exist;
+    });
+    clock.restore();
+    return result;
+  });
+
+  it('should show confirmation message when resending code message', function() {
     // given
     const email = 'toto@example.net';
     const password = 'pix123';
@@ -47,9 +68,8 @@ describe('Integration | Component | user-account | email-verification-code', fun
       await clickByLabel(this.intl.t('pages.email-verification.send-back-the-code'));
 
       // then
-      expect(contains(this.intl.t('pages.email-verification.did-not-receive'))).to.exist;
-      expect(contains(this.intl.t('pages.email-verification.send-back-the-code'))).to.exist;
-      sinon.assert.calledOnce(sendNewEmailStub);
+      expect(contains(this.intl.t('pages.email-verification.confirmation-message'))).to.exist;
+      expect(contains(this.intl.t('pages.email-verification.send-back-the-code'))).to.not.exist;
     });
     clock.restore();
     return result;

--- a/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
@@ -87,7 +87,7 @@ describe('Integration | Component | user-account | email-with-validation-form', 
       store = this.owner.lookup('service:store');
     });
 
-    it('should call the show verification code method', async function() {
+    it('should call the show verification code method only once', async function() {
       // given
       const newEmail = 'newEmail@example.net';
       const password = 'password';
@@ -99,6 +99,7 @@ describe('Integration | Component | user-account | email-with-validation-form', 
       // when
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
+      await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
       await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
       // then

--- a/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
@@ -99,7 +99,7 @@ describe('Integration | Component | user-account | email-with-validation-form', 
       // when
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'), newEmail);
       await fillInByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'), password);
-      await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
+      clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
       await clickByLabel(this.intl.t('pages.user-account.account-update-email-with-validation.save-button'));
 
       // then

--- a/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+
+describe('Unit | Component | user-account | email-verification-code', function() {
+  setupTest();
+
+  context('#resendVerificationCodeByEmail', function() {
+
+    it('should prevent to double click on resend verification code', async function() {
+      // given
+      const component = createGlimmerComponent('component:user-account/email-verification-code');
+      const newEmail = 'toto@example.net';
+      const password = 'pix123';
+      const sendNewEmail = sinon.stub();
+      component.store = { createRecord: () => ({ sendNewEmail }) };
+      component.args.email = newEmail;
+      component.args.password = password;
+      sinon.spy(component.store, 'createRecord');
+
+      // when
+      await component.resendVerificationCodeByEmail();
+      await component.resendVerificationCodeByEmail();
+
+      // then
+      expect(component.wasButtonClicked).to.be.true;
+      sinon.assert.calledOnce(sendNewEmail);
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
@@ -40,5 +40,24 @@ describe('Unit | Component | user-account | email-with-validation-form', functio
       sinon.assert.notCalled(component.store.createRecord);
       sinon.assert.notCalled(sendNewEmail);
     });
+
+    it('should prevent double clicking on submit', async function() {
+      // given
+      const component = createGlimmerComponent('component:user-account/email-with-validation-form');
+      const newEmail = 'toto@example.net';
+      const password = 'pix123';
+      const sendNewEmail = sinon.stub();
+      component.store = { createRecord: () => ({ sendNewEmail }) };
+      component.newEmail = newEmail;
+      component.password = password;
+      sinon.spy(component.store, 'createRecord');
+
+      // when
+      await component.onSubmit();
+      await component.onSubmit();
+
+      // then
+      sinon.assert.calledOnce(sendNewEmail);
+    });
   });
 });

--- a/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
@@ -53,7 +53,7 @@ describe('Unit | Component | user-account | email-with-validation-form', functio
       sinon.spy(component.store, 'createRecord');
 
       // when
-      await component.onSubmit();
+      component.onSubmit();
       await component.onSubmit();
 
       // then

--- a/mon-pix/tests/unit/components/user-account/update-email-with-validation-test.js
+++ b/mon-pix/tests/unit/components/user-account/update-email-with-validation-test.js
@@ -11,9 +11,10 @@ describe('Unit | Component | user-account | update-email-with-validation', funct
       // given
       const component = createGlimmerComponent('component:user-account/update-email-with-validation');
       const newEmail = 'toto@example.net';
+      const password = 'pix123';
 
       // when
-      await component.showVerificationCode(newEmail);
+      component.showVerificationCode({ newEmail, password });
 
       // then
       expect(component.showEmailForm).to.be.false;
@@ -23,12 +24,26 @@ describe('Unit | Component | user-account | update-email-with-validation', funct
       // given
       const component = createGlimmerComponent('component:user-account/update-email-with-validation');
       const newEmail = '   Toto@Example.net    ';
+      const password = 'pix123';
 
       // when
-      await component.showVerificationCode(newEmail);
+      component.showVerificationCode({ newEmail, password });
 
       // then
       expect(component.newEmail).to.equal('Toto@Example.net');
+    });
+
+    it('should save password on sendVerificationCode', async function() {
+      // given
+      const component = createGlimmerComponent('component:user-account/update-email-with-validation');
+      const newEmail = 'toto@example.net';
+      const password = 'pix123';
+
+      // when
+      component.showVerificationCode({ newEmail, password });
+
+      // then
+      expect(component.password).to.equal('pix123');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors du nouveau changement d'email nous envoyons un code de vérification par email.
Cependant, s'il y a eu un soucis lors de l'envoi du code de vérification par email l'utilisateur doit recommencer le process à partir du début.

## :robot: Solution
Permettre à l'utilisateur de demander de renvoyer le code de vérification par email.

## :rainbow: Remarques
La feature est soumise à feature toggle.
Pour limiter les abus lors de l'envois des emails, nous mettons un timers entre chaque clicks possibles sur le bouton de ré-envois.

## ❓  Questions
- Combien de temps on met entre 2 clicks d'envoies d'email ?  => 7 secondes 
- Est-ce qu'on met une sécurité côté API ? Si oui, a t-on déjà un exemple dans le code ? => pas d'exemple dans le code, ça semble difficile d'implémentation

## :100: Pour tester
Lancer l'API avec le feature toggle à true : 
- ` FT_VALIDATE_EMAIL=true npm start -- --watch `

Lancer mon-pix : 
- se connecter avec un user qui se connecte via un email
- aller dans le menu en haut à droite en cliquant sur le nom de l'utilisateur
- cliquer sur "Mon compte"
- aller dans "Mes méthodes de connexion"
- cliquer sur "Modifier"
- remplir un nouvel email auquel vous avez accès (votre email pix par ex)
- mettre le mdp de l'utilisateur 
- cliquer sur "Recevoir un code de vérification"
- attendre 5 secondes 
- constater qu'on peut cliquer sur "me renvoyer le code"
- ouvrir la console
- cliquer sur "me renvoyer le code"
- constater qu'on envoie une requête sur `api/users/{id}/email/verification-code`
- constater qu'un message de confirmation d'envoi s'affiche temporairement 
- constater qu'on a bien recu le nouvel email
