### PR TITLE
[TECH] Refacto du filtre des classes dans l'onglet activité et résultats de Pix Orga (PIX-3618)

### DIFF
--- a/orga/app/components/campaign/filter/divisions-filter.hbs
+++ b/orga/app/components/campaign/filter/divisions-filter.hbs
@@ -1,0 +1,31 @@
+{{#if this.isLoading}}
+  <PixMultiSelect
+    @id="division"
+    @title={{t "pages.campaign-results.filters.type.divisions.title"}}
+    @emptyMessage={{this.emptyMessage}}
+    @placeholder={{this.placeholder}}
+    @isSearchable={{true}}
+    @showOptionsOnInput={{true}}
+    @options={{this.divisions}}
+    @selected={{@selected}}
+    @onSelect={{@onSelect}}
+    as |option|
+  >
+    {{option.label}}
+  </PixMultiSelect>
+{{else}}
+  <PixMultiSelect
+    @id="division"
+    @title={{t "pages.campaign-results.filters.type.divisions.title"}}
+    @emptyMessage={{this.emptyMessage}}
+    @placeholder={{this.placeholder}}
+    @isSearchable={{true}}
+    @showOptionsOnInput={{true}}
+    @options={{this.divisions}}
+    @selected={{@selected}}
+    @onSelect={{@onSelect}}
+    as |option|
+  >
+    {{option.label}}
+  </PixMultiSelect>
+{{/if}}

--- a/orga/app/components/campaign/filter/divisions-filter.js
+++ b/orga/app/components/campaign/filter/divisions-filter.js
@@ -1,0 +1,40 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+export default class CampaignDivisionsFilter extends Component {
+  @service intl;
+  @service currentUser;
+  @service store;
+
+  @tracked divisions = [];
+  @tracked isLoading = true;
+
+  constructor() {
+    super(...arguments);
+
+    this.args.campaign.divisions.then((divisions) => {
+      this.divisions = divisions?.map((division) => ({ value: division.name, label: division.name })) ?? [];
+      this.isLoading = false;
+    });
+  }
+
+  get emptyMessage() {
+    if (this.isLoading) {
+      return this.intl.t('common.filters.loading');
+    }
+    return this.intl.t('pages.campaign-results.filters.type.divisions.empty');
+  }
+
+  get placeholder() {
+    const { selected } = this.args;
+    if (selected?.length > 0) {
+      const divisions = this.divisions
+        .filter(({ value }) => selected.includes(value))
+        .map(({ label }) => label)
+        .join(', ');
+      return this.intl.t('pages.campaign-results.filters.type.divisions.selected', { divisions });
+    }
+    return this.intl.t('pages.campaign-results.filters.type.divisions.title');
+  }
+}

--- a/orga/app/components/campaign/filter/participation-filters.hbs
+++ b/orga/app/components/campaign/filter/participation-filters.hbs
@@ -18,20 +18,11 @@
       />
     {{/if}}
     {{#if this.displayDivisionFilter}}
-      <PixMultiSelect
-        @id="division"
-        @title={{t "pages.campaign-results.filters.type.divisions.title"}}
-        @placeholder={{t "pages.campaign-results.filters.type.divisions.title"}}
-        @isSearchable={{true}}
-        @showOptionsOnInput={{true}}
-        @emptyMessage={{t "pages.campaign-results.filters.type.divisions.empty"}}
-        @onSelect={{this.onSelectDivision}}
+      <Campaign::Filter::DivisionsFilter
+        @campaign={{@campaign}}
         @selected={{@selectedDivisions}}
-        @options={{this.divisionOptions}}
-        as |option|
-      >
-        {{option.label}}
-      </PixMultiSelect>
+        @onSelect={{this.onSelectDivision}}
+      />
     {{/if}}
     {{#if this.displayStagesFilter}}
       <PixMultiSelect

--- a/orga/app/components/campaign/filter/participation-filters.js
+++ b/orga/app/components/campaign/filter/participation-filters.js
@@ -23,7 +23,7 @@ export default class ParticipationFilters extends Component {
   }
 
   get displayDivisionFilter() {
-    return this.isDivisionsLoaded && this.currentUser.isSCOManagingStudents;
+    return this.currentUser.isSCOManagingStudents;
   }
 
   get displayStatusFilter() {
@@ -36,14 +36,6 @@ export default class ParticipationFilters extends Component {
 
   get badgeOptions() {
     return this.args.campaign?.badges?.map(({ id, title }) => ({ value: id, label: title }));
-  }
-
-  get isDivisionsLoaded() {
-    return this.args.campaign?.divisions?.content?.length > 0;
-  }
-
-  get divisionOptions() {
-    return this.args.campaign?.divisions?.map(({ name }) => ({ value: name, label: name }));
   }
 
   get statusOptions() {

--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -6,7 +6,7 @@
     @selectedDivisions={{@selectedDivisions}}
     @rowCount={{@profiles.meta.rowCount}}
     @onFilter={{@onFilter}}
-    @onReset={{@onReset}}
+    @onResetFilter={{@onReset}}
     @isHiddenStatus={{true}}
   />
 

--- a/orga/tests/integration/components/campaign/filter/divisions-filter_test.js
+++ b/orga/tests/integration/components/campaign/filter/divisions-filter_test.js
@@ -1,0 +1,64 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import { render } from '../../../../helpers/testing-library';
+import { click } from '@ember/test-helpers';
+import sinon from 'sinon';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Campaign::Filter::DivisionsFilter', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let store;
+
+  hooks.beforeEach(async function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('when there is no division', function () {
+    test('it should not display the filter', async function (assert) {
+      this.campaign = store.createRecord('campaign', { id: 1, divisions: [] });
+
+      await render(hbs`<Campaign::Filter::DivisionsFilter @campaign={{campaign}} />`);
+
+      assert.contains('Aucune classe');
+    });
+  });
+
+  module('when there is division', function () {
+    test('it should display the filter and campaign divisions', async function (assert) {
+      const division = store.createRecord('division', { id: 'd1', name: 'd1' });
+      this.campaign = store.createRecord('campaign', { id: 1, divisions: [division] });
+
+      const { getByPlaceholderText } = await render(hbs`<Campaign::Filter::DivisionsFilter @campaign={{campaign}} />`);
+
+      assert.ok(getByPlaceholderText('Classes'));
+      assert.contains('d1');
+    });
+
+    test('it should trigger onSelect when a division is selected', async function (assert) {
+      const division = store.createRecord('division', { id: 'd1', name: 'd1' });
+      this.campaign = store.createRecord('campaign', { id: 1, divisions: [division] });
+      this.onSelect = sinon.stub();
+
+      await render(hbs`<Campaign::Filter::DivisionsFilter @campaign={{campaign}} @onSelect={{onSelect}} />`);
+      await click('[for="division-d1"]');
+
+      assert.ok(this.onSelect.calledWith(['d1']));
+    });
+  });
+
+  module('when there are selected divisions', function () {
+    test('it should display them in placeholder', async function (assert) {
+      const division1 = store.createRecord('division', { id: 'd1', name: 'd1' });
+      const division2 = store.createRecord('division', { id: 'd2', name: 'd2' });
+      const division3 = store.createRecord('division', { id: 'd3', name: 'd3' });
+      this.campaign = store.createRecord('campaign', { id: 1, divisions: [division1, division2, division3] });
+      this.selected = ['d1', 'd2'];
+
+      const { getByPlaceholderText } = await render(
+        hbs`<Campaign::Filter::DivisionsFilter @campaign={{campaign}} @selected={{selected}} />`
+      );
+
+      assert.ok(getByPlaceholderText('Classes : d1, d2'));
+    });
+  });
+});

--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -9,6 +9,7 @@ import { clickByLabel } from '../../../../helpers/testing-library';
 module('Integration | Component | Campaign::Filter::ParticipationFilters', function (hooks) {
   setupIntlRenderingTest(hooks);
   let store;
+  const campaignId = 1;
 
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
@@ -16,7 +17,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
   module('when campaign does not need filters', function () {
     test('it should not display anything', async function (assert) {
-      const campaign = store.createRecord('campaign', { id: 1 });
+      const campaign = store.createRecord('campaign', { id: campaignId });
       this.set('campaign', campaign);
 
       // when
@@ -33,58 +34,24 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       isSCOManagingStudents = true;
     }
 
-    module('when there is no division', function () {
-      test('it should not display division filter', async function (assert) {
+    module('when there are some divisions', function (hooks) {
+      hooks.beforeEach(function () {
         this.owner.register('service:current-user', CurrentUserStub);
-        const campaign = store.createRecord('campaign', { id: 1 });
-        campaign.set('divisions', []);
-        this.set('campaign', campaign);
-
-        // when
-        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
-
-        // then
-        assert.notContains('Classes');
+        const division = store.createRecord('division', { id: 'd1', name: 'd1' });
+        this.campaign = store.createRecord('campaign', { id: 1, divisions: [division] });
       });
-    });
 
-    module('when there are some divisions', function () {
       test('it displays the division filter', async function (assert) {
-        this.owner.register('service:current-user', CurrentUserStub);
-
-        // given
-        const division = store.createRecord('division', {
-          id: 'd1',
-          name: 'd1',
-        });
-        const campaign = store.createRecord('campaign', { id: 1 });
-        campaign.set('divisions', [division]);
-        this.set('campaign', campaign);
-
         // when
         await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);
+
         // then
         assert.contains('Classes');
         assert.contains('d1');
       });
 
       test('it triggers the filter when a division is selected', async function (assert) {
-        this.owner.register('service:current-user', CurrentUserStub);
-
-        // given
-        const division = store.createRecord('division', {
-          id: 'd1',
-          name: 'd1',
-        });
-        const campaign = store.createRecord('campaign', {
-          id: 1,
-          name: 'campagne 1',
-          stages: [],
-        });
-        campaign.set('divisions', [division]);
-
         const triggerFiltering = sinon.stub();
-        this.set('campaign', campaign);
         this.set('triggerFiltering', triggerFiltering);
 
         // when
@@ -103,7 +70,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     test('it triggers the filter when a status is selected', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
+        id: campaignId,
         name: 'campagne 1',
         type: 'ASSESSMENT',
         stages: [],
@@ -126,7 +93,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     test('it select the option passed as selectedStatus args', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
+        id: campaignId,
         name: 'campagne 1',
         type: 'ASSESSMENT',
         stages: [],
@@ -148,7 +115,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     test('it should display 3 statuses for assessment campaign', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
+        id: campaignId,
         name: 'campagne 1',
         type: 'ASSESSMENT',
         stages: [],
@@ -171,7 +138,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
     test('it should display 2 statuses for profiles collection campaign', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
+        id: campaignId,
         name: 'campagne 1',
         type: 'PROFILES_COLLECTION',
         stages: [],
@@ -202,18 +169,8 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       this.owner.register('service:current-user', CurrentUserStub);
 
       // given
-      const division = store.createRecord('division', {
-        id: 'd2',
-        name: 'd2',
-      });
-      const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        stages: [],
-        divisions: [division],
-      });
-
-      this.set('campaign', campaign);
+      const division = store.createRecord('division', { id: 'd2', name: 'd2' });
+      this.campaign = store.createRecord('campaign', { id: 1, divisions: [division] });
 
       // when
       await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} />`);

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -18,9 +18,7 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
   test('it should display a link to access to result page', async function (assert) {
     // given
     this.owner.setupRouter();
-    const campaign = store.createRecord('campaign', {
-      id: 1,
-    });
+    const campaign = store.createRecord('campaign', { id: 1 });
 
     const participations = [
       {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -141,6 +141,9 @@
       "cancel": "Cancel",
       "close": "Close"
     },
+    "filters": {
+      "loading": "Loading..."
+    },
     "help-form": "https://pix.org/en-gb/contact-form",
     "home-page": "Pix Orga home page",
     "loading": "Loading",
@@ -329,7 +332,8 @@
         "type": {
           "badges": "Thematic results",
           "divisions": {
-            "title": "Class",
+            "title": "Classes",
+            "selected": "Classes: {divisions}",
             "empty": "No class"
           },
           "status": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -141,6 +141,9 @@
       "cancel": "Annuler",
       "close": "Fermer"
     },
+    "filters": {
+      "loading": "Chargement..."
+    },
     "help-form": "https://support.pix.fr/support/tickets/new",
     "home-page": "Page d'accueil de Pix Orga",
     "loading": "Chargement en cours",
@@ -330,7 +333,8 @@
           "badges": "Thématiques",
           "divisions": {
             "title": "Classes",
-            "empty": "Pas de classe"
+            "selected": "Classes : {divisions}",
+            "empty": "Aucune classe"
           },
           "status": {
             "title": "Statut",


### PR DESCRIPTION
## :jack_o_lantern: Problème

Le filtre des classes, présent sur les pages activité et résultats, se base sur l'objet campagne pour récupérer les informations des classes de la campagne. Or on souhaite refactorer ce composant dans le même esprit que les filtres de groupe et le rendre indépendant pour le réutiliser facilement à différents endroits.

## :bat: Solution

Ajouter un adapteur dédié aux divisions d'une campagne et créer un composant dédié à réutiliser dans les pages activité et résultats

## :spider_web: Remarques

**Bonus :** 
- Afficher dans le placeholder les éléments sélectionnés dans le filtre.
- Correction d'un bug du reset des filtres qui ne fonctionnait pas sur la page de résultat des collectes de profil.

## :ghost: Pour tester

Sur une organisation SCO, pour les campagnes de collectes & évaluation : 
- Tester le filtre de classe sur l'onglet "Activité" 
- Tester le filtre de classe sur l'onglet "Résultat"

