### PR TITLE
[FEATURE] Ignorer les espaces lors d'un changement d'email et amélioration de design (PIX-3691)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/email-verification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/email-verification-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   deserialize(payload) {
     return new Deserializer().deserialize(payload).then((record) => {
       return {
-        newEmail: record['new-email'].toLowerCase(),
+        newEmail: record['new-email'].trim()?.toLowerCase(),
         password: record['password'],
       };
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/email-verification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/email-verification-serializer_test.js
@@ -9,7 +9,7 @@ describe('Unit | Serializer | JSONAPI | email-verification-serializer', function
         data: {
           type: 'email-verification-code',
           attributes: {
-            'new-email': 'EMAIL@example.net',
+            'new-email': '   EMAIL@example.net   ',
             password: 'myPassword',
           },
         },

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -29,6 +29,7 @@ export default class EmailWithValidationForm extends Component {
 
   @action
   validateNewEmail() {
+    this.newEmail = this.newEmail.trim();
     const isInvalidInput = !isEmailValid(this.newEmail);
 
     this.newEmailValidationMessage = null;
@@ -51,7 +52,7 @@ export default class EmailWithValidationForm extends Component {
 
           const emailVerificationCode = this.store.createRecord('email-verification-code', {
             password: this.password,
-            newEmail: this.newEmail.trim().toLowerCase(),
+            newEmail: this.newEmail,
           });
           await emailVerificationCode.sendNewEmail();
 

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -134,7 +134,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'pages/user-tutorials';
 @import 'pages/user-tests';
 @import 'pages/personal-information';
-@import 'pages/connexion-methods';
+@import 'pages/connection-methods';
 @import 'pages/language';
 
 * {

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -1,17 +1,26 @@
+main {
+  min-height: calc(100vh - 101px - 100px);
+}
+
 .footer {
+  padding: 18px 16px;
 
   &__container {
     display: flex;
     flex-direction: column;
-    margin: 0 auto;
+    padding-top: 24px;
     max-width: 1280px;
-    padding: 18px 16px;
     width: 100%;
+    margin: auto;
 
-    @include device-is('desktop') {
+    @include device-is('tablet') {
       flex-direction: row;
-      padding: 18px 20px 48px 20px;
+      padding-top: 18px;
     }
+  }
+
+  @include device-is('tablet') {
+    height: 100px;
   }
 }
 
@@ -21,14 +30,11 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    border-top: 1px solid $grey-20;
-    padding-top: 16px;
 
-    @include device-is('desktop') {
+    @include device-is('tablet') {
       flex-direction: row;
       align-items: center;
       justify-content: space-between;
-      padding-top: 0;
       border: none;
     }
   }
@@ -38,7 +44,7 @@
     align-items: center;
     padding-bottom: 16px;
 
-    @include device-is('desktop') {
+    @include device-is('tablet') {
       padding-bottom: 0;
     }
   }
@@ -47,11 +53,7 @@
 .footer-container-content {
 
   &__navigation {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-
-    @include device-is('desktop') {
+    @include device-is('tablet') {
       padding: 0 15px;
       flex-direction: row;
       align-items: center;
@@ -60,25 +62,25 @@
     &-list {
       list-style: none;
       display: flex;
+      flex-direction: column;
       padding: 0;
+      margin: 0;
 
-      li {
+      @include device-is('tablet') {
+        flex-direction: row;
         align-self: center;
-        display: inline;
-        padding: 0;
       }
     }
   }
 
   &__copyrights {
     color: $grey-50;
-    cursor: default;
     font-size: 0.75rem;
     letter-spacing: 0.008rem;
     font-family: $font-roboto;
     padding-top: 16px;
 
-    @include device-is('desktop') {
+    @include device-is('tablet') {
       padding-top: 0;
     }
   }
@@ -101,7 +103,7 @@
       }
     }
 
-    @include device-is('desktop') {
+    @include device-is('tablet') {
       margin: 0 12px;
     }
 
@@ -130,7 +132,7 @@
 
     > img {
       height: 45px;
-      margin-left: 24px;
+      margin-right: 24px;
 
       @include device-is('tablet') {
         height: 54px;

--- a/mon-pix/app/styles/pages/_connection-methods.scss
+++ b/mon-pix/app/styles/pages/_connection-methods.scss
@@ -1,21 +1,26 @@
 .user-account-panel__item {
   display: flex;
   align-content: flex-start;
-  border-bottom: $grey-15 1px solid;
+  border-top: $grey-15 1px solid;
+  padding-top: 16px;
+  padding-bottom: 16px;
 
-  &.with-success-message {
-    border-bottom: none;
+  &--with-success-message {
     margin: 20px 0 0 0;
   }
 
+  &:first-child {
+    padding-top: 0;
+    border-top: none;
+  }
+
   &:last-child {
-    border-bottom: none;
+    padding-bottom: 0;
   }
 }
 
-.success-message {
-  padding: 20px 0;
-  border-bottom: $grey-15 1px solid;
+.user-account-panel__success-message + .user-account-panel__item {
+  margin-top: 20px;
 }
 
 .user-account-panel-item__text {

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -5,6 +5,9 @@
 
   &__container {
     padding-bottom: 30px;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
 
     @include device-is('tablet') {
       padding: 40px;
@@ -41,7 +44,6 @@
     justify-content: space-between;
     align-items: center;
     height: 118px;
-    margin-bottom: 30px;
   }
 
   &__actions {
@@ -61,6 +63,6 @@
     color: $grey-90;
     font-size: 0.875rem;
     text-align: center;
-    margin-top: 10px;
+    margin-top: 40px;
   }
 }

--- a/mon-pix/app/styles/pages/_user-certifications.scss
+++ b/mon-pix/app/styles/pages/_user-certifications.scss
@@ -1,5 +1,4 @@
 .user-certifications-page__container {
-  min-height: 500px;
   padding: 0 10px;
 
   @include device-is('desktop') {

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -3,28 +3,30 @@
   <burger.outlet>
 
     <NavbarHeader @burger={{burger}} />
-    <PixBackgroundHeader id="main">
+    <main>
+      <PixBackgroundHeader id="main">
 
-      {{#if this.model.isCertifiable}}
-        <PixBlock @shadow="heavy" class="certification-start-page__block">
-          {{#if this.showCongratulationsBanner}}
-            <CongratulationsCertificationBanner
-              @certificationEligibility={{this.model}}
-              @fullName={{this.currentUser.user.fullName}}
-              @closeBanner={{this.closeBanner}}
-            />
-          {{/if}}
-          {{#if (eq this.currentStep "join")}}
-            <CertificationJoiner @onStepChange={{this.changeStep}} />
-          {{else}}
-            <CertificationStarter @sessionId={{this.sessionId}} />
-          {{/if}}
-        </PixBlock>
-      {{else}}
-        <CertificationNotCertifiable />
-      {{/if}}
+        {{#if this.model.isCertifiable}}
+          <PixBlock @shadow="heavy" class="certification-start-page__block">
+            {{#if this.showCongratulationsBanner}}
+              <CongratulationsCertificationBanner
+                @certificationEligibility={{this.model}}
+                @fullName={{this.currentUser.user.fullName}}
+                @closeBanner={{this.closeBanner}}
+              />
+            {{/if}}
+            {{#if (eq this.currentStep "join")}}
+              <CertificationJoiner @onStepChange={{this.changeStep}} />
+            {{else}}
+              <CertificationStarter @sessionId={{this.sessionId}} />
+            {{/if}}
+          </PixBlock>
+        {{else}}
+          <CertificationNotCertifiable />
+        {{/if}}
 
-    </PixBackgroundHeader>
+      </PixBackgroundHeader>
+    </main>
 
     <Footer />
 

--- a/mon-pix/app/templates/components/footer.hbs
+++ b/mon-pix/app/templates/components/footer.hbs
@@ -1,8 +1,6 @@
 <footer id="footer" class="footer">
   <div class="footer__container">
     <div class="footer-container__logos">
-      <PixLogo />
-
       {{#if this.shouldShowTheMarianneLogo}}
         <div class="footer-logos__french-government">
           <img
@@ -11,6 +9,8 @@
           />
         </div>
       {{/if}}
+
+      <PixLogo />
     </div>
 
     <div class="footer-container__content">

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -4,61 +4,58 @@
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
 
-    <div class="background-banner-wrapper">
-      <div class="background-banner"></div>
+    <main>
+      <PixBackgroundHeader>
+        <PixBlock class="fill-in-campaign-code__container">
+          <h1 class="fill-in-campaign-code__title rounded-panel-title">
+            {{this.firstTitle}}
+          </h1>
 
-      <main
-        id="main"
-        class="fill-in-campaign-code__container rounded-panel rounded-panel--strong rounded-panel--over-background-banner"
-      >
-        <h1 class="fill-in-campaign-code__title rounded-panel-title">
-          {{this.firstTitle}}
-        </h1>
+          <label for="campaign-code" class="fill-in-campaign-code__instruction">{{{t
+              "pages.fill-in-campaign-code.description"
+            }}}</label>
+          <form class="fill-in-campaign-code__form" autocomplete="off">
 
-        <label for="campaign-code" class="fill-in-campaign-code__instruction">{{{t
-            "pages.fill-in-campaign-code.description"
-          }}}</label>
-        <form class="fill-in-campaign-code__form" autocomplete="off">
+            <div class="fill-in-campaign-code__form-field">
+              <Input
+                required
+                @id="campaign-code"
+                class="input-code"
+                @type="text"
+                @value={{this.campaignCode}}
+                @maxlength="9"
+                @key-down={{this.clearErrorMessage}}
+              />
+            </div>
 
-          <div class="fill-in-campaign-code__form-field">
-            <Input
-              required
-              @id="campaign-code"
-              class="input-code"
-              @type="text"
-              @value={{this.campaignCode}}
-              @maxlength="9"
-              @key-down={{this.clearErrorMessage}}
-            />
-          </div>
+            {{#if this.errorMessage}}
+              <div class="fill-in-campaign-code__error" aria-live="polite">
+                {{this.errorMessage}}
+              </div>
+            {{/if}}
 
-          {{#if this.errorMessage}}
-            <div class="fill-in-campaign-code__error" aria-live="polite">
-              {{this.errorMessage}}
+            <div class="fill-in-campaign-code__actions">
+              <PixButton
+                @type="submit"
+                class="fill-in-campaign-code__start-button"
+                @triggerAction={{action "startCampaign"}}
+              >
+                {{t "pages.fill-in-campaign-code.start"}}
+              </PixButton>
+            </div>
+          </form>
+
+          {{#if this.showWarningMessage}}
+            <div class="fill-in-campaign-code__warning">
+              <span>{{this.warningMessage}}</span>
+              <a href="#" class="link" {{action this.disconnect}}>{{t
+                  "pages.fill-in-campaign-code.warning-message-logout"
+                }}</a>
             </div>
           {{/if}}
-
-          <div class="fill-in-campaign-code__actions">
-            <PixButton
-              @type="submit"
-              class="fill-in-campaign-code__start-button"
-              @triggerAction={{action "startCampaign"}}
-            >
-              {{t "pages.fill-in-campaign-code.start"}}
-            </PixButton>
-          </div>
-        </form>
-
-        {{#if this.showWarningMessage}}
-          <div class="fill-in-campaign-code__warning">
-            <span>{{this.warningMessage}}</span>
-            <a href="#" class="link" {{action this.disconnect}}>{{t
-                "pages.fill-in-campaign-code.warning-message-logout"
-              }}</a>
-          </div>
-        {{/if}}
-      </main>
-    </div>
+        </PixBlock>
+      </PixBackgroundHeader>
+    </main>
 
     <Footer />
 

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -4,52 +4,54 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
-    <PixBackgroundHeader id="main">
-      <PixBlock class="fill-in-certificate-verification-code">
-        <form class="fill-in-certificate-verification-code__form" autocomplete="off">
+    <main>
+      <PixBackgroundHeader id="main">
+        <PixBlock class="fill-in-certificate-verification-code">
+          <form class="fill-in-certificate-verification-code__form" autocomplete="off">
 
-          <h1 class="form__title">
-            {{t "pages.fill-in-certificate-verification-code.first-title"}}
-          </h1>
+            <h1 class="form__title">
+              {{t "pages.fill-in-certificate-verification-code.first-title"}}
+            </h1>
 
-          <p class="form__description">
-            {{t "pages.fill-in-certificate-verification-code.description"}}
-          </p>
+            <p class="form__description">
+              {{t "pages.fill-in-certificate-verification-code.description"}}
+            </p>
 
-          <div class="form__input-and-label">
-            <label for="certificate-verification-code">
-              {{t "pages.fill-in-certificate-verification-code.label"}}
-            </label>
-            <Input
-              required
-              class="input-code"
-              @type="text"
-              @id="certificate-verification-code"
-              @value={{this.certificateVerificationCode}}
-              @maxlength="10"
-              @key-down={{this.clearErrorMessage}}
-            />
-          </div>
-
-          {{#if this.errorMessage}}
-            <div class="form__error--validation" aria-live="polite">
-              {{this.errorMessage}}
+            <div class="form__input-and-label">
+              <label for="certificate-verification-code">
+                {{t "pages.fill-in-certificate-verification-code.label"}}
+              </label>
+              <Input
+                required
+                class="input-code"
+                @type="text"
+                @id="certificate-verification-code"
+                @value={{this.certificateVerificationCode}}
+                @maxlength="10"
+                @key-down={{this.clearErrorMessage}}
+              />
             </div>
-          {{/if}}
 
-          <PixButton @type="submit" @triggerAction={{this.checkCertificate}} class="form__actions">
-            {{t "pages.fill-in-certificate-verification-code.verify"}}
-          </PixButton>
+            {{#if this.errorMessage}}
+              <div class="form__error--validation" aria-live="polite">
+                {{this.errorMessage}}
+              </div>
+            {{/if}}
 
-          {{#if this.showNotFoundCertificationErrorMessage}}
-            <PixMessage @type="alert" class="form__error--not-found">
-              <FaIcon @icon="exclamation-triangle" />
-              <span>{{t "pages.fill-in-certificate-verification-code.errors.not-found"}}</span>
-            </PixMessage>
-          {{/if}}
-        </form>
-      </PixBlock>
-    </PixBackgroundHeader>
+            <PixButton @type="submit" @triggerAction={{this.checkCertificate}} class="form__actions">
+              {{t "pages.fill-in-certificate-verification-code.verify"}}
+            </PixButton>
+
+            {{#if this.showNotFoundCertificationErrorMessage}}
+              <PixMessage @type="alert" class="form__error--not-found">
+                <FaIcon @icon="exclamation-triangle" />
+                <span>{{t "pages.fill-in-certificate-verification-code.errors.not-found"}}</span>
+              </PixMessage>
+            {{/if}}
+          </form>
+        </PixBlock>
+      </PixBackgroundHeader>
+    </main>
     <Footer />
   </burger.outlet>
 </BurgerMenu>

--- a/mon-pix/app/templates/user-account/connection-methods.hbs
+++ b/mon-pix/app/templates/user-account/connection-methods.hbs
@@ -31,11 +31,9 @@
         </div>
 
         {{#if this.showEmailUpdatedMessage}}
-          <div class="success-message">
-            <PixMessage @type="success" @withIcon={{true}}>
-              {{t "pages.user-account.email-verification.update-successful"}}
-            </PixMessage>
-          </div>
+          <PixMessage @type="success" @withIcon={{true}} class="user-account-panel__success-message">
+            {{t "pages.user-account.email-verification.update-successful"}}
+          </PixMessage>
         {{/if}}
       {{/if}}
 

--- a/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
@@ -2,9 +2,25 @@ import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import { expect } from 'chai';
 
 describe('Unit | Component | user-account | email-with-validation-form', function () {
   setupTest();
+
+  context('#validateNewEmail', function () {
+    it('should trim on email validation', function () {
+      // given
+      const emailWithSpaces = '   lea@example.net   ';
+      const component = createGlimmerComponent('component:user-account/email-with-validation-form');
+      component.newEmail = emailWithSpaces;
+
+      // when
+      component.validateNewEmail();
+
+      // then
+      expect(component.newEmail).to.equal(emailWithSpaces.trim());
+    });
+  });
 
   context('#onSubmit', function () {
     it('should send new email and password', async function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Contexte : feature de changement d'adresse email (mon compte -> méthodes de connexion -> modifier)
Pendant la démo on s'est apperçu du soucis suivant : 
Il y avait 2 espaces avant le champ adresse email et il n'était pas possible de cliquer sur le bouton pour envoyer l’email. Pas de retour visuel.

De plus, il y avait un petit soucis de design : les différentes méthode de connexion sont toutes collées, ce qui rend la lecture difficile. 

![image](https://user-images.githubusercontent.com/38167520/138454057-4755c7c2-4441-4f95-baa1-a1b0bf3ee705.png)

## :bat: Solution
Ignorer les espaces avant et après l’adresse email. Faire un trim.
Réparer le design cassé suite à la mise à jour du bouton ‘Modifier’

## :spider_web: Remarques
Lors de la design review avec Quentin on a remarqué que le footer n'est pas collé en bas de page.
On en a profité pour améliorer un peu son style. 🌟 .

## :ghost: Pour tester
- Aller dans Mon Compte
- Cliquer sur Mes méthodes de connexion
- Constater que le design est réparé pour un utilisateur ayant + d'une méthode de connexion
- Cliquer sur "Modifier" pour modifier l'email de connexion
- Remplir le premier champ avec des espaces + le mdp
- Tenter de passer à l'étape suivante
- Constater qu'il n'y a pas d'erreur
