### PR TITLE
[FEATURE] Inviter un membre à une organisation PRO avec un rôle défini dans le fichier de création des organisations PRO (PIX-3493).

### DIFF
--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -45,6 +45,7 @@ const createProOrganizationInvitation = async ({
   organizationInvitationRepository,
   organizationId,
   email,
+  role,
   locale,
   tags,
   name,
@@ -56,7 +57,7 @@ const createProOrganizationInvitation = async ({
 
   if (!organizationInvitation) {
     const code = _generateCode();
-    organizationInvitation = await organizationInvitationRepository.create({ organizationId, email, code });
+    organizationInvitation = await organizationInvitationRepository.create({ organizationId, email, role, code });
   }
 
   await mailService.sendOrganizationInvitationEmail({

--- a/api/lib/domain/usecases/create-pro-organizations-with-tags.js
+++ b/api/lib/domain/usecases/create-pro-organizations-with-tags.js
@@ -52,13 +52,14 @@ module.exports = async function createProOrganizationsWithTags({
   const createdOrganizationsWithEmail = createdOrganizations.filter((organization) => !!organization.email);
 
   await bluebird.mapSeries(createdOrganizationsWithEmail, (organization) => {
-    const locale = organizationsData.get(organization.externalId).locale;
+    const { locale, organizationInvitationRole } = organizationsData.get(organization.externalId);
     return organizationInvitationService.createProOrganizationInvitation({
       organizationRepository,
       organizationInvitationRepository,
       organizationId: organization.id,
       name: organization.name,
       email: organization.email,
+      role: organizationInvitationRole?.toUpperCase(),
       locale,
     });
   });
@@ -102,6 +103,7 @@ function _validateAndMapOrganizationsData(organizations) {
         type: Organization.types.PRO,
       }),
       tags: organization.tags.split(ORGANIZATION_TAG_SEPARATOR),
+      organizationInvitationRole: organization.organizationInvitationRole,
       locale: organization.locale,
     });
   }

--- a/api/scripts/create-pro-organizations-with-tags.js
+++ b/api/scripts/create-pro-organizations-with-tags.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 // Usage: node create-pro-organizations-with-tags.js path/file.csv
-// To use on file with columns |externalId, name, provinceCode, canCollectProfiles, credit, email, locale, tags, createdBy|
+// To use on file with columns |externalId, name, provinceCode, canCollectProfiles, credit, email, organizationInvitationRole, locale, tags, createdBy|
 
 'use strict';
 require('dotenv').config();

--- a/api/tests/integration/domain/usecases/create-pro-organization-with-tags_test.js
+++ b/api/tests/integration/domain/usecases/create-pro-organization-with-tags_test.js
@@ -38,7 +38,6 @@ describe('Integration | UseCases | create-pro-organization', function () {
         canCollectProfiles: false,
         credit: 0,
         email: 'youness@example.net',
-        organizationInvitationRole: Membership.roles.ADMIN,
         locale: 'fr-fr',
         tags: 'Tag1_Tag2',
       },
@@ -49,7 +48,6 @@ describe('Integration | UseCases | create-pro-organization', function () {
         canCollectProfiles: true,
         credit: 10,
         email: 'andreia@example.net',
-        organizationInvitationRole: Membership.roles.MEMBER,
         locale: 'fr-fr',
         tags: 'Tag2_Tag3',
       },
@@ -60,7 +58,6 @@ describe('Integration | UseCases | create-pro-organization', function () {
         canCollectProfiles: false,
         credit: 20,
         email: 'mathieu@example.net',
-        organizationInvitationRole: Membership.roles.ADMIN,
         locale: 'fr-fr',
         tags: 'Tag1_Tag3',
       },
@@ -86,9 +83,7 @@ describe('Integration | UseCases | create-pro-organization', function () {
       const organizationInDB = await knex('organizations')
         .first('id', 'externalId', 'name', 'provinceCode', 'canCollectProfiles', 'credit', 'email')
         .where({ externalId: organization.externalId });
-      expect(omit(organizationInDB, 'id')).to.be.deep.equal(
-        omit(organization, 'organizationInvitationRole', 'locale', 'tags')
-      );
+      expect(omit(organizationInDB, 'id')).to.be.deep.equal(omit(organization, 'locale', 'tags'));
 
       const organizationTagInDB = await knex('organization-tags')
         .select()
@@ -101,7 +96,7 @@ describe('Integration | UseCases | create-pro-organization', function () {
     }
   });
 
-  it('should create organization invitation with role when email is specified', async function () {
+  it('should create organization invitation with role when role is specified', async function () {
     // given
     const organizationsWithInvitationRole = [
       {

--- a/api/tests/unit/domain/services/organization-invitation-service_test.js
+++ b/api/tests/unit/domain/services/organization-invitation-service_test.js
@@ -1,6 +1,8 @@
 const { expect, sinon } = require('../../../test-helper');
 
 const mailService = require('../../../../lib/domain/services/mail-service');
+const Membership = require('../../../../lib/domain/models/Membership');
+
 const {
   createOrganizationInvitation,
   createScoOrganizationInvitation,
@@ -284,12 +286,13 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           .withArgs({
             organizationId,
             email: userEmailAddress,
+            role: Membership.roles.MEMBER,
             code: sinon.match.string,
           })
           .resolves({ id: organizationInvitationId, code });
       });
 
-      it('should create a new organization-invitation and send an email with organizationId, name, email, code, locale and tags', async function () {
+      it('should create a new organization-invitation and send an email with organizationId, name, email, role, code, locale and tags', async function () {
         // given
         const tags = ['JOIN_ORGA'];
         const locale = 'fr-fr';
@@ -310,6 +313,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           organizationId,
           name: organizationName,
           email: userEmailAddress,
+          role: Membership.roles.MEMBER,
           locale,
           tags,
         });
@@ -339,6 +343,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           organizationId,
           name: organizationName,
           email: userEmailAddress,
+          role: Membership.roles.ADMIN,
           locale,
           tags,
         });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, le script de création des organisations PRO permet de créer des organisations et de leur rattacher un membre avec le role ADMIN. Or, pour certaines organisations disposant de tags spécifiques,  on veut leur attribuer le role MEMBER uniquement. 

## :robot: Solution
Rajouter une colonne dans le fichier CSV [organizationInvitationRole] qui va contenir le rôle à attribuer. [ ADMIN ou MEMBER ]

## :100: Pour tester
Lancer le script avec le fichier csv ci-dessous:

`node scripts/create-pro-organizations-with-tags.js /path/ORGA.csv`

externalId;name;provinceCode;canCollectProfiles;credit;email;organizationInvitationRole;locale;tags;createdBy
111111;orgatest;31;TRUE;0;votreemail@pix.fr;MEMBER;fr-fr;mednum;1

Vérifier qu'une invitation a été créé avec le rôle mentionné dans le fichier dans la table organizationInvitation.