### PR TITLE
[FEATURE] Autoriser l'accès à l'espace surveillant après entrée d'un numéro de session et mot de passe valide (PIX-3729).

### DIFF
--- a/api/db/database-builder/factory/build-session.js
+++ b/api/db/database-builder/factory/build-session.js
@@ -22,6 +22,7 @@ module.exports = function buildSession({
   juryComment = null,
   juryCommentAuthorId = null,
   juryCommentedAt = null,
+  supervisorPassword = null,
 } = {}) {
   if (_.isUndefined(certificationCenterId)) {
     const builtCertificationCenter = buildCertificationCenter();
@@ -48,6 +49,7 @@ module.exports = function buildSession({
     juryComment,
     juryCommentAuthorId,
     juryCommentedAt,
+    supervisorPassword,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/db/migrations/20211103094329_create-table-supervisor-accesses.js
+++ b/api/db/migrations/20211103094329_create-table-supervisor-accesses.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'supervisor-accesses';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('sessionId').references('sessions.id').notNullable();
+    t.integer('userId').references('users.id').notNullable();
+    t.dateTime('authorizedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -5,6 +5,7 @@ const sessionForMonitoringController = require('./session-for-supervising-contro
 const finalizedSessionController = require('./finalized-session-controller');
 const authorization = require('../preHandlers/authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
+const { sendJsonApiError, UnprocessableEntityError } = require('../http-errors');
 
 exports.register = async (server) => {
   server.route([
@@ -358,6 +359,33 @@ exports.register = async (server) => {
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',
           "Elle retourne les informations d'une session à surveiller",
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/sessions/supervise',
+      config: {
+        validate: {
+          payload: Joi.object({
+            data: {
+              id: Joi.string().required(),
+              type: 'supervisor-authentications',
+              attributes: {
+                'supervisor-password': Joi.string().required(),
+                'session-id': Joi.number().required(),
+              },
+            },
+          }),
+          failAction: (request, h) => {
+            return sendJsonApiError(new UnprocessableEntityError('Un des champs saisis n’est pas valide.'), h);
+          },
+        },
+        handler: sessionForMonitoringController.supervise,
+        tags: ['api', 'sessions', 'supervising'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          "Elle valide l'accès du'un surveillant à l'espace surveillant",
         ],
       },
     },

--- a/api/lib/application/sessions/session-for-supervising-controller.js
+++ b/api/lib/application/sessions/session-for-supervising-controller.js
@@ -13,4 +13,15 @@ module.exports = {
     const session = await usecases.getSessionForSupervising({ sessionId });
     return sessionForSupervisingSerializer.serialize(session);
   },
+
+  async supervise(request, h) {
+    if (!featureToggles.isEndTestScreenRemovalEnabled) {
+      throw new NotFoundError();
+    }
+
+    const { userId } = request.auth.credentials;
+    const { 'supervisor-password': supervisorPassword, 'session-id': sessionId } = request.payload.data.attributes;
+    await usecases.superviseSession({ sessionId, userId, supervisorPassword });
+    return h.response().code(204);
+  },
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -910,6 +910,12 @@ class EmailModificationDemandNotFoundOrExpiredError extends DomainError {
   }
 }
 
+class InvalidSessionSupervisorPasswordError extends DomainError {
+  constructor(message = 'Le mot de passe de la session ne correspond pas au numéro de la session.') {
+    super(message);
+  }
+}
+
 module.exports = {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryDemandExpired,
@@ -974,6 +980,7 @@ module.exports = {
   InvalidPasswordForUpdateEmailError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultError,
+  InvalidSessionSupervisorPasswordError,
   InvalidTemporaryKeyError,
   InvalidVerificationCodeError,
   ManyOrganizationsFoundError,

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -84,6 +84,10 @@ class Session {
   generateSupervisorPassword() {
     this.supervisorPassword = _.times(NB_CHAR, _randomCharacter).join('');
   }
+
+  isSupervisable(supervisorPassword) {
+    return this.supervisorPassword === supervisorPassword;
+  }
 }
 
 module.exports = Session;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -108,6 +108,7 @@ const dependencies = {
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
   stageRepository: require('../../infrastructure/repositories/stage-repository'),
   studentRepository: require('../../infrastructure/repositories/student-repository'),
+  supervisorAccessRepository: require('../../infrastructure/repositories/supervisor-access-repository'),
   tagRepository: require('../../infrastructure/repositories/tag-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),
   targetProfileShareRepository: require('../../infrastructure/repositories/target-profile-share-repository'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -322,6 +322,7 @@ module.exports = injectDependencies(
     startOrResumeCompetenceEvaluation: require('./start-or-resume-competence-evaluation'),
     startWritingCampaignAssessmentResultsToStream: require('./start-writing-campaign-assessment-results-to-stream'),
     startWritingCampaignProfilesCollectionResultsToStream: require('./start-writing-campaign-profiles-collection-results-to-stream'),
+    superviseSession: require('./supervise-session'),
     unarchiveCampaign: require('./unarchive-campaign'),
     unpublishSession: require('./unpublish-session'),
     updateCampaign: require('./update-campaign'),

--- a/api/lib/domain/usecases/supervise-session.js
+++ b/api/lib/domain/usecases/supervise-session.js
@@ -1,0 +1,17 @@
+const { SessionNotAccessible, InvalidSessionSupervisorPasswordError } = require('../errors');
+module.exports = async function superviseSession({
+  sessionId,
+  supervisorPassword,
+  userId,
+  sessionRepository,
+  supervisorAccessRepository,
+}) {
+  const session = await sessionRepository.get(sessionId);
+  if (!session.isSupervisable(supervisorPassword)) {
+    throw new InvalidSessionSupervisorPasswordError();
+  }
+  if (!session.isAccessible()) {
+    throw new SessionNotAccessible();
+  }
+  await supervisorAccessRepository.create({ sessionId, userId });
+};

--- a/api/lib/infrastructure/repositories/supervisor-access-repository.js
+++ b/api/lib/infrastructure/repositories/supervisor-access-repository.js
@@ -1,0 +1,7 @@
+const { knex } = require('../bookshelf');
+
+module.exports = {
+  async create({ sessionId, userId }) {
+    await knex('supervisor-accesses').insert({ sessionId, userId });
+  },
+};

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
@@ -1,0 +1,60 @@
+const {
+  expect,
+  databaseBuilder,
+  domainBuilder,
+  generateValidRequestAuthorizationHeader,
+  sinon,
+  knex,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+const { featureToggles } = require('../../../../lib/config');
+
+describe('Acceptance | Controller | session-for-supervising-controller-supervise', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  afterEach(function () {
+    return knex('supervisor-accesses').delete();
+  });
+
+  it('should return a HTTP 204 No Content', async function () {
+    // given
+    sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+    const session = domainBuilder.buildSession({ id: 121 });
+    session.generateSupervisorPassword();
+    const supervisorPassword = session.supervisorPassword;
+
+    databaseBuilder.factory.buildSession(session);
+    databaseBuilder.factory.buildUser({ id: 3456 });
+    await databaseBuilder.commit();
+
+    const headers = { authorization: generateValidRequestAuthorizationHeader(3456, 'pix-certif') };
+
+    const options = {
+      headers,
+      method: 'POST',
+      url: '/api/sessions/supervise',
+      payload: {
+        data: {
+          id: '1234',
+          type: 'supervisor-authentications',
+          attributes: {
+            'session-id': '121',
+            'supervisor-password': supervisorPassword,
+          },
+        },
+      },
+    };
+
+    // when
+    const response = await server.inject(options);
+
+    // then
+    const supervisedSessionInDB = await knex('supervisor-accesses').where({ userId: 3456, sessionId: 121 }).first();
+    expect(supervisedSessionInDB).to.exist;
+    expect(response.statusCode).to.equal(204);
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
@@ -1,0 +1,25 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const supervisorAccessRepository = require('../../../../lib/infrastructure/repositories/supervisor-access-repository');
+
+describe('Integration | Repository | supervisor-access-repository', function () {
+  describe('#create', function () {
+    afterEach(function () {
+      return knex('supervisor-accesses').delete();
+    });
+
+    it('should save a supervisor access', async function () {
+      // given
+      const sessionId = databaseBuilder.factory.buildSession().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      await supervisorAccessRepository.create({ sessionId, userId });
+
+      // then
+      const supervisorAccessInDB = await knex.from('supervisor-accesses').first();
+      expect(supervisorAccessInDB.sessionId).to.equal(sessionId);
+      expect(supervisorAccessInDB.userId).to.equal(userId);
+    });
+  });
+});

--- a/api/tests/unit/application/session/session-for-supervising-controller_test.js
+++ b/api/tests/unit/application/session/session-for-supervising-controller_test.js
@@ -57,4 +57,66 @@ describe('Unit | Controller | session-for-supervising', function () {
       });
     });
   });
+
+  describe('#supervise', function () {
+    context('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+      it('should return a HTTP 204 No Content', async function () {
+        // given
+        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+        const request = {
+          auth: {
+            credentials: {
+              userId: 274939274,
+            },
+          },
+          payload: {
+            data: {
+              attributes: {
+                'session-id': '123',
+                'supervisor-password': '567',
+              },
+            },
+          },
+        };
+        sinon.stub(usecases, 'superviseSession');
+        usecases.superviseSession
+          .withArgs({ sessionId: '123', userId: 274939274, supervisorPassword: '567' })
+          .resolves();
+
+        // when
+        const response = await sessionForSupervisingController.supervise(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
+    context('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is disabled', function () {
+      it('should throw a NotFoundError', async function () {
+        // given
+        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(false);
+        const request = {
+          auth: {
+            credentials: {
+              userId: 274939274,
+            },
+          },
+          payload: {
+            data: {
+              attributes: {
+                'session-id': '123',
+                'supervisor-password': '567',
+              },
+            },
+          },
+        };
+
+        // when
+        const error = await catchErr(sessionForSupervisingController.supervise)(request);
+
+        // then
+        expect(error).to.be.instanceof(NotFoundError);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -206,6 +206,31 @@ describe('Unit | Domain | Models | Session', function () {
       expect(isAccessible).to.be.false;
     });
   });
+
+  context('#isSupervisable', function () {
+    it('should return true when the supervisor password match', function () {
+      // given
+      const session = domainBuilder.buildSession.created();
+      session.generateSupervisorPassword();
+
+      // when
+      const isSupervisable = session.isSupervisable(session.supervisorPassword);
+
+      // then
+      expect(isSupervisable).to.be.true;
+    });
+
+    it('should return false when the supervisor password does not match', function () {
+      // given
+      const session = domainBuilder.buildSession.created();
+
+      // when
+      const isSupervisable = session.isSupervisable('NOT_MATCHING-SUPERVISOR_PASSWORD');
+
+      // then
+      expect(isSupervisable).to.be.false;
+    });
+  });
 });
 
 context('#generateSupervisorPassword', function () {

--- a/certif/app/adapters/supervisor-authentication.js
+++ b/certif/app/adapters/supervisor-authentication.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class SupervisorAuthenticationAdapter extends ApplicationAdapter {
+  urlForCreateRecord() {
+    return `${this.host}/${this.namespace}/sessions/supervise`;
+  }
+}

--- a/certif/app/components/login-session-supervisor-form.hbs
+++ b/certif/app/components/login-session-supervisor-form.hbs
@@ -8,13 +8,13 @@
 
   <p class="login-session-supervisor-form__required-fields-notice">Tous les champs sont obligatoires.</p>
 
-  {{#if this.isErrorMessagePresent}}
+  {{#if this.errorMessage}}
     <p id="login-session-supervisor-form-error-message" class="login-session-supervisor-form__error-message error-message">
       {{this.errorMessage}}
     </p>
   {{/if}}
 
-  <form class="login-session-supervisor-form__form" {{on 'submit' this.authenticate}}>
+  <form class="login-session-supervisor-form__form" {{on 'submit' this.superviseSession}}>
     <PixInput
       @id="session-id"
       @label="Numéro de la session"
@@ -28,7 +28,7 @@
       @information="Exemple : C-12345"
       @prefix="C-"
       placeholder="XXXXXX"
-      @value={{this.sessionSupervisorPassword}}
+      @value={{this.supervisorPassword}}
     />
 
     <PixButton

--- a/certif/app/components/login-session-supervisor-form.js
+++ b/certif/app/components/login-session-supervisor-form.js
@@ -1,19 +1,35 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import get from 'lodash/get';
 
 export default class LoginSessionSupervisorForm extends Component {
 
-  @tracked isErrorMessagePresent = false;
+  @tracked sessionId;
+  @tracked supervisorPassword;
   @tracked errorMessage = null;
-  sessionId = null;
-  sessionSupervisorPassword = null;
 
   @action
-  authenticate(event) {
+  async superviseSession(event) {
     event.preventDefault();
 
-    this.args.authorize(this.sessionId);
+    if (!this.sessionId || !this.supervisorPassword) {
+      this._displayError('Les champs "Numéro de la session" et "Mot de passe de session" sont obligatoires.');
+      return;
+    }
 
+    try {
+      await this.args.onFormSubmit({
+        sessionId: this.sessionId,
+        supervisorPassword: this.supervisorPassword,
+      });
+    } catch (error) {
+      const errorMessage = get(error, 'errors[0].detail');
+      this._displayError(errorMessage);
+    }
+  }
+
+  _displayError(message) {
+    this.errorMessage = message;
   }
 }

--- a/certif/app/controllers/login-session-supervisor.js
+++ b/certif/app/controllers/login-session-supervisor.js
@@ -2,11 +2,22 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-export default class LoginSessionSupervisor extends Controller {
+export default class LoginSessionSupervisorController extends Controller {
+  @service store;
   @service router;
 
   @action
-  async authorize(sessionId) {
+  async authenticateSupervisor({ sessionId, supervisorPassword }) {
+    const supervisorAuthentication = this.store.createRecord('supervisor-authentication', {
+      id: sessionId,
+      sessionId,
+      supervisorPassword,
+    });
+    try {
+      await supervisorAuthentication.save();
+    } finally {
+      supervisorAuthentication.unloadRecord();
+    }
     return this.router.transitionTo('session-supervising', sessionId);
   }
 }

--- a/certif/app/models/supervisor-authentication.js
+++ b/certif/app/models/supervisor-authentication.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class SupervisorAuthentication extends Model {
+  @attr('string') sessionId;
+  @attr('string') supervisorPassword;
+}

--- a/certif/app/routes/login-session-supervisor.js
+++ b/certif/app/routes/login-session-supervisor.js
@@ -20,8 +20,4 @@ export default class LoginSessionSupervisorRoute extends Route {
       this.router.replaceWith('terms-of-service');
     }
   }
-
-  model() {
-    return this.currentUser.currentAllowedCertificationCenterAccess;
-  }
 }

--- a/certif/app/templates/login-session-supervisor.hbs
+++ b/certif/app/templates/login-session-supervisor.hbs
@@ -1,4 +1,4 @@
 {{page-title "Connexion à l'espace surveillant"}}
 <div class="login-session-supervisor-page">
-  <LoginSessionSupervisorForm @authorize={{this.authorize}} />
+  <LoginSessionSupervisorForm @onFormSubmit={{this.authenticateSupervisor}}/>
 </div>

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -185,4 +185,13 @@ export default function() {
   this.get('/countries', (schema, _) => {
     return schema.countries.all();
   });
+
+  this.get('/sessions/:id/supervising', (schema, request) => {
+    const sessionId = request.params.id;
+    return schema.sessionForSupervisings.find(sessionId);
+  });
+
+  this.post('/sessions/supervise', () => {
+    return new Response(204);
+  });
 }

--- a/certif/tests/acceptance/supervisor-portal-access_test.js
+++ b/certif/tests/acceptance/supervisor-portal-access_test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { fillIn, click, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit as visitScreen } from '@pix/ember-testing-library';
+import { authenticateSession } from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Supervisor Portal', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    const certificationPointOfContact = server.create('certification-point-of-contact', {
+      firstName: 'Buffy',
+      lastName: 'Summers',
+      pixCertifTermsOfServiceAccepted: true,
+      allowedCertificationCenterAccesses: [],
+    });
+    await authenticateSession(certificationPointOfContact.id);
+
+    server.create('session-for-supervising', { id: 12345 });
+  });
+
+  module('When supervisor authentication is successful', function() {
+    test('it should redirect to ', async function(assert) {
+      // given
+      const screen = await visitScreen('/connexion-espace-surveillant');
+      await fillIn(screen.getByLabelText('Numéro de la session'), '12345');
+      await fillIn(screen.getByLabelText('Mot de passe de la session'), '6789');
+
+      // when
+      await click(screen.getByText('Surveiller la session'));
+
+      // then
+      assert.equal(currentURL(), '/sessions/12345/surveiller');
+    });
+  });
+});

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -1,8 +1,8 @@
-/* eslint-disable ember/no-classic-classes,ember/require-tagless-components*/
-
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import { click, fillIn } from '@ember/test-helpers';
 import { render as renderScreen } from '@pix/ember-testing-library';
+import sinon from 'sinon';
 
 import hbs from 'htmlbars-inline-precompile';
 
@@ -11,11 +11,55 @@ module('Integration | Component | login-session-supervisor-form', function(hooks
 
   test('it should render supervisor login form', async function(assert) {
     // when
-    const screen = await renderScreen(hbs`<LoginSessionSupervisorForm />`);
+    this.onFormSubmit = sinon.stub();
+    const screen = await renderScreen(hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}} />`);
 
     // then
     assert.dom(screen.getByLabelText('Numéro de la session')).exists();
     assert.dom(screen.getByLabelText('Mot de passe de la session')).exists();
     assert.dom(screen.getByText('Surveiller la session')).exists();
+  });
+
+  module('On click on supervise button', function() {
+    test('it should display an error message when the session id is empty', async function(assert) {
+      // given
+      this.onFormSubmit = sinon.stub();
+      const screen = await renderScreen(hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}} />`);
+      await fillIn(screen.getByLabelText('Mot de passe de la session'), '12345');
+
+      // when
+      await click(screen.getByText('Surveiller la session'));
+
+      // then
+      assert.contains('Les champs "Numéro de la session" et "Mot de passe de session" sont obligatoires.');
+    });
+
+    test('it should display an error message when the supervisor password is empty', async function(assert) {
+      // given
+      this.onFormSubmit = sinon.stub();
+      const screen = await renderScreen(hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}} />`);
+      await fillIn(screen.getByLabelText('Numéro de la session'), '12345');
+
+      // when
+      await click(screen.getByText('Surveiller la session'));
+
+      // then
+      assert.contains('Les champs "Numéro de la session" et "Mot de passe de session" sont obligatoires.');
+    });
+
+    test('it should call onFormSubmit when all the fields are filled', async function(assert) {
+      // given
+      this.onFormSubmit = sinon.stub();
+      const screen = await renderScreen(hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}} />`);
+      await fillIn(screen.getByLabelText('Numéro de la session'), '12345');
+      await fillIn(screen.getByLabelText('Mot de passe de la session'), '6789');
+
+      // when
+      await click(screen.getByText('Surveiller la session'));
+
+      // then
+      sinon.assert.calledWith(this.onFormSubmit, { sessionId: '12345', supervisorPassword: '6789' });
+      assert.ok(true);
+    });
   });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème
L'accès au portail surveillant s'effectue grâce à la saisie du numéro de la session et du mot de passe surveillant associé. Aujourd'hui, la concordance de ces champs n'est pas vérifiée.

## :bat: Solution
- Ajout du endpoint POST /api/sessions/supervise afin de permettre le contrôle des champs saisis dans le formulaire d'accès à l'espace surveillant.

## :ghost: Pour tester
- Se connecter à Pix Certif avec le compte `certif-success@example.net`.
- Rentrer les informations numéro de session 1 et mot de passe surveillant 1111.
- Vérifier que l'on arrive bien sur l'espace surveillant pour la session 1.
- Se déconnecter en rentrant l'url `/logout`.
- Refaire le même test avec la session 3 et le mot de passe surveillant 3333.
- Vérifier en base que la table `supervised-sessions` a bien été alimentée avec les deux accès.