### PR TITLE
[TECH] Supprimer le isShared du buildCampaignParticipation. (PIX-3498)

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -4,12 +4,11 @@ const databaseBuffer = require('../database-buffer');
 const CampaignParticipation = require('../../../lib/domain/models/CampaignParticipation');
 const _ = require('lodash');
 
-const { SHARED, STARTED } = CampaignParticipation.statuses;
+const { SHARED } = CampaignParticipation.statuses;
 
 module.exports = function buildCampaignParticipation({
   id = databaseBuffer.getNextId(),
   campaignId,
-  isShared = true,
   createdAt = new Date('2020-01-01'),
   sharedAt = new Date('2020-01-02'),
   userId,
@@ -17,13 +16,13 @@ module.exports = function buildCampaignParticipation({
   validatedSkillsCount,
   masteryRate,
   pixScore,
-  status = STARTED,
+  status = SHARED,
   isImproved = false,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   campaignId = _.isUndefined(campaignId) ? buildCampaign().id : campaignId;
+  const isShared = status === SHARED;
   sharedAt = isShared ? sharedAt : null;
-  status = isShared ? SHARED : status;
 
   const values = {
     id,

--- a/api/db/database-builder/factory/campaign-participation-overview-factory.js
+++ b/api/db/database-builder/factory/campaign-participation-overview-factory.js
@@ -4,6 +4,9 @@ const buildCampaignParticipation = require('./build-campaign-participation');
 const buildTargetProfileSkill = require('./build-target-profile-skill');
 const buildTargetProfile = require('./build-target-profile');
 const Assessment = require('../../../lib/domain/models/Assessment');
+const CampaignParticipation = require('../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED, SHARED } = CampaignParticipation.statuses;
 
 module.exports = {
   build({ userId, createdAt, sharedAt, assessmentCreatedAt, assessmentState, campaignId, id } = {}) {
@@ -12,7 +15,7 @@ module.exports = {
       campaignId,
       createdAt: createdAt,
       sharedAt: sharedAt,
-      status: sharedAt ? 'SHARED' : 'STARTED',
+      status: sharedAt ? SHARED : STARTED,
     });
 
     buildAssessment({
@@ -37,7 +40,7 @@ module.exports = {
       userId,
       createdAt: createdAt,
       sharedAt: null,
-      status: 'STARTED',
+      status: STARTED,
       campaignId: campaign.id,
     });
 
@@ -62,7 +65,7 @@ module.exports = {
       userId,
       createdAt: createdAt,
       sharedAt: null,
-      status: 'STARTED',
+      status: STARTED,
       campaignId: campaign.id,
     });
 
@@ -119,7 +122,7 @@ module.exports = {
       campaignId: campaign.id,
       createdAt: createdAt,
       sharedAt: sharedAt || createdAt,
-      status: 'STARTED',
+      status: STARTED,
     });
 
     buildAssessment({

--- a/api/db/database-builder/factory/campaign-participation-overview-factory.js
+++ b/api/db/database-builder/factory/campaign-participation-overview-factory.js
@@ -12,7 +12,7 @@ module.exports = {
       campaignId,
       createdAt: createdAt,
       sharedAt: sharedAt,
-      isShared: sharedAt ? true : false,
+      status: sharedAt ? 'SHARED' : 'STARTED',
     });
 
     buildAssessment({
@@ -37,7 +37,7 @@ module.exports = {
       userId,
       createdAt: createdAt,
       sharedAt: null,
-      isShared: false,
+      status: 'STARTED',
       campaignId: campaign.id,
     });
 
@@ -62,7 +62,7 @@ module.exports = {
       userId,
       createdAt: createdAt,
       sharedAt: null,
-      isShared: false,
+      status: 'STARTED',
       campaignId: campaign.id,
     });
 
@@ -87,7 +87,6 @@ module.exports = {
       userId,
       createdAt: createdAt,
       sharedAt: sharedAt || createdAt,
-      isShared: true,
       campaignId: campaign.id,
     });
 
@@ -120,7 +119,7 @@ module.exports = {
       campaignId: campaign.id,
       createdAt: createdAt,
       sharedAt: sharedAt || createdAt,
-      isShared: false,
+      status: 'STARTED',
     });
 
     buildAssessment({

--- a/api/db/seeds/data/campaign-participations-builder.js
+++ b/api/db/seeds/data/campaign-participations-builder.js
@@ -55,7 +55,6 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
       userId: user.id,
       participantExternalId,
       createdAt,
-      isShared: status === SHARED,
       status,
       sharedAt,
       isImproved,
@@ -136,7 +135,6 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
       campaignId,
       userId,
       participantExternalId: userId,
-      isShared: status === SHARED,
       status,
       sharedAt,
     });
@@ -150,7 +148,6 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
         campaignId,
         userId,
         participantExternalId: userId,
-        isShared: status === SHARED,
         status: status,
         sharedAt: oldSharedAt,
         isImproved,

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -88,7 +88,6 @@ describe('Acceptance | API | Campaign Controller', function () {
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         userId,
-        isShared: true,
         createdAt: new Date(participationStartDate),
         sharedAt: new Date('2018-01-27'),
       });
@@ -377,7 +376,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         organizationId: organization.id,
         targetProfileId: targetProfile.id,
       });
-      databaseBuilder.factory.buildCampaignParticipation({ isShared: true, campaignId: campaign.id });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
 
       await databaseBuilder.commit();
 
@@ -688,11 +687,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         });
 
         const participantId1 = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCampaignParticipation({
-          isShared: true,
-          campaignId: campaign.id,
-          userId: participantId1,
-        });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId1 });
         databaseBuilder.factory.buildSchoolingRegistration({
           firstName: 'Barry',
           lastName: 'Withe',
@@ -702,11 +697,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         });
 
         const participantId2 = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCampaignParticipation({
-          isShared: true,
-          campaignId: campaign.id,
-          userId: participantId2,
-        });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId2 });
         databaseBuilder.factory.buildSchoolingRegistration({
           firstName: 'Marvin',
           lastName: 'Gaye',
@@ -755,11 +746,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         });
 
         const participantId1 = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCampaignParticipation({
-          isShared: true,
-          campaignId: campaign.id,
-          userId: participantId1,
-        });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId1 });
         databaseBuilder.factory.buildSchoolingRegistration({
           firstName: 'Barry',
           lastName: 'Withe',
@@ -769,11 +756,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         });
 
         const participantId2 = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCampaignParticipation({
-          isShared: true,
-          campaignId: campaign.id,
-          userId: participantId2,
-        });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId2 });
         databaseBuilder.factory.buildSchoolingRegistration({
           firstName: 'Marvin',
           lastName: 'Gaye',
@@ -783,11 +766,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         });
 
         const participantId3 = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCampaignParticipation({
-          isShared: true,
-          campaignId: campaign.id,
-          userId: participantId3,
-        });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId3 });
         databaseBuilder.factory.buildSchoolingRegistration({
           firstName: 'Aretha',
           lastName: 'Franklin',
@@ -917,7 +896,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         userId: participant1.id,
       });
       databaseBuilder.factory.buildAssessmentFromParticipation(
-        { campaignId: campaign.id, isShared: false },
+        { campaignId: campaign.id, status: 'STARTED' },
         participant2
       );
       databaseBuilder.factory.buildSchoolingRegistration({

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1,5 +1,9 @@
 const jwt = require('jsonwebtoken');
 
+const CampaignParticipation = require('../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
+
 const {
   databaseBuilder,
   expect,
@@ -896,7 +900,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         userId: participant1.id,
       });
       databaseBuilder.factory.buildAssessmentFromParticipation(
-        { campaignId: campaign.id, status: 'STARTED' },
+        { campaignId: campaign.id, status: STARTED },
         participant2
       );
       databaseBuilder.factory.buildSchoolingRegistration({

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -10,7 +10,7 @@ const {
   knex,
 } = require('../../test-helper');
 
-const { SHARED } = CampaignParticipation.statuses;
+const { SHARED, STARTED } = CampaignParticipation.statuses;
 
 describe('Acceptance | API | Campaign Participations', function () {
   let server, options, user;
@@ -65,7 +65,7 @@ describe('Acceptance | API | Campaign Participations', function () {
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         id: campaignParticipationId,
         userId: user.id,
-        status: 'STARTED',
+        status: STARTED,
         sharedAt: null,
         campaignId: campaign.id,
       });
@@ -186,7 +186,7 @@ describe('Acceptance | API | Campaign Participations', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
-        status: 'STARTED',
+        status: STARTED,
       }).id;
       databaseBuilder.factory.buildAssessment({
         userId,
@@ -240,7 +240,7 @@ describe('Acceptance | API | Campaign Participations', function () {
       const anotherUserId = databaseBuilder.factory.buildUser().id;
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId: anotherUserId,
-        status: 'STARTED',
+        status: STARTED,
       }).id;
       databaseBuilder.factory.buildAssessment({
         userId,

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -65,7 +65,7 @@ describe('Acceptance | API | Campaign Participations', function () {
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         id: campaignParticipationId,
         userId: user.id,
-        isShared: false,
+        status: 'STARTED',
         sharedAt: null,
         campaignId: campaign.id,
       });
@@ -186,7 +186,7 @@ describe('Acceptance | API | Campaign Participations', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
-        isShared: false,
+        status: 'STARTED',
       }).id;
       databaseBuilder.factory.buildAssessment({
         userId,
@@ -212,7 +212,7 @@ describe('Acceptance | API | Campaign Participations', function () {
     it('should return 412 HTTP status code when user has already shared his results', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId, isShared: true }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId }).id;
       databaseBuilder.factory.buildAssessment({
         userId,
         campaignParticipationId,
@@ -240,7 +240,7 @@ describe('Acceptance | API | Campaign Participations', function () {
       const anotherUserId = databaseBuilder.factory.buildUser().id;
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId: anotherUserId,
-        isShared: false,
+        status: 'STARTED',
       }).id;
       databaseBuilder.factory.buildAssessment({
         userId,

--- a/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-analyses_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-analyses_test.js
@@ -39,7 +39,6 @@ describe('Acceptance | API | Campaign Participations | Analyses', function () {
       });
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
-        isShared: true,
       });
 
       await databaseBuilder.commit();

--- a/api/tests/acceptance/application/campaign-stats/campaign-stats-get-participations-count-by-mastery-rate_test.js
+++ b/api/tests/acceptance/application/campaign-stats/campaign-stats-get-participations-count-by-mastery-rate_test.js
@@ -14,12 +14,7 @@ describe('Acceptance | API | Campaign Stats | GetParticipationCountByMasteryRate
       const { id: organizationId } = databaseBuilder.factory.buildOrganization();
       databaseBuilder.factory.buildMembership({ organizationId, userId });
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ organizationId });
-      databaseBuilder.factory.buildCampaignParticipation({
-        campaignId,
-        masteryRate: 0.5,
-        isShared: true,
-        sharedAt: '2020-01-01',
-      });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.5, sharedAt: '2020-01-01' });
 
       await databaseBuilder.commit();
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -429,7 +429,7 @@ describe('Acceptance | Application | organization-controller', function () {
           return { name: camp.name, code: camp.code, id: builtCampaign.id };
         }
       );
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignsData[4].id, isShared: true });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignsData[4].id });
       await databaseBuilder.commit();
 
       options = {

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -33,7 +33,6 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       campaignId: campaign.id,
       userId: user.id,
       sharedAt: recentDate,
-      isShared: true,
       masteryRate: 0.38,
     });
     assessment = databaseBuilder.factory.buildAssessment({

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const {
   knex,
   databaseBuilder,
@@ -6,9 +7,10 @@ const {
   sinon,
   mockLearningContent,
 } = require('../../../test-helper');
-const _ = require('lodash');
-
 const createServer = require('../../../../server');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Acceptance | Controller | users-controller-reset-scorecard', function () {
   let options;
@@ -172,7 +174,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
             },
             {
               assessment: { userId, type: 'CAMPAIGN' },
-              campaignParticipation: { campaignId: campaign.id, status: 'STARTED' },
+              campaignParticipation: { campaignId: campaign.id, status: STARTED },
               knowledgeElements: [
                 { skillId: 'url1', status: 'validated', source: 'direct', competenceId, earnedPix: 2, createdAt },
               ],

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -172,7 +172,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
             },
             {
               assessment: { userId, type: 'CAMPAIGN' },
-              campaignParticipation: { campaignId: campaign.id, isShared: false },
+              campaignParticipation: { campaignId: campaign.id, status: 'STARTED' },
               knowledgeElements: [
                 { skillId: 'url1', status: 'validated', source: 'direct', competenceId, earnedPix: 2, createdAt },
               ],

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -54,7 +54,6 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId: campaign.id,
-        isShared: true,
         sharedAt,
         pixScore,
       });

--- a/api/tests/integration/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/integration/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -7,8 +7,6 @@ describe('Integration | UseCase | begin-campaign-participation-improvement', fun
   it('should change campaignParticipation status to STARTED', async function () {
     const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
       status: 'TO_SHARE',
-      isShared: false,
-      sharedAt: null,
     });
     databaseBuilder.factory.buildAssessment({
       userId: campaignParticipation.userId,

--- a/api/tests/integration/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/integration/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -2,11 +2,14 @@ const { expect, databaseBuilder, knex } = require('../../../test-helper');
 const beginCampaignParticipationImprovement = require('../../../../lib/domain/usecases/begin-campaign-participation-improvement');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED, TO_SHARE } = CampaignParticipation.statuses;
 
 describe('Integration | UseCase | begin-campaign-participation-improvement', function () {
   it('should change campaignParticipation status to STARTED', async function () {
     const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-      status: 'TO_SHARE',
+      status: TO_SHARE,
     });
     databaseBuilder.factory.buildAssessment({
       userId: campaignParticipation.userId,
@@ -24,6 +27,6 @@ describe('Integration | UseCase | begin-campaign-participation-improvement', fun
 
     const [campaignParticipationFound] = await knex('campaign-participations').where({ id: campaignParticipation.id });
 
-    expect(campaignParticipationFound.status).to.equal('STARTED');
+    expect(campaignParticipationFound.status).to.equal(STARTED);
   });
 });

--- a/api/tests/integration/domain/usecases/get-campaign-participations-activity-by-day_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-activity-by-day_test.js
@@ -1,6 +1,9 @@
 const { expect, catchErr, databaseBuilder } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | UseCase | get-campaign-participations-activity-by-day', function () {
   let organizationId;
@@ -33,7 +36,7 @@ describe('Integration | UseCase | get-campaign-participations-activity-by-day', 
 
   context('when requesting user is allowed to access campaign', function () {
     it('should return participations activity', async function () {
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, createdAt: '2021-06-01', status: 'STARTED' });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, createdAt: '2021-06-01', status: STARTED });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/domain/usecases/get-campaign-participations-activity-by-day_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-activity-by-day_test.js
@@ -33,7 +33,7 @@ describe('Integration | UseCase | get-campaign-participations-activity-by-day', 
 
   context('when requesting user is allowed to access campaign', function () {
     it('should return participations activity', async function () {
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, createdAt: '2021-06-01', isShared: false });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, createdAt: '2021-06-01', status: 'STARTED' });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-status_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-status_test.js
@@ -2,6 +2,9 @@ const { expect, catchErr, databaseBuilder } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | UseCase | get-campaign-participations-counts-by-status', function () {
   let organizationId;
@@ -34,8 +37,8 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-status',
 
   it('should return participations counts by status', async function () {
     databaseBuilder.factory.buildCampaignParticipation({ campaignId });
-    const participation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' }).id;
-    const participation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' }).id;
+    const participation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED }).id;
+    const participation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED }).id;
 
     databaseBuilder.factory.buildAssessment({
       campaignParticipationId: participation1,

--- a/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-status_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-status_test.js
@@ -33,9 +33,9 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-status',
   });
 
   it('should return participations counts by status', async function () {
-    databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true });
-    const participation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false }).id;
-    const participation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false }).id;
+    databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+    const participation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' }).id;
+    const participation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' }).id;
 
     databaseBuilder.factory.buildAssessment({
       campaignParticipationId: participation1,

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -106,7 +106,6 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         sharedAt: new Date('2019-03-01T23:04:05Z'),
         participantExternalId: '+Mon mail pro',
         campaignId: campaign.id,
-        isShared: true,
         userId: participant.id,
         masteryRate: 0.67,
       });

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -139,7 +139,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           sharedAt: new Date('2019-03-01T23:04:05Z'),
           participantExternalId: '+Mon mail pro',
           campaignId: campaign.id,
-          isShared: true,
           userId: participant.id,
           pixScore: 52,
         });
@@ -219,7 +218,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           sharedAt: new Date('2019-03-01T23:04:05Z'),
           participantExternalId: '+Mon mail pro',
           campaignId: campaign.id,
-          isShared: true,
           userId: participant.id,
           pixScore: 52,
         });
