### PR TITLE
[FEATURE] Toujours afficher la page de présentation au début de la campagne (Pix-3180).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -44,23 +44,23 @@ Fonctionnalité: Campagne d'évaluation
     Et je vais sur la page d'accès à une campagne
     Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours"
     Et je clique sur "Commencer"
+    Alors je vois la page de "presentation" de la campagne
+    Lorsque je clique sur "Je commence"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis "Daenerys" dans le champ "Prénom"
     Et je saisis "Targaryen" dans le champ "Nom"
     Et je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"
     Et je clique sur le bouton "Associer"
-    Alors je vois la page de "presentation" de la campagne
-    Lorsque je clique sur "Je commence"
     Alors je vois la page de "didacticiel" de la campagne
 
   Scénario: Je rejoins un parcours prescrit restreint en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
     Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours"
     Et je clique sur "Commencer"
+    Alors je vois la page de "presentation" de la campagne
+    Lorsque je clique sur "Je commence"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"
-    Alors je vois la page de "presentation" de la campagne
-    Lorsque je clique sur "Je commence"
     Alors je vois la page de "didacticiel" de la campagne

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
@@ -36,14 +36,14 @@ Fonctionnalité: Campagne de collecte de profils
     Et je vais sur la page d'accès à une campagne
     Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours"
     Et je clique sur "Commencer"
+    Alors je vois la page de "presentation" de la campagne
+    Lorsque je clique sur "C'est parti !"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis "Daenerys" dans le champ "Prénom"
     Et je saisis "Targaryen" dans le champ "Nom"
     Et je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"
     Et je clique sur le bouton "Associer"
-    Alors je vois la page de "presentation" de la campagne
-    Lorsque je clique sur "C'est parti !"
     Alors je vois la page d'"envoi-profil" de la campagne
     Lorsque je clique sur "J'envoie mon profil"
     Alors je vois que j'ai partagé mon profil
@@ -52,11 +52,11 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je me connecte à Pix via le GAR
     Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours"
     Et je clique sur "Commencer"
+    Alors je vois la page de "presentation" de la campagne
+    Lorsque je clique sur "C'est parti !"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"
-    Alors je vois la page de "presentation" de la campagne
-    Lorsque je clique sur "C'est parti !"
     Alors je vois la page d'"envoi-profil" de la campagne
     Lorsque je clique sur "J'envoie mon profil"
     Alors je vois que j'ai partagé mon profil

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -29,7 +29,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       await this._findOngoingCampaignParticipationAndUpdateState(campaign);
     }
 
-    if (this._shouldVisitLandingPage) {
+    if (this._shouldVisitLandingPage(campaign)) {
       return this.replaceWith('campaigns.campaign-landing-page', campaign);
     }
 
@@ -108,13 +108,11 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       externalUser: null,
       isCampaignPoleEmploi: false,
       isUserLoggedInPoleEmploi: false,
-      isCampaignForNoviceUser: false,
     };
   }
 
   _updateStateFrom({ campaign = {}, ongoingCampaignParticipation = null, session }) {
     const hasUserCompletedRestrictedCampaignAssociation = this.campaignStorage.get(campaign.code, 'associationDone') || false;
-    const isCampaignForNoviceUser = get(campaign, 'isForAbsoluteNovice', this.state.isCampaignForNoviceUser);
     const hasUserSeenJoinPage = this.campaignStorage.get(campaign.code, 'hasUserSeenJoinPage');
     const participantExternalId = this.campaignStorage.get(campaign.code, 'participantExternalId');
     this.state = {
@@ -131,7 +129,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       externalUser: get(session, 'data.externalUser'),
       isCampaignPoleEmploi: get(campaign, 'organizationIsPoleEmploi', this.state.isCampaignPoleEmploi),
       isUserLoggedInPoleEmploi: get(session, 'data.authenticated.source') === 'pole_emploi_connect' || this.state.isUserLoggedInPoleEmploi,
-      isCampaignForNoviceUser,
     };
   }
 
@@ -208,8 +205,8 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       && !this.state.participantExternalId;
   }
 
-  get _shouldVisitLandingPage() {
-    const shouldDisplayLandingPage = this.state.isCampaignForNoviceUser ? false : !this.campaignStorage.get(this.state.campaignCode, 'landingPageShown');
+  _shouldVisitLandingPage(campaign) {
+    const shouldDisplayLandingPage = campaign.isForAbsoluteNovice ? false : !this.campaignStorage.get(this.state.campaignCode, 'landingPageShown');
     return shouldDisplayLandingPage
       && !this.state.doesUserHaveOngoingParticipation;
   }

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -25,6 +25,13 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     }
 
     this._updateStateFrom({ campaign, session: this.session });
