### PR TITLE
[TECH] Ajouter le métrique duration dans le monitoring des appels externe en error.

### DIFF
--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -23,7 +23,9 @@ module.exports = {
         return usecases.startCampaignParticipation({ campaignParticipation, userId, domainTransaction });
       }
     );
-    events.eventDispatcher.dispatch(event).catch((error) => monitoringTools.logErrorWithCorrelationIds(error));
+    events.eventDispatcher
+      .dispatch(event)
+      .catch((error) => monitoringTools.logErrorWithCorrelationIds({ message: error }));
 
     return h.response(campaignParticipationSerializer.serialize(campaignParticipationCreated)).created();
   },
@@ -40,7 +42,9 @@ module.exports = {
       });
     });
 
-    events.eventDispatcher.dispatch(event).catch((error) => monitoringTools.logErrorWithCorrelationIds(error));
+    events.eventDispatcher
+      .dispatch(event)
+      .catch((error) => monitoringTools.logErrorWithCorrelationIds({ message: error }));
     return null;
   },
 

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -39,7 +39,7 @@ module.exports = {
 
       if (!tokenResponse.isSuccessful) {
         const errorMessage = _getErrorMessage(tokenResponse.data);
-        monitoringTools.logErrorWithCorrelationIds(errorMessage);
+        monitoringTools.logErrorWithCorrelationIds({ message: errorMessage });
         return {
           isSuccessful: tokenResponse.isSuccessful,
           code: tokenResponse.code || '500',
@@ -70,7 +70,7 @@ module.exports = {
 
     if (!httpResponse.isSuccessful) {
       const errorMessage = _getErrorMessage(httpResponse.data);
-      monitoringTools.logErrorWithCorrelationIds(errorMessage);
+      monitoringTools.logErrorWithCorrelationIds({ message: errorMessage });
     }
 
     return {

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -14,11 +14,12 @@ class HttpResponse {
 module.exports = {
   async post({ url, payload, headers }) {
     const startTime = performance.now();
+    let duration = null;
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
       });
-      const duration = performance.now() - startTime;
+      duration = performance.now() - startTime;
       logInfoWithCorrelationIds({
         metrics: { duration },
         message: `End POST request to ${url} success: ${httpResponse.status}`,
@@ -30,6 +31,7 @@ module.exports = {
         isSuccessful: true,
       });
     } catch (httpErr) {
+      duration = performance.now() - startTime;
       let code = null;
       let data;
 
@@ -40,7 +42,10 @@ module.exports = {
         data = httpErr.message;
       }
 
-      logErrorWithCorrelationIds({ message: `End POST request to ${url} error: ${code} ${data.toString()}` });
+      logErrorWithCorrelationIds({
+        metrics: { duration },
+        message: `End POST request to ${url} error: ${code || ''} ${data.toString()}`,
+      });
 
       return new HttpResponse({
         code,
@@ -51,10 +56,11 @@ module.exports = {
   },
   async get({ url, payload, headers }) {
     const startTime = performance.now();
+    let duration = null;
     try {
       const config = { data: payload, headers };
       const httpResponse = await axios.get(url, config);
-      const duration = performance.now() - startTime;
+      duration = performance.now() - startTime;
       logInfoWithCorrelationIds({
         metrics: { duration },
         message: `End GET request to ${url} success: ${httpResponse.status}`,
@@ -66,6 +72,7 @@ module.exports = {
         isSuccessful: true,
       });
     } catch (httpErr) {
+      duration = performance.now() - startTime;
       const isSuccessful = false;
 
       let code;
@@ -79,7 +86,10 @@ module.exports = {
         data = null;
       }
 
-      logErrorWithCorrelationIds(`End GET request to ${url} error: ${code}`);
+      logErrorWithCorrelationIds({
+        metrics: { duration },
+        message: `End GET request to ${url} error: ${code}`,
+      });
 
       return new HttpResponse({
         code,

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -28,7 +28,7 @@ function logInfoWithCorrelationIds(data) {
   }
 }
 
-function logErrorWithCorrelationIds(error) {
+function logErrorWithCorrelationIds(data) {
   if (settings.hapi.enableRequestMonitoring) {
     const context = asyncLocalStorage.getStore();
     const request = get(context, 'request');
@@ -36,11 +36,12 @@ function logErrorWithCorrelationIds(error) {
       {
         user_id: extractUserIdFromRequest(request),
         request_id: `${get(request, 'info.id', '-')}`,
+        ...get(data, 'metrics', {}),
       },
-      error
+      get(data, 'message', '-')
     );
   } else {
-    logger.error(error);
+    logger.error(get(data, 'message', '-'));
   }
 }
 

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -82,7 +82,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
 
       // then
       expect(events.eventDispatcher.dispatch).to.have.been.calledWith(campaignParticipationResultsSharedEvent);
-      expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith(errorInHandler);
+      expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({ message: errorInHandler });
     });
 
     context('when the request comes from a different user', function () {
@@ -218,7 +218,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const response = await campaignParticipationController.save(request, hFake);
 
       // then
-      expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith(errorInHandler);
+      expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({ message: errorInHandler });
       expect(campaignParticipationSerializer.serialize).to.have.been.calledWith(campaignParticipation);
       expect(response.statusCode).to.equal(201);
       expect(response.source).to.deep.equal(serializedCampaignParticipation);

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -227,7 +227,9 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           const result = await notify(userId, payload, poleEmploiSending);
 
           // then
-          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith(expectedLoggerMessage);
+          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+            message: expectedLoggerMessage,
+          });
           expect(result).to.deep.equal(expectedResult);
         });
 
@@ -274,7 +276,9 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           const result = await notify(userId, payload, poleEmploiSending);
 
           // then
-          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith(expectedLoggerMessage);
+          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+            message: expectedLoggerMessage,
+          });
           expect(result).to.deep.equal(expectedResult);
         });
       });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Il existe aujourd'hui un monitoring pour les appels externes comme Pôle Emploi.

Exemple Datadog ci-dessous:
https://app.datadoghq.eu/logs?cols=host%2Cservice%2C%40http.status_code%2C%40duration&context_event=AQAAAXxzuEKgkasW5AAAAABBWHh6dUVRVUFBQ21pb040cjRpOWx3QUE&event&from_ts=1631450038975&index=&live=true&messageDisplay=inline&query=service%3Apix-api-production+%40msg%3A%2AEnd%3FPOST%3Frequest%3Fto%2A&stream_sort=%40duration%2Cdesc&to_ts=1634042038975&viz=stream

Exemple en cas de réponse PE avec une erreur :
![image](https://user-images.githubusercontent.com/10045497/139457327-08cddf76-70e6-407a-9935-fea6f339e80b.png)

Néanmoins lorsque des erreurs 500 surviennent, on a pas le métrique duration.


## :bat: Solution
Rajouter le métrique duration pour les logs en ERROR du monitoring tools.


## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Tester une connexion avec Pole Emploi, démarrer une campagne et publier les résultats à PE.
Simuler une erreur dans le handler PE en faisant un throw new Error() et verifier que dans les logs, on dispose bien du métrique duration.