### PR TITLE
[TECH] Sortir la brique "page de présentation" du `start-or-resume` (PIX-3183).

### DIFF
--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -8,7 +8,6 @@ export default class CampaignLandingPageController extends Controller {
 
   @action
   startCampaignParticipation() {
-    this.campaignStorage.set(this.model.code, 'landingPageShown', true);
     return this.router.transitionTo('campaigns.start-or-resume', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/fill-in-participant-external-id.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-participant-external-id.js
@@ -8,14 +8,12 @@ export default class FillInParticipantExternalId extends Controller {
 
   @action
   onSubmitParticipantExternalId(participantExternalId) {
-
     this.campaignStorage.set(this.model.code, 'participantExternalId', participantExternalId);
     return this.router.transitionTo('campaigns.start-or-resume', this.model);
   }
 
   @action
   onCancel() {
-    this.campaignStorage.set(this.model.code, 'landingPageShown', false);
-    return this.router.transitionTo('campaigns.start-or-resume', this.model.code);
+    return this.router.transitionTo('campaigns.campaign-landing-page', this.model.code);
   }
 }

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -6,4 +6,9 @@ export default class CampaignLandingPageRoute extends Route {
     return this.modelFor('campaigns');
   }
 
+  redirect(campaign) {
+    if (campaign.isForAbsoluteNovice) {
+      return this.replaceWith('campaigns.start-or-resume', campaign);
+    }
+  }
 }

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -6,7 +6,4 @@ export default class CampaignLandingPageRoute extends Route {
     return this.modelFor('campaigns');
   }
 
-  resetController(controller) {
-    controller.set('isLoading', false);
-  }
 }

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -37,6 +37,6 @@ export default class EntryPoint extends Route {
       return this.replaceWith('campaigns.campaign-not-found', campaign);
     }
 
-    return this.replaceWith('campaigns.start-or-resume', campaign);
+    return this.replaceWith('campaigns.campaign-landing-page', campaign);
   }
 }

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -29,10 +29,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       await this._findOngoingCampaignParticipationAndUpdateState(campaign);
     }
 
-    if (this._shouldVisitLandingPage(campaign)) {
-      return this.replaceWith('campaigns.campaign-landing-page', campaign);
-    }
-
     if (this._shouldVisitPoleEmploiLoginPage) {
       return this._redirectToPoleEmploiLoginPage(transition);
     }
@@ -203,12 +199,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     return this.state.isUserLogged
       && this.currentUser.user.isAnonymous
       && !this.state.participantExternalId;
-  }
-
-  _shouldVisitLandingPage(campaign) {
-    const shouldDisplayLandingPage = campaign.isForAbsoluteNovice ? false : !this.campaignStorage.get(this.state.campaignCode, 'landingPageShown');
-    return shouldDisplayLandingPage
-      && !this.state.doesUserHaveOngoingParticipation;
   }
 
   get _shouldProvideExternalIdToAccessCampaign() {

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -208,7 +208,8 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
 
           it('should redirect to tutoriel page', async function() {
             // given
-            await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
+            await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('Je commence');
             await fillIn('#firstName', 'Robert');
             await fillIn('#lastName', 'Smith');
             await fillIn('#dayOfBirth', '10');
@@ -216,7 +217,6 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await fillIn('#yearOfBirth', '2000');
             await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
-            await clickByLabel(this.intl.t('pages.campaign-landing.assessment.action'));
             await fillIn('#id-pix-label', 'truc');
 
             // when

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -178,7 +178,8 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
         context('When association is not already done', function() {
           it('should redirect to send profile page', async function() {
             // given
-            await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
+            await visit(`/campagnes/${campaign.code}`);
+            await clickByLabel('C\'est parti !');
             await fillIn('#firstName', 'Robert');
             await fillIn('#lastName', 'Smith');
             await fillIn('#dayOfBirth', '10');
@@ -186,7 +187,6 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await fillIn('#yearOfBirth', '2000');
             await clickByLabel(this.intl.t('pages.join.button'));
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
-            await clickByLabel(this.intl.t('pages.campaign-landing.profiles-collection.action'));
             await fillIn('#id-pix-label', 'truc');
 
             // when
@@ -206,7 +206,8 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
 
             it('should display error modal when fields are filled in', async function() {
               // given
-              await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
+              await visit(`/campagnes/${campaign.code}`);
+              await clickByLabel('C\'est parti !');
 
               // when
               await fillIn('#firstName', 'Robert');
@@ -222,7 +223,8 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
 
             it('should redirect to connection form when continue button is clicked', async function() {
               // given
-              await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
+              await visit(`/campagnes/${campaign.code}`);
+              await clickByLabel('C\'est parti !');
 
               // when
               await fillIn('#firstName', 'Robert');
@@ -232,7 +234,6 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#yearOfBirth', '2000');
               await clickByLabel(this.intl.t('pages.join.button'));
               await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
-              await clickByLabel('C\'est parti !');
 
               //then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification?displayRegisterForm=false`);

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -654,25 +654,6 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
           it('should begin campaign participation when fields are filled in and associate button is clicked', async function() {
             // given
-            await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
-
-            // when
-            await fillIn('#firstName', 'Robert');
-            await fillIn('#lastName', 'Smith');
-            await fillIn('#dayOfBirth', '10');
-            await fillIn('#monthOfBirth', '12');
-            await fillIn('#yearOfBirth', '2000');
-
-            // when
-            await clickByLabel(this.intl.t('pages.join.button'));
-            await clickByLabel(this.intl.t('pages.join.sco.associate'));
-
-            //then
-            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
-          });
-
-          it('should begin campaign participation when landing page has been seen', async function() {
-            // given
             await visit(`/campagnes/${campaign.code}`);
             await clickByLabel('Je commence');
             await fillIn('#firstName', 'Robert');
@@ -981,7 +962,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
           it('should redirect to landing page', async function() {
             // when
-            await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
+            await visit(`/campagnes/${campaign.code}`);
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-participant-external-id_test.js
@@ -30,12 +30,12 @@ describe('Unit | Controller | Campaigns | FillInParticipantExternalId', function
   });
 
   describe('#onCancel', () => {
-    it('should transition to start or resume', () => {
+    it('should transition to landing page', () => {
       // when
       controller.actions.onCancel.call(controller);
 
       // then
-      sinon.assert.calledWithExactly(controller.router.transitionTo, 'campaigns.start-or-resume', controller.get('model.code'));
+      sinon.assert.calledWithExactly(controller.router.transitionTo, 'campaigns.campaign-landing-page', controller.get('model.code'));
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'alors le fameux fichier `start-or-resume` était et est encore pour un petit moment un plat de spaghettis.

## :robot: Solution
On décomissionne ce fichier petit à petit, ici en sortant la page de présentation (`landing-page`).

## :rainbow: Remarques
RAS

## :100: Pour tester
Tester l'accès campagnes au global
