### PR TITLE
[FEATURE] Compléter le wording pour les établissements qui se connecte sur Pix Orga (PIX-3695).

### DIFF
--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -14,6 +14,8 @@
     </div>
   {{/if}}
 
+  <p class="login-form__information">{{t "pages.login-form.mandatory-all-fields"}}</p>
+
   <form {{on "submit" this.authenticate}}>
 
     <div class="input-container">

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -43,7 +43,11 @@
         />
         <PixIconButton
           @icon="{{if this.isPasswordVisible "eye" "eye-slash"}}"
-          aria-label="{{t "pages.login-form.show-password"}}"
+          aria-label={{if
+            this.isPasswordVisible
+            (t "pages.login-form.hide-password")
+            (t "pages.login-form.show-password")
+          }}
           @triggerAction={{this.togglePasswordVisibility}}
           @withBackground={{false}}
           @color="dark-grey"

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -9,7 +9,7 @@
   {{/if}}
 
   {{#if this.isErrorMessagePresent}}
-    <div id="login-form-error-message" class="login-form__error-message error-message">
+    <div id="login-form-error-message" class="login-form__error-message error-message" role="alert">
       {{this.errorMessage}}
     </div>
   {{/if}}

--- a/orga/app/templates/join-request.hbs
+++ b/orga/app/templates/join-request.hbs
@@ -17,7 +17,10 @@
     {{else}}
       <h1 class="join-request__title">Activez ou récupérez votre espace</h1>
       <p class="join-request__description">
-        A l'attention des personnels de direction.
+        A l'attention des personnels de direction des établissements
+        <br />
+        scolaires publics et privés sous contrat.
+        <br />
         <br />
         Saisissez ces informations pour recevoir un lien d'activation à l'adresse e-mail de votre établissement et
         devenir administrateur de l'espace Pix Orga.

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -1,5 +1,5 @@
 {{page-title (t "pages.login.title")}}
-<div class="login-page">
+<main class="login-page">
   <div class="panel login-page__panel">
     <div class="panel__image">
       <img src="/pix-orga.svg" alt="Pix Orga" />
@@ -7,4 +7,4 @@
     <h1 class="form-title">{{t "pages.login.title"}}</h1>
     <Auth::LoginForm @isWithInvitation={{false}} @hasInvitationError={{this.hasInvitationError}} />
   </div>
-</div>
+</main>

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -2,7 +2,7 @@
 <div class="login-page">
   <div class="panel login-page__panel">
     <div class="panel__image">
-      <img src="/pix-orga.svg" alt="" role="none" />
+      <img src="/pix-orga.svg" alt="Pix Orga" />
     </div>
     <h1 class="form-title">{{t "pages.login.title"}}</h1>
     <Auth::LoginForm @isWithInvitation={{false}} @hasInvitationError={{this.hasInvitationError}} />

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -4,7 +4,7 @@
     <div class="panel__image">
       <img src="/pix-orga.svg" alt="" role="none" />
     </div>
-    <h3 class="form-title">{{t "pages.login.title"}}</h3>
+    <h1 class="form-title">{{t "pages.login.title"}}</h1>
     <Auth::LoginForm @isWithInvitation={{false}} @hasInvitationError={{this.hasInvitationError}} />
   </div>
 </div>

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -500,7 +500,8 @@
       "only-for-admin": "only for school administrations",
       "password": "Password",
       "show-password": "Show password",
-      "hide-password": "Hide password"
+      "hide-password": "Hide password",
+      "mandatory-all-fields": "All fields are required."
     },
     "login-or-register": {
       "title": "You have been invited to join the organisation {organizationName}",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -499,7 +499,8 @@
       "login": "Log in",
       "only-for-admin": "only for school administrations",
       "password": "Password",
-      "show-password": "Show password"
+      "show-password": "Show password",
+      "hide-password": "Hide password"
     },
     "login-or-register": {
       "title": "You have been invited to join the organisation {organizationName}",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -497,10 +497,10 @@
       "invitation-already-accepted": "Cette invitation a déjà été acceptée. Connectez-vous ou contactez l'administrateur de votre espace Pix Orga.",
       "is-only-accessible": "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.",
       "login": "Je me connecte",
-      "only-for-admin": "réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",
+      "only-for-admin": "Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",
       "password": "Mot de passe",
-      "show-password": "rendre le mot de passe lisible",
-      "hide-password": "masquer le mot de passe",
+      "show-password": "Afficher le mot de passe",
+      "hide-password": "Masquer le mot de passe",
       "mandatory-all-fields": "Tous les champs sont obligatoires."
     },
     "login-or-register": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -500,7 +500,8 @@
       "only-for-admin": "réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",
       "password": "Mot de passe",
       "show-password": "rendre le mot de passe lisible",
-      "hide-password": "masquer le mot de passe"
+      "hide-password": "masquer le mot de passe",
+      "mandatory-all-fields": "Tous les champs sont obligatoires."
     },
     "login-or-register": {
       "title": "Vous êtes invité(e) à rejoindre l'organisation {organizationName}",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -499,7 +499,8 @@
       "login": "Je me connecte",
       "only-for-admin": "réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",
       "password": "Mot de passe",
-      "show-password": "rendre le mot de passe lisible"
+      "show-password": "rendre le mot de passe lisible",
+      "hide-password": "masquer le mot de passe"
     },
     "login-or-register": {
       "title": "Vous êtes invité(e) à rejoindre l'organisation {organizationName}",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -497,7 +497,7 @@
       "invitation-already-accepted": "Cette invitation a déjà été acceptée. Connectez-vous ou contactez l'administrateur de votre espace Pix Orga.",
       "is-only-accessible": "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.",
       "login": "Je me connecte",
-      "only-for-admin": "réservé aux personnels de direction des établissements scolaires",
+      "only-for-admin": "réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",
       "password": "Mot de passe",
       "show-password": "rendre le mot de passe lisible"
     },


