### PR TITLE
[BUGFIX] Mettre à jour la date de dernière modif quand la demande de récupération est mise à jour (PIX-3489)

### DIFF
--- a/api/db/database-builder/factory/build-account-recovery-demand.js
+++ b/api/db/database-builder/factory/build-account-recovery-demand.js
@@ -13,6 +13,7 @@ module.exports = function buildAccountRecoveryDemand({
   temporaryKey = 'OWIxZGViNGQtM2I3ZC00YmFkLTliZGQtMmIwZDdiM2RjYjZk',
   used = false,
   createdAt = new Date(),
+  updatedAt = new Date(),
 } = {}) {
   let schoolingRegistrationAttributes;
   let user;
@@ -41,6 +42,7 @@ module.exports = function buildAccountRecoveryDemand({
     temporaryKey,
     used,
     createdAt,
+    updatedAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -44,10 +44,10 @@ module.exports = {
     return _toDomain(result[0]);
   },
 
-  markAsBeingUsed(temporaryKey, domainTransaction = DomainTransaction.emptyTransaction()) {
+  async markAsBeingUsed(temporaryKey, domainTransaction = DomainTransaction.emptyTransaction()) {
     return knex('account-recovery-demands')
       .transacting(domainTransaction)
       .where({ temporaryKey })
-      .update({ used: true });
+      .update({ used: true, updatedAt: knex.fn.now() });
   },
 };


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un élève avec identifiant fait le process de récupération de compte SCO et qu’il saisit un mot de passe pour son adresse email, alors le 'account-recovery-demands.used” passe à `true`, mais le “updated_at” reste inchangé. 

## :robot: Solution
Mettre à jour le `updatedAt` lorsqu'on updated le `used` des account-recovery-demands

## :rainbow: Remarques
Lorsqu'on fait un `update` avec `knex`, ce dernier ne met pas à jour automatiquement la colonne `updatedAt` (comme le faisait Bookshelf).
Comme nous souhaitons ne plus dépendre de Bookshelf, mettre à jour les updatedAt reviens donc à la charge des dev. 
Comme cette action est assez redondante, nous pourrions essayer de l'automatiser.

Discussion sur le sujet : https://1024pix.slack.com/archives/C658LDBAQ/p1633596476089600

## :100: Pour tester
- lancer les tests
- ou alors faire le scénario de récupération de compte (aller sur /recuperer-mon-compte et mettre les infos de George DeCambridge)
