### PR TITLE
[FEATURE] Ajouter le nombre de résultats dans la pagination de tableau Pix Orga (PIX-3538)

### DIFF
--- a/orga/app/components/table/pagination-control.hbs
+++ b/orga/app/components/table/pagination-control.hbs
@@ -1,4 +1,4 @@
-<footer class="pagination-control content-text content-text--small">
+<footer class="pagination-control">
   <section class="page-size">
     <p class="page-size__label">{{t "common.pagination.result-by-page"}}</p>
     <PixSelect
@@ -10,6 +10,18 @@
     />
   </section>
   <section class="page-navigation">
+    <p>
+      {{#if (eq this.pageCount 1)}}
+        {{t "common.pagination.page-results" total=this.resultsCount}}
+      {{else}}
+        {{t
+          "common.pagination.page-info"
+          start=this.firstItemPosition
+          end=this.lastItemPosition
+          total=this.resultsCount
+        }}
+      {{/if}}
+    </p>
     <PixIconButton
       @icon="arrow-left"
       aria-label={{t "common.pagination.action.previous"}}
@@ -17,12 +29,12 @@
       @withBackground={{false}}
       @size="small"
       @color="dark-grey"
-      disabled={{eq this.currentPage 1}}
-      aria-disabled="{{eq this.currentPage 1}}"
+      disabled={{this.isPreviousPageDisabled}}
+      aria-disabled="{{this.isPreviousPageDisabled}}"
       class="page-navigation__arrow page-navigation__arrow--previous"
     />
     <p>
-      {{t "common.pagination.page-number" current=this.currentPage total=(if this.pageCount this.pageCount 1)}}
+      {{t "common.pagination.page-number" current=this.currentPage total=this.pageCount}}
     </p>
     <PixIconButton
       @icon="arrow-right"
@@ -31,8 +43,8 @@
       @withBackground={{false}}
       @size="small"
       @color="dark-grey"
-      disabled={{or (eq this.currentPage this.pageCount) (eq this.pageCount 0)}}
-      aria-disabled="{{or (eq this.currentPage this.pageCount) (eq this.pageCount 0)}}"
+      disabled={{this.isNextPageDisabled}}
+      aria-disabled="{{this.isNextPageDisabled}}"
       class="page-navigation__arrow page-navigation__arrow--next"
     />
   </section>

--- a/orga/app/components/table/pagination-control.js
+++ b/orga/app/components/table/pagination-control.js
@@ -2,6 +2,8 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
+const DEFAULT_PAGE_SIZE = 10;
+
 export default class PaginationControl extends Component {
   @service router;
 
@@ -10,19 +12,44 @@ export default class PaginationControl extends Component {
   }
 
   get pageCount() {
-    return this.args.pagination ? this.args.pagination.pageCount : 0;
+    if (!this.args.pagination) return 0;
+    if (this.args.pagination.pageCount === 0) return 1;
+    return this.args.pagination.pageCount;
   }
 
   get pageSize() {
-    return this.args.pagination ? this.args.pagination.pageSize : 10;
+    return this.args.pagination ? this.args.pagination.pageSize : DEFAULT_PAGE_SIZE;
+  }
+
+  get isNextPageDisabled() {
+    return this.currentPage === this.pageCount || this.pageCount === 0;
   }
 
   get nextPage() {
     return Math.min(this.currentPage + 1, this.pageCount);
   }
 
+  get isPreviousPageDisabled() {
+    return this.currentPage === 1 || this.pageCount === 0;
+  }
+
   get previousPage() {
     return Math.max(this.currentPage - 1, 1);
+  }
+
+  get resultsCount() {
+    return this.args.pagination ? this.args.pagination.rowCount : 0;
+  }
+
+  get firstItemPosition() {
+    if (!this.args.pagination) return 0;
+    return (this.currentPage - 1) * this.pageSize + 1;
+  }
+
+  get lastItemPosition() {
+    if (!this.args.pagination) return 0;
+    const { rowCount } = this.args.pagination;
+    return Math.min(rowCount, this.firstItemPosition + this.pageSize - 1);
   }
 
   get pageOptions() {

--- a/orga/app/styles/components/pagination-control.scss
+++ b/orga/app/styles/components/pagination-control.scss
@@ -2,7 +2,9 @@
   display: flex;
   justify-content: space-between;
   margin: 16px 0;
-  font-weight: 500;
+  color: $grey-60;
+  font-family: $roboto;
+  font-size: 0.875rem;
 }
 
 .page-size {
@@ -29,7 +31,7 @@ select.page-size__choice {
 
   &__arrow {
     &--previous {
-      margin-right: 8px;
+      margin: 0 8px;
     }
 
     &--next {

--- a/orga/tests/integration/components/tables/pagination-control_test.js
+++ b/orga/tests/integration/components/tables/pagination-control_test.js
@@ -119,7 +119,75 @@ module('Integration | Component | Table::PaginationControl', function (hooks) {
     assert.ok(replaceWithStub.calledWith({ queryParams: { pageSize: '10', pageNumber: 1 } }));
   });
 
+  module('Display start and end items index of the page', () => {
+    test('it should display start and end index of the first page (full)', async function (assert) {
+      // given
+      this.set('meta', getMetaForPage({ pageNumber: 1, rowCount: 50 }));
+
+      // when
+      await render(hbs`<Table::PaginationControl @pagination={{meta}}/>`);
+
+      // then
+      assert.contains('1-25 sur 50 éléments');
+    });
+
+    test('it should display only result counts when page count is 1', async function (assert) {
+      // given
+      this.set('meta', getMetaForPage({ pageNumber: 1, rowCount: 20 }));
+
+      // when
+      await render(hbs`<Table::PaginationControl @pagination={{meta}}/>`);
+
+      // then
+      assert.contains('20 éléments');
+    });
+
+    test('it should display start and end index of a middle page', async function (assert) {
+      // given
+      this.set('meta', getMetaForPage({ pageNumber: 2, rowCount: 70 }));
+
+      // when
+      await render(hbs`<Table::PaginationControl @pagination={{meta}}/>`);
+
+      // then
+      assert.contains('26-50 sur 70 éléments');
+    });
+
+    test('it should display start and end index of the last page (full)', async function (assert) {
+      // given
+      this.set('meta', getMetaForPage({ pageNumber: 2, rowCount: 50 }));
+
+      // when
+      await render(hbs`<Table::PaginationControl @pagination={{meta}}/>`);
+
+      // then
+      assert.contains('26-50 sur 50 éléments');
+    });
+
+    test('it should display start and end index of a full page (partial)', async function (assert) {
+      // given
+      this.set('meta', getMetaForPage({ pageNumber: 2, rowCount: 45 }));
+
+      // when
+      await render(hbs`<Table::PaginationControl @pagination={{meta}}/>`);
+
+      // then
+      assert.contains('26-45 sur 45 éléments');
+    });
+  });
+
   module('When no results', function () {
+    test('it should not display start and end index ', async function (assert) {
+      // given
+      this.set('meta', getMetaForPage({ pageNumber: 1, rowCount: 0 }));
+
+      // when
+      await render(hbs`<Table::PaginationControl @pagination={{meta}}/>`);
+
+      // then
+      assert.contains('0 élément');
+    });
+
     test('it should disable previous button and next button', async function (assert) {
       // given
       this.set('meta', getMetaForPage({ pageNumber: 1, rowCount: 0 }));

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -150,7 +150,9 @@
         "previous": "Go to previous page",
         "select-page-size": "Select the number of items by page"
       },
-      "page-number": "Page {current} / {total}",
+      "page-info": "{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}",
+      "page-results": "{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}",
+      "page-number": "Page {current, number} / {total, number}",
       "result-by-page": "See"
     },
     "percentage": "{value, number, ::percent}"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -150,7 +150,9 @@
         "previous": "Aller à la page précédente",
         "select-page-size": "Sélectionner une pagination"
       },
-      "page-number": "Page {current} / {total}",
+      "page-info": "{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}",
+      "page-results": "{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}",
+      "page-number": "Page {current, number} / {total, number}",
       "result-by-page": "Voir"
     },
     "percentage": "{value, number, ::percent}"


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, il n'est pas possible de visualiser le nombre de résultats total liés aux résultats affichés dans un table. Par exemple, dans la liste des élèves, des étudiants ou des participations.

## :robot: Solution

Visualiser le nombre de résultats total dans le composant de pagination.

![image](https://user-images.githubusercontent.com/516360/136790030-7b5f1fb0-b31d-4a9d-81da-7881ae569070.png)

## :rainbow: Remarques

N/A

## :100: Pour tester
Tester les tableaux possédant un pagination dans Pix Orga
- Liste des campagnes
- Onglet Activité
- Onglet Résultats assessment et collecte
- Liste des élèves
- Liste des étudiants
