### PR TITLE
[BUGFIX] Harmoniser les footers d'accessibilité dans Pix Certif (PIX-3692)

### DIFF
--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -58,7 +58,7 @@ module.exports = function(environment) {
     },
 
     googleFonts: [
-      'Roboto:300,400,700,900', // main font
+      'Roboto:300,400,500,700,900', // main font
       'Open+Sans:300',
     ],
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les labels du footer dans Pix Certif ne sont pas ISO avec ceux de Pix Orga qui sont en semi bold

## :bat: Solution
Importer le font-weight manquant depuis GoogleFont

## :ghost: Pour tester
- Se connecter à pix-certif
- Constater que les liens du footer sont en semi-bold 

![image](https://user-images.githubusercontent.com/37305474/138429024-3da8622e-f965-43f5-80c3-10ed5b767bcb.png)
