### PR TITLE
[TECH] Linter les fichiers YAML.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ workflows:
           requires:
             - checkout
 
-
 jobs:
   checkout:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
           command: |
             npm ci
             npm run lint:scripts
+            npm run lint:yaml
             npm run test:ci
             rm -rf .git/
       - persist_to_workspace:

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,6 @@ insert_final_newline = false
 
 [*.{diff,md}]
 trim_trailing_whitespace = false
+
+[*.yml]
+quote_type = single

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,4 +1,6 @@
-extends: 'eslint:recommended'
+extends:
+  - 'eslint:recommended'
+  - 'plugin:yml/standard'
 root: true
 parserOptions:
   ecmaVersion: 2018
@@ -73,3 +75,7 @@ rules:
     - error
   no-multi-spaces:
     - error
+  yml/quotes:
+    - error
+    - prefer: single
+      avoidEscape: true

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,11 +17,11 @@ jobs:
           || contains(github.event.pull_request.labels.*.name, ':warning: Blocked')
         run: exit 1
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.8.3"
+        uses: pascalgn/automerge-action@v0.8.3
         env:
-          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
-          MERGE_LABELS: ":rocket: Ready to Merge"
-          MERGE_COMMIT_MESSAGE: "pull-request-title"
-          UPDATE_LABELS: ":rocket: Ready to Merge"
-          UPDATE_METHOD: "rebase"
-          MERGE_FORKS: "false"
+          GITHUB_TOKEN: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
+          MERGE_LABELS: ':rocket: Ready to Merge'
+          MERGE_COMMIT_MESSAGE: pull-request-title
+          UPDATE_LABELS: ':rocket: Ready to Merge'
+          UPDATE_METHOD: rebase
+          MERGE_FORKS: 'false'

--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -8,34 +8,34 @@ jobs:
     name: Transition Issue
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@master
+      - name: Checkout
+        uses: actions/checkout@master
 
-    - name: Login
-      uses: atlassian/gajira-login@master
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      - name: Login
+        uses: atlassian/gajira-login@master
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
-    - name: Find Issue Key
-      id: find
-      uses: atlassian/gajira-find-issue-key@master
-      continue-on-error: true
-      with:
-        from: commits
+      - name: Find Issue Key
+        id: find
+        uses: atlassian/gajira-find-issue-key@master
+        continue-on-error: true
+        with:
+          from: commits
 
-    - name: Transition issue
-      uses: atlassian/gajira-transition@master
-      if: ${{ steps.find.outputs.issue }}
-      continue-on-error: true
-      with:
-        issue: ${{ steps.find.outputs.issue }}
-        transition: "Move to 'Deployed in Integration'"
+      - name: Transition issue
+        uses: atlassian/gajira-transition@master
+        if: ${{ steps.find.outputs.issue }}
+        continue-on-error: true
+        with:
+          issue: ${{ steps.find.outputs.issue }}
+          transition: "Move to 'Deployed in Integration'"
 
-    - name: Notify team on config file change
-      uses: 1024pix/notify-team-on-config-file-change@v1.0.1
-      with:
-        GITHUB_TOKEN: ${{ github.token }}
-        SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}
-        INTEGRATION_ENV_URL: ${{ secrets.INTEGRATION_ENV_URL }}
+      - name: Notify team on config file change
+        uses: 1024pix/notify-team-on-config-file-change@v1.0.1
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}
+          INTEGRATION_ENV_URL: ${{ secrets.INTEGRATION_ENV_URL }}

--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -1,5 +1,5 @@
 extends:
-  - '../.eslintrc.yaml'
+  - ../.eslintrc.yaml
   - 'plugin:i18n-json/recommended'
   - 'plugin:mocha/recommended'
   - 'plugin:prettier/recommended'
@@ -17,12 +17,12 @@ rules:
   mocha/no-hooks-for-single-case: off
   no-sync: error
   no-restricted-syntax:
