### PR TITLE
[BUGFIX] Harmoniser les champs des formulaires dans Pix Certif (PIX-3724)

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -56,7 +56,10 @@
           </div>
 
           <div class="new-certification-candidate-details-modal__form__field">
-            <span class="required-field-indicator">*</span> Sexe
+            <fieldset>
+            <legend class="label">
+              <span class="required-field-indicator">*</span> Sexe
+            </legend>
             <div class="radio-button-container">
               <input
                 type="radio"
@@ -76,6 +79,7 @@
                 >
               <label class="radio-button-label" for="male">Homme</label>
             </div>
+            </fieldset>
           </div>
 
           <div class="new-certification-candidate-details-modal__form__field">
@@ -111,8 +115,10 @@
 
           {{#if this.isBirthGeoCodeRequired}}
             <div class="new-certification-candidate-details-modal__form__field">
-              <span class="required-field-indicator">*</span>
-              Code géographique de naissance
+              <fieldset>
+              <legend class="label">
+                <span class="required-field-indicator">*</span> Code géographique de naissance
+              </legend>
               <div class="radio-button-container">
                 <input
                   type="radio"
@@ -133,6 +139,7 @@
                 >
                 <label class="radio-button-label" for="postal-code-choice">Code postal</label>
               </div>
+              </fieldset>
             </div>
           {{/if}}
 

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -17,7 +17,6 @@
   }
 
   &__content {
-    font-size: 0.875rem;
     color: $grey-70;
     border-top: 1px solid $grey-20;
     border-bottom: 1px solid $grey-20;
@@ -46,7 +45,6 @@
 
       label {
         display: block;
-        font-size: 0.875rem;
 
         &.radio-button-label {
           display: inline-block;

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -80,7 +80,6 @@
       .radio-button-container {
         align-items: center;
         display: flex;
-        margin-top: 12px;
       }
 
       &-double {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite à PIX-3692, les labels s'affichent avec un font-weight de 500. 
Certaines libellés de formulaires s'affichent différements car ce ne sont pas des labels.

## :bat: Solution
Harmoniser le tout, en appliquant le même style (font-weight 500)

## :spider_web: Remarques
Je ne vois pas le problême sur mon poste. Difficile de faire le test fonctionnel

## :ghost: Pour tester
- Verifier que les libellés s'affiche bien dans l'ajout de candidat sur une session
