### PR TITLE
[FIX] Supprimer la phrase "un seul envoi possible" lors de l'envoi de profil (PIX-3675)

### DIFF
--- a/mon-pix/app/styles/pages/_send-profile.scss
+++ b/mon-pix/app/styles/pages/_send-profile.scss
@@ -69,12 +69,6 @@
     font-family: $font-open-sans;
     font-size: 1.25rem;
     font-weight: $font-medium;
-  }
-
-  &__warning {
-    color: $grey-90;
-    font-size: 0.75rem;
-    letter-spacing: 0.36px;
-    padding-top: 10px;
+    margin-top: 0;
   }
 }

--- a/mon-pix/app/templates/components/profile-sharing-form.hbs
+++ b/mon-pix/app/templates/components/profile-sharing-form.hbs
@@ -20,11 +20,6 @@
     <PixButton @type="submit">
       {{t "pages.send-profile.form.send"}}
     </PixButton>
-
-    <p class="send-profile-header__warning">
-      <FaIcon @icon="exclamation-circle" />
-      {{t "pages.send-profile.form.info"}}
-    </p>
   {{/if}}
 
 </form>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1087,7 +1087,6 @@
       "first-title": "Submitting your Pix profile",
       "form": {
         "continue": "Continue my Pix experience",
-        "info": "You can only submit it once",
         "recipient": "Recipient: {recipient}",
         "send": "Submit my profile",
         "shared": "Thank you, your profile has been submitted!"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1087,7 +1087,6 @@
       "first-title": "Envoi de votre profil Pix",
       "form": {
         "continue": "Continuez votre expérience Pix",
-        "info": "Cet envoi n’est possible qu’une seule fois",
         "recipient": "Destinataire : {recipient}",
         "send": "J'envoie mon profil",
         "shared": "Merci, votre profil a bien été envoyé !"


### PR DESCRIPTION
## :jack_o_lantern: Problème
Au moment de l'envoi du profil, nous affichions une phrase qui indiquait qu'on ne pouvait envoyer son profil qu'un seule fois.
Or nous avons décidé d’ouvrir la collecte de profil à l'envoi multiple. Comme il est maintenant possible d'envoyer plusieurs fois son profil cette phrase n'a plus de sens.

## :bat: Solution
Retirer cette phrase.

## :spider_web: Remarques


## :ghost: Pour tester
Aller sur pix app, entrer le code d'une campagne et au moment d'envoyer le profil, souligner la disparition de cette phrase.
