### PR TITLE
[FEATURE] Afficher les méthodes de connexion de l'utilisateur dans Mon Compte sur Pix App (PIX-3514).

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -755,6 +755,24 @@ exports.register = async function (server) {
         tags: ['api', 'user', 'verification-code'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/users/{id}/authentication-methods',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        handler: userController.getUserAuthenticationMethods,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Elle permet la récupération des noms des méthodes de connexion de l'utilisateur.",
+        ],
+        tags: ['api', 'user', 'authentication-methods'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -10,6 +10,7 @@ const userSerializer = require('../../infrastructure/serializers/jsonapi/user-se
 const emailVerificationSerializer = require('../../infrastructure/serializers/jsonapi/email-verification-serializer');
 const userDetailsForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
 const updateEmailSerializer = require('../../infrastructure/serializers/jsonapi/update-email-serializer');
+const authenticationMethodsSerializer = require('../../infrastructure/serializers/jsonapi/authentication-methods-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
@@ -291,5 +292,13 @@ module.exports = {
     });
 
     return updateEmailSerializer.serialize(updatedUserAttributes);
+  },
+
+  async getUserAuthenticationMethods(request) {
+    const userId = request.params.id;
+
+    const authenticationMethods = await usecases.findUserAuthenticationMethods({ userId });
+
+    return authenticationMethodsSerializer.serialize(authenticationMethods);
   },
 };

--- a/api/lib/domain/usecases/find-user-authentication-methods.js
+++ b/api/lib/domain/usecases/find-user-authentication-methods.js
@@ -1,0 +1,3 @@
+module.exports = function findUserAuthenticationMethods({ userId, authenticationMethodRepository }) {
+  return authenticationMethodRepository.findByUserId({ userId });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -278,6 +278,7 @@ module.exports = injectDependencies(
     getTargetProfileDetails: require('./get-target-profile-details'),
     getAccountRecoveryDetails: require('./account-recovery/get-account-recovery-details'),
     getParticipationsCountByMasteryRate: require('./get-participations-count-by-mastery-rate'),
+    findUserAuthenticationMethods: require('./find-user-authentication-methods'),
     getUserByResetPasswordDemand: require('./get-user-by-reset-password-demand'),
     getUserCampaignAssessmentResult: require('./get-user-campaign-assessment-result'),
     getUserCampaignParticipationToCampaign: require('./get-user-campaign-participation-to-campaign'),

--- a/api/lib/infrastructure/serializers/jsonapi/authentication-methods-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/authentication-methods-serializer.js
@@ -1,0 +1,9 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(authenticationMethods) {
+    return new Serializer('authentication-methods', {
+      attributes: ['identityProvider'],
+    }).serialize(authenticationMethods);
+  },
+};

--- a/api/tests/acceptance/application/users/get-user-authentication-methods-route-get_test.js
+++ b/api/tests/acceptance/application/users/get-user-authentication-methods-route-get_test.js
@@ -1,0 +1,44 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Route | Users', function () {
+  describe('GET /api/users/{id}/authentication-methods', function () {
+    it('should return 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+
+      const user = databaseBuilder.factory.buildUser({});
+      const garAuthenticationMethod = databaseBuilder.factory.buildAuthenticationMethod({ userId: user.id });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/users/${user.id}/authentication-methods`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(user.id),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const expectedJson = {
+        data: [
+          {
+            type: 'authentication-methods',
+            id: garAuthenticationMethod.id.toString(),
+            attributes: {
+              'identity-provider': AuthenticationMethod.identityProviders.GAR,
+            },
+          },
+        ],
+      };
+
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal(expectedJson);
+    });
+  });
+});

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -18,6 +18,7 @@ const userSerializer = require('../../../../lib/infrastructure/serializers/jsona
 const userDetailsForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
 const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
 const updateEmailSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/update-email-serializer');
+const authenticationMethodsSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/authentication-methods-serializer');
 
 const userController = require('../../../../lib/application/users/user-controller');
 
@@ -973,6 +974,40 @@ describe('Unit | Controller | user-controller', function () {
         code,
         userId,
       });
+      expect(response).to.deep.equal(responseSerialized);
+    });
+  });
+
+  describe('#getUserAuthenticationMethods', function () {
+    it('should call the usecase to find user authentication methods', async function () {
+      // given
+      const user = domainBuilder.buildUser();
+      const authenticationMethods = [
+        domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId: user.id }),
+      ];
+
+      const responseSerialized = Symbol('an response serialized');
+      sinon.stub(usecases, 'findUserAuthenticationMethods');
+      sinon.stub(authenticationMethodsSerializer, 'serialize');
+
+      usecases.findUserAuthenticationMethods.withArgs({ userId: user.id }).resolves(authenticationMethods);
+      authenticationMethodsSerializer.serialize.withArgs(authenticationMethods).returns(responseSerialized);
+
+      const request = {
+        auth: {
+          credentials: {
+            userId: user.id,
+          },
+        },
+        params: {
+          id: user.id,
+        },
+      };
+
+      // when
+      const response = await userController.getUserAuthenticationMethods(request);
+
+      // then
       expect(response).to.deep.equal(responseSerialized);
     });
   });

--- a/api/tests/unit/domain/usecases/find-user-authentication-methods.js
+++ b/api/tests/unit/domain/usecases/find-user-authentication-methods.js
@@ -1,0 +1,20 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const findUserAuthenticationMethods = require('../../../../lib/domain/usecases/find-user-authentication-methods');
+
+describe('Unit | UseCase | find-user-authentication-methods', function () {
+  it('should find user authentication methods', async function () {
+    // given
+    const authenticationMethodRepository = {
+      findByUserId: sinon.stub(),
+    };
+
+    const user = domainBuilder.buildUser();
+    domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId: user.id });
+
+    // when
+    await findUserAuthenticationMethods({ userId: user.id, authenticationMethodRepository });
+
+    // then
+    expect(authenticationMethodRepository.findByUserId).to.have.been.calledWith({ userId: user.id });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/authentication-methods-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/authentication-methods-serializer_test.js
@@ -1,0 +1,31 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/authentication-methods-serializer');
+
+describe('Unit | Serializer | JSONAPI | authentication-methods-serializer', function () {
+  describe('#serialize()', function () {
+    it('should format a authentication method model object into JSON API data', function () {
+      // given
+      const user = domainBuilder.buildUser();
+      const authenticationMethods = [
+        domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId: user.id }),
+      ];
+
+      // when
+      const json = serializer.serialize(authenticationMethods);
+
+      // then
+      const expectedJson = {
+        data: [
+          {
+            type: 'authentication-methods',
+            attributes: {
+              'identity-provider': AuthenticationMethod.identityProviders.POLE_EMPLOI,
+            },
+          },
+        ],
+      };
+      expect(json).to.deep.equal(expectedJson);
+    });
+  });
+});

--- a/mon-pix/app/adapters/authentication-method.js
+++ b/mon-pix/app/adapters/authentication-method.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+import { inject as service } from '@ember/service';
+
+export default class AuthenticationMethod extends ApplicationAdapter {
+  @service currentUser;
+
+  namespace = `api/users/${this.currentUser.user.id}`;
+}

--- a/mon-pix/app/controllers/user-account/connection-methods.js
+++ b/mon-pix/app/controllers/user-account/connection-methods.js
@@ -10,11 +10,23 @@ export default class ConnectionMethodsController extends Controller {
   @tracked showEmailUpdatedMessage = false;
 
   get shouldShowEmail() {
-    return !!this.model.email;
+    return !!this.model.user.email;
   }
 
   get shouldShowUsername() {
-    return !!this.model.username;
+    return !!this.model.user.username;
+  }
+
+  get shouldShowPixAuthenticationMethod() {
+    return this.model.authenticationMethods.any((authenticationMethod) => authenticationMethod.isPixIdentityProvider);
+  }
+
+  get shouldShowGarAuthenticationMethod() {
+    return this.model.authenticationMethods.any((authenticationMethod) => authenticationMethod.isGarIdentityProvider);
+  }
+
+  get shouldShowPoleEmploiAuthenticationMethod() {
+    return this.model.authenticationMethods.any((authenticationMethod) => authenticationMethod.isPoleEmploiIdentityProvider);
   }
 
   @action
@@ -34,10 +46,10 @@ export default class ConnectionMethodsController extends Controller {
 
   @action
   async saveNewEmail(newEmail, password) {
-    this.model.email = newEmail.trim().toLowerCase();
-    this.model.password = password;
-    await this.model.save({ adapterOptions: { updateEmail: true } });
-    this.model.password = null;
+    this.model.user.email = newEmail.trim().toLowerCase();
+    this.model.user.password = password;
+    await this.model.user.save({ adapterOptions: { updateEmail: true } });
+    this.model.user.password = null;
     this.disableEmailEditionMode();
   }
 }

--- a/mon-pix/app/models/authentication-method.js
+++ b/mon-pix/app/models/authentication-method.js
@@ -1,0 +1,24 @@
+import Model, { attr } from '@ember-data/model';
+
+const identityProviders = {
+  PIX: 'PIX',
+  GAR: 'GAR',
+  POLE_EMPLOI: 'POLE_EMPLOI',
+};
+
+export default class AuthenticationMethod extends Model {
+  @attr() identityProvider;
+
+  get isPixIdentityProvider() {
+    return this.identityProvider === identityProviders.PIX;
+  }
+
+  get isGarIdentityProvider() {
+    return this.identityProvider === identityProviders.GAR;
+  }
+
+  get isPoleEmploiIdentityProvider() {
+    return this.identityProvider === identityProviders.POLE_EMPLOI;
+  }
+
+}

--- a/mon-pix/app/routes/user-account/connection-methods.js
+++ b/mon-pix/app/routes/user-account/connection-methods.js
@@ -1,9 +1,16 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ConnectionMethodsRoute extends Route {
+  @service store;
 
-  model() {
-    return this.modelFor('user-account');
+  async model() {
+    const user = this.modelFor('user-account');
+    const authenticationMethods = await this.store.findAll('authentication-method', user.id);
+    return {
+      user,
+      authenticationMethods,
+    };
   }
 
   setupController(controller, model) {

--- a/mon-pix/app/templates/user-account/connection-methods.hbs
+++ b/mon-pix/app/templates/user-account/connection-methods.hbs
@@ -12,34 +12,63 @@
       />
     {{/if}}
   {{else}}
-    {{#if this.shouldShowEmail}}
-      <div class="user-account-panel__item{{if this.showEmailUpdatedMessage " with-success-message"}}">
-        <div class="user-account-panel-item__text">
-          <p class="form-textfield__label user-account-panel-item__label">{{t
-              "pages.user-account.connexion-methods.email"
-            }}</p>
-          <p class="user-account-panel-item__value" data-test-email>{{@model.email}}</p>
+    {{#if this.shouldShowPixAuthenticationMethod}}
+      {{#if this.shouldShowEmail}}
+        <div class="user-account-panel__item{{if this.showEmailUpdatedMessage " with-success-message"}}">
+          <div class="user-account-panel-item__text">
+            <p class="form-textfield__label user-account-panel-item__label">
+              {{t "pages.user-account.connexion-methods.email"}}
+            </p>
+            <p class="user-account-panel-item__value" data-test-email>{{@model.user.email}}</p>
+          </div>
+          <PixButton class="user-account-panel-item__button" @triggerAction={{this.enableEmailEditionMode}}>
+            {{t "pages.user-account.connexion-methods.edit-button"}}
+          </PixButton>
         </div>
-        <PixButton class="user-account-panel-item__button" @triggerAction={{this.enableEmailEditionMode}}>
-          {{t "pages.user-account.connexion-methods.edit-button"}}
-        </PixButton>
-      </div>
 
-      {{#if this.showEmailUpdatedMessage}}
-        <div class="success-message">
-          <PixMessage @type="success" @withIcon={{true}}>
-            {{t "pages.user-account.email-verification.update-successful"}}
-          </PixMessage>
+        {{#if this.showEmailUpdatedMessage}}
+          <div class="success-message">
+            <PixMessage @type="success" @withIcon={{true}}>
+              {{t "pages.user-account.email-verification.update-successful"}}
+            </PixMessage>
+          </div>
+        {{/if}}
+      {{/if}}
+
+      {{#if this.shouldShowUsername}}
+        <div class="user-account-panel__item">
+          <div class="user-account-panel-item__text">
+            <p class="form-textfield__label user-account-panel-item__label">
+              {{t "pages.user-account.connexion-methods.username"}}
+            </p>
+            <p class="user-account-panel-item__value" data-test-username>{{@model.user.username}}</p>
+          </div>
         </div>
       {{/if}}
     {{/if}}
-    {{#if this.shouldShowUsername}}
+
+    {{#if this.shouldShowGarAuthenticationMethod}}
       <div class="user-account-panel__item">
         <div class="user-account-panel-item__text">
           <p class="form-textfield__label user-account-panel-item__label">{{t
-              "pages.user-account.connexion-methods.username"
+              "pages.user-account.connexion-methods.authentication-methods.label"
             }}</p>
-          <p class="user-account-panel-item__value" data-test-username>{{@model.username}}</p>
+          <p class="user-account-panel-item__value">
+            {{t "pages.user-account.connexion-methods.authentication-methods.gar"}}
+          </p>
+        </div>
+      </div>
+    {{/if}}
+
+    {{#if this.shouldShowPoleEmploiAuthenticationMethod}}
+      <div class="user-account-panel__item">
+        <div class="user-account-panel-item__text">
+          <p class="form-textfield__label user-account-panel-item__label">
+            {{t "pages.user-account.connexion-methods.authentication-methods.label"}}
+          </p>
+          <p class="user-account-panel-item__value">
+            {{t "pages.user-account.connexion-methods.authentication-methods.pole-emploi"}}
+          </p>
         </div>
       </div>
     {{/if}}

--- a/mon-pix/mirage/factories/authentication-method.js
+++ b/mon-pix/mirage/factories/authentication-method.js
@@ -1,0 +1,13 @@
+import { Factory, trait } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  withPixIdentityProvider: trait({
+    identityProvider: 'PIX',
+  }),
+  withGarIdentityProvider: trait({
+    identityProvider: 'GAR',
+  }),
+  withPoleEmploiIdentityProvider: trait({
+    identityProvider: 'POLE_EMPLOI',
+  }),
+});

--- a/mon-pix/mirage/models/authentication-method.js
+++ b/mon-pix/mirage/models/authentication-method.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  user: belongsTo(),
+});

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -25,6 +25,10 @@ export default function index(config) {
   config.get('/users/:id/campaign-participations', getUserCampaignParticipations);
   config.get('/users/:id/campaign-participation-overviews', getUserCampaignParticipationOverviews);
 
+  config.get('/users/:id/authentication-methods', (schema, request) => {
+    return schema.authenticationMethods.where({ userId: request.params.id });
+  });
+
   config.patch('/users/:id/email', (schema, request) => {
     const body = JSON.parse(request.requestBody);
     const user = schema.users.find(request.params.id);

--- a/mon-pix/tests/unit/controllers/user-account/connection-methods_test.js
+++ b/mon-pix/tests/unit/controllers/user-account/connection-methods_test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import EmberObject from '@ember/object';
 
 describe('Unit | Controller | user-account | connection-methods', function() {
   setupTest();
@@ -44,6 +45,63 @@ describe('Unit | Controller | user-account | connection-methods', function() {
 
       // then
       expect(controller.showEmailUpdatedMessage).to.be.true;
+    });
+  });
+
+  context('#shouldShowPixAuthenticationMethod', function() {
+    it('should display pix authentication method', function() {
+    // given & when
+      const controller = this.owner.lookup('controller:user-account/connection-methods');
+      const authenticationMethods = [EmberObject.create({
+        identityProvider: 'PIX',
+        isPixIdentityProvider: true,
+      })];
+      const model = {
+        user: {},
+        authenticationMethods,
+      };
+      controller.set('model', model);
+
+      // then
+      expect(controller.shouldShowPixAuthenticationMethod).to.be.true;
+    });
+  });
+
+  context('#shouldShowGarAuthenticationMethod', function() {
+    it('should display gar authentication method', function() {
+    // given & when
+      const controller = this.owner.lookup('controller:user-account/connection-methods');
+      const authenticationMethods = [EmberObject.create({
+        identityProvider: 'GAR',
+        isGarIdentityProvider: true,
+      })];
+      const model = {
+        user: {},
+        authenticationMethods,
+      };
+      controller.set('model', model);
+
+      // then
+      expect(controller.shouldShowGarAuthenticationMethod).to.be.true;
+    });
+  });
+
+  context('#shouldShowPoleEmploiAuthenticationMethod', function() {
+    it('should display pole emploi authentication method', function() {
+    // given & when
+      const controller = this.owner.lookup('controller:user-account/connection-methods');
+      const authenticationMethods = [EmberObject.create({
+        identityProvider: 'POLE_EMPLOI',
+        isPoleEmploiIdentityProvider: true,
+      })];
+      const model = {
+        user: {},
+        authenticationMethods,
+      };
+      controller.set('model', model);
+
+      // then
+      expect(controller.shouldShowPoleEmploiAuthenticationMethod).to.be.true;
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1346,7 +1346,12 @@
         "edit-button": "Edit",
         "email": "Email address",
         "menu-link-title": "Log in methods",
-        "username": "Username"
+        "username": "Username",
+        "authentication-methods": {
+          "label": "External login",
+          "gar": "ENT/Mediacentre",
+          "pole-emploi": "Pôle Emploi"
+        }
       },
       "email-verification": {
         "title": "Verify your email address",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1346,7 +1346,12 @@
         "edit-button": "Modifier",
         "email": "Adresse e-mail",
         "menu-link-title": "Mes méthodes de connexion",
-        "username": "Identifiant"
+        "username": "Identifiant",
+        "authentication-methods": {
+          "label": "Connexion externe",
+          "gar": "via ENT/Mediacentre",
+          "pole-emploi": "via Pôle Emploi"
+        }
       },
       "email-verification": {
         "title": "Vérification de votre adresse e-mail",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, quand un utilisateur est connecté à Pix, via le GAR ou Pôle Emploi, il ne voit rien dans "mes méthodes de connexions" sur Pix App.

## :robot: Solution
Afficher les méthodes de connexion GAR et Pôle Emploi si l'utilisateur en a.

## 🎃 Remarques

Ajout d'un booléen `shouldShowPixAuthenticationMethod` pour faire la distinction, sur la page hbs de `connection-methods`, des 3 méthodes de connexion possible.

## :100: Pour tester
Tester avec un seed GAR ( exemple: First Last ) : 
- Se connecter sur Pix
- Aller sur Mon Compte 

Si l'utilisateur à uniquement une méthode de connexion GAR : 
- On affiche uniquement : "connexion externe via ENT/Mediacentre"

Si l'utilisateur à GAR et PIX (identifiant ou email ):
- On affiche son email (ou indentifiant ) et "connexion externe via ENT/Mediacentre"

---

Tester avec un seed Pôle Emploi ( exemple:  ) : 

Si l'utilisateur à uniquement une méthode de connexion POLE EMPLOI : 
- On affiche uniquement : "connexion externe via Pôle Emploi"

Si l'utilisateur à POLE EMPLOI et PIX : 
- On affiche son email (ou indentifiant ) et "connexion externe via Pôle Emploi"