+    if (this.state.isUserLogged) {
+      await this._findOngoingCampaignParticipationAndUpdateState(campaign);
+    }
+
+    if (this._shouldVisitLandingPage) {
+      return this.replaceWith('campaigns.campaign-landing-page', campaign);
+    }
 
     if (this._shouldVisitPoleEmploiLoginPage) {
       return this._redirectToPoleEmploiLoginPage(transition);
@@ -39,11 +46,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
         return this._redirectToTermsOfServicesBeforeAccessingToCampaign(transition);
       }
 
-      if (this.state.externalUser) {
-        return this.replaceWith('campaigns.restricted.join', campaign);
-      }
-
-      await this._findOngoingCampaignParticipationAndUpdateState(campaign);
       if (!this.state.doesUserHaveOngoingParticipation) {
         return this.replaceWith('campaigns.restricted.join', campaign);
       }
@@ -60,10 +62,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       await this.currentUser.load();
     }
 
-    if (this._shouldVisitLandingPageAsVisitor) {
-      return this.replaceWith('campaigns.campaign-landing-page', campaign);
-    }
-
     super.beforeModel(...arguments);
   }
 
@@ -73,12 +71,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
   }
 
   async afterModel(campaign) {
-    await this._findOngoingCampaignParticipationAndUpdateState(campaign);
-
-    if (this._shouldVisitLandingPageAsLoggedUser && !campaign.isForAbsoluteNovice) {
-      return this.replaceWith('campaigns.campaign-landing-page', campaign);
-    }
-
     if (this._shouldProvideExternalIdToAccessCampaign) {
       return this.replaceWith('campaigns.fill-in-participant-external-id', campaign);
     }
@@ -109,7 +101,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       isCampaignSimplifiedAccess: false,
       hasUserCompletedRestrictedCampaignAssociation: false,
       hasUserSeenJoinPage: false,
-      shouldDisplayLandingPage: true,
       isUserLogged: false,
       doesUserHaveOngoingParticipation: false,
       doesCampaignAskForExternalId: false,
@@ -126,7 +117,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     const isCampaignForNoviceUser = get(campaign, 'isForAbsoluteNovice', this.state.isCampaignForNoviceUser);
     const hasUserSeenJoinPage = this.campaignStorage.get(campaign.code, 'hasUserSeenJoinPage');
     const participantExternalId = this.campaignStorage.get(campaign.code, 'participantExternalId');
-    const shouldDisplayLandingPage = isCampaignForNoviceUser ? false : !this.campaignStorage.get(campaign.code, 'landingPageShown');
     this.state = {
       campaignCode: get(campaign, 'code', this.state.campaignCode),
       isCampaignRestricted: get(campaign, 'isRestricted', this.state.isCampaignRestricted),
@@ -134,7 +124,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       isCampaignForSCOOrganization: get(campaign, 'organizationType') === 'SCO',
       hasUserCompletedRestrictedCampaignAssociation,
       hasUserSeenJoinPage,
-      shouldDisplayLandingPage,
       isUserLogged: this.session.isAuthenticated,
       doesUserHaveOngoingParticipation: Boolean(ongoingCampaignParticipation),
       doesCampaignAskForExternalId: get(campaign, 'idPixLabel', this.state.doesCampaignAskForExternalId),
@@ -209,8 +198,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
   }
 
   get _shouldJoinSimplifiedCampaignAsAnonymous() {
-    return !this.state.shouldDisplayLandingPage
-      && this.state.isCampaignSimplifiedAccess
+    return this.state.isCampaignSimplifiedAccess
       && !this.state.isUserLogged;
   }
 
@@ -220,15 +208,9 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       && !this.state.participantExternalId;
   }
 
