### PR TITLE
[TECH] Rendre les tests E2E plus résilients.

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Transition issue
       uses: atlassian/gajira-transition@master
       if: ${{ steps.find.outputs.issue }}
+      continue-on-error: true
       with:
         issue: ${{ steps.find.outputs.issue }}
         transition: "Move to 'Deployed in Integration'"

--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -12,5 +12,8 @@
   "projectId": "g2rfqp",
   "numTestsKeptInMemory": 0,
   "viewportWidth": 1500,
-  "nodeVersion": "system"
+  "nodeVersion": "system",
+  "retries": {
+    "runMode": 2
+  }
 }


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les timeouts E2E font apparaître les commits comme rouge dans Github
Si le ticket n'est pas au bon statut, le commit devient rouge dans Github

## :bat: Solution
Si on étend le timeout, on risque d'avoir des déviations non détectées.
On a préféré relancer le test en erreur au plus 2 fois.

Ignorer les erreurs sur le workflow de transition Jira

## :ghost: Pour tester
Merger le ticket et observer si les fails se reproduisent:
- [test CircleCI](https://app.circleci.com/pipelines/github/1024pix/pix?branch=dev&status=failed)
- [workflow Jira ](https://github.com/1024pix/pix/actions/workflows/on-dev-merge.yml?query=is%3Afailure)