### PR TITLE
[FEATURE] Exporter les résultats d'une campagne d'évaluation SUP avec le groupe (PIX-3541).

### DIFF
--- a/api/lib/domain/read-models/CampaignParticipationInfo.js
+++ b/api/lib/domain/read-models/CampaignParticipationInfo.js
@@ -14,6 +14,7 @@ const validationSchema = Joi.object({
   createdAt: Joi.date().required(),
   sharedAt: Joi.date().required().allow(null),
   division: Joi.string().allow(null).optional(),
+  group: Joi.string().allow(null).optional(),
   masteryRate: Joi.number().required().allow(null),
 });
 
@@ -30,6 +31,7 @@ class CampaignParticipationInfo {
     createdAt,
     sharedAt,
     division,
+    group,
     masteryRate,
   } = {}) {
     this.participantFirstName = participantFirstName;
@@ -42,8 +44,8 @@ class CampaignParticipationInfo {
     this.createdAt = createdAt;
     this.sharedAt = sharedAt;
     this.division = division;
+    this.group = group;
     this.masteryRate = !_.isNil(masteryRate) ? Number(masteryRate) : null;
-
     validateEntity(validationSchema, this);
   }
 

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -102,7 +102,7 @@ async function _checkCreatorHasAccessToCampaignOrganization(userId, organization
 }
 
 function _createHeaderOfCSV(targetProfile, idPixLabel, organization, translate) {
-  const displayStudentNumber = organization.isSup && organization.isManagingStudents;
+  const forSupStudents = organization.isSup && organization.isManagingStudents;
   const displayDivision = organization.isSco && organization.isManagingStudents;
 
   return [
@@ -113,7 +113,8 @@ function _createHeaderOfCSV(targetProfile, idPixLabel, organization, translate) 
     translate('campaign-export.common.participant-lastname'),
     translate('campaign-export.common.participant-firstname'),
     ...(displayDivision ? [translate('campaign-export.common.participant-division')] : []),
-    ...(displayStudentNumber ? [translate('campaign-export.common.participant-student-number')] : []),
+    ...(forSupStudents ? [translate('campaign-export.common.participant-group')] : []),
+    ...(forSupStudents ? [translate('campaign-export.common.participant-student-number')] : []),
     ...(idPixLabel ? [idPixLabel] : []),
 
     translate('campaign-export.assessment.progress'),

--- a/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
@@ -14,6 +14,7 @@ module.exports = {
           knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
           'schooling-registrations.studentNumber',
           'schooling-registrations.division',
+          'schooling-registrations.group',
         ])
           .from('campaign-participations')
           .join('users', 'campaign-participations.userId', 'users.id')
@@ -48,6 +49,7 @@ function _rowToCampaignParticipationInfo(row) {
     createdAt: new Date(row.createdAt),
     sharedAt: row.sharedAt ? new Date(row.sharedAt) : null,
     division: row.division,
+    group: row.group,
     masteryRate: row.masteryRate,
   });
 }

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -91,6 +91,7 @@ class CampaignAssessmentCsvLine {
       this.campaignParticipationInfo.participantLastName,
       this.campaignParticipationInfo.participantFirstName,
       ...this._division,
+      ...this._group,
       ...this._studentNumber,
       ...(this.campaign.idPixLabel ? [this.campaignParticipationInfo.participantExternalId] : []),
       this.campaignParticipationService.progress(this.campaignParticipationInfo.isCompleted, this.targetedKnowledgeElementsCount, this.targetProfileWithLearningContent.skills.length),
@@ -164,6 +165,14 @@ class CampaignAssessmentCsvLine {
   get _division() {
     if (this.organization.isSco && this.organization.isManagingStudents) {
       return [this.campaignParticipationInfo.division || ''];
+    }
+
+    return [];
+  }
+
+  get _group() {
+    if (this.organization.isSup && this.organization.isManagingStudents) {
+      return [this.campaignParticipationInfo.group || ''];
     }
 
     return [];

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -64,6 +64,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
             participantLastName: 'Last',
             studentNumber: null,
             division: null,
+            group: null,
           },
         ]);
         expect(campaignParticipationInfos[0].isShared).to.be.true;
@@ -128,6 +129,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           participantLastName: 'Narrator',
           studentNumber: null,
           division: null,
+          group: null,
         });
         expect(campaignParticipationInfosOrdered[0].isShared).to.equal(true);
 
@@ -143,6 +145,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           participantLastName: 'Durden',
           studentNumber: null,
           division: null,
+          group: null,
         });
         expect(campaignParticipationInfosOrdered[1].isShared).to.equal(false);
       });
@@ -197,6 +200,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           participantLastName: 'Narrator',
           studentNumber: null,
           division: null,
+          group: null,
         }]);
       });
     });
@@ -260,6 +264,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           participantLastName: 'Narrator',
           studentNumber: null,
           division: null,
+          group: null,
         }]);
       });
     });
