### PR TITLE
[BUGFIX] Use https instead of git protocol for pix-ui dependency

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -28142,8 +28142,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#692ab777207865162e5405c65d8c9bc3c9b21538",
-      "from": "git://github.com/1024pix/pix-ui.git#v8.4.0",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v8.4.0",
+      "integrity": "sha512-tsOKzotYTV1pXjFv73ikUDCY+2UuIqkY564x337WkjfYGSJb6NtSXOGk9Dx5DD0bKPC7eUeoOM0WVbJersRfQQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/admin/package.json
+++ b/admin/package.json
@@ -102,7 +102,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.1",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v8.4.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v8.4.0",
     "popper.js": "^1.16.1",
     "prettier": "^2.4.1",
     "query-string": "^7.0.0",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -35148,8 +35148,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#254dc026b2312f22c5e02a3ee84bec64cf0870b4",
-      "from": "git://github.com/1024pix/pix-ui.git#v10.0.0",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v10.0.0",
+      "integrity": "sha512-bR/XHTY5/0SwujvhF4yop2at1NVAM/qKhefzKEtKqyKYCVhPHwSwQssIcFQ1VDiLOKWJFwkCVV3cWo4FmtOXZA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -118,7 +118,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v10.0.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v10.0.0",
     "prettier": "^2.4.1",
     "sass": "^1.38.0",
     "showdown": "^1.9.1",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26433,8 +26433,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#3525b98e7a6c759cd3c833d1063bd8b096173705",
-      "from": "git://github.com/1024pix/pix-ui.git#v9.1.0",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v9.1.0",
+      "integrity": "sha512-VRj+TPEleSrKw3bVV9+/Vda1xT3UJrkfzl2GsAx/jojyT91kY4h3rhpANnsTTo0DSPP76wE3nqSc4qKRHrpoew==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package.json
+++ b/orga/package.json
@@ -99,7 +99,7 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v9.1.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v9.1.0",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",


### PR DESCRIPTION

## :jack_o_lantern: Problème
Suite à une sécurisation des appels à GitHub (ref : https://github.blog/2021-09-01-improving-git-protocol-security-github/), le téléchargement des dépendances à Pix-UI ne fonctionnent plus

## :bat: Solution
Il ne faut désormais plus passer par le protocol `git`, mais par un protocol sécurisé tel que `ssh` ou `https:`

## :ghost: Pour tester
Vérifier que les dépendances sont bien téléchargeables, et que la commande `npm ci` passe correctement.
