### PR TITLE
[BUGFIX] Conservation statut focusedOutOfWindow si retour en arrière (PIX-3640).

### DIFF
--- a/mon-pix/app/adapters/assessment.js
+++ b/mon-pix/app/adapters/assessment.js
@@ -1,19 +1,18 @@
 import ApplicationAdapter from './application';
 
 export default class Assessment extends ApplicationAdapter {
-  urlForUpdateRecord(id, modelName, { adapterOptions }) {
-    const url = super.urlForUpdateRecord(...arguments);
+  urlForUpdateRecord(...args) {
+    const [, , snapshot] = args;
+    const url = super.urlForUpdateRecord(...args);
 
-    if (adapterOptions && adapterOptions.completeAssessment) {
-      delete adapterOptions.completeAssessment;
+    if (snapshot.adapterOptions?.completeAssessment) {
+      delete snapshot.adapterOptions.completeAssessment;
       return url + '/complete-assessment';
     }
 
-    if (adapterOptions && adapterOptions.updateLastQuestionsState) {
-      const state = adapterOptions.state;
-      delete adapterOptions.updateLastQuestionsState;
-      delete adapterOptions.state;
-      return url + '/last-challenge-state/' + state;
+    if (snapshot.adapterOptions?.updateLastQuestionState) {
+      delete snapshot.adapterOptions.updateLastQuestionState;
+      return url + '/last-challenge-state/' + snapshot.attr('lastQuestionState');
     }
 
     return url;

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -63,13 +63,13 @@ export default class ChallengeItemGeneric extends Component {
         this.args.hasFocusedOutOfWindow
       )
       .finally(() => {
-        this.args.resetChallengeInfo();
+        this.args.resetAllChallengeInfo();
       });
   }
 
   @action
   resumeAssessment() {
-    this.args.resetChallengeInfo();
+    this.args.resetChallengeInfoOnResume();
     return this.args.resumeAssessment(this.args.assessment);
   }
 
@@ -85,7 +85,7 @@ export default class ChallengeItemGeneric extends Component {
         this.args.hasFocusedOutOfWindow
       )
       .finally(() => {
-        this.args.resetChallengeInfo();
+        this.args.resetAllChallengeInfo();
       });
   }
 }

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -14,7 +14,8 @@
     answer=@answer
     assessment=@assessment
     timeoutChallenge=@timeoutChallenge
-    resetChallengeInfo=@resetChallengeInfo
+    resetAllChallengeInfo=@resetAllChallengeInfo
+    resetChallengeInfoOnResume=@resetChallengeInfoOnResume
     hasFocusedOutOfWindow=@hasFocusedOutOfWindow
     answerValidated=@answerValidated
     resumeAssessment=@resumeAssessment

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -78,13 +78,24 @@ export default class ChallengeController extends Controller {
     await this.model.assessment.save({ adapterOptions: { updateLastQuestionsState: true, state: 'timeout' } });
   }
 
-  @action
-  resetChallengeInfo() {
+  _resetNonContextualChallengeInfo() {
     this.challengeTitle = defaultPageTitle;
     this.hasUserConfirmedWarning = false;
     this.hasFocusedOutOfChallenge = false;
+  }
+
+  @action
+  resetAllChallengeInfo() {
+    this._resetNonContextualChallengeInfo();
     this.hasFocusedOutOfWindow = false;
     this.model.assessment.lastQuestionState = 'asked';
+  }
+
+  @action
+  resetChallengeInfoOnResume() {
+    this._resetNonContextualChallengeInfo();
+    // Keep focused out of window state
+    this.hasFocusedOutOfWindow = this.model.assessment.hasFocusedOutChallenge;
   }
 
   get displayHomeLink() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -69,13 +69,15 @@ export default class ChallengeController extends Controller {
   @action
   async focusedOutOfWindow() {
     this.hasFocusedOutOfWindow = true;
-    await this.model.assessment.save({ adapterOptions: { updateLastQuestionsState: true, state: 'focusedout' } });
+    this.model.assessment.lastQuestionState = 'focusedout';
+    await this.model.assessment.save({ adapterOptions: { updateLastQuestionState: true } });
   }
 
   @action
   async timeoutChallenge() {
     this.challengeTitle = timedOutPageTitle;
-    await this.model.assessment.save({ adapterOptions: { updateLastQuestionsState: true, state: 'timeout' } });
+    this.model.assessment.lastQuestionState = 'timeout';
+    await this.model.assessment.save({ adapterOptions: { updateLastQuestionState: true } });
   }
 
   _resetNonContextualChallengeInfo() {

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -49,7 +49,8 @@
         @assessment={{@model.assessment}}
         @answer={{@model.answer}}
         @timeoutChallenge={{this.timeoutChallenge}}
-        @resetChallengeInfo={{this.resetChallengeInfo}}
+        @resetAllChallengeInfo={{this.resetAllChallengeInfo}}
+        @resetChallengeInfoOnResume={{this.resetChallengeInfoOnResume}}
         @answerValidated={{route-action "saveAnswerAndNavigate"}}
         @resumeAssessment={{route-action "resumeAssessment"}}
         @onFocusIntoChallenge={{fn this.setFocusedOutOfChallenge false}}

--- a/mon-pix/tests/unit/adapters/assessment_test.js
+++ b/mon-pix/tests/unit/adapters/assessment_test.js
@@ -15,8 +15,10 @@ describe('Unit | Adapters | assessment', function () {
 
   describe('#urlForUpdateRecord', () => {
     it('should build update url from assessment id', async function () {
-      // when
+      // given
       const options = { adapterOptions: {} };
+
+      // when
       const url = await adapter.urlForUpdateRecord(123, 'assessment', options);
 
       // then
@@ -24,8 +26,10 @@ describe('Unit | Adapters | assessment', function () {
     });
 
     it('should redirect to complete-assessment', async function () {
-      // when
+      // given
       const options = { adapterOptions: { completeAssessment: true } };
+
+      // when
       const url = await adapter.urlForUpdateRecord(123, 'assessment', options);
 
       // then
@@ -33,9 +37,15 @@ describe('Unit | Adapters | assessment', function () {
     });
 
     it('should redirect to update last-question-state', async function () {
+      // given
+      const attrStub = (name) => (name === 'lastQuestionState' ? 'timeout' : null);
+      const snapshot = {
+        adapterOptions: { updateLastQuestionState: true },
+        attr: attrStub,
+      };
+
       // when
-      const options = { adapterOptions: { updateLastQuestionsState: true, state: 'timeout' } };
-      const url = await adapter.urlForUpdateRecord(123, 'assessment', options);
+      const url = await adapter.urlForUpdateRecord(123, 'assessment', snapshot);
 
       // then
       expect(url.endsWith('/assessments/123/last-challenge-state/timeout')).to.be.true;


### PR DESCRIPTION
## :jack_o_lantern: Problème
En mode focus, si l'utilisateur revient en arrière puis poursuit son parcours, Pix app ne conserve pas pour l'instant pas le statut permettant de savoir il est sorti de la fenêtre.

## :bat: Solution
Différencier le `resetChallenge` utilisé lors de la validation+du skip et celui du resume.

## :spider_web: Remarques
Je ne suis pas sûr de moi sur le nommage des nouvelles fonctions, preneur de vos retours ;) 

Est-ce qu'on peut ajouter des tests ? 😄 

## :ghost: Pour tester
1. Se rendre sur mon-pix
1. Accéder à une question focus
1. Sortir de la fenêtre en cliquant en dehors de la page (un message doit s'afficher en bas de la page)
1. Revenir sur la page précédante
1. Cliquer sur "Poursuivre"
1. Constater que le message est toujours bien affiché, contrairement à avant

À vérifier : le statut est-il toujours bien conservé sur deux questions focus de même type qui s'enchaine ?