### PR TITLE
[FEATURE] Ajouter le type de la campagne dans l'onglet paramètres (PIX-3676)

### DIFF
--- a/orga/app/components/campaign/settings.hbs
+++ b/orga/app/components/campaign/settings.hbs
@@ -1,6 +1,12 @@
 <div class="panel campaign-settings">
   <dl>
     <div class="campaign-settings-row">
+      <div class="campaign-settings-content">
+        <dt class="label-text campaign-settings-content__label">{{t "pages.campaign-settings.campaign-type.title"}}</dt>
+        <dd class="content-text campaign-settings-content__text">{{this.campaignType}}</dd>
+      </div>
+    </div>
+    <div class="campaign-settings-row">
       {{#if @campaign.isTypeAssessment}}
         <div class="campaign-settings-content">
           <dt class="label-text campaign-settings-content__label">{{t "pages.campaign-settings.target-profile"}}</dt>

--- a/orga/app/components/campaign/settings.js
+++ b/orga/app/components/campaign/settings.js
@@ -12,6 +12,12 @@ export default class CampaignSettings extends Component {
     return `${this.url.campaignsRootUrl}${this.args.campaign.code}`;
   }
 
+  get campaignType() {
+    return this.args.campaign.isTypeAssessment
+      ? this.intl.t('pages.campaign-settings.campaign-type.assessment')
+      : this.intl.t('pages.campaign-settings.campaign-type.profiles-collection');
+  }
+
   @action
   async archiveCampaign(campaignId) {
     try {

--- a/orga/tests/integration/components/campaign/settings_test.js
+++ b/orga/tests/integration/components/campaign/settings_test.js
@@ -17,6 +17,37 @@ module('Integration | Component | Campaign::Settings', function (hooks) {
     this.owner.register('service:url', UrlStub);
   });
 
+  module('display the type of campaign', function () {
+    module('when type is ASSESSMENT', function () {
+      test('it should display assessment type', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'ASSESSMENT',
+        });
+
+        // when
+        await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+
+        // then
+        assert.contains(`Campagne d'évaluation`);
+      });
+    });
+
+    module('when type is PROFILES_COLLECTION', function () {
+      test('it should display profile collection campaign', async function (assert) {
+        this.campaign = store.createRecord('campaign', {
+          type: 'PROFILES_COLLECTION',
+        });
+
+        // when
+        await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+
+        // then
+        assert.contains('Campagne de collecte de profils');
+      });
+    });
+  });
+
   module('on TargetProfile display', function () {
     module('when type is ASSESSMENT', function () {
       test('it should display target profile related to campaign', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -302,6 +302,11 @@
         "archive": "Archive",
         "edit": "Edit"
       },
+      "campaign-type": {
+        "title": "Type of campaign",
+        "assessment": "Assessment campaign",
+        "profiles-collection": "Profiles collection campaign"
+      },
       "direct-link": "Direct link",
       "external-user-id-label": "External user ID label",
       "landing-page-text": "Text to display on the starting page",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -302,6 +302,11 @@
         "archive": "Archiver",
         "edit": "Modifier"
       },
+      "campaign-type": {
+        "title": "Type de la campagne",
+        "assessment": "Campagne d'évaluation",
+        "profiles-collection": "Campagne de collecte de profils"
+      },
       "direct-link": "Lien direct",
       "external-user-id-label": "Libellé de l'identifiant",
       "landing-page-text": "Texte de la page d'accueil",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement sur Pix Orga, il n'y a aucun moyen de connaitre le type de la campagne.

## :bat: Solution
Ajouter cette info dans la page paramètres de la campagne

## :spider_web: Remarques


## :ghost: Pour tester
Aller sur
Pix Orga > campagne > paramètres
