### PR TITLE
[FEATURE] Ajout du filtre "Groupe" dans la page d'activité d'une campagne (PIX-3542)

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -187,6 +187,9 @@ module.exports = {
     if (filters.divisions && !Array.isArray(filters.divisions)) {
       filters.divisions = [filters.divisions];
     }
+    if (filters.groups && !Array.isArray(filters.groups)) {
+      filters.groups = [filters.groups];
+    }
 
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
     const paginatedParticipations = await usecases.findPaginatedCampaignParticipantsActivities({

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -258,6 +258,7 @@ exports.register = async function (server) {
             'filter[status]': Joi.string()
               .valid(...campaignParticipationStatuses)
               .empty(''),
+            'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
           }),
         },
         handler: campaignController.findParticipantsActivity,

--- a/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -39,7 +39,8 @@ function _buildCampaignParticipationByParticipant(qb, campaignId, filters) {
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.isImproved', '=', false)
     .modify(_filterByDivisions, filters)
-    .modify(_filterByStatus, filters);
+    .modify(_filterByStatus, filters)
+    .modify(_filterByGroup, filters);
 }
 
 function _buildPaginationQuery(queryBuilder, campaignId, filters) {
@@ -55,7 +56,8 @@ function _buildPaginationQuery(queryBuilder, campaignId, filters) {
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.isImproved', '=', false)
     .modify(_filterByDivisions, filters)
-    .modify(_filterByStatus, filters);
+    .modify(_filterByStatus, filters)
+    .modify(_filterByGroup, filters);
 }
 
 function _filterByDivisions(qb, filters) {
@@ -68,6 +70,12 @@ function _filterByDivisions(qb, filters) {
 function _filterByStatus(qb, filters) {
   if (filters.status) {
     qb.where('campaign-participations.status', filters.status);
+  }
+}
+function _filterByGroup(qb, filters) {
+  if (filters.groups) {
+    const groupsLowerCase = filters.groups.map((group) => group.toLowerCase());
+    qb.whereIn(knex.raw('LOWER("schooling-registrations"."group")'), groupsLowerCase);
   }
 }
 

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1031,6 +1031,7 @@ describe('Acceptance | API | Campaign Controller', function () {
   describe('GET /api/campaigns/{id}/participants-activity', function () {
     const participant1 = { firstName: 'John', lastName: 'McClane', id: 12, email: 'john.mclane@die.hard' };
     const participant2 = { firstName: 'Holly', lastName: 'McClane', id: 13, email: 'holly.mclane@die.hard' };
+    const participant3 = { firstName: 'Mary', lastName: 'McClane', id: 14, email: 'mary.mclane@die.hard' };
 
     let campaign;
     let userId;
@@ -1067,6 +1068,14 @@ describe('Acceptance | API | Campaign Controller', function () {
         lastName: 'McClane',
         userId: participant2.id,
       });
+      databaseBuilder.factory.buildAssessmentFromParticipation({ campaignId: campaign.id }, participant3);
+      databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: organization.id,
+        group: 'L1',
+        firstName: 'Mary',
+        lastName: 'McClane',
+        userId: participant3.id,
+      });
 
       return databaseBuilder.commit();
     });
@@ -1081,7 +1090,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       const response = await server.inject(options);
 
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data).to.have.lengthOf(2);
+      expect(response.result.data).to.have.lengthOf(3);
     });
 
     it('should return two pages as JSONAPI', async function () {
@@ -1095,7 +1104,7 @@ describe('Acceptance | API | Campaign Controller', function () {
 
       expect(response.statusCode).to.equal(200);
       const meta = response.result.meta;
-      expect(meta.pageCount).to.equal(2);
+      expect(meta.pageCount).to.equal(3);
     });
 
     it('should return the campaign participant activity from division 5eme as JSONAPI', async function () {
@@ -1126,6 +1135,21 @@ describe('Acceptance | API | Campaign Controller', function () {
       const participation = response.result.data[0].attributes;
       expect(response.result.data).to.have.lengthOf(1);
       expect(participation['first-name']).to.equal(participant2.firstName);
+    });
+
+    it('should return the campaign participant activity with group L1 as JSONAPI', async function () {
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/participants-activity?filter[groups][]=L1`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(200);
+      const participation = response.result.data[0].attributes;
+      expect(response.result.data).to.have.lengthOf(1);
+      expect(participation['first-name']).to.equal(participant3.firstName);
     });
 
     it('should return 400 when status is not valid', async function () {

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -2,10 +2,10 @@
   @campaign={{@campaign}}
   @selectedDivisions={{@selectedDivisions}}
   @selectedStatus={{@selectedStatus}}
+  @selectedGroups={{@selectedGroups}}
   @rowCount={{@rowCount}}
   @isHiddenStages={{true}}
   @isHiddenBadges={{true}}
-  @isHiddenGroup={{true}}
   @onFilter={{@onFilter}}
   @onResetFilter={{@onResetFilter}}
 />

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -8,6 +8,7 @@ export default class ActivityController extends Controller {
   @tracked pageSize = 25;
   @tracked divisions = [];
   @tracked status = null;
+  @tracked groups = [];
 
   @action
   goToParticipantPage(campaignId, participationId) {
@@ -22,6 +23,7 @@ export default class ActivityController extends Controller {
   triggerFiltering(filters) {
     this.pageNumber = null;
     this.divisions = filters.divisions || this.divisions;
+    this.groups = filters.groups || this.groups;
     if (filters.status !== undefined) {
       this.status = filters.status;
     }
@@ -32,5 +34,6 @@ export default class ActivityController extends Controller {
     this.pageNumber = null;
     this.divisions = [];
     this.status = null;
+    this.groups = [];
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/activity.js
@@ -16,6 +16,9 @@ export default class ActivityRoute extends Route {
     status: {
       refreshModel: true,
     },
+    groups: {
+      refreshModel: true,
+    },
   };
 
   model(params) {
@@ -36,6 +39,7 @@ export default class ActivityRoute extends Route {
       filter: {
         divisions: params.divisions,
         status: params.status,
+        groups: params.groups,
       },
     });
   }
@@ -54,6 +58,7 @@ export default class ActivityRoute extends Route {
       controller.pageSize = 25;
       controller.divisions = [];
       controller.status = null;
+      controller.groups = [];
     }
   }
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -12,6 +12,7 @@
     @participations={{@model.participations}}
     @selectedStatus={{this.status}}
     @selectedDivisions={{this.divisions}}
+    @selectedGroups={{this.groups}}
     @rowCount={{@model.participations.meta.rowCount}}
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
@@ -46,14 +46,16 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
       controller.pageNumber = 5;
       controller.divisions = ['A2'];
       controller.status = 'SHARED';
+      controller.groups = ['L3'];
 
       // when
-      controller.send('triggerFiltering', { divisions: ['A1'], status: 'STARTED' });
+      controller.send('triggerFiltering', { divisions: ['A1'], status: 'STARTED', groups: ['L3'] });
 
       // then
       assert.equal(controller.pageNumber, null);
       assert.deepEqual(controller.divisions, ['A1']);
       assert.equal(controller.status, 'STARTED');
+      assert.deepEqual(controller.groups, ['L3']);
     });
 
     module('when division filter does not change', function () {
@@ -69,6 +71,23 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         // then
         assert.equal(controller.pageNumber, null);
         assert.deepEqual(controller.divisions, ['A2']);
+        assert.equal(controller.status, 'COMPLETED');
+      });
+    });
+
+    module('when groups filter does not change', function () {
+      test('it does not update groups', function (assert) {
+        // given
+        controller.pageNumber = 5;
+        controller.groups = ['A2'];
+        controller.status = 'SHARED';
+
+        // when
+        controller.send('triggerFiltering', { status: 'COMPLETED' });
+
+        // then
+        assert.equal(controller.pageNumber, null);
+        assert.deepEqual(controller.groups, ['A2']);
         assert.equal(controller.status, 'COMPLETED');
       });
     });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Il était impossible de filtrer par groupe pour une orga sup

## :bat: Solution
Ajout du filtre 'Groupe'

## :spider_web: Remarques

## :ghost: Pour tester
Aller dans Pix Orga d'une orga sup et regarder l'onglet `Activité` pour les 2 types de campagnes.
