### PR TITLE
Revert "[TECH] Utiliser le token de github pour sécuriser l'auto merge."

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,5 +1,4 @@
 name: automerge check
-
 on:
   pull_request:
     types:
@@ -7,20 +6,14 @@ on:
   check_suite:
     types:
       - completed
-
-permissions:
-  checks: read
-  contents: write
-  actions: write
-
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.14.3"
+        uses: "pascalgn/automerge-action@v0.8.3"
         env:
-          GITHUB_TOKEN: "${{ github.token }}"
+          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
           MERGE_LABELS: ":rocket: Ready to Merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: ":rocket: Ready to Merge"


### PR DESCRIPTION
Au vu des soucis qui ont eu lieu après le merge de la PR je propose de la revert le temps d'étudier plus en détail ce qu'il manque à son bon fonctionnement.

Soucis remontés : 
- le label `ready-to-merge` ne merge plus automatiquement les PR non à jour sur dev. Il faut remettre le label `ready-to-merge` après avoir mis la PR à jour sur dev pour qu'il merge automatiquement (probablement un soucis des permissions du github token)
- Jira n'est plus mis à jour automatiquement (à enquêter)