### PR DESCRIPTION
## :jack_o_lantern: Problème
Beaucoup d'établissements privés hors contrat tentent de se connecter à Pix Orga via leur UAI/RNE. 
Sur la page de connexion de Pix Orga rien n'indique qu'ils n'ont pas accès à leur interface au même titre que les établissements publics et privés sous-contrat.

## :bat: Solution
Mentionner les établissements publics et privés dans le wording des pages : 
- /connexion
- /demande-administration-sco

## :spider_web: Remarques
Amélioration de l'accessibilité de la page de connexion (/connexion), suite à l'audit de Tanaguru sur Pix Orga. (6/7)

1 - Le logo Pix Orga doit avoir une alternative textuelle (+retirer le role='none')
2 - Le bouton permettant d'afficher le mot de passe ne doit pas avoir le même intitulé quand on doit effectuer l'action inverse (re-masquer le mot de passe).
3 - Fournir un role="alert" aux messages d'erreur indiquant que l'e-mail et/ou le mot de passe sont incorrects pour qu'ils soient restitué par les lecteurs d'écran.
(Attention, pour fonctionner, la `<div>` contenant le message doit être présente à vide dans le code et se peupler lorsque le formulaire est soumis avec une ou des erreurs.)
4 - Le titre "Connectez-vous" devrait être un titre de niveau 1 ( actuellement à h3 )
5 - Utiliser des balises structurantes pour délimiter les zones de la page. Pour une structure simple on utilise un `<main></main>`.
6 - Les champs obligatoires portant un attribut "required" comme c'est le cas ici devraient avoir une indication visible située dans l'étiquette (mention "obligatoire" ou * explicitée)

## :ghost: Pour tester
Sur Pix Orga, se rendre sur la page /connexion.
⚠️ préciser le domaine en fr, car ce morceaux apparaît uniquement dans ce domaine
Vérifier la présence de cette phrase : "réservé aux personnels de direction des établissements scolaires publics et privés sous contrat."
⚠️ On a volontairement pas changé la traduction anglaise.

Se rendre sur /demande-administration-sco
Vérifier la présence de cette phrase : "A l'attention des personnels de direction des établissements scolaires publics et privés sous contrat."
( on peut constater que ce fichier `join-request.hbs` n'utilise pas de clés de traduction, c'est écrit en dur, car comme cette page n'est "accessible que sur le domaine fr", elle n'a pas été traduite. Est-ce que ce ticket doit changer ça ? )
