### PR TITLE
[FEATURE] Rediriger les utilisateurs non-membres d'un centre de certification vers le portail surveillant depuis la page de connexion de Pix Certif (PIX-3625).

### DIFF
--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -72,10 +72,6 @@ class User {
     return this.memberships.length > 0;
   }
 
-  isLinkedToCertificationCenters() {
-    return this.certificationCenterMemberships.length > 0;
-  }
-
   hasAccessToOrganization(organizationId) {
     return this.memberships.some((membership) => membership.organization.id === organizationId);
   }

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -17,10 +17,6 @@ function _checkUserAccessScope(scope, user) {
   if (scope === apps.PIX_ADMIN.SCOPE && !user.hasRolePixMaster) {
     throw new ForbiddenAccess(apps.PIX_ADMIN.NOT_PIXMASTER_MSG);
   }
-
-  if (scope === apps.PIX_CERTIF.SCOPE && !user.isLinkedToCertificationCenters()) {
-    throw new ForbiddenAccess(apps.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG);
-  }
 }
 
 module.exports = async function authenticateUser({ password, scope, source, username, tokenService, userRepository }) {

--- a/api/lib/domain/usecases/get-certification-point-of-contact.js
+++ b/api/lib/domain/usecases/get-certification-point-of-contact.js
@@ -1,15 +1,3 @@
-const { NotFoundError } = require('../errors');
-
-module.exports = async function getCertificationPointOfContact({
-  userId,
-  certificationCenterMembershipRepository,
-  certificationPointOfContactRepository,
-}) {
-  const isCertificationCenterMember =
-    await certificationCenterMembershipRepository.doesUserHaveMembershipToAnyCertificationCenter(userId);
-  if (!isCertificationCenterMember) {
-    throw new NotFoundError(`Le référent de certification d'id ${userId} n’existe pas.`);
-  }
-
+module.exports = async function getCertificationPointOfContact({ userId, certificationPointOfContactRepository }) {
   return certificationPointOfContactRepository.get(userId);
 };

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -64,12 +64,4 @@ module.exports = {
     }).fetch({ require: false, columns: 'id' });
     return Boolean(certificationCenterMembership);
   },
-
-  async doesUserHaveMembershipToAnyCertificationCenter(userId) {
-    const certificationCenterMembership = await BookshelfCertificationCenterMembership.where({ userId }).fetch({
-      require: false,
-      columns: 'id',
-    });
-    return Boolean(certificationCenterMembership);
-  },
 };

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -16,7 +16,7 @@ module.exports = {
         certificationCenterIds: knex.raw('array_agg(??)', 'certification-center-memberships.certificationCenterId'),
       })
       .from('users')
-      .join('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')
+      .leftJoin('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')
       .where('users.id', userId)
       .groupByRaw('1, 2, 3, 4, 5')
       .first();

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -211,37 +211,4 @@ describe('Integration | Repository | Certification Center Membership', function 
       expect(hasMembership).to.be.true;
     });
   });
