### PR TITLE
[FEATURE] Permettre la création de campagne de collecte à envoi multiple (PIX-3674).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -25,6 +25,7 @@ module.exports = {
       name,
       type,
       title,
+      'multiple-sendings': multipleSendings,
       'id-pix-label': idPixLabel,
       'custom-landing-page-text': customLandingPageText,
     } = request.payload.data.attributes;
@@ -42,6 +43,7 @@ module.exports = {
       creatorId: userId,
       organizationId,
       targetProfileId,
+      multipleSendings,
     };
     const createdCampaign = await usecases.createCampaign({ campaign });
     return h.response(campaignReportSerializer.serialize(createdCampaign)).created();

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -48,6 +48,7 @@ module.exports = {
       'creatorId',
       'organizationId',
       'targetProfileId',
+      'multipleSendings',
     ]);
     const createdCampaign = await new BookshelfCampaign(campaignAttributes).save();
     return bookshelfToDomainConverter.buildDomainObject(BookshelfCampaign, createdCampaign);

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -73,7 +73,7 @@ describe('Integration | Repository | Campaign', function () {
     });
   });
 
-  describe('#save', function () {
+  describe('#create', function () {
     let creatorId, organizationId, targetProfileId;
     let savedCampaign, campaignToSave, campaignAttributes;
 
@@ -92,6 +92,7 @@ describe('Integration | Repository | Campaign', function () {
         customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
         creatorId,
         organizationId,
+        multipleSendings: true,
       };
     });
 
@@ -125,6 +126,7 @@ describe('Integration | Repository | Campaign', function () {
           'creator',
           'organization',
           'targetProfile',
+          'multipleSendings',
         ])
       );
     });
