### PR TITLE
[BUGFIX] Réparer le script d'installation suite à la mise à jour du nom des conteneurs docker.

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -104,7 +104,7 @@ function setup_and_run_infrastructure() {
 
   echo "Waiting for PostgreSQL server to be ready…"
 
-  timeout 20s bash -c "until docker exec pix_postgres_1 pg_isready ; do sleep 1 ; done"
+  timeout 20s bash -c "until docker-compose exec postgres pg_isready ; do sleep 1 ; done"
 
   echo "✅ PostgreSQL server is ready."
   echo ""


### PR DESCRIPTION
## :unicorn: Problème
Le nom des conteneurs ont été mis à jour mais pas dans le script configure.

## :robot: Solution
Le nom du conteneur postgres a été mis à jour dans le script configure.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer la commande `npm run configure` à la racine du monorepo. 
S'assurer que l'étape de création de conteneurs se passe correctement.
Vérifier que l'étape de création de base de données s'enchaîne sans erreur.
Il n'est pas nécessaire d'attendre la fin du script qui lance l'ensemble des tests de Pix.
