### PR TITLE
[BUGFIX] Corriger le type de l'appel PUT /{id}/email/verification-code, coté Pix App (PIX-3576).

### DIFF
--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -61,7 +61,7 @@ export default class EmailWithValidationForm extends Component {
           password: this.password,
           newEmail: this.newEmail.trim().toLowerCase(),
         });
-        await emailVerificationCode.send();
+        await emailVerificationCode.sendNewEmail();
         this.args.showVerificationCode(this.newEmail);
       } catch (response) {
         const status = get(response, 'errors[0].status');

--- a/mon-pix/app/models/email-verification-code.js
+++ b/mon-pix/app/models/email-verification-code.js
@@ -5,14 +5,12 @@ export default class EmailVerificationCode extends Model {
   @attr('string') newEmail;
   @attr('string') password;
 
-  send = memberAction({
+  sendNewEmail = memberAction({
     path: 'email/verification-code',
     type: 'PUT',
     urlType: 'email-verification-code',
     before() {
-      const payload = this.serialize();
-      payload.data.type = 'email-verification-code';
-      return payload;
+      return this.serialize();
     },
   });
 }

--- a/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
@@ -92,7 +92,7 @@ describe('Integration | Component | user-account | email-with-validation-form', 
       const newEmail = 'newEmail@example.net';
       const password = 'password';
       this.set('showVerificationCode', sinon.stub());
-      store.createRecord = () => ({ send: sinon.stub() });
+      store.createRecord = () => ({ sendNewEmail: sinon.stub() });
 
       await render(hbs`<UserAccount::EmailWithValidationForm @showVerificationCode={{this.showVerificationCode}} />`);
 
@@ -110,7 +110,7 @@ describe('Integration | Component | user-account | email-with-validation-form', 
       const emailAlreadyExist = 'email@example.net';
       const password = 'password';
       store.createRecord = () => ({
-        send: sinon.stub().throws(
+        sendNewEmail: sinon.stub().throws(
           { errors: [{ status: '400', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS' }] }),
       });
 
@@ -130,7 +130,7 @@ describe('Integration | Component | user-account | email-with-validation-form', 
       const newEmail = 'newEmail@example.net';
       const password = 'password';
       store.createRecord = () => ({
-        send: sinon.stub().throws(
+        sendNewEmail: sinon.stub().throws(
           { errors: [{ status: '400' }] }),
       });
 
@@ -150,7 +150,7 @@ describe('Integration | Component | user-account | email-with-validation-form', 
       const newEmail = 'newEmail@example.net';
       const password = 'password';
       store.createRecord = () => ({
-        send: sinon.stub().throws(
+        sendNewEmail: sinon.stub().throws(
           { errors: [{ status: '422', source: { pointer: 'attributes/email' } }] }),
       });
 
@@ -170,7 +170,7 @@ describe('Integration | Component | user-account | email-with-validation-form', 
       const newEmail = 'newEmail@example.net';
       const password = 'password';
       store.createRecord = () => ({
-        send: sinon.stub().throws(
+        sendNewEmail: sinon.stub().throws(
           { errors: [{ status: '422', source: { pointer: 'attributes/password' } }] }),
       });
 

--- a/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
@@ -12,8 +12,8 @@ describe('Unit | Component | user-account | email-with-validation-form', functio
       const component = createGlimmerComponent('component:user-account/email-with-validation-form');
       const newEmail = 'toto@example.net';
       const password = 'pix123';
-      const send = sinon.stub();
-      component.store = { createRecord: () => ({ send }) };
+      const sendNewEmail = sinon.stub();
+      component.store = { createRecord: () => ({ sendNewEmail }) };
       component.newEmail = newEmail;
       component.password = password;
       sinon.spy(component.store, 'createRecord');
@@ -23,14 +23,14 @@ describe('Unit | Component | user-account | email-with-validation-form', functio
 
       // then
       sinon.assert.calledWith(component.store.createRecord, 'email-verification-code', { password, newEmail });
-      sinon.assert.calledOnce(send);
+      sinon.assert.calledOnce(sendNewEmail);
     });
 
     it('should not send new email and password when form is not valid', async function() {
       // given
       const component = createGlimmerComponent('component:user-account/email-with-validation-form');
-      const send = sinon.stub();
-      component.store = { createRecord: () => ({ send }) };
+      const sendNewEmail = sinon.stub();
+      component.store = { createRecord: () => ({ sendNewEmail }) };
       sinon.spy(component.store, 'createRecord');
 
       // when
@@ -38,7 +38,7 @@ describe('Unit | Component | user-account | email-with-validation-form', functio
 
       // then
       sinon.assert.notCalled(component.store.createRecord);
-      sinon.assert.notCalled(send);
+      sinon.assert.notCalled(sendNewEmail);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors du merge d'une PR, la correction du type de cet appel à été fait coté API mais pas coté front.

## :robot: Solution
Corriger le type par `"email-verification-codes"`

## :rainbow: Remarques
Renommer la méthode send par sendNewEmail, pour être plus explicite.

## :100: Pour tester
Aller sur Mon compte > Méthodes de connexion > modifier > ajouter une adresse e-mail et le mot de passe > Accéder à la page suivante