@@ -301,7 +299,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           sharedAt: new Date('2019-03-01T23:04:05Z'),
           participantExternalId: '+Mon mail pro',
           campaignId: campaign.id,
-          isShared: true,
           userId: participant.id,
           pixScore: 52,
         });

--- a/api/tests/integration/infrastructure/repositories/campaign-analysis-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-analysis-repository_test.js
@@ -8,7 +8,7 @@ function _createUserWithSharedCampaignParticipation(userName, campaignId, shared
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
     campaignId,
     userId,
-    isShared: Boolean(sharedAt),
+    status: 'SHARED',
     sharedAt,
     isImproved,
   });
@@ -21,7 +21,7 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
     campaignId,
     userId,
-    isShared: false,
+    status: 'STARTED',
     isImproved: false,
   });
 
@@ -148,7 +148,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId: goliathId,
-            isShared: false,
+            status: 'STARTED',
             isImproved: false,
           });
 
@@ -206,7 +206,6 @@ describe('Integration | Repository | Campaign analysis repository', function () 
             campaignId: anotherCampaignId,
             userId: paulId,
             sharedAt: shareDate,
-            isShared: true,
           });
 
           _.each(

--- a/api/tests/integration/infrastructure/repositories/campaign-analysis-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-analysis-repository_test.js
@@ -1,14 +1,17 @@
+const _ = require('lodash');
 const { expect, databaseBuilder, domainBuilder, knex } = require('../../../test-helper');
 const campaignAnalysisRepository = require('../../../../lib/infrastructure/repositories/campaign-analysis-repository');
 const CampaignAnalysis = require('../../../../lib/domain/read-models/CampaignAnalysis');
-const _ = require('lodash');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED, SHARED } = CampaignParticipation.statuses;
 
 function _createUserWithSharedCampaignParticipation(userName, campaignId, sharedAt, isImproved) {
   const userId = databaseBuilder.factory.buildUser({ firstName: userName }).id;
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
     campaignId,
     userId,
-    status: 'SHARED',
+    status: SHARED,
     sharedAt,
     isImproved,
   });
@@ -21,7 +24,7 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
     campaignId,
     userId,
-    status: 'STARTED',
+    status: STARTED,
     isImproved: false,
   });
 
