### PR TITLE
[BUGFIX] Le commentaire global de session affiché est celui de la session vue précédemment (PIX-3644)

### DIFF
--- a/admin/app/components/sessions/jury-comment.js
+++ b/admin/app/components/sessions/jury-comment.js
@@ -5,14 +5,15 @@ import noop from 'lodash/noop';
 
 export default class JuryComment extends Component {
   @tracked editingMode = false;
-  @tracked comment;
   @tracked commentBeingEdited;
   @tracked shouldDisplayDeletionConfirmationModal = false;
 
   constructor() {
     super(...arguments);
-    this.comment = this.args.comment;
-    this.commentBeingEdited = this.args.comment;
+  }
+
+  get comment() {
+    return this.args.comment;
   }
 
   @action
@@ -20,7 +21,6 @@ export default class JuryComment extends Component {
     event.preventDefault();
     try {
       await this.args.onFormSubmit(this.commentBeingEdited);
-      this.comment = this.commentBeingEdited;
       this.exitEditingMode();
     } catch {
       noop();
@@ -53,7 +53,6 @@ export default class JuryComment extends Component {
   async confirmDeletion() {
     try {
       await this.args.onDeleteButtonClicked();
-      this.comment = null;
       this.closeDeletionConfirmationModal();
     } catch {
       noop();

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -254,8 +254,17 @@ export default function () {
     return schema.accreditations.all();
   });
 
-  this.put('/admin/sessions/:id/comment', () => new Response(204));
-  this.delete('/admin/sessions/:id/comment', () => new Response(204));
+  this.put('/admin/sessions/:id/comment', (schema, request) => {
+    const sessionToUpdate = schema.sessions.find(request.params.id);
+    const params = JSON.parse(request.requestBody);
+    sessionToUpdate.update({ juryComment: params['jury-comment'] });
+    return new Response(204);
+  });
+  this.delete('/admin/sessions/:id/comment', async (schema, request) => {
+    const sessionToUpdate = schema.sessions.find(request.params.id);
+    sessionToUpdate.update({ juryComment: 'null' });
+    return new Response(204);
+  });
 
   this.post('/admin/certification-courses/:id/cancel', (schema, request) => {
     const certificationId = request.params.id;


### PR DESCRIPTION
## :jack_o_lantern: Problème
Sur admin, lorsque l'on sélectionne une session via la recherche d'id (en haut à droite), le commentaire n'est pas mis à jour. Il s'affiche celui qui était auparavant (ou champs vide s'il n'y en avait pas)

## :bat: Solution
Afficher le commentaire lié à la session

## :spider_web: Remarques
-

## :ghost: Pour tester
- Aller sur une session
- ajouter un commentaire
- changer de session via la recherche
![image](https://user-images.githubusercontent.com/3769147/137281033-3f4965c3-8f6e-46a7-859b-853ee395f32f.png)
- voir que la nouvelle session est bien chargé et que le commentaire correspond à celui de la session en cours
- Faire un refresh de la page, et voir que le commentaire reste le même