### PR TITLE
[BUGFIX] On ne peut pas filtrer par classe et statut en même temps (PIX-3601).

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -21,8 +21,10 @@ export default class ActivityController extends Controller {
   @action
   triggerFiltering(filters) {
     this.pageNumber = null;
-    this.divisions = filters.divisions;
-    this.status = filters.status;
+    this.divisions = filters.divisions || this.divisions;
+    if (filters.status !== undefined) {
+      this.status = filters.status;
+    }
   }
 
   @action

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
@@ -35,4 +35,73 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
       assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.participant-assessment', 123, 456));
     });
   });
+
+  module('#action triggerFiltering', function (hooks) {
+    hooks.beforeEach(function () {
+      controller.model = { campaign: { isTypeAssessment: false } };
+    });
+
+    test('it updates all filters', function (assert) {
+      // given
+      controller.pageNumber = 5;
+      controller.divisions = ['A2'];
+      controller.status = 'SHARED';
+
+      // when
+      controller.send('triggerFiltering', { divisions: ['A1'], status: 'STARTED' });
+
+      // then
+      assert.equal(controller.pageNumber, null);
+      assert.deepEqual(controller.divisions, ['A1']);
+      assert.equal(controller.status, 'STARTED');
+    });
+
+    module('when division filter does not change', function () {
+      test('it does not update divisions', function (assert) {
+        // given
+        controller.pageNumber = 5;
+        controller.divisions = ['A2'];
+        controller.status = 'SHARED';
+
+        // when
+        controller.send('triggerFiltering', { status: 'COMPLETED' });
+
+        // then
+        assert.equal(controller.pageNumber, null);
+        assert.deepEqual(controller.divisions, ['A2']);
+        assert.equal(controller.status, 'COMPLETED');
+      });
+    });
+
+    module('when status filter does not change', function () {
+      test('it does not update status', function (assert) {
+        // given
+        controller.pageNumber = 5;
+        controller.divisions = ['A2'];
+        controller.status = 'SHARED';
+
+        // when
+        controller.send('triggerFiltering', { divisions: ['A1'] });
+
+        // then
+        assert.equal(controller.pageNumber, null);
+        assert.deepEqual(controller.divisions, ['A1']);
+        assert.equal(controller.status, 'SHARED');
+      });
+    });
+
+    module('when status filter is reseted', function () {
+      test('it updates status', function (assert) {
+        // given
+        controller.pageNumber = 5;
+        controller.status = 'SHARED';
+
+        // when
+        controller.send('triggerFiltering', { status: '' });
+
+        // then
+        assert.equal(controller.status, '');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les filtres sur les classes et sur les statuts ne peuvent pas être utilisés en même temps.

## :robot: Solution
Ne mettre à jour les statuts que lorsque qu'on leur donne un nouvelle valeur.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Essayer de filtrer les participations dans l'onglet activité avec une classe et un statut en même temps