-  get _shouldVisitLandingPageAsVisitor() {
-    return this.state.shouldDisplayLandingPage
-      && !this.state.isCampaignRestricted
-      && !this.state.isUserLogged;
-  }
-
-  get _shouldVisitLandingPageAsLoggedUser() {
-    return this.state.shouldDisplayLandingPage
-      && this.state.isUserLogged
+  get _shouldVisitLandingPage() {
+    const shouldDisplayLandingPage = this.state.isCampaignForNoviceUser ? false : !this.campaignStorage.get(this.state.campaignCode, 'landingPageShown');
+    return shouldDisplayLandingPage
       && !this.state.doesUserHaveOngoingParticipation;
   }
 

--- a/mon-pix/tests/acceptance/footer_test.js
+++ b/mon-pix/tests/acceptance/footer_test.js
@@ -28,7 +28,7 @@ describe('Acceptance | Footer', function() {
       const campaign = server.create('campaign', 'withOneChallenge');
 
       // when
-      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false, this.intl);
+      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false);
 
       // then
       expect(find('.footer')).to.not.exist;

--- a/mon-pix/tests/acceptance/navigation_test.js
+++ b/mon-pix/tests/acceptance/navigation_test.js
@@ -55,7 +55,7 @@ describe('Acceptance | Navbar', function() {
       const campaign = server.create('campaign', 'withOneChallenge');
 
       // when
-      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false, this.intl);
+      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false);
 
       // then
       expect(find('.navbar-desktop-header')).to.not.exist;

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment_test.js
@@ -1,0 +1,122 @@
+import { click, fillIn, currentURL } from '@ember/test-helpers';
+import { beforeEach, describe, it } from 'mocha';
+import { expect } from 'chai';
+import { authenticateByEmail } from '../helpers/authentication';
+import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
+import visit from '../helpers/visit';
+import { clickByLabel } from '../helpers/click-by-label';
+import { invalidateSession } from '../helpers/invalidate-session';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+const ASSESSMENT = 'ASSESSMENT';
+
+describe('Acceptance | Campaigns | Resume Campaigns with type Assessment', function() {
+  setupApplicationTest();
+  setupMirage();
+  let campaign;
+  let studentInfo;
+
+  beforeEach(async function() {
+    studentInfo = server.create('user', 'withEmail');
+    await authenticateByEmail(studentInfo);
+    campaign = server.create('campaign', { idPixLabel: 'email', type: ASSESSMENT });
+    await resumeCampaignOfTypeAssessmentByCode(campaign.code, true);
+  });
+
+  context('When the user is not logged', function() {
+
+    beforeEach(async function() {
+      await invalidateSession();
+      await visit(`/campagnes/${campaign.code}`);
+      await clickByLabel('Je commence');
+    });
+
+    it('should propose to signup', function() {
+      expect(currentURL()).to.contains('/inscription');
+    });
+
+    it('should redirect to campaign participation when user logs in', async function() {
+      // given
+      await click('[href="/connexion"]');
+      await fillIn('#login', studentInfo.email);
+      await fillIn('#password', studentInfo.password);
+
+      // when
+      await click('.sign-form-body__bottom-button button');
+
+      // then
+      expect(currentURL()).to.contains('/assessments/');
+    });
+
+  });
+
+  context('When user is logged', async function() {
+
+    context('When there is no more questions', async function() {
+
+      it('should redirect to last checkpoint page', async function() {
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+
+        // then
+        expect(currentURL()).to.contains('/checkpoint?finalCheckpoint=true');
+      });
+    });
+
+    context('When user has completed his campaign participation', async function() {
+
+      it('should redirect directly to results', async function() {
+        // given
+        await visit(`/campagnes/${campaign.code}`);
+        await clickByLabel('Voir mes résultats');
+
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+
+        // then
+        expect(currentURL()).to.contains(`/campagnes/${campaign.code}/evaluation/resultats`);
+      });
+    });
+
+    context('When user has already send his results', async function() {
+
+      it('should redirect directly to shared results', async function() {
+        // given
+        await visit(`/campagnes/${campaign.code}`);
+        await clickByLabel('Voir mes résultats');
+        await clickByLabel('J\'envoie mes résultats');
+
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+
+        // then
+        expect(currentURL()).to.contains(`/campagnes/${campaign.code}/evaluation/resultats`);
+      });
+    });
+
+    context('When the campaign is restricted and schooling-registration is disabled', function() {
+      beforeEach(async function() {
+        campaign = server.create('campaign', { code: 'FORBIDDEN', isRestricted: true, type: ASSESSMENT });
+        server.create('campaign-participation', { campaign });
+      });
+
+      it('should be able to resume', async function() {
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+
+        // then
+        expect(currentURL()).to.contains('/assessments/');
+      });
+
+      it('should display results page', async function() {
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+        await clickByLabel('Voir mes résultats');
+
+        // then
+        expect(currentURL()).to.contains(`/campagnes/${campaign.code}/evaluation/resultats`);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -39,7 +39,7 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
 
     it('should redirect to send profile page when user logs in', async function() {
       // given
-      await click('.sign-form-header__subtitle [href="/connexion"]');
+      await click('[href="/connexion"]');
       await fillIn('#login', studentInfo.email);
       await fillIn('#password', studentInfo.password);
 
@@ -54,7 +54,7 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
 
   context('When user is logged', async function() {
 
-    context('When user has seen send profile page but has not send it', async function() {
+    context('When user has seen profile page but has not send it', async function() {
 
       it('should redirect directly to send profile page', async function() {
         // when

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -96,15 +96,25 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
       beforeEach(async function() {
         campaign = server.create('campaign', { code: 'FORBIDDEN', isRestricted: true, type: PROFILES_COLLECTION });
         server.create('campaign-participation', { campaign });
-        await completeCampaignOfTypeProfilesCollectionByCode(campaign.code);
       });
 
-      it('should display results page', async function() {
+      it('should be able to resume', async function() {
         // when
         await visit(`/campagnes/${campaign.code}`);
 
         // then
-        expect(currentURL()).to.contains('/deja-envoye');
+        expect(currentURL()).to.contains(`/campagnes/${campaign.code}/collecte/envoi-profil`);
+      });
+
+      it('should display results page', async function() {
+        // given
+        await completeCampaignOfTypeProfilesCollectionByCode(campaign.code);
+
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+
+        // then
+        expect(currentURL()).to.contains(`/campagnes/${campaign.code}/collecte/deja-envoye`);
       });
     });
   });

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -29,8 +29,6 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
 
     beforeEach(async function() {
       await invalidateSession();
-      // Reset state, invalidateSession() is not doing it...
-      this.owner.lookup('route:campaigns.start-or-resume')._resetState();
       await visit(`/campagnes/${campaign.code}`);
       await clickByLabel('C\'est parti !');
     });

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -106,7 +106,8 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               // given
               campaign = server.create('campaign', 'restricted', { idPixLabel: 'toto', organizationType: 'SCO', type: ASSESSMENT });
               await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
-              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification`);
+              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+              await clickByLabel('Je commence');
 
               // when
               await click('#login-button');
@@ -122,7 +123,6 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               await fillIn('#yearOfBirth', '2000');
               await clickByLabel(this.intl.t('pages.join.button'));
               await clickByLabel(this.intl.t('pages.join.sco.associate'));
-              await click('.campaign-landing-page__start-button');
 
               // then
               expect(currentURL()).to.contains('/didacticiel');

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -91,8 +91,8 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               //given
               campaign = server.create('campaign', { type: PROFILES_COLLECTION, isRestricted: true, idPixLabel: 'toto', organizationType: 'SCO' });
               await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
-
-              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification`);
+              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+              await clickByLabel('C\'est parti !');
 
               // when
               await click('#login-button');
@@ -108,7 +108,6 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#yearOfBirth', '2000');
               await clickByLabel(this.intl.t('pages.join.button'));
               await clickByLabel(this.intl.t('pages.join.sco.associate'));
-              await click('.campaign-landing-page__start-button');
 
               // then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -233,6 +232,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#yearOfBirth', '2000');
               await clickByLabel(this.intl.t('pages.join.button'));
               await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
+              await clickByLabel('C\'est parti !');
 
               //then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification?displayRegisterForm=false`);

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -73,7 +73,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
         context('When campaign is not restricted', function() {
 
-          it('should access presentation page', async function() {
+          it('should display landing page', async function() {
             // given
             const campaign = server.create('campaign', { isRestricted: false });
             await visit('/campagnes');
@@ -83,7 +83,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await click('.fill-in-campaign-code__start-button');
 
             // then
-            expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
           });
 
           context('When user create its account', function() {
@@ -109,9 +109,9 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await visit('/campagnes');
               await fillIn('#campaign-code', campaign.code);
               await click('.fill-in-campaign-code__start-button');
-              expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
+              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
               await click('.campaign-landing-page__start-button');
-              expect(currentURL().toLowerCase()).to.equal('/inscription'.toLowerCase());
+              expect(currentURL()).to.equal('/inscription');
               await fillIn('#firstName', prescritUser.firstName);
               await fillIn('#lastName', prescritUser.lastName);
               await fillIn('#email', prescritUser.email);
@@ -142,19 +142,20 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
               // when
               await fillIn('#campaign-code', campaign.code);
-              await click('.fill-in-campaign-code__start-button');
+              await clickByLabel('Commencer');
+              await clickByLabel('Je commence');
               await click('#login-button');
               await fillIn('#login', prescritUser.email);
               await fillIn('#password', prescritUser.password);
               await click('#submit-connexion');
 
               // then
-              expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`.toLowerCase());
+              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
             });
 
             context('When student is reconciled in another organization', function() {
 
-              it('should reconcile and redirect to landing-page', async function() {
+              it('should reconcile and begin campaign participation', async function() {
                 // given
                 server.get('schooling-registration-user-associations', () => {
                   return { data: null };
@@ -166,26 +167,28 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
                 // when
                 await fillIn('#campaign-code', campaign.code);
-                await click('.fill-in-campaign-code__start-button');
+                await clickByLabel('Commencer');
+                await clickByLabel('Je commence');
                 await click('#login-button');
                 await fillIn('#login', prescritUser.email);
                 await fillIn('#password', prescritUser.password);
                 await click('#submit-connexion');
 
                 // then
-                expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
+                expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
               });
             });
           });
 
           context('When user must accept Pix last terms of service', async function() {
 
-            it('should redirect to campaign landing page after accept terms of service', async function() {
+            it('should redirect to reconciliation page after accept terms of service', async function() {
               // given
               await visit('/campagnes');
               prescritUser.mustValidateTermsOfService = true;
               await fillIn('#campaign-code', campaign.code);
-              await click('.fill-in-campaign-code__start-button');
+              await clickByLabel('Commencer');
+              await clickByLabel('Je commence');
               await click('#login-button');
               await fillIn('#login', prescritUser.email);
               await fillIn('#password', prescritUser.password);
@@ -196,57 +199,30 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await clickByLabel(this.intl.t('pages.terms-of-service-pe.form.button'));
 
               // then
-              expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`.toLowerCase());
-
+              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
             });
           });
 
-          it('should redirect to login-or-register page', async function() {
+          it('should redirect to landing-page page', async function() {
             // when
             await visit(`/campagnes/${campaign.code}`);
+
+            // then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          });
+
+          it('should redirect to login-or-register page when landing page has been seen', async function() {
+            // given
+            await visit(`/campagnes/${campaign.code}`);
+
+            // when
+            await clickByLabel('Je commence');
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification`);
           });
 
-          it('should redirect to landing page when reconciliation and registration are done', async function() {
-            // given
-            this.server.put('schooling-registration-user-associations/possibilities', () => {
-
-              const studentFoundWithUsernameGenerated = {
-                'data': {
-                  'attributes': {
-                    'last-name': 'JeanPrescrit',
-                    'first-name': 'Campagne',
-                    'birthdate': '2010-12-10',
-                    'campaign-code': 'RESTRICTD',
-                    'username': 'jeanprescrit.campagne1012',
-                  }, 'type': 'schooling-registration-user-associations',
-                },
-              };
-
-              return new Response(200, {}, studentFoundWithUsernameGenerated);
-            });
-
-            await visit(`/campagnes/${campaign.code}`);
-
-            // when
-            await fillIn('#firstName', 'JeanPrescrit');
-            await fillIn('#lastName', 'Campagne');
-            await fillIn('#dayOfBirth', '10');
-            await fillIn('#monthOfBirth', '12');
-            await fillIn('#yearOfBirth', '2000');
-            await click('#submit-search');
-
-            await fillIn('#password', 'Password123');
-            await click('#submit-registration');
-
-            // then
-            expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
-          });
-
-          it('should not alter inputs(username,password,email) when email already exists ', async function() {
-
+          it('should not alter inputs(username,password,email) when email already exists', async function() {
             //given
             this.server.put('schooling-registration-user-associations/possibilities', () => {
 
@@ -280,6 +256,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             });
 
             await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('Je commence');
 
             // when
             await fillIn('#firstName', prescritUser.firstName);
@@ -311,6 +288,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           it('should redirect to join restricted campaign page when connection is done', async function() {
             // given
             await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('Je commence');
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification`);
 
             // when
@@ -323,9 +301,10 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
           });
 
-          it('should redirect to landing page when fields are filled in and associate button is clicked', async function() {
+          it('should begin campaign participation when fields are filled in and associate button is clicked', async function() {
             // given
             await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('Je commence');
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification`);
 
             await click('#login-button');
@@ -346,7 +325,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             //then
-            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
 
         });
@@ -357,21 +336,34 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             campaign = server.create('campaign', { isRestricted: true, organizationType: 'SUP' });
           });
 
-          it('should redirect to simple login page', async function() {
+          it('should redirect to landing page', async function() {
             // given
             await visit('/campagnes');
 
             // when
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+
+            // then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          });
+
+          it('should redirect to simple login page when landing page has been seen', async function() {
+            // given
+            await visit(`/campagnes/${campaign.code}`);
+
+            // when
+            await clickByLabel('Je commence');
 
             // then
             expect(currentURL()).to.equal('/inscription');
           });
 
-          it('should be redirect to join page after login', async function() {
+          it('should redirect to join page after login', async function() {
             // given
             await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('Je commence');
+
             // when
             await clickByLabel('connectez-vous à votre compte');
             await fillIn('#login', prescritUser.email);
@@ -396,32 +388,46 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             campaign = server.create('campaign', { organizationIsPoleEmploi: true });
           });
 
-          it('should redirect to Pole Emploi authentication form', async function() {
+          it('should redirect to landing page', async function() {
             // given
             await visit('/campagnes');
 
             // when
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+
+            // then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          });
+
+          it('should redirect to Pole Emploi authentication form when landing page has been seen', async function() {
+            // given
+            await visit(`/campagnes/${campaign.code}`);
+
+            // when
+            await clickByLabel('Je commence');
 
             // then
             sinon.assert.called(replaceLocationStub);
             expect(currentURL()).to.equal('/connexion-pole-emploi');
           });
 
-          it('should redirect to landing page once user is authenticated', async function() {
+          it('should begin campaign participation once user is authenticated', async function() {
             // given
             const state = 'state';
 
             const session = currentSession();
             session.set('data.state', state);
-            session.set('data.nextURL', `/campagnes/${campaign.code}`);
+            session.set('data.nextURL', `/campagnes/${campaign.code}/startOrResume`);
+            const data = {};
+            data[campaign.code] = { landingPageShown: true };
+            sessionStorage.setItem('campaigns', JSON.stringify(data));
 
             // when
             await visit(`/connexion-pole-emploi?code=test&state=${state}`);
 
             // then
-            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
 
           context('When user must validate terms of service Pole Emploi', function() {
@@ -496,7 +502,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
           // when
           await fillIn('#campaign-code', campaignCode);
-          await click('.fill-in-campaign-code__start-button');
+          await clickByLabel('Commencer');
 
           // then
           expect(currentURL()).to.equal('/campagnes');
@@ -512,7 +518,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           await visit('/campagnes');
 
           // when
-          await click('.fill-in-campaign-code__start-button');
+          await clickByLabel('Commencer');
 
           // then
           expect(currentURL()).to.equal('/campagnes');
@@ -596,6 +602,18 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
         context('When association is not already done', function() {
 
+          it('should redirect to landing page', async function() {
+            // given
+            await visit('/campagnes');
+
+            //when
+            await fillIn('#campaign-code', campaign.code);
+            await clickByLabel('Commencer');
+
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          });
+
           it('should try to reconcile automatically before redirect to join restricted campaign page', async function() {
             // given
             server.get('schooling-registration-user-associations', () => {
@@ -607,34 +625,34 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
             // when
             await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('Je commence');
 
             // then
-            expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
 
-          it('should redirect to join restricted campaign page', async function() {
+          it('should redirect to join restricted campaign page when landing page has been seen', async function() {
             // given
-            await visit('/campagnes');
+            await visit(`/campagnes/${campaign.code}`);
 
             //when
-            await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Je commence');
 
             //then
-            expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`.toLowerCase());
-            expect(find('.join-restricted-campaign')).to.exist;
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
           });
 
           it('should not set any field by default', async function() {
             // when
-            await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
+            await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('Je commence');
 
             //then
             expect(find('#firstName').value).to.equal('');
             expect(find('#lastName').value).to.equal('');
           });
 
-          it('should redirect to landing page when fields are filled in and associate button is clicked', async function() {
+          it('should begin campaign participation when fields are filled in and associate button is clicked', async function() {
             // given
             await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
 
@@ -644,6 +662,8 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
+
+            // when
             await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
@@ -651,11 +671,29 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
           });
 
+          it('should begin campaign participation when landing page has been seen', async function() {
+            // given
+            await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('Je commence');
+            await fillIn('#firstName', 'Robert');
+            await fillIn('#lastName', 'Smith');
+            await fillIn('#dayOfBirth', '10');
+            await fillIn('#monthOfBirth', '12');
+            await fillIn('#yearOfBirth', '2000');
+
+            // when
+            await clickByLabel(this.intl.t('pages.join.button'));
+            await clickByLabel(this.intl.t('pages.join.sco.associate'));
+
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
+          });
+
         });
 
         context('When association is already done', function() {
 
-          beforeEach(async function() {
+          beforeEach(function() {
             server.create('schooling-registration-user-association', {
               campaignCode: campaign.code,
             });
@@ -663,18 +701,18 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
           it('should redirect to landing page', async function() {
             // when
-            await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
+            await visit(`/campagnes/${campaign.code}`);
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
           });
 
-          it('should begin campaign participation', async function() {
+          it('should begin campaign participation when landing page has been seen', async function() {
             // given
-            await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
+            await visit(`/campagnes/${campaign.code}`);
 
             // when
-            await clickByLabel(this.intl.t('pages.campaign-landing.assessment.action'));
+            await clickByLabel('Je commence');
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
@@ -688,16 +726,33 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           campaign = server.create('campaign', { isRestricted: true, organizationType: 'SUP' });
         });
 
-        it('should be redirected to join page', async function() {
-          // when
+        it('should redirect to landing page', async function() {
+          // given
+          await visit('/campagnes');
+
+          //when
+          await fillIn('#campaign-code', campaign.code);
+          await clickByLabel('Commencer');
+
+          //then
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+        });
+
+        it('should redirect to join page when landing page has been seen', async function() {
+          // given
           await visit(`/campagnes/${campaign.code}`);
+
+          // when
+          await clickByLabel('Je commence');
+
           // then
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
         });
 
-        it('the student has been associated with its student number', async function() {
+        it('should begin campaign participation when association is done', async function() {
           // given
           await visit(`/campagnes/${campaign.code}`);
+          await clickByLabel('Je commence');
 
           // when
           await fillInByLabel('Numéro étudiant', 'F100');
@@ -709,7 +764,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           await clickByLabel('C\'est parti !');
 
           // then
-          expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
       });
 
@@ -722,7 +777,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await startCampaignByCode(campaign.code);
           });
 
-          it('should show the identifiant page after clicking on start button in landing page', async function() {
+          it('should show the identifiant page after clicking on start button in landing page', function() {
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/identifiant`);
           });
         });
@@ -733,6 +788,9 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await startCampaignByCodeAndExternalId(campaign.code);
           });
 
+          it('should begin campaign participation', function() {
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
+          });
         });
       });
 
@@ -740,16 +798,23 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
         beforeEach(async function() {
           campaign = server.create('campaign', { idPixLabel: null });
-          await visit(`campagnes/${campaign.code}`);
+          await startCampaignByCode(campaign.code);
+        });
+
+        it('should begin campaign participation', function() {
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
       });
 
       context('When campaign does not have external id but a participant external id is set in the url', function() {
         beforeEach(async function() {
           campaign = server.create('campaign', { idPixLabel: null });
-          await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
+          await startCampaignByCodeAndExternalId(campaign.code);
         });
 
+        it('should begin campaign participation', function() {
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
+        });
       });
 
       context('When the campaign is restricted and schooling-registration is disabled', function() {
@@ -757,13 +822,21 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           campaign = server.create('campaign', { code: 'FORBIDDEN', isRestricted: true });
         });
 
-        it('should show an error message when user starts the campaign', async function() {
+        it('should redirect to landing page', async function() {
           // when
           await visit(`/campagnes/${campaign.code}`);
 
           // then
-          expect(currentURL()).to.equal(`/campagnes/${campaign.code}`);
-          expect(find('.title').textContent).to.contains('Oups, la page demandée n’est pas accessible.');
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+        });
+
+        it('should show an error message when user starts the campaign', async function() {
+          // when
+          await visit(`/campagnes/${campaign.code}`);
+          await clickByLabel('Je commence');
+
+          // then
+          expect(contains('Oups, la page demandée n’est pas accessible.')).to.exist;
         });
       });
 
@@ -822,7 +895,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
         // when
         await visit('/campagnes');
         await fillIn('#campaign-code', campaign.code);
-        await click('.fill-in-campaign-code__start-button');
+        await clickByLabel('Commencer');
         await click('button[type="submit"]');
 
         const currentUserId = session.data.authenticated['user_id'];
@@ -847,10 +920,20 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await visit(`/campagnes?externalUser=${externalUserToken}`);
           });
 
-          it('should redirect to reconciliation form', async function() {
+          it('should redirect to landing page', async function() {
             // when
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+
+            // then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          });
+
+          it('should redirect to reconciliation form when landing page has been seen', async function() {
+            // when
+            await fillIn('#campaign-code', campaign.code);
+            await clickByLabel('Commencer');
+            await clickByLabel('Je commence');
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
@@ -859,17 +942,19 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           it('should set by default firstName and lastName', async function() {
             // when
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+            await clickByLabel('Je commence');
 
             //then
             expect(find('#firstName').value).to.equal('JeanPrescrit');
             expect(find('#lastName').value).to.equal('Campagne');
           });
 
-          it('should redirect to landing page when fields are filled in', async function() {
+          it('should begin campaign participation when reconciliation is done', async function() {
             // given
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+            await clickByLabel('Je commence');
 
             // when
             await fillIn('#dayOfBirth', '10');
@@ -878,7 +963,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await clickByLabel(this.intl.t('pages.join.button'));
 
             //then
-            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
 
@@ -916,10 +1001,10 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
               // when
               await fillIn('#campaign-code', campaign.code);
-              await click('.fill-in-campaign-code__start-button');
+              await clickByLabel('Commencer');
 
               // then
-              expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
+              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
             });
           });
         });
@@ -948,13 +1033,14 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await visit(`/campagnes?externalUser=${externalUserToken}`);
           });
 
-          it('should land on start campaign page if GAR authentication method has been added', async function() {
+          it('should begin campaign participation if GAR authentication method has been added', async function() {
             // given
             server.create('schooling-registration-user-association', {
               campaignCode: campaign.code,
             });
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+            await clickByLabel('Je commence');
 
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
@@ -971,8 +1057,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(session.data.authenticated.source).to.equal(AUTHENTICATED_SOURCE_FROM_MEDIACENTRE);
 
             // then
-            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
-            expect(contains('Commencez votre parcours')).to.exist;
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
 
           it('should display an specific error message if GAR authentication method adding has failed with http statusCode 4xx', async function() {
@@ -984,7 +1069,8 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             server.post('/token-from-external-user', () => errorsApi);
 
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+            await clickByLabel('Je commence');
 
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
@@ -1016,7 +1102,8 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             server.post('/token-from-external-user', () => errorsApi);
 
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+            await clickByLabel('Je commence');
 
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
@@ -1040,7 +1127,8 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             server.post('/token-from-external-user', () => new Response(500));
 
             await fillIn('#campaign-code', campaign.code);
-            await click('.fill-in-campaign-code__start-button');
+            await clickByLabel('Commencer');
+            await clickByLabel('Je commence');
 
             await fillIn('#dayOfBirth', '10');
             await fillIn('#monthOfBirth', '12');
@@ -1060,8 +1148,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
           context('When user should change password', () => {
 
-            it('should land on start campaign page after updating password expired', async function() {
-
+            it('should begin campaign participation after updating password expired', async function() {
               // given
               const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
 
@@ -1087,7 +1174,8 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
               // when
               await fillIn('#campaign-code', campaign.code);
-              await click('.fill-in-campaign-code__start-button');
+              await clickByLabel('Commencer');
+              await clickByLabel('Je commence');
 
               await fillIn('#dayOfBirth', '10');
               await fillIn('#monthOfBirth', '12');
@@ -1106,8 +1194,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
               // then
-              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
-              expect(contains('Commencez votre parcours')).to.exist;
+              expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
             });
           });
         });

--- a/mon-pix/tests/helpers/campaign.js
+++ b/mon-pix/tests/helpers/campaign.js
@@ -12,15 +12,14 @@ export async function startCampaignByCodeAndExternalId(campaignCode, externalId 
   await click('.campaign-landing-page__start-button');
 }
 
-export async function resumeCampaignOfTypeAssessmentByCode(campaignCode, hasExternalParticipantId, intl) {
+export async function resumeCampaignOfTypeAssessmentByCode(campaignCode, hasExternalParticipantId) {
   await visit(`/campagnes/${campaignCode}`);
-  await click('.campaign-landing-page__start-button');
+  await clickByLabel('Je commence');
   if (hasExternalParticipantId) {
     await fillIn('#id-pix-label', 'monmail@truc.fr');
-    await click('.button');
+    await clickByLabel('Continuer');
   }
-  await clickByLabel(intl.t('pages.tutorial.pass'));
-  await click('.challenge-actions__action-skip');
+  await clickByLabel('Ignorer');
 }
 
 export async function resumeCampaignOfTypeProfilesCollectionByCode(campaignCode, hasExternalParticipantId) {
@@ -35,17 +34,4 @@ export async function resumeCampaignOfTypeProfilesCollectionByCode(campaignCode,
 export async function completeCampaignOfTypeProfilesCollectionByCode(campaignCode) {
   await visit(`/campagnes/${campaignCode}`);
   await clickByLabel('J\'envoie mon profil');
-}
-
-export async function completeCampaignOfTypeAssessmentByCode(campaignCode) {
-  await visit(`/campagnes/${campaignCode}`);
-  await click('.challenge-actions__action-skip');
-  await click('.challenge-actions__action-skip');
-}
-
-export async function completeCampaignOfTypeAssessmentAndSeeResultsByCode(campaignCode) {
-  await visit(`/campagnes/${campaignCode}`);
-  await click('.challenge-actions__action-skip');
-  await click('.challenge-actions__action-skip');
-  await click('.checkpoint__continue-button');
 }

--- a/mon-pix/tests/unit/routes/logout_test.js
+++ b/mon-pix/tests/unit/routes/logout_test.js
@@ -86,7 +86,6 @@ describe('Unit | Route | logout', () => {
     const route = this.owner.lookup('route:logout');
     route.set('campaignStorage', campaignStorageStub);
     route.set('session', sessionStub);
-    route.set('campaignStorage', campaignStorageStub);
 
     // When
     route.beforeModel();


### PR DESCRIPTION
## :unicorn: Problème
Selon si la campagne était restreinte ou non, la page de présentation était affichée avant ou après la connexion/inscription.

## :robot: Solution
Pour une question de simplicité, nous avons choisi de toujours afficher cette page à chaque début de campagne.

## :rainbow: Remarques
RAS

## :100: Pour tester
Tester tous les cas de l'accès parcours.
<img width="1227" alt="Capture d’écran 2021-10-06 à 11 58 26" src="https://user-images.githubusercontent.com/23451175/136181921-da42ef24-ba7e-47cf-88fc-3cb2c37b0224.png">
