### PR TITLE
[CLEAN] Nettoyer les fichiers helper de build des AuthenticationMethods (PIX-3606)

### DIFF
--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -4,7 +4,9 @@ const buildUser = require('./build-user');
 const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');
 const encrypt = require('../../../lib/domain/services/encryption-service');
 
-const buildAuthenticationMethod = function ({
+const buildAuthenticationMethod = {};
+
+buildAuthenticationMethod.withGarAuthenticationComplement = function ({
   id = databaseBuffer.getNextId(),
   identityProvider = AuthenticationMethod.identityProviders.GAR,
   externalIdentifier = 'externalId',

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -29,7 +29,7 @@ const buildAuthenticationMethod = function ({
   });
 };
 
-buildAuthenticationMethod.buildWithHashedPassword = function ({
+buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword = function ({
   id = databaseBuffer.getNextId(),
   hashedPassword = 'ABCDEF123',
   shouldChangePassword = false,

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -6,7 +6,7 @@ const encrypt = require('../../../lib/domain/services/encryption-service');
 
 const buildAuthenticationMethod = {};
 
-buildAuthenticationMethod.withGarAuthenticationComplement = function ({
+buildAuthenticationMethod.withGarAsIdentityProvider = function ({
   id = databaseBuffer.getNextId(),
   identityProvider = AuthenticationMethod.identityProviders.GAR,
   externalIdentifier = 'externalId',
@@ -31,7 +31,7 @@ buildAuthenticationMethod.withGarAuthenticationComplement = function ({
   });
 };
 
-buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword = function ({
+buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword = function ({
   id = databaseBuffer.getNextId(),
   hashedPassword = 'ABCDEF123',
   shouldChangePassword = false,
@@ -59,7 +59,7 @@ buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword = fun
   });
 };
 
-buildAuthenticationMethod.withPixAuthenticationComplementAndPassword = function ({
+buildAuthenticationMethod.withPixAsIdentityProviderAndPassword = function ({
   id = databaseBuffer.getNextId(),
   password = 'Password123',
   shouldChangePassword = false,
@@ -89,7 +89,7 @@ buildAuthenticationMethod.withPixAuthenticationComplementAndPassword = function 
   });
 };
 
-buildAuthenticationMethod.withPoleEmploiAuthenticationComplement = function ({
+buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   id = databaseBuffer.getNextId(),
   externalIdentifier,
   accessToken = 'ABC789',

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -57,7 +57,7 @@ buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword = fun
   });
 };
 
-buildAuthenticationMethod.buildWithPassword = function ({
+buildAuthenticationMethod.withPixAuthenticationComplementAndPassword = function ({
   id = databaseBuffer.getNextId(),
   password = 'Password123',
   shouldChangePassword = false,

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -87,7 +87,7 @@ buildAuthenticationMethod.withPixAuthenticationComplementAndPassword = function 
   });
 };
 
-buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod = function ({
+buildAuthenticationMethod.withPoleEmploiAuthenticationComplement = function ({
   id = databaseBuffer.getNextId(),
   externalIdentifier,
   accessToken = 'ABC789',

--- a/api/db/database-builder/factory/pole-emploi-sending-factory.js
+++ b/api/db/database-builder/factory/pole-emploi-sending-factory.js
@@ -1,6 +1,6 @@
 const buildCampaignParticipation = require('./build-campaign-participation');
 const buildUser = require('./build-user');
-const buildAuthencationMethod = require('./build-authentication-method');
+const buildAuthenticationMethod = require('./build-authentication-method');
 const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
@@ -34,7 +34,7 @@ function build({
 
 function buildWithUser(sendingAttributes, externalIdentifier) {
   const { id: userId } = buildUser();
-  buildAuthencationMethod.buildPoleEmploiAuthenticationMethod({ userId, externalIdentifier });
+  buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId, externalIdentifier });
   const { id: campaignParticipationId } = buildCampaignParticipation({ userId });
   return build({ ...sendingAttributes, campaignParticipationId });
 }

--- a/api/db/database-builder/factory/pole-emploi-sending-factory.js
+++ b/api/db/database-builder/factory/pole-emploi-sending-factory.js
@@ -34,7 +34,7 @@ function build({
 
 function buildWithUser(sendingAttributes, externalIdentifier) {
   const { id: userId } = buildUser();
-  buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId, externalIdentifier });
+  buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId, externalIdentifier });
   const { id: campaignParticipationId } = buildCampaignParticipation({ userId });
   return build({ ...sendingAttributes, campaignParticipationId });
 }

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -209,7 +209,7 @@ function organizationsScoBuilder({ databaseBuilder }) {
     cgu: false,
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod({
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
     identityProvider: AuthenticationMethod.identityProviders.GAR,
     externalIdentifier: '1234567',
     userId: userWithGAR.id,
@@ -354,7 +354,7 @@ function organizationsScoBuilder({ databaseBuilder }) {
     emailConfirmedAt: new Date(),
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod({
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
     identityProvider: AuthenticationMethod.identityProviders.GAR,
     externalIdentifier: '1234555',
     userId: userWhoHasLeftSCO.id,

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -208,7 +208,7 @@ function organizationsScoBuilder({ databaseBuilder }) {
     cgu: false,
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
     externalIdentifier: '1234567',
     userId: userWithGAR.id,
   });
@@ -352,12 +352,12 @@ function organizationsScoBuilder({ databaseBuilder }) {
     emailConfirmedAt: new Date(),
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
     externalIdentifier: '1234555',
     userId: userWhoHasLeftSCO.id,
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndPassword({
+  databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndPassword({
     userId: userWhoHasLeftSCO.id,
   });
 

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -1,5 +1,4 @@
 const Membership = require('../../../lib/domain/models/Membership');
-const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');
 const { DEFAULT_PASSWORD } = require('./users-builder');
 const SCO_MIDDLE_SCHOOL_ID = 3;
 const SCO_HIGH_SCHOOL_ID = 6;

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -210,7 +210,6 @@ function organizationsScoBuilder({ databaseBuilder }) {
   });
 
   databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-    identityProvider: AuthenticationMethod.identityProviders.GAR,
     externalIdentifier: '1234567',
     userId: userWithGAR.id,
   });
@@ -355,7 +354,6 @@ function organizationsScoBuilder({ databaseBuilder }) {
   });
 
   databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-    identityProvider: AuthenticationMethod.identityProviders.GAR,
     externalIdentifier: '1234555',
     userId: userWhoHasLeftSCO.id,
   });

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -360,7 +360,7 @@ function organizationsScoBuilder({ databaseBuilder }) {
     userId: userWhoHasLeftSCO.id,
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod.buildWithPassword({
+  databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndPassword({
     userId: userWhoHasLeftSCO.id,
   });
 

--- a/api/db/seeds/data/pole-emploi-sendings-builder.js
+++ b/api/db/seeds/data/pole-emploi-sendings-builder.js
@@ -14,7 +14,7 @@ module.exports = function poleEmploisSendingsBuilder({ databaseBuilder }) {
 
   _.times(300, async (index) => {
     const user = await databaseBuilder.factory.buildUser({ firstName: `FirstName-${index}`, lastName: `LastName-${index}` });
-    await databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id, identityProvider: 'POLE_EMPLOI', externalIdentifier: `externalUserId${user.id}` });
+    await databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId: user.id, externalIdentifier: `externalUserId${user.id}` });
     const campaignParticipationId = await databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, campaignId: POLE_EMPLOI_CAMPAIGN_ID }).id;
     await databaseBuilder.factory.poleEmploiSendingFactory.build({ ..._generateStatus(), campaignParticipationId, createdAt: _generateDate(index), payload: {
       campagne: {

--- a/api/db/seeds/data/pole-emploi-sendings-builder.js
+++ b/api/db/seeds/data/pole-emploi-sendings-builder.js
@@ -14,7 +14,7 @@ module.exports = function poleEmploisSendingsBuilder({ databaseBuilder }) {
 
   _.times(300, async (index) => {
     const user = await databaseBuilder.factory.buildUser({ firstName: `FirstName-${index}`, lastName: `LastName-${index}` });
-    await databaseBuilder.factory.buildAuthenticationMethod({ userId: user.id, identityProvider: 'POLE_EMPLOI', externalIdentifier: `externalUserId${user.id}` });
+    await databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id, identityProvider: 'POLE_EMPLOI', externalIdentifier: `externalUserId${user.id}` });
     const campaignParticipationId = await databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, campaignId: POLE_EMPLOI_CAMPAIGN_ID }).id;
     await databaseBuilder.factory.poleEmploiSendingFactory.build({ ..._generateStatus(), campaignParticipationId, createdAt: _generateDate(index), payload: {
       campagne: {

--- a/api/db/seeds/data/pole-emploi-sendings-builder.js
+++ b/api/db/seeds/data/pole-emploi-sendings-builder.js
@@ -14,7 +14,7 @@ module.exports = function poleEmploisSendingsBuilder({ databaseBuilder }) {
 
   _.times(300, async (index) => {
     const user = await databaseBuilder.factory.buildUser({ firstName: `FirstName-${index}`, lastName: `LastName-${index}` });
-    await databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId: user.id, externalIdentifier: `externalUserId${user.id}` });
+    await databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId: user.id, externalIdentifier: `externalUserId${user.id}` });
     const campaignParticipationId = await databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, campaignId: POLE_EMPLOI_CAMPAIGN_ID }).id;
     await databaseBuilder.factory.poleEmploiSendingFactory.build({ ..._generateStatus(), campaignParticipationId, createdAt: _generateDate(index), payload: {
       campagne: {

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -1,6 +1,5 @@
 const PIX_MASTER_ID = 199;
 const DEFAULT_PASSWORD = 'pix123';
-const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');
 
 function usersBuilder({ databaseBuilder }) {
 

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -49,7 +49,7 @@ function usersBuilder({ databaseBuilder }) {
     cgu: false,
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
     externalIdentifier: 'samlId',
     userId: userWithSamlId.id,
   });
@@ -62,7 +62,7 @@ function usersBuilder({ databaseBuilder }) {
     cgu: false,
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+  databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
     userId: userFromPoleEmploi.id,
   });
 

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -50,7 +50,7 @@ function usersBuilder({ databaseBuilder }) {
     cgu: false,
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod({
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
     identityProvider: AuthenticationMethod.identityProviders.GAR,
     externalIdentifier: 'samlId',
     userId: userWithSamlId.id,

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -64,7 +64,7 @@ function usersBuilder({ databaseBuilder }) {
     cgu: false,
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+  databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
     userId: userFromPoleEmploi.id,
   });
 

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -51,7 +51,6 @@ function usersBuilder({ databaseBuilder }) {
   });
 
   databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-    identityProvider: AuthenticationMethod.identityProviders.GAR,
     externalIdentifier: 'samlId',
     userId: userWithSamlId.id,
   });

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -350,7 +350,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
             lastName,
           }).id;
 
-          databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
             externalIdentifier,
             accessToken: 'old_access_token',
             refreshToken: 'old_refresh_token',
@@ -443,7 +443,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
       context('When the user does have a POLE_EMPLOI authentication method', function () {
         it('should update POLE_EMPLOI authentication method authentication complement', async function () {
           // given
-          databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
             externalIdentifier,
             accessToken: 'old_access_token',
             refreshToken: 'old_refresh_token',
@@ -472,7 +472,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
         it('should return a 409 Conflict if the authenticated user is not the expected one', async function () {
           // given
           const otherUser = databaseBuilder.factory.buildUser();
-          databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
             externalIdentifier: 'other_external_identifier',
             userId: otherUser.id,
           });

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -350,7 +350,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
             lastName,
           }).id;
 
-          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
             externalIdentifier,
             accessToken: 'old_access_token',
             refreshToken: 'old_refresh_token',
@@ -443,7 +443,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
       context('When the user does have a POLE_EMPLOI authentication method', function () {
         it('should update POLE_EMPLOI authentication method authentication complement', async function () {
           // given
-          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
             externalIdentifier,
             accessToken: 'old_access_token',
             refreshToken: 'old_refresh_token',
@@ -472,7 +472,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
         it('should return a 409 Conflict if the authenticated user is not the expected one', async function () {
           // given
           const otherUser = databaseBuilder.factory.buildUser();
-          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
             externalIdentifier: 'other_external_identifier',
             userId: otherUser.id,
           });

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -868,7 +868,6 @@ describe('Acceptance | Application | organization-controller', function () {
     beforeEach(async function () {
       user = databaseBuilder.factory.buildUser();
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
         externalIdentifier: '234',
         userId: user.id,
       });

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -866,7 +866,7 @@ describe('Acceptance | Application | organization-controller', function () {
 
     beforeEach(async function () {
       user = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
         externalIdentifier: '234',
         userId: user.id,
       });

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -15,7 +15,6 @@ const createServer = require('../../../../server');
 
 const Membership = require('../../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
-const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -867,7 +867,7 @@ describe('Acceptance | Application | organization-controller', function () {
 
     beforeEach(async function () {
       user = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildAuthenticationMethod({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         identityProvider: AuthenticationMethod.identityProviders.GAR,
         externalIdentifier: '234',
         userId: user.id,

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -33,7 +33,7 @@ describe('Acceptance | Controller | password-controller', function () {
       config.mailing.enabled = false;
 
       const userId = databaseBuilder.factory.buildUser({ email }).id;
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({ userId });
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId });
       await databaseBuilder.commit();
     });
 

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -33,7 +33,7 @@ describe('Acceptance | Controller | password-controller', function () {
       config.mailing.enabled = false;
 
       const userId = databaseBuilder.factory.buildUser({ email }).id;
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId });
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
       await databaseBuilder.commit();
     });
 

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -223,7 +223,7 @@ describe('Acceptance | Controller | saml-controller', function () {
         samlId,
         cgu: false,
       }).id;
-      databaseBuilder.factory.buildAuthenticationMethod({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         externalIdentifier: samlId,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
         userId,

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -225,7 +225,6 @@ describe('Acceptance | Controller | saml-controller', function () {
       }).id;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         externalIdentifier: samlId,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
         userId,
       });
       await databaseBuilder.commit();

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -221,7 +221,7 @@ describe('Acceptance | Controller | saml-controller', function () {
         samlId,
         cgu: false,
       }).id;
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
         externalIdentifier: samlId,
         userId,
       });

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -6,8 +6,6 @@ const samlify = require('samlify');
 const createServer = require('../../../server');
 const settings = require('../../../lib/config');
 
-const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');
-
 const testCertificate = `MIICCzCCAXQCCQD2MlHh/QmGmjANBgkqhkiG9w0BAQsFADBKMQswCQYDVQQGEwJG
 UjEPMA0GA1UECAwGRlJBTkNFMQ4wDAYDVQQHDAVQQVJJUzEMMAoGA1UECgwDUElY
 MQwwCgYDVQQLDANERVYwHhcNMTgxMDIyMTQ1MjQ5WhcNMTkxMDIyMTQ1MjQ5WjBK

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -155,7 +155,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             username: null,
             email: null,
           });
-          databaseBuilder.factory.buildAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithSamlOnly.id,
@@ -202,7 +202,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             email: null,
             username: null,
           });
-          databaseBuilder.factory.buildAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,
@@ -519,7 +519,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             lastName: schoolingRegistration.lastName,
             birthdate: schoolingRegistration.birthdate,
           });
-          databaseBuilder.factory.buildAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: user.id,
@@ -569,7 +569,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
         it('should replace the existing user samlId already reconciled in the same organization found with the authenticated user samlId', async function () {
           // given
           const userWithSamlIdOnly = databaseBuilder.factory.buildUser();
-          databaseBuilder.factory.buildAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,
@@ -1044,7 +1044,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             username: null,
             email: null,
           });
-          databaseBuilder.factory.buildAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithEmailOnly.id,
@@ -1203,7 +1203,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             email: null,
             username: null,
           });
-          databaseBuilder.factory.buildAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -155,7 +155,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             username: null,
             email: null,
           });
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: '12345678',
             userId: userWithSamlOnly.id,
           });
@@ -201,7 +201,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             email: null,
             username: null,
           });
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,
           });
@@ -517,7 +517,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             lastName: schoolingRegistration.lastName,
             birthdate: schoolingRegistration.birthdate,
           });
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: '12345678',
             userId: user.id,
           });
@@ -566,7 +566,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
         it('should replace the existing user samlId already reconciled in the same organization found with the authenticated user samlId', async function () {
           // given
           const userWithSamlIdOnly = databaseBuilder.factory.buildUser();
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,
           });
@@ -1040,7 +1040,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             username: null,
             email: null,
           });
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: '12345678',
             userId: userWithEmailOnly.id,
           });
@@ -1198,7 +1198,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             email: null,
             username: null,
           });
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,
           });

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -156,7 +156,6 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             email: null,
           });
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithSamlOnly.id,
           });
@@ -203,7 +202,6 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             username: null,
           });
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,
           });
@@ -520,7 +518,6 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             birthdate: schoolingRegistration.birthdate,
           });
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: user.id,
           });
@@ -570,7 +567,6 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
           // given
           const userWithSamlIdOnly = databaseBuilder.factory.buildUser();
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,
           });
@@ -1045,7 +1041,6 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             email: null,
           });
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithEmailOnly.id,
           });
@@ -1204,7 +1199,6 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
             username: null,
           });
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: '12345678',
             userId: userWithSamlIdOnly.id,
           });

--- a/api/tests/acceptance/application/users/get-user-authentication-methods-route-get_test.js
+++ b/api/tests/acceptance/application/users/get-user-authentication-methods-route-get_test.js
@@ -9,7 +9,9 @@ describe('Acceptance | Route | Users', function () {
       const server = await createServer();
 
       const user = databaseBuilder.factory.buildUser({});
-      const garAuthenticationMethod = databaseBuilder.factory.buildAuthenticationMethod({ userId: user.id });
+      const garAuthenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: user.id,
+      });
 
       await databaseBuilder.commit();
 

--- a/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
+++ b/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
@@ -16,7 +16,9 @@ describe('Acceptance | Controller | users-controller-remove-authentication-metho
   beforeEach(async function () {
     server = await createServer();
     user = databaseBuilder.factory.buildUser({ username: 'jhn.doe0101', email: null });
-    databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({ userId: user.id });
+    databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      userId: user.id,
+    });
     databaseBuilder.factory.buildAuthenticationMethod({
       userId: user.id,
       identityProvider: AuthenticationMethod.identityProviders.GAR,

--- a/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
+++ b/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
@@ -19,10 +19,7 @@ describe('Acceptance | Controller | users-controller-remove-authentication-metho
     databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
       userId: user.id,
     });
-    databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-      userId: user.id,
-      identityProvider: AuthenticationMethod.identityProviders.GAR,
-    });
+    databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id });
 
     const pixMaster = await insertUserWithRolePixMaster();
     options = {

--- a/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
+++ b/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Controller | users-controller-remove-authentication-metho
     databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
       userId: user.id,
     });
-    databaseBuilder.factory.buildAuthenticationMethod({
+    databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
       userId: user.id,
       identityProvider: AuthenticationMethod.identityProviders.GAR,
     });

--- a/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
+++ b/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
@@ -16,10 +16,10 @@ describe('Acceptance | Controller | users-controller-remove-authentication-metho
   beforeEach(async function () {
     server = await createServer();
     user = databaseBuilder.factory.buildUser({ username: 'jhn.doe0101', email: null });
-    databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+    databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
       userId: user.id,
     });
-    databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id });
+    databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
 
     const pixMaster = await insertUserWithRolePixMaster();
     options = {

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -23,7 +23,7 @@ describe('Integration | Domain | Services | user-service', function () {
 
     beforeEach(function () {
       user = domainBuilder.buildUser({ username: null });
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         hashedPassword,
         userId: user.id,
       });

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -23,7 +23,7 @@ describe('Integration | Domain | Services | user-service', function () {
 
     beforeEach(function () {
       user = domainBuilder.buildUser({ username: null });
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         hashedPassword,
         userId: user.id,
       });

--- a/api/tests/integration/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/integration/domain/usecases/account-recovery/update-user-account_test.js
@@ -14,9 +14,10 @@ describe('Integration | UseCases | Account-recovery | updateUserAccount', functi
     const password = 'pix123';
     const user = databaseBuilder.factory.buildUser();
     await databaseBuilder.commit();
-    const authenticatedMethod = databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
-      userId: user.id,
-    });
+    const authenticatedMethod =
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        userId: user.id,
+      });
     await databaseBuilder.commit();
     const accountRecovery = databaseBuilder.factory.buildAccountRecoveryDemand({ userId: user.id });
     await databaseBuilder.commit();

--- a/api/tests/integration/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/integration/domain/usecases/account-recovery/update-user-account_test.js
@@ -15,7 +15,7 @@ describe('Integration | UseCases | Account-recovery | updateUserAccount', functi
     const user = databaseBuilder.factory.buildUser();
     await databaseBuilder.commit();
     const authenticatedMethod =
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId: user.id,
       });
     await databaseBuilder.commit();

--- a/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
@@ -15,7 +15,7 @@ describe('Integration | UseCases | create-password-reset-demand', function () {
 
   beforeEach(async function () {
     const userId = databaseBuilder.factory.buildUser({ email }).id;
-    databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({ userId });
+    databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId });
     await databaseBuilder.commit();
   });
 

--- a/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
@@ -15,7 +15,7 @@ describe('Integration | UseCases | create-password-reset-demand', function () {
 
   beforeEach(async function () {
     const userId = databaseBuilder.factory.buildUser({ email }).id;
-    databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId });
+    databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
     await databaseBuilder.commit();
   });
 

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
@@ -260,7 +260,6 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
               birthdate: schoolingRegistration.birthdate,
             });
             databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-              identityProvider: AuthenticationMethod.identityProviders.GAR,
               externalIdentifier: '12345678',
               userId: otherAccount.id,
             });
@@ -316,7 +315,6 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
               birthdate: birthdate,
             });
             databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-              identityProvider: AuthenticationMethod.identityProviders.GAR,
               externalIdentifier: '12345678',
               userId: otherAccount.id,
             });
@@ -373,7 +371,6 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
         schoolingRegistration.userId = undefined;
         const alreadyCreatedUser = databaseBuilder.factory.buildUser({ firstName, lastName });
         databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: samlId,
           userId: alreadyCreatedUser.id,
         });

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
@@ -259,7 +259,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
               lastName: lastName,
               birthdate: schoolingRegistration.birthdate,
             });
-            databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+            databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
               externalIdentifier: '12345678',
               userId: otherAccount.id,
             });
@@ -314,7 +314,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
               lastName: lastName,
               birthdate: birthdate,
             });
-            databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+            databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
               externalIdentifier: '12345678',
               userId: otherAccount.id,
             });
@@ -370,7 +370,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
         });
         schoolingRegistration.userId = undefined;
         const alreadyCreatedUser = databaseBuilder.factory.buildUser({ firstName, lastName });
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: samlId,
           userId: alreadyCreatedUser.id,
         });

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
@@ -259,7 +259,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
               lastName: lastName,
               birthdate: schoolingRegistration.birthdate,
             });
-            databaseBuilder.factory.buildAuthenticationMethod({
+            databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
               identityProvider: AuthenticationMethod.identityProviders.GAR,
               externalIdentifier: '12345678',
               userId: otherAccount.id,
@@ -315,7 +315,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
               lastName: lastName,
               birthdate: birthdate,
             });
-            databaseBuilder.factory.buildAuthenticationMethod({
+            databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
               identityProvider: AuthenticationMethod.identityProviders.GAR,
               externalIdentifier: '12345678',
               userId: otherAccount.id,
@@ -372,7 +372,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
         });
         schoolingRegistration.userId = undefined;
         const alreadyCreatedUser = databaseBuilder.factory.buildUser({ firstName, lastName });
-        databaseBuilder.factory.buildAuthenticationMethod({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: samlId,
           userId: alreadyCreatedUser.id,

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -765,7 +765,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
         // then
         const expectedAuthenticationMethod =
-          domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+          domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
             id: 123,
             externalIdentifier: 'identifier',
             accessToken: 'new_access_token',

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -28,7 +28,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();
 
-        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: 'externalIdentifier',
           userId,
         });
@@ -51,7 +51,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();
 
-        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: 'externalIdentifier',
           userId,
         });
@@ -75,14 +75,14 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           // given
           const userIdA = databaseBuilder.factory.buildUser().id;
           const userIdB = databaseBuilder.factory.buildUser().id;
-          const authenticationMethodA = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+          const authenticationMethodA = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: 'alreadyExistingExternalIdentifier',
             userId: userIdA,
           });
           delete authenticationMethodA.id;
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethodA);
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(authenticationMethodA);
           await databaseBuilder.commit();
-          const authenticationMethodB = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+          const authenticationMethodB = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: 'alreadyExistingExternalIdentifier',
             userId: userIdB,
           });
@@ -103,14 +103,14 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       it('should throw an AlreadyExistingEntityError', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const authenticationMethodA = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        const authenticationMethodA = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: 'someIdentifierA',
           userId,
         });
         delete authenticationMethodA.id;
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethodA);
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(authenticationMethodA);
         await databaseBuilder.commit();
-        const authenticationMethodB = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        const authenticationMethodB = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: 'someIdentifierB',
           userId,
         });
@@ -130,7 +130,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         externalIdentifier: 'externalIdentifier',
         userId,
       });
@@ -161,7 +161,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should update the password in database', async function () {
       // given
       const authenticationMethodId =
-        databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           userId,
           hashedPassword,
         }).id;
@@ -183,12 +183,12 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return the updated AuthenticationMethod', async function () {
       // given
       const originalAuthenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           id: 123,
           userId,
           hashedPassword,
         });
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword(
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword(
         originalAuthenticationMethod
       );
       await databaseBuilder.commit();
@@ -201,7 +201,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
       // then
       const expectedAuthenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           id: 123,
           userId,
           hashedPassword: newHashedPassword,
@@ -212,7 +212,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should disable changing password', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId,
         hashedPassword,
         shouldChangePassword: true,
@@ -246,7 +246,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should be DomainTransaction compliant', async function () {
       // given
       const authenticationMethod =
-        databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           userId,
           hashedPassword,
         });
@@ -275,15 +275,15 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return the AuthenticationMethod associated to a user for a given identity provider', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId,
       });
-      const garAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      const garAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         id: 123,
         userId,
       });
       garAuthenticationMethod.authenticationComplement = undefined;
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(garAuthenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(garAuthenticationMethod);
       await databaseBuilder.commit();
 
       // when
@@ -300,7 +300,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return null if there is no AuthenticationMethod for the given user and identity provider', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId });
+      databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId });
       await databaseBuilder.commit();
 
       // when
@@ -320,14 +320,14 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // given
       const externalIdentifier = 'samlId';
       const userId = databaseBuilder.factory.buildUser().id;
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         id: 123,
         externalIdentifier,
         userId,
       });
       authenticationMethod.authenticationComplement = undefined;
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethod);
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(authenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
         externalIdentifier: 'another_sub',
       });
       await databaseBuilder.commit();
@@ -361,12 +361,12 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       it('should update external identifier by userId and identity provider', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: 'old_value',
           userId,
         });
         authenticationMethod.authenticationComplement = undefined;
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethod);
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(authenticationMethod);
         await databaseBuilder.commit();
 
         // when
@@ -386,12 +386,12 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       it('should return the updated AuthenticationMethod', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: 'old_value',
           userId,
         });
         authenticationMethod.authenticationComplement = undefined;
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethod);
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(authenticationMethod);
         await databaseBuilder.commit();
 
         // when
@@ -437,7 +437,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should update password in database and set shouldChangePassword to true', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         id: 123,
         userId,
         hashedPassword,
@@ -462,13 +462,13 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return an updated AuthenticationMethod', async function () {
       // given
       const originalAuthenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           id: 123,
           userId,
           hashedPassword,
           shouldChangePassword: false,
         });
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(originalAuthenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(originalAuthenticationMethod);
       await databaseBuilder.commit();
 
       // when
@@ -479,7 +479,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
       // then
       const expectedAuthenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           id: 123,
           userId,
           hashedPassword: newHashedPassword,
@@ -505,7 +505,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should be DomainTransaction compliant', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         id: 123,
         userId,
         hashedPassword,
@@ -563,7 +563,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should not replace an existing authenticationMethod with a different identity provider', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId });
       await databaseBuilder.commit();
       await authenticationMethodRepository.createPasswordThatShouldBeChanged({
         userId,
@@ -626,7 +626,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     beforeEach(async function () {
       userId = databaseBuilder.factory.buildUser({ shouldChangePassword: true }).id;
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         id: 123,
         userId,
         hashedPassword,
@@ -653,7 +653,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return the updated AuthenticationMethod', async function () {
       // given
       const expectedAuthenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           id: 123,
           userId,
           hashedPassword: newHashedPassword,
@@ -693,7 +693,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       beforeEach(function () {
         const userId = databaseBuilder.factory.buildUser().id;
         poleEmploiAuthenticationMethod =
-          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
             id: 123,
             externalIdentifier: 'identifier',
             accessToken: 'to_be_updated',
@@ -747,16 +747,15 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           });
 
         // then
-        const expectedAuthenticationMethod =
-          domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
-            id: 123,
-            externalIdentifier: 'identifier',
-            accessToken: 'new_access_token',
-            refreshToken: 'new_refresh_token',
-            expiredDate,
-            userId,
-            updatedAt: new Date(),
-          });
+        const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
+          id: 123,
+          externalIdentifier: 'identifier',
+          accessToken: 'new_access_token',
+          refreshToken: 'new_refresh_token',
+          expiredDate,
+          userId,
+          updatedAt: new Date(),
+        });
         expect(updatedAuthenticationMethod).to.deepEqualInstance(expectedAuthenticationMethod);
       });
     });
@@ -783,7 +782,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return true if user have an authenticationMethod with an IdentityProvider PIX ', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId,
       });
       await databaseBuilder.commit();
@@ -800,7 +799,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return false if user have no authenticationMethod with an IdentityProvider PIX ', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId });
       await databaseBuilder.commit();
 
       // when
@@ -817,7 +816,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should delete from database the authentication method by userId and identityProvider', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
         id: 123,
         externalIdentifier: 'externalIdentifier',
         userId,
@@ -840,20 +839,20 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it("should return the user's authentication methods", async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      const secondAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      const secondAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         id: 456,
         externalIdentifier: 'externalIdentifier',
         userId,
       });
       secondAuthenticationMethod.authenticationComplement = undefined;
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(secondAuthenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(secondAuthenticationMethod);
       const firstAuthenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           id: 123,
           userId,
           hashedPassword: 'Hello',
         });
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         ...firstAuthenticationMethod,
         hashedPassword: 'Hello',
       });

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -29,7 +29,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         await databaseBuilder.commit();
 
         const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'externalIdentifier',
           userId,
         });
@@ -53,7 +52,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         await databaseBuilder.commit();
 
         const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'externalIdentifier',
           userId,
         });
@@ -78,7 +76,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           const userIdA = databaseBuilder.factory.buildUser().id;
           const userIdB = databaseBuilder.factory.buildUser().id;
           const authenticationMethodA = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: 'alreadyExistingExternalIdentifier',
             userId: userIdA,
           });
@@ -86,7 +83,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethodA);
           await databaseBuilder.commit();
           const authenticationMethodB = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: 'alreadyExistingExternalIdentifier',
             userId: userIdB,
           });
@@ -108,7 +104,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const authenticationMethodA = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'someIdentifierA',
           userId,
         });
@@ -116,7 +111,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethodA);
         await databaseBuilder.commit();
         const authenticationMethodB = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'someIdentifierB',
           userId,
         });
@@ -137,7 +131,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
       const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
         externalIdentifier: 'externalIdentifier',
         userId,
       });
@@ -281,14 +274,12 @@ describe('Integration | Repository | AuthenticationMethod', function () {
   describe('#findOneByUserIdAndIdentityProvider', function () {
     it('should return the AuthenticationMethod associated to a user for a given identity provider', async function () {
       // given
-      const identityProvider = AuthenticationMethod.identityProviders.GAR;
       const userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         userId,
       });
       const garAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         id: 123,
-        identityProvider,
         userId,
       });
       garAuthenticationMethod.authenticationComplement = undefined;
@@ -297,7 +288,10 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
       // when
       const authenticationMethodsByUserIdAndIdentityProvider =
-        await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId, identityProvider });
+        await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+          userId,
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
+        });
 
       // then
       expect(authenticationMethodsByUserIdAndIdentityProvider).to.deepEqualInstance(garAuthenticationMethod);
@@ -327,20 +321,17 @@ describe('Integration | Repository | AuthenticationMethod', function () {
   describe('#findOneByExternalIdentifierAndIdentityProvider', function () {
     it('should return the AuthenticationMethod for a given external identifier and identity provider', async function () {
       // given
-      const identityProvider = AuthenticationMethod.identityProviders.GAR;
       const externalIdentifier = 'samlId';
       const userId = databaseBuilder.factory.buildUser().id;
       const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         id: 123,
         externalIdentifier,
-        identityProvider,
         userId,
       });
       authenticationMethod.authenticationComplement = undefined;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethod);
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         externalIdentifier: 'another_sub',
-        identityProvider,
       });
       await databaseBuilder.commit();
 
@@ -348,7 +339,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const authenticationMethodsByTypeAndValue =
         await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({
           externalIdentifier,
-          identityProvider,
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
         });
 
       // then
@@ -356,15 +347,11 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     });
 
     it('should return null if there is no AuthenticationMethods for the given external identifier and identity provider', async function () {
-      // given
-      const identityProvider = AuthenticationMethod.identityProviders.GAR;
-      const externalIdentifier = 'samlId';
-
-      // when
+      // given & when
       const authenticationMethodsByTypeAndValue =
         await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({
-          externalIdentifier,
-          identityProvider,
+          externalIdentifier: 'samlId',
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
         });
 
       // then
@@ -378,7 +365,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'old_value',
           userId,
         });
@@ -404,7 +390,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'old_value',
           userId,
         });
@@ -581,10 +566,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should not replace an existing authenticationMethod with a different identity provider', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-        userId,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
-      });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId });
       await databaseBuilder.commit();
       await authenticationMethodRepository.createPasswordThatShouldBeChanged({
         userId,
@@ -821,10 +803,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return false if user have no authenticationMethod with an IdentityProvider PIX ', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-        userId,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
-      });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId });
       await databaseBuilder.commit();
 
       // when
@@ -841,17 +820,18 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should delete from database the authentication method by userId and identityProvider', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      const identityProvider = AuthenticationMethod.identityProviders.GAR;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         id: 123,
-        identityProvider,
         externalIdentifier: 'externalIdentifier',
         userId,
       });
       await databaseBuilder.commit();
 
       // when
-      await authenticationMethodRepository.removeByUserIdAndIdentityProvider({ userId, identityProvider });
+      await authenticationMethodRepository.removeByUserIdAndIdentityProvider({
+        userId,
+        identityProvider: AuthenticationMethod.identityProviders.GAR,
+      });
 
       // then
       const result = await knex('authentication-methods').where({ id: 123 }).first();
@@ -865,7 +845,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       const secondAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         id: 456,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
         externalIdentifier: 'externalIdentifier',
         userId,
       });

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -189,11 +189,12 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should return the updated AuthenticationMethod', async function () {
       // given
-      const originalAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-        id: 123,
-        userId,
-        hashedPassword,
-      });
+      const originalAuthenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          id: 123,
+          userId,
+          hashedPassword,
+        });
       databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword(
         originalAuthenticationMethod
       );
@@ -206,12 +207,13 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       });
 
       // then
-      const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-        id: 123,
-        userId,
-        hashedPassword: newHashedPassword,
-        updatedAt: new Date(),
-      });
+      const expectedAuthenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          id: 123,
+          userId,
+          hashedPassword: newHashedPassword,
+          updatedAt: new Date(),
+        });
       expect(updatedAuthenticationMethod).to.deepEqualInstance(expectedAuthenticationMethod);
     });
 
@@ -473,12 +475,13 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should return an updated AuthenticationMethod', async function () {
       // given
-      const originalAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-        id: 123,
-        userId,
-        hashedPassword,
-        shouldChangePassword: false,
-      });
+      const originalAuthenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          id: 123,
+          userId,
+          hashedPassword,
+          shouldChangePassword: false,
+        });
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(originalAuthenticationMethod);
       await databaseBuilder.commit();
 
@@ -489,13 +492,14 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       });
 
       // then
-      const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-        id: 123,
-        userId,
-        hashedPassword: newHashedPassword,
-        shouldChangePassword: true,
-        updatedAt: new Date(),
-      });
+      const expectedAuthenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          id: 123,
+          userId,
+          hashedPassword: newHashedPassword,
+          shouldChangePassword: true,
+          updatedAt: new Date(),
+        });
       expect(updatedAuthenticationMethod).to.deepEqualInstance(expectedAuthenticationMethod);
     });
 
@@ -665,13 +669,14 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should return the updated AuthenticationMethod', async function () {
       // given
-      const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-        id: 123,
-        userId,
-        hashedPassword: newHashedPassword,
-        shouldChangePassword: false,
-        updatedAt: new Date(),
-      });
+      const expectedAuthenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          id: 123,
+          userId,
+          hashedPassword: newHashedPassword,
+          shouldChangePassword: false,
+          updatedAt: new Date(),
+        });
 
       // when
       const updatedAuthenticationMethod = await authenticationMethodRepository.updateExpiredPassword({
@@ -862,11 +867,12 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       });
       secondAuthenticationMethod.authenticationComplement = undefined;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(secondAuthenticationMethod);
-      const firstAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-        id: 123,
-        userId,
-        hashedPassword: 'Hello',
-      });
+      const firstAuthenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          id: 123,
+          userId,
+          hashedPassword: 'Hello',
+        });
       databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         ...firstAuthenticationMethod,
         hashedPassword: 'Hello',

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -702,7 +702,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       beforeEach(function () {
         const userId = databaseBuilder.factory.buildUser().id;
         poleEmploiAuthenticationMethod =
-          databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
             id: 123,
             externalIdentifier: 'identifier',
             accessToken: 'to_be_updated',

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -83,7 +83,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
             userId: userIdA,
           });
           delete authenticationMethodA.id;
-          databaseBuilder.factory.buildAuthenticationMethod(authenticationMethodA);
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethodA);
           await databaseBuilder.commit();
           const authenticationMethodB = domainBuilder.buildAuthenticationMethod({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
@@ -113,7 +113,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           userId,
         });
         delete authenticationMethodA.id;
-        databaseBuilder.factory.buildAuthenticationMethod(authenticationMethodA);
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethodA);
         await databaseBuilder.commit();
         const authenticationMethodB = domainBuilder.buildAuthenticationMethod({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
@@ -286,7 +286,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       });
       const garAuthenticationMethod = domainBuilder.buildAuthenticationMethod({ id: 123, identityProvider, userId });
       garAuthenticationMethod.authenticationComplement = undefined;
-      databaseBuilder.factory.buildAuthenticationMethod(garAuthenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(garAuthenticationMethod);
       await databaseBuilder.commit();
 
       // when
@@ -300,7 +300,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return null if there is no AuthenticationMethod for the given user and identity provider', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
         userId,
       });
@@ -331,8 +331,11 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         userId,
       });
       authenticationMethod.authenticationComplement = undefined;
-      databaseBuilder.factory.buildAuthenticationMethod(authenticationMethod);
-      databaseBuilder.factory.buildAuthenticationMethod({ externalIdentifier: 'another_sub', identityProvider });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+        externalIdentifier: 'another_sub',
+        identityProvider,
+      });
       await databaseBuilder.commit();
 
       // when
@@ -374,7 +377,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           userId,
         });
         authenticationMethod.authenticationComplement = undefined;
-        databaseBuilder.factory.buildAuthenticationMethod(authenticationMethod);
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethod);
         await databaseBuilder.commit();
 
         // when
@@ -400,7 +403,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           userId,
         });
         authenticationMethod.authenticationComplement = undefined;
-        databaseBuilder.factory.buildAuthenticationMethod(authenticationMethod);
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethod);
         await databaseBuilder.commit();
 
         // when
@@ -476,7 +479,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         hashedPassword,
         shouldChangePassword: false,
       });
-      databaseBuilder.factory.buildAuthenticationMethod(originalAuthenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(originalAuthenticationMethod);
       await databaseBuilder.commit();
 
       // when
@@ -570,7 +573,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should not replace an existing authenticationMethod with a different identity provider', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         userId,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       });
@@ -809,7 +812,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return false if user have no authenticationMethod with an IdentityProvider PIX ', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         userId,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       });
@@ -830,7 +833,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const identityProvider = AuthenticationMethod.identityProviders.GAR;
-      databaseBuilder.factory.buildAuthenticationMethod({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         id: 123,
         identityProvider,
         externalIdentifier: 'externalIdentifier',
@@ -858,7 +861,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         userId,
       });
       secondAuthenticationMethod.authenticationComplement = undefined;
-      databaseBuilder.factory.buildAuthenticationMethod(secondAuthenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(secondAuthenticationMethod);
       const firstAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
         id: 123,
         userId,

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -300,10 +300,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return null if there is no AuthenticationMethod for the given user and identity provider', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-        identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
-        userId,
-      });
+      databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -28,7 +28,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();
 
-        const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'externalIdentifier',
           userId,
@@ -52,7 +52,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();
 
-        const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'externalIdentifier',
           userId,
@@ -77,7 +77,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           // given
           const userIdA = databaseBuilder.factory.buildUser().id;
           const userIdB = databaseBuilder.factory.buildUser().id;
-          const authenticationMethodA = domainBuilder.buildAuthenticationMethod({
+          const authenticationMethodA = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: 'alreadyExistingExternalIdentifier',
             userId: userIdA,
@@ -85,7 +85,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           delete authenticationMethodA.id;
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethodA);
           await databaseBuilder.commit();
-          const authenticationMethodB = domainBuilder.buildAuthenticationMethod({
+          const authenticationMethodB = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: 'alreadyExistingExternalIdentifier',
             userId: userIdB,
@@ -107,7 +107,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       it('should throw an AlreadyExistingEntityError', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const authenticationMethodA = domainBuilder.buildAuthenticationMethod({
+        const authenticationMethodA = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'someIdentifierA',
           userId,
@@ -115,7 +115,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         delete authenticationMethodA.id;
         databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(authenticationMethodA);
         await databaseBuilder.commit();
-        const authenticationMethodB = domainBuilder.buildAuthenticationMethod({
+        const authenticationMethodB = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'someIdentifierB',
           userId,
@@ -136,7 +136,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         identityProvider: AuthenticationMethod.identityProviders.GAR,
         externalIdentifier: 'externalIdentifier',
         userId,
@@ -286,7 +286,11 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         userId,
       });
-      const garAuthenticationMethod = domainBuilder.buildAuthenticationMethod({ id: 123, identityProvider, userId });
+      const garAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        id: 123,
+        identityProvider,
+        userId,
+      });
       garAuthenticationMethod.authenticationComplement = undefined;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement(garAuthenticationMethod);
       await databaseBuilder.commit();
@@ -326,7 +330,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const identityProvider = AuthenticationMethod.identityProviders.GAR;
       const externalIdentifier = 'samlId';
       const userId = databaseBuilder.factory.buildUser().id;
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         id: 123,
         externalIdentifier,
         identityProvider,
@@ -373,7 +377,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       it('should update external identifier by userId and identity provider', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'old_value',
           userId,
@@ -399,7 +403,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       it('should return the updated AuthenticationMethod', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'old_value',
           userId,
@@ -859,7 +863,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it("should return the user's authentication methods", async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      const secondAuthenticationMethod = domainBuilder.buildAuthenticationMethod({
+      const secondAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         id: 456,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
         externalIdentifier: 'externalIdentifier',

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -167,10 +167,11 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should update the password in database', async function () {
       // given
-      const authenticationMethodId = databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
-        userId,
-        hashedPassword,
-      }).id;
+      const authenticationMethodId =
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          userId,
+          hashedPassword,
+        }).id;
       await databaseBuilder.commit();
 
       // when
@@ -193,7 +194,9 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         userId,
         hashedPassword,
       });
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword(originalAuthenticationMethod);
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword(
+        originalAuthenticationMethod
+      );
       await databaseBuilder.commit();
 
       // when
@@ -214,7 +217,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should disable changing password', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         userId,
         hashedPassword,
         shouldChangePassword: true,
@@ -247,10 +250,11 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should be DomainTransaction compliant', async function () {
       // given
-      const authenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
-        userId,
-        hashedPassword,
-      });
+      const authenticationMethod =
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          userId,
+          hashedPassword,
+        });
       await databaseBuilder.commit();
 
       // when
@@ -277,7 +281,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // given
       const identityProvider = AuthenticationMethod.identityProviders.GAR;
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         userId,
       });
       const garAuthenticationMethod = domainBuilder.buildAuthenticationMethod({ id: 123, identityProvider, userId });
@@ -442,7 +446,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should update password in database and set shouldChangePassword to true', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         id: 123,
         userId,
         hashedPassword,
@@ -508,7 +512,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     it('should be DomainTransaction compliant', async function () {
       // given
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         id: 123,
         userId,
         hashedPassword,
@@ -632,7 +636,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
     beforeEach(async function () {
       userId = databaseBuilder.factory.buildUser({ shouldChangePassword: true }).id;
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         id: 123,
         userId,
         hashedPassword,
@@ -788,7 +792,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should return true if user have an authenticationMethod with an IdentityProvider PIX ', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         userId,
       });
       await databaseBuilder.commit();
@@ -860,7 +864,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         userId,
         hashedPassword: 'Hello',
       });
-      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         ...firstAuthenticationMethod,
         hashedPassword: 'Hello',
       });

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -86,7 +86,10 @@ describe('Integration | Repository | PoleEmploiSending', function () {
     context('when the participant has several authentication method', function () {
       it('should render only one sending', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        databaseBuilder.factory.buildAuthenticationMethod({ userId, identityProvider: 'PIX' });
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+          userId,
+          identityProvider: 'PIX',
+        });
         databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
           userId,
           externalIdentifier: 'idPoleEmploi',

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -86,11 +86,11 @@ describe('Integration | Repository | PoleEmploiSending', function () {
     context('when the participant has several authentication method', function () {
       it('should render only one sending', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
           userId,
           identityProvider: 'PIX',
         });
-        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
           userId,
           externalIdentifier: 'idPoleEmploi',
         });

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -87,7 +87,7 @@ describe('Integration | Repository | PoleEmploiSending', function () {
       it('should render only one sending', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         databaseBuilder.factory.buildAuthenticationMethod({ userId, identityProvider: 'PIX' });
-        databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
           userId,
           externalIdentifier: 'idPoleEmploi',
         });

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -2056,7 +2056,6 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
             user: { email: null, username: null },
           });
           databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: 'chucky',
             userId: schoolingRegistrationOfUserWithSamlId.userId,
           });
@@ -2187,7 +2186,6 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           email: null,
         });
         databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'samlId',
           userId: user.id,
         });

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -4,7 +4,6 @@ const { expect, domainBuilder, databaseBuilder, knex, catchErr } = require('../.
 
 const SchoolingRegistration = require('../../../../lib/domain/models/SchoolingRegistration');
 const UserWithSchoolingRegistration = require('../../../../lib/domain/models/UserWithSchoolingRegistration');
-const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 
 const {
   NotFoundError,

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -2055,7 +2055,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
             lastName: 'Norris',
             user: { email: null, username: null },
           });
-          databaseBuilder.factory.buildAuthenticationMethod({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
             identityProvider: AuthenticationMethod.identityProviders.GAR,
             externalIdentifier: 'chucky',
             userId: schoolingRegistrationOfUserWithSamlId.userId,
@@ -2186,7 +2186,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           username: null,
           email: null,
         });
-        databaseBuilder.factory.buildAuthenticationMethod({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: 'samlId',
           userId: user.id,

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -2054,7 +2054,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
             lastName: 'Norris',
             user: { email: null, username: null },
           });
-          databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+          databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
             externalIdentifier: 'chucky',
             userId: schoolingRegistrationOfUserWithSamlId.userId,
           });
@@ -2184,7 +2184,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
           username: null,
           email: null,
         });
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: 'samlId',
           userId: user.id,
         });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -167,7 +167,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
       beforeEach(async function () {
         userInDb = databaseBuilder.factory.buildUser();
-        databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
           externalIdentifier: externalIdentityId,
           userId: userInDb.id,
         });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -131,7 +131,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
       beforeEach(async function () {
         userInDb = databaseBuilder.factory.buildUser(userToInsert);
-        databaseBuilder.factory.buildAuthenticationMethod({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
           externalIdentifier: 'some-saml-id',
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           userId: userInDb.id,
@@ -648,11 +648,11 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       it('should return the user with his authentication methods', async function () {
         // given
         const userInDB = databaseBuilder.factory.buildUser(userToInsert);
-        databaseBuilder.factory.buildAuthenticationMethod({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.PIX,
           userId: userInDB.id,
         });
-        databaseBuilder.factory.buildAuthenticationMethod({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           userId: userInDB.id,
         });
@@ -863,7 +863,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
     beforeEach(async function () {
       userInDb = databaseBuilder.factory.buildUser(userToInsert);
-      databaseBuilder.factory.buildAuthenticationMethod({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
         identityProvider: AuthenticationMethod.identityProviders.GAR,
         externalIdentifier: 'samlId',
         userId: userInDb.id,

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -48,11 +48,12 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
     });
 
     userInDB = databaseBuilder.factory.buildUser(userToInsert);
-    passwordAuthenticationMethodInDB = databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({
-      userId: userInDB.id,
-      hashedPassword: 'ABCDEF1234',
-      shouldChangePassword: false,
-    });
+    passwordAuthenticationMethodInDB =
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        userId: userInDB.id,
+        hashedPassword: 'ABCDEF1234',
+        shouldChangePassword: false,
+      });
 
     organizationRoleInDB = Membership.roles.ADMIN;
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -133,7 +133,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         userInDb = databaseBuilder.factory.buildUser(userToInsert);
         databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
           externalIdentifier: 'some-saml-id',
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
           userId: userInDb.id,
         });
         await databaseBuilder.commit();
@@ -652,10 +651,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           identityProvider: AuthenticationMethod.identityProviders.PIX,
           userId: userInDB.id,
         });
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
-          userId: userInDB.id,
-        });
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: userInDB.id });
         await databaseBuilder.commit();
 
         // when
@@ -864,7 +860,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
     beforeEach(async function () {
       userInDb = databaseBuilder.factory.buildUser(userToInsert);
       databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
         externalIdentifier: 'samlId',
         userId: userInDb.id,
       });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -21,7 +21,6 @@ const CertificationCenter = require('../../../../lib/domain/models/Certification
 const CertificationCenterMembership = require('../../../../lib/domain/models/CertificationCenterMembership');
 const Organization = require('../../../../lib/domain/models/Organization');
 const SchoolingRegistrationForAdmin = require('../../../../lib/domain/read-models/SchoolingRegistrationForAdmin');
-const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
@@ -647,8 +646,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       it('should return the user with his authentication methods', async function () {
         // given
         const userInDB = databaseBuilder.factory.buildUser(userToInsert);
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
-          identityProvider: AuthenticationMethod.identityProviders.PIX,
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
           userId: userInDB.id,
         });
         databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: userInDB.id });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -48,7 +48,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
     userInDB = databaseBuilder.factory.buildUser(userToInsert);
     passwordAuthenticationMethodInDB =
-      databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId: userInDB.id,
         hashedPassword: 'ABCDEF1234',
         shouldChangePassword: false,
@@ -130,7 +130,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
       beforeEach(async function () {
         userInDb = databaseBuilder.factory.buildUser(userToInsert);
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
           externalIdentifier: 'some-saml-id',
           userId: userInDb.id,
         });
@@ -165,7 +165,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
       beforeEach(async function () {
         userInDb = databaseBuilder.factory.buildUser();
-        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
           externalIdentifier: externalIdentityId,
           userId: userInDb.id,
         });
@@ -646,10 +646,10 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       it('should return the user with his authentication methods', async function () {
         // given
         const userInDB = databaseBuilder.factory.buildUser(userToInsert);
-        databaseBuilder.factory.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           userId: userInDB.id,
         });
-        databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: userInDB.id });
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: userInDB.id });
         await databaseBuilder.commit();
 
         // when
@@ -857,7 +857,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
     beforeEach(async function () {
       userInDb = databaseBuilder.factory.buildUser(userToInsert);
-      databaseBuilder.factory.buildAuthenticationMethod.withGarAuthenticationComplement({
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
         externalIdentifier: 'samlId',
         userId: userInDb.id,
       });

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -60,7 +60,7 @@ buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword = functi
   });
 };
 
-buildAuthenticationMethod.buildWithHashedPassword = function ({
+buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword = function ({
   id,
   hashedPassword = 'hashedPassword',
   shouldChangePassword = false,

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -35,7 +35,7 @@ const buildAuthenticationMethod = function ({
   });
 };
 
-buildAuthenticationMethod.buildWithRawPassword = function ({
+buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword = function ({
   id,
   rawPassword = 'pix123',
   shouldChangePassword = false,

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -16,7 +16,7 @@ function _buildUser() {
 
 const buildAuthenticationMethod = {};
 
-buildAuthenticationMethod.withGarAuthenticationComplement = function ({
+buildAuthenticationMethod.withGarAsIdentityProvider = function ({
   id = 123,
   identityProvider = AuthenticationMethod.identityProviders.GAR,
   externalIdentifier = `externalId${id}`,
@@ -37,7 +37,7 @@ buildAuthenticationMethod.withGarAuthenticationComplement = function ({
   });
 };
 
-buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword = function ({
+buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword = function ({
   id,
   rawPassword = 'pix123',
   shouldChangePassword = false,
@@ -62,7 +62,7 @@ buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword = functi
   });
 };
 
-buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword = function ({
+buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword = function ({
   id,
   hashedPassword = 'hashedPassword',
   shouldChangePassword = false,
@@ -87,7 +87,7 @@ buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword = fun
   });
 };
 
-buildAuthenticationMethod.withPoleEmploiAuthenticationComplement = function ({
+buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   id,
   externalIdentifier = `externalId${id}`,
   accessToken = 'ABC456789',

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -14,7 +14,9 @@ function _buildUser() {
   });
 }
 
-const buildAuthenticationMethod = function ({
+const buildAuthenticationMethod = {};
+
+buildAuthenticationMethod.withGarAuthenticationComplement = function ({
   id = 123,
   identityProvider = AuthenticationMethod.identityProviders.GAR,
   externalIdentifier = `externalId${id}`,

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -85,7 +85,7 @@ buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword = fun
   });
 };
 
-buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod = function ({
+buildAuthenticationMethod.withPoleEmploiAuthenticationComplement = function ({
   id,
   externalIdentifier = `externalId${id}`,
   accessToken = 'ABC456789',

--- a/api/tests/tooling/domain-builder/factory/build-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-user.js
@@ -22,7 +22,7 @@ module.exports = function buildUser({
   pixRoles = [buildPixRole()],
   memberships = [buildMembership()],
   certificationCenterMemberships = [buildCertificationCenterMembership()],
-  authenticationMethods = [buildAuthenticationMethod.withGarAuthenticationComplement()],
+  authenticationMethods = [buildAuthenticationMethod.withGarAsIdentityProvider()],
 } = {}) {
   return new User({
     id,

--- a/api/tests/tooling/domain-builder/factory/build-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-user.js
@@ -22,7 +22,7 @@ module.exports = function buildUser({
   pixRoles = [buildPixRole()],
   memberships = [buildMembership()],
   certificationCenterMemberships = [buildCertificationCenterMembership()],
-  authenticationMethods = [buildAuthenticationMethod.withGarAsIdentityProvider()],
+  authenticationMethods = [buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword()],
 } = {}) {
   return new User({
     id,

--- a/api/tests/tooling/domain-builder/factory/build-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-user.js
@@ -22,7 +22,7 @@ module.exports = function buildUser({
   pixRoles = [buildPixRole()],
   memberships = [buildMembership()],
   certificationCenterMemberships = [buildCertificationCenterMembership()],
-  authenticationMethods = [buildAuthenticationMethod()],
+  authenticationMethods = [buildAuthenticationMethod.withGarAuthenticationComplement()],
 } = {}) {
   return new User({
     id,

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -983,7 +983,7 @@ describe('Unit | Controller | user-controller', function () {
       // given
       const user = domainBuilder.buildUser();
       const authenticationMethods = [
-        domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId: user.id }),
+        domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId: user.id }),
       ];
 
       const responseSerialized = Symbol('an response serialized');

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -248,7 +248,7 @@ describe('Unit | Domain | Models | User', function () {
         const oneTimePassword = 'Azerty123*';
 
         const pixAuthenticationMethod =
-          domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
             hashedPassword: oneTimePassword,
             shouldChangePassword: true,
           });
@@ -269,7 +269,7 @@ describe('Unit | Domain | Models | User', function () {
       it('should return false when should not change password', function () {
         // given
         const pixAuthenticationMethod =
-          domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
             shouldChangePassword: false,
           });
 
@@ -291,7 +291,7 @@ describe('Unit | Domain | Models | User', function () {
       it('should return null', function () {
         // given
         const poleEmploiAuthenticationMethod =
-          domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement();
+          domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider();
 
         const user = new User({
           id: 1,

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -291,7 +291,7 @@ describe('Unit | Domain | Models | User', function () {
       it('should return null', function () {
         // given
         const poleEmploiAuthenticationMethod =
-          domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod();
+          domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement();
 
         const user = new User({
           id: 1,

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -247,10 +247,11 @@ describe('Unit | Domain | Models | User', function () {
         // given
         const oneTimePassword = 'Azerty123*';
 
-        const pixAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-          hashedPassword: oneTimePassword,
-          shouldChangePassword: true,
-        });
+        const pixAuthenticationMethod =
+          domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+            hashedPassword: oneTimePassword,
+            shouldChangePassword: true,
+          });
 
         const user = new User({
           id: 1,
@@ -267,9 +268,10 @@ describe('Unit | Domain | Models | User', function () {
 
       it('should return false when should not change password', function () {
         // given
-        const pixAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-          shouldChangePassword: false,
-        });
+        const pixAuthenticationMethod =
+          domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+            shouldChangePassword: false,
+          });
 
         const user = new User({
           id: 1,

--- a/api/tests/unit/domain/services/authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication-service_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Services | authentication-service', function () {
 
     beforeEach(function () {
       user = domainBuilder.buildUser({ username });
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword({
         userId: user.id,
         rawPassword: password,
       });

--- a/api/tests/unit/domain/services/authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication-service_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Services | authentication-service', function () {
 
     beforeEach(function () {
       user = domainBuilder.buildUser({ username });
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithRawPassword({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword({
         userId: user.id,
         rawPassword: password,
       });

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -44,7 +44,9 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     it('should return authenticated with samlId when user is authenticated with samlId only', async function () {
       // given
       const user = domainBuilder.buildUser();
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        userId: user.id,
+      });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 
       // when
@@ -84,7 +86,9 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
       const username = 'john.harry.0702';
       const email = 'john.harry@example.net';
       const user = new User({ username, email });
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        userId: user.id,
+      });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 
       // when

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -44,7 +44,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     it('should return authenticated with samlId when user is authenticated with samlId only', async function () {
       // given
       const user = domainBuilder.buildUser();
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         userId: user.id,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       });
@@ -65,7 +65,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
       // given
       const username = 'john.harry.0702';
       const user = new User({ username });
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         userId: user.id,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       });
@@ -87,7 +87,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
       const username = 'john.harry.0702';
       const email = 'john.harry@example.net';
       const user = new User({ username, email });
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         userId: user.id,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       });

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -44,10 +44,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     it('should return authenticated with samlId when user is authenticated with samlId only', async function () {
       // given
       const user = domainBuilder.buildUser();
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-        userId: user.id,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
-      });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 
       // when
@@ -87,10 +84,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
       const username = 'john.harry.0702';
       const email = 'john.harry@example.net';
       const user = new User({ username, email });
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-        userId: user.id,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
-      });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 
       // when

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -44,7 +44,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
     it('should return authenticated with samlId when user is authenticated with samlId only', async function () {
       // given
       const user = domainBuilder.buildUser();
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         userId: user.id,
       });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
@@ -64,7 +64,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
       // given
       const username = 'john.harry.0702';
       const user = new User({ username });
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         userId: user.id,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       });
@@ -86,7 +86,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
       const username = 'john.harry.0702';
       const email = 'john.harry@example.net';
       const user = new User({ username, email });
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         userId: user.id,
       });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -116,7 +116,7 @@ describe('Unit | Service | user-service', function () {
 
     beforeEach(async function () {
       user = domainBuilder.buildUser();
-      authenticationMethod = domainBuilder.buildAuthenticationMethod({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         externalIdentifier: samlId,
         userId: user.id,
       });

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -46,7 +46,7 @@ describe('Unit | Service | user-service', function () {
   describe('#createUserWithPassword', function () {
     beforeEach(function () {
       user = domainBuilder.buildUser();
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId: user.id,
         hashedPassword,
       });
@@ -77,7 +77,7 @@ describe('Unit | Service | user-service', function () {
   describe('#updateUsernameAndAddPassword', function () {
     beforeEach(function () {
       user = domainBuilder.buildUser();
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId: user.id,
         hashedPassword,
       });
@@ -116,7 +116,7 @@ describe('Unit | Service | user-service', function () {
 
     beforeEach(async function () {
       user = domainBuilder.buildUser();
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         externalIdentifier: samlId,
         userId: user.id,
       });

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -46,7 +46,7 @@ describe('Unit | Service | user-service', function () {
   describe('#createUserWithPassword', function () {
     beforeEach(function () {
       user = domainBuilder.buildUser();
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         userId: user.id,
         hashedPassword,
       });
@@ -77,7 +77,7 @@ describe('Unit | Service | user-service', function () {
   describe('#updateUsernameAndAddPassword', function () {
     beforeEach(function () {
       user = domainBuilder.buildUser();
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
+      authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
         userId: user.id,
         hashedPassword,
       });

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
@@ -49,7 +49,9 @@ describe('Unit | Usecases | update-user-account', function () {
       const hashedPassword = 'hashedpassword';
 
       const user = domainBuilder.buildUser({ id: 1234, email: null });
-      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id });
+      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+        userId: user.id,
+      });
 
       scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand.resolves({ userId: user.id });
       encryptionService.hashPassword.withArgs(password).resolves(hashedPassword);

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
@@ -98,10 +98,7 @@ describe('Unit | Usecases | update-user-account', function () {
         username: 'manuella.philippe0702',
       });
       const authenticationMethodFromGAR =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
-          userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.PIX,
-        });
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId: user.id });
 
       scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand.resolves({ userId: user.id });
       encryptionService.hashPassword.withArgs(password).resolves(hashedPassword);
@@ -143,10 +140,7 @@ describe('Unit | Usecases | update-user-account', function () {
       username: 'manuella.philippe0702',
     });
     const authenticationMethodFromGAR =
-      domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
-        userId: user.id,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
-      });
+      domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId: user.id });
 
     scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand
       .withArgs({

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
@@ -49,7 +49,7 @@ describe('Unit | Usecases | update-user-account', function () {
       const hashedPassword = 'hashedpassword';
 
       const user = domainBuilder.buildUser({ id: 1234, email: null });
-      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod({
+      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         userId: user.id,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       });

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
@@ -98,10 +98,11 @@ describe('Unit | Usecases | update-user-account', function () {
         email: null,
         username: 'manuella.philippe0702',
       });
-      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-        userId: user.id,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
-      });
+      const authenticationMethodFromGAR =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.PIX,
+        });
 
       scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand.resolves({ userId: user.id });
       encryptionService.hashPassword.withArgs(password).resolves(hashedPassword);
@@ -142,10 +143,11 @@ describe('Unit | Usecases | update-user-account', function () {
       email: null,
       username: 'manuella.philippe0702',
     });
-    const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-      userId: user.id,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
-    });
+    const authenticationMethodFromGAR =
+      domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        userId: user.id,
+        identityProvider: AuthenticationMethod.identityProviders.PIX,
+      });
 
     scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand
       .withArgs({

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
@@ -49,7 +49,7 @@ describe('Unit | Usecases | update-user-account', function () {
       const hashedPassword = 'hashedpassword';
 
       const user = domainBuilder.buildUser({ id: 1234, email: null });
-      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
+      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         userId: user.id,
       });
 
@@ -98,7 +98,7 @@ describe('Unit | Usecases | update-user-account', function () {
         username: 'manuella.philippe0702',
       });
       const authenticationMethodFromGAR =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId: user.id });
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId: user.id });
 
       scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand.resolves({ userId: user.id });
       encryptionService.hashPassword.withArgs(password).resolves(hashedPassword);
@@ -140,7 +140,7 @@ describe('Unit | Usecases | update-user-account', function () {
       username: 'manuella.philippe0702',
     });
     const authenticationMethodFromGAR =
-      domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId: user.id });
+      domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId: user.id });
 
     scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand
       .withArgs({

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-account_test.js
@@ -49,10 +49,7 @@ describe('Unit | Usecases | update-user-account', function () {
       const hashedPassword = 'hashedpassword';
 
       const user = domainBuilder.buildUser({ id: 1234, email: null });
-      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-        userId: user.id,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
-      });
+      const authenticationMethodFromGAR = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId: user.id });
 
       scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand.resolves({ userId: user.id });
       encryptionService.hashPassword.withArgs(password).resolves(hashedPassword);

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -426,10 +426,11 @@ function createUserWithValidCredentialsWhoShouldChangePassword({
   userRepository,
 }) {
   const email = 'john.doe@example.net';
-  const emailAuthenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({
-    hashedPassword: oneTimePassword,
-    shouldChangePassword: true,
-  });
+  const emailAuthenticationMethod =
+    domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+      hashedPassword: oneTimePassword,
+      shouldChangePassword: true,
+    });
 
   const user = domainBuilder.buildUser({
     email,

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -426,11 +426,10 @@ function createUserWithValidCredentialsWhoShouldChangePassword({
   userRepository,
 }) {
   const email = 'john.doe@example.net';
-  const emailAuthenticationMethod =
-    domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
-      hashedPassword: oneTimePassword,
-      shouldChangePassword: true,
-    });
+  const emailAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+    hashedPassword: oneTimePassword,
+    shouldChangePassword: true,
+  });
 
   const user = domainBuilder.buildUser({
     email,

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -323,7 +323,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           // given
           const { poleEmploiTokens } = _fakePoleEmploiAPI({ authenticationService });
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
-            domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+            domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
               externalIdentifier: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
             })
           );
@@ -362,7 +362,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           _fakePoleEmploiAPI({ authenticationService });
 
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
-            domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+            domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
               externalIdentifier: 'other_external_identifier',
             })
           );

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -323,7 +323,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           // given
           const { poleEmploiTokens } = _fakePoleEmploiAPI({ authenticationService });
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
-            domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+            domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
               externalIdentifier: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
             })
           );
@@ -362,7 +362,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           _fakePoleEmploiAPI({ authenticationService });
 
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
-            domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({
+            domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
               externalIdentifier: 'other_external_identifier',
             })
           );

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -185,11 +185,12 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
     it('should throw UserShouldChangePasswordError', async function () {
       // given
       const user = domainBuilder.buildUser({ email: userEmail });
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithRawPassword({
-        userId: user.id,
-        rawPassword: password,
-        shouldChangePassword: true,
-      });
+      const authenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword({
+          userId: user.id,
+          rawPassword: password,
+          shouldChangePassword: true,
+        });
       user.authenticationMethods = [authenticationMethod];
 
       authenticationService.getUserByUsernameAndPassword.resolves(user);

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -185,12 +185,11 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
     it('should throw UserShouldChangePasswordError', async function () {
       // given
       const user = domainBuilder.buildUser({ email: userEmail });
-      const authenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword({
-          userId: user.id,
-          rawPassword: password,
-          shouldChangePassword: true,
-        });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword({
+        userId: user.id,
+        rawPassword: password,
+        shouldChangePassword: true,
+      });
       user.authenticationMethods = [authenticationMethod];
 
       authenticationService.getUserByUsernameAndPassword.resolves(user);

--- a/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
@@ -207,7 +207,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', function () {
       };
       authenticationService.getPoleEmploiUserInfo.withArgs(poleEmploiTokens.idToken).resolves(decodedUserInfo);
 
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId });
       authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider
         .withArgs({
           externalIdentifier: decodedUserInfo.externalIdentityId,

--- a/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
@@ -207,7 +207,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', function () {
       };
       authenticationService.getPoleEmploiUserInfo.withArgs(poleEmploiTokens.idToken).resolves(decodedUserInfo);
 
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod({ userId });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId });
       authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider
         .withArgs({
           externalIdentifier: decodedUserInfo.externalIdentityId,

--- a/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
@@ -207,7 +207,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', function () {
       };
       authenticationService.getPoleEmploiUserInfo.withArgs(poleEmploiTokens.idToken).resolves(decodedUserInfo);
 
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId });
       authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider
         .withArgs({
           externalIdentifier: decodedUserInfo.externalIdentityId,

--- a/api/tests/unit/domain/usecases/find-user-authentication-methods.js
+++ b/api/tests/unit/domain/usecases/find-user-authentication-methods.js
@@ -9,7 +9,7 @@ describe('Unit | UseCase | find-user-authentication-methods', function () {
     };
 
     const user = domainBuilder.buildUser();
-    domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId: user.id });
+    domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId: user.id });
 
     // when
     await findUserAuthenticationMethods({ userId: user.id, authenticationMethodRepository });

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -21,7 +21,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
 
   function buildPIXAndGARAndPoleEmploiAuthenticationMethod(userId) {
     return [
-      domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ userId }),
+      domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId }),
       domainBuilder.buildAuthenticationMethod({
         userId,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
@@ -183,7 +183,8 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       // given
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ userId: user.id });
+      const authenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId: user.id });
       authenticationMethodRepository.findByUserId.resolves([authenticationMethod]);
 
       // when
@@ -202,7 +203,8 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       // given
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ userId: user.id });
+      const authenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId: user.id });
       authenticationMethodRepository.findByUserId.resolves([authenticationMethod]);
 
       // when

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -26,7 +26,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
         userId,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       }),
-      domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId }),
+      domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId }),
     ];
   }
 

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -21,9 +21,9 @@ describe('Unit | UseCase | remove-authentication-method', function () {
 
   function buildPIXAndGARAndPoleEmploiAuthenticationMethod(userId) {
     return [
-      domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId }),
-      domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId }),
-      domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId }),
+      domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId }),
+      domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId }),
+      domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId }),
     ];
   }
 
@@ -180,8 +180,9 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       // given
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
-      const authenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId: user.id });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+        userId: user.id,
+      });
       authenticationMethodRepository.findByUserId.resolves([authenticationMethod]);
 
       // when
@@ -200,8 +201,9 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       // given
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
-      const authenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId: user.id });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+        userId: user.id,
+      });
       authenticationMethodRepository.findByUserId.resolves([authenticationMethod]);
 
       // when

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
   function buildPIXAndGARAndPoleEmploiAuthenticationMethod(userId) {
     return [
       domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId }),
-      domainBuilder.buildAuthenticationMethod({
+      domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
         userId,
         identityProvider: AuthenticationMethod.identityProviders.GAR,
       }),

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -22,10 +22,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
   function buildPIXAndGARAndPoleEmploiAuthenticationMethod(userId) {
     return [
       domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({ userId }),
-      domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({
-        userId,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
-      }),
+      domainBuilder.buildAuthenticationMethod.withGarAuthenticationComplement({ userId }),
       domainBuilder.buildAuthenticationMethod.withPoleEmploiAuthenticationComplement({ userId }),
     ];
   }

--- a/api/tests/unit/domain/usecases/send-verification-code_test.js
+++ b/api/tests/unit/domain/usecases/send-verification-code_test.js
@@ -55,7 +55,11 @@ describe('Unit | UseCase | send-verification-code', function () {
         userId,
         identityProvider: AuthenticationMethod.identityProviders.PIX,
       })
-      .resolves(domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ hashedPassword: passwordHash }));
+      .resolves(
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          hashedPassword: passwordHash,
+        })
+      );
     encryptionService.checkPassword.withArgs({ password, passwordHash }).resolves();
     codeUtils.generateNumericalString.withArgs(6).returns(code);
 
@@ -95,7 +99,11 @@ describe('Unit | UseCase | send-verification-code', function () {
         userId,
         identityProvider: AuthenticationMethod.identityProviders.PIX,
       })
-      .resolves(domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ hashedPassword: passwordHash }));
+      .resolves(
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          hashedPassword: passwordHash,
+        })
+      );
     encryptionService.checkPassword.withArgs({ password, passwordHash }).resolves();
     codeUtils.generateNumericalString.withArgs(6).returns(code);
 
@@ -164,7 +172,11 @@ describe('Unit | UseCase | send-verification-code', function () {
         userId,
         identityProvider: AuthenticationMethod.identityProviders.PIX,
       })
-      .resolves(domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ hashedPassword: passwordHash }));
+      .resolves(
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+          hashedPassword: passwordHash,
+        })
+      );
     encryptionService.checkPassword.withArgs({ password, passwordHash }).rejects();
 
     // when

--- a/api/tests/unit/domain/usecases/send-verification-code_test.js
+++ b/api/tests/unit/domain/usecases/send-verification-code_test.js
@@ -56,7 +56,7 @@ describe('Unit | UseCase | send-verification-code', function () {
         identityProvider: AuthenticationMethod.identityProviders.PIX,
       })
       .resolves(
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           hashedPassword: passwordHash,
         })
       );
@@ -100,7 +100,7 @@ describe('Unit | UseCase | send-verification-code', function () {
         identityProvider: AuthenticationMethod.identityProviders.PIX,
       })
       .resolves(
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           hashedPassword: passwordHash,
         })
       );
@@ -173,7 +173,7 @@ describe('Unit | UseCase | send-verification-code', function () {
         identityProvider: AuthenticationMethod.identityProviders.PIX,
       })
       .resolves(
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndHashedPassword({
+        domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
           hashedPassword: passwordHash,
         })
       );

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | update-expired-password', function () {
 
   beforeEach(function () {
     user = domainBuilder.buildUser({ username });
-    const authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithRawPassword({
+    const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword({
       userId: user.id,
       rawPassword: expiredPassword,
       shouldChangePassword: true,
@@ -104,11 +104,12 @@ describe('Unit | UseCase | update-expired-password', function () {
   context('When changing password is not required', function () {
     it('should throw ForbiddenAccess when shouldChangePassword is false', async function () {
       // given
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithRawPassword({
-        userId: user.id,
-        rawPassword: expiredPassword,
-        shouldChangePassword: false,
-      });
+      const authenticationMethod =
+        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword({
+          userId: user.id,
+          rawPassword: expiredPassword,
+          shouldChangePassword: false,
+        });
       user.authenticationMethods = [authenticationMethod];
 
       authenticationService.getUserByUsernameAndPassword.resolves(user);

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | update-expired-password', function () {
 
   beforeEach(function () {
     user = domainBuilder.buildUser({ username });
-    const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword({
+    const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword({
       userId: user.id,
       rawPassword: expiredPassword,
       shouldChangePassword: true,
@@ -104,12 +104,11 @@ describe('Unit | UseCase | update-expired-password', function () {
   context('When changing password is not required', function () {
     it('should throw ForbiddenAccess when shouldChangePassword is false', async function () {
       // given
-      const authenticationMethod =
-        domainBuilder.buildAuthenticationMethod.withPixAuthenticationComplementAndRawPassword({
-          userId: user.id,
-          rawPassword: expiredPassword,
-          shouldChangePassword: false,
-        });
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword({
+        userId: user.id,
+        rawPassword: expiredPassword,
+        shouldChangePassword: false,
+      });
       user.authenticationMethods = [authenticationMethod];
 
       authenticationService.getUserByUsernameAndPassword.resolves(user);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/authentication-methods-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/authentication-methods-serializer_test.js
@@ -8,7 +8,7 @@ describe('Unit | Serializer | JSONAPI | authentication-methods-serializer', func
       // given
       const user = domainBuilder.buildUser();
       const authenticationMethods = [
-        domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId: user.id }),
+        domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId: user.id }),
       ];
 
       // when


### PR DESCRIPTION
## 🎃  Problème
Les helpers pour builder des authentications methods sont difficiles à comprendre : 
- le builder de base (`buildAuthenticationMethod`) construit une méthode d'authentification par le GAR mais le GAR n'est pas considéré comme la méthode par défaut d'authentification (c'est plutôt un cas spécifique pour les étudiants)
- le builder `buildAuthenticationMethod.buildWithRawPassword` ne spécifie pas qu'il construit une méthode de connexion via PIX
- le builder `buildAuthenticationMethod.buildWithHashedPassword` ne spécifie pas qu'il construit une méthode de connexion via PIX
- et le builder `buildPoleEmploiAuthenticationMethod` parle de construire une méthode d'authentification Pole Emploi, mais pour être plus exact, Pole Emploi est un complément d'authentification et non la méthode d'authentification (voir le model AuthentificationMethod)

## 🕸️  Solution
Rajouter un builder spécifique pour le GAR. Renommer les builders existant pour qu'ils reflètent plus le model d'AuthentificationMethod.

## 👻  Pour tester
Lancer les tests.