-
-  describe('#doesUserHaveMembershipToAnyCertificationCenter', function () {
-    it('should return false if user has no membership to any certification center', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const someOtherUserId = databaseBuilder.factory.buildUser().id;
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId: someOtherUserId, certificationCenterId });
-      await databaseBuilder.commit();
-
-      // when
-      const hasMembership =
-        await certificationCenterMembershipRepository.doesUserHaveMembershipToAnyCertificationCenter(userId);
-
-      // then
-      expect(hasMembership).to.be.false;
-    });
-
-    it('should return true if user has membership in a certification center', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-      await databaseBuilder.commit();
-
-      // when
-      const hasMembership =
-        await certificationCenterMembershipRepository.doesUserHaveMembershipToAnyCertificationCenter(userId);
-
-      // then
-      expect(hasMembership).to.be.true;
-    });
-  });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -6,10 +6,6 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 describe('Integration | Repository | CertificationPointOfContact', function () {
   describe('#get', function () {
     it('should throw NotFoundError when point of contact does not exist', async function () {
-      // given
-      databaseBuilder.factory.buildUser({ userId: 123 });
-      await databaseBuilder.commit();
-
       // when
       const error = await catchErr(certificationPointOfContactRepository.get)(123);
 

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -8,10 +8,6 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
     it('should throw NotFoundError when point of contact does not exist', async function () {
       // given
       databaseBuilder.factory.buildUser({ userId: 123 });
-      databaseBuilder.factory.buildCertificationCenter({ id: 456 });
-      databaseBuilder.factory.buildUser.withCertificationCenterMembership({
-        certificationCenterId: 456,
-      });
       await databaseBuilder.commit();
 
       // when
@@ -24,12 +20,6 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
 
     it('should return a CertificationPointOfContact', async function () {
       // given
-      databaseBuilder.factory.buildCertificationCenter({
-        id: 123,
-        name: 'Centre des papys gâteux',
-        type: CertificationCenter.types.PRO,
-        externalId: 'ABC123',
-      });
       databaseBuilder.factory.buildUser({
         id: 456,
         firstName: 'Jean',
@@ -38,31 +28,19 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         pixCertifTermsOfServiceAccepted: true,
       });
       databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: 123,
-        userId: 456,
-      });
       await databaseBuilder.commit();
 
       // when
       const certificationPointOfContact = await certificationPointOfContactRepository.get(456);
 
       // then
-      const expectedAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
-        id: 123,
-        name: 'Centre des papys gâteux',
-        externalId: 'ABC123',
-        type: CertificationCenter.types.PRO,
-        isRelatedToManagingStudentsOrganization: false,
-        relatedOrganizationTags: [],
-      });
       const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 456,
         firstName: 'Jean',
         lastName: 'Acajou',
         email: 'jean.acajou@example.net',
         pixCertifTermsOfServiceAccepted: true,
-        allowedCertificationCenterAccesses: [expectedAllowedCertificationCenterAccess],
+        allowedCertificationCenterAccesses: [],
       });
       expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
     });

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -103,32 +103,6 @@ describe('Unit | Domain | Models | User', function () {
     });
   });
 
