### PR TITLE
[FEATURE] Ajout d'un pied de page (footer) dans Pix Certif (PIX-3548)

### DIFF
--- a/certif/app/components/layout/footer.hbs
+++ b/certif/app/components/layout/footer.hbs
@@ -1,0 +1,29 @@
+<footer class="footer">
+  <nav class="footer__navigation">
+    <ul class="footer__navigation-list">
+      <li>
+        <a href="https://pix.fr/mentions-legales/"
+           target="_blank"
+           class="footer-navigation__item"
+           rel="noopener noreferrer"
+        >
+          Mentions légales
+        </a>
+      </li>
+
+      <li>
+        <a href="https://pix.fr/accessibilite-pix-certif/"
+           target="_blank"
+           class="footer-navigation__item"
+           rel="noopener noreferrer"
+        >
+          Accessibilité : non conforme
+        </a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="footer__copyright">
+    <span>© {{ this.currentYear }} Pix</span>
+  </div>
+</footer>

--- a/certif/app/components/layout/footer.js
+++ b/certif/app/components/layout/footer.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+
+export default class Footer extends Component {
+  get currentYear() {
+    const date = new Date();
+    return date.getFullYear().toString();
+  }
+}

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -29,6 +29,7 @@
 @import "components/ember-cli-notifications-ie-fallback";
 @import "components/add-issue-report-modal";
 @import "components/certification-candidate-details-modal";
+@import "components/layout/footer";
 @import "components/login-form";
 @import "components/finalize";
 @import "components/new-certification-candidate-modal";
@@ -41,7 +42,8 @@
 @import "components/dropdown";
 @import "components/user-logged-menu";
 
-body, html{
+body,
+html {
   margin: 0;
   min-height: 100%;
   min-height: 100vh;

--- a/certif/app/styles/components/layout/footer.scss
+++ b/certif/app/styles/components/layout/footer.scss
@@ -1,0 +1,71 @@
+.footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  margin: 0 35px;
+  border-top: 1px solid $grey-20;
+
+  @include device-is('desktop') {
+    flex-direction: row;
+  }
+
+  &__navigation {
+    display: flex;
+    flex-direction: column;
+
+    @include device-is('desktop') {
+      flex-direction: row;
+    }
+
+    &-list {
+      list-style: none;
+      display: flex;
+      padding: 0;
+
+      li {
+        align-self: center;
+        display: inline;
+        padding: 0;
+      }
+    }
+  }
+
+  &__copyright {
+    color: $grey-50;
+    cursor: default;
+    font-size: 0.75rem;
+    font-family: $roboto;
+    padding: 16px 0;
+  }
+}
+
+.footer-navigation {
+
+  &__item {
+    margin-right: 3px;
+    color: $grey-60;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    font-family: $roboto;
+    text-decoration: none;
+
+    @include device-is('desktop') {
+      margin-right: 12px;
+    }
+
+    &.active {
+      color: $blue;
+    }
+
+    &:focus {
+      color: $grey-50;
+    }
+
+    &:hover {
+      cursor: pointer;
+      color: $blue;
+    }
+  }
+}

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -46,6 +46,7 @@
       {{outlet}}
     </div>
 
+    <Layout::Footer />
   </div>
 
   <NotificationContainer @position="bottom-right" />

--- a/certif/tests/integration/components/layout/footer_test.js
+++ b/certif/tests/integration/components/layout/footer_test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+
+module('Integration | Component | Layout::Footer', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('should display copyright with current year', async function(assert) {
+    //given
+    const date = new Date();
+    const expectedYear = date.getFullYear().toString();
+
+    // when
+    await render(hbs`<Layout::Footer />}`);
+
+    // then
+    assert.contains(`© ${expectedYear} Pix`);
+  });
+
+  test('should display legal notice link', async function(assert) {
+    // when
+    await render(hbs`<Layout::Footer />}`);
+
+    // then
+    assert.contains('Mentions légales');
+    assert.dom('a[href="https://pix.fr/mentions-legales/"]').exists();
+  });
+
+  test('should display accessibility link', async function(assert) {
+    // when
+    await render(hbs`<Layout::Footer />}`);
+
+    // then
+    assert.contains('Accessibilité : non conforme');
+    assert.dom('a[href="https://pix.fr/accessibilite-pix-certif/"]').exists();
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Aujourd'hui, aucun pied de page n'existe dans Pix Certif. Or, on a besoin d'ajouter quelque part les mentions légales, les CGUs, une page accessibilité etc.

## :robot: Solution

Ajouter un pied de page.

![image-20210929-125425](https://user-images.githubusercontent.com/5627688/136800611-2a977429-cc3c-4167-9119-f7a97fda9adc.png)

## :rainbow: Remarques

- Les liens vers CGU et Support arriveront plus tard
- Très fortement inspiré par la PR #3510 de nos amis de la team Prescription

## :100: Pour tester

1. Se connecter à Pix Certif
2. Constater que le footer s'affiche bien sur différentes pages
3. Constater que le clic sur les deux liens ouvrent les bonnes pages dans un nouvel onglet
