### PR TITLE
[TECH] Utiliser le status de la table campaign-participations au lieu de la jointure assessment pour la page Activité sur Pix Orga (PIX-3666)

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -12,7 +12,7 @@ const DomainTransaction = require('../DomainTransaction');
 
 const _ = require('lodash');
 
-const { SHARED } = CampaignParticipation.statuses;
+const { SHARED, TO_SHARE, STARTED } = CampaignParticipation.statuses;
 
 const ATTRIBUTES_TO_SAVE = [
   'createdAt',
@@ -253,76 +253,22 @@ module.exports = {
   },
 
   async countParticipationsByStatus(campaignId, campaignType) {
-    const shared = await _countSharedParticipations(campaignId);
+    const row = await knex('campaign-participations')
+      .select([
+        // eslint-disable-next-line knex/avoid-injections
+        knex.raw(`sum(case when status = '${SHARED}' then 1 else 0 end) as shared`),
+        // eslint-disable-next-line knex/avoid-injections
+        knex.raw(`sum(case when status = '${TO_SHARE}' then 1 else 0 end) as completed`),
+        // eslint-disable-next-line knex/avoid-injections
+        knex.raw(`sum(case when status = '${STARTED}' then 1 else 0 end) as started`),
+      ])
+      .where({ campaignId, isImproved: false })
+      .groupBy('campaignId')
+      .first();
 
-    if (campaignType === Campaign.types.ASSESSMENT) {
-      const { started, completed } = await _countAssessmentParticipationsByStatus(campaignId);
-      return { started, completed, shared };
-    }
-
-    if (campaignType === Campaign.types.PROFILES_COLLECTION) {
-      const completed = await _countNotSharedParticipations(campaignId);
-      return { completed, shared };
-    }
+    return mapToParticipationByStatus(row, campaignType);
   },
 };
-
-async function _countSharedParticipations(campaignId) {
-  const { count } = await knex('campaign-participations')
-    .count('id as count')
-    .where('campaignId', campaignId)
-    .where('isImproved', false)
-    .whereNotNull('sharedAt')
-    .first();
-  return count;
-}
-
-async function _countNotSharedParticipations(campaignId) {
-  const { count } = await knex('campaign-participations')
-    .count('id as count')
-    .where('campaignId', campaignId)
-    .where('isImproved', false)
-    .whereNull('sharedAt')
-    .first();
-  return count;
-}
-
-async function _countAssessmentParticipationsByStatus(campaignId) {
-  const countCompleted = knex.raw(
-    'COUNT("campaign-participations"."id") FILTER (WHERE "assessments"."state" = ?) OVER (PARTITION BY "campaignId") AS ??',
-    [Assessment.states.COMPLETED, 'completed']
-  );
-
-  const countStarted = knex.raw(
-    'COUNT("campaign-participations"."id") FILTER (WHERE "assessments"."state" = ?) OVER (PARTITION BY "campaignId") AS ??',
-    [Assessment.states.STARTED, 'started']
-  );
-
-  const result = await knex
-    .select([countCompleted, countStarted])
-    .from('campaign-participations')
-    .join('assessments', 'campaign-participations.id', 'assessments.campaignParticipationId')
-    .where('campaign-participations.campaignId', campaignId)
-    .where('campaign-participations.isImproved', false)
-    .whereNull('campaign-participations.sharedAt')
-    .modify(_filterMostRecentAssessments)
-    .first();
-
-  return {
-    started: result ? result.started : 0,
-    completed: result ? result.completed : 0,
-  };
-}
-
-function _filterMostRecentAssessments(qb) {
-  qb.leftJoin({ newerAssessments: 'assessments' }, function () {
-    this.on('newerAssessments.campaignParticipationId', 'campaign-participations.id').andOn(
-      'assessments.createdAt',
-      '<',
-      knex.ref('newerAssessments.createdAt')
-    );
-  }).whereNull('newerAssessments.id');
-}
 
 function _adaptModelToDb(campaignParticipation) {
   return {
@@ -382,4 +328,15 @@ function _rowToResult(row) {
 
 function _getAttributes(campaignParticipation) {
   return _.pick(campaignParticipation, ATTRIBUTES_TO_SAVE);
+}
+
+function mapToParticipationByStatus(row = {}, campaignType) {
+  const participationByStatus = {
+    shared: row.shared || 0,
+    completed: row.completed || 0,
+  };
+  if (campaignType === Campaign.types.ASSESSMENT) {
+    participationByStatus.started = row.started || 0;
+  }
+  return participationByStatus;
 }

--- a/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-status_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-status_test.js
@@ -1,10 +1,9 @@
 const { expect, catchErr, databaseBuilder } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
-const Assessment = require('../../../../lib/domain/models/Assessment');
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
 
-const { STARTED } = CampaignParticipation.statuses;
+const { STARTED, TO_SHARE } = CampaignParticipation.statuses;
 
 describe('Integration | UseCase | get-campaign-participations-counts-by-status', function () {
   let organizationId;
@@ -37,17 +36,8 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-status',
 
   it('should return participations counts by status', async function () {
     databaseBuilder.factory.buildCampaignParticipation({ campaignId });
-    const participation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED }).id;
-    const participation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED }).id;
-
-    databaseBuilder.factory.buildAssessment({
-      campaignParticipationId: participation1,
-      state: Assessment.states.COMPLETED,
-    });
-    databaseBuilder.factory.buildAssessment({
-      campaignParticipationId: participation2,
-      state: Assessment.states.STARTED,
-    });
+    databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: TO_SHARE });
+    databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED });
 
     await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -8,7 +8,7 @@ const Skill = require('../../../../lib/domain/models/Skill');
 const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 
