### PR TITLE
[TECH] Suppression du formattage d'email dans les questions. 

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import config from 'mon-pix/config/environment';
 import sortBy from 'lodash/sortBy';
 import ENV from 'mon-pix/config/environment';
 
@@ -25,13 +24,7 @@ export default class ChallengeStatement extends Component {
 
   get challengeInstruction() {
     const instruction = this.args.challenge.instruction;
-    if (!instruction) {
-      return null;
-    }
-
-    const formattedEmailInstruction = this._formatEmail(instruction);
-    const formattedInstruction = this._formatLink(formattedEmailInstruction);
-    return formattedInstruction;
+    return instruction ? this._formatLink(instruction) : null;
   }
 
   get linkTitle() {
@@ -77,19 +70,6 @@ export default class ChallengeStatement extends Component {
 
   _initialiseDefaultAttachment() {
     this.selectedAttachmentUrl = this.orderedAttachments[0];
-  }
-
-  _formattedEmailForInstruction() {
-    return this.mailGenerator.generateEmail(
-      this.args.challenge.id,
-      this.args.assessment.id,
-      window.location.hostname,
-      config.environment
-    );
-  }
-
-  _formatEmail(instruction) {
-    return instruction.replace('${EMAIL}', this._formattedEmailForInstruction());
   }
 
   _formatLink(instruction) {

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -110,23 +110,6 @@ describe('Integration | Component | ChallengeStatement', function () {
       expect(find('.challenge-statement-instruction__text')).to.not.exist;
     });
 
-    it('should replace ${EMAIL} by a generated email', async function () {
-      // given
-      addAssessmentToContext(this, { id: '267845' });
-      addChallengeToContext(this, {
-        id: 'recigAYl5bl96WGXj',
-        instruction: "Veuillez envoyer un email à l'adresse ${EMAIL} pour valider cette épreuve",
-      });
-
-      // when
-      await renderChallengeStatement(this);
-
-      // then
-      expect(find('.challenge-statement-instruction__text').textContent.trim()).to.equal(
-        "Veuillez envoyer un email à l'adresse recigAYl5bl96WGXj-267845-0502@pix-infra.ovh pour valider cette épreuve"
-      );
-    });
-
     it('should add title "Nouvelle fenêtre" to external links', async function () {
       // given
       addAssessmentToContext(this, { id: '267845' });


### PR DESCRIPTION
## **🎃 Problème**

Nous avons dans le code une gestion des instructions des épreuves afin de générer un email lorsque c'est nécessaire via la présence de `${EMAIl}` dans l'instruction de l'épreuve. 

Ce système a été mis en place dans la PR : [https://github.com/betagouv/pix/pull/547](https://github.com/betagouv/pix/pull/547) à l'époque où le repository était encore chez betagouv.

Je pense que ça a été mis en place pour le type de question : `QMAIL`, qui a disparu de Pix, ce système est cependant resté en place. 

Pour vérifier cela j'ai téléchargé le référentiel dans un fichier json. 

```bash
curl https://lcms.pix.fr/api/releases/latest -H "Authorization: Bearer API_KEY" -o ref.json
```

Puis j'ai vérifié le contenu du référentiel. Plus précisément j'ai récupéré les challenges dont les instructions comprennent `EMAIL` (et non pas `${EMAIL}` car ça ne fonctionnait pas).  

```bash
jq < ref.json '.content | .challenges | map(select(.instruction | strings | test("EMAIL") )) | map({ id: .id, instruction: .instruction, type: .type, status: .status })'
```

Le résultat est le suivant : 

```json
[
  {
    "id": "recXXX",
    "instruction": "Mon email est ${EMAIL}",
    "type": "QCU",
    "status": "proposé"
  },
  {
    "id": "recXXX",
    "instruction": "Envoyez un courrier électronique à l'adresse **${EMAIL}** contenant, dans l'objet du mail, le message **No woman no cry**",
    "type": "QMAIL",
    "status": "proposé"
  },
  {
    "id": "recXXX",
    "instruction": "Envoyez un courrier électronique : \n\n- avec l’objet : **Test Pix**\n\n- le message  : **Voici le message que vous avez demandé**  \n\n- au destinataire  : **${EMAIL}**\n\n\n",
    "type": "QMAIL",
    "status": "proposé"
  },
  {
    "id": "recXXX",
    "instruction": "Envoyez un courrier électronique : \n\n- avec l’objet : **Test Pix**\n\n- le message  : **Validation d'un message sans accent ou lettre chelou**  \n\n- au destinataire  : **${EMAIL}**\n\n\n copy",
    "type": "QMAIL",
    "status": "proposé"
  },
  {
    "id": "recXXX",
    "instruction": "Envoyez un courrier électronique à l'adresse **${EMAIL}** contenant, dans l'objet du mail, le message **boubouh** copy",
    "type": "QCU",
    "status": "proposé"
  },
  {
    "id": "recXXX",
    "instruction": "Mon mail est le ${EMAIL}",
    "type": "QCU",
    "status": "périmé"
  }
]
```

Nous avons bien des challenges de type `QMAIL`, mais aussi 3 `QCU`. 

Je propose de supprimer quand même cette fonctionnalité, car tous les challenges sont en `périmé` ou `proposé`. 

Il s'agit de code à maintenir alors qu'il n'est pas utile. Au pire des cas nous récupérons le code de cette PR.

## **🦇 Solution**

Supprimer le code non utilisé. 

## **🕸️ Remarques**

> Des infos supplémentaires, trucs et astuces ?
> 

## **👻 Pour tester**

Vérifier que les épreuves fonctionnent bien.