### PR TITLE
[BUGFIX] Corriger le fichier de test mail-service dans l'API (PIX-3630).

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -338,7 +338,7 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
   };
 
   if (locale === FRENCH_SPOKEN) {
-    options.subject = translate(frTranslations['verification-code-email'].subject, { code });
+    options.subject = translate({ phrase: 'verification-code-email.subject', locale: 'fr' }, { code });
 
     options.variables = {
       code,
@@ -348,7 +348,7 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
       ...frTranslations['verification-code-email'].body,
     };
   } else if (locale === FRENCH_FRANCE) {
-    options.subject = translate(frTranslations['verification-code-email'].subject, { code });
+    options.subject = translate({ phrase: 'verification-code-email.subject', locale: 'fr' }, { code });
 
     options.variables = {
       code,
@@ -358,7 +358,7 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
       ...frTranslations['verification-code-email'].body,
     };
   } else if (locale === ENGLISH_SPOKEN) {
-    options.subject = translate(enTranslations['verification-code-email'].subject, { code });
+    options.subject = translate({ phrase: 'verification-code-email.subject', locale: 'en' }, { code });
 
     options.variables = {
       code,

--- a/api/tests/tooling/i18n/i18n.js
+++ b/api/tests/tooling/i18n/i18n.js
@@ -4,7 +4,7 @@ const i18n = require('i18n');
 function getI18n() {
   const directory = path.resolve(path.join(__dirname, '../../../translations'));
   i18n.configure({
-    locales: ['fr'],
+    locales: ['fr', 'en'],
     defaultLocale: 'fr',
     directory,
     objectNotation: true,

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -60,105 +60,62 @@ describe('Unit | Service | MailService', function () {
     });
 
     context('according to locale', function () {
-      const translationsMapping = {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        fr: mainTranslationsMapping.fr['pix-account-creation-email'],
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        en: mainTranslationsMapping.en['pix-account-creation-email'],
-      };
-
       context('should call sendEmail with localized variable options', function () {
-        const testCases = [
-          {
-            locale: undefined,
-            expected: {
-              fromName: 'PIX - Ne pas répondre',
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.fr.subject,
-              variables: {
-                homeName: 'pix.fr',
-                homeUrl: 'https://pix.fr',
-                helpdeskUrl: 'https://support.pix.fr/support/tickets/new',
-                displayNationalLogo: true,
-                redirectionUrl: 'https://app.pix.fr/connexion',
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.fr.params,
-              },
-            },
-          },
-          {
-            locale: FRENCH_FRANCE,
-            expected: {
-              fromName: 'PIX - Ne pas répondre',
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.fr.subject,
-              variables: {
-                homeName: 'pix.fr',
-                homeUrl: 'https://pix.fr',
-                helpdeskUrl: 'https://support.pix.fr/support/tickets/new',
-                displayNationalLogo: true,
-                redirectionUrl: 'https://app.pix.fr/connexion',
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.fr.params,
-              },
-            },
-          },
-          {
-            locale: FRENCH_SPOKEN,
-            expected: {
-              fromName: 'PIX - Ne pas répondre',
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.fr.subject,
-              variables: {
-                homeName: 'pix.org',
-                homeUrl: 'https://pix.org/fr/',
-                helpdeskUrl: 'https://pix.org/fr/formulaire-aide',
-                displayNationalLogo: false,
-                redirectionUrl: 'https://app.pix.org/connexion/?lang=fr',
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.fr.params,
-              },
-            },
-          },
-          {
-            locale: ENGLISH_SPOKEN,
-            expected: {
-              fromName: 'PIX - Noreply',
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.en.subject,
-              variables: {
-                homeName: 'pix.org',
-                homeUrl: 'https://pix.org/en-gb/',
-                helpdeskUrl: 'https://pix.org/en-gb/contact-form',
-                displayNationalLogo: false,
-                redirectionUrl: 'https://app.pix.org/connexion/?lang=en',
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.en.params,
-              },
-            },
-          },
-        ];
+        it(`should call sendEmail with from, to, template and locale ${FRENCH_SPOKEN} or undefined`, async function () {
+          // given
+          const locale = FRENCH_SPOKEN;
 
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        testCases.forEach((testCase) => {
-          it(`when locale is ${testCase.locale}`, async function () {
-            // when
-            await mailService.sendAccountCreationEmail(userEmailAddress, testCase.locale);
+          // when
+          await mailService.sendAccountCreationEmail(userEmailAddress, locale);
 
-            // then
-            const options = mailer.sendEmail.firstCall.args[0];
-            expect(options.fromName).to.equal(testCase.expected.fromName);
-            expect(options.variables).to.include(testCase.expected.variables);
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.fromName).to.equal('PIX - Ne pas répondre');
+          expect(options.variables).to.include({
+            homeName: 'pix.org',
+            homeUrl: 'https://pix.org/fr/',
+            helpdeskUrl: 'https://pix.org/fr/formulaire-aide',
+            displayNationalLogo: false,
+            redirectionUrl: 'https://app.pix.org/connexion/?lang=fr',
+            ...mainTranslationsMapping.fr['pix-account-creation-email'].params,
+          });
+        });
+        it(`should call sendEmail with from, to, template and locale ${FRENCH_FRANCE}`, async function () {
+          // given
+          const locale = FRENCH_FRANCE;
+
+          // when
+          await mailService.sendAccountCreationEmail(userEmailAddress, locale);
+
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.fromName).to.equal('PIX - Ne pas répondre');
+          expect(options.variables).to.include({
+            homeName: 'pix.fr',
+            homeUrl: 'https://pix.fr',
+            helpdeskUrl: 'https://support.pix.fr/support/tickets/new',
+            displayNationalLogo: true,
+            redirectionUrl: 'https://app.pix.fr/connexion',
+            ...mainTranslationsMapping.fr['pix-account-creation-email'].params,
+          });
+        });
+        it(`should call sendEmail with from, to, template and locale ${ENGLISH_SPOKEN}`, async function () {
+          // given
+          const locale = ENGLISH_SPOKEN;
+
+          // when
+          await mailService.sendAccountCreationEmail(userEmailAddress, locale);
+
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.fromName).to.equal('PIX - Noreply');
+          expect(options.variables).to.include({
+            homeName: 'pix.org',
+            homeUrl: 'https://pix.org/en-gb/',
+            helpdeskUrl: 'https://pix.org/en-gb/contact-form',
+            displayNationalLogo: false,
+            redirectionUrl: 'https://app.pix.org/connexion/?lang=en',
+            ...mainTranslationsMapping.en['pix-account-creation-email'].params,
           });
         });
       });
@@ -211,124 +168,118 @@ describe('Unit | Service | MailService', function () {
     const template = 'test-password-reset-template-id';
     const temporaryKey = 'token';
 
-    const translationsMapping = {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      fr: mainTranslationsMapping.fr['reset-password-demand-email'],
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      en: mainTranslationsMapping.en['reset-password-demand-email'],
-    };
-
     context('according to locale', function () {
-      const testCases = [
-        {
-          locale: undefined,
-          expectedTranslationLanguage: FRENCH_SPOKEN,
-          expectedOptions: {
-            from,
-            to,
-            template,
-            fromName: 'PIX - Ne pas répondre',
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            subject: translationsMapping.fr.subject,
-            variables: {
-              locale: FRENCH_FRANCE,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              ...translationsMapping.fr.params,
-              homeName: 'pix.fr',
-              homeUrl: 'https://pix.fr',
-              resetUrl: `https://app.pix.fr/changer-mot-de-passe/${temporaryKey}`,
-              helpdeskURL: 'https://support.pix.fr/support/tickets/new',
-            },
+      it(`should call mailer with translated texts if locale is ${ENGLISH_SPOKEN}`, async function () {
+        // given
+        const expectedOptions = {
+          from,
+          to,
+          template,
+          fromName: 'PIX - Noreply',
+          subject: mainTranslationsMapping.en['reset-password-demand-email'].subject,
+          variables: {
+            locale: ENGLISH_SPOKEN,
+            ...mainTranslationsMapping.en['reset-password-demand-email'].params,
+            homeName: 'pix.org',
+            homeUrl: 'https://pix.org/en-gb/',
+            resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=en`,
+            helpdeskURL: 'https://pix.org/en-gb/contact-form',
           },
-        },
-        {
-          locale: FRENCH_FRANCE,
-          expectedTranslationLanguage: FRENCH_SPOKEN,
-          expectedOptions: {
-            from,
-            to,
-            template,
-            fromName: 'PIX - Ne pas répondre',
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            subject: translationsMapping.fr.subject,
-            variables: {
-              locale: FRENCH_FRANCE,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              ...translationsMapping.fr.params,
-              homeName: 'pix.fr',
-              homeUrl: 'https://pix.fr',
-              resetUrl: `https://app.pix.fr/changer-mot-de-passe/${temporaryKey}`,
-              helpdeskURL: 'https://support.pix.fr/support/tickets/new',
-            },
-          },
-        },
-        {
-          locale: FRENCH_SPOKEN,
-          expectedTranslationLanguage: FRENCH_SPOKEN,
-          expectedOptions: {
-            from,
-            to,
-            template,
-            fromName: 'PIX - Ne pas répondre',
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            subject: translationsMapping.fr.subject,
-            variables: {
-              locale: FRENCH_SPOKEN,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              ...translationsMapping.fr.params,
-              homeName: 'pix.org',
-              homeUrl: 'https://pix.org/fr/',
-              resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
-              helpdeskURL: 'https://pix.org/fr/formulaire-aide',
-            },
-          },
-        },
-        {
+        };
+
+        // when
+        await mailService.sendResetPasswordDemandEmail({
+          email: userEmailAddress,
           locale: ENGLISH_SPOKEN,
-          expectedTranslationLanguage: ENGLISH_SPOKEN,
-          expectedOptions: {
-            from,
-            to,
-            template,
-            fromName: 'PIX - Noreply',
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            subject: translationsMapping.en.subject,
-            variables: {
-              locale: ENGLISH_SPOKEN,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              ...translationsMapping.en.params,
-              homeName: 'pix.org',
-              homeUrl: 'https://pix.org/en-gb/',
-              resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=en`,
-              helpdeskURL: 'https://pix.org/en-gb/contact-form',
-            },
-          },
-        },
-      ];
-
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      testCases.forEach((testCase) => {
-        it(`should call mailer with ${testCase.expectedTranslationLanguage} translated texts if locale is ${testCase.locale}`, async function () {
-          // when
-          await mailService.sendResetPasswordDemandEmail({
-            email: userEmailAddress,
-            locale: testCase.locale,
-            temporaryKey,
-          });
-
-          // then
-          expect(mailer.sendEmail).to.have.been.calledWithExactly(testCase.expectedOptions);
+          temporaryKey,
         });
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      });
+      it(`should call mailer with translated texts if locale is ${FRENCH_SPOKEN}`, async function () {
+        // given
+        const expectedOptions = {
+          from,
+          to,
+          template,
+          fromName: 'PIX - Ne pas répondre',
+          subject: mainTranslationsMapping.fr['reset-password-demand-email'].subject,
+          variables: {
+            locale: FRENCH_SPOKEN,
+            ...mainTranslationsMapping.fr['reset-password-demand-email'].params,
+            homeName: 'pix.org',
+            homeUrl: 'https://pix.org/fr/',
+            resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
+            helpdeskURL: 'https://pix.org/fr/formulaire-aide',
+          },
+        };
+
+        // when
+        await mailService.sendResetPasswordDemandEmail({
+          email: userEmailAddress,
+          locale: FRENCH_SPOKEN,
+          temporaryKey,
+        });
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      });
+      it(`should call mailer with translated texts if locale is ${FRENCH_FRANCE}`, async function () {
+        // given
+        const expectedOptions = {
+          from,
+          to,
+          template,
+          fromName: 'PIX - Ne pas répondre',
+          subject: mainTranslationsMapping.fr['reset-password-demand-email'].subject,
+          variables: {
+            locale: FRENCH_FRANCE,
+            ...mainTranslationsMapping.fr['reset-password-demand-email'].params,
+            homeName: 'pix.fr',
+            homeUrl: 'https://pix.fr',
+            resetUrl: `https://app.pix.fr/changer-mot-de-passe/${temporaryKey}`,
+            helpdeskURL: 'https://support.pix.fr/support/tickets/new',
+          },
+        };
+
+        // when
+        await mailService.sendResetPasswordDemandEmail({
+          email: userEmailAddress,
+          locale: FRENCH_FRANCE,
+          temporaryKey,
+        });
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      });
+      it(`should call mailer with fr-fr translated texts if locale is undefined`, async function () {
+        // given
+        const expectedOptions = {
+          from,
+          to,
+          template,
+          fromName: 'PIX - Ne pas répondre',
+          subject: mainTranslationsMapping.fr['reset-password-demand-email'].subject,
+          variables: {
+            locale: FRENCH_FRANCE,
+            ...mainTranslationsMapping.fr['reset-password-demand-email'].params,
+            homeName: 'pix.fr',
+            homeUrl: 'https://pix.fr',
+            resetUrl: `https://app.pix.fr/changer-mot-de-passe/${temporaryKey}`,
+            helpdeskURL: 'https://support.pix.fr/support/tickets/new',
+          },
+        };
+
+        // when
+        await mailService.sendResetPasswordDemandEmail({
+          email: userEmailAddress,
+          locale: undefined,
+          temporaryKey,
+        });
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
       });
     });
   });
@@ -409,112 +360,97 @@ describe('Unit | Service | MailService', function () {
     });
 
     context('according to locale', function () {
-      const translationsMapping = {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        fr: mainTranslationsMapping.fr['organization-invitation-email'],
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        en: mainTranslationsMapping.en['organization-invitation-email'],
-      };
-
       context('should call sendEmail with localized variable options', function () {
-        const testCases = [
-          {
-            locale: undefined,
-            expected: {
-              fromName: 'Pix Orga - Ne pas répondre',
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.fr.subject,
-              variables: {
-                pixHomeName: 'pix.fr',
-                pixHomeUrl: 'https://pix.fr',
-                pixOrgaHomeUrl: 'https://orga.pix.fr',
-                redirectionUrl: `https://orga.pix.fr/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-                supportUrl: 'https://support.pix.fr/support/tickets/new',
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.fr.params,
-              },
-            },
-          },
-          {
+        it(`when locale is ${FRENCH_SPOKEN}`, async function () {
+          // when
+          await mailService.sendOrganizationInvitationEmail({
+            email: userEmailAddress,
+            organizationName,
+            organizationInvitationId,
+            code,
             locale: FRENCH_SPOKEN,
-            expected: {
-              fromName: 'Pix Orga - Ne pas répondre',
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.fr.subject,
-              variables: {
-                pixHomeName: 'pix.org',
-                pixHomeUrl: 'https://pix.org',
-                pixOrgaHomeUrl: 'https://orga.pix.org',
-                redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-                supportUrl: 'https://pix.org/fr/formulaire-aide',
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.fr.params,
-              },
-            },
-          },
-          {
+          });
+
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
+          expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
+          expect(options.variables).to.include({
+            pixHomeName: 'pix.org',
+            pixHomeUrl: 'https://pix.org',
+            pixOrgaHomeUrl: 'https://orga.pix.org',
+            redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
+            supportUrl: 'https://pix.org/fr/formulaire-aide',
+            ...mainTranslationsMapping.fr['organization-invitation-email'].params,
+          });
+        });
+        it(`when locale is ${FRENCH_FRANCE}`, async function () {
+          // when
+          await mailService.sendOrganizationInvitationEmail({
+            email: userEmailAddress,
+            organizationName,
+            organizationInvitationId,
+            code,
             locale: FRENCH_FRANCE,
-            expected: {
-              fromName: 'Pix Orga - Ne pas répondre',
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.fr.subject,
-              variables: {
-                pixHomeName: 'pix.fr',
-                pixHomeUrl: 'https://pix.fr',
-                pixOrgaHomeUrl: 'https://orga.pix.fr',
-                redirectionUrl: `https://orga.pix.fr/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-                supportUrl: 'https://support.pix.fr/support/tickets/new',
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.fr.params,
-              },
-            },
-          },
-          {
+          });
+
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
+          expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
+          expect(options.variables).to.include({
+            pixHomeName: 'pix.fr',
+            pixHomeUrl: 'https://pix.fr',
+            pixOrgaHomeUrl: 'https://orga.pix.fr',
+            redirectionUrl: `https://orga.pix.fr/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
+            supportUrl: 'https://support.pix.fr/support/tickets/new',
+            ...mainTranslationsMapping.fr['organization-invitation-email'].params,
+          });
+        });
+        it('when locale is undefined', async function () {
+          // when
+          await mailService.sendOrganizationInvitationEmail({
+            email: userEmailAddress,
+            organizationName,
+            organizationInvitationId,
+            code,
+            locale: undefined,
+          });
+
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
+          expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
+          expect(options.variables).to.include({
+            pixHomeName: 'pix.fr',
+            pixHomeUrl: 'https://pix.fr',
+            pixOrgaHomeUrl: 'https://orga.pix.fr',
+            redirectionUrl: `https://orga.pix.fr/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
+            supportUrl: 'https://support.pix.fr/support/tickets/new',
+            ...mainTranslationsMapping.fr['organization-invitation-email'].params,
+          });
+        });
+        it(`when locale is ${ENGLISH_SPOKEN}`, async function () {
+          // when
+          await mailService.sendOrganizationInvitationEmail({
+            email: userEmailAddress,
+            organizationName,
+            organizationInvitationId,
+            code,
             locale: ENGLISH_SPOKEN,
-            expected: {
-              fromName: 'Pix Orga - Noreply',
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.en.subject,
-              variables: {
-                pixHomeName: 'pix.org',
-                pixHomeUrl: 'https://pix.org/en-gb/',
-                pixOrgaHomeUrl: 'https://orga.pix.org?lang=en',
-                redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`,
-                supportUrl: 'https://pix.org/en-gb/contact-form',
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.en.params,
-              },
-            },
-          },
-        ];
+          });
 
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        testCases.forEach((testCase) => {
-          it(`when locale is ${testCase.locale}`, async function () {
-            // when
-            await mailService.sendOrganizationInvitationEmail({
-              email: userEmailAddress,
-              organizationName,
-              organizationInvitationId,
-              code,
-              locale: testCase.locale,
-            });
-
-            // then
-            const options = mailer.sendEmail.firstCall.args[0];
-            expect(options.fromName).to.equal(testCase.expected.fromName);
-            expect(options.subject).to.equal(testCase.expected.subject);
-            expect(options.variables).to.include(testCase.expected.variables);
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.fromName).to.equal('Pix Orga - Noreply');
+          expect(options.subject).to.equal(mainTranslationsMapping.en['organization-invitation-email'].subject);
+          expect(options.variables).to.include({
+            pixHomeName: 'pix.org',
+            pixHomeUrl: 'https://pix.org/en-gb/',
+            pixOrgaHomeUrl: 'https://orga.pix.org?lang=en',
+            redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`,
+            supportUrl: 'https://pix.org/en-gb/contact-form',
+            ...mainTranslationsMapping.en['organization-invitation-email'].params,
           });
         });
       });
@@ -593,77 +529,47 @@ describe('Unit | Service | MailService', function () {
     });
 
     context('according to locale', function () {
-      const translationsMapping = {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        fr: mainTranslationsMapping.fr['email-change-email'],
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        en: mainTranslationsMapping.en['email-change-email'],
-      };
-
       context('should call sendEmail with localized variable options', function () {
-        const testCases = [
-          {
-            locale: FRENCH_SPOKEN,
-            expected: {
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.fr.subject,
-              variables: {
-                homeName: 'pix.org',
-                homeUrl: 'https://pix.org/fr/',
-                displayNationalLogo: false,
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.fr.body,
-              },
-            },
-          },
-          {
-            locale: FRENCH_FRANCE,
-            expected: {
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.fr.subject,
-              variables: {
-                homeName: 'pix.fr',
-                homeUrl: 'https://pix.fr',
-                displayNationalLogo: true,
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.fr.body,
-              },
-            },
-          },
-          {
-            locale: ENGLISH_SPOKEN,
-            expected: {
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              subject: translationsMapping.en.subject,
-              variables: {
-                homeName: 'pix.org',
-                homeUrl: 'https://pix.org/en-gb/',
-                displayNationalLogo: false,
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                ...translationsMapping.en.body,
-              },
-            },
-          },
-        ];
+        it(`when locale is ${FRENCH_SPOKEN}`, async function () {
+          // when
+          await mailService.notifyEmailChange({ email: userEmailAddress, locale: FRENCH_SPOKEN });
 
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        testCases.forEach((testCase) => {
-          it(`when locale is ${testCase.locale}`, async function () {
-            // when
-            await mailService.notifyEmailChange({ email: userEmailAddress, locale: testCase.locale });
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.subject).to.equal(mainTranslationsMapping.fr['email-change-email'].subject);
+          expect(options.variables).to.include({
+            homeName: 'pix.org',
+            homeUrl: 'https://pix.org/fr/',
+            displayNationalLogo: false,
+            ...mainTranslationsMapping.fr['email-change-email'].body,
+          });
+        });
+        it(`when locale is ${FRENCH_FRANCE}`, async function () {
+          // when
+          await mailService.notifyEmailChange({ email: userEmailAddress, locale: FRENCH_FRANCE });
 
-            // then
-            const options = mailer.sendEmail.firstCall.args[0];
-            expect(options.subject).to.equal(testCase.expected.subject);
-            expect(options.variables).to.include(testCase.expected.variables);
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.subject).to.equal(mainTranslationsMapping.fr['email-change-email'].subject);
+          expect(options.variables).to.include({
+            homeName: 'pix.fr',
+            homeUrl: 'https://pix.fr',
+            displayNationalLogo: true,
+            ...mainTranslationsMapping.fr['email-change-email'].body,
+          });
+        });
+        it(`when locale is ${ENGLISH_SPOKEN}`, async function () {
+          // when
+          await mailService.notifyEmailChange({ email: userEmailAddress, locale: ENGLISH_SPOKEN });
+
+          // then
+          const options = mailer.sendEmail.firstCall.args[0];
+          expect(options.subject).to.equal(mainTranslationsMapping.en['email-change-email'].subject);
+          expect(options.variables).to.include({
+            homeName: 'pix.org',
+            homeUrl: 'https://pix.org/en-gb/',
+            displayNationalLogo: false,
+            ...mainTranslationsMapping.en['email-change-email'].body,
           });
         });
       });

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -707,129 +707,84 @@ describe('Unit | Service | MailService', function () {
   });
 
   describe('#sendVerificationCodeEmail', function () {
-    let translationsMapping;
-    let testCases;
-    let code;
-    let userEmail;
-    let translate;
-
-    before(function () {
-      translate = getI18n().__;
-      userEmail = 'user@example.net';
-      code = '999999';
-
-      translationsMapping = {
-        fr: mainTranslationsMapping.fr['verification-code-email'],
-        en: mainTranslationsMapping.en['verification-code-email'],
-      };
-
-      testCases = [
-        {
-          locale: FRENCH_SPOKEN,
-          expected: {
-            from: 'ne-pas-repondre@pix.fr',
-            to: userEmail,
-            subject: translate(translationsMapping.fr.subject, { code }),
-            template: 'test-email-verification-code-template-id',
-            tags: ['EMAIL_VERIFICATION_CODE'],
-            variables: {
-              homeName: 'pix.org',
-              homeUrl: 'https://pix.org/fr/',
-              displayNationalLogo: false,
-              code,
-              ...translationsMapping.fr.body,
-            },
-          },
-        },
-        {
-          locale: FRENCH_FRANCE,
-          expected: {
-            from: 'ne-pas-repondre@pix.fr',
-            to: userEmail,
-            subject: translate(translationsMapping.fr.subject, { code }),
-            template: 'test-email-verification-code-template-id',
-            tags: ['EMAIL_VERIFICATION_CODE'],
-            variables: {
-              homeName: 'pix.fr',
-              homeUrl: 'https://pix.fr',
-              displayNationalLogo: true,
-              code,
-              ...translationsMapping.fr.body,
-            },
-          },
-        },
-        {
-          locale: ENGLISH_SPOKEN,
-          expected: {
-            from: 'ne-pas-repondre@pix.fr',
-            to: userEmail,
-            subject: translate(translationsMapping.en.subject, { code }),
-            tags: ['EMAIL_VERIFICATION_CODE'],
-            template: 'test-email-verification-code-template-id',
-            variables: {
-              homeName: 'pix.org',
-              homeUrl: 'https://pix.org/en-gb/',
-              displayNationalLogo: false,
-              code,
-              ...translationsMapping.en.body,
-            },
-          },
-        },
-      ];
-    });
-
     it(`should call sendEmail with from, to, template, tags and locale ${FRENCH_SPOKEN}`, async function () {
       // given
-      const testCase = testCases[0];
+      const translate = getI18n().__;
+      const userEmail = 'user@example.net';
+      const code = '999999';
 
       // when
       await mailService.sendVerificationCodeEmail({
         code,
         email: userEmail,
-        locale: testCase.locale,
+        locale: FRENCH_SPOKEN,
         translate,
       });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
-      expect(options.subject).to.equal(testCase.expected.subject);
-      expect(options.variables).to.include(testCase.expected.variables);
+      expect(options.subject).to.equal(translate('verification-code-email.subject', { code }));
+      expect(options.variables).to.include({
+        homeName: 'pix.org',
+        homeUrl: 'https://pix.org/fr/',
+        displayNationalLogo: false,
+        code,
+        ...mainTranslationsMapping.fr['verification-code-email'].body,
+      });
     });
 
     it(`should call sendEmail with from, to, template, tags and locale ${FRENCH_FRANCE}`, async function () {
       // given
-      const testCase = testCases[1];
+      const translate = getI18n().__;
+      const userEmail = 'user@example.net';
+      const code = '999999';
 
       // when
       await mailService.sendVerificationCodeEmail({
         code,
         email: userEmail,
-        locale: testCase.locale,
+        locale: FRENCH_FRANCE,
         translate,
       });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
-      expect(options.subject).to.equal(testCase.expected.subject);
-      expect(options.variables).to.include(testCase.expected.variables);
+      expect(options.subject).to.equal(translate('verification-code-email.subject', { code }));
+      expect(options.variables).to.include({
+        homeName: 'pix.fr',
+        homeUrl: 'https://pix.fr',
+        displayNationalLogo: true,
+        code,
+        ...mainTranslationsMapping.fr['verification-code-email'].body,
+      });
     });
 
     it(`should call sendEmail with from, to, template, tags and locale ${ENGLISH_SPOKEN}`, async function () {
       // given
-      const testCase = testCases[2];
+      const translate = getI18n().__;
+      const userEmail = 'user@example.net';
+      const code = '999999';
 
       // when
       await mailService.sendVerificationCodeEmail({
         code,
         email: userEmail,
-        locale: testCase.locale,
+        locale: ENGLISH_SPOKEN,
         translate,
       });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
-      expect(options.subject).to.equal(testCase.expected.subject);
-      expect(options.variables).to.include(testCase.expected.variables);
+      expect(options.subject).to.equal(
+        translate({ phrase: 'verification-code-email.subject', locale: 'en' }, { code })
+      );
+      expect(options.variables).to.include({
+        homeName: 'pix.org',
+        homeUrl: 'https://pix.org/en-gb/',
+        displayNationalLogo: false,
+        code,
+        ...mainTranslationsMapping.en['verification-code-email'].body,
+      });
     });
   });
 });


### PR DESCRIPTION
## 🎃 Problème
Depuis une semaine, plusieurs devs ont constatés que le fichier json de traduction coté API générait des clés automatiquement lorsqu'ils lançaient leurs tests. 
Ces clés ajoutées sont liées à un mail concernant la validation de la nouvelle adresse email, où nous utilisons [i18n](https://github.com/funktionswerk/hapi-i18n) pour y inclure le code de manière dynamique.

Discussion Slack sur le sujet avec proposition de solution de Sebastien : https://1024pix.slack.com/archives/C658LDBAQ/p1633705215109100

## 🦇 Solution
Corriger l'implémentation de la traduction de i18n dans le mail-service et dans son test pour ne plus que le fichier génère les clés automatiquement.

## 🕸 Remarques
Nettoyage du fichier de test pour enlever les todo eslint.

## 👻 Pour tester
Lancer les tests et vérifier que le json ne se manifeste plus.
