### PR TITLE
[FEATURE] Modification des tooltips sur les différents types de questions (PIX-3639).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/page-title.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/page-title.feature
@@ -25,4 +25,4 @@ Fonctionnalité: Titre des pages
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la compétence "recH9MjIzN54zXlwr"
     Lorsque je clique sur "Commencer"
-    Alors je vois le titre de la page "Question 1 sur 5 | Mathématiques | Pix"
+    Alors je vois le titre de la page "Mode libre - Question 1 sur 5 | Mathématiques | Pix"

--- a/mon-pix/app/components/challenge/statement/tooltip.hbs
+++ b/mon-pix/app/components/challenge/statement/tooltip.hbs
@@ -17,12 +17,24 @@
     {{on-key "Escape" (fn this.displayTooltip false) event="keyup"}}
     {{on "focusout" (fn this.displayTooltip false)}}
   >
+    <h3 class="tooltip-tag-information__title">
+      {{t
+        (if
+          this.isFocusedChallenge
+          "pages.challenge.statement.tooltip.focused.title"
+          "pages.challenge.statement.tooltip.other.title"
+        )
+      }}
+    </h3>
+
     <p class="tooltip-tag-information__text">
-      {{#if this.isFocusedChallenge}}
-        {{t "pages.challenge.statement.tooltip.focused"}}
-      {{else}}
-        {{t "pages.challenge.statement.tooltip.other"}}
-      {{/if}}
+      {{t
+        (if
+          this.isFocusedChallenge
+          "pages.challenge.statement.tooltip.focused.content"
+          "pages.challenge.statement.tooltip.other.content"
+        )
+      }}
     </p>
     {{#if this.shouldDisplayButton}}
       <PixButton class="tooltip-tag-information__button" @size="small" @triggerAction={{this.confirmInformationIsRead}}>

--- a/mon-pix/app/styles/components/_tooltip.scss
+++ b/mon-pix/app/styles/components/_tooltip.scss
@@ -83,6 +83,14 @@
 
 .tooltip-tag-information {
 
+  &__title {
+    margin-bottom: 16px;
+    line-height: 1rem;
+    font-family: $font-roboto;
+    font-size: 1.125rem;
+    font-weight: $font-medium;
+  }
+
   &__text {
     font-family: $font-roboto;
     font-size: 0.875rem;
@@ -91,10 +99,6 @@
     text-align: left;
     font-weight: $font-normal;
     letter-spacing: 0;
-
-    @include device-is('tablet') {
-      font-size: 1rem;
-    }
   }
 
   &__button {

--- a/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
@@ -9,6 +9,7 @@ describe('Integration | Component | Tooltip', function () {
   setupIntlRenderingTest();
 
   const tooltip = '.tooltip-tag__information';
+  const tooltipTitle = '.tooltip-tag-information__title';
   const confirmationButton = '.tooltip-tag-information__button';
 
   describe('when challenge is focused', function () {
@@ -35,6 +36,7 @@ describe('Integration | Component | Tooltip', function () {
       it('should render the tooltip with a confirmation button', async function () {
         // then
         expect(find(tooltip)).to.be.displayed;
+        expect(find(tooltipTitle)).to.exist;
         expect(find('.tooltip__tag--focused')).to.be.displayed;
         expect(find(confirmationButton)).to.exist;
       });
@@ -82,6 +84,7 @@ describe('Integration | Component | Tooltip', function () {
 
             // then
             expect(find(tooltip)).to.be.displayed;
+            expect(find(tooltipTitle)).to.exist;
             expect(find(confirmationButton)).to.not.exist;
           });
 
@@ -118,6 +121,7 @@ describe('Integration | Component | Tooltip', function () {
 
           // then
           expect(find(tooltip)).to.be.displayed;
+          expect(find(tooltipTitle)).to.exist;
           expect(find(confirmationButton)).to.not.exist;
         });
       });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -494,8 +494,14 @@
         "tooltip": {
           "aria-label": "Show question's warning",
           "close": "Ok, got it",
-          "focused": "Stay on this page! To answer this question, you should neither search the internet, nor use any piece of software.",
-          "other": "To answer this question, feel free to search the internet or use an external application."
+          "focused": {
+            "content": "Stay on this page! To answer this question, you should neither search the internet, nor use any piece of software.",
+            "title": "Focus Mode"
+          },
+          "other": {
+            "content": "To answer this question, feel free to search the internet or use an external application.",
+            "title": "Free Mode"
+          }
         }
       },
       "timed": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -315,7 +315,7 @@
     },
     "challenge": {
       "title": {
-        "default": "Question {stepNumber} of {totalChallengeNumber}",
+        "default": "Free Mode - Question {stepNumber} of {totalChallengeNumber}",
         "timed-out": "Timed out - Question {stepNumber} of {totalChallengeNumber}",
         "focused": "Focus Mode - Question {stepNumber} of {totalChallengeNumber}",
         "focused-out": "Failed - Focus Mode - Question {stepNumber} of {totalChallengeNumber}"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -315,7 +315,7 @@
     },
     "challenge": {
       "title": {
-        "default": "Question {stepNumber} sur {totalChallengeNumber}",
+        "default": "Mode libre - Question {stepNumber} sur {totalChallengeNumber}",
         "timed-out": "Temps écoulé - Question {stepNumber} sur {totalChallengeNumber}",
         "focused": "Mode focus - Question {stepNumber} sur {totalChallengeNumber}",
         "focused-out": "Échoué - Mode focus - Question {stepNumber} sur {totalChallengeNumber}"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -494,8 +494,14 @@
         "tooltip": {
           "aria-label": "Afficher l'indication sur l'épreuve.",
           "close": "J'ai compris",
-          "focused": "Restez sur cette page ! Vous ne devez pas faire une recherche sur internet ni utiliser de logiciels pour répondre à cette question.",
-          "other": "Essayez de répondre à cette question en recherchant sur internet ou avec l'aide d'une application externe."
+          "focused": {
+            "content": "Restez sur cette page ! Vous ne devez pas faire une recherche sur internet ni utiliser de logiciels pour répondre à cette question.",
+            "title": "Mode Focus"
+          },
+          "other": {
+            "content": "Vous êtes libre d’utiliser internet ou des applications pour répondre à cette question.",
+            "title": "Mode Libre"
+          }
         }
       },
       "timed": {


### PR DESCRIPTION
## :jack_o_lantern: Problème

La distinction entre les épreuves `focus` et `non-focus` n'est pas vraiment explicite sur la tooltip associée à chacune des questions.

## :bat: Solution

- [x] Ajout d'un titre sur chacune des tooltips
- [x] Modification du contenu de la tooltip des questions `non-focus`

## :spider_web: Remarques

Le contenu de la tooltip a uniquement été modifié dans sa version française, la version anglaise a été conservée.

## :ghost: Pour tester

Se rendre sur `mon-pix`

Passer des questions et constater de l'ajout du titre sur les tooltips de chaque type de question ainsi que de la modification du contenu de la tooltip (en français uniquement)
