### PR TITLE
[FEATURE] Mise en place du feature toggle pour le RIP FDT (PIX-3554)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -157,6 +157,7 @@ module.exports = (function () {
     featureToggles: {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
+      isEndTestScreenRemovalEnabled: isFeatureEnabled(process.env.FT_END_TEST_SCREEN_REMOVAL_ENABLED),
     },
 
     infra: {

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,6 +23,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           attributes: {
             'is-manage-uncompleted-certif-enabled': false,
             'is-email-validation-enabled': false,
+            'is-end-test-screen-removal-enabled': false,
           },
           type: 'feature-toggles',
         },

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isManageUncompletedCertifEnabled;
+  @attr('boolean') isEndTestScreenRemovalEnabled;
 }


### PR DESCRIPTION
## :jack_o_lantern: Problème
L’épix “RIP FDT” nécessite l’implémentation de plusieurs fonctionnalité, notamment dans Pix Certif et sur Pix app, qui ne peuvent pas être mise à disposition de nos utilisateurs sans que le process entier soit implémenté.


## :bat: Solution
Mettre en place un FT pour cet épix


## :ghost: Pour tester
S'assurer que les tests api passent