@@ -148,7 +151,7 @@ describe('Integration | Repository | Campaign analysis repository', function () 
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId: goliathId,
-            status: 'STARTED',
+            status: STARTED,
             isImproved: false,
           });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -3,6 +3,9 @@ const Assessment = require('../../../../lib/domain/models/Assessment');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const CampaignAssessmentParticipation = require('../../../../lib/domain/read-models/CampaignAssessmentParticipation');
 const campaignAssessmentParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-assessment-participation-repository');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | Campaign Assessment Participation', function () {
   describe('#getByCampaignIdAndCampaignParticipationId', function () {
@@ -144,7 +147,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
         campaignId = databaseBuilder.factory.buildAssessmentCampaign({}, [skill1]).id;
         campaignParticipationId = databaseBuilder.factory.buildAssessmentFromParticipation(
           {
-            status: 'STARTED',
+            status: STARTED,
             sharedAt: null,
             campaignId,
           },
@@ -180,7 +183,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
           campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId,
-            status: 'STARTED',
+            status: STARTED,
             sharedAt: null,
           }).id;
 

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -20,7 +20,6 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
       const participation = {
         participantExternalId: '123AZ',
         createdAt: new Date('2020-10-10'),
-        isShared: true,
         sharedAt: new Date('2020-12-12'),
         masteryRate: 0.5,
       };
@@ -103,7 +102,6 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           userId,
-          isShared: true,
           sharedAt: new Date('2020-12-12'),
         }).id;
         databaseBuilder.factory.buildAssessment({
@@ -146,7 +144,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
         campaignId = databaseBuilder.factory.buildAssessmentCampaign({}, [skill1]).id;
         campaignParticipationId = databaseBuilder.factory.buildAssessmentFromParticipation(
           {
-            isShared: false,
+            status: 'STARTED',
             sharedAt: null,
             campaignId,
           },
@@ -182,7 +180,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
           campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId,
-            isShared: false,
+            status: 'STARTED',
             sharedAt: null,
           }).id;
 
@@ -249,7 +247,6 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           userId,
-          isShared: true,
           sharedAt: new Date('2020-12-12'),
         }).id;
 

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -17,7 +17,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           {
             participantExternalId: 'The good',
             campaignId: campaign.id,
-            isShared: true,
           },
           {
             firstName: 'John',
@@ -28,12 +27,11 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         databaseBuilder.factory.buildAssessmentFromParticipation({
           participantExternalId: 'The bad',
           campaignId: campaign.id,
-          isShared: false,
+          status: 'STARTED',
         });
 
         databaseBuilder.factory.buildAssessmentFromParticipation({
           participantExternalId: 'The ugly',
-          isShared: true,
         });
 
         await databaseBuilder.commit();
@@ -80,7 +78,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         databaseBuilder.factory.buildCampaignParticipation({
           participantExternalId: 'My first',
           campaignId: campaign.id,
-          isShared: true,
           isImproved: true,
           userId,
         });
@@ -88,7 +85,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         databaseBuilder.factory.buildCampaignParticipation({
           participantExternalId: 'My last',
           campaignId: campaign.id,
-          isShared: true,
           isImproved: false,
           userId,
         });
@@ -131,7 +127,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
 
         const { userId } = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
-          isShared: true,
         });
 
         databaseBuilder.factory.buildSchoolingRegistration({
@@ -185,7 +180,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
-          isShared: true,
           userId,
         });
 
@@ -234,7 +228,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
-          isShared: true,
           userId,
         });
         badge1Id = databaseBuilder.factory.buildBadge({
@@ -298,7 +291,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
-          isShared: true,
           masteryRate: 0.33,
         });
 
@@ -682,7 +674,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignId: campaign.id,
           userId: user1.id,
           participantExternalId: 'The good',
-          isShared: true,
         });
         databaseBuilder.factory.buildAssessment({
           userId: user1.id,
@@ -698,7 +689,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignId: campaign.id,
           userId: user2.id,
           participantExternalId: 'The bad',
-          isShared: false,
+          status: 'STARTED',
         });
         databaseBuilder.factory.buildAssessment({
           userId: user2.id,

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -1,5 +1,8 @@
 const { expect, databaseBuilder, knex, mockLearningContent, learningContentBuilder } = require('../../../test-helper');
 const campaignAssessmentParticipationResultListRepository = require('../../../../lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | Campaign Assessment Participation Result List', function () {
   describe('#findPaginatedByCampaignId', function () {
@@ -27,7 +30,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         databaseBuilder.factory.buildAssessmentFromParticipation({
           participantExternalId: 'The bad',
           campaignId: campaign.id,
-          status: 'STARTED',
+          status: STARTED,
         });
 
         databaseBuilder.factory.buildAssessmentFromParticipation({
@@ -689,7 +692,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignId: campaign.id,
           userId: user2.id,
           participantExternalId: 'The bad',
-          status: 'STARTED',
+          status: STARTED,
         });
         databaseBuilder.factory.buildAssessment({
           userId: user2.id,

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
@@ -83,7 +83,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           userId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         }).id;
 
@@ -151,7 +150,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           userId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         }).id;
         databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
@@ -178,7 +176,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           userId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         }).id;
         databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
@@ -204,7 +201,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           userId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         }).id;
         databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });

--- a/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -1,7 +1,10 @@
+const _ = require('lodash');
 const { expect, databaseBuilder, domainBuilder, knex } = require('../../../test-helper');
 const campaignCollectiveResultRepository = require('../../../../lib/infrastructure/repositories/campaign-collective-result-repository');
 const CampaignCollectiveResult = require('../../../../lib/domain/read-models/CampaignCollectiveResult');
-const _ = require('lodash');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 function _createUserWithSharedCampaignParticipation(userName, campaignId, sharedAt, isImproved) {
   const userId = databaseBuilder.factory.buildUser({ firstName: userName }).id;
@@ -20,7 +23,7 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
     campaignId,
     userId,
-    status: 'STARTED',
+    status: STARTED,
     isImproved: false,
   });
 
@@ -227,7 +230,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId: goliathId,
-            status: 'STARTED',
+            status: STARTED,
             isImproved: false,
           });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -8,7 +8,6 @@ function _createUserWithSharedCampaignParticipation(userName, campaignId, shared
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
     campaignId,
     userId,
-    isShared: true,
     sharedAt,
     isImproved,
   });
@@ -21,7 +20,7 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
     campaignId,
     userId,
-    isShared: false,
+    status: 'STARTED',
     isImproved: false,
   });
 
@@ -228,7 +227,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId: goliathId,
-            isShared: false,
+            status: 'STARTED',
             isImproved: false,
           });
 
@@ -862,14 +861,12 @@ describe('Integration | Repository | Campaign collective result repository', fun
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId,
-            isShared: true,
             sharedAt: new Date('2020-01-01'),
             isImproved: true,
           });
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId,
-            isShared: true,
             sharedAt: new Date('2020-01-04'),
             isImproved: false,
           });

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -50,7 +50,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         databaseBuilder.factory.buildAssessmentFromParticipation({
           participantExternalId: 'The bad',
           campaignId: campaign.id,
-          status: 'STARTED',
+          status: STARTED,
           userId: user.id,
           isImproved: true,
         });
@@ -58,7 +58,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         databaseBuilder.factory.buildAssessmentFromParticipation({
           participantExternalId: 'The good',
           campaignId: campaign.id,
-          status: 'STARTED',
+          status: STARTED,
           userId: user.id,
           isImproved: false,
         });
@@ -82,7 +82,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
           const user = databaseBuilder.factory.buildUser();
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId: campaign.id,
-            status: 'STARTED',
+            status: STARTED,
             userId: user.id,
           });
 
@@ -221,13 +221,13 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         campaign = databaseBuilder.factory.buildAssessmentCampaign({});
 
         databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The good', campaignId: campaign.id, status: 'STARTED' },
+          { participantExternalId: 'The good', campaignId: campaign.id, status: STARTED },
           { id: 1 }
         );
         databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 1 });
 
         databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The bad', campaignId: campaign.id, status: 'TO_SHARE' },
+          { participantExternalId: 'The bad', campaignId: campaign.id, status: TO_SHARE },
           { id: 2 }
         );
         databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 2 });
@@ -238,7 +238,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         const { campaignParticipantsActivities, pagination } =
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({
             campaignId: campaign.id,
-            filters: { status: 'STARTED' },
+            filters: { status: STARTED },
           });
 
         const participantExternalIds = campaignParticipantsActivities.map((result) => result.participantExternalId);

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -50,7 +50,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         databaseBuilder.factory.buildAssessmentFromParticipation({
           participantExternalId: 'The bad',
           campaignId: campaign.id,
-          isShared: false,
+          status: 'STARTED',
           userId: user.id,
           isImproved: true,
         });
@@ -58,7 +58,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         databaseBuilder.factory.buildAssessmentFromParticipation({
           participantExternalId: 'The good',
           campaignId: campaign.id,
-          isShared: false,
+          status: 'STARTED',
           userId: user.id,
           isImproved: false,
         });
@@ -82,7 +82,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
           const user = databaseBuilder.factory.buildUser();
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId: campaign.id,
-            isShared: false,
+            status: 'STARTED',
             userId: user.id,
           });
 
@@ -104,7 +104,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       context('when the participation is shared', function () {
         it('should return status shared', async function () {
           campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, isShared: true });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
           await databaseBuilder.commit();
 
           const { campaignParticipantsActivities } =
@@ -116,11 +116,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       context('when the participation is not shared', function () {
         it('should return status to share', async function () {
           campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaign.id,
-            isShared: false,
-            status: TO_SHARE,
-          });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, status: TO_SHARE });
           await databaseBuilder.commit();
 
           const { campaignParticipantsActivities } =
@@ -225,13 +221,13 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         campaign = databaseBuilder.factory.buildAssessmentCampaign({});
 
         databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The good', campaignId: campaign.id, isShared: false, status: 'STARTED' },
+          { participantExternalId: 'The good', campaignId: campaign.id, status: 'STARTED' },
           { id: 1 }
         );
         databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 1 });
 
         databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The bad', campaignId: campaign.id, isShared: false, status: 'TO_SHARE' },
