### PR TITLE
[BUGFIX] à l'import, ne pas réconcilier les nouveaux élèves qui sont liés par ailleurs au même compte utilisateur (PIX-3643).

### DIFF
--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -63,7 +63,10 @@ function _setSchoolingRegistrationFilters(
   }
 }
 
-function _canReconcile(existingRegistrationForUserId, student) {
+function _canReconcile(existingSchoolingRegistrations, student) {
+  const existingRegistrationForUserId = existingSchoolingRegistrations.find((currentSchoolingRegistration) => {
+    return currentSchoolingRegistration.userId === student.account.userId;
+  });
   return (
     existingRegistrationForUserId == null ||
     existingRegistrationForUserId.nationalStudentId === student.nationalStudentId
@@ -193,13 +196,16 @@ module.exports = {
     );
 
     _.each(students, (student) => {
-      const schoolingRegistration = _.find(schoolingRegistrationsToImport, {
-        nationalStudentId: student.nationalStudentId,
+      const alreadyReconciledSchoolingRegistration = _.find(schoolingRegistrationsToImport, {
+        userId: student.account.userId,
       });
-      const existingRegistrationForUserId = existingSchoolingRegistrations.find((currentSchoolingRegistration) => {
-        return currentSchoolingRegistration.userId === student.account.userId;
-      });
-      if (_canReconcile(existingRegistrationForUserId, student)) {
+
+      if (alreadyReconciledSchoolingRegistration) {
+        alreadyReconciledSchoolingRegistration.userId = null;
+      } else if (_canReconcile(existingSchoolingRegistrations, student)) {
+        const schoolingRegistration = _.find(schoolingRegistrationsToImport, {
+          nationalStudentId: student.nationalStudentId,
+        });
         schoolingRegistration.userId = student.account.userId;
       }
     });


### PR DESCRIPTION
## :jack_o_lantern: Problème
L'import Siècle échoue parfois et les utilisateurs ont un message d'erreur générique. En fouillant quelque peu dans Datadog, il se trouve qu'il y a une contrainte en base de données qui n'est pas respectée (contrainte sur l'unicité [userId-organisationId]).

## :bat: Solution
Pourquoi cela se produit-il ?
En fait il se trouve qu'il y a 2 élèves préalablement réconciliés (= lié) dans des organisations différentes mais avec le même compte utilisateur, qui sont cette année tous les 2 dans un nouvel établissement :

Explications détaillée :
- élève 1 lié à orga A qui utilise un compte 
- élève 2 lié à orga B qui utilise le même compte (même famille donc même ordinateur de bureau par exemple)
Nouvelle année, déménagement (que sais-je), ces 2 élèves rejoignent tous les 2 le même établissement, l'orga C. Or, dans un même établissement, il ne peut y avoir 2 fois le même compte utilisateur.

Le problème est à la base, les 2 élèves ne devraient pas être liés au même compte utilisateur. Malheureusement c'est fait, donc on doit trouver autre chose pour les débloquer.

A l'import donc (c'est ce qui échoue), d'habitude on récupère la précédente liaison élève-compte utilisateur. Ici, on ne va plus le faire pour ce cas précis. L'élève devra par la suite se réconcilier manuellement, et là, lui ou son prof contactera le support pour être débloqué.

## :spider_web: Remarques
RAS

## :ghost: Pour tester
Reproduire le cas à l'import.
