### PR TITLE
[TECH] Mettre à jour la version de la GitHub Action "Notify team on config file change"

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -33,7 +33,7 @@ jobs:
         transition: "Move to 'Deployed in Integration'"
 
     - name: Notify team on config file change
-      uses: 1024pix/notify-team-on-config-file-change@v1.0.0
+      uses: 1024pix/notify-team-on-config-file-change@v1.0.1
       with:
         GITHUB_TOKEN: ${{ github.token }}
         SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}


### PR DESCRIPTION
## :jack_o_lantern: Problème
La github action "Notify team on config file change" contenait une erreur au niveau des noms des channels Slack à notifier. Cette erreur a été corrigée et un nouveau tag a été créé. 

## :bat: Solution
Faire la montée de version pour la GitHub action "Notify team on config file change".

## :ghost: Pour tester
Testé à l'aide d'un Repo de test reproduisant une modification du fichier config.js. Attendre une PR portée par une des équipes pas pingées jusqu'alors.