-const { STARTED, SHARED } = CampaignParticipation.statuses;
+const { STARTED, SHARED, TO_SHARE } = CampaignParticipation.statuses;
 
 describe('Integration | Repository | Campaign Participation', function () {
   describe('#get', function () {
@@ -1122,7 +1122,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       describe('Count shared Participation', function () {
-        it('returns an object with 1 participation shared', async function () {
+        it('counts participations shared', async function () {
           databaseBuilder.factory.buildCampaignParticipation();
           databaseBuilder.factory.buildCampaignParticipation({ campaignId });
           await databaseBuilder.commit();
@@ -1132,7 +1132,7 @@ describe('Integration | Repository | Campaign Participation', function () {
           expect(result).to.deep.equal({ started: 0, completed: 0, shared: 1 });
         });
 
-        it('returns an object with 1 participation shared and isImproved=false', async function () {
+        it('counts the last participation shared by user', async function () {
           databaseBuilder.factory.buildCampaignParticipation({ campaignId, isImproved: true });
           databaseBuilder.factory.buildCampaignParticipation({ campaignId });
           await databaseBuilder.commit();
@@ -1144,18 +1144,11 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       describe('Count completed Participation', function () {
-        it('returns an object with 1 participation completed', async function () {
-          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: STARTED }).id;
-          const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        it('counts participations completed', async function () {
+          databaseBuilder.factory.buildCampaignParticipation({ status: TO_SHARE });
+          databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: STARTED,
-          }).id;
-
-          databaseBuilder.factory.buildAssessment({ campaignParticipationId: idSomeParticipation });
-          databaseBuilder.factory.buildAssessment({ campaignParticipationId: idParticipation });
-          databaseBuilder.factory.buildAssessment({
-            campaignParticipationId: idParticipation,
-            createdAt: new Date('2010-01-01'),
+            status: TO_SHARE,
           });
 
           await databaseBuilder.commit();
@@ -1165,19 +1158,16 @@ describe('Integration | Repository | Campaign Participation', function () {
           expect(result).to.deep.equal({ started: 0, completed: 1, shared: 0 });
         });
 
-        it('returns an object with 1 participation completed and isImproved=false', async function () {
-          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        it('counts the last participations completed by user', async function () {
+          databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: STARTED,
+            status: TO_SHARE,
             isImproved: true,
-          }).id;
-          const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: STARTED,
-          }).id;
-
-          databaseBuilder.factory.buildAssessment({ campaignParticipationId: idSomeParticipation });
-          databaseBuilder.factory.buildAssessment({ campaignParticipationId: idParticipation });
+            status: TO_SHARE,
+          });
 
           await databaseBuilder.commit();
 
@@ -1188,25 +1178,11 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       describe('Count started Participation', function () {
-        it('returns an object with 1 participation started', async function () {
-          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({ status: STARTED }).id;
-          const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        it('counts participations started', async function () {
+          databaseBuilder.factory.buildCampaignParticipation({ status: STARTED });
+          databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             status: STARTED,
-          }).id;
-
-          databaseBuilder.factory.buildAssessment({
-            campaignParticipationId: idSomeParticipation,
-            state: Assessment.states.STARTED,
-          });
-          databaseBuilder.factory.buildAssessment({
-            campaignParticipationId: idParticipation,
-            state: Assessment.states.STARTED,
-            createdAt: new Date('2010-01-01'),
-          });
-          databaseBuilder.factory.buildAssessment({
-            campaignParticipationId: idParticipation,
-            state: Assessment.states.STARTED,
           });
 
           await databaseBuilder.commit();
@@ -1216,24 +1192,15 @@ describe('Integration | Repository | Campaign Participation', function () {
           expect(result).to.deep.equal({ started: 1, completed: 0, shared: 0 });
         });
 
-        it('returns an object with 1 participation started and isImproved=false', async function () {
-          const idSomeParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        it('counts the last participation started by user', async function () {
+          databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             status: STARTED,
             isImproved: true,
-          }).id;
-          const idParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             status: STARTED,
-          }).id;
-
-          databaseBuilder.factory.buildAssessment({
-            campaignParticipationId: idSomeParticipation,
-            state: Assessment.states.STARTED,
-          });
-          databaseBuilder.factory.buildAssessment({
-            campaignParticipationId: idParticipation,
-            state: Assessment.states.STARTED,
           });
 
           await databaseBuilder.commit();
@@ -1265,7 +1232,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       describe('Count shared Participation', function () {
-        it('returns an object with 1 participation shared', async function () {
+        it('counts participations shared', async function () {
           databaseBuilder.factory.buildCampaignParticipation();
           databaseBuilder.factory.buildCampaignParticipation({ campaignId });
           await databaseBuilder.commit();
@@ -1275,7 +1242,7 @@ describe('Integration | Repository | Campaign Participation', function () {
           expect(result).to.deep.equal({ completed: 0, shared: 1 });
         });
 
-        it('returns an object with 1 participation shared and isImproved=false', async function () {
+        it('counts the last participation shared by user', async function () {
           databaseBuilder.factory.buildCampaignParticipation({ campaignId, isImproved: true });
           databaseBuilder.factory.buildCampaignParticipation({ campaignId });
           await databaseBuilder.commit();
@@ -1287,9 +1254,9 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       describe('Count completed Participation', function () {
-        it('returns an object with 1 participation completed', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ status: STARTED });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED });
+        it('counts participations completed', async function () {
+          databaseBuilder.factory.buildCampaignParticipation({ status: TO_SHARE });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: TO_SHARE });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
@@ -1297,9 +1264,9 @@ describe('Integration | Repository | Campaign Participation', function () {
           expect(result).to.deep.equal({ completed: 1, shared: 0 });
         });
 
-        it('returns an object with 1 participation completed and isImproved=false', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED, isImproved: true });
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED });
+        it('counts the last participation completed by user', async function () {
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: TO_SHARE, isImproved: true });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: TO_SHARE });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous avons remarqué en production des lenteurs/crash de container suite à un trop important appel sur la page d'accueil de Pix APP qui n'utilisait pas encore la colonne `status `de la table `campaign-participations`.

Or Nous avons oublié aussi d'utiliser cette nouvelle colonne dans un appel API côté Pix Orga

## :bat: Solution
Remplacer la jointure de la table `assessments` par la colonne `status` de la table `campaign-participations`

## :spider_web: Remarques


## :ghost: Pour tester
Se connecter à Pix Orga et vérifier que les statisques soit conformes aux données remonté dans la page activité d'une campagne.

pro.admin@example.net , aller sur une campagne collecte de profile et assessment, vérifier le bonne affichage du graphe des status par rapport aux participations