### PR TITLE
[FEATURE] Ajouter un filtrer sur les groupes pour les résultats de campagnes d'évaluation (Pix-3544).

### DIFF
--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -112,6 +112,9 @@ module.exports = {
     if (filters.divisions && !Array.isArray(filters.divisions)) {
       filters.divisions = [filters.divisions];
     }
+    if (filters.groups && !Array.isArray(filters.groups)) {
+      filters.groups = [filters.groups];
+    }
     if (filters.badges && !Array.isArray(filters.badges)) {
       filters.badges = [filters.badges];
     }

--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -149,6 +149,7 @@ exports.register = async function (server) {
           }),
           query: Joi.object({
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
+            'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[badges][]': [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
             'filter[stages][]': [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
             'page[number]': Joi.number().integer().empty(''),

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -52,6 +52,7 @@ function _getParticipations(qb, campaignId, targetProfile, filters) {
     .where('campaign-participations.status', '=', SHARED)
     .where('campaign-participations.isImproved', '=', false)
     .modify(_filterByDivisions, filters)
+    .modify(_filterByGroups, filters)
     .modify(_addAcquiredBadgeids, filters)
     .modify(_filterByStage, targetProfile, filters);
 }
@@ -60,6 +61,13 @@ function _filterByDivisions(qb, filters) {
   if (filters.divisions) {
     const divisionsLowerCase = filters.divisions.map((division) => division.toLowerCase());
     qb.whereRaw('LOWER("schooling-registrations"."division") = ANY(:divisionsLowerCase)', { divisionsLowerCase });
+  }
+}
+
+function _filterByGroups(qb, filters) {
+  if (filters.groups) {
+    const groupsLowerCase = filters.groups.map((group) => group.toLowerCase());
+    qb.whereIn(knex.raw('LOWER("schooling-registrations"."group")'), groupsLowerCase);
   }
 }
 

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -4,11 +4,11 @@
   <Campaign::Filter::ParticipationFilters
     @campaign={{@campaign}}
     @selectedDivisions={{@selectedDivisions}}
+    @selectedGroups={{@selectedGroups}}
     @selectedBadges={{@selectedBadges}}
     @selectedStages={{@selectedStages}}
     @rowCount={{@participations.meta.rowCount}}
     @isHiddenStatus={{true}}
-    @isHiddenGroup={{true}}
     @onResetFilter={{@onResetFilter}}
     @onFilter={{@onFilter}}
   />

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -3,11 +3,12 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
 export default class AssessmentResultsController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'divisions', 'badges', 'stages'];
+  queryParams = ['pageNumber', 'pageSize', 'divisions', 'groups', 'badges', 'stages'];
 
   @tracked pageNumber = 1;
   @tracked pageSize = 25;
   @tracked divisions = [];
+  @tracked groups = [];
   @tracked badges = [];
   @tracked stages = [];
 
@@ -27,6 +28,7 @@ export default class AssessmentResultsController extends Controller {
   triggerFiltering(filters) {
     this.pageNumber = null;
     this.divisions = filters.divisions || this.divisions;
+    this.groups = filters.groups || this.groups;
     this.badges = filters.badges || this.badges;
     this.stages = filters.stages || this.stages;
   }
@@ -35,6 +37,7 @@ export default class AssessmentResultsController extends Controller {
   resetFiltering() {
     this.pageNumber = null;
     this.divisions = [];
+    this.groups = [];
     this.badges = [];
     this.stages = [];
   }

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -13,6 +13,9 @@ export default class AssessmentResultsRoute extends Route {
     divisions: {
       refreshModel: true,
     },
+    groups: {
+      refreshModel: true,
+    },
     badges: {
       refreshModel: true,
     },
@@ -44,6 +47,7 @@ export default class AssessmentResultsRoute extends Route {
       },
       filter: {
         divisions: params.divisions,
+        groups: params.groups,
         badges: params.badges,
         stages: params.stages,
       },
@@ -56,6 +60,7 @@ export default class AssessmentResultsRoute extends Route {
       controller.pageNumber = 1;
       controller.pageSize = 25;
       controller.divisions = [];
+      controller.groups = [];
       controller.badges = [];
       controller.stages = [];
     }

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -15,6 +15,7 @@
     @campaign={{@model.campaign}}
     @participations={{@model.participations}}
     @selectedDivisions={{this.divisions}}
+    @selectedGroups={{this.groups}}
     @selectedBadges={{this.badges}}
     @selectedStages={{this.stages}}
     @onClickParticipant={{this.goToAssessmentPage}}

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results_test.js
@@ -32,6 +32,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         pageNumber: 1,
         pageSize: 2,
         divisions: ['4eme'],
+        groups: [],
         badges: [],
         stages: [],
         campaignId: 3,
@@ -50,6 +51,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
           },
           filter: {
             divisions: params.divisions,
+            groups: params.groups,
             badges: params.badges,
             stages: params.stages,
           },
@@ -60,6 +62,84 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
       const participations = route.fetchResultMinimalList(params);
 
       assert.equal(participations, expectedParticipations);
+    });
+  });
+
+  module('resetController', function () {
+    module('when isExiting is true', function () {
+      test('it reset pageNumber', function (assert) {
+        const controller = { pageNumber: 2 };
+        route.resetController(controller, true);
+        assert.equal(controller.pageNumber, 1);
+      });
+
+      test('it reset pageSize', function (assert) {
+        const controller = { pageSize: 10 };
+        route.resetController(controller, true);
+        assert.equal(controller.pageSize, 25);
+      });
+
+      test('it reset divisions', function (assert) {
+        const controller = { divisions: ['10'] };
+        route.resetController(controller, true);
+        assert.deepEqual(controller.divisions, []);
+      });
+
+      test('it reset groups', function (assert) {
+        const controller = { groups: ['10'] };
+        route.resetController(controller, true);
+        assert.deepEqual(controller.groups, []);
+      });
+
+      test('it reset badges', function (assert) {
+        const controller = { badges: ['10'] };
+        route.resetController(controller, true);
+        assert.deepEqual(controller.badges, []);
+      });
+
+      test('it reset stages', function (assert) {
+        const controller = { stages: ['10'] };
+        route.resetController(controller, true);
+        assert.deepEqual(controller.stages, []);
+      });
+    });
+
+    module('when isExiting is false', function () {
+      test('it does not reset pageNumber', function (assert) {
+        const controller = { pageNumber: 2 };
+        route.resetController(controller, false);
+        assert.equal(controller.pageNumber, 2);
+      });
+
+      test('it does not reset pageSize', function (assert) {
+        const controller = { pageSize: 10 };
+        route.resetController(controller, false);
+        assert.equal(controller.pageSize, 10);
+      });
+
+      test('it does not reset divisions', function (assert) {
+        const controller = { divisions: ['10'] };
+        route.resetController(controller, false);
+        assert.deepEqual(controller.divisions, ['10']);
+      });
+
+      test('it does not reset groups', function (assert) {
+        const controller = { groups: ['10'] };
+        route.resetController(controller, false);
+        assert.deepEqual(controller.groups, ['10']);
+      });
+
+      test('it does not reset badges', function (assert) {
+        const controller = { badges: ['10'] };
+        route.resetController(controller, false);
+        assert.deepEqual(controller.badges, ['10']);
+      });
+
+      test('it does not reset stages', function (assert) {
+        const controller = { stages: ['10'] };
+        route.resetController(controller, false);
+        assert.deepEqual(controller.stages, ['10']);
+      });
     });
   });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les prescripteurs ne peuvent pas filter les résultats des campagnes en fonction des groupes des participants.

## :bat: Solution
Ajouter un filtrer en fonction du groupe pour filtrer les résultats des participants aux campagnes SUP.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
- Se connecter à PixOrga avec le compte sup.admin@example.net
- Aller sur les resultats de la campagnes .....
- FIlter les résultats en fonction des groupes

