### PR TITLE
[FEATURE] Afficher un message de confirmation quand une invitation est envoyée sur Pix Orga (PIX-731).

### DIFF
--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -16,6 +16,7 @@ export default class NewController extends Controller {
     event.preventDefault();
     this.isLoading = true;
     this.notifications.clearAll();
+    const emails = this.model.email.split(',');
 
     try {
       await this.model.save({
@@ -26,6 +27,12 @@ export default class NewController extends Controller {
       const organization = this.currentUser.organization;
       await organization.organizationInvitations.reload();
       this.transitionToRoute('authenticated.team.list.invitations');
+
+      const message =
+        emails.length > 1
+          ? this.intl.t('pages.team-new.success.multiple-invitations')
+          : this.intl.t('pages.team-new.success.invitation', { email: emails[0] });
+      this.notifications.success(message);
     } catch (error) {
       this._handleResponseError(error);
     }
@@ -34,7 +41,7 @@ export default class NewController extends Controller {
 
   @action
   cancel() {
-    this.transitionToRoute('authenticated.team');
+    this.transitionToRoute('authenticated.team.list.invitations');
   }
 
   _handleResponseError({ errors }) {

--- a/orga/tests/acceptance/team-creation_test.js
+++ b/orga/tests/acceptance/team-creation_test.js
@@ -76,7 +76,7 @@ module('Acceptance | Team Creation', function (hooks) {
         assert.equal(currentURL(), '/equipe/creation');
       });
 
-      test('it should allow to invite a prescriber and redirect to invitations list', async function (assert) {
+      test('it should allow to invite a prescriber, redirect to invitations list and display confirmation invitation message', async function (assert) {
         // given
         const code = 'ABCDEFGH01';
         server.create('user', {
@@ -99,6 +99,21 @@ module('Acceptance | Team Creation', function (hooks) {
         assert.equal(organizationInvitation.code, code);
         assert.equal(currentURL(), '/equipe/invitations');
         assert.contains(email);
+        assert.contains(this.intl.t('pages.team-new.success.invitation', { email }));
+      });
+
+      test('it should display other confirm invitation message when there is multiple invitations', async function (assert) {
+        // given
+        const emails = 'elisa.agnard@example.net,fred.durand@example.net';
+
+        await visit('/equipe/creation');
+        await fillInByLabel(inputLabel, emails);
+
+        // when
+        await clickByLabel(inviteButton);
+
+        // then
+        assert.contains(this.intl.t('pages.team-new.success.multiple-invitations'));
       });
 
       test('it should not allow to invite a prescriber when an email is not given', async function (assert) {
@@ -123,7 +138,18 @@ module('Acceptance | Team Creation', function (hooks) {
         await visit('/equipe/creation');
 
         // then
-        assert.dom('#email').hasText('');
+        assert.contains('');
+      });
+
+      test('should redirect to invitations list after cancelling on invite page', async function (assert) {
+        // given
+        await visit('/equipe/creation');
+
+        // when
+        await clickByLabel(cancelButton);
+
+        // then
+        assert.equal(currentURL(), '/equipe/invitations');
       });
 
       test('it should display error on global form when error 500 is returned from backend', async function (assert) {
@@ -151,8 +177,7 @@ module('Acceptance | Team Creation', function (hooks) {
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
-        assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]').hasText(expectedErrorMessage);
+        assert.contains(expectedErrorMessage);
       });
 
       test('it should display error on global form when error 412 is returned from backend', async function (assert) {
@@ -180,8 +205,7 @@ module('Acceptance | Team Creation', function (hooks) {
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
-        assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]').hasText(expectedErrorMessage);
+        assert.contains(expectedErrorMessage);
       });
 
       test('it should display error on global form when error 404 is returned from backend', async function (assert) {
@@ -209,8 +233,7 @@ module('Acceptance | Team Creation', function (hooks) {
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
-        assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]').hasText(expectedErrorMessage);
+        assert.contains(expectedErrorMessage);
       });
 
       test('it should display error on global form when error 400 is returned from backend', async function (assert) {
@@ -238,8 +261,7 @@ module('Acceptance | Team Creation', function (hooks) {
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
-        assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]').hasText(expectedErrorMessage);
+        assert.contains(expectedErrorMessage);
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -782,6 +782,10 @@
     "team-new": {
       "title": "Invite a member",
       "email-requirement": "Enter here the email address of the member you want to invite.",
+      "success": {
+        "invitation": "An invitation has been sent to the email address {email}.",
+        "multiple-invitations": "An invitation has been sent to the listed email addresses."
+      },
       "errors": {
         "default": "The service is temporarily unavailable. Please try again later.",
         "status": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -782,6 +782,10 @@
     "team-new": {
       "title": "Inviter un membre",
       "email-requirement": "Saisissez ici l'adresse e-mail du membre que vous souhaitez inviter.",
+      "success": {
+        "invitation": "Une invitation a bien été envoyée à l’adresse e-mail {email}.",
+        "multiple-invitations": "Une invitation a bien été envoyée aux adresses e-mails listées."
+      },
       "errors": {
         "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
         "status": {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, lorsque qu'une invitation est envoyée sur Pix Orga, aucun message n'indique que l'envoi de l'invitation s'est déroulée avec succès.

## :bat: Solution
Afficher une notification de succès lorsque l'invitation a été envoyée.

## :spider_web: Remarques
Wording différent en fonction du nombre d'invitation envoyés.

Lorsqu'on clique sur Annuler dans la page des invitations, on est redirigé vers la liste des invitations désormais.

## :ghost: Pour tester
Se connecter sur Pix Orga (sco.admin@example.net)
Aller sur Equipe, cliquer sur le bouton "Inviter un membre"

Entrer une adresse e-mail, le message de succès sera la suivant `"Une invitation a bien été envoyée à l’adresse e-mail {{email}}"`

Entrer plusieurs adresses e-mails, le message de succès sera : `"Une invitation a bien été envoyée aux adresses e-mails listées."`