### PR TITLE
[BUGFIX] Suppression de l'event de focusOut quand une question a déjà été répondue. 

### DIFF
--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -8,7 +8,7 @@ export default class Item extends Component {
 
   constructor() {
     super(...arguments);
-    if (this.isFocusedChallenge) {
+    if (this.isFocusedChallenge && !this.args.answer) {
       this._setOnBlurEventToWindow();
     }
   }


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous détectons toujours le focus out même quand la question a déjà été répondue. Ce qui a pour conséquence de mettre le champ : `lastQuestionState` de l'assessments en `focusedout`. Cela met donc l'application dans un état non souhaité où la prochaine question affiche le bandeau de focusedOut 

## :bat: Solution
Ne pas détecter le focus out quand la question est déjà répondue. 

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
- Répondre à une question focus
- En arrivant sur une nouvelle question pas focus : faire précédent 
- En arrivant sur la question déjà répondu : sortir de la fenêtre
- Cliquer sur poursuivre
- Constater que le message de focusOut ne s'affiche pas sur la question pas focus
