### PR TITLE
[TECH] Corriger l'erreur flaky sur la gestion des erreurs du fichier SIECLE

### DIFF
--- a/api/lib/infrastructure/utils/xml/siecle-file-streamer.js
+++ b/api/lib/infrastructure/utils/xml/siecle-file-streamer.js
@@ -78,7 +78,6 @@ async function _unzipFile(directory, path) {
   try {
     await zip.extract(fileName, extractedFileName);
   } catch (error) {
-    await zip.close();
     throw new FileValidationError(ERRORS.INVALID_FILE);
   }
   await zip.close();


### PR DESCRIPTION
## :unicorn: Problème
Les tests sont en erreurs de temps en temps sur la CI/Local. Ce serait lié à la tentative d'ouverture d'un zip corrompu. 

## :robot: Solution
Ne pas fermer le Zip qu'on a pas réussi à ouvrir.

## :rainbow: Remarques

## :100: Pour tester
Vérifier que les tests passent tout le temps 