+          { participantExternalId: 'The bad', campaignId: campaign.id, status: 'TO_SHARE' },
           { id: 2 }
         );
         databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 2 });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -18,7 +18,6 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign1.id,
           userId,
-          isShared: true,
         });
 
         databaseBuilder.factory.buildAssessment({
@@ -33,7 +32,6 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign2.id,
           userId,
-          isShared: true,
         });
 
         databaseBuilder.factory.buildAssessment({
@@ -85,7 +83,6 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId: user1Id,
-          isShared: true,
           sharedAt: new Date(),
         });
 
@@ -98,7 +95,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId: user2Id,
-          isShared: false,
+          status: 'STARTED',
           sharedAt: null,
         });
 
@@ -163,7 +160,6 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
-          isShared: true,
           sharedAt: new Date(),
         });
 
@@ -220,7 +216,6 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
-          isShared: true,
           sharedAt: new Date(),
           isImproved: true,
         });
@@ -228,7 +223,6 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
-          isShared: true,
           sharedAt: new Date(),
           isImproved: false,
         });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -1,6 +1,9 @@
 const { expect, databaseBuilder } = require('../../../test-helper');
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const campaignParticipationInfoRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-info-repository');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | Campaign Participation Info', function () {
   describe('#findByCampaignId', function () {
@@ -95,7 +98,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId: user2Id,
-          status: 'STARTED',
+          status: STARTED,
           sharedAt: null,
         });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -21,7 +21,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       }).id;
       campaignParticipationNotSharedId = databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
-        isShared: false,
+        status: 'STARTED',
         sharedAt: null,
       }).id;
 
@@ -163,7 +163,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignParticipationId = 12;
       const campaignParticipationToUpdate = databaseBuilder.factory.buildCampaignParticipation({
         id: campaignParticipationId,
-        isShared: false,
+        status: 'STARTED',
         sharedAt: null,
         validatedSkillsCount: null,
       });
@@ -197,7 +197,6 @@ describe('Integration | Repository | Campaign Participation', function () {
       const oldCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01'),
         isImproved: false,
       }).id;
@@ -225,7 +224,6 @@ describe('Integration | Repository | Campaign Participation', function () {
       const oldCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01'),
         isImproved: false,
       }).id;
@@ -334,13 +332,12 @@ describe('Integration | Repository | Campaign Participation', function () {
       _.times(5, () => {
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
-          isShared: true,
         });
       });
       _.times(3, () => {
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
-          isShared: false,
+          status: 'STARTED',
         });
       });
 
@@ -392,12 +389,10 @@ describe('Integration | Repository | Campaign Participation', function () {
       campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign1.id,
         userId,
-        isShared: true,
         createdAt: new Date('2017-03-15T14:59:35Z'),
       });
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign2.id,
-        isShared: true,
       });
       await databaseBuilder.commit();
     });
@@ -532,14 +527,12 @@ describe('Integration | Repository | Campaign Participation', function () {
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaignId,
           userId,
-          isShared: true,
           createdAt: new Date('2016-01-15T14:59:35Z'),
           isImproved: true,
         });
         improvedCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaignId,
           userId,
-          isShared: true,
           createdAt: new Date('2016-07-15T14:59:35Z'),
           isImproved: false,
         });
@@ -562,7 +555,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
-          isShared: false,
+          status: 'STARTED',
           sharedAt: null,
         });
 
@@ -773,7 +766,7 @@ describe('Integration | Repository | Campaign Participation', function () {
 
     beforeEach(async function () {
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-        isShared: false,
+        status: 'STARTED',
         sharedAt: null,
       });
 
@@ -860,9 +853,9 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignId = databaseBuilder.factory.buildCampaign({}).id;
       const otherCampaignId = databaseBuilder.factory.buildCampaign({}).id;
 
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true });
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false });
-      databaseBuilder.factory.buildCampaignParticipation({ otherCampaignId, isShared: true });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
+      databaseBuilder.factory.buildCampaignParticipation({ otherCampaignId });
 
       await databaseBuilder.commit();
 
@@ -1180,8 +1173,8 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       describe('Count shared Participation', function () {
         it('returns an object with 1 participation shared', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ isShared: true });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true });
+          databaseBuilder.factory.buildCampaignParticipation();
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
@@ -1190,8 +1183,8 @@ describe('Integration | Repository | Campaign Participation', function () {
         });
 
         it('returns an object with 1 participation shared and isImproved=false', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, isImproved: true });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isImproved: true });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
@@ -1202,10 +1195,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       describe('Count completed Participation', function () {
         it('returns an object with 1 participation completed', async function () {
-          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ isShared: false }).id;
+          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: 'STARTED' }).id;
           const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            isShared: false,
+            status: 'STARTED',
           }).id;
 
           databaseBuilder.factory.buildAssessment({ campaignParticipationId: idSomeParticipation });
@@ -1225,12 +1218,12 @@ describe('Integration | Repository | Campaign Participation', function () {
         it('returns an object with 1 participation completed and isImproved=false', async function () {
           const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            isShared: false,
+            status: 'STARTED',
             isImproved: true,
           }).id;
           const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            isShared: false,
+            status: 'STARTED',
           }).id;
 
           databaseBuilder.factory.buildAssessment({ campaignParticipationId: idSomeParticipation });
@@ -1246,10 +1239,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       describe('Count started Participation', function () {
         it('returns an object with 1 participation started', async function () {
-          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ isShared: false }).id;
+          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: 'STARTED' }).id;
           const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            isShared: false,
+            status: 'STARTED',
           }).id;
 
           databaseBuilder.factory.buildAssessment({
@@ -1276,12 +1269,12 @@ describe('Integration | Repository | Campaign Participation', function () {
         it('returns an object with 1 participation started and isImproved=false', async function () {
           const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            isShared: false,
+            status: 'STARTED',
             isImproved: true,
           }).id;
           const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            isShared: false,
+            status: 'STARTED',
           }).id;
 
           databaseBuilder.factory.buildAssessment({
@@ -1323,8 +1316,8 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       describe('Count shared Participation', function () {
         it('returns an object with 1 participation shared', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ isShared: true });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true });
+          databaseBuilder.factory.buildCampaignParticipation();
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
@@ -1333,8 +1326,8 @@ describe('Integration | Repository | Campaign Participation', function () {
         });
 
         it('returns an object with 1 participation shared and isImproved=false', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, isImproved: true });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isImproved: true });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
@@ -1345,8 +1338,8 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       describe('Count completed Participation', function () {
         it('returns an object with 1 participation completed', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ isShared: false });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false });
+          databaseBuilder.factory.buildCampaignParticipation({ status: 'STARTED' });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
@@ -1355,8 +1348,8 @@ describe('Integration | Repository | Campaign Participation', function () {
         });
 
         it('returns an object with 1 participation completed and isImproved=false', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false, isImproved: true });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED', isImproved: true });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -8,6 +8,8 @@ const Skill = require('../../../../lib/domain/models/Skill');
 const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 
+const { STARTED, SHARED } = CampaignParticipation.statuses;
+
 describe('Integration | Repository | Campaign Participation', function () {
   describe('#get', function () {
     let campaignId, recentAssessmentId;
@@ -21,7 +23,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       }).id;
       campaignParticipationNotSharedId = databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
-        status: 'STARTED',
+        status: STARTED,
         sharedAt: null,
       }).id;
 
@@ -163,7 +165,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignParticipationId = 12;
       const campaignParticipationToUpdate = databaseBuilder.factory.buildCampaignParticipation({
         id: campaignParticipationId,
-        status: 'STARTED',
+        status: STARTED,
         sharedAt: null,
         validatedSkillsCount: null,
       });
@@ -173,7 +175,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       await campaignParticipationRepository.update({
         ...campaignParticipationToUpdate,
         sharedAt: new Date('2021-01-01'),
-        status: CampaignParticipation.statuses.SHARED,
+        status: SHARED,
         validatedSkillsCount: 10,
         pixScore: 10,
         masteryRate: 0.9,
@@ -183,7 +185,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         .first();
 
       expect(campaignParticipation.sharedAt).to.deep.equals(new Date('2021-01-01'));
-      expect(campaignParticipation.status).to.equals(CampaignParticipation.statuses.SHARED);
+      expect(campaignParticipation.status).to.equals(SHARED);
       expect(campaignParticipation.validatedSkillsCount).to.equals(10);
       expect(campaignParticipation.pixScore).to.equals(10);
       expect(campaignParticipation.masteryRate).to.equals('0.90');
@@ -337,7 +339,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       _.times(3, () => {
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
-          status: 'STARTED',
+          status: STARTED,
         });
       });
 
@@ -555,7 +557,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
-          status: 'STARTED',
+          status: STARTED,
           sharedAt: null,
         });
 
@@ -766,7 +768,7 @@ describe('Integration | Repository | Campaign Participation', function () {
 
     beforeEach(async function () {
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-        status: 'STARTED',
+        status: STARTED,
         sharedAt: null,
       });
 
@@ -791,7 +793,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       campaignParticipation.user = {};
       campaignParticipation.assessmentId = {};
       campaignParticipation.isShared = true;
-      campaignParticipation.status = CampaignParticipation.statuses.SHARED;
+      campaignParticipation.status = SHARED;
       campaignParticipation.participantExternalId = 'Laura';
 
       // when
@@ -801,7 +803,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         .where({ id: campaignParticipation.id })
         .first();
       // then
-      expect(updatedCampaignParticipation.status).to.equals(CampaignParticipation.statuses.SHARED);
+      expect(updatedCampaignParticipation.status).to.equals(SHARED);
       expect(updatedCampaignParticipation.participantExternalId).to.equals('Laura');
     });
 
