### PR TITLE
[BUGFIX] Changer la redirection de fin de parcours statique vers la page d'inscription de prod (PIX-3595).

### DIFF
--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -20,15 +20,14 @@
 
     <div class="assessment-results__index-link-container">
       {{#if @model.isDemo}}
-        <LinkTo
-          @route="inscription"
+        <PixButtonLink
+          @href="https://app.pix.fr/inscription"
           class="assessment-results__index-link__element assessment-results__index-a-link"
-          @tagName="button"
         >
           <span class="assessment-results__link-back">{{t
               "pages.assessment-results.actions.continue-pix-experience"
             }}</span>
-        </LinkTo>
+        </PixButtonLink>
       {{else}}
         <LinkTo @route="index" class="assessment-results__index-link__element" @tagName="button">
           <span class="assessment-results__link-back">{{t "pages.assessment-results.actions.return-to-homepage"}}</span>

--- a/mon-pix/tests/acceptance/course-ending-screen_test.js
+++ b/mon-pix/tests/acceptance/course-ending-screen_test.js
@@ -1,4 +1,4 @@
-import { click, currentURL, find, findAll } from '@ember/test-helpers';
+import { currentURL, find, findAll } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
@@ -60,12 +60,10 @@ describe('Acceptance | Course ending screen', function() {
     expect(find('.assessment-results__assessment-banner')).to.exist;
   });
 
-  it('should display a button that redirect to inscription page', async function() {
+  it('should display a button that redirects to inscription page', async function() {
     expect(find('.assessment-results__index-link__element')).to.exist;
+    expect(find('.assessment-results__index-a-link').attributes.href.value).to.equal('https://app.pix.fr/inscription');
     expect(find('.assessment-results__link-back').textContent).to.contains('Continuer mon expérience Pix');
-    await click(find('.assessment-results__index-link__element'));
-
-    expect(currentURL()).to.equal('/inscription');
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème

A la fin d'un parcours statique, le bouton de redirection renvoie systématiquement à la page d'inscription de l'environnement actuellement utilisé, créant des inscriptions sur des environnement non désirés.

## :robot: Solution

Modifier la redirection pour retourner vers `app.pix.fr`

## :rainbow: Remarques

Nous avons supprimé le `click` dans le test d'acceptation n'étant plus utile et créant un appel vers la page d'accueil pendant les tests.
Le test de redirection est désormais porté par `Pix-UI` sur le test du `@href`

## :100: Pour tester

Réaliser le parcours statique `rec4bpmfJ7RVYPwu7` en entier et cliquer sur le bouton de redirection.
Vérifier que l'on atterit sur `app.pix.fr`
