### PR TITLE
[BUGFIX] Suppression de l'activation de sortie de question sur les champs `select` dans Firefox (PIX-3598).

### DIFF
--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -4,6 +4,7 @@
   data-challenge-id="{{@challenge.id}}"
   {{on "mouseenter" this.hideOutOfFocusBorder}}
   {{on "mouseleave" this.showOutOfFocusBorder}}
+  {{will-destroy this.clearOnBlurMethod}}
 >
   <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -4,7 +4,6 @@ import Component from '@glimmer/component';
 import ENV from 'mon-pix/config/environment';
 
 export default class Item extends Component {
-
   @service currentUser;
 
   constructor() {
@@ -22,10 +21,20 @@ export default class Item extends Component {
   }
 
   @action
-  showOutOfFocusBorder() {
+  showOutOfFocusBorder(event) {
     if (this.isFocusedChallenge && !this.args.answer) {
+      // linked to a Firefox issue where the mouseleave is triggered
+      // when hovering the select options on mouse navigation
+      // see: https://stackoverflow.com/questions/46831247/select-triggers-mouseleave-event-on-parent-element-in-mozilla-firefox
+      if (this.shouldPreventFirefoxSelectMouseLeaveBehavior(event)) {
+        return;
+      }
       this.args.onFocusOutOfChallenge();
     }
+  }
+
+  shouldPreventFirefoxSelectMouseLeaveBehavior(event) {
+    return event.relatedTarget === null;
   }
 
   _setOnBlurEventToWindow() {

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -40,11 +40,11 @@ export default class Item extends Component {
   _setOnBlurEventToWindow() {
     window.onblur = () => {
       this.args.onFocusOutOfWindow();
-      this._clearOnBlurMethod();
+      this.clearOnBlurMethod();
     };
   }
 
-  _clearOnBlurMethod() {
+  clearOnBlurMethod() {
     window.onblur = null;
   }
 

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -58,7 +58,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           it('should display an info alert with dashed border and overlay', async function() {
             // when
             const challengeItem = find('.challenge-item');
-            await triggerEvent(challengeItem, 'mouseleave');
+            await triggerEvent(challengeItem, 'mouseleave', { relatedTarget: challengeItem });
 
             // then
             expect(find('.challenge__info-alert--show')).to.exist;
@@ -100,7 +100,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             it('should display an info alert with dashed border and overlay', async function() {
               // when
               const challengeItem = find('.challenge-item');
-              await triggerEvent(challengeItem, 'mouseleave');
+              await triggerEvent(challengeItem, 'mouseleave', { relatedTarget: challengeItem });
 
               // then
               expect(find('.challenge__info-alert--could-show')).to.exist;
@@ -111,7 +111,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             it('should display only the warning alert when it has been triggered', async function() {
               // given
               const challengeItem = find('.challenge-item');
-              await triggerEvent(challengeItem, 'mouseleave');
+              await triggerEvent(challengeItem, 'mouseleave', { relatedTarget: challengeItem });
 
               expect(find('.challenge__info-alert--could-show')).to.exist;
               expect(find('.challenge-item--focused')).to.exist;


### PR DESCRIPTION
## :unicorn: Problème

Sur Firefox, dans une épreuve focus qui contient des `select`, le survol à la souris des réponses en `option` active la sortie d'épreuve, ajoutant l'overlay et le message d'alerte de sortie d'épreuve en bas de page.

## :robot: Solution

Nous ajoutons une vérification sur la propriété `relatedTarget` de l'évènement `MouseEvent` afin de supprimer ce comportement gênant.
[Documentation](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/relatedTarget)

## :rainbow: Remarques
N/A

## :100: Pour tester

Sur Firefox et Chrome : 
Aller sur l'épreuve `challenge1Si9MaoPUbbSG6`
Vérifier que le fait de cliquer sur les `select` et survoler les options n'active pas le mécanisme de sortie d'épreuve
