### PR TITLE
 [FEATURE] Afficher dans l'onglet paramètre si l'envoi multiple pour une campagne de collecte de profils est activé ( PIX-3677).

### DIFF
--- a/api/lib/domain/read-models/CampaignReport.js
+++ b/api/lib/domain/read-models/CampaignReport.js
@@ -23,6 +23,7 @@ class CampaignReport {
     averageResult,
     badges = [],
     stages = [],
+    multipleSendings,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -44,6 +45,7 @@ class CampaignReport {
     this.averageResult = averageResult;
     this.badges = badges;
     this.stages = stages;
+    this.multipleSendings = multipleSendings;
   }
 
   get isAssessment() {

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -34,6 +34,7 @@ module.exports = {
         'stages',
         'badges',
         'groups',
+        'multipleSendings',
       ],
       stages: {
         ref: 'id',

--- a/api/tests/tooling/domain-builder/factory/build-campaign-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-report.js
@@ -22,6 +22,7 @@ module.exports = function buildCampaignReport({
   averageResult = 0.4,
   badges = [],
   stages = [],
+  multiplesendings = false,
 } = {}) {
   return new CampaignReport({
     id,
@@ -44,5 +45,6 @@ module.exports = function buildCampaignReport({
     averageResult,
     badges,
     stages,
+    multiplesendings,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -84,6 +84,7 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
             'custom-landing-page-text': report.customLandingPageText,
             'id-pix-label': report.idPixLabel,
             'is-archived': report.isArchived,
+            'multiple-sendings': report.multipleSendings,
             'target-profile-id': report.targetProfileId,
             'target-profile-name': report.targetProfileName,
             'target-profile-image-url': report.targetProfileImageUrl,

--- a/orga/app/components/campaign/settings.hbs
+++ b/orga/app/components/campaign/settings.hbs
@@ -5,6 +5,14 @@
         <dt class="label-text campaign-settings-content__label">{{t "pages.campaign-settings.campaign-type.title"}}</dt>
         <dd class="content-text campaign-settings-content__text">{{this.campaignType}}</dd>
       </div>
+      {{#if @campaign.isTypeProfilesCollection}}
+        <div class="campaign-settings-content">
+          <dt class="label-text campaign-settings-content__label">{{t
+              "pages.campaign-settings.multiple-sendings.title"
+            }}</dt>
+          <dd class="content-text campaign-settings-content__text">{{this.multipleSendingsText}}</dd>
+        </div>
+      {{/if}}
     </div>
     <div class="campaign-settings-row">
       {{#if @campaign.isTypeAssessment}}

--- a/orga/app/components/campaign/settings.js
+++ b/orga/app/components/campaign/settings.js
@@ -18,6 +18,12 @@ export default class CampaignSettings extends Component {
       : this.intl.t('pages.campaign-settings.campaign-type.profiles-collection');
   }
 
+  get multipleSendingsText() {
+    return this.args.campaign.multipleSendings
+      ? this.intl.t('pages.campaign-settings.multiple-sendings.status.enabled')
+      : this.intl.t('pages.campaign-settings.multiple-sendings.status.disabled');
+  }
+
   @action
   async archiveCampaign(campaignId) {
     try {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -23,6 +23,7 @@ export default class Campaign extends Model {
   @attr('number') participationsCount;
   @attr('number') sharedParticipationsCount;
   @attr('number') averageResult;
+  @attr('boolean') multipleSendings;
 
   @belongsTo('user') creator;
   @belongsTo('organization') organization;

--- a/orga/tests/integration/components/campaign/settings_test.js
+++ b/orga/tests/integration/components/campaign/settings_test.js
@@ -198,4 +198,63 @@ module('Integration | Component | Campaign::Settings', function (hooks) {
       });
     });
   });
+
+  module('display wether if a campaign is multiple sendings or not', function () {
+    module('when type is PROFILES_COLLECTION', function () {
+      test('it should display multiple sendings label', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'PROFILES_COLLECTION',
+        });
+
+        // when
+        await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+
+        // then
+        assert.contains('Envoi multiple');
+      });
+
+      test("it should display 'oui' when campaign is multiple sendings", async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'PROFILES_COLLECTION',
+          multipleSendings: true,
+        });
+
+        // when
+        await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+
+        // then
+        assert.contains('Oui');
+      });
+
+      test("it should display 'Non' when campaign is not multiple sendings", async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'PROFILES_COLLECTION',
+          multipleSendings: false,
+        });
+
+        // when
+        await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+
+        // then
+        assert.contains('Non');
+      });
+    });
+    module('when type is ASSESSMENT', function () {
+      test('it should not display multiple sendings label', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'ASSESSMENT',
+        });
+
+        // when
+        await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+
+        // then
+        assert.notContains('Envoi multiple');
+      });
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -310,6 +310,13 @@
       "direct-link": "Direct link",
       "external-user-id-label": "External user ID label",
       "landing-page-text": "Text to display on the starting page",
+      "multiple-sendings": {
+        "title": "Multiple Sendings",
+        "status": {
+          "enabled": "Yes",
+          "disabled": "No"
+        }
+      },
       "personalised-test-title": "Title of the customised test",
       "target-profile": "Target profile"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -310,6 +310,13 @@
       "direct-link": "Lien direct",
       "external-user-id-label": "Libellé de l'identifiant",
       "landing-page-text": "Texte de la page d'accueil",
+      "multiple-sendings": {
+        "title": "Envoi multiple",
+        "status": {
+          "enabled": "Oui",
+          "disabled": "Non"
+        }
+      },
       "personalised-test-title": "Titre du parcours",
       "target-profile": "Profil cible"
     },


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les campaigns d'envoi multiple sont maintenant ouverts, ce qui a introduit la possibilité d’envoyer plusieurs fois son résultat ou son profil à partir de la même campagne.
Pour améliorer l’affichage d’une campagne lorsque celle ci est créée, nous avons décidé d’ajouter des informations comme son type ou l’activation de l’envoi multiples dans l’onglet paramètres.

## :bat: Solution
Ajouter l'information de l'envoi multiple d'une campaign de "collect de profile" dans l’onglet paramètres 

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Allez sur Pix Orga --> campagne --> paramètres, Constater que l’information sur l'envoi multiple existe. ( Oui / Non )
