### PR TITLE
[BUGFIX] Correction de l'affichage des dropdown dans les épreuves avec champs select (PIX-3705).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -64,7 +64,6 @@
 
     &--selector {
       display: inline-block;
-      min-width: 180px;
     }
   }
 


### PR DESCRIPTION
## :jack_o_lantern: Problème

Sur certaines questions contenant des champs `select`, la flèche de sélection apparaît en dehors du cadre.

![image](https://user-images.githubusercontent.com/36371437/138292148-7ab5fb0d-1264-4411-8abb-a58d7633d021.png)

## :bat: Solution

Suppression d'une propriété CSS `min-width`
<img width="491" alt="Capture d’écran 2021-10-21 à 15 56 29" src="https://user-images.githubusercontent.com/36371437/138292619-2eff7e67-c10a-4c6b-bd27-a6f22fcd18e5.png">

## :spider_web: Remarques

La taille du placeholder semble importante dans l'apparition de ce souci, il convient de tester avec des questions ayant différents placeholders afin de vérifier de la réelle disparition du problème.

## :ghost: Pour tester

Tester des épreuves ayant des `select` sur mon-pix (ex: recSJFKDaccMw7Mq)

