### PR TITLE
[FEATURE] Supprimer le Feature toggle FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED (PIX-3602)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -156,9 +156,6 @@ module.exports = (function () {
 
     featureToggles: {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
-      isDownloadCertificationAttestationByDivisionEnabled: isFeatureEnabled(
-        process.env.FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED
-      ),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
     },
 

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -21,7 +21,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
         data: {
           id: '0',
           attributes: {
-            'is-download-certification-attestation-by-division-enabled': false,
             'is-manage-uncompleted-certif-enabled': false,
             'is-email-validation-enabled': false,
           },

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -9,7 +9,6 @@ export default class AuthenticatedCertificationsController extends Controller {
   @service currentUser;
   @service notifications;
   @service intl;
-  @service featureToggles;
 
   @tracked selectedDivision = '';
 
@@ -95,10 +94,6 @@ export default class AuthenticatedCertificationsController extends Controller {
     }
 
     return `${this.model.options[0].label}, ${this.model.options[1].label} …`;
-  }
-
-  get isCertificationAttestationDownloadEnabled() {
-    return this.featureToggles.featureToggles.isDownloadCertificationAttestationByDivisionEnabled;
   }
 }
 

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,5 +1,3 @@
-import Model, { attr } from '@ember-data/model';
+import Model from '@ember-data/model';
 
-export default class FeatureToggle extends Model {
-  @attr('boolean') isDownloadCertificationAttestationByDivisionEnabled;
-}
+export default class FeatureToggle extends Model {}

--- a/orga/app/routes/authenticated/certifications.js
+++ b/orga/app/routes/authenticated/certifications.js
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 
 export default class AuthenticatedCertificationsRoute extends Route {
   @service currentUser;
-  @service featureToggles;
 
   beforeModel() {
     if (!(this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents)) {

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -22,11 +22,9 @@
     <PixButton @type="submit" id="download_results">
       {{t "pages.certifications.download-button"}}
     </PixButton>
-    {{#if this.isCertificationAttestationDownloadEnabled}}
-      <PixButton @triggerAction={{this.downloadAttestation}} id="download_attestations">
-        {{t "pages.certifications.download-attestations-button"}}
-      </PixButton>
-    {{/if}}
+    <PixButton @triggerAction={{this.downloadAttestation}} id="download_attestations">
+      {{t "pages.certifications.download-attestations-button"}}
+    </PixButton>
   </form>
 
   <PixMessage @withIcon={{true}}>

--- a/orga/tests/acceptance/certifications_test.js
+++ b/orga/tests/acceptance/certifications_test.js
@@ -49,26 +49,12 @@ module('Acceptance | Certifications page', function (hooks) {
       assert.dom('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]').exists();
     });
 
-    test('should display attestation download button if toggle is enabled', async function (assert) {
-      // given
-      server.create('feature-toggle', { id: 0, isDownloadCertificationAttestationByDivisionEnabled: true });
-
+    test('should display attestation download button', async function (assert) {
       // when
       await visit('/certifications');
 
       // then
       assert.dom('button[id="download_attestations"]').exists();
-    });
-
-    test('should not display attestation download button when toggle not enabled', async function (assert) {
-      // given
-      server.create('feature-toggle', { id: 0 });
-
-      // when
-      await visit('/certifications');
-
-      // then
-      assert.dom('button[id="download_attestations"]').doesNotExist();
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
-import { run } from '@ember/runloop';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Unit | Controller | authenticated/certifications', function (hooks) {
@@ -112,42 +111,6 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
         { autoClear: false }
       );
       assert.ok(true);
-    });
-  });
-
-  module('#isCertificationAttestationDownloadEnabled', function () {
-    test('should return true if toggle is enabled', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const featureToggles = run(() =>
-        store.createRecord('feature-toggle', { isDownloadCertificationAttestationByDivisionEnabled: true })
-      );
-      class FeatureTogglesStub extends Service {
-        featureToggles = featureToggles;
-      }
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
-
-      const controller = this.owner.lookup('controller:authenticated/certifications');
-
-      // when / then
-      assert.ok(controller.isCertificationAttestationDownloadEnabled);
-    });
-
-    test('should return false if toggle is disabled', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const featureToggles = run(() =>
-        store.createRecord('feature-toggle', { isDownloadCertificationAttestationByDivisionEnabled: false })
-      );
-      class FeatureTogglesStub extends Service {
-        featureToggles = featureToggles;
-      }
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
-
-      const controller = this.owner.lookup('controller:authenticated/certifications');
-
-      // when / then
-      assert.notOk(controller.isCertificationAttestationDownloadEnabled);
     });
   });
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
Le feature toggle FT_IS_DOWNLOAD_CERTIFICATION_ATTESTATION_BY_DIVISION_ENABLED est désormais activé en production

## :bat: Solution
Enlever le code de toggelisation de la feature

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Non régression sur les téléchargement d'attestations par classe côté pix-orga
- Se connecter à Pix Orga (par ex: sco.admin@example.net)
- Aller sur Certifications depuis la navbar de gauche
- Sélectionner une classe dans la selecteur (ex 3A)
- Cliquer sur Télécharger les attestations
- Vérifier le contenu téléchargé

