### PR TITLE
[BUGFIX] Fermer la tooltip dès que l'utilisateur clique dessus (PIX-3708).

### DIFF
--- a/mon-pix/app/components/challenge/statement/tooltip.js
+++ b/mon-pix/app/components/challenge/statement/tooltip.js
@@ -69,8 +69,8 @@ export default class Tooltip extends Component {
 
   @action
   async confirmInformationIsRead() {
-    await this._rememberUserHasSeenChallengeTooltip();
     this.shouldDisplayTooltip = false;
+    await this._rememberUserHasSeenChallengeTooltip();
   }
 
   async _rememberUserHasSeenChallengeTooltip() {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Quand les utilisateurs ont des problèmes de connexion, ils tentent de fermer la tooltip d'explication des épreuves, mais elle ne se ferme pas quand l'api ne répond pas.

## :bat: Solution
Fermer visuellement la tooltip, même si l'appel api n'a pas été refait

## :spider_web: Remarques
Pour l'utilisateur, il risque de revoir la tooltip tant qu'il n'a pas réussit à valider en cliquant sur "J'ai compris" et en faisant l'appel API pour s'en souvenir

## :ghost: Pour tester
Avoir un nouveau compte
Arriver sur une épreuve
Couper la connexion
Fermer la tooltip et voir qu'elle est bien fermé, même si l'api ne répond pas.