### PR TITLE
[BUGFIX] Bloquer la publication d'une session de certification "aborted" (PIX-3573).

### DIFF
--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -39,6 +39,7 @@ module.exports = class FinalizedSession {
       sessionTime,
       isPublishable: !hasExaminerGlobalComment
         && _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries)
+        && _isNotFlaggedAsAborted(juryCertificationSummaries)
         && _hasNoScoringErrorOrUncompletedAssessmentResults(juryCertificationSummaries)
         && _hasExaminerSeenAllEndScreens(juryCertificationSummaries),
       publishedAt: null,
@@ -61,6 +62,10 @@ module.exports = class FinalizedSession {
 
 function _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries) {
   return !juryCertificationSummaries.some((summary) => summary.isActionRequired());
+}
+
+function _isNotFlaggedAsAborted(juryCertificationSummaries) {
+  return !juryCertificationSummaries.some((summary) => summary.isFlaggedAborted);
 }
 
 function _hasNoScoringErrorOrUncompletedAssessmentResults(juryCertificationSummaries) {

--- a/api/tests/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/unit/domain/models/FinalizedSession_test.js
@@ -38,6 +38,21 @@ describe('Unit | Domain | Models | FinalizedSession', function() {
       expect(finalizedSession.isPublishable).to.be.false;
     });
 
+    it('is not publishable when at least one test is not completed and has an abort reason', function() {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _someWhichAreFlaggedAborted(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+      // then
+      expect(finalizedSession.isPublishable).to.be.false;
+    });
+
     it('is not publishable when has at least one unresolved issue report that requires action', function() {
       // given / when
       const finalizedSession = FinalizedSession.from({
@@ -338,6 +353,31 @@ function _someWithResolvedRequiredActionButNoErrorOrStartedStatus() {
       completedAt: new Date(),
       isPublished: false,
       hasSeenEndTestScreen: true,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.FRAUD,
+          resolvedAt: new Date('2020-01-01'),
+          resolution: 'des points gratos offerts',
+        }),
+      ],
+    }),
+  ];
+}
+
+function _someWhichAreFlaggedAborted() {
+  return [
+    new JuryCertificationSummary({
+      id: 1,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: 'validated',
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: null,
+      isPublished: false,
+      hasSeenEndTestScreen: true,
+      abortReason: 'candidate',
       cleaCertificationStatus: 'not_passed',
       certificationIssueReports: [
         domainBuilder.buildCertificationIssueReport({

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -106,9 +106,11 @@ export default class SessionsFinalizeController extends Controller {
   toggleAllCertificationReportsHasSeenEndTestScreen(someWereChecked) {
     const newState = !someWereChecked;
 
-    this.session.certificationReports.forEach((certificationReport) => {
-      certificationReport.hasSeenEndTestScreen = newState;
-    });
+    this.session.certificationReports
+      .filter((certificationReport) => certificationReport.isCompleted)
+      .forEach((certificationReport) => {
+        certificationReport.hasSeenEndTestScreen = newState;
+      });
   }
 
   @action

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -193,14 +193,13 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       { hasSeenEndTestScreen1: false, hasSeenEndTestScreen2: false, expectedState: true },
     ].forEach(({ hasSeenEndTestScreen1, hasSeenEndTestScreen2, expectedState }) =>
       test('it should toggle the hasSeenEndTestScreen attribute of all certifs in session to false depending on if some were checked', function(assert) {
-        assert.expect(2);
         // given
         const someWereChecked = hasSeenEndTestScreen1 || hasSeenEndTestScreen2;
         const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
         const session = {
           certificationReports: [
-            { hasSeenEndTestScreen: hasSeenEndTestScreen1 },
-            { hasSeenEndTestScreen: hasSeenEndTestScreen2 },
+            { hasSeenEndTestScreen: hasSeenEndTestScreen1, isCompleted: true },
+            { hasSeenEndTestScreen: hasSeenEndTestScreen2, isCompleted: true },
           ],
         };
         controller.model = session;
@@ -209,11 +208,29 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
         controller.send('toggleAllCertificationReportsHasSeenEndTestScreen', someWereChecked);
 
         // then
-        session.certificationReports.forEach((certif) => {
-          assert.equal(certif.hasSeenEndTestScreen, expectedState);
-        });
+        assert.equal(session.certificationReports[0].hasSeenEndTestScreen, expectedState);
+        assert.equal(session.certificationReports[1].hasSeenEndTestScreen, expectedState);
       }),
     );
+
+    test('it should toggle the hasSeenEndTestScreen attribute only for completed certifs in session', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const session = {
+        certificationReports: [
+          { hasSeenEndTestScreen: false, isCompleted: true },
+          { hasSeenEndTestScreen: false, isCompleted: false },
+        ],
+      };
+      controller.model = session;
+
+      // when
+      controller.send('toggleAllCertificationReportsHasSeenEndTestScreen', false);
+
+      // then
+      assert.true(session.certificationReports[0].hasSeenEndTestScreen);
+      assert.false(session.certificationReports[1].hasSeenEndTestScreen);
+    });
   });
 
   module('#action openModal', function() {


### PR DESCRIPTION
## :unicorn: Problème
Lors de la finalisation de session il est possible d'utiliser la case à cocher sur toute la colonne pour la "case de fin de test". Or cela s'applique sur toutes les certif dont celles qui sont "abort"

## :robot: Solution
Coté front: on applique la "case de fin de tests" que sur les certif completed.
Coté back: on ne peut publier une session si une des sessions n'est pas complétée + raison d'annulation (abortReason)

## :rainbow: Remarques


## :100: Pour tester
- Créer une session avec 2 candidats
- Démarrer une certif sans la terminer
- Démarrer une autre certif et la terminer
- Dans admin "finaliser la session" puis sélectionner la case "
Écran de fin du test vu " sur TOUTE la colonne (pas sur la ligne terminée uniquement)
- Cliquer sur Finaliser
- Vérifier sur pix admin que la session est dans les sessions à traiter et non dans les sessions à publier