-     -  error
-     # These 2 selectors are duplicated from ../eslintrc.yaml as they are overridden by default
-     # TODO: find a way to keep without redefining them
-     -  selector: "NewExpression[callee.name=Date][arguments.length=1][arguments.0.type=Literal]:not([arguments.0.value=/^[12][0-9]{3}-(0[0-9]|1[0-2])-([0-2][0-9]|3[01])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z)?$/])"
-        message: "Use only ISO8601 UTC syntax ('2019-03-12T01:02:03Z') in Date constructor"
-     -  selector: "CallExpression[callee.object.object.name='faker'][callee.object.property.name='internet'][callee.property.name='email']"
-        message: "Use only faker.internet.exampleEmail()"
+    - error
+    # These 2 selectors are duplicated from ../eslintrc.yaml as they are overridden by default
+    # TODO: find a way to keep without redefining them
+    - selector: 'NewExpression[callee.name=Date][arguments.length=1][arguments.0.type=Literal]:not([arguments.0.value=/^[12][0-9]{3}-(0[0-9]|1[0-2])-([0-2][0-9]|3[01])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z)?$/])'
+      message: "Use only ISO8601 UTC syntax ('2019-03-12T01:02:03Z') in Date constructor"
+    - selector: "CallExpression[callee.object.object.name='faker'][callee.object.property.name='internet'][callee.property.name='email']"
+      message: Use only faker.internet.exampleEmail()
   knex/avoid-injections: error
   i18n-json/valid-message-syntax: warn

--- a/api/db/migrations/.eslintrc.yaml
+++ b/api/db/migrations/.eslintrc.yaml
@@ -1,4 +1,4 @@
-extends: '../../../.eslintrc.yaml'
+extends: ../../../.eslintrc.yaml
 
 rules:
   no-restricted-syntax: off

--- a/api/db/seeds/.eslintrc.yaml
+++ b/api/db/seeds/.eslintrc.yaml
@@ -1,4 +1,4 @@
-extends: '../../../.eslintrc.yaml'
+extends: ../../../.eslintrc.yaml
 
 rules:
   no-restricted-syntax: off

--- a/api/scripts/.eslintrc.yaml
+++ b/api/scripts/.eslintrc.yaml
@@ -1,4 +1,4 @@
-extends: '../.eslintrc.yaml'
+extends: ../.eslintrc.yaml
 
 env:
   mocha: true

--- a/api/tests/.eslintrc.yaml
+++ b/api/tests/.eslintrc.yaml
@@ -1,4 +1,4 @@
-extends: '../.eslintrc.yaml'
+extends: ../.eslintrc.yaml
 
 env:
   mocha: true

--- a/api/tests/integration/.eslintrc.yaml
+++ b/api/tests/integration/.eslintrc.yaml
@@ -1,6 +1,6 @@
-extends: '../.eslintrc.yaml'
+extends: ../.eslintrc.yaml
 
 rules:
   no-restricted-modules:
-    -  error
-    -  paths: ['@hapi/hapi']
+    - error
+    - paths: ['@hapi/hapi']

--- a/high-level-tests/test-algo/.eslintrc.yaml
+++ b/high-level-tests/test-algo/.eslintrc.yaml
@@ -1,4 +1,4 @@
-extends: '../../.eslintrc.yaml'
+extends: ../../.eslintrc.yaml
 
 globals:
   include: true

--- a/high-level-tests/test-algo/tests/.eslintrc.yaml
+++ b/high-level-tests/test-algo/tests/.eslintrc.yaml
@@ -1,4 +1,4 @@
-extends: '../.eslintrc.yaml'
+extends: ../.eslintrc.yaml
 
 env:
   mocha: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -4993,6 +4993,18 @@
         "ramda": "^0.27.1"
       }
     },
