### PR TITLE
[FEATURE] Assurer le type d'un centre de certification (PIX-3777).

### DIFF
--- a/api/db/migrations/20211029181054_set-certification-center-type-as-not-null.js
+++ b/api/db/migrations/20211029181054_set-certification-center-type-as-not-null.js
@@ -1,0 +1,7 @@
+exports.up = function(knex) {
+  return knex.raw('ALTER TABLE "certification-centers" ALTER COLUMN "type" SET NOT NULL');
+};
+
+exports.down = function(knex) {
+  return knex.raw('ALTER TABLE "certification-centers" ALTER COLUMN "type" DROP NOT NULL');
+};

--- a/api/db/seeds/data/certification/certification-center-memberships-builder.js
+++ b/api/db/seeds/data/certification/certification-center-memberships-builder.js
@@ -3,7 +3,6 @@ const {
   SCO_LYCEE_CERTIF_CENTER_ID,
   PRO_CERTIF_CENTER_ID,
   SUP_CERTIF_CENTER_ID,
-  NONE_CERTIF_CENTER_ID,
   DROIT_CERTIF_CENTER_ID,
   SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID,
   AGRI_SCO_MANAGING_STUDENT_ID,
@@ -12,7 +11,6 @@ const {
   PIX_SCO_CERTIF_USER_ID,
   PIX_PRO_CERTIF_USER_ID,
   PIX_SUP_CERTIF_USER_ID,
-  PIX_NONE_CERTIF_USER_ID,
   CERTIF_REGULAR_USER1_ID,
   CERTIF_DROIT_USER5_ID,
 } = require('./users');
@@ -41,6 +39,5 @@ module.exports = function certificationCenterMembershipsBuilder({ databaseBuilde
 
   databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_PRO_CERTIF_USER_ID, certificationCenterId: PRO_CERTIF_CENTER_ID });
   databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_SUP_CERTIF_USER_ID, certificationCenterId: SUP_CERTIF_CENTER_ID });
-  databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_NONE_CERTIF_USER_ID, certificationCenterId: NONE_CERTIF_CENTER_ID });
   databaseBuilder.factory.buildCertificationCenterMembership({ userId: CERTIF_DROIT_USER5_ID, certificationCenterId: DROIT_CERTIF_CENTER_ID });
 };

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -7,8 +7,6 @@ const PRO_CERTIF_CENTER_ID = 2;
 const PRO_CERTIF_CENTER_NAME = 'Centre PRO des Anne-Étoiles';
 const SUP_CERTIF_CENTER_ID = 3;
 const SUP_CERTIF_CENTER_NAME = 'Centre SUP des Anne-Étoiles';
-const NONE_CERTIF_CENTER_ID = 4;
-const NONE_CERTIF_CENTER_NAME = 'Centre NOTYPE des Anne-Étoiles';
 const DROIT_CERTIF_CENTER_ID = 5;
 const DROIT_CERTIF_CENTER_NAME = 'Centre DROIT des Anne-Étoiles';
 const SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID = 6;
@@ -97,15 +95,9 @@ function certificationCentersBuilder({ databaseBuilder }) {
   });
 
   databaseBuilder.factory.buildCertificationCenter({
-    id: NONE_CERTIF_CENTER_ID,
-    name: NONE_CERTIF_CENTER_NAME,
-    type: null,
-  });
-
-  databaseBuilder.factory.buildCertificationCenter({
     id: DROIT_CERTIF_CENTER_ID,
     name: DROIT_CERTIF_CENTER_NAME,
-    type: null,
+    type: 'SUP',
   });
 
   for (let i = 0; i < 200; i++) {
@@ -125,8 +117,6 @@ module.exports = {
   PRO_CERTIF_CENTER_NAME,
   SUP_CERTIF_CENTER_ID,
   SUP_CERTIF_CENTER_NAME,
-  NONE_CERTIF_CENTER_ID,
-  NONE_CERTIF_CENTER_NAME,
   DROIT_CERTIF_CENTER_ID,
   DROIT_CERTIF_CENTER_NAME,
   SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID,

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -297,7 +297,7 @@ describe('Integration | Repository | Certification Center', function () {
 
     it('should save the given certification center', async function () {
       // given
-      const certificationCenter = new CertificationCenter({ name: 'CertificationCenterName' });
+      const certificationCenter = new CertificationCenter({ name: 'CertificationCenterName', type: 'SCO' });
 
       // when
       const savedCertificationCenter = await certificationCenterRepository.save(certificationCenter);


### PR DESCRIPTION
## :jack_o_lantern: Problème
Il fut un temps où un centre de certification pouvait ne pas avoir de type, mais ce temps est révolu.
Il existe bien une contrainte qui impose un type s'il est défini, mais il peut ne pas être renseigné.
```
Check constraints:
    "certification-centers_type_check" CHECK (type = ANY (ARRAY['SCO'::text, 'SUP'::text, 'PRO'::text]))
```
Cela peut poser problème lors d'une modification de données manuelle: s'il est passé à `NULL`, il n'est plus modifiable dans PixAdmin

![image](https://user-images.githubusercontent.com/56302715/139831222-9d33e6d1-8bfa-41e4-845f-2971e917b5a5.png)


## :bat: Solution
Empêcher que ce type ne soit pas renseigné en ajoutant `une contrainte NOT NULL`

## :spider_web: Remarques
Supprimer les seeds associées.

L'absence l'absence de type a été vérifié en :
- recette
- production

```sql
select * from "certification-centers" where type IS NULL;
```

Les 2 centres avec un type NULL en intégration ont été supprimés manuellement.

## :ghost: Pour tester

Créer un centre manuellement
```sql
INSERT INTO "certification-centers" (name, type) VALUES ('foo', NULL);
```

Vérifier le message
```
[2021-11-02 11:38:17] [23502] ERROR: null value in column "type" of relation "certification-centers" violates not-null constraint
[2021-11-02 11:38:17] Detail: Failing row contains (10000001, foo, 2021-11-02 10:38:17.485636+00, null, null
```