@@ -307,6 +312,7 @@ describe('Integration | Repository | Campaign Participation Info', function() {
           userId,
           studentNumber: 'Pipon et Jambon',
           division: '6eme',
+          group: 'G1',
         });
         databaseBuilder.factory.buildSchoolingRegistration({
           userId,
@@ -342,6 +348,15 @@ describe('Integration | Repository | Campaign Participation Info', function() {
 
         // then
         expect(campaignParticipationInfos[0].division).to.equal(schoolingRegistration.division);
+      });
+
+      it('should return the group', async function() {
+
+        // when
+        const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
+
+        // then
+        expect(campaignParticipationInfos[0].group).to.equal(schoolingRegistration.group);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -180,7 +180,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     expect(csv).to.equal(csvExpected);
   });
 
-  it('should contains studentNumber header when organization is SUP and managing students', async function() {
+  it('should contains specific header when organization is SUP and managing students', async function() {
     // given
     const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign({ isManagingStudents: true, type: 'SUP' });
     const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
@@ -198,6 +198,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       '"Nom du Profil Cible";' +
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
+      '"Groupe";' +
       '"Numéro Étudiant";' +
       '"% de progression";' +
       '"Date de début";' +

--- a/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
@@ -118,7 +118,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
           '"Nom de la campagne";' +
           '"Nom du Participant";' +
           '"Prénom du Participant";' +
-          '"Groupe du Participant";' +
+          '"Groupe";' +
           '"Numéro Étudiant";' +
           '"Envoi (O/N)";' +
           '"Date de l\'envoi";' +

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -35,9 +35,10 @@ function _computeExpectedColumnsIndex(campaign, organization, badges, stages) {
 }
 
 describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function() {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const translate = getI18n().__;
+  let translate;
+  beforeEach(function() {
+    translate = getI18n().__;
+  });
 
   describe('#toCsvLine', function() {
 

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -75,35 +75,6 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function()
       expect(csvLine[cols.PARTICIPATION_PROGRESSION], 'participation progression').to.equal(0);
     });
 
-    context('on student number column', function() {
-      it('should write the student number when organization is of type SUP and campaign is restricted', function() {
-        // given
-        const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
-        const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
-        const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ studentNumber: 'someStudentNumber' });
-        const targetProfileWithLearningContent = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
-        const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
-          organization,
-          campaign,
-          campaignParticipationInfo,
-          targetProfileWithLearningContent,
-          stages: [],
-          participantKnowledgeElementsByCompetenceId: {
-            [targetProfileWithLearningContent.competences[0].id]: [],
-          },
-          campaignParticipationService,
-          translate,
-        });
-
-        // when
-        const csvLine = campaignAssessmentCsvLine.toCsvLine();
-
-        // then
-        const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
-        expect(csvLine[cols.STUDENT_NUMBER_COL], 'student number').to.equal(campaignParticipationInfo.studentNumber);
-      });
-    });
-
     context('on external id column', function() {
 
       it('should write the participantExternalId when campaign has an idPixLabel', function() {
@@ -439,7 +410,34 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function()
       });
 
       context('when organization type is SUP and manage students', function() {
-        it('returns the group', function() {
+        it('writes the student number', function() {
+          // given
+          const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
+          const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ studentNumber: 'someStudentNumber' });
+          const targetProfileWithLearningContent = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
+          const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+            organization,
+            campaign,
+            campaignParticipationInfo,
+            targetProfileWithLearningContent,
+            stages: [],
+            participantKnowledgeElementsByCompetenceId: {
+              [targetProfileWithLearningContent.competences[0].id]: [],
+            },
+            campaignParticipationService,
+            translate,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          // then
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
+          expect(csvLine[cols.STUDENT_NUMBER_COL], 'student number').to.equal(campaignParticipationInfo.studentNumber);
+        });
+
+        it('writes the group', function() {
           // given
           const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
           const campaign = domainBuilder.buildCampaign({ idPixLabel: null });

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -34,7 +34,7 @@
       "organization-name": "Organisation’s name",
       "participant-division": "Class",
       "participant-firstname": "Participant's first name",
-      "participant-group": "Participant's group",
+      "participant-group": "Group",
       "participant-lastname": "Participant's last name",
       "participant-student-number": "Student number",
       "yes": "Yes"

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -46,7 +46,7 @@
       "organization-name": "Nom de l'organisation",
       "participant-division": "Classe",
       "participant-firstname": "Prénom du Participant",
-      "participant-group": "Groupe du Participant",
+      "participant-group": "Groupe",
       "participant-lastname": "Nom du Participant",
       "participant-student-number": "Numéro Étudiant",
       "yes": "Oui"


### PR DESCRIPTION
## :unicorn: Problème
Le prescripteur n'a pas le nom du groupe du participant dans l'export des résultats

## :robot: Solution
Ajouter la colonne groupe à l'export des résultats d'une campagne d'évaluation

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Participer à la campagne AZERTY789 avec un étudiant de l'université du Lion.
- Télécharger l'export des résultats.

Le nom du groupe du participant doit être dans l'export.
