### PR TITLE
[FEATURE] Optimiser la page des utilisateurs dans Pix Admin qui déclenche des requêtes couteuses à chaque chargement et à chaque recherche (PIX-3667).

### DIFF
--- a/admin/app/components/users/list-items.hbs
+++ b/admin/app/components/users/list-items.hbs
@@ -7,36 +7,6 @@
         <th>Nom</th>
         <th>Adresse électronique</th>
       </tr>
-      <tr>
-        <th></th>
-        <th>
-          <input
-            id="firstName"
-            type="text"
-            value={{@firstName}}
-            oninput={{perform @triggerFiltering "firstName"}}
-            class="table-admin-input"
-          />
-        </th>
-        <th>
-          <input
-            id="lastName"
-            type="text"
-            value={{@lastName}}
-            oninput={{perform @triggerFiltering "lastName"}}
-            class="table-admin-input"
-          />
-        </th>
-        <th>
-          <input
-            id="email"
-            type="text"
-            value={{@email}}
-            oninput={{perform @triggerFiltering "email"}}
-            class="table-admin-input"
-          />
-        </th>
-      </tr>
     </thead>
 
     {{#if @users}}

--- a/admin/app/routes/authenticated/users/list.js
+++ b/admin/app/routes/authenticated/users/list.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+
 export default class ListRoute extends Route {
   @service store;
 
@@ -11,7 +12,9 @@ export default class ListRoute extends Route {
     email: { refreshModel: true },
   };
 
-  model(params) {
+  async model(params) {
+    if (!params.firstName && !params.lastName && !params.email) return [];
+
     return this.store.query('user', {
       filter: {
         firstName: params.firstName ? params.firstName.trim() : '',

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -1,7 +1,14 @@
 {{page-title "Utilisateurs"}}
+
 <header class="page-header">
-  <div class="page-title">Tous les utilisateurs</div>
+  <h1 class="page-title">Rechercher un(des) utilisateur(s)</h1>
   <div class="page-actions">
+    <form class="form-inline" {{on "submit" this.refreshModel}}>
+      <PixInput @id="firstName" @value={{this.firstNameForm}} placeholder="Prénom" />
+      <PixInput @id="lastName" @value={{this.lastNameForm}} placeholder="Nom" />
+      <PixInput @id="email" @value={{this.emailForm}} placeholder="Email" />
+      <PixButton @size="small" @type="submit">Charger</PixButton>
+    </form>
   </div>
 </header>
 
@@ -12,7 +19,6 @@
       @firstName={{this.firstName}}
       @lastName={{this.lastName}}
       @email={{this.email}}
-      @triggerFiltering={{this.triggerFiltering}}
     />
   </section>
 </main>

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -21,7 +21,24 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   test('User detail page can be accessed from user list page', async function (assert) {
-    await visit('/users');
+    const usersListAfterFilteredSearch = {
+      data: [
+        {
+          type: 'users',
+          id: '1',
+          attributes: {
+            'first-name': 'Pix',
+            'last-name': 'Aile',
+            email: 'userpix1@example.net',
+          },
+        },
+      ],
+    };
+
+    this.server.get('/users', () => usersListAfterFilteredSearch);
+
+    // when
+    await visit('/users/list?email=userpix1example.net');
     await click('tbody > tr:nth-child(1) > td:nth-child(1) > a');
     assert.equal(currentURL(), `/users/${currentUser.id}`);
   });

--- a/admin/tests/acceptance/user-list_test.js
+++ b/admin/tests/acceptance/user-list_test.js
@@ -33,27 +33,38 @@ module('Acceptance | User List', function (hooks) {
       assert.equal(currentURL(), '/users/list');
     });
 
-    test('it should list the users', async function (assert) {
-      // given
-      const nbUser = 12;
-      server.createList('user', nbUser);
-
+    test('it should not list the users at loading page', async function (assert) {
       // when
       await visit('/users/list');
 
       // then
-      assert.dom('.table-admin tbody tr').exists({ count: nbUser + 1 });
+      assert.dom('.table-admin tbody tr').doesNotExist();
     });
 
     test('it should display the current filter when users are filtered', async function (assert) {
       // given
-      server.createList('user', 12);
+      const expectedUsersCount = 1;
+      const result = {
+        data: [
+          {
+            type: 'users',
+            id: '1',
+            attributes: {
+              'first-name': 'Pix',
+              'last-name': 'Aile',
+              email: 'userpix1@example.net',
+            },
+          },
+        ],
+      };
+
+      this.server.get('/users', () => result);
 
       // when
-      await visit('/users/list?email=sav');
+      await visit('/users/list?email=example.net');
 
       // then
-      assert.dom('#email').hasValue('sav');
+      assert.dom('.table-admin tbody tr').exists({ count: expectedUsersCount });
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/users/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/users/list_test.js
@@ -9,16 +9,14 @@ module('Unit | Controller | authenticated/users/list', function (hooks) {
     controller = this.owner.lookup('controller:authenticated.users.list');
   });
 
-  module('#triggerFiltering task', function () {
+  module('#updateFilters', function () {
     module('updating firstName', function () {
       test('it should update controller firstName field', async function (assert) {
         // given
         controller.firstName = 'someFirstName';
         const expectedValue = 'someOtherFirstName';
-
         // when
-        await controller.triggerFiltering.perform('firstName', { target: { value: expectedValue } });
-
+        await controller.updateFilters({ firstName: expectedValue });
         // then
         assert.equal(controller.firstName, expectedValue);
       });
@@ -29,10 +27,8 @@ module('Unit | Controller | authenticated/users/list', function (hooks) {
         // given
         controller.lastName = 'someLastName';
         const expectedValue = 'someOtherLastName';
-
         // when
-        await controller.triggerFiltering.perform('lastName', { target: { value: expectedValue } });
-
+        await controller.updateFilters({ lastName: expectedValue });
         // then
         assert.equal(controller.lastName, expectedValue);
       });
@@ -43,10 +39,8 @@ module('Unit | Controller | authenticated/users/list', function (hooks) {
         // given
         controller.email = 'someEmail';
         const expectedValue = 'someOtherEmail';
-
         // when
-        await controller.triggerFiltering.perform('email', { target: { value: expectedValue } });
-
+        await controller.updateFilters({ email: expectedValue });
         // then
         assert.equal(controller.email, expectedValue);
       });

--- a/admin/tests/unit/routes/authenticated/users/list_test.js
+++ b/admin/tests/unit/routes/authenticated/users/list_test.js
@@ -25,7 +25,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
     });
 
     module('when queryParams filters are falsy', function () {
-      test('it should call store.query with no filters on name, type and externalId', async function (assert) {
+      test('it should not call store.query', async function (assert) {
         // when
         await route.model(params);
         expectedQueryArgs.filter = {
@@ -35,7 +35,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         };
 
         // then
-        sinon.assert.calledWith(route.store.query, 'user', expectedQueryArgs);
+        sinon.assert.notCalled(route.store.query);
         assert.ok(true);
       });
     });


### PR DESCRIPTION
## :jack_o_lantern: Problème

Lorsqu’on affiche la page utilisateur dans Pix admin, cette dernière fait appel à une requête très couteuse pour compter le nombre d’utilisateurs en production ( nb > 6 millions ). D’autant plus, à chaque fois qu’on saisit des caractères de recherche, une requête est déclenchée après 10 ms pour filtrer les données affichées. Or, cet affichage est impacté par les lenteurs de la recherche.

![image](https://user-images.githubusercontent.com/10045497/139315007-b4bfef65-538c-4691-befa-424c969065b3.png)

Exemple de temps de réponses couteux:

![image](https://user-images.githubusercontent.com/10045497/139315101-e3e7df69-e40f-44d0-a878-48238495b7d7.png)


Pour plus de détails => https://1024pix.slack.com/archives/C658LDBAQ/p1630339648020100

## :bat: Solution
Proposer un formulaire de recherche, et ne pas afficher la liste des utilisateurs par défaut dans Pix Admin. Pour filtrer on saisit les données à chercher et on clique sur un bouton rechercher qui déclencher un seul appel

## :spider_web: Remarques
La recherche via le formulaire enlève le mécanisme de recherche qui se déclenchait à chaque saisie de caractère.
On gagne un nombre important d'appels APIs qui consultent la table user qui est très volumineuse.
On peut étendre le même principe de recherche à d'autres pages afin de réduire le nombre d'appel et soulager la plateforme.

## :ghost: Pour tester
Faire une non régression pour la page utilisateur dans Pix Admin.
Vérifier que lors du chargement de la page aucun appel à l'API /user n'est pas effectué.