### PR TITLE
[BUGFIX] Mettre à jour la version d'hapi utilisée

### DIFF
--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -87,7 +87,7 @@ function pushInContext(path, value) {
 function installHapiHook() {
   if (!settings.hapi.enableRequestMonitoring) return;
 
-  if (require('@hapi/hapi/package.json').version !== '20.1.3') {
+  if (require('@hapi/hapi/package.json').version !== '20.2.1') {
     throw new Error('Hapi version changed, please check if patch still works');
   }
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
La version utilisée d'hapi est fixée dans le code et n'a pas été mis à jour durant la montée de version.

## :bat: Solution
Mettre à jour la version utilisée.

## :spider_web: Remarques
Je ne comprends pas l'intérêt de vérifier la version dans le code, sachant que c'est le but du `package-lock.json`

## :ghost: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