-  describe('isLinkedToCertificationCenters', function () {
-    it('should be true if user has a role in a certification center', function () {
-      // given
-      const user = domainBuilder.buildUser({
-        certificationCenterMemberships: [domainBuilder.buildCertificationCenterMembership()],
-      });
-
-      // when
-      const isLinked = user.isLinkedToCertificationCenters();
-
-      // then
-      expect(isLinked).to.be.true;
-    });
-
-    it('should be false if user has no role in certification center', function () {
-      // given
-      const user = new User();
-
-      // when
-      const isLinked = user.isLinkedToCertificationCenters();
-
-      // then
-      expect(isLinked).to.be.false;
-    });
-  });
-
   describe('hasAccessToOrganization', function () {
     it('should be false is user has no access to no organizations', function () {
       // given

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -157,28 +157,6 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
       expect(error).to.be.an.instanceOf(ForbiddenAccess);
       expect(error.message).to.be.equal(expectedErrorMessage);
     });
-
-    it('should rejects an error when scope is pix-certif and user is not linked to any certification centers', async function () {
-      // given
-      const scope = appMessages.PIX_CERTIF.SCOPE;
-      const user = domainBuilder.buildUser({ email: userEmail, certificationCenterMemberships: [] });
-      authenticationService.getUserByUsernameAndPassword.resolves(user);
-
-      const expectedErrorMessage = appMessages.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG;
-
-      // when
-      const error = await catchErr(authenticateUser)({
-        username: userEmail,
-        password,
-        scope,
-        tokenService,
-        userRepository,
-      });
-
-      // then
-      expect(error).to.be.an.instanceOf(ForbiddenAccess);
-      expect(error.message).to.be.equal(expectedErrorMessage);
-    });
   });
 
   context('when user should change password', function () {

--- a/api/tests/unit/domain/usecases/get-certification-point-of-contact_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-point-of-contact_test.js
@@ -1,46 +1,22 @@
-const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const getCertificationPointOfContact = require('../../../../lib/domain/usecases/get-certification-point-of-contact');
-const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-certification-point-of-contact', function () {
   const userId = 123;
-  let certificationCenterMembershipRepository;
   let certificationPointOfContactRepository;
 
   beforeEach(function () {
-    certificationCenterMembershipRepository = { doesUserHaveMembershipToAnyCertificationCenter: sinon.stub() };
     certificationPointOfContactRepository = { get: sinon.stub() };
   });
 
-  it('should throw NotFoundError when user is not member of any certification center', async function () {
-    // given
-    certificationCenterMembershipRepository.doesUserHaveMembershipToAnyCertificationCenter
-      .withArgs(userId)
-      .resolves(false);
-
-    // when
-    const error = await catchErr(getCertificationPointOfContact)({
-      userId,
-      certificationCenterMembershipRepository,
-      certificationPointOfContactRepository,
-    });
-
-    // then
-    expect(error).to.be.instanceOf(NotFoundError);
-  });
-
-  it('should return the CertificationPointOfContact when user is member of a certification center', async function () {
+  it('should return the CertificationPointOfContact', async function () {
     // given
     const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({ id: userId });
-    certificationCenterMembershipRepository.doesUserHaveMembershipToAnyCertificationCenter
-      .withArgs(userId)
-      .resolves(true);
     certificationPointOfContactRepository.get.withArgs(userId).resolves(expectedCertificationPointOfContact);
 
     // when
     const actualCertificationPointOfContact = await getCertificationPointOfContact({
       userId,
-      certificationCenterMembershipRepository,
       certificationPointOfContactRepository,
     });
 

--- a/api/tests/unit/domain/usecases/get-certification-point-of-contact_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-point-of-contact_test.js
@@ -1,20 +1,15 @@
-const _ = require('lodash');
-const { expect, sinon, catchErr } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const getCertificationPointOfContact = require('../../../../lib/domain/usecases/get-certification-point-of-contact');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-certification-point-of-contact', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certificationCenterMembershipRepository = { doesUserHaveMembershipToAnyCertificationCenter: _.noop() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certificationPointOfContactRepository = { get: _.noop() };
   const userId = 123;
+  let certificationCenterMembershipRepository;
+  let certificationPointOfContactRepository;
 
   beforeEach(function () {
-    certificationCenterMembershipRepository.doesUserHaveMembershipToAnyCertificationCenter = sinon.stub();
-    certificationPointOfContactRepository.get = sinon.stub();
+    certificationCenterMembershipRepository = { doesUserHaveMembershipToAnyCertificationCenter: sinon.stub() };
+    certificationPointOfContactRepository = { get: sinon.stub() };
   });
 
   it('should throw NotFoundError when user is not member of any certification center', async function () {
@@ -36,7 +31,7 @@ describe('Unit | UseCase | get-certification-point-of-contact', function () {
 
   it('should return the CertificationPointOfContact when user is member of a certification center', async function () {
     // given
-    const expectedCertificationPointOfContact = Symbol('somePointOfContact');
+    const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({ id: userId });
     certificationCenterMembershipRepository.doesUserHaveMembershipToAnyCertificationCenter
       .withArgs(userId)
       .resolves(true);

--- a/certif/app/models/certification-point-of-contact.js
+++ b/certif/app/models/certification-point-of-contact.js
@@ -10,4 +10,8 @@ export default class CertificationPointOfContact extends Model {
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }
+
+  get isMemberOfACertificationCenter() {
+    return this.allowedCertificationCenterAccesses.length > 0;
+  }
 }

--- a/certif/app/routes/authenticated.js
+++ b/certif/app/routes/authenticated.js
@@ -15,6 +15,10 @@ export default class AuthenticatedRoute extends Route {
       return;
     }
 
+    if (!this.currentUser.certificationPointOfContact.isMemberOfACertificationCenter) {
+      this.router.replaceWith('login-session-supervisor');
+    }
+
     const pixCertifTermsOfServiceAccepted = get(this.currentUser, 'certificationPointOfContact.pixCertifTermsOfServiceAccepted');
     if (!pixCertifTermsOfServiceAccepted) {
       this.router.replaceWith('terms-of-service');

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -23,7 +23,8 @@ export default class CurrentUserService extends Service {
   }
 
   checkRestrictedAccess() {
-    if (this.currentAllowedCertificationCenterAccess.isAccessRestricted) {
+    if (this.certificationPointOfContact.isMemberOfACertificationCenter
+      && this.currentAllowedCertificationCenterAccess.isAccessRestricted) {
       return this.router.replaceWith('authenticated.restricted-access');
     }
   }

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -2,27 +2,20 @@ import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 
 export default class CurrentSessionService extends SessionService {
-
   @service currentUser;
   @service router;
   @service url;
 
-  routeAfterAuthentication = 'authenticated';
-
   async handleAuthentication() {
     await this.currentUser.load();
-    super.handleAuthentication(this.routeAfterAuthentication);
+    const isCurrentUserMemberOfACertificationCenter = this.currentUser.certificationPointOfContact.isMemberOfACertificationCenter;
+    const routeAfterAuthentication = isCurrentUserMemberOfACertificationCenter
+      ? 'authenticated'
+      : 'login-session-supervisor';
+    super.handleAuthentication(routeAfterAuthentication);
   }
 
   handleInvalidation() {
-    const routeAfterInvalidation = this._getRouteAfterInvalidation();
-    super.handleInvalidation(routeAfterInvalidation);
-  }
-
-  _getRouteAfterInvalidation() {
-    const alternativeRootURL = this.alternativeRootURL;
-    this.alternativeRootURL = null;
-
-    return alternativeRootURL ? alternativeRootURL : this.url.homeUrl;
+    super.handleInvalidation('/connexion');
   }
 }

--- a/certif/tests/unit/services/current-user_test.js
+++ b/certif/tests/unit/services/current-user_test.js
@@ -93,12 +93,16 @@ module('Unit | Service | current-user', function(hooks) {
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         isAccessBlockedCollege: true,
       });
+      const certificationPointOfContact = store.createRecord('certification-point-of-contact', {
+        allowedCertificationCenterAccesses: [currentAllowedCertificationCenterAccess],
+      });
       const replaceWithStub = sinon.stub();
       class RouterStub extends Service {
         replaceWith = replaceWithStub;
       }
       this.owner.register('service:router', RouterStub);
       const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.certificationPointOfContact = certificationPointOfContact;
       currentUser.currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
 
       // when
@@ -118,12 +122,16 @@ module('Unit | Service | current-user', function(hooks) {
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
       });
+      const certificationPointOfContact = store.createRecord('certification-point-of-contact', {
+        allowedCertificationCenterAccesses: [currentAllowedCertificationCenterAccess],
+      });
       const replaceWithStub = sinon.stub();
       class RouterStub extends Service {
         replaceWith = replaceWithStub;
       }
       this.owner.register('service:router', RouterStub);
       const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.certificationPointOfContact = certificationPointOfContact;
       currentUser.currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
 
       // when


### PR DESCRIPTION
## :jack_o_lantern: Problème
Un surveillant de session de certification n’est pas forcément membre de l’espace Pix Certif de son centre. Néanmoins, pour des raisons de sécurité et de traçabilité, nous préférons exiger a minima un accès Pix App pour les surveillant : tout surveillant souhaitant administrer une session de certification devra en effet se créer un compte Pix afin d’accéder au Portail surveillant. Il pourra ainsi entrer ses identifiants Pix App sur la page de connexion Pix Certif, et accéder au Portail surveillant.

## :bat: Solution
- Rediriger l'utilisateur sur le portail surveillant si celui-ci n'est pas membre d'un centre de certification.

## :ghost: Pour tester

### Classique

#### Surveillant
- Aller sur Pix Certif
- Se connecter avec le compte `certif-success@example.net`
- Vérifier que l'on arrive bien sur l'url `/connexion-portail-surveillant`
- Se déconnecter en tapant l'url `/logout`

#### Centre de certification
- Se connecter avec le compte `certifsco@example.net`
- Vérifier que l'on accède bien à Pix Certif.

### Multi-compte
- Aller sur Pix Certif
- Se connecter avec le compte `certifsco@example.net`
- Vérifier que l'on accède bien à Pix Certif.
- Se déconnecter
- Se connecter avec le compte `certif-success@example.net`
- Vérifier que l'on arrive bien sur l'url `/connexion-portail-surveillant`
