### PR TITLE
[FEATURE] Ajouter la bannière d'information dans Pix Certif (PIX-3559).

### DIFF
--- a/certif/app/components/communication-banner.hbs
+++ b/certif/app/components/communication-banner.hbs
@@ -1,0 +1,5 @@
+{{#if this.isEnabled}}
+  <PixBanner @type={{this.bannerType}}>
+    {{this.bannerContent}}
+  </PixBanner>
+{{/if}}

--- a/certif/app/components/communication-banner.js
+++ b/certif/app/components/communication-banner.js
@@ -1,0 +1,18 @@
+import { htmlSafe } from '@ember/string';
+import Component from '@glimmer/component';
+import isEmpty from 'lodash/isEmpty';
+import ENV from 'pix-certif/config/environment';
+
+export default class CommunicationBanner extends Component {
+  bannerType = ENV.APP.BANNER.TYPE;
+
+  _rawBannerContent = ENV.APP.BANNER.CONTENT;
+
+  get isEnabled() {
+    return !isEmpty(this._rawBannerContent) && !isEmpty(this.bannerType);
+  }
+
+  get bannerContent() {
+    return htmlSafe(this._rawBannerContent);
+  }
+}

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -26,6 +26,7 @@
 @import "pages/terms-of-service";
 @import "components/add-student-list";
 @import "components/certif-checkbox";
+@import "components/communication-banner";
 @import "components/ember-cli-notifications-ie-fallback";
 @import "components/add-issue-report-modal";
 @import "components/certification-candidate-details-modal";

--- a/certif/app/styles/components/communication-banner.scss
+++ b/certif/app/styles/components/communication-banner.scss
@@ -1,0 +1,3 @@
+.pix-banner {
+  justify-content: center;
+}

--- a/certif/app/templates/application.hbs
+++ b/certif/app/templates/application.hbs
@@ -1,2 +1,3 @@
 {{page-title 'Pix Certif'}}
+<CommunicationBanner />
 {{outlet}}

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -36,6 +36,10 @@ module.exports = function(environment) {
 
     APP: {
       API_HOST: process.env.API_HOST || '',
+      BANNER: {
+        CONTENT: process.env.BANNER_CONTENT || '',
+        TYPE: process.env.BANNER_TYPE || '',
+      },
       API_ERROR_MESSAGES: {
         BAD_REQUEST: { CODE: '400', MESSAGE: 'Les données envoyées ne sont pas au bon format.' },
         INTERNAL_SERVER_ERROR: {

--- a/certif/tests/integration/components/communication-banner_test.js
+++ b/certif/tests/integration/components/communication-banner_test.js
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import ENV from 'pix-certif/config/environment';
+
+module('Integration | Component | communication-banner', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const originalBannerContent = ENV.APP.BANNER.CONTENT;
+  const originalBannerType = ENV.APP.BANNER.TYPE;
+
+  hooks.afterEach(function() {
+    ENV.APP.BANNER.CONTENT = originalBannerContent;
+    ENV.APP.BANNER.TYPE = originalBannerType;
+  });
+
+  test('should not display the banner when no banner content', async function(assert) {
+    // given
+    ENV.APP.BANNER.CONTENT = '';
+    ENV.APP.BANNER.TYPE = '';
+
+    // when
+    await render(hbs`<CommunicationBanner />`);
+
+    // then
+    assert.dom('.pix-banner').doesNotExist();
+  });
+
+  test('should display the information banner', async function(assert) {
+    // given
+    ENV.APP.BANNER.CONTENT = 'information banner text ...';
+    ENV.APP.BANNER.TYPE = 'information';
+
+    // when
+    await render(hbs`<CommunicationBanner />`);
+
+    // then
+    assert.dom('.pix-banner--information').exists();
+    assert.dom('.pix-banner--information').containsText('information banner text ...');
+  });
+});


### PR DESCRIPTION
## :jack_o_lantern: Problème
Lorsque des incidents surviennent en production, il est possible d'afficher une bannière d'avertissement sur Pix App et Pix Orga, mais pas Pix Certif. C'est possible sans avoir à modifier le code, grâce à deux variables d'environnement activables en prod.

## :bat: Solution
Ajouter la bannière sur l'application Pix Certif.

## :spider_web: Remarques
Le code de la bannière a été intégralement repris de la [PR  équivalente sur Pix Orga](https://github.com/1024pix/pix/pull/3025).

## :ghost: Pour tester
- Aller sur Scalingo est mettre à jour les valeurs des variables `BANNER_TYPE` (error, warning ou info) et `BANNER_CONTENT` de l'environnement front. 
- Redéployer l'environnement front et constater l'apparition de la bannière avec le message défini. 
