### PR TITLE
[BUGFIX] Ne plus voir les pointillés quand on revient en arrière après une focus (PIX-3720).

### DIFF
--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -1,6 +1,6 @@
 <article
   class="rounded-panel rounded-panel--no-margin-bottom challenge-item
-    {{if @hasFocusedOutOfChallenge "challenge-item--focused"}}"
+    {{if @isFocusedChallengeAndUserHasFocusedOutOfChallenge "challenge-item--focused"}}"
   data-challenge-id="{{@challenge.id}}"
   {{on "mouseenter" this.hideOutOfFocusBorder}}
   {{on "mouseleave" this.showOutOfFocusBorder}}

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -57,7 +57,7 @@
         @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
         @onFocusOutOfWindow={{this.focusedOutOfWindow}}
         @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
-        @hasFocusedOutOfChallenge={{this.hasFocusedOutOfChallenge}}
+        @isFocusedChallengeAndUserHasFocusedOutOfChallenge={{this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
       />
     {{/if}}
   </main>


### PR DESCRIPTION
## :jack_o_lantern: Problème
Lorsque l'utilisateur est sur une épreuve focus, voit les pointillés et revient en arrière, les pointillés reste.

## :bat: Solution
Ne plus utilisé l'attribut indiquant si on est sorti de la zone, mais `isFocusedChallengeAndUserHasFocusedOutOfChallenge` 

## :spider_web: Remarques

## :ghost: Pour tester
Passer le courses recBCwxarnE8QntZr et faire des retours en arrière quand on est sur une épreuve focus