### PR TITLE
[BUGFIX] Corriger le label du bouton pour éditer une organisation sur Pix Admin (PIX-3454).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -133,7 +133,7 @@
               @isBorderVisible={{true}}
               @triggerAction={{this.cancel}}
             >Annuler</PixButton>
-            <PixButton @type="submit" @size="small" @backgroundColor="green">Ajouter</PixButton>
+            <PixButton @type="submit" @size="small" @backgroundColor="green">Enregistrer</PixButton>
           </div>
         </form>
       </div>

--- a/admin/tests/acceptance/organization-information-management_test.js
+++ b/admin/tests/acceptance/organization-information-management_test.js
@@ -24,7 +24,7 @@ module('Acceptance | organization information management', function (hooks) {
 
       // when
       await fillInByLabel('Nom', 'newOrganizationName');
-      await clickByLabel('Ajouter', { exact: true });
+      await clickByLabel('Enregistrer', { exact: true });
 
       // then
       assert.contains('newOrganizationName');

--- a/admin/tests/integration/components/organization-information-section_test.js
+++ b/admin/tests/integration/components/organization-information-section_test.js
@@ -261,7 +261,7 @@ module('Integration | Component | organization-information-section', function (h
       await clickByLabel('Collecte de profils');
 
       // when
-      await clickByLabel('Ajouter');
+      await clickByLabel('Enregistrer');
 
       // then
       assert.dom('.organization__name').hasText('new name');


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on souhaite modifier une organisation sur Pix Admin et enregistrer ces modifications, le bouton affiche `Ajouter`, ce qui peut sembler incohérent avec son action.

## :robot: Solution
Remplacer le wording par `Enregistrer`.

## :100: Pour tester
Cliquer sur une organisation au hasard dans la liste, cliquer sur Editer, vérifier la modification du wording.
