### PR TITLE
[TECH] Echouer le check de l'automerge si la PR a les labels "i18n needed" ou "blocked".

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types:
       - labeled
+      - unlabeled
   check_suite:
     types:
       - completed
@@ -10,6 +11,11 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
+      - name: verify labels
+        if: >
+          contains(github.event.pull_request.labels.*.name, ':earth_africa: i18n needed')
+          || contains(github.event.pull_request.labels.*.name, ':warning: Blocked')
+        run: exit 1
       - name: automerge
         uses: "pascalgn/automerge-action@v0.8.3"
         env:


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les PR sont souvent approuvées alors qu'il y manque des traductions ou qu'elle a été amenée à être re-travailler.
Des labels de PR 'i18n needed' et 'blocked' sont utilisés mais ne bloquent pas le merge.

## :bat: Solution
Vérifier dans le check de l'automerge, si ces deux labels ne sont pas présents.
S'ils le sont, alors le check échoue.

## :spider_web: Remarques
Je n'ai pas pris en compte le label "Development in progress" car si la PR est reviewable c'est qu'elle n'est pas en "Development in progress".

## :ghost: Pour tester
Ajouter/Enlever les labels sur cette PR et vérifier que le check de l'automerge passe ou non.
