### PR TITLE
[BUGFIX] Correction de l'affichage de l'épreuve focus à la reprise d'un parcours (PIX-3585).

### DIFF
--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -10,7 +10,7 @@
     <ChallengeStatement
       @challenge={{@challenge}}
       @assessment={{@assessment}}
-      @onTooltipClose={{this.enableFocusedChallenge}}
+      @onTooltipClose={{this.enableChallenge}}
     />
 
     {{component

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -1,28 +1,22 @@
 <article
   class="rounded-panel rounded-panel--no-margin-bottom challenge-item
-    {{if this.hasFocusedOutOfChallenge "challenge-item--overlay"}}"
+    {{if this.hasFocusedOutOfChallenge "challenge-item--focused"}}"
   data-challenge-id="{{@challenge.id}}"
   {{on "mouseenter" this.hideOutOfFocusBorder}}
   {{on "mouseleave" this.showOutOfFocusBorder}}
 >
+  <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
-  <div class="challenge-item__container {{if this.hasFocusedOutOfChallenge "challenge-item__container--focused"}}">
-    <ChallengeStatement
-      @challenge={{@challenge}}
-      @assessment={{@assessment}}
-    />
-
-    {{component
-      (get-challenge-component-class @challenge)
-      challenge=@challenge
-      answer=@answer
-      assessment=@assessment
-      timeoutChallenge=@timeoutChallenge
-      resetChallengeInfo=@resetChallengeInfo
-      hasFocusedOutOfWindow=this.hasFocusedOutOfWindow
-      answerValidated=@answerValidated
-      resumeAssessment=@resumeAssessment
-      isFocusedChallenge=this.isFocusedChallenge
-    }}
-  </div>
+  {{component
+    (get-challenge-component-class @challenge)
+    challenge=@challenge
+    answer=@answer
+    assessment=@assessment
+    timeoutChallenge=@timeoutChallenge
+    resetChallengeInfo=@resetChallengeInfo
+    hasFocusedOutOfWindow=this.hasFocusedOutOfWindow
+    answerValidated=@answerValidated
+    resumeAssessment=@resumeAssessment
+    isFocusedChallenge=this.isFocusedChallenge
+  }}
 </article>

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -10,7 +10,6 @@
     <ChallengeStatement
       @challenge={{@challenge}}
       @assessment={{@assessment}}
-      @onTooltipCloseForChallengeItem={{@onTooltipCloseForChallenge}}
     />
 
     {{component

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -1,6 +1,6 @@
 <article
   class="rounded-panel rounded-panel--no-margin-bottom challenge-item
-    {{if this.hasFocusedOutOfChallenge "challenge-item--focused"}}"
+    {{if @hasFocusedOutOfChallenge "challenge-item--focused"}}"
   data-challenge-id="{{@challenge.id}}"
   {{on "mouseenter" this.hideOutOfFocusBorder}}
   {{on "mouseleave" this.showOutOfFocusBorder}}
@@ -14,7 +14,7 @@
     assessment=@assessment
     timeoutChallenge=@timeoutChallenge
     resetChallengeInfo=@resetChallengeInfo
-    hasFocusedOutOfWindow=this.hasFocusedOutOfWindow
+    hasFocusedOutOfWindow=@hasFocusedOutOfWindow
     answerValidated=@answerValidated
     resumeAssessment=@resumeAssessment
     isFocusedChallenge=this.isFocusedChallenge

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -10,7 +10,7 @@
     <ChallengeStatement
       @challenge={{@challenge}}
       @assessment={{@assessment}}
-      @onTooltipCloseForChallengeItem={{this.enableChallenge}}
+      @onTooltipCloseForChallengeItem={{@onTooltipCloseForChallenge}}
     />
 
     {{component

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -10,7 +10,7 @@
     <ChallengeStatement
       @challenge={{@challenge}}
       @assessment={{@assessment}}
-      @onTooltipClose={{this.enableChallenge}}
+      @onTooltipCloseForChallengeItem={{this.enableChallenge}}
     />
 
     {{component

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -34,7 +34,7 @@ export default class Item extends Component {
   }
 
   @action
-  enableFocusedChallenge() {
+  enableChallenge() {
     this.isTooltipClosed = true;
     this.args.onTooltipClose();
   }

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -1,14 +1,11 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import ENV from 'mon-pix/config/environment';
 
 export default class Item extends Component {
 
   @service currentUser;
-  @tracked hasFocusedOutOfWindow = false || this.args.assessment.hasFocusedOutChallenge;
-  @tracked hasFocusedOutOfChallenge = false;
 
   constructor() {
     super(...arguments);
@@ -21,7 +18,6 @@ export default class Item extends Component {
   hideOutOfFocusBorder() {
     if (this.isFocusedChallenge) {
       this.args.onFocusIntoChallenge();
-      this.hasFocusedOutOfChallenge = false;
     }
   }
 
@@ -29,13 +25,11 @@ export default class Item extends Component {
   showOutOfFocusBorder() {
     if (this.isFocusedChallenge && !this.args.answer) {
       this.args.onFocusOutOfChallenge();
-      this.hasFocusedOutOfChallenge = true;
     }
   }
 
   _setOnBlurEventToWindow() {
     window.onblur = () => {
-      this.hasFocusedOutOfWindow = true;
       this.args.onFocusOutOfWindow();
       this._clearOnBlurMethod();
     };

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -36,7 +36,7 @@ export default class Item extends Component {
   @action
   enableChallenge() {
     this.isTooltipClosed = true;
-    this.args.onTooltipClose();
+    this.args.onTooltipCloseForChallenge();
   }
 
   _setOnBlurEventToWindow() {

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -33,12 +33,6 @@ export default class Item extends Component {
     }
   }
 
-  @action
-  enableChallenge() {
-    this.isTooltipClosed = true;
-    this.args.onTooltipCloseForChallenge();
-  }
-
   _setOnBlurEventToWindow() {
     window.onblur = () => {
       this.hasFocusedOutOfWindow = true;

--- a/mon-pix/app/components/challenge/statement/tooltip.js
+++ b/mon-pix/app/components/challenge/statement/tooltip.js
@@ -73,12 +73,12 @@ export default class Tooltip extends Component {
   }
 
   async _rememberUserHasSeenChallengeTooltip() {
-    if (this.currentUser.user) {
-      if (this.args.challenge.focused && !this.currentUser.user.hasSeenFocusedChallengeTooltip) {
-        await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'focused' } });
-      } else if (!this.args.challenge.focused && !this.currentUser.user.hasSeenOtherChallengesTooltip) {
-        await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'other' } });
-      }
+    if (!this.currentUser.user) return;
+
+    if (this.args.challenge.focused && !this.currentUser.user.hasSeenFocusedChallengeTooltip) {
+      await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'focused' } });
+    } else if (!this.args.challenge.focused && !this.currentUser.user.hasSeenOtherChallengesTooltip) {
+      await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'other' } });
     }
   }
 }

--- a/mon-pix/app/components/challenge/statement/tooltip.js
+++ b/mon-pix/app/components/challenge/statement/tooltip.js
@@ -22,7 +22,6 @@ export default class Tooltip extends Component {
       this.shouldDisplayTooltip = true;
     } else {
       this.shouldDisplayTooltip = false;
-      this._notifyChallengeTooltipIsClosed();
     }
   }
 
@@ -68,12 +67,18 @@ export default class Tooltip extends Component {
   }
 
   @action
-  confirmInformationIsRead() {
+  async confirmInformationIsRead() {
+    await this._rememberUserHasSeenChallengeTooltip();
     this.shouldDisplayTooltip = false;
-    this._notifyChallengeTooltipIsClosed();
   }
 
-  _notifyChallengeTooltipIsClosed() {
-    this.args.onTooltipClose();
+  async _rememberUserHasSeenChallengeTooltip() {
+    if (this.currentUser.user) {
+      if (this.args.challenge.focused && !this.currentUser.user.hasSeenFocusedChallengeTooltip) {
+        await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'focused' } });
+      } else if (!this.args.challenge.focused && !this.currentUser.user.hasSeenOtherChallengesTooltip) {
+        await this.currentUser.user.save({ adapterOptions: { tooltipChallengeType: 'other' } });
+      }
+    }
   }
 }

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -18,7 +18,7 @@ export default class ChallengeController extends Controller {
   @tracked competenceLeveled = null;
   @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOutOfChallenge = false;
-  @tracked hasFocusedOutOfWindow = false;
+  @tracked hasFocusedOutOfWindow = false || this.model.assessment.hasFocusedOutChallenge;
   @tracked hasUserConfirmedWarning = false;
 
   get showLevelup() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -18,7 +18,7 @@ export default class ChallengeController extends Controller {
   @tracked competenceLeveled = null;
   @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOutOfChallenge = false;
-  @tracked hasFocusedOutOfWindow = false || this.model.assessment.hasFocusedOutChallenge;
+  @tracked hasFocusedOutOfWindow = this.model.assessment.hasFocusedOutChallenge;
   @tracked hasUserConfirmedWarning = false;
 
   get showLevelup() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -54,21 +54,6 @@ export default class ChallengeController extends Controller {
   }
 
   @action
-  async removeTooltipOverlay() {
-    if (this.currentUser.user) {
-      if (this.model.challenge.focused && !this.currentUser.user.hasSeenFocusedChallengeTooltip) {
-        await this._updateUserAndTriggerOverlayRemoval({ tooltipChallengeType: 'focused' });
-      } else if (!this.model.challenge.focused && !this.currentUser.user.hasSeenOtherChallengesTooltip) {
-        await this._updateUserAndTriggerOverlayRemoval({ tooltipChallengeType: 'other' });
-      }
-    }
-  }
-
-  async _updateUserAndTriggerOverlayRemoval(tooltipChallengeType) {
-    await this.currentUser.user.save({ adapterOptions: tooltipChallengeType });
-  }
-
-  @action
   setFocusedOutOfChallenge(value) {
     this.hasFocusedOutOfChallenge = value;
   }

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -1,15 +1,9 @@
 .challenge-item {
+  border: 3px solid transparent;
 
-  &__container {
-    border: 3px solid transparent;
-
-    &--focused {
-      border: 3px dashed $grey-70;
-      border-radius: 10px;
-    }
-  }
-
-  &--overlay {
+  &--focused {
+    border: 3px dashed $grey-70;
+    border-radius: 10px;
     z-index: 1;
   }
 }

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -39,6 +39,7 @@
         @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
         @onFocusOutOfWindow={{this.focusedOutOfWindow}}
         @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
+        @hasFocusedOutOfChallenge={{this.hasFocusedOutOfChallenge}}
       />
     {{/if}}
   </main>

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -39,7 +39,6 @@
         @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
         @onFocusOutOfWindow={{this.focusedOutOfWindow}}
         @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
-        @onTooltipCloseForChallenge={{this.removeTooltipOverlay}}
       />
     {{/if}}
   </main>

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -39,7 +39,7 @@
         @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
         @onFocusOutOfWindow={{this.focusedOutOfWindow}}
         @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
-        @onTooltipClose={{this.removeTooltipOverlay}}
+        @onTooltipCloseForChallenge={{this.removeTooltipOverlay}}
       />
     {{/if}}
   </main>

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -5,7 +5,7 @@
       <MarkdownToHtmlUnsafe @class="challenge-statement-instruction__text" @markdown={{this.challengeInstruction}} />
 
       {{#if this.isFocusedChallengeToggleEnabled}}
-        <Challenge::Statement::Tooltip @challenge={{@challenge}} @onTooltipClose={{@onTooltipCloseForChallengeItem}} />
+        <Challenge::Statement::Tooltip @challenge={{@challenge}} />
       {{/if}}
     </div>
   {{/if}}

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -5,7 +5,7 @@
       <MarkdownToHtmlUnsafe @class="challenge-statement-instruction__text" @markdown={{this.challengeInstruction}} />
 
       {{#if this.isFocusedChallengeToggleEnabled}}
-        <Challenge::Statement::Tooltip @challenge={{@challenge}} @onTooltipClose={{@onTooltipClose}} />
+        <Challenge::Statement::Tooltip @challenge={{@challenge}} @onTooltipClose={{@onTooltipCloseForChallengeItem}} />
       {{/if}}
     </div>
   {{/if}}

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -398,7 +398,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.alert')).to.exist;
         const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
         const optionToFillIn = selectOptions[1];
-        console.log(optionToFillIn);
+
         // when
         await fillIn('select[data-test="challenge-response-proposal-selector"]', optionToFillIn.value);
 

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -62,7 +62,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
             // then
             expect(find('.challenge__info-alert--show')).to.exist;
-            expect(find('.challenge-item__container--focused')).to.exist;
+            expect(find('.challenge-item--focused')).to.exist;
             expect(find('.challenge__focused-out-overlay')).to.exist;
           });
 
@@ -104,7 +104,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
               // then
               expect(find('.challenge__info-alert--could-show')).to.exist;
-              expect(find('.challenge-item__container--focused')).to.exist;
+              expect(find('.challenge-item--focused')).to.exist;
               expect(find('.challenge__focused-out-overlay')).to.exist;
             });
 
@@ -114,7 +114,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await triggerEvent(challengeItem, 'mouseleave');
 
               expect(find('.challenge__info-alert--could-show')).to.exist;
-              expect(find('.challenge-item__container--focused')).to.exist;
+              expect(find('.challenge-item--focused')).to.exist;
               expect(find('.challenge__focused-out-overlay')).to.exist;
 
               // when
@@ -123,7 +123,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               // then
               expect(find('.challenge__info-alert--could-show')).to.not.exist;
               expect(find('[data-test="alert-message-focused-out-of-window"]')).to.exist;
-              expect(find('.challenge-item__container--focused')).to.exist;
+              expect(find('.challenge-item--focused')).to.exist;
               expect(find('.challenge__focused-out-overlay')).to.exist;
             });
           });

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -19,8 +19,11 @@ describe('Integration | Component | ChallengeStatement', function() {
   }
 
   function renderChallengeStatement(component) {
-    component.set('enableChallenge', () => {});
-    return render(hbs`<ChallengeStatement @challenge={{this.challenge}} @assessment={{this.assessment}} @onTooltipCloseForChallengeItem={{this.enableChallenge}}/>`);
+    component.set('onTooltipCloseForChallenge', () => {});
+    return render(hbs`<ChallengeStatement
+                          @challenge={{this.challenge}}
+                          @assessment={{this.assessment}}
+                          @onTooltipCloseForChallengeItem={{this.onTooltipCloseForChallenge}}/>`);
   }
 
   beforeEach(async function() {

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -19,8 +19,8 @@ describe('Integration | Component | ChallengeStatement', function() {
   }
 
   function renderChallengeStatement(component) {
-    component.set('onTooltipClose', () => {});
-    return render(hbs`<ChallengeStatement @challenge={{this.challenge}} @assessment={{this.assessment}} @onTooltipClose={{this.onTooltipClose}}/>`);
+    component.set('enableChallenge', () => {});
+    return render(hbs`<ChallengeStatement @challenge={{this.challenge}} @assessment={{this.assessment}} @onTooltipCloseForChallengeItem={{this.enableChallenge}}/>`);
   }
 
   beforeEach(async function() {

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -18,12 +18,10 @@ describe('Integration | Component | ChallengeStatement', function() {
     component.set('assessment', assessment);
   }
 
-  function renderChallengeStatement(component) {
-    component.set('onTooltipCloseForChallenge', () => {});
+  function renderChallengeStatement() {
     return render(hbs`<ChallengeStatement
                           @challenge={{this.challenge}}
-                          @assessment={{this.assessment}}
-                          @onTooltipCloseForChallengeItem={{this.onTooltipCloseForChallenge}}/>`);
+                          @assessment={{this.assessment}}/>`);
   }
 
   beforeEach(async function() {

--- a/mon-pix/tests/integration/components/challenge/item_test.js
+++ b/mon-pix/tests/integration/components/challenge/item_test.js
@@ -22,6 +22,5 @@ describe('Integration | Component | Challenge | Item', function() {
 
     // then
     expect(find('.challenge-item')).to.exist;
-    expect(find('.challenge-item__container')).to.exist;
   });
 });

--- a/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
@@ -29,9 +29,9 @@ describe('Integration | Component | Tooltip', function() {
           id: 'rec_challenge',
           focused: true,
         });
-        this.set('onTooltipClose', () => {});
+        this.set('onTooltipCloseForChallengeItem', () => {});
 
-        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipClose}}/>`);
+        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipCloseForChallengeItem}}/>`);
       });
 
       it('should render the tooltip with a confirmation button', async function() {
@@ -67,9 +67,9 @@ describe('Integration | Component | Tooltip', function() {
           id: 'rec_challenge',
           focused: true,
         });
-        this.set('onTooltipClose', () => {});
+        this.set('onTooltipCloseForChallengeItem', () => {});
 
-        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipClose}}/>`);
+        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipCloseForChallengeItem}}/>`);
       });
 
       describe('when the challenge starts', function() {
@@ -146,9 +146,9 @@ describe('Integration | Component | Tooltip', function() {
           id: 'rec_challenge',
           focused: false,
         });
-        this.set('onTooltipClose', () => {});
+        this.set('onTooltipCloseForChallengeItem', () => {});
 
-        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipClose}}/>`);
+        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipCloseForChallengeItem}}/>`);
       });
 
       it('should render the tooltip with a confirmation button', async function() {
@@ -184,9 +184,9 @@ describe('Integration | Component | Tooltip', function() {
           id: 'rec_challenge',
           focused: false,
         });
-        this.set('onTooltipClose', () => {});
+        this.set('onTooltipCloseForChallengeItem', () => {});
 
-        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipClose}}/>`);
+        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipCloseForChallengeItem}}/>`);
       });
 
       describe('when the challenge starts', function() {

--- a/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
@@ -19,6 +19,7 @@ describe('Integration | Component | Tooltip', function() {
         class currentUser extends Service {
             user = {
               hasSeenFocusedChallengeTooltip: false,
+              save: () => {},
             }
         }
         this.owner.unregister('service:currentUser');
@@ -29,9 +30,7 @@ describe('Integration | Component | Tooltip', function() {
           id: 'rec_challenge',
           focused: true,
         });
-        this.set('onTooltipCloseForChallengeItem', () => {});
-
-        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipCloseForChallengeItem}}/>`);
+        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}}/>`);
       });
 
       it('should render the tooltip with a confirmation button', async function() {
@@ -44,7 +43,6 @@ describe('Integration | Component | Tooltip', function() {
       it('should remove the tooltip when confirmation button has been clicked', async function() {
         // when
         await click('.tooltip-tag-information__button');
-
         // then
         expect(find(tooltip)).not.to.be.displayed;
       });
@@ -67,9 +65,7 @@ describe('Integration | Component | Tooltip', function() {
           id: 'rec_challenge',
           focused: true,
         });
-        this.set('onTooltipCloseForChallengeItem', () => {});
-
-        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipCloseForChallengeItem}}/>`);
+        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}}/>`);
       });
 
       describe('when the challenge starts', function() {
@@ -136,6 +132,7 @@ describe('Integration | Component | Tooltip', function() {
         class currentUser extends Service {
           user = {
             hasSeenOtherChallengesTooltip: false,
+            save: () => {},
           }
         }
         this.owner.unregister('service:currentUser');
@@ -146,9 +143,7 @@ describe('Integration | Component | Tooltip', function() {
           id: 'rec_challenge',
           focused: false,
         });
-        this.set('onTooltipCloseForChallengeItem', () => {});
-
-        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipCloseForChallengeItem}}/>`);
+        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}}/>`);
       });
 
       it('should render the tooltip with a confirmation button', async function() {
@@ -184,9 +179,7 @@ describe('Integration | Component | Tooltip', function() {
           id: 'rec_challenge',
           focused: false,
         });
-        this.set('onTooltipCloseForChallengeItem', () => {});
-
-        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}} @onTooltipClose={{this.onTooltipCloseForChallengeItem}}/>`);
+        await render(hbs`<Challenge::Statement::Tooltip @challenge={{this.challenge}}/>`);
       });
 
       describe('when the challenge starts', function() {


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on souhaite reprendre un parcours et que l'on atterrit sur une épreuve `focus`, l'overlay ne s'affiche pas correctement et apparaît au dessus de l'épreuve, cassant le comportement habituel jusqu'au survol de la tooltip de l'épreuve par l'utilisateur.

## :robot: Solution

Centralisation des états `hasFocusedOutOfChallenge` et `hasFocusedOutOfWindow` dans la route `challenge` plutôt que de les maintenir simultanément dans la route `challenge` et dans le composant `item`

## :rainbow: Remarques

Du nettoyage a été fait sur l'implémentation technique des épreuves focus, avec la suppression de la chaine d'évènements utilisée jusqu'à maintenant et remplacée par l'ajout de responsabilité à la tooltip.

## :100: Pour tester

Se connecter à `mon-pix`
Reprendre un parcours et naviguer jusqu'à arriver sur une épreuve `focus`
Constater que l'overlay n'apparait plus au dessus de l'épreuve mais autour, ne bloquant pas l'utilisateur
