### PR TITLE
[FEATURE] Ajout d'un script de comparaison du nombre de pix avec la dernière release (PIX-3547).

### DIFF
--- a/api/lib/infrastructure/caches/DistributedCache.js
+++ b/api/lib/infrastructure/caches/DistributedCache.js
@@ -30,6 +30,12 @@ class DistributedCache extends Cache {
   flushAll() {
     return this._redisClientPublisher.publish(this._channel, 'Flush all');
   }
+
+  quit() {
+    this._underlyingCache.quit();
+    this._redisClientPublisher.quit();
+    this._redisClientSubscriber.quit();
+  }
 }
 
 module.exports = DistributedCache;

--- a/api/lib/infrastructure/caches/InMemoryCache.js
+++ b/api/lib/infrastructure/caches/InMemoryCache.js
@@ -8,6 +8,10 @@ class InMemoryCache extends Cache {
     this._queue = Promise.resolve();
   }
 
+  quit() {
+    this._cache.close();
+  }
+
   async get(key, generator) {
     return this._syncGet(key, () =>
       this._chainPromise(() => {

--- a/api/lib/infrastructure/caches/LayeredCache.js
+++ b/api/lib/infrastructure/caches/LayeredCache.js
@@ -23,6 +23,11 @@ class LayeredCache extends Cache {
     await this._firstLevelCache.flushAll();
     return this._secondLevelCache.flushAll();
   }
+
+  quit() {
+    this._firstLevelCache.quit();
+    this._secondLevelCache.quit();
+  }
 }
 
 module.exports = LayeredCache;

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -64,6 +64,10 @@ class RedisCache extends Cache {
 
     return this._client.flushall();
   }
+
+  quit() {
+    this._client.quit();
+  }
 }
 
 module.exports = RedisCache;

--- a/api/lib/infrastructure/caches/learning-content-cache.js
+++ b/api/lib/infrastructure/caches/learning-content-cache.js
@@ -12,14 +12,14 @@ class LearningContentCache extends Cache {
   constructor() {
     super();
     if (settings.caching.redisUrl) {
-      const distributedCache = new DistributedCache(
+      this.distributedCache = new DistributedCache(
         new InMemoryCache(),
         settings.caching.redisUrl,
         LEARNING_CONTENT_CHANNEL
       );
-      const redisCache = new RedisCache(settings.caching.redisUrl);
+      this.redisCache = new RedisCache(settings.caching.redisUrl);
 
-      this._underlyingCache = new LayeredCache(distributedCache, redisCache);
+      this._underlyingCache = new LayeredCache(this.distributedCache, this.redisCache);
     } else {
       this._underlyingCache = new InMemoryCache();
     }
@@ -35,6 +35,12 @@ class LearningContentCache extends Cache {
 
   flushAll() {
     return this._underlyingCache.flushAll();
+  }
+
+  quit() {
+    this._underlyingCache.quit();
+    this.redisCache.quit();
+    this.distributedCache.quit();
   }
 }
 

--- a/api/lib/infrastructure/datasources/learning-content/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/skill-datasource.js
@@ -29,6 +29,11 @@ module.exports = datasource.extend({
     );
   },
 
+  async findActiveByTubeId(tubeId) {
+    const skills = await this.list();
+    return _.filter(skills, { status: ACTIVE_STATUS, tubeId });
+  },
+
   async findActiveByCompetenceId(competenceId) {
     const skills = await this.list();
     return _.filter(skills, { status: ACTIVE_STATUS, competenceId });

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -13,8 +13,17 @@ function _toDomain(skillData) {
 }
 
 module.exports = {
+  async get(id) {
+    return _toDomain(await skillDatasource.get(id));
+  },
+
   async list() {
     const skillDatas = await skillDatasource.list();
+    return skillDatas.map(_toDomain);
+  },
+
+  async findActiveByTubeId(tubeId) {
+    const skillDatas = await skillDatasource.findActiveByTubeId(tubeId);
     return skillDatas.map(_toDomain);
   },
 

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -44,4 +44,8 @@ module.exports = class RedisClient {
   on(event, callback) {
     this._client.on(event, callback);
   }
+
+  quit() {
+    this._client.quit();
+  }
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -459,3 +459,16 @@ AUTH_SECRET=Change me!
 # type: Integer
 # default: 600
 TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS=
+
+
+# ========
+# MAX REACHABLE LEVEL
+# ========
+
+# Max reachable level by competence for a user
+#
+# presence: optional
+# type: Integer
+# default: 5
+# note: Pay attention to sync it whit prod
+MAX_REACHABLE_LEVEL=

--- a/api/scripts/compare-pix-with-latest-release.js
+++ b/api/scripts/compare-pix-with-latest-release.js
@@ -1,0 +1,129 @@
+require('dotenv').config();
+const _ = require('lodash');
+const calculateScoringInformationForCompetence =
+  require('../lib/domain/services/scoring/scoring-service').calculateScoringInformationForCompetence;
+const buildKnowledgeElement = require('../db/database-builder/factory/build-knowledge-element');
+const tubeRepository = require('../lib/infrastructure/repositories/tube-repository');
+const skillRepository = require('../lib/infrastructure/repositories/skill-repository');
+const knowledgeElementRepository = require('../lib/infrastructure/repositories/knowledge-element-repository');
+const cache = require('../lib/infrastructure/caches/learning-content-cache');
+const { disconnect } = require('../db/knex-database-connection');
+
+async function getUserSkillsGroupedByTubeId(elements) {
+  const ids = _.map(elements, (current) => current.skillId);
+  const skills = [];
+  for (const id of ids) {
+    const skill = await skillRepository.get(id);
+    skills.push(skill);
+  }
+
+  // we group them by tube id
+  return _.groupBy(skills, 'tubeId');
+}
+
+function getHardestSkillByTubeId(skillsGroupedByTubeId) {
+  const result = {};
+  _.forIn(skillsGroupedByTubeId, (tubeSkills, tubeId) => {
+    result[tubeId] = _.maxBy(tubeSkills, 'difficulty');
+  });
+
+  return result;
+}
+
+async function getTubeByIds(ids) {
+  return Promise.all(ids.map(async (tubeId) => tubeRepository.get(tubeId)));
+}
+
+async function getUserValidatedKnowledgeElements(userId) {
+  const foundKnowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId });
+  return await foundKnowledgeElements.filter((ke) => {
+    return ke.isValidated;
+  });
+}
+
+function buildKnowledgeElementsFromSkillsInTube(skills) {
+  return _.map(skills, (current, index) => {
+    const options = {};
+    options.skillId = current.id;
+    options.source = index === skills.length - 1 ? 'direct' : 'inferred';
+    options.competenceId = current.competenceId;
+    options.earnedPix = current.pixValue;
+    const ke = buildKnowledgeElement(options);
+    return ke;
+  });
+}
+
+async function compareUserScoreWithLatestRelease(userId) {
+  const knowledgeElements = await getUserValidatedKnowledgeElements(userId);
+
+  // we get the actual pix score
+  const knowledgeElementsByCompetenceId = await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({
+    userId,
+  });
+
+  // then we get the score for each competence
+  const scores = _.map(knowledgeElementsByCompetenceId, function (knowledgeElements) {
+    return calculateScoringInformationForCompetence({ knowledgeElements });
+  });
+
+  // and we sum it
+  const userScore = _.sumBy(scores, 'pixScoreForCompetence');
+
+  // we get the user skills
+  const skillsGroupedByTubeId = await getUserSkillsGroupedByTubeId(knowledgeElements);
+
+  // and we keep the hardest skill by tube id
+  const hardestSkillByTubeId = getHardestSkillByTubeId(skillsGroupedByTubeId);
+
+  // then we get the tubes
+  const tubes = await getTubeByIds(Object.keys(hardestSkillByTubeId));
+
+  // then we loop over the tubes
+  const fakeKnowledgeElements = [];
+
+  for (const currentTube of tubes) {
+    const hardestSkill = hardestSkillByTubeId[currentTube.id];
+
+    if (!hardestSkill) continue;
+
+    // we find active skills by competence and tube id
+    const activeSkills = await skillRepository.findActiveByTubeId(currentTube.id);
+    currentTube.skills = activeSkills;
+
+    // and we get the actual ref skills into the tube that are easier or equal the hardest Skill
+    const earnedSkills = currentTube.getEasierThan(hardestSkill);
+
+    // then, we rebuild fake knowledgeElements based on those skills and we store it
+    fakeKnowledgeElements.push(...buildKnowledgeElementsFromSkillsInTube(earnedSkills));
+  }
+
+  const fakeKnowledgeElementsGroupedCompetenceId = _.groupBy(fakeKnowledgeElements, 'competenceId');
+  const scoresByCompetenceId = _.map(fakeKnowledgeElementsGroupedCompetenceId, function (current) {
+    return calculateScoringInformationForCompetence({ knowledgeElements: current }).pixScoreForCompetence;
+  });
+
+  const todayScore = _.sum(scoresByCompetenceId);
+
+  return {
+    userId,
+    userScore,
+    todayScore,
+  };
+}
+
+async function main(userId) {
+  const result = await compareUserScoreWithLatestRelease(userId);
+  cache.quit();
+  disconnect();
+  console.log(result);
+}
+
+module.exports = {
+  compareUserScoreWithLatestRelease,
+  getUserValidatedKnowledgeElements,
+  getUserSkillsGroupedByTubeId,
+  getHardestSkillByTubeId,
+  getTubeByIds,
+};
+
+main(parseInt(process.argv[2]));

--- a/api/tests/unit/infrastructure/datasources/learning-content/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/skill-datasource_test.js
@@ -147,6 +147,24 @@ describe('Unit | Infrastructure | Datasource | LearningContent | SkillDatasource
     });
   });
 
+  describe('#findActiveByTubeId', function () {
+    beforeEach(function () {
+      const acquix1 = { id: 'recSkill1', status: 'actif', competenceId: 'recCompetence', tubeId: 'recTube' };
+      const acquix2 = { id: 'recSkill2', status: 'actif', competenceId: 'recCompetence', tubeId: 'recTube' };
+      const acquix3 = { id: 'recSkill3', status: 'périmé', competenceId: 'recCompetence', tubeId: 'recTube' };
+      const acquix4 = { id: 'recSkill4', status: 'actif', competenceId: 'recOtherCompetence', tubeId: 'recOtherTube' };
+      sinon.stub(lcms, 'getLatestRelease').resolves({ skills: [acquix1, acquix2, acquix3, acquix4] });
+    });
+
+    it('should retrieve all skills from learning content for one competence', async function () {
+      // when
+      const skills = await skillDatasource.findActiveByTubeId('recTube');
+
+      // then
+      expect(_.map(skills, 'id')).to.have.members(['recSkill1', 'recSkill2']);
+    });
+  });
+
   describe('#findOperativeByCompetenceId', function () {
     beforeEach(function () {
       const acquix1 = { id: 'recSkill1', status: 'actif', competenceId: 'recCompetence' };

--- a/api/tests/unit/scripts/compare-pix-with-latest-release_test.js
+++ b/api/tests/unit/scripts/compare-pix-with-latest-release_test.js
@@ -1,0 +1,145 @@
+const { expect, sinon } = require('../../test-helper');
+const {
+  getUserValidatedKnowledgeElements,
+  getTubeByIds,
+  getUserSkillsGroupedByTubeId,
+  getHardestSkillByTubeId,
+  compareUserScoreWithLatestRelease,
+} = require('../../../scripts/compare-pix-with-latest-release');
+const knowledgeElementRepository = require('../../../lib/infrastructure/repositories/knowledge-element-repository');
+const tubeRepository = require('../../../lib/infrastructure/repositories/tube-repository');
+const skillRepository = require('../../../lib/infrastructure/repositories/skill-repository');
+
+// mock datas
+const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
+const Tube = require('../../../lib/domain/models/Tube');
+const Skill = require('../../../lib/domain/models/Skill');
+
+const skill1 = new Skill({
+  id: 'skill1',
+  name: '@info1',
+  tubeId: 'tube1',
+  tutorialIds: [],
+  pixValue: 10,
+  competenceId: 'comp1',
+});
+const skill2 = new Skill({
+  id: 'skill2',
+  name: '@info2',
+  tubeId: 'tube1',
+  tutorialIds: [],
+  pixValue: 10,
+  competenceId: 'comp1',
+});
+const skill3 = new Skill({
+  id: 'skill3',
+  name: '@hack3',
+  tubeId: 'tube2',
+  tutorialIds: [],
+  pixValue: 10,
+  competenceId: 'comp1',
+});
+
+// additionnal 'active' skill which level is beyond user level
+// should not be retained for calculating today score
+const skill4 = new Skill({
+  id: 'skill4',
+  name: '@info3',
+  tubeId: 'tube1',
+  tutorialIds: [],
+  pixValue: 10,
+  competenceId: 'comp1',
+});
+
+const activeSkills = [skill1, skill2, skill3, skill4];
+const skills = [skill1, skill2, skill3];
+
+const tube1 = new Tube({ id: 'tube1', skills: [skill1, skill2] });
+const tube2 = new Tube({ id: 'tube2', skills: [skill3] });
+const tubes = [tube1, tube2];
+
+const knowledge1 = new KnowledgeElement({ id: 'ke1', status: 'validated', skillId: 'skill1', earnedPix: 5 });
+const knowledge2 = new KnowledgeElement({ id: 'ke2', status: 'validated', skillId: 'skill2', earnedPix: 5 });
+const knowledge3 = new KnowledgeElement({ id: 'ke3', status: 'validated', skillId: 'skill3', earnedPix: 5 });
+
+const invalidatedKe = new KnowledgeElement({ id: 'ke3', status: 'invalidated', skillId: 'skill1' });
+const knowledgeElements = [knowledge1, knowledge2, invalidatedKe, knowledge3];
+
+describe('Unit | Scripts | compare-pix-with-latest-release.js', function () {
+  beforeEach(async function () {
+    // stub repositories
+    knowledgeElementRepository.findUniqByUserId = sinon.stub().resolves(knowledgeElements);
+    tubeRepository.get = sinon.stub().callsFake((tubeId) => tubes.find((tube) => tube.id === tubeId));
+    skillRepository.get = sinon.stub().callsFake((skillId) => skills.find((skill) => skill.id === skillId));
+    skillRepository.findActiveByTubeId = sinon.stub().callsFake((tubeId) => {
+      const result = activeSkills.filter((skill) => skill.tubeId === tubeId);
+      return result;
+    });
+  });
+
+  afterEach(async function () {
+    sinon.restore();
+  });
+
+  describe('#getUserValidatedKnowledgeElements', function () {
+    it('should return validated knowledgeElementsOnly', async function () {
+      // when
+      const validated = await getUserValidatedKnowledgeElements(1);
+
+      // then
+      validated.forEach((current) => {
+        expect(current.status).to.equal('validated');
+      });
+    });
+  });
+
+  describe('#getTubeByIds', function () {
+    it('should return the tube instances by their ids', async function () {
+      // when
+      const result = await getTubeByIds(['tube1', 'tube2']);
+
+      // then
+      expect(tubes).to.deep.equal(result);
+    });
+  });
+
+  describe('#getUserSkillsGroupedByTubeId', function () {
+    it('should return the skills associated to the knowledgeElements grouped by their tube ids', async function () {
+      // when
+      const validated = await getUserValidatedKnowledgeElements(1);
+      const result = await getUserSkillsGroupedByTubeId(validated);
+
+      // then
+      expect(result).to.deep.equal({
+        tube1: [skill1, skill2],
+        tube2: [skill3],
+      });
+    });
+  });
+
+  describe('#getHardestSkillByTubeId', function () {
+    it('should keep only the hardest skill for each tube', async function () {
+      // when
+      const validated = await getUserValidatedKnowledgeElements(1);
+      const grouped = await getUserSkillsGroupedByTubeId(validated);
+      const hardest = getHardestSkillByTubeId(grouped);
+
+      // then
+      expect(hardest).to.deep.equal({
+        tube1: skill2,
+        tube2: skill3,
+      });
+    });
+  });
+
+  describe('#compareUserScoreWithLatestRelease', function () {
+    it('should be able to calculate the user score according to his knowledge elements', async function () {
+      // when
+      const result = await compareUserScoreWithLatestRelease(1);
+
+      // then
+      expect(result.userScore).to.equal(15);
+      expect(result.todayScore).to.equal(30);
+    });
+  });
+});


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous avons besoin de savoir quel serait le nombre de pix obtenus par un utilisateur aujourd'hui s'il validait des questions de niveau équivalent à celles qu'il a déjà validé. 

## :bat: Solution
Ajouter un script de recalcul du nombre de pix aujourd'hui en se basant sur le référentiel

## :spider_web: Remarques

## :ghost: Pour tester
Se rendre dans le dossier api/scripts et lancer la commande suivante: 
```bash
node scripts/compare-pix-with-latest-release.js <pix-user-id>
```
