### PR TITLE
[FEATURE] Retourner sur la liste des invitations après avoir invité un membre (PIX-3526)

### DIFF
--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -25,7 +25,7 @@ export default class NewController extends Controller {
       });
       const organization = this.currentUser.organization;
       await organization.organizationInvitations.reload();
-      this.transitionToRoute('authenticated.team');
+      this.transitionToRoute('authenticated.team.list.invitations');
     } catch (error) {
       this._handleResponseError(error);
     }

--- a/orga/tests/acceptance/team-creation_test.js
+++ b/orga/tests/acceptance/team-creation_test.js
@@ -76,10 +76,8 @@ module('Acceptance | Team Creation', function (hooks) {
         assert.equal(currentURL(), '/equipe/creation');
       });
 
-      test('it should allow to invite a prescriber and redirect to team page', async function (assert) {
+      test('it should allow to invite a prescriber and redirect to invitations list', async function (assert) {
         // given
-        const ariaLabelMember = this.intl.t('pages.team-members.table.row-title');
-
         const code = 'ABCDEFGH01';
         server.create('user', {
           firstName: 'Gigi',
@@ -99,8 +97,8 @@ module('Acceptance | Team Creation', function (hooks) {
         assert.equal(organizationInvitation.email, email);
         assert.equal(organizationInvitation.status, 'PENDING');
         assert.equal(organizationInvitation.code, code);
-        assert.equal(currentURL(), '/equipe/membres');
-        assert.dom(`[aria-label="${ariaLabelMember}"]`).exists({ count: 1 });
+        assert.equal(currentURL(), '/equipe/invitations');
+        assert.contains(email);
       });
 
       test('it should not allow to invite a prescriber when an email is not given', async function (assert) {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Après avoir invité un membre sur PixOrga, l'utilisateur a souvent besoin d'avoir en suivant la vue d'ensemble sur les invitations qu'il vient d'envoyer. Notamment lorsque l'administrateur gère d'un seul coup toutes les invitations des membres de son équipe. 
Cependant actuellement après avoir rempli le formulaire d'invitation d'un membre, il retourne sur la page listant les membres. Et doit donc cliquer sur l'onglet "Invitations" s'il veut voir le suivis des invitations.

## :bat: Solution
Rediriger vers la liste des invitations après avoir invité un membre.

## :spider_web: Remarques
L'IDE me marquait `this.transitionToRoute` comme étant déprécié, cependant ce n'est pas marqué dans la doc de l'api d'ember : https://api.emberjs.com/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo. 
> Calling transitionTo from the Router service will cause default query parameter values to be included in the URL. This behavior is different from calling transitionTo on a route or transitionToRoute on a controller.
Les forum parlant du sujet datent d'il y a pas mal d'année, donc dans le doute je n'ai pas fait de [SR] sur le sujet.

## :ghost: Pour tester
- Aller dans Pix Orga
- Cliquer sur "Equipes"
- Cliquer sur "Inviter un membre"
- Remplir le formulaire et valider
- Constater qu'on arrive sur la page de la liste des invitations (`/equipe/invitations`) 