### PR TITLE
[FEATURE] Générer le mot de passe surveillant lors de la création de la session (PIX-3650).

### DIFF
--- a/api/db/migrations/20211019121329_add_session_password.js
+++ b/api/db/migrations/20211019121329_add_session_password.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'sessions';
+const COLUMN_NAME = 'supervisorPassword';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME, 5);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -5,6 +5,9 @@ const FINALIZED = 'finalized';
 const IN_PROCESS = 'in_process';
 const PROCESSED = 'processed';
 
+const availableCharactersForPasswordGeneration = '2346789BCDFGHJKMPQRTVWXY'.split('');
+const NB_CHAR = 5;
+
 const statuses = {
   CREATED,
   FINALIZED,
@@ -75,8 +78,16 @@ class Session {
   isAccessible() {
     return this.status === statuses.CREATED;
   }
+
+  generateSupervisorPassword() {
+    this.supervisorPassword = _.times(NB_CHAR, _randomCharacter).join('');
+  }
 }
 
 module.exports = Session;
 module.exports.statuses = statuses;
 module.exports.NO_EXAMINER_GLOBAL_COMMENT = NO_EXAMINER_GLOBAL_COMMENT;
+
+function _randomCharacter() {
+  return _.sample(availableCharactersForPasswordGeneration);
+}

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -35,6 +35,7 @@ class Session {
     certificationCandidates,
     certificationCenterId,
     assignedCertificationOfficerId,
+    supervisorPassword,
   } = {}) {
     this.id = id;
     this.accessCode = accessCode;
@@ -52,6 +53,7 @@ class Session {
     this.certificationCandidates = certificationCandidates;
     this.certificationCenterId = certificationCenterId;
     this.assignedCertificationOfficerId = assignedCertificationOfficerId;
+    this.supervisorPassword = supervisorPassword;
   }
 
   areResultsFlaggedAsSent() {

--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -1,6 +1,7 @@
 const { ForbiddenAccess } = require('../errors');
 const sessionValidator = require('../validators/session-validator');
 const sessionCodeService = require('../services/session-code-service');
+const Session = require('../models/Session');
 
 module.exports = async function createSession({
   userId,
@@ -21,10 +22,13 @@ module.exports = async function createSession({
 
   const accessCode = await sessionCodeService.getNewSessionCode();
   const { name: certificationCenter } = await certificationCenterRepository.get(certificationCenterId);
-  const sessionWithCode = {
+  const domainSession = new Session({
     ...session,
     accessCode,
     certificationCenter,
-  };
-  return sessionRepository.save(sessionWithCode);
+  });
+
+  domainSession.generateSupervisorPassword();
+
+  return sessionRepository.save(domainSession);
 };

--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const { ForbiddenAccess } = require('../errors');
 const sessionValidator = require('../validators/session-validator');
 const sessionCodeService = require('../services/session-code-service');
@@ -20,9 +19,12 @@ module.exports = async function createSession({
     );
   }
 
-  const sessionWithCode = _.clone(session);
-  sessionWithCode.accessCode = await sessionCodeService.getNewSessionCode();
-  const certificationCenter = await certificationCenterRepository.get(certificationCenterId);
-  sessionWithCode.certificationCenter = certificationCenter.name;
+  const accessCode = await sessionCodeService.getNewSessionCode();
+  const { name: certificationCenter } = await certificationCenterRepository.get(certificationCenterId);
+  const sessionWithCode = {
+    ...session,
+    accessCode,
+    certificationCenter,
+  };
   return sessionRepository.save(sessionWithCode);
 };

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -18,8 +18,14 @@ describe('Integration | Repository | Session', function () {
         room: '28D',
         examiner: 'Michel Essentiel',
         date: '2017-12-08',
-        time: '14:30',
+        time: '14:30:00',
         description: 'Première certification EVER !!!',
+        examinerGlobalComment: 'No comment',
+        finalizedAt: new Date('2017-12-07'),
+        publishedAt: new Date('2017-12-07'),
+        resultsSentToPrescriberAt: new Date('2017-12-07'),
+        assignedCertificationOfficerId: null,
+        accessCode: 'XXXX',
       });
 
       await databaseBuilder.commit();
@@ -45,7 +51,7 @@ describe('Integration | Repository | Session', function () {
       // then
       expect(savedSession).to.be.an.instanceOf(Session);
       expect(savedSession).to.have.property('id').and.not.null;
-      expect(savedSession.certificationCenter).to.equal(certificationCenter.name);
+      expect(savedSession).to.deepEqualInstance(new Session({ ...session, id: savedSession.id }));
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -26,6 +26,7 @@ describe('Integration | Repository | Session', function () {
         resultsSentToPrescriberAt: new Date('2017-12-07'),
         assignedCertificationOfficerId: null,
         accessCode: 'XXXX',
+        supervisorPassword: 'AB2C7',
       });
 
       await databaseBuilder.commit();

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -20,6 +20,7 @@ const SESSION_PROPS = [
   'certificationCandidates',
   'certificationCenterId',
   'assignedCertificationOfficerId',
+  'supervisorPassword',
 ];
 
 describe('Unit | Domain | Models | Session', function () {

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -206,3 +206,14 @@ describe('Unit | Domain | Models | Session', function () {
     });
   });
 });
+
+context('#generateSupervisorPassword', function () {
+  it('should return a supervisor password containing 5 digits/letters except 0, 1 and vowels', async function () {
+    // when
+    const session = domainBuilder.buildSession();
+    session.generateSupervisorPassword();
+
+    // then
+    expect(session.supervisorPassword).to.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/);
+  });
+});

--- a/api/tests/unit/domain/services/session-code-service_test.js
+++ b/api/tests/unit/domain/services/session-code-service_test.js
@@ -3,7 +3,7 @@ const sessionCodeService = require('../../../../lib/domain/services/session-code
 const sessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');
 const _ = require('lodash');
 
-describe('Unit | Service | CodeSession', function () {
+describe('Unit | Service | CodeSession', function () {
   describe('#isSessionCodeAvailable', function () {
     it('should return a session code with 4 random capital letters and 2 random numbers', async function () {
       // given

--- a/api/tests/unit/domain/usecases/create-session_test.js
+++ b/api/tests/unit/domain/usecases/create-session_test.js
@@ -1,5 +1,5 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
-
+const { noop } = require('lodash/noop');
 const createSession = require('../../../../lib/domain/usecases/create-session');
 const sessionCodeService = require('../../../../lib/domain/services/session-code-service');
 const sessionValidator = require('../../../../lib/domain/validators/session-validator');
@@ -12,28 +12,15 @@ describe('Unit | UseCase | create-session', function () {
     const certificationCenterName = 'certificationCenterName';
     const certificationCenter = { id: certificationCenterId, name: certificationCenterName };
     const sessionToSave = { certificationCenterId };
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const certificationCenterRepository = { get: sinon.stub() };
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const sessionRepository = { save: sinon.stub() };
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const userRepository = { getWithCertificationCenterMemberships: sinon.stub() };
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const userWithMemberships = { hasAccessToCertificationCenter: sinon.stub() };
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const accessCode = Symbol('accessCode');
+    const certificationCenterRepository = { get: noop };
+    const sessionRepository = { save: noop };
+    const userRepository = { getWithCertificationCenterMemberships: noop };
+    const userWithMemberships = { hasAccessToCertificationCenter: noop };
 
     context('when session is not valid', function () {
-      beforeEach(function () {
-        sinon.stub(sessionValidator, 'validate').throws();
-      });
-
       it('should throw an error', function () {
+        sessionValidator.validate = sinon.stub();
+        sessionValidator.validate.throws();
         const promise = createSession({
           userId,
           session: sessionToSave,
@@ -44,22 +31,20 @@ describe('Unit | UseCase | create-session', function () {
 
         // then
         expect(promise).to.be.rejected;
-        expect(sessionValidator.validate.calledWithExactly(sessionToSave));
+        expect(sessionValidator.validate).to.have.been.calledWithExactly(sessionToSave);
       });
     });
 
     context('when session is valid', function () {
-      beforeEach(function () {
-        sinon.stub(sessionValidator, 'validate').returns();
-      });
-
       context('when user has no certification center membership', function () {
-        beforeEach(function () {
-          userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(false);
-          userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
-        });
-
         it('should throw a Forbidden error', async function () {
+          // given
+          userWithMemberships.hasAccessToCertificationCenter = sinon.stub();
+          userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(false);
+          userRepository.getWithCertificationCenterMemberships = sinon.stub();
+          userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
+          sessionValidator.validate.returns();
+
           // when
           const error = await catchErr(createSession)({
             userId,
@@ -75,15 +60,22 @@ describe('Unit | UseCase | create-session', function () {
       });
 
       context('when user has certification center membership', function () {
-        beforeEach(function () {
+        it('should save the session with appropriate arguments', async function () {
+          // given
+          const accessCode = Symbol('accessCode');
+          userWithMemberships.hasAccessToCertificationCenter = sinon.stub();
+          userRepository.getWithCertificationCenterMemberships = sinon.stub();
+          sessionCodeService.getNewSessionCode = sinon.stub();
+          certificationCenterRepository.get = sinon.stub();
+          sessionRepository.save = sinon.stub();
+
           userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
           userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
-          sinon.stub(sessionCodeService, 'getNewSessionCode').resolves(accessCode);
+          sessionCodeService.getNewSessionCode.resolves(accessCode);
           certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
           sessionRepository.save.resolves();
-        });
+          sessionValidator.validate.returns();
 
-        it('should save the session with appropriate arguments', async function () {
           // when
           await createSession({
             userId,
@@ -94,13 +86,11 @@ describe('Unit | UseCase | create-session', function () {
           });
 
           // then
-          expect(
-            sessionRepository.save.calledWithExactly({
-              certificationCenterId,
-              certificationCenter: certificationCenterName,
-              accessCode,
-            })
-          ).to.be.true;
+          expect(sessionRepository.save).to.have.been.calledWithExactly({
+            certificationCenterId,
+            certificationCenter: certificationCenterName,
+            accessCode,
+          });
         });
       });
     });

--- a/api/tests/unit/domain/usecases/update-session_test.js
+++ b/api/tests/unit/domain/usecases/update-session_test.js
@@ -26,7 +26,6 @@ describe('Unit | UseCase | update-session', function () {
       updateSessionInfo: sinon.stub(),
     };
     sinon.stub(sessionValidator, 'validate');
-
     sessionRepository.get.withArgs(originalSession.id).resolves(originalSession);
     sessionRepository.updateSessionInfo.callsFake((updatedSession) => updatedSession);
     sessionValidator.validate.withArgs(originalSession).returns();


### PR DESCRIPTION
## :jack_o_lantern: Problème
On a besoin d'un mot de passe pour accéder à l'espace surveillant pour une session de certification.

## :bat: Solution
Ajouter sur la session un 'supervisorPassword'
Mot de passe 
- non crypté
- de 5 caractères alphanumériques (lettre ET/OU chiffre) 
- aléatoires
- incluant uniquement `2346789BCDFGHJKMPQRTVWXY` (pour véiter les confusion o et zéro, i et le chifre un..)

## :spider_web: Remarques
Le sureveillant se logguera via numero de session + mot de passe
Pas de nécessité d'unicité numéro de session + mot de passe de session

## :ghost: Pour tester
Créer une session
Verifier en base que la nouvelle session renseigne bien un `supervisorPassword`
```sql
 select id, "supervisorPassword" from sessions where "supervisorPassword" IS NOT NULL;
```
