### PR TITLE
[TECH] Mettre en avant la configuration de la CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,5 +387,5 @@ jobs:
 
       - run:
           name: Test
-          command: npm test
+          command: npm run test:ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
           command: npm run lint:ci
       - run:
           name: Test
-          command: npm test
+          command: npm run test:ci
 
   certif_build_and_test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ jobs:
           name: Test
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-          command: npx wait-on http://localhost:3000/api http://localhost:4200 http://localhost:4201 http://localhost:4203 && npm run cy:run:ci
+          command: npm run test:ci
       - store_test_results:
           path: /home/circleci/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
           command: npm run lint
       - run:
           name: Test
-          command: npm test
+          command: npm run test:ci
 
   e2e_test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           name: Lint and test
           command: |
             npm run lint
-            npm test
+            npm run test:ci
           environment:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
             MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           command: |
             npm ci
             npm run lint:scripts
-            npm run test:scripts
+            npm run test:ci
             rm -rf .git/
       - persist_to_workspace:
           root: ~/pix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
           command: npm run lint:ci
       - run:
           name: Test
-          command: npm test
+          command: npm run test:ci
 
   admin_build_and_test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,9 +144,8 @@ jobs:
           name: Lint
           command: npm run lint
       - run:
-         name: Test
-         command: |
-          npx ember exam --split=$CIRCLE_NODE_TOTAL --partition=$((1 + CIRCLE_NODE_INDEX)) --reporter dot
+          name: Test
+          command: npm run test:ci
 
   orga_build_and_test:
     docker:

--- a/admin/package.json
+++ b/admin/package.json
@@ -29,6 +29,7 @@
     "preinstall": "npx check-engine",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
+    "test:ci": "npm run test",
     "test:lint": "npm test && npm run lint",
     "test:watch": "ember exam --serve --reporter dot"
   },

--- a/api/package.json
+++ b/api/package.json
@@ -132,6 +132,7 @@
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
+    "test:ci": "npm run test",
     "test:lint": "npm test && npm run lint"
   },
   "nodemonConfig": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -33,6 +33,7 @@
     "preinstall": "npx check-engine",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
+    "test:ci": "npm run test",
     "test:lint": "npm test && npm run lint",
     "test:watch": "ember exam --serve --reporter dot"
   },

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -31,7 +31,8 @@
     "start:api": "cd ../../api && DATABASE_URL=postgresql://postgres@localhost/pix_test npm run start:watch",
     "start:mon-pix": "cd ../../mon-pix && npm start",
     "start:orga": "cd ../../orga && npm start",
-    "start:certif": "cd ../../certif && npm start"
+    "start:certif": "cd ../../certif && npm start",
+    "test:ci": "npx wait-on http://localhost:3000/api http://localhost:4200 http://localhost:4201 http://localhost:4203 && npm run cy:run:ci"
   },
   "devDependencies": {
     "axe-core": "^4.1.3",

--- a/high-level-tests/test-algo/package.json
+++ b/high-level-tests/test-algo/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "eslint . --fix",
     "test-unit": "mocha  --exit ./tests/*.js",
     "test-bash": "./tests/tests.sh",
-    "test": "npm run lint && npm run test-unit && npm run test-bash"
+    "test": "npm run lint && npm run test-unit && npm run test-bash",
+    "test:ci": "npm run test"
   },
   "keywords": [],
   "author": "GIP Pix",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -34,6 +34,7 @@
     "preinstall": "npx check-engine",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
+    "test:ci": "npx ember exam --split=$CIRCLE_NODE_TOTAL --partition=$((1 + CIRCLE_NODE_INDEX)) --reporter dot",
     "test:lint": "npm test && npm run lint",
     "test:watch": "ember exam --serve --reporter dot"
   },

--- a/orga/package.json
+++ b/orga/package.json
@@ -33,6 +33,7 @@
     "preinstall": "npx check-engine",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
+    "test:ci": "npm run test",
     "test:lint": "npm test && npm run lint",
     "test:watch": "ember exam --serve --reporter dot"
   },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "start:certif": "cd certif && npm start",
     "start:mon-pix": "cd mon-pix && npm start",
     "start:orga": "cd orga && npm start",
+    "test:ci" : "npm run test:scripts",
     "test": "run-p --print-label test:api test:mon-pix test:orga test:certif test:admin test:scripts",
     "test:admin": "cd admin && npm test",
     "test:api": "cd api && npm run lint && npm test",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les test automatisés exécutés par la CI sont :
- parfois la tâche par défaut `test`
- parfois une ligne de command custom, comme `npx ember exam --split=$CIRCLE_NODE_TOTAL --partition=$((1 + CIRCLE_NODE_INDEX)) --reporter dot",`

## :bat: Solution
Créer une tâche npm `test:ci` pour expliciter la commande lancée

## :spider_web: Remarques
C'est un poil plus verbeux, mais "better explicit than implicit", surtout pour des configurations qui ne changent presque jamais.

## :ghost: Pour tester
Vérifier que la CI passe toujours