### PR TITLE
[TECH] Créer un helper de test permettant de sélectionner une valeur dans une liste déroulante.

### DIFF
--- a/admin/tests/helpers/extended-ember-test-helpers/fill-in-select.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/fill-in-select.js
@@ -1,0 +1,31 @@
+import { fillIn, find } from '@ember/test-helpers';
+import queryByLabel from './query-by-label';
+
+export default function fillInSelect({ labelText, id, value }) {
+  let select;
+  if (labelText) {
+    select = queryByLabel(labelText);
+  } else if (id) {
+    select = find(id);
+  } else {
+    select = find('.pix-select > select');
+  }
+
+  if (!select) {
+    throw new Error('No select element found.');
+  }
+
+  let optionValueToSelect;
+  for (let i = 0; i < select.options.length; i++) {
+    const option = select.options[i];
+    if (option.label === value) {
+      optionValueToSelect = option.value;
+    }
+  }
+
+  if (!optionValueToSelect) {
+    throw new Error(`No option found with label ${value}.`);
+  }
+
+  return fillIn(select, optionValueToSelect);
+}

--- a/admin/tests/integration/test-helpers/fill-in-select_test.js
+++ b/admin/tests/integration/test-helpers/fill-in-select_test.js
@@ -1,0 +1,65 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import fillInSelect from '../../helpers/extended-ember-test-helpers/fill-in-select';
+
+module('Integration | Test Helper | fill-in-select', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('should fill in select with option label', async function (assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<PixSelect @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+
+  test('should fill in select with option label by associated label text', async function (assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(
+      hbs`<label for="select">Label de mon select</label><PixSelect id="select" @options={{this.options}} />`
+    );
+
+    // when
+    await fillInSelect({ labelText: 'Label de mon select', value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+
+  test('should fill in select with option label by select id', async function (assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<PixSelect id="select" @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ id: 'select', value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+});

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -3,6 +3,7 @@ import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
+import fillInSelect from '../helpers/extended-ember-test-helpers/fill-in-select';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -237,13 +238,14 @@ module('Acceptance | Session Finalization', function(hooks) {
 
           test('it should validate the form', async function(assert) {
             // given
-            const certificationReport = server.create('certification-report', { isCompleted: false, abortReason: 'technical' });
+            const certificationReport = server.create('certification-report', { isCompleted: false });
             server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
             session.update({ certificationReports: [certificationReport] });
 
             // when
             await visit(`/sessions/${session.id}/finalisation`);
 
+            await fillInSelect({ value: 'Problème technique' });
             await clickByLabel('Finaliser');
 
             // then

--- a/certif/tests/helpers/extended-ember-test-helpers/fill-in-select.js
+++ b/certif/tests/helpers/extended-ember-test-helpers/fill-in-select.js
@@ -1,0 +1,31 @@
+import { fillIn, find } from '@ember/test-helpers';
+import queryByLabel from './query-by-label';
+
+export default function fillInSelect({ labelText, id, value }) {
+  let select;
+  if (labelText) {
+    select = queryByLabel(labelText);
+  } else if (id) {
+    select = find(id);
+  } else {
+    select = find('.pix-select > select');
+  }
+
+  if (!select) {
+    throw new Error('No select element found.');
+  }
+
+  let optionValueToSelect;
+  for (let i = 0; i < select.options.length; i++) {
+    const option = select.options[i];
+    if (option.label === value) {
+      optionValueToSelect = option.value;
+    }
+  }
+
+  if (!optionValueToSelect) {
+    throw new Error(`No option found with label ${value}.`);
+  }
+
+  return fillIn(select, optionValueToSelect);
+}

--- a/certif/tests/integration/test-helpers/fill-in-select_test.js
+++ b/certif/tests/integration/test-helpers/fill-in-select_test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import fillInSelect from '../../helpers/extended-ember-test-helpers/fill-in-select';
+
+module('Integration | Test Helper | fill-in-select', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('should fill in select with option label', async function(assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<PixSelect @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+
+  test('should fill in select with option label by associated label text', async function(assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<label for="select">Label de mon select</label><PixSelect id="select" @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ labelText: 'Label de mon select', value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+
+  test('should fill in select with option label by select id', async function(assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<PixSelect id="select" @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ id: 'select', value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+});

--- a/mon-pix/tests/helpers/fill-in-select.js
+++ b/mon-pix/tests/helpers/fill-in-select.js
@@ -1,0 +1,31 @@
+import { fillIn, find } from '@ember/test-helpers';
+import queryByLabel from './query-by-label';
+
+export default function fillInSelect({ labelText, id, value }) {
+  let select;
+  if (labelText) {
+    select = queryByLabel(labelText);
+  } else if (id) {
+    select = find(id);
+  } else {
+    select = find('.pix-select > select');
+  }
+
+  if (!select) {
+    throw new Error('No select element found.');
+  }
+
+  let optionValueToSelect;
+  for (let i = 0; i < select.options.length; i++) {
+    const option = select.options[i];
+    if (option.label === value) {
+      optionValueToSelect = option.value;
+    }
+  }
+
+  if (!optionValueToSelect) {
+    throw new Error(`No option found with label ${value}.`);
+  }
+
+  return fillIn(select, optionValueToSelect);
+}

--- a/mon-pix/tests/helpers/query-by-label.js
+++ b/mon-pix/tests/helpers/query-by-label.js
@@ -1,0 +1,56 @@
+import { findAll } from '@ember/test-helpers';
+
+export default function queryByLabel(labelText) {
+  const labelElement = _findLabelElement(labelText);
+  if (labelElement) {
+    return _getElementControlledByLabel(labelElement, labelText);
+  }
+
+  const labelledElement = _findElementWithLabel(labelText);
+  if (!labelledElement) {
+    return null;
+  }
+
+  return labelledElement;
+}
+
+function _findLabelElement(labelText) {
+  return findAll('label').find((label) => label.innerText.includes(labelText));
+}
+
+function _getElementControlledByLabel(label, labelText) {
+  if (!label.control) {
+    throw new Error(`Found label "${labelText}" but no associated form control.`);
+  }
+
+  return label.control;
+}
+
+function _findElementWithLabel(labelText) {
+  const labellableElementSelectors = ['button', 'a[href]', '[role="button"]', 'input', 'textarea', 'select', 'label[for]', 'img'];
+  return findAll(labellableElementSelectors.join(',')).find(_matchesLabel(labelText));
+}
+
+function _matchesLabel(labelText) {
+  return (element) => _matchesInnerText(element, labelText)
+    || _matchesTitle(element, labelText)
+    || _matchesAriaLabel(element, labelText)
+    || _matchesAltAttribute(element, labelText);
+}
+
+function _matchesInnerText(element, labelText) {
+  return element.innerText.includes(labelText);
+}
+
+function _matchesTitle(element, labelText) {
+  return element.title?.includes(labelText);
+}
+
+function _matchesAltAttribute(element, labelText) {
+  return element.alt?.includes(labelText);
+}
+
+function _matchesAriaLabel(element, labelText) {
+  const ariaLabel = element.getAttribute('aria-label');
+  return ariaLabel?.includes(labelText);
+}

--- a/mon-pix/tests/integration/test-helpers/fill-in-select_test.js
+++ b/mon-pix/tests/integration/test-helpers/fill-in-select_test.js
@@ -1,0 +1,64 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import fillInSelect from '../../helpers/fill-in-select';
+
+describe('Integration | Test Helper | fill-in-select', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  it('should fill in select with option label', async function() {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<PixSelect @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ value: 'Option 2' });
+
+    // then
+    expect(find('select').textContent, 'opt2');
+  });
+
+  it('should fill in select with option label by associated label text', async function() {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<label for="select">Label de mon select</label><PixSelect id="select" @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ labelText: 'Label de mon select', value: 'Option 2' });
+
+    // then
+    expect(find('select').textContent, 'opt2');
+  });
+
+  it('should fill in select with option label by select id', async function() {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<PixSelect id="select" @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ id: 'select', value: 'Option 2' });
+
+    // then
+    expect(find('select').textContent, 'opt2');
+  });
+});

--- a/orga/tests/helpers/extended-ember-test-helpers/fill-in-select.js
+++ b/orga/tests/helpers/extended-ember-test-helpers/fill-in-select.js
@@ -1,0 +1,31 @@
+import { fillIn, find } from '@ember/test-helpers';
+import queryByLabel from './query-by-label';
+
+export default function fillInSelect({ labelText, id, value }) {
+  let select;
+  if (labelText) {
+    select = queryByLabel(labelText);
+  } else if (id) {
+    select = find(id);
+  } else {
+    select = find('.pix-select > select');
+  }
+
+  if (!select) {
+    throw new Error('No select element found.');
+  }
+
+  let optionValueToSelect;
+  for (let i = 0; i < select.options.length; i++) {
+    const option = select.options[i];
+    if (option.label === value) {
+      optionValueToSelect = option.value;
+    }
+  }
+
+  if (!optionValueToSelect) {
+    throw new Error(`No option found with label ${value}.`);
+  }
+
+  return fillIn(select, optionValueToSelect);
+}

--- a/orga/tests/helpers/extended-ember-test-helpers/query-by-label.js
+++ b/orga/tests/helpers/extended-ember-test-helpers/query-by-label.js
@@ -1,0 +1,66 @@
+import { findAll } from '@ember/test-helpers';
+
+export default function queryByLabel(labelText) {
+  const labelElement = _findLabelElement(labelText);
+  if (labelElement) {
+    return _getElementControlledByLabel(labelElement, labelText);
+  }
+
+  const labelledElement = _findElementWithLabel(labelText);
+  if (!labelledElement) {
+    return null;
+  }
+
+  return labelledElement;
+}
+
+function _findLabelElement(labelText) {
+  return findAll('label').find((label) => label.innerText.includes(labelText));
+}
+
+function _getElementControlledByLabel(label, labelText) {
+  if (!label.control) {
+    throw new Error(`Found label "${labelText}" but no associated form control.`);
+  }
+
+  return label.control;
+}
+
+function _findElementWithLabel(labelText) {
+  const labellableElementSelectors = [
+    'button',
+    'a[href]',
+    '[role="button"]',
+    'input',
+    'textarea',
+    'select',
+    'label[for]',
+    'img',
+  ];
+  return findAll(labellableElementSelectors.join(',')).find(_matchesLabel(labelText));
+}
+
+function _matchesLabel(labelText) {
+  return (element) =>
+    _matchesInnerText(element, labelText) ||
+    _matchesTitle(element, labelText) ||
+    _matchesAriaLabel(element, labelText) ||
+    _matchesAltAttribute(element, labelText);
+}
+
+function _matchesInnerText(element, labelText) {
+  return element.innerText.includes(labelText);
+}
+
+function _matchesTitle(element, labelText) {
+  return element.title?.includes(labelText);
+}
+
+function _matchesAltAttribute(element, labelText) {
+  return element.alt?.includes(labelText);
+}
+
+function _matchesAriaLabel(element, labelText) {
+  const ariaLabel = element.getAttribute('aria-label');
+  return ariaLabel?.includes(labelText);
+}

--- a/orga/tests/integration/test-helpers/fill-in-select_test.js
+++ b/orga/tests/integration/test-helpers/fill-in-select_test.js
@@ -1,0 +1,65 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import fillInSelect from '../../helpers/extended-ember-test-helpers/fill-in-select';
+
+module('Integration | Test Helper | fill-in-select', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('should fill in select with option label', async function (assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<PixSelect @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+
+  test('should fill in select with option label by associated label text', async function (assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(
+      hbs`<label for="select">Label de mon select</label><PixSelect id="select" @options={{this.options}} />`
+    );
+
+    // when
+    await fillInSelect({ labelText: 'Label de mon select', value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+
+  test('should fill in select with option label by select id', async function (assert) {
+    // given
+    const options = [
+      { label: 'Option 1', value: 'opt1' },
+      { label: 'Option 2', value: 'opt2' },
+      { label: 'Option 3', value: 'opt3' },
+    ];
+
+    this.set('options', options);
+    await render(hbs`<PixSelect id="select" @options={{this.options}} />`);
+
+    // when
+    await fillInSelect({ id: 'select', value: 'Option 2' });
+
+    // then
+    assert.dom('select').hasValue('opt2');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Avec l'utilisation de plus en plus grande de PixSelect, il devient nécessaire de pouvoir sélectionner une valeur dans une liste déroulante par un moyen plus compréhensible qu'en utilisant un `fillIn` avec en valeur l'attribut `value` de l'option.

## :robot: Solution
Ajout du helper `fillInSelect`.

## :rainbow: Remarques
Des tests d'intégration ont été ajoutés afin d'expliciter les différents moyens d'utilisation de ce nouveau helper.