### PR TITLE
[TECH] Sortir la brique entrée de la campagne pour décommissionner `start-or-resume` (PIX-3182).

### DIFF
--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -78,6 +78,7 @@ Router.map(function () {
       this.route('login-or-register-to-access', { path: '/identification' });
       this.route('join', { path: '/rejoindre' });
     });
+    this.route('entrance', { path: '/entree' });
     this.route('profiles-collection', { path: '/collecte' }, function () {
       this.route('start-or-resume', { path: '/' });
       this.route('send-profile', { path: '/envoi-profil' });

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -1,16 +1,62 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
+import get from 'lodash/get';
 
 export default class Entrance extends Route.extend(SecuredRouteMixin) {
+  @service campaignStorage;
+  @service store;
+  @service currentUser;
+
   model() {
     return this.modelFor('campaigns');
   }
 
+  async afterModel(campaign) {
+    if (this.shouldBeginCampaignParticipation(campaign)) {
+      await this._beginCampaignParticipation(campaign);
+    }
+  }
+
   redirect(campaign) {
+    const hasParticipated = this.campaignStorage.get(campaign.code, 'hasParticipated');
+    if (!hasParticipated) {
+      return;
+    }
+
     if (campaign.isProfilesCollection) {
       this.replaceWith('campaigns.profiles-collection.start-or-resume', campaign);
     } else {
       this.replaceWith('campaigns.assessment.start-or-resume', campaign);
     }
+  }
+
+  async _beginCampaignParticipation(campaign) {
+    const participantExternalId = this.campaignStorage.get(campaign.code, 'participantExternalId');
+    const campaignParticipation = this.store.createRecord('campaign-participation', {
+      campaign,
+      participantExternalId,
+    });
+
+    try {
+      await campaignParticipation.save();
+      this.campaignStorage.set(campaign.code, 'hasParticipated', true);
+    } catch (err) {
+      const error = get(err, 'errors[0]', {});
+      campaignParticipation.deleteRecord();
+
+      if (error.status == 400 && error.detail.includes('participant-external-id')) {
+        this.campaignStorage.set(campaign.code, 'participantExternalId', null);
+        return this.replaceWith('campaigns.fill-in-participant-external-id', campaign);
+      }
+
+      throw err;
+    }
+  }
+
+  shouldBeginCampaignParticipation(campaign) {
+    const retry = this.campaignStorage.get(campaign.code, 'retry');
+    const hasParticipated = this.campaignStorage.get(campaign.code, 'hasParticipated');
+    return !hasParticipated || (campaign.multipleSendings && retry);
   }
 }

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -5,4 +5,12 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
   model() {
     return this.modelFor('campaigns');
   }
+
+  redirect(campaign) {
+    if (campaign.isProfilesCollection) {
+      this.replaceWith('campaigns.profiles-collection.start-or-resume', campaign);
+    } else {
+      this.replaceWith('campaigns.assessment.start-or-resume', campaign);
+    }
+  }
 }

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+
+export default class Entrance extends Route.extend(SecuredRouteMixin) {
+  model() {
+    return this.modelFor('campaigns');
+  }
+}

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -8,6 +8,12 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
   @service store;
   @service currentUser;
 
+  beforeModel(transition) {
+    if (!transition.from) {
+      this.replaceWith('campaigns.entry-point');
+    }
+  }
+
   model() {
     return this.modelFor('campaigns');
   }

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -38,7 +38,7 @@ export default class EntryPoint extends Route {
     }
 
     if (ongoingCampaignParticipation) {
-      return this.replaceWith('campaigns.start-or-resume', campaign);
+      return this.replaceWith('campaigns.entrance', campaign);
     }
 
     return this.replaceWith('campaigns.campaign-landing-page', campaign);

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -24,20 +24,22 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'retry', transition.to.queryParams.retry);
     }
 
