### PR TITLE
[BUGFIX] Mettre à jour le menu après la déconnexion via la page de lancement d'une campagne (PIX-3722)

### DIFF
--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class NavbarDesktopHeader extends Component {
   @service router;
@@ -8,7 +7,9 @@ export default class NavbarDesktopHeader extends Component {
   @service intl;
   @service currentUser;
 
-  @tracked isUserLogged = this.session.isAuthenticated;
+  get isUserLogged() {
+    return this.session.isAuthenticated;
+  }
 
   get menu() {
     return this.isUserLogged || this._isExternalUser ? [] : this._menuItems;

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -48,9 +48,9 @@
           {{#if this.showWarningMessage}}
             <div class="fill-in-campaign-code__warning">
               <span>{{this.warningMessage}}</span>
-              <a href="#" class="link" {{action this.disconnect}}>{{t
-                  "pages.fill-in-campaign-code.warning-message-logout"
-                }}</a>
+              <a href="#" class="link" {{action this.disconnect}}>
+                {{t "pages.fill-in-campaign-code.warning-message-logout"}}
+              </a>
             </div>
           {{/if}}
         </PixBlock>

--- a/mon-pix/tests/acceptance/user-dashboard_test.js
+++ b/mon-pix/tests/acceptance/user-dashboard_test.js
@@ -8,6 +8,7 @@ import visit from '../helpers/visit';
 import { authenticateByEmail } from '../helpers/authentication';
 import { contains } from '../helpers/contains';
 import setupIntl from '../helpers/setup-intl';
+import { clickByLabel } from '../helpers/click-by-label';
 
 const ASSESSMENT = 'ASSESSMENT';
 
@@ -46,6 +47,21 @@ describe('Acceptance | User dashboard page', function () {
   describe('campaign-participation-overviews', function () {
     beforeEach(async function () {
       user = server.create('user', 'withEmail');
+    });
+
+    describe('when user is on campaign start page', function () {
+      it('it should change menu on click on disconnect link', async function () {
+        // given
+        await authenticateByEmail(user);
+        await visit('/campagnes');
+
+        // when
+        await clickByLabel(this.intl.t('pages.fill-in-campaign-code.warning-message-logout'));
+
+        // then
+        expect(contains(user.firstName)).to.be.null;
+        expect(contains(this.intl.t('navigation.not-logged.sign-in')));
+      });
     });
 
     describe('when user is doing a campaign of type assessment', function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Lorsqu'un utilisateur est connecté et se rend sur la page de la campagne il peut se déconnecter via un lien présent sur cette page.

Cependant lorsque l'utilisateur clique sur le lien, le menu ne change pas et s'affiche comme si la personne était encore connectée alors qu'elle ne l'est plus.

## :bat: Solution
Afficher la bonne version du menu lorsque l'utilisateur cliquer sur "Se déconnecter" de la page pour lancer une campagne.

## :spider_web: Remarques
RAS

## :ghost: Pour tester
Lancer l'API et mon-pix
- Se connecter sur PixApp avec n'importe quel utilisateur (`certif-success@example.net` par ex)
- Aller sur `/campagnes` 
- Cliquer sur le lien `Vous n'êtes pas AnneSuccess Certif ? Se déconnecter` 
- Constater que le menu change en conséquence : le menu utilisateur "AnneSuccess", les onglets "Accueil", "Compétences", "Certification", "Mes tutos", "J'ai un code" on disparu et on été remplacé par "Se connecter" et "S'inscrire".