@@ -141,7 +143,16 @@ describe('Integration | Repository | Campaign', function () {
       expect(savedCampaign.id).to.exist;
 
       expect(savedCampaign).to.deep.include(
-        _.pick(campaignToSave, ['name', 'code', 'title', 'type', 'customLandingPageText', 'creator', 'organization'])
+        _.pick(campaignToSave, [
+          'name',
+          'code',
+          'title',
+          'type',
+          'customLandingPageText',
+          'creator',
+          'organization',
+          'multipleSendings',
+        ])
       );
     });
   });

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -33,6 +33,7 @@ describe('Unit | Application | Controller | Campaign', function () {
               title: 'title',
               'id-pix-label': 'idPixLabel',
               'custom-landing-page-text': 'customLandingPageText',
+              'multiple-sendings': true,
             },
             relationships: {
               'target-profile': { data: { id: '123' } },
@@ -53,6 +54,7 @@ describe('Unit | Application | Controller | Campaign', function () {
         organizationId: 456,
         targetProfileId: 123,
         creatorId: 1,
+        multipleSendings: true,
       };
 
       const expectedResult = Symbol('result');

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -77,6 +77,43 @@
     </div>
   {{/if}}
 
+  {{#if this.isCampaignGoalProfileCollection}}
+    <div class="form__field-with-info">
+      <div class="form__field">
+        <p class="label">{{t "pages.campaign-creation.multiple-sendings.question-label"}}</p>
+        <div class="form__radio-button">
+          <input
+            type="radio"
+            checked={{this.multipleSendingsEnabled}}
+            id="multiple-sendings-enabled"
+            name="multiple-sendings-label"
+            value="true"
+            {{on "change" this.selectMultipleSendingsStatus}}
+          />
+          <label for="multiple-sendings-enabled">{{t "pages.campaign-creation.yes"}}</label>
+        </div>
+        <div class="form__radio-button">
+          <input
+            type="radio"
+            checked={{not this.multipleSendingsEnabled}}
+            id="multiple-sendings-disabled"
+            name="multiple-sendings-label"
+            value=""
+            {{on "change" this.selectMultipleSendingsStatus}}
+          />
+          <label for="multiple-sendings-disabled">{{t "pages.campaign-creation.no"}}</label>
+        </div>
+      </div>
+      <div class="form__field-info">
+        <span class="form__field-info-title">
+          <FaIcon @icon="info-circle" class="form__field-info-icon" />
+          <span>{{t "pages.campaign-creation.multiple-sendings.info-title"}}</span>
+        </span>
+        <span class="form__field-info-message">{{t "pages.campaign-creation.multiple-sendings.info"}}</span>
+      </div>
+    </div>
+  {{/if}}
+
   <div class="form__field">
     <p class="label">{{t "pages.campaign-creation.external-id-label.question-label"}}</p>
     <div class="form__radio-button">

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -7,7 +7,9 @@ export default class CreateForm extends Component {
   @service currentUser;
 
   @tracked wantIdPix = false;
+  @tracked multipleSendingsEnabled = true;
   @tracked isCampaignGoalAssessment = null;
+  @tracked isCampaignGoalProfileCollection = null;
 
   constructor() {
     super(...arguments);
@@ -46,14 +48,25 @@ export default class CreateForm extends Component {
   }
 
   @action
+  selectMultipleSendingsStatus(event) {
+    const status = Boolean(event.target.value);
+    this.multipleSendingsEnabled = status;
+    this.args.campaign.multipleSendings = status;
+  }
+
+  @action
   setCampaignGoal(event) {
     if (event.target.value === 'collect-participants-profile') {
       this.isCampaignGoalAssessment = false;
+      this.isCampaignGoalProfileCollection = true;
+      this.args.campaign.multipleSendings = true;
       this.args.campaign.title = null;
       this.args.campaign.targetProfile = null;
       return (this.args.campaign.type = 'PROFILES_COLLECTION');
     }
     this.isCampaignGoalAssessment = true;
+    this.isCampaignGoalProfileCollection = false;
+    this.args.campaign.multipleSendings = false;
     return (this.args.campaign.type = 'ASSESSMENT');
   }
 }

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -10,6 +10,7 @@ export default class Campaign extends Model {
   @attr('string') type;
   @attr('string') title;
   @attr('boolean') isArchived;
+  @attr('boolean') multipleSendings;
   @attr('string') idPixLabel;
   @attr('string') customLandingPageText;
   @attr('string') tokenForCampaignResults;

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -3,17 +3,60 @@
   flex-direction: column;
   margin-bottom: 30px;
 
-  @include device-is('desktop') {
-    max-width: 500px;
-  }
-
   &__field {
     display: flex;
     flex-direction: column;
     margin-bottom: 16px;
 
+    @include device-is('desktop') {
+      max-width: 500px;
+    }
+
     &--wide > input,select,textarea {
       width: 100%;
+    }
+  }
+
+  &__field-with-info {
+    display: flex;
+    align-content: center;
+    width: 100%;
+    flex-direction: column;
+
+
+    @include device-is('desktop') {
+      flex-direction: row;
+    }
+  }
+
+  &__field-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    border-radius: 8px;
+    background: $grey-15;
+    height: max-content;
+
+    @include device-is('desktop') {
+      max-width: 500px;
+    }
+
+    &-icon {
+      color: $blue;
+      margin-right: 8px;
+    }
+
+    &-title {
+      font-weight: 500;
+      font-size: 14px;
+      margin: 16px 0 8px 16px;
+      color: $grey-90;
+    }
+
+    &-message {
+      color: $grey-60;
+      font-size: 13px;
+      margin: 0 16px 16px 16px;
     }
   }
 

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { currentURL, visit } from '@ember/test-helpers';
-import { clickByLabel, fillInByLabel } from '../helpers/testing-library';
+import { clickByLabel, fillInByLabel, selectChoiceForLabel } from '../helpers/testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import {
@@ -55,7 +55,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
       await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
       await fillInByLabel('Nom de la campagne', 'Ma Campagne');
-      await clickByLabel('Oui');
+      await selectChoiceForLabel('Souhaitez-vous demander un identifiant externe ?', 'Oui');
       await fillInByLabel('Libellé de l’identifiant', 'Mail Pro');
       await fillInByLabel('Titre du parcours', 'Savoir rechercher');
       await fillInByLabel("Texte de la page d'accueil", 'Texte personnalisé');
@@ -101,8 +101,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await clickByLabel('Évaluer les participants');
       await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
       await fillInByLabel('Nom de la campagne', 'Ma Campagne');
-      await clickByLabel('Non');
-
+      await selectChoiceForLabel('Souhaitez-vous demander un identifiant externe ?', 'Non');
       // when
       await clickByLabel('Créer la campagne');
 
@@ -117,8 +116,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       // given
       await clickByLabel('Collecter les profils Pix des participants');
       await fillInByLabel('Nom de la campagne', 'Ma Campagne');
-      await clickByLabel('Non');
-
+      await selectChoiceForLabel('Souhaitez-vous demander un identifiant externe ?', 'Non');
       // when
       await clickByLabel('Créer la campagne');
 
@@ -134,8 +132,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
       await fillInByLabel('Nom de la campagne', 'Ma Campagne');
       await fillInByLabel('Titre du parcours', 'Savoir rechercher');
-      await clickByLabel('Non');
-      await clickByLabel('Collecter les profils Pix des participants');
+      await selectChoiceForLabel('Souhaitez-vous demander un identifiant externe ?', 'Non');
 
       // when
       await clickByLabel('Créer la campagne');

--- a/orga/tests/helpers/testing-library.js
+++ b/orga/tests/helpers/testing-library.js
@@ -56,3 +56,17 @@ export function fillInByLabel(label, value) {
   const element = getByLabelText(label);
   return fillIn(element, value);
 }
+
+/**
+ * Select a choice for a given label.
+ *
+ * @param {*} label Label of field to fill.
+ * @param {*} answerText Label of choice to select.
+ * @returns Promise of the filling.
+ */
+export function selectChoiceForLabel(label, answerText) {
+  const { getByText } = getScreen();
+  const parent = getByText(label).parentNode;
+  const answer = within(parent).getByText(answerText);
+  return click(answer);
+}

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -89,6 +89,20 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       assert.contains(t('pages.campaign-creation.test-title.label'));
       assert.contains(t('pages.campaign-creation.purpose.label'));
     });
+
+    test('it should not display multiple sendings field', async function (assert) {
+      //given
+      this.campaign = EmberObject.create({});
+
+      // when
+      await render(
+        hbs`<Campaign::CreateForm @campaign={{campaign}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}/>`
+      );
+
+      // then
+      assert.notContains(t('pages.campaign-creation.multiple-sendings.question-label'));
+      assert.notContains(t('pages.campaign-creation.multiple-sendings.info'));
+    });
   });
 
   module('when user choose to create a campaign of type PROFILES_COLLECTION', () => {
@@ -109,6 +123,25 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // then
       assert.notContains(t('pages.campaign-creation.test-title.label'));
       assert.notContains(t('pages.campaign-creation.target-profiles-list.label'));
+    });
+
+    test('it should display fields for enabling multiple sendings', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        organization = EmberObject.create({ canCollectProfiles: true });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.campaign = EmberObject.create({});
+
+      // when
+      await render(
+        hbs`<Campaign::CreateForm @campaign={{campaign}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}/>`
+      );
+      await clickByLabel(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert.contains(t('pages.campaign-creation.multiple-sendings.question-label'));
+      assert.contains(t('pages.campaign-creation.multiple-sendings.info'));
     });
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -278,6 +278,11 @@
         "label": "Text to display on the starting page"
       },
       "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
+      "multiple-sendings": {
+        "question-label": "Do you want to allow participants to submit their profile more than once?",
+        "info": "If you choose to allow multiple submissions, the participants will be able to submit their profile several times by re-entering the campaign code. Within Pix Orga you will find the latest submitted profile.",
+        "info-title": "Multiple submissions"
+      },
       "name": {
         "label": "Name of the campaign"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -278,6 +278,11 @@
         "label": "Texte de la page d'accueil"
       },
       "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
+      "multiple-sendings": {
+        "question-label": "Souhaitez-vous permettre aux participants d'envoyer plusieurs fois leur profil ?",
+        "info": "Si vous choisissez l’envoi multiple, le participant pourra envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez le dernier profil envoyé.",
+        "info-title": "Envoi multiple"
+      },
       "name": {
         "label": "Nom de la campagne"
       },


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les campagnes à envoie multiple ne peut pas être créer par les utilisateurs et sont créés par les pôles métiers.

## :bat: Solution
Permettre de créer des campagnes à envoie multiple dans PixOrga.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Créer une campagne à envoie multiple dans Pix Orga.
