### PR TITLE
[BUGFIX] La barre de progression n'était pas à jour lors de la reprise d'une campagne (PIX-3518).

### DIFF
--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -14,13 +14,16 @@ export default class ResumeRoute extends Route {
     this.campaignCode = transition.to.queryParams.campaignCode;
     this.newLevel = transition.to.queryParams.newLevel || null;
     this.competenceLeveled = transition.to.queryParams.competenceLeveled || null;
-    this.assessmentHasNoMoreQuestions = transition.to.queryParams.assessmentHasNoMoreQuestions || false;
+    this.assessmentHasNoMoreQuestions = transition.to.queryParams.assessmentHasNoMoreQuestions == 'true' || false;
   }
 
   async redirect(assessment) {
     if (assessment.isCompleted) {
       return this._routeToResults(assessment);
     }
+
+    await assessment.answers.reload();
+
     if (assessment.hasCheckpoints) {
       return this._resumeAssessmentWithCheckpoint(assessment);
     }

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -14,7 +14,7 @@ export default class ResumeRoute extends Route {
     this.campaignCode = transition.to.queryParams.campaignCode;
     this.newLevel = transition.to.queryParams.newLevel || null;
     this.competenceLeveled = transition.to.queryParams.competenceLeveled || null;
-    this.assessmentHasNoMoreQuestions = transition.to.queryParams.assessmentHasNoMoreQuestions == 'true' || false;
+    this.assessmentHasNoMoreQuestions = transition.to.queryParams.assessmentHasNoMoreQuestions == 'true';
   }
 
   async redirect(assessment) {

--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -24,10 +24,10 @@ export default class EvaluationStartOrResumeRoute extends Route.extend(SecuredRo
     const assessment = await campaignAssessment.get('firstObject');
 
     if (this._shouldShowTutorial(assessment, campaign.isForAbsoluteNovice)) {
-      return this.replaceWith('campaigns.assessment.tutorial', campaign.code);
+      this.replaceWith('campaigns.assessment.tutorial', campaign.code);
+    } else {
+      this.replaceWith('assessments.resume', assessment.id);
     }
-
-    this.replaceWith('assessments.resume', assessment.id);
   }
 
   _shouldShowTutorial(assessment, isCampaignForAbsoluteNovice) {

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -36,13 +36,11 @@ export default class EntryPoint extends Route {
     }
 
     if (campaign.isArchived && !hasParticipated) {
-      return this.replaceWith('campaigns.campaign-not-found', campaign);
+      this.replaceWith('campaigns.campaign-not-found', campaign);
+    } else if (hasParticipated) {
+      this.replaceWith('campaigns.entrance', campaign);
+    } else {
+      this.replaceWith('campaigns.campaign-landing-page', campaign);
     }
-
-    if (hasParticipated) {
-      return this.replaceWith('campaigns.entrance', campaign);
-    }
-
-    return this.replaceWith('campaigns.campaign-landing-page', campaign);
   }
 }

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -24,7 +24,11 @@
 
         </div>
         <div class="checkpoint__continue-wrapper">
-          <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />
+          <CheckpointContinue
+            @assessmentId={{@model.id}}
+            @nextPageButtonText={{this.nextPageButtonText}}
+            @finalCheckpoint={{this.finalCheckpoint}}
+          />
         </div>
       {{/if}}
     </div>
@@ -42,7 +46,11 @@
             <ResultItem @answer={{answer}} @openAnswerDetails={{this.openComparisonWindow}} />
           {{/each}}
         </div>
-        <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />
+        <CheckpointContinue
+          @assessmentId={{@model.id}}
+          @nextPageButtonText={{this.nextPageButtonText}}
+          @finalCheckpoint={{this.finalCheckpoint}}
+        />
       {{else}}
         <div class="checkpoint-no-answer">
           <div class="checkpoint-no-answer__header">
@@ -51,7 +59,11 @@
           <div class="checkpoint-no-answer__info">
             {{t "pages.checkpoint.answers.already-finished.explanation"}}
           </div>
-          <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />
+          <CheckpointContinue
+            @assessmentId={{@model.id}}
+            @nextPageButtonText={{this.nextPageButtonText}}
+            @finalCheckpoint={{this.finalCheckpoint}}
+          />
         </div>
       {{/if}}
     </main>

--- a/mon-pix/app/templates/components/checkpoint-continue.hbs
+++ b/mon-pix/app/templates/components/checkpoint-continue.hbs
@@ -2,7 +2,7 @@
   <PixButtonLink
     @route="assessments.resume"
     @model={{@assessmentId}}
-    @query={{hash hasSeenCheckpoint=true}}
+    @query={{hash hasSeenCheckpoint=true assessmentHasNoMoreQuestions=@finalCheckpoint}}
     @backgroundColor="yellow"
     class="checkpoint__continue-button"
   >

--- a/mon-pix/tests/unit/routes/assessments/resume_test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume_test.js
@@ -30,7 +30,9 @@ describe('Unit | Route | Assessments | Resume', function () {
     let assessment;
 
     beforeEach(function () {
-      assessment = EmberObject.create({ id: 123, isDemo: true, competenceId: 'recCompetenceId' });
+      const answers = EmberObject.create();
+      answers.reload = sinon.stub().resolves();
+      assessment = EmberObject.create({ id: 123, isDemo: true, competenceId: 'recCompetenceId', answers });
       assessment.save = sinon.stub().resolves();
     });
 
@@ -53,6 +55,7 @@ describe('Unit | Route | Assessments | Resume', function () {
         context('when checkpoint is reached', function () {
           beforeEach(function () {
             assessment.answers = [{}, {}, {}, {}, {}];
+            assessment.answers.reload = sinon.stub().resolves();
           });
 
           context('when user has seen checkpoint', function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Lorsqu'on a une campagne en cours et qu'on la reprend plus tard, la barre de progression était à 1/5.
L'`assessment` n'avait pas ses `answers`.

## :bat: Solution
- Reload des `answers` lors d'un resume d'`assessment`, pour s'assurer qu'on a bien toutes les `answers`.
- Pour éviter des bugs, vérifier que l'info de fin d'assessment passe bien entre le checkpoint et le resume.

## :spider_web: Remarques
- BSR sur les erreurs en console sur les TransactionAborted liés à des `return` lors des changements de pages.

## :ghost: Pour tester
Lancer une campagne, s'arrêter à la question 2 ou 3, revenir sur le tableau de bord, recharger, reprendre et avoir la bonne question et la bonne progression.
Faire de même sur une compétence.