### PR TITLE
[FEATURE] Redirige vers la page des paramètres de la campagne quand elle est modifiée. (PIX-3516)

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/update.js
+++ b/orga/app/controllers/authenticated/campaigns/update.js
@@ -10,11 +10,11 @@ export default class UpdateController extends Controller {
     event.preventDefault();
     return this.model
       .save()
-      .then((campaign) => this.transitionToRoute('authenticated.campaigns.campaign', campaign.id));
+      .then((campaign) => this.transitionToRoute('authenticated.campaigns.campaign.settings', campaign.id));
   }
 
   @action
   cancel(campaignId) {
-    this.transitionToRoute('authenticated.campaigns.campaign', campaignId);
+    this.transitionToRoute('authenticated.campaigns.campaign.settings', campaignId);
   }
 }

--- a/orga/tests/acceptance/campaign-update_test.js
+++ b/orga/tests/acceptance/campaign-update_test.js
@@ -34,6 +34,6 @@ module('Acceptance | Campaign Update', function (hooks) {
     // then
     assert.equal(server.db.campaigns.find(1).name, newName);
     assert.equal(server.db.campaigns.find(1).customLandingPageText, newText);
-    assert.equal(currentURL(), '/campagnes/1');
+    assert.equal(currentURL(), '/campagnes/1/parametres');
   });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème

Une fois que l'utilisateur clique sur le bouton modifier d'une campagne depuis l'onglet paramètres, il est actuellement redirigé sur la page d'activité.  
Il faudrait si il annule ou si il modifie sa campagne revenir sur la page d'ou il vient.

## :bat: Solution

Si l'utilisateur clique sur le bouton retour ou modifier dans la page de modification d'une campagne, il est redirigé vers la page "Paramètres" d'une campagne.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
