### PR TITLE
[FEATURE] Mettre à jour le PixInputCode et corrections de style de Mon Compte sur Pix App (PIX-3605).

### DIFF
--- a/mon-pix/app/components/user-account/email-verification-code.hbs
+++ b/mon-pix/app/components/user-account/email-verification-code.hbs
@@ -5,6 +5,8 @@
   <div class="email-verification-code__input-code">
     <PixInputCode
       @ariaLabel={{t "pages.user-account.email-verification.code-label"}}
+      @legend={{t "pages.user-account.email-verification.code-legend"}}
+      @explanationOfUse={{t "pages.user-account.email-verification.code-explanation-of-use"}}
       @numInputs={{6}}
       @onAllInputsFilled={{this.onSubmitCode}}
     />

--- a/mon-pix/app/components/user-account/email-with-validation-form.hbs
+++ b/mon-pix/app/components/user-account/email-with-validation-form.hbs
@@ -40,7 +40,7 @@
     <PixButton
       class="update-email-with-validation-actions__confirm-button"
       @type="submit"
-      @isDisabled={{this.wasButtonClicked}}
+      @isDisabled={{this.hasRequestedUpdate}}
     >
       {{t "pages.user-account.account-update-email-with-validation.save-button"}}
     </PixButton>

--- a/mon-pix/app/components/user-account/email-with-validation-form.hbs
+++ b/mon-pix/app/components/user-account/email-with-validation-form.hbs
@@ -5,6 +5,7 @@
       @id="newEmail"
       @label={{t "pages.user-account.account-update-email-with-validation.fields.new-email.label"}}
       @errorMessage={{this.newEmailValidationMessage}}
+      @value={{this.newEmail}}
       type="email"
       {{on "focusout" this.validateNewEmail}}
       autocomplete="off"
@@ -16,10 +17,9 @@
   </div>
   <div class="update-email-with-validation__password-input">
     <PixInputPassword
-      @id="password"
+      @id="update-email-with-validation__password"
       @label={{t "pages.user-account.account-update-email-with-validation.fields.password.label"}}
