### PR TITLE
[DESIGN] Corriger la hauteur du contenu dans Pix App

### DIFF
--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -1,4 +1,4 @@
-main {
+.main {
   min-height: calc(100vh - 101px - 100px);
 }
 

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -3,7 +3,7 @@
   <burger.outlet>
 
     <NavbarHeader @burger={{burger}} />
-    <main>
+    <main class="main">
       <PixBackgroundHeader id="main">
 
         {{#if this.model.isCertifiable}}

--- a/mon-pix/app/templates/competences/details.hbs
+++ b/mon-pix/app/templates/competences/details.hbs
@@ -4,7 +4,7 @@
   <burger.outlet>
 
     <NavbarHeader @burger={{burger}} />
-    <main id="main" class="background-banner-wrapper competence-details">
+    <main id="main" class="main background-banner-wrapper competence-details">
       <div class="background-banner"></div>
 
       <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -4,7 +4,7 @@
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
 
-    <main>
+    <main class="main">
       <PixBackgroundHeader>
         <PixBlock class="fill-in-campaign-code__container">
           <h1 class="fill-in-campaign-code__title rounded-panel-title">

--- a/mon-pix/app/templates/user-account.hbs
+++ b/mon-pix/app/templates/user-account.hbs
@@ -5,7 +5,7 @@
 
     <NavbarHeader @burger={{burger}} @campaignParticipations={{@model.campaignParticipations}} />
 
-    <main id="main">
+    <main id="main" class="main">
       <PixBackgroundHeader>
 
         <h1 class="user-account__title">{{t "pages.user-account.title"}}</h1>

--- a/mon-pix/app/templates/user-certifications/index.hbs
+++ b/mon-pix/app/templates/user-certifications/index.hbs
@@ -1,4 +1,4 @@
-<main id="main" class="page-container user-certifications-page__container">
+<main id="main" class="main page-container user-certifications-page__container">
   <h1 class="user-certifications-page__title">{{t "pages.certifications-list.title"}}</h1>
 
   <UserCertificationsPanel @certifications={{@model}} />

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -3,7 +3,7 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
-    <main id="main">
+    <main id="main" class="main">
       <header role="banner" class="background-banner">
         <div class="user-tutorials-banner">
           <img


### PR DESCRIPTION
## :jack_o_lantern: Problème
Lors d'une PR récente (https://github.com/1024pix/pix/pull/3641) le design du footer a été modifié lors de la design review avec Quentin.
Cependant la correction apportée n'était pas tout à fait adapté au problème.


En effet, le footer ne "collait" pas le bas des pages dont le contenu était mince. Pour résoudre ça, un `min-height: calc(100vh - 101px - 100px);` a été rajouté sur tout les `<main>` de l'app. 

Cependant cela a créé un décalage sur les pages n'ayant pas le footer : 
![image](https://user-images.githubusercontent.com/38167520/139077732-e31a01c3-8a18-4fe4-94ed-7d68eeda81b2.png)


## :bat: Solution
N'appliquer l'étirement du contenu UNIQUEMENT sur les pages concernées. 
![image](https://user-images.githubusercontent.com/38167520/139077808-47716a12-c575-4a90-98dd-a58b582cce49.png)


## :ghost: Pour tester
- naviguer sur toutes les pages de PixApp
- constater que le footer est bien en bas de chaques pages 
- constater que les pages ne changent pas de design même quand le footer n'est pas présent
