### PR TITLE
[TECH] Utiliser PixButtonLink sur la page de checkpoint

### DIFF
--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -59,11 +59,8 @@
 }
 
 .checkpoint__continue-button {
-  padding: 0 10px;
-  width: 300px;
-  height: 50px;
-  line-height: 50px;
   display: inline-block;
+  font-weight: $font-bold;
 
   @include device-is('tablet') {
     width: 230px;
@@ -71,8 +68,6 @@
 
   & > svg {
     margin-left: 30px;
-    padding-top: 6px;
-    font-size: 1.5em;
     position: relative;
     left: 0;
     transition: all 0.25s ease-in-out;

--- a/mon-pix/app/templates/components/checkpoint-continue.hbs
+++ b/mon-pix/app/templates/components/checkpoint-continue.hbs
@@ -1,11 +1,12 @@
 <div class="checkpoint__continue">
-  <LinkTo
+  <PixButtonLink
     @route="assessments.resume"
     @model={{@assessmentId}}
     @query={{hash hasSeenCheckpoint=true}}
-    class="button button--link button--yellow checkpoint__continue-button"
+    @backgroundColor="yellow"
+    class="checkpoint__continue-button"
   >
     {{@nextPageButtonText}}
     <FaIcon @icon="long-arrow-alt-right" />
-  </LinkTo>
+  </PixButtonLink>
 </div>


### PR DESCRIPTION
## :jack_o_lantern: Problème
Le bouton jaune du checkpoint n'utilise pas le style de bouton de pix-ui.

## :bat: Solution
Utiliser `PixButtonLink`.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Aller sur la page de checkpoint