-      @errorMessage={{this.passwordValidationMessage}}
-      {{on "input" this.validatePassword}}
+      @value={{this.password}}
       autocomplete="off"
       required
     />

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -21,7 +21,7 @@ export default class EmailWithValidationForm extends Component {
   @tracked password = '';
   @tracked newEmailValidationMessage = null;
   @tracked errorMessage = null;
-  @tracked wasButtonClicked = false;
+  @tracked hasRequestedUpdate = false;
 
   get isFormValid() {
     return isEmailValid(this.newEmail) && !isEmpty(this.password);
@@ -46,8 +46,8 @@ export default class EmailWithValidationForm extends Component {
 
     if (this.isFormValid) {
       try {
-        if (!this.wasButtonClicked) {
-          this.wasButtonClicked = true;
+        if (!this.hasRequestedUpdate) {
+          this.hasRequestedUpdate = true;
 
           const emailVerificationCode = this.store.createRecord('email-verification-code', {
             password: this.password,
@@ -60,7 +60,7 @@ export default class EmailWithValidationForm extends Component {
       } catch (response) {
         this.handleSubmitError(response);
       } finally {
-        this.wasButtonClicked = false;
+        this.hasRequestedUpdate = false;
       }
     }
   }

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -20,7 +20,6 @@ export default class EmailWithValidationForm extends Component {
   @tracked newEmail = '';
   @tracked password = '';
   @tracked newEmailValidationMessage = null;
-  @tracked passwordValidationMessage = null;
   @tracked errorMessage = null;
   @tracked wasButtonClicked = false;
 
@@ -29,26 +28,13 @@ export default class EmailWithValidationForm extends Component {
   }
 
   @action
-  validateNewEmail(event) {
-    this.newEmail = event.target.value;
+  validateNewEmail() {
     const isInvalidInput = !isEmailValid(this.newEmail);
 
     this.newEmailValidationMessage = null;
 
     if (isInvalidInput) {
       this.newEmailValidationMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidEmail']);
-    }
-  }
-
-  @action
-  validatePassword(event) {
-    this.password = event.target.value;
-    const isInvalidInput = isEmpty(this.password);
-
-    this.passwordValidationMessage = null;
-
-    if (isInvalidInput) {
-      this.passwordValidationMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
     }
   }
 

--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -106,16 +106,7 @@
   }
 
   &__connection-methods {
-    margin: 0 auto;
     max-width: 980px;
-    padding: 0 20px;
-
-    @include device-is('desktop') {
-      padding: 0;
-    }
-
-    @include device-is('mobile') {
-      padding: 0;
-    }
+    padding: 10px 0;
   }
 }

--- a/mon-pix/app/styles/components/user-account/_update-email-with-validation.scss
+++ b/mon-pix/app/styles/components/user-account/_update-email-with-validation.scss
@@ -17,20 +17,10 @@
 
   &__email-input {
     padding-bottom: 32px;
-
-    .pix-input > svg {
-      width: 18px;
-      height: 18px;
-    }
   }
 
   &__password-input {
     padding-bottom: 20px;
-
-    .pix-input-password > svg {
-      width: 18px;
-      height: 18px;
-    }
   }
 
   &__informations {

--- a/mon-pix/app/styles/pages/_connexion-methods.scss
+++ b/mon-pix/app/styles/pages/_connexion-methods.scss
@@ -14,7 +14,7 @@
 }
 
 .success-message {
-  padding-bottom: 20px;
+  padding: 20px 0;
   border-bottom: $grey-15 1px solid;
 }
 

--- a/mon-pix/app/styles/pages/_connexion-methods.scss
+++ b/mon-pix/app/styles/pages/_connexion-methods.scss
@@ -1,9 +1,7 @@
 .user-account-panel__item {
-  margin: 20px 0 0 0;
   display: flex;
   align-content: flex-start;
   border-bottom: $grey-15 1px solid;
-  padding-bottom: 20px;
 
   &.with-success-message {
     border-bottom: none;
@@ -12,8 +10,6 @@
 
   &:last-child {
     border-bottom: none;
-    padding-bottom: 0;
-    margin: 20px 0;
   }
 }
 
@@ -52,5 +48,4 @@
 .user-account-panel-item__button,
 .user-account-panel-item__edit-button {
   margin-left: auto;
-  padding: 0 20px;
 }

--- a/mon-pix/app/templates/user-account/connection-methods.hbs
+++ b/mon-pix/app/templates/user-account/connection-methods.hbs
@@ -21,7 +21,11 @@
             </p>
             <p class="user-account-panel-item__value" data-test-email>{{@model.user.email}}</p>
           </div>
-          <PixButton class="user-account-panel-item__button" @triggerAction={{this.enableEmailEditionMode}}>
+          <PixButton
+            class="user-account-panel-item__button"
+            @triggerAction={{this.enableEmailEditionMode}}
+            @size="small"
+          >
             {{t "pages.user-account.connexion-methods.edit-button"}}
           </PixButton>
         </div>

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -35148,8 +35148,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#cfb66d54461eb491c187abb8332aaea86012303a",
-      "from": "git://github.com/1024pix/pix-ui.git#v9.0.1",
+      "version": "git://github.com/1024pix/pix-ui.git#254dc026b2312f22c5e02a3ee84bec64cf0870b4",
+      "from": "git://github.com/1024pix/pix-ui.git#v10.0.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -35148,8 +35148,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#6886e1fac01c0f11fdd569bfd1a9addda21e4baa",
-      "from": "git://github.com/1024pix/pix-ui.git#v8.2.0",
+      "version": "git://github.com/1024pix/pix-ui.git#cfb66d54461eb491c187abb8332aaea86012303a",
+      "from": "git://github.com/1024pix/pix-ui.git#v9.0.1",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -117,7 +117,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v8.2.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v9.0.1",
     "prettier": "^2.4.1",
     "sass": "^1.38.0",
     "showdown": "^1.9.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -117,7 +117,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v9.0.1",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v10.0.0",
     "prettier": "^2.4.1",
     "sass": "^1.38.0",
     "showdown": "^1.9.1",

--- a/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
@@ -60,33 +60,6 @@ describe('Integration | Component | user-account | email-with-validation-form', 
           ).to.exist;
         });
       });
-
-      context('in password input', function () {
-        it('should display an empty password error message when focus-out', async function () {
-          // given
-          const newEmail = 'newEmail@example.net';
-          const emptyPassword = '';
-
-          await render(hbs`<UserAccount::EmailWithValidationForm />`);
-
-          // when
-          await fillInByLabel(
-            this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'),
-            newEmail
-          );
-          await fillInByLabel(
-            this.intl.t('pages.user-account.account-update-email-with-validation.fields.password.label'),
-            emptyPassword
-          );
-
-          // then
-          expect(
-            contains(
-              this.intl.t('pages.user-account.account-update-email-with-validation.fields.errors.empty-password')
-            )
-          ).to.exist;
-        });
-      });
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1365,7 +1365,9 @@
         "did-not-receive": "You haven’t received anything?",
         "send-back-the-code": "Send the code again",
         "confirmation-message": "Email sent!",
-        "code-label": "Field to enter your verification code",
+        "code-label": "Field",
+        "code-legend": "Input the verification code you received by email",
+        "code-explanation-of-use": "To move from one field to another, use either the tabulation, or the left and right arrows of the keyboard. To fill in a field, type a number between 1 and 9, or use the up and down arrows of the keyboard.",
         "update-successful": "Your email address has been changed!",
         "errors": {
           "incorrect-code": "The code entered is incorrect.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1368,7 +1368,7 @@
         "code-label": "Champ",
         "code-legend": "Saisir le code de vérification envoyé par email",
         "code-explanation-of-use": "Pour se déplacer de champ en champ, utilisez soit la tabulation, soit les flèches gauche et droite du clavier. Pour remplir un champ, saisissez des chiffres de 1 à 9 ou bien utilisez les flèches haut et bas du clavier.",
-        "update-successful": "Votre adresse e-mail a été changé !",
+        "update-successful": "Votre adresse e-mail a été changée !",
         "errors": {
           "incorrect-code": "Le code saisi est incorrect.",
           "email-modification-demand-expired": "Ce code a expiré. Veuillez renouveler la demande.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1365,7 +1365,9 @@
         "did-not-receive": "Je n'ai rien reçu,",
         "send-back-the-code": "me renvoyer le code",
         "confirmation-message": "E-mail envoyé !",
-        "code-label": "Champ du code de vérification",
+        "code-label": "Champ",
+        "code-legend": "Saisir le code de vérification envoyé par email",
+        "code-explanation-of-use": "Pour se déplacer de champ en champ, utilisez soit la tabulation, soit les flèches gauche et droite du clavier. Pour remplir un champ, saisissez des chiffres de 1 à 9 ou bien utilisez les flèches haut et bas du clavier.",
         "update-successful": "Votre adresse e-mail a été changé !",
         "errors": {
           "incorrect-code": "Le code saisi est incorrect.",


### PR DESCRIPTION
## 🎃  Problème
Le composant Pix-UI `PixInputCode` avait quelques soucis lors du copier/coller et n'était pas accessible.
Suite à deux fix à ce sujet https://github.com/1024pix/pix-ui/pull/152 , https://github.com/1024pix/pix-ui/pull/153 nous pouvons désormais utiliser ce composant là sans soucis.

Par ailleurs, nous en profitons pour corriger l'aspect du bouton "Modifier" dans les méthodes de connexion qui est un peu aplatis et ne suit donc pas notre design system.

## 🦇   Solution
Mettre à jour le PixInputCode. Corriger la taille du bouton "Modifier" dans les méthodes de connexion.
Cette PR a permis de faire un fix de Pix-UI : https://github.com/1024pix/pix-ui/pull/156.

## 👻  Pour tester
Lancer l'api avec : 
- FT_VALIDATE_EMAIL=true npm start -- --watch 
Lancer mon-pix puis : 
- Se connecter avec un utilisateur via un email
- Aller dans le menu en cliquant sur le pseudo de l'utilisateur
- Cliquer sur "Mon compte" et "Mes méthodes de connexion"
- Constater que le bouton modifier est sexy (mais genre, plus qu'avant)
- Cliquer sur "Modifier", remplir le formulaire
- Tenter de faire des copier/coller dans le champ du code de vérification (en sélectionnant votre texte de droite vers gauche ou en double cliquant dessus avant de le copier)
- Constater que le champ n'a pas d'autres soucis


Pour relancer les jeux de données en RA : `scalingo -a pix-api-review-pr3591 --region osc-fr1 run "npm run db:seed"`