+    "eslint-plugin-yml": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-0.10.1.tgz",
+      "integrity": "sha512-af0WgO3qaH+RW6jv1s6RzXKlg2NZLisN95lqGUf1KqBT6rEJyGSCpM49QYaSTvzmMaB/gcdbrnAfNoYwUn0Yig==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "lodash": "^4.17.19",
+        "natural-compare": "^1.4.0",
+        "yaml-eslint-parser": "^0.4.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -10397,6 +10409,31 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
+    },
+    "yaml-eslint-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-0.4.1.tgz",
+      "integrity": "sha512-GoJ/p1EW8O2tbTbuhfxjo1XhfUFU3uX3kwvfEQoOaZjO2Lubx8POjlsSqB+18b3SxkujAdQYT9r9nURaUWNYWQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.1.0",
+        "lodash": "^4.17.20",
+        "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,9 @@
     "lint:mon-pix:json": "cd mon-pix && npm run lint:json",
     "lint:orga": "cd orga && npm run lint",
     "lint:orga:json": "cd orga && npm run lint:json",
-    "lint:scripts": "cd scripts && eslint .",
+    "lint:scripts": "cd scripts && eslint --ext .js .",
     "lint:json": "run-p --print-label lint:api:json lint:mon-pix:json lint:orga:json",
+    "lint:yaml": "eslint --ext .yml .circleci && eslint --ext .yml .github",
     "lint:docs": "find ./docs -type f -name '*.md' | xargs -L1 markdown-link-check --quiet --config ./docs/link--check-config.json ",
     "preinstall": "npx check-engine",
     "start": "run-p --print-label start:api start:mon-pix start:orga start:certif start:admin",
@@ -93,6 +94,7 @@
     "ember-template-lint": "^3.7.0",
     "eslint": "^7.20.0",
     "eslint-plugin-mocha": "^8.0.0",
+    "eslint-plugin-yml": "^0.10.1",
     "mocha": "^8.3.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint:mon-pix:json": "cd mon-pix && npm run lint:json",
     "lint:orga": "cd orga && npm run lint",
     "lint:orga:json": "cd orga && npm run lint:json",
-    "lint:scripts": "cd scripts && eslint --ext .js .",
+    "lint:scripts": "eslint scripts",
     "lint:json": "run-p --print-label lint:api:json lint:mon-pix:json lint:orga:json",
     "lint:yaml": "eslint --ext .yml .circleci && eslint --ext .yml .github",
     "lint:docs": "find ./docs -type f -name '*.md' | xargs -L1 markdown-link-check --quiet --config ./docs/link--check-config.json ",

--- a/scripts/.eslintrc.yaml
+++ b/scripts/.eslintrc.yaml
@@ -1,4 +1,4 @@
-extends: '../.eslintrc.yaml'
+extends: ../.eslintrc.yaml
 
 globals:
   include: true

--- a/scripts/local-domains/docker-compose.yml
+++ b/scripts/local-domains/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3'
 
 services:
   nginx:
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
     ports:
-      - "80:80"
+      - '80:80'
     container_name: pix_local_domains
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - 'host.docker.internal:host-gateway'


### PR DESCRIPTION
## :jack_o_lantern: Problème
Le fichier de configuration de CircleCi et des Github actions (entre autres) sont au format YAML.
Les indentations sont signifiantes dans ce format.
Dédicace `linterman` @sbedeau 

## :bat: Solution
Ajouter un plugin de lint (de préférence ESLint):
- [eslint-plugin-yaml](https://github.com/aminya/eslint-plugin-yaml): 13k weekely, peu de doc, pas de ` # eslint-disable`
- [eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml): 15k weekly, bonne doc

=> choix de `eslint-plugin-yml`

## :spider_web: Remarques
Ajout du set `recommended` par la même occasion.

Il y a un plugin VSCode mais pas IntelliJ.

J'ai dû configurer la simple quote comme délimiteur de chaine
```
  yml/quotes:
    - error
    - prefer: single
      avoidEscape: true
```

Pour matcher  le `.prettierrc.json`
```
{
  "singleQuote": true
}
```

## :ghost: Pour tester
Modifier l'indentation et vérifier que la CI casse
