### PR TITLE
[FEATURE] Empêcher la connexion à Pix Certif en tant que surveilant si le FT n'est pas activé (PIX-3769).

### DIFF
--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -72,6 +72,10 @@ class User {
     return this.memberships.length > 0;
   }
 
+  isLinkedToCertificationCenters() {
+    return this.certificationCenterMemberships.length > 0;
+  }
+
   hasAccessToOrganization(organizationId) {
     return this.memberships.some((membership) => membership.organization.id === organizationId);
   }

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -17,6 +17,10 @@ function _checkUserAccessScope(scope, user) {
   if (scope === apps.PIX_ADMIN.SCOPE && !user.hasRolePixMaster) {
     throw new ForbiddenAccess(apps.PIX_ADMIN.NOT_PIXMASTER_MSG);
   }
+
+  if (scope === apps.PIX_CERTIF.SCOPE && !user.isLinkedToCertificationCenters()) {
+    throw new ForbiddenAccess(apps.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG);
+  }
 }
 
 module.exports = async function authenticateUser({ password, scope, source, username, tokenService, userRepository }) {

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -1,4 +1,5 @@
 const get = require('lodash/get');
+const { featureToggles } = require('../../config');
 
 const {
   ForbiddenAccess,
@@ -19,7 +20,9 @@ function _checkUserAccessScope(scope, user) {
   }
 
   if (scope === apps.PIX_CERTIF.SCOPE && !user.isLinkedToCertificationCenters()) {
-    throw new ForbiddenAccess(apps.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG);
+    if (!featureToggles.isEndTestScreenRemovalEnabled) {
+      throw new ForbiddenAccess(apps.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG);
+    }
   }
 }
 

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -103,6 +103,32 @@ describe('Unit | Domain | Models | User', function () {
     });
   });
 
+  describe('isLinkedToCertificationCenters', function () {
+    it('should be true if user has a role in a certification center', function () {
+      // given
+      const user = domainBuilder.buildUser({
+        certificationCenterMemberships: [domainBuilder.buildCertificationCenterMembership()],
+      });
+
+      // when
+      const isLinked = user.isLinkedToCertificationCenters();
+
+      // then
+      expect(isLinked).to.be.true;
+    });
+
+    it('should be false if user has no role in certification center', function () {
+      // given
+      const user = new User();
+
+      // when
+      const isLinked = user.isLinkedToCertificationCenters();
+
+      // then
+      expect(isLinked).to.be.false;
+    });
+  });
+
   describe('hasAccessToOrganization', function () {
     it('should be false is user has no access to no organizations', function () {
       // given

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -157,6 +157,28 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
       expect(error).to.be.an.instanceOf(ForbiddenAccess);
       expect(error.message).to.be.equal(expectedErrorMessage);
     });
+
+    it('should rejects an error when scope is pix-certif and user is not linked to any certification centers', async function () {
+      // given
+      const scope = appMessages.PIX_CERTIF.SCOPE;
+      const user = domainBuilder.buildUser({ email: userEmail, certificationCenterMemberships: [] });
+      authenticationService.getUserByUsernameAndPassword.resolves(user);
+
+      const expectedErrorMessage = appMessages.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG;
+
+      // when
+      const error = await catchErr(authenticateUser)({
+        username: userEmail,
+        password,
+        scope,
+        tokenService,
+        userRepository,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(ForbiddenAccess);
+      expect(error.message).to.be.equal(expectedErrorMessage);
+    });
   });
 
   context('when user should change password', function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Si le FT n'est pas activé, la page de mot de passe de session est affichée après connexion.

## :bat: Solution
Ne plus afficher le page en refusant la connexion

## :spider_web: Remarques
Pas de message d'information "Le portail surveillant n'est pas encore actif"

## :ghost: Pour tester
Désactiver le FT `FT_END_TEST_SCREEN_REMOVAL_ENABLED`

Se connecter en tant que `sco.admin@example.net`

Vérifier que la [connexion](https://certif-pr3676.review.pix.fr/) échoue

![image](https://user-images.githubusercontent.com/56302715/139463320-05b5d84d-f3b4-4d92-9863-3aa6021d8c29.png)
