### PR TITLE
[FEATURE] Retirer le délai pour envoyer sa collecte de profil lorsqu'une campagne autorise le renvoi (PIX-3672)

### DIFF
--- a/api/lib/domain/models/SharedProfileForCampaign.js
+++ b/api/lib/domain/models/SharedProfileForCampaign.js
@@ -1,6 +1,3 @@
-const moment = require('moment');
-const constants = require('../constants');
-
 class SharedProfileForCampaign {
   constructor({ id, sharedAt, pixScore, campaignAllowsRetry, isRegistrationActive, scorecards = [] }) {
     this.id = id;
@@ -11,12 +8,7 @@ class SharedProfileForCampaign {
   }
 
   _computeCanRetry(campaignAllowsRetry, sharedAt, isRegistrationActive) {
-    return campaignAllowsRetry && this._timeBeforeRetryingPassed(sharedAt) && isRegistrationActive;
-  }
-
-  _timeBeforeRetryingPassed(sharedAt) {
-    if (!sharedAt) return false;
-    return sharedAt && moment().diff(sharedAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+    return campaignAllowsRetry && Boolean(sharedAt) && isRegistrationActive;
   }
 }
 

--- a/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
@@ -1,30 +1,11 @@
-const { expect, sinon } = require('../../../test-helper');
-const constants = require('../../../../lib/domain/constants');
+const { expect } = require('../../../test-helper');
+
 const SharedProfileForCampaign = require('../../../../lib/domain/models/SharedProfileForCampaign');
 
 describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
-  let clock;
-
-  beforeEach(function () {
-    constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 5;
-  });
-
-  afterEach(function () {
-    clock.restore();
-    constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = originalConstantValue;
-  });
-
   describe('#canRetry', function () {
     context('when participant is disabled', function () {
-      beforeEach(function () {
-        const now = new Date('2020-01-06');
-        clock = sinon.useFakeTimers(now);
-      });
-
-      it('return true', function () {
+      it('cannot retry', function () {
         const sharedProfileForCampaign = new SharedProfileForCampaign({
           campaignAllowsRetry: true,
           isRegistrationActive: false,
@@ -36,27 +17,34 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
       });
     });
 
-    context('when participation is not shared', function () {
-      it('return true', function () {
+    context('when the campaign does not allow retry', function () {
+      it('return false', function () {
         const sharedProfileForCampaign = new SharedProfileForCampaign({
-          campaignAllowsRetry: true,
-          isRegistrationActive: false,
+          campaignAllowsRetry: false,
+          isRegistrationActive: true,
           scorecards: [],
-          sharedAt: null,
+          sharedAt: new Date('2020-01-01'),
         });
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
       });
     });
 
-    context(
-      'when participant is active and the profile has been shared MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago',
-      function () {
-        beforeEach(function () {
-          const now = new Date('2020-01-06');
-          clock = sinon.useFakeTimers(now);
-        });
+    context('when participant is  active', function () {
+      context('when participation is not shared', function () {
+        it('return false', function () {
+          const sharedProfileForCampaign = new SharedProfileForCampaign({
+            campaignAllowsRetry: true,
+            isRegistrationActive: true,
+            scorecards: [],
+            sharedAt: null,
+          });
 
+          expect(sharedProfileForCampaign.canRetry).to.equal(false);
+        });
+      });
+
+      context('when the profile has been shared', function () {
         it('return true', function () {
           const sharedProfileForCampaign = new SharedProfileForCampaign({
             campaignAllowsRetry: true,
@@ -67,63 +55,6 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
 
           expect(sharedProfileForCampaign.canRetry).to.equal(true);
         });
-      }
-    );
-
-    context('when the profile has been shared less than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago', function () {
-      beforeEach(function () {
-        const now = new Date('2020-01-06');
-        clock = sinon.useFakeTimers(now);
-      });
-
-      it('return false', function () {
-        const sharedProfileForCampaign = new SharedProfileForCampaign({
-          campaignAllowsRetry: true,
-          isRegistrationActive: true,
-          scorecards: [],
-          sharedAt: new Date('2020-01-04'),
-        });
-
-        expect(sharedProfileForCampaign.canRetry).to.equal(false);
-      });
-    });
-
-    context(
-      'when participant is active and the profile has been shared more than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago',
-      function () {
-        beforeEach(function () {
-          const now = new Date('2020-01-09');
-          clock = sinon.useFakeTimers(now);
-        });
-
-        it('return true', function () {
-          const sharedProfileForCampaign = new SharedProfileForCampaign({
-            campaignAllowsRetry: true,
-            isRegistrationActive: true,
-            scorecards: [],
-            sharedAt: new Date('2020-01-02'),
-          });
-
-          expect(sharedProfileForCampaign.canRetry).to.equal(true);
-        });
-      }
-    );
-
-    context('when the campaign does not allow retry', function () {
-      beforeEach(function () {
-        const now = new Date('2020-01-06');
-        clock = sinon.useFakeTimers(now);
-      });
-
-      it('return false', function () {
-        const sharedProfileForCampaign = new SharedProfileForCampaign({
-          campaignAllowsRetry: false,
-          isRegistrationActive: true,
-          scorecards: [],
-          sharedAt: new Date('2020-01-01'),
-        });
-
-        expect(sharedProfileForCampaign.canRetry).to.equal(false);
       });
     });
   });


### PR DESCRIPTION
## :jack_o_lantern: Problème
La collecte de profil est soumis à la même règle que les campagnes d'évaluation, l'utilisateur devait attendre x jours avant de renvoyer sa collecte de profil

## :bat: Solution
Retirer cette contriante qui permettrait à l'utilisateur de le renvoyer plus facilement

## :spider_web: Remarques

## :ghost: Pour tester
Tester sur mon pix avec une campagne collecte de profil afin de vérifier le bon fonctionnement.