-    let ongoingCampaignParticipation = null;
+    let hasParticipated = false;
     if (this.session.isAuthenticated) {
       const currentUserId = get(this.currentUser, 'user.id', null);
-      ongoingCampaignParticipation = await this.store.queryRecord('campaignParticipation', {
+      const ongoingCampaignParticipation = await this.store.queryRecord('campaignParticipation', {
         campaignId: campaign.id,
         userId: currentUserId,
       });
+      hasParticipated = Boolean(ongoingCampaignParticipation);
+      this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
     }
 
-    if (campaign.isArchived && !ongoingCampaignParticipation) {
+    if (campaign.isArchived && !hasParticipated) {
       return this.replaceWith('campaigns.campaign-not-found', campaign);
     }
 
-    if (ongoingCampaignParticipation) {
+    if (hasParticipated) {
       return this.replaceWith('campaigns.entrance', campaign);
     }
 

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -76,13 +76,9 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     }
   }
 
-  async redirect(campaign) {
+  redirect(campaign) {
     if (this.state.doesUserHaveOngoingParticipation) {
-      if (campaign.isProfilesCollection) {
-        this.replaceWith('campaigns.profiles-collection.start-or-resume', campaign);
-      } else {
-        return this.replaceWith('campaigns.assessment.start-or-resume', campaign);
-      }
+      return this.replaceWith('campaigns.entrance', campaign);
     }
   }
 

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -55,7 +55,6 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
   }
 
   async model() {
-    this.isLoading = true;
     return this.modelFor('campaigns');
   }
 

--- a/mon-pix/app/templates/campaigns/start-or-resume.hbs
+++ b/mon-pix/app/templates/campaigns/start-or-resume.hbs
@@ -1,7 +1,0 @@
-{{#if @model.isLoading}}
-  <div class="app-loader">
-    <p class="app-loader__image">
-      <img src="/images/interwind.gif" alt={{t "common.loading"}} />
-    </p>
-  </div>
-{{/if}}

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -1,3 +1,4 @@
+import EmberObject from '@ember/object';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
@@ -5,7 +6,7 @@ import sinon from 'sinon';
 describe('Unit | Route | Entrance', function () {
   setupTest();
 
-  let route;
+  let route, campaign;
 
   beforeEach(function () {
     route = this.owner.lookup('route:campaigns.entrance');
@@ -20,6 +21,38 @@ describe('Unit | Route | Entrance', function () {
 
       //then
       sinon.assert.calledWith(route.modelFor, 'campaigns');
+    });
+  });
+
+  describe('#redirect', function () {
+    beforeEach(function () {
+      route.replaceWith = sinon.stub();
+    });
+
+    it('should redirect to profiles-collection when campaign is of type PROFILES COLLECTION', async function () {
+      //given
+      campaign = EmberObject.create({
+        isProfilesCollection: true,
+      });
+
+      //when
+      await route.redirect(campaign);
+
+      //then
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.profiles-collection.start-or-resume');
+    });
+
+    it('should redirect to assessment when campaign is of type ASSESSMENT', async function () {
+      //given
+      campaign = EmberObject.create({
+        isProfilesCollection: false,
+      });
+
+      //when
+      await route.redirect(campaign);
+
+      //then
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.assessment.start-or-resume');
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -1,0 +1,25 @@
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Route | Entrance', function () {
+  setupTest();
+
+  let route;
+
+  beforeEach(function () {
+    route = this.owner.lookup('route:campaigns.entrance');
+
+    route.modelFor = sinon.stub();
+  });
+
+  describe('#model', function () {
+    it('should load model', async function () {
+      //when
+      await route.model();
+
+      //then
+      sinon.assert.calledWith(route.modelFor, 'campaigns');
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -15,6 +15,24 @@ describe('Unit | Route | Entrance', function () {
     route.replaceWith = sinon.stub();
   });
 
+  describe('#beforeModel', function () {
+    it('should redirect to entry point when /entree is directly set in the url', async function () {
+      //when
+      await route.beforeModel({ from: null });
+
+      //then
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.entry-point');
+    });
+
+    it('should continue en entrance route when from is set', async function () {
+      //when
+      await route.beforeModel({ from: 'campaigns.entry-point' });
+
+      //then
+      sinon.assert.notCalled(route.replaceWith);
+    });
+  });
+
   describe('#model', function () {
     it('should load model', async function () {
       //when

--- a/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
@@ -117,7 +117,7 @@ describe('Unit | Route | Entry Point', function () {
         sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-landing-page');
       });
 
-      it('should redirect to start-or-resume when ongoing campaign participation is existing', async function () {
+      it('should redirect to entrance when ongoing campaign participation is existing', async function () {
         //given
         route.store.queryRecord
           .withArgs('campaignParticipation', {
@@ -130,7 +130,7 @@ describe('Unit | Route | Entry Point', function () {
         await route.redirect(campaign, transition);
 
         //then
-        sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume');
+        sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance');
       });
 
       describe('archived campaign', function () {
@@ -154,7 +154,7 @@ describe('Unit | Route | Entry Point', function () {
           sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-not-found');
         });
 
-        it('should redirect to start or resume page with participation', async function () {
+        it('should redirect to entrance with participation', async function () {
           //given
           route.store.queryRecord
             .withArgs('campaignParticipation', {
@@ -167,7 +167,7 @@ describe('Unit | Route | Entry Point', function () {
           await route.redirect(campaign, transition);
 
           //then
-          sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume');
+          sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance');
         });
       });
     });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Jusqu'alors le fameux fichier start-or-resume était et est encore pour un petit moment un plat de spaghettis.

## :bat: Solution
On décomissionne ce fichier petit à petit, ici en sortant la brique entrée de la campagne.

## :spider_web: Remarques
RAS

## :ghost: Pour tester
Tester l'accès parcours au global
