### PR TITLE
[FEATURE] Bloquer l'obtention d'une certification complémentaire lorsque la session a été passée dans un centre de certification non habilité (PIX-3525).

### DIFF
--- a/api/lib/domain/events/handle-clea-certification-rescoring.js
+++ b/api/lib/domain/events/handle-clea-certification-rescoring.js
@@ -7,9 +7,15 @@ async function handleCleaCertificationRescoring({
   event,
   cleaCertificationResultRepository,
   partnerCertificationScoringRepository,
+  certificationCenterRepository,
 }) {
   checkEventTypes(event, eventTypes);
   const { certificationCourseId } = event;
+
+  const certificationCenter = await certificationCenterRepository.getByCertificationCourseId(certificationCourseId);
+  if (!certificationCenter.isAccreditedClea) {
+    return;
+  }
   const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
   if (!cleaCertificationResult.isTaken()) {
     return;

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -8,15 +8,23 @@ async function handleCleaCertificationScoring({
   partnerCertificationScoringRepository,
   badgeRepository,
   certificationCourseRepository,
+  certificationCenterRepository,
   knowledgeElementRepository,
   targetProfileRepository,
   badgeCriteriaService,
 }) {
   checkEventTypes(event, eventTypes);
+  const { certificationCourseId, userId, reproducibilityRate } = event;
+
+  const certificationCenter = await certificationCenterRepository.getByCertificationCourseId(certificationCourseId);
+  if (!certificationCenter.isAccreditedClea) {
+    return;
+  }
+
   const cleaCertificationScoring = await partnerCertificationScoringRepository.buildCleaCertificationScoring({
-    certificationCourseId: event.certificationCourseId,
-    userId: event.userId,
-    reproducibilityRate: event.reproducibilityRate,
+    certificationCourseId,
+    userId,
+    reproducibilityRate,
   });
 
   if (cleaCertificationScoring.hasAcquiredBadge) {

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -16,6 +16,7 @@ const dependencies = {
   campaignParticipationRepository: require('../../infrastructure/repositories/campaign-participation-repository'),
   campaignParticipationResultRepository: require('../../infrastructure/repositories/campaign-participation-result-repository'),
   certificationAssessmentRepository: require('../../infrastructure/repositories/certification-assessment-repository'),
+  certificationCenterRepository: require('../../infrastructure/repositories/certification-center-repository'),
   certificationCourseRepository: require('../../infrastructure/repositories/certification-course-repository'),
   cleaCertificationResultRepository: require('../../infrastructure/repositories/clea-certification-result-repository'),
   certificationIssueReportRepository: require('../../infrastructure/repositories/certification-issue-report-repository'),

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -2,6 +2,8 @@ const SUP = 'SUP';
 const SCO = 'SCO';
 const PRO = 'PRO';
 
+const PIX_PLUS_DROIT = 'Pix+ Droit';
+
 const types = {
   SUP,
   SCO,
@@ -20,6 +22,10 @@ class CertificationCenter {
 
   get isSco() {
     return this.type === types.SCO;
+  }
+
+  get isAccreditedPixPlusDroit() {
+    return this.accreditations.some((accreditation) => accreditation.name === PIX_PLUS_DROIT);
   }
 }
 

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -3,6 +3,7 @@ const SCO = 'SCO';
 const PRO = 'PRO';
 
 const PIX_PLUS_DROIT = 'Pix+ Droit';
+const CLEA = 'CléA Numérique';
 
 const types = {
   SUP,
@@ -26,6 +27,10 @@ class CertificationCenter {
 
   get isAccreditedPixPlusDroit() {
     return this.accreditations.some((accreditation) => accreditation.name === PIX_PLUS_DROIT);
+  }
+
+  get isAccreditedClea() {
+    return this.accreditations.some((accreditation) => accreditation.name === CLEA);
   }
 }
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -192,6 +192,104 @@ describe('Integration | Repository | Certification Center', function () {
     });
   });
 
+  describe('#getByCertificationCourseId', function () {
+    context('the certification center is found for a certificationCourseId', function () {
+      it('should return the certification center of the given certificationCourseId', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'Given session center',
+          externalId: '123456',
+          type: 'SCO',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        }).id;
+        const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId }).id;
+        const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
+          id: 1,
+          name: 'Given session center',
+          type: 'SCO',
+          externalId: '123456',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [],
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenter = await certificationCenterRepository.getByCertificationCourseId(
+          certificationCourseId
+        );
+
+        // then
+        expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
+      });
+
+      it('should return the certification center and accreditations of the given certificationCourseId', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'certificationCenterName',
+          type: CertificationCenter.types.SUP,
+          externalId: 'externalId',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+        }).id;
+        databaseBuilder.factory.buildAccreditation({
+          id: 1234,
+          name: 'Accreditation name',
+        });
+        databaseBuilder.factory.buildGrantedAccreditation({
+          certificationCenterId: 1,
+          accreditationId: 1234,
+        });
+
+        const expectedAccreditation = domainBuilder.buildAccreditation({
+          id: 1234,
+          name: 'Accreditation name',
+        });
+        const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
+          id: 1,
+          name: 'certificationCenterName',
+          type: CertificationCenter.types.SUP,
+          externalId: 'externalId',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          accreditations: [expectedAccreditation],
+        });
+        const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId }).id;
+
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenter = await certificationCenterRepository.getByCertificationCourseId(
+          certificationCourseId
+        );
+
+        expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
+      });
+    });
+
+    context('the certification center could not be found for a sessionId', function () {
+      it('should throw a NotFound error', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 7,
+          name: 'certificationCenterName',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          externalId: '123456',
+          type: 'SCO',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(certificationCenterRepository.getBySessionId)(8);
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+  });
+
   describe('#save', function () {
     afterEach(function () {
       return knex('certification-centers').delete();

--- a/api/tests/unit/domain/events/handle-clea-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-rescoring_test.js
@@ -1,31 +1,13 @@
-const _ = require('lodash');
 const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
 const { handleCleaCertificationRescoring } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 
 describe('Unit | Domain | Events | handle-clea-certification-rescoring', function () {
-  const partnerCertificationScoringRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    buildCleaCertificationScoring: _.noop(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    save: _.noop(),
-  };
-  const cleaCertificationResultRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    get: _.noop(),
-  };
-
-  const dependencies = {
-    partnerCertificationScoringRepository,
-    cleaCertificationResultRepository,
-  };
+  let partnerCertificationScoringRepository;
+  let cleaCertificationResultRepository;
 
   beforeEach(function () {
-    partnerCertificationScoringRepository.buildCleaCertificationScoring = sinon.stub();
-    partnerCertificationScoringRepository.save = sinon.stub();
-    cleaCertificationResultRepository.get = sinon.stub();
+    partnerCertificationScoringRepository = { buildCleaCertificationScoring: sinon.stub(), save: sinon.stub() };
+    cleaCertificationResultRepository = { get: sinon.stub() };
   });
 
   it('fails when event is not of correct type', async function () {
@@ -33,7 +15,11 @@ describe('Unit | Domain | Events | handle-clea-certification-rescoring', functio
     const event = 'not an event of the correct type';
 
     // when / then
-    const error = await catchErr(handleCleaCertificationRescoring)({ event, ...dependencies });
+    const error = await catchErr(handleCleaCertificationRescoring)({
+      event,
+      partnerCertificationScoringRepository,
+      cleaCertificationResultRepository,
+    });
 
     // then
     expect(error.message).to.equal('event must be one of types CertificationRescoringCompleted');
@@ -54,7 +40,8 @@ describe('Unit | Domain | Events | handle-clea-certification-rescoring', functio
 
         // when
         await handleCleaCertificationRescoring({
-          ...dependencies,
+          partnerCertificationScoringRepository,
+          cleaCertificationResultRepository,
           event: certificationRescoringCompletedEvent,
         });
 
@@ -81,7 +68,8 @@ describe('Unit | Domain | Events | handle-clea-certification-rescoring', functio
 
         // when
         await handleCleaCertificationRescoring({
-          ...dependencies,
+          partnerCertificationScoringRepository,
+          cleaCertificationResultRepository,
           event: certificationRescoringCompletedEvent,
         });
 

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -1,147 +1,158 @@
-const _ = require('lodash');
-const { catchErr, expect, sinon } = require('../../../test-helper');
+const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
 const CertificationScoringCompleted = require('../../../../lib/domain/events/CertificationScoringCompleted');
 const { handleCleaCertificationScoring } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 
 describe('Unit | Domain | Events | handle-clea-certification-scoring', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const reproducibilityRate = Symbol('reproducibilityRate');
+  let partnerCertificationScoringRepository;
+  let certificationCourseRepository;
+  let badgeRepository;
+  let knowledgeElementRepository;
+  let targetProfileRepository;
+  let badgeCriteriaService;
 
-  let event;
-  const partnerCertificationScoringRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    buildCleaCertificationScoring: _.noop(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    save: _.noop(),
-  };
+  beforeEach(function () {
+    partnerCertificationScoringRepository = {
+      buildCleaCertificationScoring: sinon.stub(),
+      save: sinon.stub(),
+    };
 
-  const badgeRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    getByKey: _.noop(),
-  };
-  const knowledgeElementRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    findUniqByUserId: _.noop(),
-  };
-  const targetProfileRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    get: _.noop(),
-  };
-  const badgeCriteriaService = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    areBadgeCriteriaFulfilled: _.noop(),
-  };
+    badgeRepository = {
+      getByKey: sinon.stub(),
+    };
 
-  const certificationCourseRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    getCreationDate: _.noop(),
-  };
+    knowledgeElementRepository = {
+      findUniqByUserId: sinon.stub(),
+    };
 
-  const dependencies = {
-    partnerCertificationScoringRepository,
-    badgeRepository,
-    knowledgeElementRepository,
-    certificationCourseRepository,
-    targetProfileRepository,
-    badgeCriteriaService,
-  };
+    targetProfileRepository = {
+      get: sinon.stub(),
+    };
+
+    badgeCriteriaService = {
+      areBadgeCriteriaFulfilled: sinon.stub(),
+    };
+
+    certificationCourseRepository = {
+      getCreationDate: sinon.stub(),
+    };
+  });
 
   it('fails when event is not of correct type', async function () {
     // given
     const event = 'not an event of the correct type';
 
     // when / then
-    const error = await catchErr(handleCleaCertificationScoring)({ event, ...dependencies });
+    const error = await catchErr(handleCleaCertificationScoring)({
+      event,
+      partnerCertificationScoringRepository,
+      badgeRepository,
+      knowledgeElementRepository,
+      certificationCourseRepository,
+      targetProfileRepository,
+      badgeCriteriaService,
+    });
 
     // then
     expect(error).not.to.be.null;
   });
 
-  context('#handleCleaCertificationScoring', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const certificationCourseId = Symbol('certificationCourseId');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const userId = Symbol('userId');
-    const cleaCertificationScoring = { hasAcquiredBadge: true };
-    const targetProfile = { id: 'targetProfileId' };
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const badge = { targetProfileId: targetProfile.id };
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const knowledgeElements = Symbol('KnowledgeElements@& ');
+  context('when badge is not acquired', function () {
+    it('should not save a certif partner', async function () {
+      // given
+      const userId = 1234;
+      const certificationCourseId = 4567;
 
-    beforeEach(function () {
-      event = new CertificationScoringCompleted({
+      const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
+        reproducibilityRate: 85,
+        hasAcquiredBadge: false,
+      });
+
+      const event = new CertificationScoringCompleted({
         certificationCourseId,
         userId,
         isCertification: true,
-        reproducibilityRate,
+        reproducibilityRate: 85,
       });
-      const date = '2021-01-01';
-      certificationCourseRepository.getCreationDate = sinon.stub().withArgs(certificationCourseId).resolves(date);
-      badgeRepository.getByKey = sinon.stub().resolves(badge);
-      targetProfileRepository.get = sinon.stub().withArgs(targetProfile.id).resolves(targetProfile);
-      knowledgeElementRepository.findUniqByUserId = sinon
-        .stub()
-        .withArgs({ userId: event.userId, limitDate: date })
-        .resolves(knowledgeElements);
-      badgeCriteriaService.areBadgeCriteriaFulfilled = sinon
-        .stub()
-        .withArgs({ knowledgeElements, targetProfile, badge })
-        .returns(true);
-      cleaCertificationScoring.setBadgeAcquisitionStillValid = sinon.stub().returns(true);
 
-      partnerCertificationScoringRepository.save = sinon.stub();
-      partnerCertificationScoringRepository.buildCleaCertificationScoring = sinon.stub();
-      partnerCertificationScoringRepository.save.resolves();
       partnerCertificationScoringRepository.buildCleaCertificationScoring
         .withArgs({
           certificationCourseId,
           userId,
-          reproducibilityRate,
+          reproducibilityRate: 85,
         })
         .resolves(cleaCertificationScoring);
-    });
 
-    context('when certification is eligible', function () {
-      it('should verify if the badge is still acquired', async function () {
-        // given
-        cleaCertificationScoring.isEligible = () => true;
-
-        // when
-        await handleCleaCertificationScoring({
-          event,
-          ...dependencies,
-        });
-
-        // then
-        expect(badgeCriteriaService.areBadgeCriteriaFulfilled).to.have.been.calledWith({
-          knowledgeElements,
-          targetProfile,
-          badge,
-        });
-        expect(cleaCertificationScoring.setBadgeAcquisitionStillValid).to.have.been.calledWith(true);
+      // when
+      await handleCleaCertificationScoring({
+        event,
+        partnerCertificationScoringRepository,
+        badgeRepository,
+        knowledgeElementRepository,
+        certificationCourseRepository,
+        targetProfileRepository,
+        badgeCriteriaService,
       });
 
+      // then
+      expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
+    });
+  });
+
+  context('#handleCleaCertificationScoring', function () {
+    context('when certification is eligible', function () {
       it('should save a certif partner', async function () {
         // given
-        cleaCertificationScoring.isEligible = () => true;
+        const userId = 1234;
+        const certificationCourseId = 4567;
+        const knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({ userId }),
+          domainBuilder.buildKnowledgeElement({ userId }),
+        ];
+        const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
+          reproducibilityRate: 85,
+          hasAcquiredBadge: true,
+        });
+        const targetProfile = domainBuilder.buildTargetProfile({ id: 34435 });
+        const badge = domainBuilder.buildBadge({ targetProfileId: 34435 });
+        const event = new CertificationScoringCompleted({
+          certificationCourseId,
+          userId,
+          isCertification: true,
+          reproducibilityRate: 85,
+        });
+        const date = '2021-01-01';
+
+        partnerCertificationScoringRepository.buildCleaCertificationScoring
+          .withArgs({
+            certificationCourseId,
+            userId,
+            reproducibilityRate: 85,
+          })
+          .resolves(cleaCertificationScoring);
+
+        certificationCourseRepository.getCreationDate.withArgs(certificationCourseId).resolves(date);
+
+        badgeRepository.getByKey.resolves(badge);
+
+        targetProfileRepository.get.withArgs(34435).resolves(targetProfile);
+
+        knowledgeElementRepository.findUniqByUserId
+          .withArgs({ userId: event.userId, limitDate: date })
+          .resolves(knowledgeElements);
+
+        badgeCriteriaService.areBadgeCriteriaFulfilled
+          .withArgs({ knowledgeElements, targetProfile, badge })
+          .returns(true);
 
         // when
         await handleCleaCertificationScoring({
           event,
-          ...dependencies,
+          partnerCertificationScoringRepository,
+          badgeRepository,
+          knowledgeElementRepository,
+          certificationCourseRepository,
+          targetProfileRepository,
+          badgeCriteriaService,
         });
 
         // then
@@ -152,30 +163,59 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
     });
 
     context('when certification is not eligible', function () {
-      it('should not verify if the badge is still acquired if the badge is not acquired', async function () {
-        // given
-        cleaCertificationScoring.hasAcquiredBadge = false;
-        cleaCertificationScoring.isEligible = () => true;
-
-        // when
-        await handleCleaCertificationScoring({
-          event,
-          ...dependencies,
-        });
-
-        // then
-        expect(badgeCriteriaService.areBadgeCriteriaFulfilled).to.not.to.have.been.called;
-        expect(cleaCertificationScoring.setBadgeAcquisitionStillValid).to.not.to.have.been.called;
-      });
-
       it('should not save a certif partner', async function () {
         // given
-        cleaCertificationScoring.isEligible = () => false;
+        const userId = 1234;
+        const certificationCourseId = 4567;
+        const knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({ userId }),
+          domainBuilder.buildKnowledgeElement({ userId }),
+        ];
+        const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
+          reproducibilityRate: 85,
+          hasAcquiredBadge: true,
+        });
+        const targetProfile = domainBuilder.buildTargetProfile({ id: 34435 });
+        const badge = domainBuilder.buildBadge({ targetProfileId: 34435 });
+        const event = new CertificationScoringCompleted({
+          certificationCourseId,
+          userId,
+          isCertification: true,
+          reproducibilityRate: 85,
+        });
+        const date = '2021-01-01';
+
+        partnerCertificationScoringRepository.buildCleaCertificationScoring
+          .withArgs({
+            certificationCourseId,
+            userId,
+            reproducibilityRate: 85,
+          })
+          .resolves(cleaCertificationScoring);
+
+        certificationCourseRepository.getCreationDate.withArgs(certificationCourseId).resolves(date);
+
+        badgeRepository.getByKey.resolves(badge);
+
+        targetProfileRepository.get.withArgs(34435).resolves(targetProfile);
+
+        knowledgeElementRepository.findUniqByUserId
+          .withArgs({ userId: event.userId, limitDate: date })
+          .resolves(knowledgeElements);
+
+        badgeCriteriaService.areBadgeCriteriaFulfilled
+          .withArgs({ knowledgeElements, targetProfile, badge })
+          .returns(false);
 
         // when
         await handleCleaCertificationScoring({
           event,
-          ...dependencies,
+          partnerCertificationScoringRepository,
+          badgeRepository,
+          knowledgeElementRepository,
+          certificationCourseRepository,
+          targetProfileRepository,
+          badgeCriteriaService,
         });
 
         // then

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -5,12 +5,17 @@ const { handleCleaCertificationScoring } = require('../../../../lib/domain/event
 describe('Unit | Domain | Events | handle-clea-certification-scoring', function () {
   let partnerCertificationScoringRepository;
   let certificationCourseRepository;
+  let certificationCenterRepository;
   let badgeRepository;
   let knowledgeElementRepository;
   let targetProfileRepository;
   let badgeCriteriaService;
 
   beforeEach(function () {
+    certificationCenterRepository = {
+      getByCertificationCourseId: sinon.stub(),
+    };
+
     partnerCertificationScoringRepository = {
       buildCleaCertificationScoring: sinon.stub(),
       save: sinon.stub(),
@@ -74,6 +79,18 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
         reproducibilityRate: 85,
       });
 
+      const accreditation = domainBuilder.buildAccreditation({
+        name: 'CléA Numérique',
+      });
+
+      const certificationCenter = domainBuilder.buildCertificationCenter({
+        accreditations: [accreditation],
+      });
+
+      certificationCenterRepository.getByCertificationCourseId
+        .withArgs(certificationCourseId)
+        .resolves(certificationCenter);
+
       partnerCertificationScoringRepository.buildCleaCertificationScoring
         .withArgs({
           certificationCourseId,
@@ -88,6 +105,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
         partnerCertificationScoringRepository,
         badgeRepository,
         knowledgeElementRepository,
+        certificationCenterRepository,
         certificationCourseRepository,
         targetProfileRepository,
         badgeCriteriaService,
@@ -122,6 +140,18 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
         });
         const date = '2021-01-01';
 
+        const accreditation = domainBuilder.buildAccreditation({
+          name: 'CléA Numérique',
+        });
+
+        const certificationCenter = domainBuilder.buildCertificationCenter({
+          accreditations: [accreditation],
+        });
+
+        certificationCenterRepository.getByCertificationCourseId
+          .withArgs(certificationCourseId)
+          .resolves(certificationCenter);
+
         partnerCertificationScoringRepository.buildCleaCertificationScoring
           .withArgs({
             certificationCourseId,
@@ -151,6 +181,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
           badgeRepository,
           knowledgeElementRepository,
           certificationCourseRepository,
+          certificationCenterRepository,
           targetProfileRepository,
           badgeCriteriaService,
         });
@@ -185,6 +216,18 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
         });
         const date = '2021-01-01';
 
+        const accreditation = domainBuilder.buildAccreditation({
+          name: 'CléA Numérique',
+        });
+
+        const certificationCenter = domainBuilder.buildCertificationCenter({
+          accreditations: [accreditation],
+        });
+
+        certificationCenterRepository.getByCertificationCourseId
+          .withArgs(certificationCourseId)
+          .resolves(certificationCenter);
+
         partnerCertificationScoringRepository.buildCleaCertificationScoring
           .withArgs({
             certificationCourseId,
@@ -214,6 +257,49 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
           badgeRepository,
           knowledgeElementRepository,
           certificationCourseRepository,
+          certificationCenterRepository,
+          targetProfileRepository,
+          badgeCriteriaService,
+        });
+
+        // then
+        expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
+      });
+    });
+
+    context('when certification center is not accredited', function () {
+      it('should not save a certif partner', async function () {
+        // given
+        const userId = 1234;
+        const certificationCourseId = 4567;
+
+        const event = new CertificationScoringCompleted({
+          certificationCourseId,
+          userId,
+          isCertification: true,
+          reproducibilityRate: 85,
+        });
+
+        const accreditation = domainBuilder.buildAccreditation({
+          name: 'Tarte au fromage',
+        });
+
+        const certificationCenter = domainBuilder.buildCertificationCenter({
+          accreditations: [accreditation],
+        });
+
+        certificationCenterRepository.getByCertificationCourseId
+          .withArgs(certificationCourseId)
+          .resolves(certificationCenter);
+
+        // when
+        await handleCleaCertificationScoring({
+          event,
+          partnerCertificationScoringRepository,
+          badgeRepository,
+          knowledgeElementRepository,
+          certificationCourseRepository,
+          certificationCenterRepository,
           targetProfileRepository,
           badgeCriteriaService,
         });

--- a/api/tests/unit/domain/models/CertificationCenter_test.js
+++ b/api/tests/unit/domain/models/CertificationCenter_test.js
@@ -39,4 +39,25 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
       expect(certificationCenter.isAccreditedPixPlusDroit).to.be.true;
     });
   });
+
+  describe('#isAccreditedClea', function () {
+    it('should return false when the certification center does not have Cléa numérique accreditation', function () {
+      // given
+      const certificationCenter = domainBuilder.buildCertificationCenter({ accreditations: [] });
+
+      // then
+      expect(certificationCenter.isAccreditedClea).to.be.false;
+    });
+
+    it('should return true when the certification center has Cléa numérique accreditation', function () {
+      // given
+      const pixPlusDroitAccreditation = domainBuilder.buildAccreditation({ name: 'CléA Numérique' });
+      const certificationCenter = domainBuilder.buildCertificationCenter({
+        accreditations: [pixPlusDroitAccreditation],
+      });
+
+      // then
+      expect(certificationCenter.isAccreditedClea).to.be.true;
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CertificationCenter_test.js
+++ b/api/tests/unit/domain/models/CertificationCenter_test.js
@@ -18,4 +18,25 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
       expect(certificationCenter.isSco).is.false;
     });
   });
+
+  describe('#isAccreditedPixPlusDroit', function () {
+    it('should return false when the certification center does not have Pix+ Droit accreditation', function () {
+      // given
+      const certificationCenter = domainBuilder.buildCertificationCenter({ accreditations: [] });
+
+      // then
+      expect(certificationCenter.isAccreditedPixPlusDroit).to.be.false;
+    });
+
+    it('should return true when the certification center has Pix+ Droit accreditation', function () {
+      // given
+      const pixPlusDroitAccreditation = domainBuilder.buildAccreditation({ name: 'Pix+ Droit' });
+      const certificationCenter = domainBuilder.buildCertificationCenter({
+        accreditations: [pixPlusDroitAccreditation],
+      });
+
+      // then
+      expect(certificationCenter.isAccreditedPixPlusDroit).to.be.true;
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -11,80 +11,51 @@ const _ = require('lodash');
 
 describe('Unit | UseCase | retrieve-last-or-create-certification-course', function () {
   let clock;
-  const now = new Date('2019-01-01T05:06:07Z');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const domainTransaction = Symbol('someDomainTransaction');
-  const userId = 'userId';
-  const sessionId = 'sessionId';
-  const accessCode = 'accessCode';
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const verificationCode = Symbol('verificationCode');
-  let foundSession;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const assessmentRepository = { save: sinon.stub() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const competenceRepository = { listPixCompetencesOnly: sinon.stub() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certificationChallengeRepository = { save: sinon.stub() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certificationChallengesService = {
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    pickCertificationChallengesForPixPlus: sinon.stub(),
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    pickCertificationChallenges: sinon.stub(),
-  };
-  const certificationCourseRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    findOneCertificationCourseByUserIdAndSessionId: sinon.stub(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    save: sinon.stub(),
-  };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const sessionRepository = { get: sinon.stub() };
-  const placementProfileService = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    getPlacementProfile: sinon.stub(),
-  };
-  const verifyCertificateCodeService = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    generateCertificateVerificationCode: sinon.stub().resolves(verificationCode),
-  };
-  const locale = 'fr';
+  let now;
+  let domainTransaction;
+  let verificationCode;
 
-  const parameters = {
-    locale,
-    domainTransaction,
-    assessmentRepository,
-    competenceRepository,
-    certificationCandidateRepository,
-    certificationChallengeRepository,
-    certificationCourseRepository,
-    sessionRepository,
-    certificationBadgesService,
-    certificationChallengesService,
-    placementProfileService,
-    verifyCertificateCodeService,
-  };
+  let sessionRepository;
+  let assessmentRepository;
+  let competenceRepository;
+  let certificationCandidateRepository;
+  let certificationChallengeRepository;
+  let certificationChallengesService;
+  let certificationCourseRepository;
+  let certificationCenterRepository;
+  let certificationBadgesService;
+  let placementProfileService;
+  let verifyCertificateCodeService;
 
   beforeEach(function () {
+    now = new Date('2019-01-01T05:06:07Z');
     clock = sinon.useFakeTimers(now);
+    domainTransaction = Symbol('someDomainTransaction');
+    verificationCode = Symbol('verificationCode');
+
+    assessmentRepository = { save: sinon.stub() };
+    competenceRepository = { listPixCompetencesOnly: sinon.stub() };
+    certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
+    certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub() };
+    certificationChallengeRepository = { save: sinon.stub() };
+    certificationChallengesService = {
+      pickCertificationChallengesForPixPlus: sinon.stub(),
+      pickCertificationChallenges: sinon.stub(),
+    };
+    certificationCourseRepository = {
+      findOneCertificationCourseByUserIdAndSessionId: sinon.stub(),
+      save: sinon.stub(),
+    };
+    sessionRepository = { get: sinon.stub() };
+    placementProfileService = {
+      getPlacementProfile: sinon.stub(),
+    };
+    verifyCertificateCodeService = {
+      generateCertificateVerificationCode: sinon.stub().resolves(verificationCode),
+    };
+    certificationCenterRepository = {
+      getBySessionId: sinon.stub(),
+    };
   });
 
   afterEach(function () {
@@ -93,18 +64,32 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
   });
 
   context('when session access code is different from provided access code', function () {
-    beforeEach(function () {
-      foundSession = { accessCode: 'differentAccessCode' };
-      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
-    });
-
     it('should throw a not found error', async function () {
+      // given
+      const sessionId = 1;
+      const accessCode = 'accessCode';
+      const userId = 2;
+      const foundSession = domainBuilder.buildSession({ accessCode: 'differentAccessCode' });
+      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
       // when
       const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
+        domainTransaction,
         sessionId,
         accessCode,
         userId,
-        ...parameters,
+        locale: 'fr',
+        assessmentRepository,
+        competenceRepository,
+        certificationCandidateRepository,
+        certificationChallengeRepository,
+        certificationCourseRepository,
+        sessionRepository,
+        certificationCenterRepository,
+        certificationBadgesService,
+        certificationChallengesService,
+        placementProfileService,
+        verifyCertificateCodeService,
       });
 
       // then
@@ -118,15 +103,30 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     context('when session is not accessible', function () {
       it('should throw a SessionNotAccessible error', async function () {
         // given
-        const foundSession = domainBuilder.buildSession.finalized({ accessCode });
+        const sessionId = 1;
+        const accessCode = 'accessCode';
+        const userId = 2;
+        const foundSession = domainBuilder.buildSession.finalized({ id: sessionId, accessCode });
         sessionRepository.get.withArgs(sessionId).resolves(foundSession);
 
         // when
         const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
+          domainTransaction,
           sessionId,
           accessCode,
           userId,
-          ...parameters,
+          locale: 'fr',
+          assessmentRepository,
+          competenceRepository,
+          certificationCandidateRepository,
+          certificationChallengeRepository,
+          certificationCourseRepository,
+          sessionRepository,
+          certificationCenterRepository,
+          certificationBadgesService,
+          certificationChallengesService,
+          placementProfileService,
+          verifyCertificateCodeService,
         });
 
         // then
@@ -137,27 +137,40 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     });
 
     context('when session is accessible', function () {
-      beforeEach(function () {
-        const foundSession = domainBuilder.buildSession.created({ accessCode });
-        sessionRepository.get.withArgs(sessionId).resolves(foundSession);
-      });
-
       context('when a certification course with provided userId and sessionId already exists', function () {
-        let existingCertificationCourse;
-        beforeEach(function () {
-          existingCertificationCourse = Symbol('existingCertificationCourse');
+        it('should return it with flag created marked as false', async function () {
+          // given
+          const sessionId = 1;
+          const accessCode = 'accessCode';
+          const userId = 2;
+          const domainTransaction = Symbol('someDomainTransaction');
+
+          const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+          sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+          const existingCertificationCourse = domainBuilder.buildCertificationCourse({ userId, sessionId });
           certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
             .withArgs({ userId, sessionId, domainTransaction })
             .resolves(existingCertificationCourse);
-        });
 
-        it('should return it with flag created marked as false', async function () {
           // when
           const result = await retrieveLastOrCreateCertificationCourse({
+            domainTransaction,
             sessionId,
             accessCode,
             userId,
-            ...parameters,
+            locale: 'fr',
+            assessmentRepository,
+            competenceRepository,
+            certificationCandidateRepository,
+            certificationChallengeRepository,
+            certificationCourseRepository,
+            sessionRepository,
+            certificationCenterRepository,
+            certificationBadgesService,
+            certificationChallengesService,
+            placementProfileService,
+            verifyCertificateCodeService,
           });
 
           // then
@@ -172,31 +185,44 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
       });
 
       context('when no certification course exists for this userId and sessionId', function () {
-        let placementProfile;
-        let competences;
-
-        beforeEach(function () {
-          competences = [{ id: 'rec123' }, { id: 'rec456' }];
-          competenceRepository.listPixCompetencesOnly.resolves(competences);
-          certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-            .withArgs({ userId, sessionId, domainTransaction })
-            .onCall(0)
-            .resolves(null);
-        });
-
         context('when the user is not certifiable', function () {
-          beforeEach(function () {
-            placementProfile = { isCertifiable: sinon.stub().returns(false) };
-            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
-          });
-
           it('should throw a UserNotAuthorizedToCertifyError', async function () {
+            // given
+            const sessionId = 1;
+            const accessCode = 'accessCode';
+            const userId = 2;
+            const domainTransaction = Symbol('someDomainTransaction');
+
+            const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+            sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+              .withArgs({ userId, sessionId, domainTransaction })
+              .resolves(null);
+
+            const competences = [{ id: 'rec123' }, { id: 'rec456' }];
+            competenceRepository.listPixCompetencesOnly.resolves(competences);
+
+            const placementProfile = { isCertifiable: sinon.stub().returns(false) };
+            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
             // when
             const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
+              domainTransaction,
               sessionId,
               accessCode,
               userId,
-              ...parameters,
+              locale: 'fr',
+              assessmentRepository,
+              competenceRepository,
+              certificationCandidateRepository,
+              certificationChallengeRepository,
+              certificationCourseRepository,
+              sessionRepository,
+              certificationCenterRepository,
+              certificationBadgesService,
+              certificationChallengesService,
+              placementProfileService,
+              verifyCertificateCodeService,
             });
 
             // then
@@ -204,12 +230,42 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
           });
 
           it('should not create any new resource', async function () {
+            // given
+            const sessionId = 1;
+            const accessCode = 'accessCode';
+            const userId = 2;
+            const domainTransaction = Symbol('someDomainTransaction');
+
+            const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+            sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+              .withArgs({ userId, sessionId, domainTransaction })
+              .resolves(null);
+
+            const competences = [{ id: 'rec123' }, { id: 'rec456' }];
+            competenceRepository.listPixCompetencesOnly.resolves(competences);
+
+            const placementProfile = { isCertifiable: sinon.stub().returns(false) };
+            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
             // when
             await catchErr(retrieveLastOrCreateCertificationCourse)({
+              domainTransaction,
               sessionId,
               accessCode,
               userId,
-              ...parameters,
+              locale: 'fr',
+              assessmentRepository,
+              competenceRepository,
+              certificationCandidateRepository,
+              certificationChallengeRepository,
+              certificationCourseRepository,
+              sessionRepository,
+              certificationCenterRepository,
+              certificationBadgesService,
+              certificationChallengesService,
+              placementProfileService,
+              verifyCertificateCodeService,
             });
 
             // then
@@ -221,51 +277,66 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
         });
 
         context('when user is certifiable', function () {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          const skill1 = domainBuilder.buildSkill();
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          const skill2 = domainBuilder.buildSkill();
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-
-          beforeEach(function () {
-            // TODO : use the domainBuilder to instanciate userCompetences
-            placementProfile = {
-              isCertifiable: sinon.stub().returns(true),
-              userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-            };
-            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
-            const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-            userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-            userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
-            certificationChallengesService.pickCertificationChallenges
-              .withArgs(placementProfile)
-              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-          });
-
           context('when a certification course has been created meanwhile', function () {
-            let existingCertificationCourse;
-            beforeEach(function () {
-              existingCertificationCourse = Symbol('existingCertificationCourse');
+            it('should return it with flag created marked as false', async function () {
+              // given
+              const sessionId = 1;
+              const accessCode = 'accessCode';
+              const userId = 2;
+              const domainTransaction = Symbol('someDomainTransaction');
+
+              const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+              sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+              const existingCertificationCourse = domainBuilder.buildCertificationCourse({ userId, sessionId });
+              certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                .withArgs({ userId, sessionId, domainTransaction })
+                .onCall(0)
+                .resolves(null);
+
               certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
                 .withArgs({ userId, sessionId, domainTransaction })
                 .onCall(1)
                 .resolves(existingCertificationCourse);
-            });
 
-            it('should return it with flag created marked as false', async function () {
+              const skill1 = domainBuilder.buildSkill();
+              const skill2 = domainBuilder.buildSkill();
+              const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
+              const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+              // TODO : use the domainBuilder to instanciate userCompetences
+              const placementProfile = {
+                isCertifiable: sinon.stub().returns(true),
+                userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
+              };
+              placementProfileService.getPlacementProfile
+                .withArgs({ userId, limitDate: now })
+                .resolves(placementProfile);
+
+              const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
+              userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
+              userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+              certificationChallengesService.pickCertificationChallenges
+                .withArgs(placementProfile)
+                .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
               // when
               const result = await retrieveLastOrCreateCertificationCourse({
+                domainTransaction,
                 sessionId,
                 accessCode,
                 userId,
-                ...parameters,
+                locale: 'fr',
+                assessmentRepository,
+                competenceRepository,
+                certificationCandidateRepository,
+                certificationChallengeRepository,
+                certificationCourseRepository,
+                sessionRepository,
+                certificationCenterRepository,
+                certificationBadgesService,
+                certificationChallengesService,
+                placementProfileService,
+                verifyCertificateCodeService,
               });
 
               // then
@@ -276,119 +347,99 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               expect(certificationCourseRepository.save).not.to.have.been.called;
               expect(verifyCertificateCodeService.generateCertificateVerificationCode).not.to.have.been.called;
             });
-
-            it('should have filled the certification profile with challenges anyway', async function () {
-              // when
-              await retrieveLastOrCreateCertificationCourse({
-                sessionId,
-                accessCode,
-                userId,
-                ...parameters,
-              });
-
-              // then
-              expect(certificationChallengesService.pickCertificationChallenges).to.have.been.calledWith(
-                placementProfile
-              );
-            });
           });
 
           context('when a certification still has not been created meanwhile', function () {
-            const foundCertificationCandidate = {
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              firstName: Symbol('firstName'),
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              lastName: Symbol('lastName'),
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              birthdate: Symbol('birthdate'),
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              birthCity: Symbol('birthCity'),
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              birthCountry: Symbol('birthCountry'),
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              externalId: Symbol('externalId'),
-              userId,
-              sessionId,
-            };
-            const mockCertificationCourse = {
-              _userId: userId,
-              _sessionId: sessionId,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              _firstName: foundCertificationCandidate.firstName,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              _lastName: foundCertificationCandidate.lastName,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              _birthdate: foundCertificationCandidate.birthdate,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              _birthplace: foundCertificationCandidate.birthCity,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              _birthCountry: foundCertificationCandidate.birthCountry,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              _externalId: foundCertificationCandidate.externalId,
-              _isV2Certification: true,
-            };
+            it('should return it with flag created marked as true with related resources', async function () {
+              // given
+              const sessionId = 1;
+              const accessCode = 'accessCode';
+              const userId = 2;
+              const domainTransaction = Symbol('someDomainTransaction');
 
-            const savedCertificationChallenge1 = { id: 'savedCertificationChallenge1' };
-            const savedCertificationChallenge2 = { id: 'savedCertificationChallenge2' };
+              const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+              sessionRepository.get.withArgs(sessionId).resolves(foundSession);
 
-            const savedCertificationCourse = new CertificationCourse({
-              id: 'savedCertificationCourse',
-              challenges: [savedCertificationChallenge1, savedCertificationChallenge2],
-            });
-
-            const mockAssessment = {
-              userId,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              certificationCourseId: savedCertificationCourse.getId(),
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              state: Assessment.states.STARTED,
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line mocha/no-setup-in-describe
-              type: Assessment.types.CERTIFICATION,
-            };
-            const savedAssessment = {
-              id: 'savedAssessment',
-            };
-
-            beforeEach(function () {
               certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
                 .withArgs({ userId, sessionId, domainTransaction })
-                .onCall(1)
                 .resolves(null);
+
+              const skill1 = domainBuilder.buildSkill();
+              const skill2 = domainBuilder.buildSkill();
+              const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
+              const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+              // TODO : use the domainBuilder to instanciate userCompetences
+              const placementProfile = {
+                isCertifiable: sinon.stub().returns(true),
+                userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
+              };
               placementProfileService.getPlacementProfile
                 .withArgs({ userId, limitDate: now })
                 .resolves(placementProfile);
+
+              const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
+              userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
+              userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+              certificationChallengesService.pickCertificationChallenges
+                .withArgs(placementProfile)
+                .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+              const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({ userId, sessionId });
               certificationCandidateRepository.getBySessionIdAndUserId
                 .withArgs({ sessionId, userId })
                 .resolves(foundCertificationCandidate);
-              certificationCourseRepository.save.resolves(savedCertificationCourse);
-              assessmentRepository.save.resolves(savedAssessment);
+
+              const certificationCourseToSave = CertificationCourse.from({
+                certificationCandidate: foundCertificationCandidate,
+                challenges: [challenge1, challenge2],
+                verificationCode,
+                maxReachableLevelOnCertificationDate: 5,
+              });
+              const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                certificationCourseToSave.toDTO()
+              );
+              certificationCourseRepository.save
+                .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                .resolves(savedCertificationCourse);
+
+              const assessmentToSave = new Assessment({
+                userId,
+                certificationCourseId: savedCertificationCourse.getId(),
+                state: Assessment.states.STARTED,
+                type: Assessment.types.CERTIFICATION,
+                isImproving: false,
+                method: Assessment.methods.CERTIFICATION_DETERMINED,
+              });
+              const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+              assessmentRepository.save
+                .withArgs({ assessment: assessmentToSave, domainTransaction })
+                .resolves(savedAssessment);
+
               certificationBadgesService.findStillValidBadgeAcquisitions
                 .withArgs({ userId, domainTransaction })
                 .resolves([]);
-            });
 
-            it('should return it with flag created marked as true with related ressources', async function () {
+              const session = domainBuilder.buildSession({ accreditations: [] });
+              certificationCenterRepository.getBySessionId.resolves(session);
+
               // when
               const result = await retrieveLastOrCreateCertificationCourse({
+                domainTransaction,
                 sessionId,
                 accessCode,
                 userId,
-                ...parameters,
+                locale: 'fr',
+                assessmentRepository,
+                competenceRepository,
+                certificationCandidateRepository,
+                certificationChallengeRepository,
+                certificationCourseRepository,
+                sessionRepository,
+                certificationCenterRepository,
+                certificationBadgesService,
+                certificationChallengesService,
+                placementProfileService,
+                verifyCertificateCodeService,
               });
 
               // then
@@ -397,47 +448,51 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 certificationCourse: new CertificationCourse({
                   ...savedCertificationCourse.toDTO(),
                   assessment: savedAssessment,
-                  challenges: [savedCertificationChallenge1, savedCertificationChallenge2],
+                  challenges: [challenge1, challenge2],
                 }),
-              });
-            });
-
-            it('should have save the certification course based on an appropriate argument', async function () {
-              // when
-              await retrieveLastOrCreateCertificationCourse({
-                sessionId,
-                accessCode,
-                userId,
-                ...parameters,
-              });
-
-              // then
-              expect(certificationCourseRepository.save).to.have.been.calledWith({
-                certificationCourse: sinon.match(mockCertificationCourse),
-                domainTransaction,
-              });
-            });
-
-            it('should have save the assessment based on an appropriate argument', async function () {
-              // when
-              await retrieveLastOrCreateCertificationCourse({
-                sessionId,
-                accessCode,
-                userId,
-                ...parameters,
-              });
-
-              // then
-              expect(assessmentRepository.save).to.have.been.calledWith({
-                assessment: sinon.match(mockAssessment),
-                domainTransaction,
               });
             });
 
             context('when user has certifiable badges with pix plus', function () {
               it('should save all the challenges from pix and pix plus', async function () {
                 // given
-                sinon.spy(CertificationCourse, 'from');
+                const sessionId = 1;
+                const accessCode = 'accessCode';
+                const userId = 2;
+                const domainTransaction = Symbol('someDomainTransaction');
+
+                const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+                sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+                certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                  .withArgs({ userId, sessionId, domainTransaction })
+                  .resolves(null);
+
+                const skill1 = domainBuilder.buildSkill();
+                const skill2 = domainBuilder.buildSkill();
+                const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
+                const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+                // TODO : use the domainBuilder to instanciate userCompetences
+                const placementProfile = {
+                  isCertifiable: sinon.stub().returns(true),
+                  userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
+                };
+                placementProfileService.getPlacementProfile
+                  .withArgs({ userId, limitDate: now })
+                  .resolves(placementProfile);
+
+                const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
+                userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
+                userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                certificationChallengesService.pickCertificationChallenges
+                  .withArgs(placementProfile)
+                  .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                const certificationCenter = domainBuilder.buildCertificationCenter({
+                  accreditations: [domainBuilder.buildAccreditation({ name: 'Pix+ Droit' })],
+                });
+                certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+
                 const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
                 const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
                 const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
@@ -445,36 +500,120 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
                 const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge1 });
                 const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: certifiableBadge2 });
+
                 certificationBadgesService.findStillValidBadgeAcquisitions
                   .withArgs({ userId, domainTransaction })
                   .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
+
                 certificationChallengesService.pickCertificationChallengesForPixPlus
                   .withArgs(certifiableBadge1, userId)
                   .resolves([challengePlus1, challengePlus2])
                   .withArgs(certifiableBadge2, userId)
                   .resolves([challengePlus3]);
-                const expectedChallenges = [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3];
+
+                const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({ userId, sessionId });
+                certificationCandidateRepository.getBySessionIdAndUserId
+                  .withArgs({ sessionId, userId })
+                  .resolves(foundCertificationCandidate);
+
+                const certificationCourseToSave = CertificationCourse.from({
+                  certificationCandidate: foundCertificationCandidate,
+                  challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
+                  verificationCode,
+                  maxReachableLevelOnCertificationDate: 5,
+                });
+
+                const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                  certificationCourseToSave.toDTO()
+                );
+                certificationCourseRepository.save
+                  .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                  .resolves(savedCertificationCourse);
+
+                const assessmentToSave = new Assessment({
+                  userId,
+                  certificationCourseId: savedCertificationCourse.getId(),
+                  state: Assessment.states.STARTED,
+                  type: Assessment.types.CERTIFICATION,
+                  isImproving: false,
+                  method: Assessment.methods.CERTIFICATION_DETERMINED,
+                });
+                const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                assessmentRepository.save
+                  .withArgs({ assessment: assessmentToSave, domainTransaction })
+                  .resolves(savedAssessment);
+
                 // when
-                await retrieveLastOrCreateCertificationCourse({
+                const result = await retrieveLastOrCreateCertificationCourse({
+                  domainTransaction,
                   sessionId,
                   accessCode,
                   userId,
-                  ...parameters,
+                  locale: 'fr',
+                  assessmentRepository,
+                  competenceRepository,
+                  certificationCandidateRepository,
+                  certificationChallengeRepository,
+                  certificationCourseRepository,
+                  sessionRepository,
+                  certificationCenterRepository,
+                  certificationBadgesService,
+                  certificationChallengesService,
+                  placementProfileService,
+                  verifyCertificateCodeService,
                 });
 
                 // then
-                expect(CertificationCourse.from).to.have.been.calledWith({
-                  certificationCandidate: foundCertificationCandidate,
-                  challenges: expectedChallenges,
-                  maxReachableLevelOnCertificationDate: 5,
-                  verificationCode,
+                expect(result).to.deep.equal({
+                  created: true,
+                  certificationCourse: new CertificationCourse({
+                    ...savedCertificationCourse.toDTO(),
+                    assessment: savedAssessment,
+                    challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
+                  }),
                 });
               });
 
               context('pix+ droit', function () {
                 it('should generate challenges for expert badge only if both maitre and expert badges are acquired', async function () {
                   // given
-                  sinon.spy(CertificationCourse, 'from');
+                  const sessionId = 1;
+                  const accessCode = 'accessCode';
+                  const userId = 2;
+                  const domainTransaction = Symbol('someDomainTransaction');
+
+                  const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+                  sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+                  certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                    .withArgs({ userId, sessionId, domainTransaction })
+                    .resolves(null);
+
+                  const skill1 = domainBuilder.buildSkill();
+                  const skill2 = domainBuilder.buildSkill();
+                  const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
+                  const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+                  // TODO : use the domainBuilder to instanciate userCompetences
+                  const placementProfile = {
+                    isCertifiable: sinon.stub().returns(true),
+                    userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
+                  };
+                  placementProfileService.getPlacementProfile
+                    .withArgs({ userId, limitDate: now })
+                    .resolves(placementProfile);
+
+                  const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
+                  userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
+                  userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                  certificationChallengesService.pickCertificationChallenges
+                    .withArgs(placementProfile)
+                    .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                  const certificationCenter = domainBuilder.buildCertificationCenter({
+                    accreditations: [domainBuilder.buildAccreditation({ name: 'Pix+ Droit' })],
+                  });
+                  certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+
                   const challengesForMaitre = [
                     domainBuilder.buildChallenge({ id: 'challenge-pixmaitre1' }),
                     domainBuilder.buildChallenge({ id: 'challenge-pixmaitre2' }),
@@ -490,58 +629,166 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   certificationBadgesService.findStillValidBadgeAcquisitions
                     .withArgs({ userId, domainTransaction })
                     .resolves([certifiableBadgeAcquisition2]);
+
                   certificationChallengesService.pickCertificationChallengesForPixPlus
                     .withArgs(maitreBadge, userId)
                     .resolves(challengesForMaitre)
                     .withArgs(expertBadge, userId)
                     .resolves(challengesForExpert);
-                  const expectedChallenges = [challenge1, challenge2, ...challengesForExpert];
+
+                  const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({ userId, sessionId });
+                  certificationCandidateRepository.getBySessionIdAndUserId
+                    .withArgs({ sessionId, userId })
+                    .resolves(foundCertificationCandidate);
+                  const savedCertificationCourse = domainBuilder.buildCertificationCourse({
+                    ...foundCertificationCandidate,
+                    isV2Certification: true,
+                    challenges: [challenge1, challenge2, ...challengesForExpert],
+                  });
+                  certificationCourseRepository.save.resolves(savedCertificationCourse);
+                  const savedAssessment = domainBuilder.buildAssessment({
+                    userId,
+                    certificationCourseId: savedCertificationCourse.id,
+                    state: Assessment.states.STARTED,
+                    type: Assessment.types.CERTIFICATION,
+                    isImproving: false,
+                    method: Assessment.methods.CERTIFICATION_DETERMINED,
+                  });
+                  assessmentRepository.save.resolves(savedAssessment);
 
                   // when
-                  await retrieveLastOrCreateCertificationCourse({
+                  const result = await retrieveLastOrCreateCertificationCourse({
+                    domainTransaction,
                     sessionId,
                     accessCode,
                     userId,
-                    ...parameters,
+                    locale: 'fr',
+                    assessmentRepository,
+                    competenceRepository,
+                    certificationCandidateRepository,
+                    certificationChallengeRepository,
+                    certificationCourseRepository,
+                    sessionRepository,
+                    certificationCenterRepository,
+                    certificationBadgesService,
+                    certificationChallengesService,
+                    placementProfileService,
+                    verifyCertificateCodeService,
                   });
 
                   // then
-                  expect(CertificationCourse.from).to.have.been.calledWith({
-                    certificationCandidate: foundCertificationCandidate,
-                    challenges: expectedChallenges,
-                    maxReachableLevelOnCertificationDate: 5,
-                    verificationCode,
+                  expect(result).to.deep.equal({
+                    created: true,
+                    certificationCourse: new CertificationCourse({
+                      ...savedCertificationCourse.toDTO(),
+                      assessment: savedAssessment,
+                      challenges: [challenge1, challenge2, ...challengesForExpert],
+                    }),
                   });
                 });
               });
             });
 
-            context('when user has no certifiable badges with pix plus', function () {
-              beforeEach(function () {
-                sinon.spy(CertificationCourse, 'from');
-                certificationBadgesService.findStillValidBadgeAcquisitions
-                  .withArgs({ userId, domainTransaction })
-                  .resolves([]);
-                certificationChallengesService.pickCertificationChallengesForPixPlus.throws();
-              });
-
+            context('when certification center has no accreditation for pix plus', function () {
               it('should save only the challenges from pix', async function () {
                 // given
-                const expectedChallenges = [challenge1, challenge2];
+                const sessionId = 1;
+                const accessCode = 'accessCode';
+                const userId = 2;
+                const domainTransaction = Symbol('someDomainTransaction');
+
+                const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+                sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+                certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                  .withArgs({ userId, sessionId, domainTransaction })
+                  .resolves(null);
+
+                const skill1 = domainBuilder.buildSkill();
+                const skill2 = domainBuilder.buildSkill();
+                const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
+                const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+                // TODO : use the domainBuilder to instanciate userCompetences
+                const placementProfile = {
+                  isCertifiable: sinon.stub().returns(true),
+                  userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
+                };
+                placementProfileService.getPlacementProfile
+                  .withArgs({ userId, limitDate: now })
+                  .resolves(placementProfile);
+
+                const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
+                userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
+                userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                certificationChallengesService.pickCertificationChallenges
+                  .withArgs(placementProfile)
+                  .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                const certificationCenter = domainBuilder.buildCertificationCenter({
+                  accreditations: [],
+                });
+                certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+
+                const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({ userId, sessionId });
+                certificationCandidateRepository.getBySessionIdAndUserId
+                  .withArgs({ sessionId, userId })
+                  .resolves(foundCertificationCandidate);
+
+                const certificationCourseToSave = CertificationCourse.from({
+                  certificationCandidate: foundCertificationCandidate,
+                  challenges: [challenge1, challenge2],
+                  verificationCode,
+                  maxReachableLevelOnCertificationDate: 5,
+                });
+
+                const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                  certificationCourseToSave.toDTO()
+                );
+                certificationCourseRepository.save
+                  .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                  .resolves(savedCertificationCourse);
+
+                const assessmentToSave = new Assessment({
+                  userId,
+                  certificationCourseId: savedCertificationCourse.getId(),
+                  state: Assessment.states.STARTED,
+                  type: Assessment.types.CERTIFICATION,
+                  isImproving: false,
+                  method: Assessment.methods.CERTIFICATION_DETERMINED,
+                });
+                const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                assessmentRepository.save
+                  .withArgs({ assessment: assessmentToSave, domainTransaction })
+                  .resolves(savedAssessment);
+
                 // when
-                await retrieveLastOrCreateCertificationCourse({
+                const result = await retrieveLastOrCreateCertificationCourse({
+                  domainTransaction,
                   sessionId,
                   accessCode,
                   userId,
-                  ...parameters,
+                  locale: 'fr',
+                  assessmentRepository,
+                  competenceRepository,
+                  certificationCandidateRepository,
+                  certificationChallengeRepository,
+                  certificationCourseRepository,
+                  sessionRepository,
+                  certificationCenterRepository,
+                  certificationBadgesService,
+                  certificationChallengesService,
+                  placementProfileService,
+                  verifyCertificateCodeService,
                 });
 
                 // then
-                expect(CertificationCourse.from).to.have.been.calledWith({
-                  certificationCandidate: foundCertificationCandidate,
-                  challenges: expectedChallenges,
-                  maxReachableLevelOnCertificationDate: 5,
-                  verificationCode,
+                expect(result).to.deep.equal({
+                  created: true,
+                  certificationCourse: new CertificationCourse({
+                    ...savedCertificationCourse.toDTO(),
+                    assessment: savedAssessment,
+                    challenges: [challenge1, challenge2],
+                  }),
                 });
               });
             });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, lorsqu’un candidat est éligible à passer une certification complémentaire en plus de sa certification Pix, il la passe qu’il soit dans un centre habilité pour cette certification complémentaire ou non, ce qui ne devrait pas être possible.

## :robot: Solution
Ne pas permettre à un candidat éligible à une certif complémentaire de passer cette certif (et donc d’obtenir un scoring lié à cette certification) s’il passe cette certification dans un centre qui n’a pas l’habilitation adéquate : 
- Si Pix+ Droit, ne pas proposer les questions du référentiel Pix+ Droit.
- Si Cléa numérique, bloquer le scoring de la certification Cléa numérique.

## :rainbow: Remarques
Nous n'avons pas effectué de blocage lors du scoring/rescoring d'une certification Pix+ Droit car les challenges ne devraient pas être proposés mais on pourrait effectuer ce blocage par sécurité.

## :100: Pour tester

1. Se connecter à Pix Admin et vérifier que le centre de certif `Centre SUP des Anne-Étoiles` est bien habilité `CléA Numérique` et `Pix+ Droit`.
2. Se connecter à Pix Certif avec le compte `certifsup@example.net`
3. Créer une session de certification et y inscrire un candidat
4. Se connecter à Pix App avec le compte `certif-success@example.net`
5. Passer la certification en apportant une bonne réponse à plus de 80% des épreuves.
6. Finaliser la session
7. Aller sur Pix Admin et vérifier que le candidat a bien validé les certifications complémentaires `CléA Numérique` et `Pix+ Droit`.  

1. Se connecter à Pix Admin et retirer les habilitations `CléA Numérique` et `Pix+ Droit` pour le centre de certif `Centre SUP des Anne-Étoiles`.
2. Se connecter à Pix Certif avec le compte `certifsup@example.net`
3. Créer une session de certification et y inscrire un candidat
4. Se connecter à Pix App avec le compte `certif-success@example.net`
5. Passer la certification en apportant une bonne réponse à plus de 80% des épreuves.
6. Finaliser la session
7. Aller sur Pix Admin et vérifier que le candidat n'a pas passé les certifications complémentaires `CléA Numérique` et `Pix+ Droit`.  