@@ -854,7 +856,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       const otherCampaignId = databaseBuilder.factory.buildCampaign({}).id;
 
       databaseBuilder.factory.buildCampaignParticipation({ campaignId });
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED });
       databaseBuilder.factory.buildCampaignParticipation({ otherCampaignId });
 
       await databaseBuilder.commit();
@@ -1195,10 +1197,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       describe('Count completed Participation', function () {
         it('returns an object with 1 participation completed', async function () {
-          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: 'STARTED' }).id;
+          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: STARTED }).id;
           const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: 'STARTED',
+            status: STARTED,
           }).id;
 
           databaseBuilder.factory.buildAssessment({ campaignParticipationId: idSomeParticipation });
@@ -1218,12 +1220,12 @@ describe('Integration | Repository | Campaign Participation', function () {
         it('returns an object with 1 participation completed and isImproved=false', async function () {
           const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: 'STARTED',
+            status: STARTED,
             isImproved: true,
           }).id;
           const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: 'STARTED',
+            status: STARTED,
           }).id;
 
           databaseBuilder.factory.buildAssessment({ campaignParticipationId: idSomeParticipation });
@@ -1239,10 +1241,10 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       describe('Count started Participation', function () {
         it('returns an object with 1 participation started', async function () {
-          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: 'STARTED' }).id;
+          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: STARTED }).id;
           const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: 'STARTED',
+            status: STARTED,
           }).id;
 
           databaseBuilder.factory.buildAssessment({
@@ -1269,12 +1271,12 @@ describe('Integration | Repository | Campaign Participation', function () {
         it('returns an object with 1 participation started and isImproved=false', async function () {
           const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: 'STARTED',
+            status: STARTED,
             isImproved: true,
           }).id;
           const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: 'STARTED',
+            status: STARTED,
           }).id;
 
           databaseBuilder.factory.buildAssessment({
@@ -1338,8 +1340,8 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       describe('Count completed Participation', function () {
         it('returns an object with 1 participation completed', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ status: 'STARTED' });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
+          databaseBuilder.factory.buildCampaignParticipation({ status: STARTED });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
@@ -1348,8 +1350,8 @@ describe('Integration | Repository | Campaign Participation', function () {
         });
 
         it('returns an object with 1 participation completed and isImproved=false', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED', isImproved: true });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED, isImproved: true });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
@@ -1,6 +1,9 @@
 const { expect, databaseBuilder, mockLearningContent } = require('../../../test-helper');
 const campaignParticipationResultRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-result-repository');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | Campaign Participation Result', function () {
   describe('#getByParticipationId', function () {
@@ -237,7 +240,7 @@ describe('Integration | Repository | Campaign Participation Result', function ()
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          status: 'STARTED',
+          status: STARTED,
           sharedAt: null,
         });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
@@ -96,7 +96,6 @@ describe('Integration | Repository | Campaign Participation Result', function ()
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-02'),
       });
 
@@ -158,7 +157,6 @@ describe('Integration | Repository | Campaign Participation Result', function ()
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-02'),
       });
 
@@ -239,7 +237,7 @@ describe('Integration | Repository | Campaign Participation Result', function ()
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: false,
+          status: 'STARTED',
           sharedAt: null,
         });
 
@@ -299,7 +297,6 @@ describe('Integration | Repository | Campaign Participation Result', function ()
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         });
 
@@ -394,7 +391,6 @@ describe('Integration | Repository | Campaign Participation Result', function ()
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         });
 
@@ -465,7 +461,6 @@ describe('Integration | Repository | Campaign Participation Result', function ()
           const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId,
-            isShared: true,
             sharedAt: new Date('2020-01-02'),
           });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -36,26 +36,20 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           createdAt: '2021-01-01',
-          isShared: true,
           sharedAt: '2021-01-01',
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           createdAt: '2021-01-01',
-          isShared: true,
           sharedAt: '2021-01-03',
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           createdAt: '2021-01-02',
-          isShared: false,
+          status: 'STARTED',
           sharedAt: null,
         });
-        databaseBuilder.factory.buildCampaignParticipation({
-          createdAt: '2021-01-01',
-          isShared: true,
-          sharedAt: '2021-01-01',
-        });
+        databaseBuilder.factory.buildCampaignParticipation({ createdAt: '2021-01-01', sharedAt: '2021-01-01' });
         await databaseBuilder.commit();
 
         const activityByDate = await campaignParticipationsStatsRepository.getParticipationsActivityByDate(campaignId);
