### PR TITLE
[TECH] Permettre l'activation de la souscription de la certification complémentaire à chaud (PIX-3678).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -158,6 +158,9 @@ module.exports = (function () {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
       isEndTestScreenRemovalEnabled: isFeatureEnabled(process.env.FT_END_TEST_SCREEN_REMOVAL_ENABLED),
+      isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
+        process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
+      ),
     },
 
     infra: {

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -27,6 +27,7 @@ const schema = Joi.object({
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   CACHE_RELOAD_TIME: Joi.string().optional(),
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
+  FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -28,6 +28,7 @@ const schema = Joi.object({
   CACHE_RELOAD_TIME: Joi.string().optional(),
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
   FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
+  FT_END_TEST_SCREEN_REMOVAL_ENABLED: Joi.string().optional().valid('true', 'false'),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -29,6 +29,13 @@
 
 FT_VALIDATE_EMAIL=false
 
+# Prevent candidate from getting a complementary certification without applying
+#
+# presence: optionnal
+# type: boolean
+# default: false
+FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED=false
+
 # =======
 # CACHING
 # =======

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,6 +24,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-manage-uncompleted-certif-enabled': false,
             'is-email-validation-enabled': false,
             'is-end-test-screen-removal-enabled': false,
+            'is-complementary-certification-subscription-enabled': false,
           },
           type: 'feature-toggles',
         },


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, le candidat passe automatiquement les certifications complementaires, s'il est elligible et si le centre de certification est habilité.
On veut désactiver ce comportement: il devra le demander explicitement son inscription.

En attendant la fin de l'implémentation, on veut pouvoir garder le comportement actuel.

## :bat: Solution
Ajouter le feature toogle `FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED` et l'exposer au Front-end

## :spider_web: Remarques
Validation d'un autre feature toggle en passant

## :ghost: Pour tester
Alimenter `.env` avec `FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED=true`
Appeler `http://localhost:3000/api/feature-toggles`

La réponse doit être 
```
{
   "data":{
      "type":"feature-toggles",
      "id":"0",
      "attributes":{
         (..)
         "is-complementary-certification-subscription-enabled":true
      }
   }
}