### PR TITLE
[FEATURE] Accéder au Portail surveillant en étant connecté à pix-certif (PIX-3624)

### DIFF
--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -11,6 +11,7 @@ export default class AuthenticatedController extends Controller {
   @tracked isBannerVisible = true;
   @service router;
   @service currentUser;
+  @service featureToggles;
 
   get showBanner() {
     const isOnFinalizationPage = this.router.currentRouteName === 'authenticated.sessions.finalize';
@@ -29,6 +30,10 @@ export default class AuthenticatedController extends Controller {
 
   get showLinkToSessions() {
     return !this.currentUser.currentAllowedCertificationCenterAccess.isAccessRestricted;
+  }
+
+  get isEndTestScreenRemovalEnabled() {
+    return this.featureToggles.featureToggles.isEndTestScreenRemovalEnabled;
   }
 
   @action

--- a/certif/app/router.js
+++ b/certif/app/router.js
@@ -17,6 +17,7 @@ Router.map(function() {
   this.route('login', { path: 'connexion' });
 
   this.route('terms-of-service', { path: '/cgu' });
+  this.route('login-session-supervisor', { path: '/connexion-portail-surveillant' });
   this.route('authenticated', { path: '' }, function() {
     this.route('restricted-access', { path: '/espace-ferme' });
     this.route('sessions', function() {

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -16,6 +16,14 @@
               Sessions
             </LinkTo>
           </li>
+          {{#if this.isEndTestScreenRemovalEnabled}}
+            <li>
+              <LinkTo @route="login-session-supervisor" class="sidebar-menu__item" type="button" aria-label="Portail surveillant">
+                <FaIcon @icon='eye' @class="sidebar-menu__item-icon" />
+                Portail surveillant
+              </LinkTo>
+            </li>
+          {{/if}}
         {{/if}}
         <li>
           <a class="sidebar-menu__item" href="{{this.documentationLink}}" target="_blank" rel="noopener noreferrer">

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -226,4 +226,44 @@ module('Unit | Controller | authenticated', function(hooks) {
       assert.true(showLinkToSessions);
     });
   });
+
+  module('#get isEndTestScreenRemovalEnabled', function() {
+    test('should return true when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function(assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = {
+          isEndTestScreenRemovalEnabled: true,
+        };
+      }
+
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+
+      const controller = this.owner.lookup('controller:authenticated');
+
+      // when
+      const isEndTestScreenRemovalEnabled = controller.isEndTestScreenRemovalEnabled;
+
+      // then
+      assert.true(isEndTestScreenRemovalEnabled);
+    });
+
+    test('should return false when FT_END_TEST_SCREEN_REMOVAL_ENABLED is not enbaled', function(assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = {
+          isEndTestScreenRemovalEnabled: false,
+        };
+      }
+
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+
+      const controller = this.owner.lookup('controller:authenticated');
+
+      // when
+      const isEndTestScreenRemovalEnabled = controller.isEndTestScreenRemovalEnabled;
+
+      // then
+      assert.false(isEndTestScreenRemovalEnabled);
+    });
+  });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Dans le cadre de l'épix RIP case FDT, un surveillant de session de certification peut également être membre de l’accès Pix Certif de son centre. Dans ce cas, il doit pouvoir accéder au Portail Surveillant depuis la page d’accueil Pix Certif.

## :bat: Solution
Ajouter un bouton "Portail surveillant" dans le menu latéral qui redirige vers une page pour l'instant uniquement munie d'un titre

![image](https://user-images.githubusercontent.com/37305474/137488692-181a7800-5de5-46ad-b42b-c20158db714b.png)


## :spider_web: Remarques
Epix soumise à feature toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED

## :ghost: Pour tester
- Activer le toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED
- Se connecter à pix-certif
- Constater que le bouton "Portail surveillant" est bien présent
- Cliquer dessus et constater la redirection vers la page de portail (sans menu) 