@@ -72,7 +66,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
     context('When there is no shared participation', function () {
       it('return an empty array', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
 
         const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({
           campaignId,
@@ -85,9 +79,9 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
     context('When there are shared participation', function () {
       it('returns the participation count by mastery rate', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, masteryRate: 0.2 });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, masteryRate: 0.1 });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, masteryRate: 0.1 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.2 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.1 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.1 });
 
         await databaseBuilder.commit();
         const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({
@@ -103,14 +97,10 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
     context('When there are shared participation for other campaign', function () {
       it('returns only participation count for given campaign', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, masteryRate: 0.1 });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, masteryRate: 0.2 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.1 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.2 });
         const { id: otherCampaignId } = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: otherCampaignId,
-          isShared: true,
-          masteryRate: 0.2,
-        });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: otherCampaignId, masteryRate: 0.2 });
 
         await databaseBuilder.commit();
         const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({
@@ -126,8 +116,8 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
     context('When there are participation without mastery rate', function () {
       it('returns only participation count for participation with mastery rate', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, masteryRate: 0.1 });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, masteryRate: null });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.1 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: null });
 
         await databaseBuilder.commit();
         const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({
@@ -140,8 +130,8 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
     context('When there are participation not shared', function () {
       it('returns only shared participation', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false, masteryRate: 0.1 });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: true, masteryRate: 1 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED', masteryRate: 0.1 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 1 });
 
         await databaseBuilder.commit();
         const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({
@@ -155,20 +145,8 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
       it('counts the last participation for each participant', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
         const { id: userId } = databaseBuilder.factory.buildUser();
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId,
-          userId,
-          isShared: true,
-          masteryRate: 0.5,
-          isImproved: true,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId,
-          userId,
-          isShared: true,
-          masteryRate: 1,
-          isImproved: false,
-        });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId, masteryRate: 0.5, isImproved: true });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId, masteryRate: 1, isImproved: false });
 
         await databaseBuilder.commit();
         const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({

--- a/api/tests/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -1,5 +1,8 @@
 const campaignParticipationsStatsRepository = require('../../../../lib/infrastructure/repositories/campaign-participations-stats-repository');
 const { expect, databaseBuilder } = require('../../../test-helper');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | Campaign Participations Stats', function () {
   describe('#getParticipationsActivityByDate', function () {
@@ -46,7 +49,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           createdAt: '2021-01-02',
-          status: 'STARTED',
+          status: STARTED,
           sharedAt: null,
         });
         databaseBuilder.factory.buildCampaignParticipation({ createdAt: '2021-01-01', sharedAt: '2021-01-01' });
@@ -66,7 +69,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
     context('When there is no shared participation', function () {
       it('return an empty array', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED });
 
         const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({
           campaignId,
@@ -130,7 +133,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
     context('When there are participation not shared', function () {
       it('returns only shared participation', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED', masteryRate: 0.1 });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED, masteryRate: 0.1 });
         databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 1 });
 
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
@@ -75,7 +75,6 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
             campaignId,
             createdAt: new Date('2020-01-01'),
             sharedAt: new Date('2020-01-02'),
-            isShared: true,
             participantExternalId: 'Friday the 13th',
           },
           false
@@ -213,7 +212,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithUser(
           { firstName: 'John', lastName: 'Shaft' },
-          { campaignId, isShared: true },
+          { campaignId },
           false
         );
 
@@ -233,7 +232,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithUser(
           { firstName: 'John', lastName: 'Shaft' },
-          { campaignId, isShared: true },
+          { campaignId },
           false
         );
 
@@ -258,7 +257,6 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
           campaignId,
           userId: user.id,
           sharedAt: new Date('2020-01-02'),
-          isShared: true,
         });
         databaseBuilder.factory.buildKnowledgeElement({
           userId: user.id,
@@ -287,7 +285,6 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
           campaignId,
           userId: user.id,
           sharedAt: new Date('2020-01-02'),
-          isShared: true,
           pixScore: 80,
         });
         databaseBuilder.factory.buildKnowledgeElement({
@@ -325,7 +322,6 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
           campaignId,
           userId: user.id,
           sharedAt: new Date('2020-01-02'),
-          isShared: true,
         });
         databaseBuilder.factory.buildKnowledgeElement({
           userId: user.id,

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -35,7 +35,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
 
     it('should not return participant data summary for a not shared campaign participation', async function () {
       // given
-      const campaignParticipation = { campaignId, isShared: false, sharedAt: null };
+      const campaignParticipation = { campaignId, status: 'STARTED', sharedAt: null };
       databaseBuilder.factory.buildCampaignParticipationWithUser({}, campaignParticipation, false);
       await databaseBuilder.commit();
 
@@ -116,15 +116,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       beforeEach(async function () {
         const createdAt = new Date('2018-04-06T10:00:00Z');
         const userId = 999;
-        campaignParticipation = {
-          id: 888,
-          userId,
-          campaignId,
-          isShared: true,
-          sharedAt,
-          participantExternalId: 'JeBu',
-          pixScore: 46,
-        };
+        campaignParticipation = { id: 888, userId, campaignId, sharedAt, participantExternalId: 'JeBu', pixScore: 46 };
         databaseBuilder.factory.buildCampaignParticipationWithUser(
           { id: userId, firstName: 'Jérémy', lastName: 'bugietta' },
           campaignParticipation,
@@ -179,7 +171,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
 
       beforeEach(async function () {
         const userId = 999;
-        const oldCampaignParticipation = { userId, campaignId, isShared: true, sharedAt, isImproved: true };
+        const oldCampaignParticipation = { userId, campaignId, sharedAt, isImproved: true };
         databaseBuilder.factory.buildCampaignParticipationWithUser({ id: userId }, oldCampaignParticipation, false);
 
         recentCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
@@ -187,7 +179,6 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           isImproved: false,
           sharedAt,
           campaignId,
-          isShared: true,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -1,6 +1,9 @@
 const { expect, databaseBuilder, mockLearningContent, knex } = require('../../../test-helper');
 const CampaignProfilesCollectionParticipationSummary = require('../../../../lib/domain/read-models/CampaignProfilesCollectionParticipationSummary');
 const campaignProfilesCollectionParticipationSummaryRepository = require('../../../../lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | Campaign Profiles Collection Participation Summary repository', function () {
   describe('#findPaginatedByCampaignId', function () {
@@ -35,7 +38,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
 
     it('should not return participant data summary for a not shared campaign participation', async function () {
       // given
-      const campaignParticipation = { campaignId, status: 'STARTED', sharedAt: null };
+      const campaignParticipation = { campaignId, status: STARTED, sharedAt: null };
       databaseBuilder.factory.buildCampaignParticipationWithUser({}, campaignParticipation, false);
       await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1,8 +1,11 @@
+const _ = require('lodash');
 const { expect, databaseBuilder, catchErr } = require('../../../test-helper');
 const campaignReportRepository = require('../../../../lib/infrastructure/repositories/campaign-report-repository');
 const CampaignReport = require('../../../../lib/domain/read-models/CampaignReport');
 const { NotFoundError } = require('../../../../lib/domain/errors');
-const _ = require('lodash');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | Campaign-Report', function () {
   describe('#get', function () {
@@ -72,7 +75,7 @@ describe('Integration | Repository | Campaign-Report', function () {
         userId,
         campaignId: campaign.id,
         sharedAt: null,
-        status: 'STARTED',
+        status: STARTED,
         isImproved: false,
       });
       await databaseBuilder.commit();
@@ -138,7 +141,7 @@ describe('Integration | Repository | Campaign-Report', function () {
         campaignId,
         masteryRate: 0.3,
         sharedAt: null,
-        status: 'STARTED',
+        status: STARTED,
       });
       await databaseBuilder.commit();
 
@@ -347,7 +350,7 @@ describe('Integration | Repository | Campaign-Report', function () {
             userId,
             campaignId: campaign.id,
             isImproved: false,
-            status: 'STARTED',
+            status: STARTED,
             sharedAt: null,
           });
           await databaseBuilder.commit();
@@ -369,8 +372,8 @@ describe('Integration | Repository | Campaign-Report', function () {
           _.each(
             [
               { campaignId: campaign.id },
-              { campaignId: campaign.id, status: 'STARTED' },
-              { campaignId: campaign.id, status: 'STARTED' },
+              { campaignId: campaign.id, status: STARTED },
+              { campaignId: campaign.id, status: STARTED },
             ],
             (campaignParticipation) => {
               databaseBuilder.factory.buildCampaignParticipation(campaignParticipation);

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -66,14 +66,13 @@ describe('Integration | Repository | Campaign-Report', function () {
         userId,
         campaignId: campaign.id,
         sharedAt: new Date(),
-        isShared: true,
         isImproved: true,
       });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId: campaign.id,
         sharedAt: null,
-        isShared: false,
+        status: 'STARTED',
         isImproved: false,
       });
       await databaseBuilder.commit();
@@ -134,17 +133,12 @@ describe('Integration | Repository | Campaign-Report', function () {
 
     it('should only take into account shared participations', async function () {
       // given
-      databaseBuilder.factory.buildCampaignParticipation({
-        campaignId,
-        masteryRate: 0.1,
-        sharedAt: new Date(),
-        isShared: true,
-      });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.1, sharedAt: new Date() });
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
         masteryRate: 0.3,
         sharedAt: null,
-        isShared: false,
+        status: 'STARTED',
       });
       await databaseBuilder.commit();
 
@@ -346,7 +340,6 @@ describe('Integration | Repository | Campaign-Report', function () {
           databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId: campaign.id,
-            isShared: true,
             sharedAt: new Date(),
             isImproved: true,
           });
@@ -354,7 +347,7 @@ describe('Integration | Repository | Campaign-Report', function () {
             userId,
             campaignId: campaign.id,
             isImproved: false,
-            isShared: false,
+            status: 'STARTED',
             sharedAt: null,
           });
           await databaseBuilder.commit();
@@ -375,9 +368,9 @@ describe('Integration | Repository | Campaign-Report', function () {
           const campaign = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId });
           _.each(
             [
-              { campaignId: campaign.id, isShared: true },
-              { campaignId: campaign.id, isShared: false },
-              { campaignId: campaign.id, isShared: false },
+              { campaignId: campaign.id },
+              { campaignId: campaign.id, status: 'STARTED' },
+              { campaignId: campaign.id, status: 'STARTED' },
             ],
             (campaignParticipation) => {
               databaseBuilder.factory.buildCampaignParticipation(campaignParticipation);

--- a/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
@@ -7,6 +7,9 @@ const {
   AlreadyExistingCampaignParticipationError,
 } = require('../../../../lib/domain/errors');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | CampaignToJoin', function () {
   describe('#get', function () {
@@ -340,7 +343,7 @@ describe('Integration | Repository | CampaignToJoin', function () {
         databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId: campaignData.id,
-          status: 'STARTED',
+          status: STARTED,
           sharedAt: null,
         });
         const campaignToJoin = domainBuilder.buildCampaignToJoin({
@@ -373,7 +376,7 @@ describe('Integration | Repository | CampaignToJoin', function () {
         databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId: campaignData.id,
-          status: 'STARTED',
+          status: STARTED,
           sharedAt: null,
           isImproved: false,
           validatedSkillsCount: 2,

--- a/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
@@ -315,7 +315,6 @@ describe('Integration | Repository | CampaignToJoin', function () {
         databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId: campaignData.id,
-          isShared: true,
           sharedAt: new Date('2020-01-01'),
         });
         const campaignToJoin = domainBuilder.buildCampaignToJoin({
@@ -341,7 +340,7 @@ describe('Integration | Repository | CampaignToJoin', function () {
         databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId: campaignData.id,
-          isShared: false,
+          status: 'STARTED',
           sharedAt: null,
         });
         const campaignToJoin = domainBuilder.buildCampaignToJoin({
@@ -368,14 +367,13 @@ describe('Integration | Repository | CampaignToJoin', function () {
         databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId: campaignData.id,
-          isShared: true,
           sharedAt: new Date('2020-01-01'),
           isImproved: true,
         });
         databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId: campaignData.id,
-          isShared: false,
+          status: 'STARTED',
           sharedAt: null,
           isImproved: false,
           validatedSkillsCount: 2,
@@ -405,7 +403,6 @@ describe('Integration | Repository | CampaignToJoin', function () {
           databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId: campaignData.id,
-            isShared: true,
             sharedAt: new Date('2020-01-01'),
             isImproved: true,
             validatedSkillsCount: 1,
@@ -413,7 +410,6 @@ describe('Integration | Repository | CampaignToJoin', function () {
           databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId: campaignData.id,
-            isShared: true,
             sharedAt: new Date('2020-01-01'),
             isImproved: false,
             validatedSkillsCount: 2,
@@ -442,7 +438,6 @@ describe('Integration | Repository | CampaignToJoin', function () {
           databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId: campaignData.id,
-            isShared: true,
             sharedAt: new Date('2020-01-01'),
             isImproved: false,
             validatedSkillsCount: 3,
@@ -475,7 +470,6 @@ describe('Integration | Repository | CampaignToJoin', function () {
           databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId: campaignData.id,
-            isShared: true,
             sharedAt: new Date('2020-01-01'),
             isImproved: true,
             validatedSkillsCount: 1,
@@ -483,7 +477,6 @@ describe('Integration | Repository | CampaignToJoin', function () {
           databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId: campaignData.id,
-            isShared: true,
             sharedAt: new Date('2020-01-05'),
             isImproved: false,
             validatedSkillsCount: 2,

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -269,7 +269,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
 
@@ -297,7 +296,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: false,
+        status: 'STARTED',
       });
 
       databaseBuilder.factory.buildKnowledgeElement({
@@ -326,13 +325,12 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildCampaignParticipation({
         userId: otherUserId,
         campaignId,
-        isShared: false,
+        status: 'STARTED',
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
@@ -373,7 +371,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -407,7 +404,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -441,7 +437,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -475,7 +470,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -511,7 +505,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
 
@@ -524,7 +517,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId: userId2,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -557,7 +549,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
 
@@ -571,7 +562,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId: userId2,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -618,13 +608,11 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildCampaignParticipation({
         userId: otherUserId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -667,7 +655,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -703,7 +690,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -746,7 +732,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -5,6 +5,9 @@ const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement
 const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
 const knowledgeElementSnapshotRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | knowledgeElementRepository', function () {
   afterEach(function () {
@@ -296,7 +299,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        status: 'STARTED',
+        status: STARTED,
       });
 
       databaseBuilder.factory.buildKnowledgeElement({
@@ -330,7 +333,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         userId: otherUserId,
         campaignId,
-        status: 'STARTED',
+        status: STARTED,
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -269,7 +269,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-02'),
       });
 
@@ -320,7 +319,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-02'),
       });
 
@@ -363,7 +361,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2020-01-02'),
       });
 
@@ -442,7 +439,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: true,
           masteryRate: 0.65,
           sharedAt: new Date('2020-01-02'),
         });
@@ -535,7 +531,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         });
 
@@ -604,13 +599,11 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         });
         const { id: otherCampaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId: otherCampaignId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
         });
 
@@ -690,7 +683,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId,
-            isShared: true,
             sharedAt: new Date('2020-01-02'),
           });
 
@@ -808,7 +800,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
           masteryRate: 0.6,
         });
@@ -832,7 +823,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: false,
+          status: 'STARTED',
           sharedAt: null,
         });
 

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -2,6 +2,9 @@ const { catchErr, expect, databaseBuilder, mockLearningContent } = require('../.
 const participantResultRepository = require('../../../../lib/infrastructure/repositories/participant-result-repository');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const { NotFoundError } = require('../../../../lib/domain/errors');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | ParticipantResultRepository', function () {
   describe('#getByUserIdAndCampaignId', function () {
@@ -823,7 +826,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          status: 'STARTED',
+          status: STARTED,
           sharedAt: null,
         });
 

--- a/api/tests/integration/scripts/prod/compute-participation-results_test.js
+++ b/api/tests/integration/scripts/prod/compute-participation-results_test.js
@@ -7,7 +7,7 @@ describe('computeParticipationResults', function () {
     it('computes results using all knowledge elements', async function () {
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
 
-      _buildParticipationWithSnapshot({ campaignId, isShared: true, sharedAt: new Date('2020-01-02') }, [
+      _buildParticipationWithSnapshot({ campaignId, sharedAt: new Date('2020-01-02') }, [
         { skillId: 'skill_1', status: 'invalidated', earnedPix: 0 },
         { skillId: 'skill_2', status: 'validated', earnedPix: 3 },
         { skillId: 'skill_3', status: 'validated', earnedPix: 1 },
@@ -31,7 +31,7 @@ describe('computeParticipationResults', function () {
     it('computes results on target skills', async function () {
       const { id: campaignId } = _buildCampaignForSkills(['skill_1']);
 
-      _buildParticipationWithSnapshot({ campaignId, isShared: true, sharedAt: new Date('2020-01-02') }, [
+      _buildParticipationWithSnapshot({ campaignId, sharedAt: new Date('2020-01-02') }, [
         { skillId: 'skill_1', status: 'validated', earnedPix: 5 },
         { skillId: 'skill_2', status: 'validated', earnedPix: 3 },
         { skillId: 'skill_3', status: 'validated', earnedPix: 1 },
@@ -63,11 +63,11 @@ describe('computeParticipationResults', function () {
       it('computes results for each participation', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
 
-        _buildParticipationWithSnapshot({ id: 1, campaignId, isShared: true, sharedAt: new Date('2020-01-02') }, [
+        _buildParticipationWithSnapshot({ id: 1, campaignId, sharedAt: new Date('2020-01-02') }, [
           { skillId: 'skill_1', status: 'validated', earnedPix: 40 },
         ]);
 
-        _buildParticipationWithSnapshot({ id: 2, campaignId, isShared: true, sharedAt: new Date('2020-01-03') }, [
+        _buildParticipationWithSnapshot({ id: 2, campaignId, sharedAt: new Date('2020-01-03') }, [
           { skillId: 'skill_1', status: 'invalidated', earnedPix: 0 },
         ]);
 
@@ -92,18 +92,14 @@ describe('computeParticipationResults', function () {
         const { id: campaignId1 } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
         const { id: campaignId2 } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
 
-        _buildParticipationWithSnapshot(
-          { id: 1, campaignId: campaignId1, isShared: true, sharedAt: new Date('2020-01-02') },
-          [
-            { skillId: 'skill_1', competenceId: 'C1', status: 'validated', earnedPix: 40 },
-            { skillId: 'skill_2', competenceId: 'C2', status: 'validated', earnedPix: 40 },
-          ]
-        );
+        _buildParticipationWithSnapshot({ id: 1, campaignId: campaignId1, sharedAt: new Date('2020-01-02') }, [
+          { skillId: 'skill_1', competenceId: 'C1', status: 'validated', earnedPix: 40 },
+          { skillId: 'skill_2', competenceId: 'C2', status: 'validated', earnedPix: 40 },
+        ]);
 
-        _buildParticipationWithSnapshot(
-          { id: 2, campaignId: campaignId2, isShared: true, sharedAt: new Date('2020-01-03') },
-          [{ skillId: 'skill_1', status: 'validated', earnedPix: 40 }]
-        );
+        _buildParticipationWithSnapshot({ id: 2, campaignId: campaignId2, sharedAt: new Date('2020-01-03') }, [
+          { skillId: 'skill_1', status: 'validated', earnedPix: 40 },
+        ]);
 
         await databaseBuilder.commit();
 
@@ -127,7 +123,6 @@ describe('computeParticipationResults', function () {
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
-          isShared: true,
           sharedAt: new Date('2020-01-02'),
           validatedSkillsCount: 10,
           masteryRate: 0.2,
@@ -152,7 +147,7 @@ describe('computeParticipationResults', function () {
       it('does not compute results', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
 
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, isShared: false });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
 
         await databaseBuilder.commit();
 

--- a/api/tests/integration/scripts/prod/compute-participation-results_test.js
+++ b/api/tests/integration/scripts/prod/compute-participation-results_test.js
@@ -1,6 +1,9 @@
 const { expect, mockLearningContent, databaseBuilder, knex } = require('../../../test-helper');
 const computeParticipationResults = require('../../../../scripts/prod/compute-participation-results');
 const Campaign = require('../../../../lib/domain/models/Campaign');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('computeParticipationResults', function () {
   context('when there is one campaign participation on profile collection campaign', function () {
@@ -147,7 +150,7 @@ describe('computeParticipationResults', function () {
       it('does not compute results', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
 
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: 'STARTED' });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED });
 
         await databaseBuilder.commit();
 

--- a/api/tests/integration/scripts/prod/compute-participation-statuses_test.js
+++ b/api/tests/integration/scripts/prod/compute-participation-statuses_test.js
@@ -10,14 +10,13 @@ describe('compute-participation-statuses script', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
         participantExternalId: 'shared participation',
-        isShared: true,
         sharedAt: new Date('2020-01-02'),
       });
 
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
         participantExternalId: 'to share participation',
-        isShared: false,
+        status: 'STARTED',
       });
 
       await databaseBuilder.commit();
@@ -148,7 +147,7 @@ function _buildParticipationWithAssessment({
     campaignId,
     userId,
     participantExternalId,
-    isShared,
+    status: isShared ? 'SHARED' : 'STARTED',
     sharedAt: isShared ? new Date('2020-01-02') : null,
   }).id;
 

--- a/api/tests/integration/scripts/prod/compute-participation-statuses_test.js
+++ b/api/tests/integration/scripts/prod/compute-participation-statuses_test.js
@@ -1,6 +1,9 @@
 const { expect, databaseBuilder, knex } = require('../../../test-helper');
 const computeParticipantStatuses = require('../../../../scripts/prod/compute-participation-statuses');
 const Campaign = require('../../../../lib/domain/models/Campaign');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED, SHARED, TO_SHARE } = CampaignParticipation.statuses;
 
 describe('compute-participation-statuses script', function () {
   context('For profile collection campaign', function () {
@@ -16,7 +19,7 @@ describe('compute-participation-statuses script', function () {
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
         participantExternalId: 'to share participation',
-        status: 'STARTED',
+        status: STARTED,
       });
 
       await databaseBuilder.commit();
@@ -28,7 +31,7 @@ describe('compute-participation-statuses script', function () {
       const campaignParticipation = await knex('campaign-participations')
         .where({ participantExternalId: 'to share participation' })
         .first();
-      expect(campaignParticipation.status).to.equals('TO_SHARE');
+      expect(campaignParticipation.status).to.equals(TO_SHARE);
     });
 
     it('computes "SHARED" participations status', async function () {
@@ -37,7 +40,7 @@ describe('compute-participation-statuses script', function () {
       const campaignParticipation = await knex('campaign-participations')
         .where({ participantExternalId: 'shared participation' })
         .first();
-      expect(campaignParticipation.status).to.equals('SHARED');
+      expect(campaignParticipation.status).to.equals(SHARED);
     });
   });
 
@@ -76,7 +79,7 @@ describe('compute-participation-statuses script', function () {
       const campaignParticipation = await knex('campaign-participations')
         .where({ participantExternalId: 'started participation' })
         .first();
-      expect(campaignParticipation.status).to.equals('STARTED');
+      expect(campaignParticipation.status).to.equals(STARTED);
     });
 
     it('computes "TO_SHARE" participations status', async function () {
@@ -85,7 +88,7 @@ describe('compute-participation-statuses script', function () {
       const campaignParticipation = await knex('campaign-participations')
         .where({ participantExternalId: 'to share participation' })
         .first();
-      expect(campaignParticipation.status).to.equals('TO_SHARE');
+      expect(campaignParticipation.status).to.equals(TO_SHARE);
     });
 
     it('computes "SHARED" participations status', async function () {
@@ -94,7 +97,7 @@ describe('compute-participation-statuses script', function () {
       const campaignParticipation = await knex('campaign-participations')
         .where({ participantExternalId: 'shared participation' })
         .first();
-      expect(campaignParticipation.status).to.equals('SHARED');
+      expect(campaignParticipation.status).to.equals(SHARED);
     });
   });
 
@@ -124,12 +127,12 @@ describe('compute-participation-statuses script', function () {
       const campaignParticipation1 = await knex('campaign-participations')
         .where({ participantExternalId: 'shared participation' })
         .first();
-      expect(campaignParticipation1.status).to.equals('SHARED');
+      expect(campaignParticipation1.status).to.equals(SHARED);
 
       const campaignParticipation2 = await knex('campaign-participations')
         .where({ participantExternalId: 'to share participation' })
         .first();
-      expect(campaignParticipation2.status).to.equals('TO_SHARE');
+      expect(campaignParticipation2.status).to.equals(TO_SHARE);
     });
   });
 });
@@ -147,7 +150,7 @@ function _buildParticipationWithAssessment({
     campaignId,
     userId,
     participantExternalId,
-    status: isShared ? 'SHARED' : 'STARTED',
+    status: isShared ? SHARED : STARTED,
     sharedAt: isShared ? new Date('2020-01-02') : null,
   }).id;
 

--- a/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
+++ b/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
@@ -11,6 +11,9 @@ const {
 const computePoleEmploiSendings = require('../../../../scripts/prod/compute-pole-emploi-sendings');
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSending');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 const poleEmploiSendingFactory = databaseBuilder.factory.poleEmploiSendingFactory;
 function setLearningContent(learningContent) {
   const learningObjects = learningContentBuilder.buildLearningContent(learningContent);
@@ -86,7 +89,7 @@ describe('computePoleEmploiSendings', function () {
       campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        status: 'STARTED',
+        status: STARTED,
         sharedAt: null,
       }).id;
       databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'started', type: 'CAMPAIGN' });
@@ -144,7 +147,7 @@ describe('computePoleEmploiSendings', function () {
       campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        status: 'STARTED',
+        status: STARTED,
         sharedAt: null,
       }).id;
       databaseBuilder.factory.buildAssessment({
@@ -211,7 +214,7 @@ describe('computePoleEmploiSendings', function () {
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          status: 'STARTED',
+          status: STARTED,
           sharedAt: null,
         }).id;
         oldAssessment = databaseBuilder.factory.buildAssessment({

--- a/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
+++ b/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
@@ -86,7 +86,7 @@ describe('computePoleEmploiSendings', function () {
       campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: false,
+        status: 'STARTED',
         sharedAt: null,
       }).id;
       databaseBuilder.factory.buildAssessment({ userId, campaignParticipationId, state: 'started', type: 'CAMPAIGN' });
@@ -144,7 +144,7 @@ describe('computePoleEmploiSendings', function () {
       campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: false,
+        status: 'STARTED',
         sharedAt: null,
       }).id;
       databaseBuilder.factory.buildAssessment({
@@ -211,7 +211,7 @@ describe('computePoleEmploiSendings', function () {
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
-          isShared: false,
+          status: 'STARTED',
           sharedAt: null,
         }).id;
         oldAssessment = databaseBuilder.factory.buildAssessment({
@@ -252,7 +252,6 @@ describe('computePoleEmploiSendings', function () {
       campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2021-10-10'),
       }).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({
@@ -359,7 +358,6 @@ describe('computePoleEmploiSendings', function () {
       campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2021-10-10'),
       }).id;
       databaseBuilder.factory.buildAssessment({
@@ -389,7 +387,6 @@ describe('computePoleEmploiSendings', function () {
       campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
-        isShared: true,
         sharedAt: new Date('2021-10-10'),
       }).id;
       poleEmploiSendingFactory.build({

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
@@ -1,25 +1,25 @@
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
 const buildCampaign = require('./build-campaign');
-const { SHARED, STARTED } = CampaignParticipation.statuses;
+const { SHARED } = CampaignParticipation.statuses;
 
 module.exports = function buildCampaignParticipation({
   id = 1,
   campaign = buildCampaign(),
-  isShared = true,
   sharedAt = new Date('2020-02-01'),
   createdAt = new Date('2020-01-01'),
   participantExternalId = 'Mon mail pro',
   campaignId = campaign.id,
   assessmentId = null,
   userId = 123,
-  status = STARTED,
+  status = SHARED,
   validatedSkillsCount,
 } = {}) {
+  const isShared = status === SHARED;
   return new CampaignParticipation({
     id,
     campaign,
-    status: isShared ? SHARED : status,
-    sharedAt,
+    status,
+    sharedAt: isShared ? sharedAt : null,
     createdAt,
     participantExternalId,
     campaignId,

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -246,13 +246,13 @@ describe('Unit | Service | ScorecardService', function () {
           id: 1,
           campaign,
           campaignId: campaign.id,
-          isShared: false,
+          status: 'STARTED',
         });
         campaignParticipation2 = domainBuilder.buildCampaignParticipation({
           id: 2,
           campaign,
           campaignId: campaign.id,
-          isShared: false,
+          status: 'STARTED',
         });
         oldAssessment1 = domainBuilder.buildAssessment.ofTypeCampaign({
           id: assessmentId1,
@@ -398,13 +398,11 @@ describe('Unit | Service | ScorecardService', function () {
             assessmentId: assessmentId1,
             campaign,
             campaignId: campaign.id,
-            isShared: true,
           });
           const campaignParticipation4 = domainBuilder.buildCampaignParticipation({
             assessmentId: assessmentId2,
             campaign,
             campaignId: campaign.id,
-            isShared: true,
           });
           campaignParticipationRepository.findOneByAssessmentIdWithSkillIds
             .withArgs(assessmentId1)

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -3,6 +3,9 @@ const Assessment = require('../../../../lib/domain/models/Assessment');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
 const CompetenceEvaluation = require('../../../../lib/domain/models/CompetenceEvaluation');
 const scorecardService = require('../../../../lib/domain/services/scorecard-service');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Unit | Service | ScorecardService', function () {
   describe('#computeScorecard', function () {
@@ -246,13 +249,13 @@ describe('Unit | Service | ScorecardService', function () {
           id: 1,
           campaign,
           campaignId: campaign.id,
-          status: 'STARTED',
+          status: STARTED,
         });
         campaignParticipation2 = domainBuilder.buildCampaignParticipation({
           id: 2,
           campaign,
           campaignId: campaign.id,
-          status: 'STARTED',
+          status: STARTED,
         });
         oldAssessment1 = domainBuilder.buildAssessment.ofTypeCampaign({
           id: assessmentId1,

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -52,7 +52,6 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function (
     const campaignParticipation = domainBuilder.buildCampaignParticipation({
       userId,
       id: campaignParticipationId,
-      isShared: true,
     });
     campaignParticipationRepository.get.withArgs(campaignParticipationId, {}).resolves(campaignParticipation);
 
@@ -74,7 +73,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function (
     const campaignParticipation = domainBuilder.buildCampaignParticipation({
       userId,
       id: campaignParticipationId,
-      isShared: false,
+      status: 'STARTED',
     });
     campaignParticipationRepository.get.withArgs(campaignParticipationId, {}).resolves(campaignParticipation);
     const ongoingAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
@@ -96,7 +95,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function (
     const campaignParticipation = domainBuilder.buildCampaignParticipation({
       userId,
       id: campaignParticipationId,
-      isShared: false,
+      status: 'STARTED',
     });
     campaignParticipationRepository.get.withArgs(campaignParticipationId, {}).resolves(campaignParticipation);
     const latestAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -6,6 +6,9 @@ const {
   AlreadySharedCampaignParticipationError,
   UserNotAuthorizedToAccessEntityError,
 } = require('../../../../lib/domain/errors');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+const { STARTED } = CampaignParticipation.statuses;
 
 describe('Unit | Usecase | begin-campaign-participation-improvement', function () {
   let dependencies;
@@ -73,7 +76,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function (
     const campaignParticipation = domainBuilder.buildCampaignParticipation({
       userId,
       id: campaignParticipationId,
-      status: 'STARTED',
+      status: STARTED,
     });
     campaignParticipationRepository.get.withArgs(campaignParticipationId, {}).resolves(campaignParticipation);
     const ongoingAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
@@ -95,7 +98,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', function (
     const campaignParticipation = domainBuilder.buildCampaignParticipation({
       userId,
       id: campaignParticipationId,
-      status: 'STARTED',
+      status: STARTED,
     });
     campaignParticipationRepository.get.withArgs(campaignParticipationId, {}).resolves(campaignParticipation);
     const latestAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });

--- a/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -26,7 +26,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', function ()
     targetProfileWithLearningContentRepository = { getByCampaignId: sinon.stub() };
     tutorialRepository = { list: sinon.stub() };
 
-    campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId, isShared: true });
+    campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
   });
 
   context('User has access to this result', function () {

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -68,7 +68,7 @@ describe('Unit | UseCase | start-campaign-participation', function () {
     let campaignParticipation;
 
     beforeEach(function () {
-      campaignParticipation = domainBuilder.buildCampaignParticipation({ isShared: false, status: STARTED, userId });
+      campaignParticipation = domainBuilder.buildCampaignParticipation({ status: STARTED, userId });
       campaignToJoin = domainBuilder.buildCampaignToJoin({
         id: campaignParticipation.campaignId,
         organizationIsManagingStudents: false,
@@ -175,7 +175,7 @@ describe('Unit | UseCase | start-campaign-participation', function () {
     let campaignParticipation;
 
     beforeEach(function () {
-      campaignParticipation = domainBuilder.buildCampaignParticipation({ isShared: false, status: TO_SHARE, userId });
+      campaignParticipation = domainBuilder.buildCampaignParticipation({ status: TO_SHARE, userId });
       campaignToJoin = domainBuilder.buildCampaignToJoin({
         id: campaignParticipation.campaignId,
         organizationIsManagingStudents: false,


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que nous stockons le status directement dans la participation, nous n'avons plus besoin du champ isShared. Il n'est plus utilisé dans aucune requête (https://github.com/1024pix/pix/pull/3487). En vu de sa suppression nous le retirons des factories qui construisent des participations à des campagnes.

## :robot: Solution

Les factories ne prennent plus en entrée une propriété isShared.

## :rainbow: Remarques

La domain factory continue à retourner une propriété isShared qui est utilisé par le front.
Est ce que la database factory doit continuer à insérer le champ isShared tant que celui-ci n'a pas été supprimé ?

## :100: Pour tester
La CI passe ✅ 
