### PR TITLE
[FEATURE] Afficher les certifications complémentaires dans la modale d'inscription d'un candidat à une session de certification (PIX-3685)

### DIFF
--- a/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
@@ -1,13 +1,22 @@
 const { features } = require('../../config');
 
 class AllowedCertificationCenterAccess {
-  constructor({ id, name, externalId, type, isRelatedToManagingStudentsOrganization, relatedOrganizationTags }) {
+  constructor({
+    id,
+    name,
+    externalId,
+    type,
+    isRelatedToManagingStudentsOrganization,
+    relatedOrganizationTags,
+    habilitations,
+  }) {
     this.id = id;
     this.name = name;
     this.externalId = externalId;
     this.type = type;
     this.isRelatedToManagingStudentsOrganization = isRelatedToManagingStudentsOrganization;
     this.relatedOrganizationTags = relatedOrganizationTags;
+    this.habilitations = habilitations;
   }
 
   isAccessBlockedCollege() {

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -24,6 +24,7 @@ module.exports = {
           'isAccessBlockedAEFE',
           'isAccessBlockedAgri',
           'relatedOrganizationTags',
+          'habilitations',
         ],
       },
       typeForAttribute: function (attribute) {

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -78,6 +78,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         type: CertificationCenter.types.PRO,
         isRelatedToManagingStudentsOrganization: true,
         relatedOrganizationTags: [],
+        habilitations: [],
       });
       const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 456,
@@ -172,6 +173,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         type: CertificationCenter.types.PRO,
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: [],
+        habilitations: [],
       });
       const expectedSecondAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 2,
@@ -180,6 +182,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         type: CertificationCenter.types.PRO,
         isRelatedToManagingStudentsOrganization: true,
         relatedOrganizationTags: [],
+        habilitations: [],
       });
       const expectedThirdAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 3,
@@ -188,6 +191,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         type: CertificationCenter.types.SUP,
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: ['premier tag'],
+        habilitations: [],
       });
       const expectedFourthAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 4,
@@ -196,6 +200,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         type: CertificationCenter.types.SCO,
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: ['deuxieme tag', 'troisieme tag'],
+        habilitations: [],
       });
       const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 123,
@@ -208,6 +213,91 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
           expectedSecondAllowedCertificationCenterAccess,
           expectedThirdAllowedCertificationCenterAccess,
           expectedFourthAllowedCertificationCenterAccess,
+        ],
+      });
+      expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
+    });
+
+    it('should return all the certification center habilitations', async function () {
+      // given
+      databaseBuilder.factory.buildComplementaryCertification({ id: 1, name: 'Certif comp 1' });
+      databaseBuilder.factory.buildComplementaryCertification({ id: 2, name: 'Certif comp 2' });
+      databaseBuilder.factory.buildComplementaryCertification({ id: 3, name: 'Certif comp 3' });
+      databaseBuilder.factory.buildCertificationCenter({
+        id: 1,
+        name: 'Centre de certif sans orga reliée',
+        type: CertificationCenter.types.PRO,
+        externalId: 'Centre1',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId: 1,
+        complementaryCertificationId: 1,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId: 1,
+        complementaryCertificationId: 2,
+      });
+      databaseBuilder.factory.buildCertificationCenter({
+        id: 2,
+        name: 'Centre de certif reliée à une orga sans tags',
+        type: CertificationCenter.types.PRO,
+        externalId: 'Centre2',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId: 2,
+        complementaryCertificationId: 3,
+      });
+      databaseBuilder.factory.buildUser({
+        id: 123,
+        firstName: 'Jean',
+        lastName: 'Acajou',
+        email: 'jean.acajou@example.net',
+        pixCertifTermsOfServiceAccepted: true,
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: 1,
+        userId: 123,
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: 2,
+        userId: 123,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationPointOfContact = await certificationPointOfContactRepository.get(123);
+
+      // then
+      const expectedFirstAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+        id: 1,
+        name: 'Centre de certif sans orga reliée',
+        externalId: 'Centre1',
+        type: CertificationCenter.types.PRO,
+        isRelatedToManagingStudentsOrganization: false,
+        relatedOrganizationTags: [],
+        habilitations: [
+          { id: 1, name: 'Certif comp 1' },
+          { id: 2, name: 'Certif comp 2' },
+        ],
+      });
+      const expectedSecondAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+        id: 2,
+        name: 'Centre de certif reliée à une orga sans tags',
+        externalId: 'Centre2',
+        type: CertificationCenter.types.PRO,
+        isRelatedToManagingStudentsOrganization: false,
+        relatedOrganizationTags: [],
+        habilitations: [{ id: 3, name: 'Certif comp 3' }],
+      });
+      const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
+        id: 123,
+        firstName: 'Jean',
+        lastName: 'Acajou',
+        email: 'jean.acajou@example.net',
+        pixCertifTermsOfServiceAccepted: true,
+        allowedCertificationCenterAccesses: [
+          expectedFirstAllowedCertificationCenterAccess,
+          expectedSecondAllowedCertificationCenterAccess,
         ],
       });
       expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);

--- a/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
+++ b/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
@@ -7,6 +7,7 @@ function buildAllowedCertificationCenterAccess({
   type = 'PRO',
   isRelatedToManagingStudentsOrganization = false,
   relatedOrganizationTags = [],
+  habilitations = [],
 } = {}) {
   return new AllowedCertificationCenterAccess({
     id,
@@ -15,6 +16,7 @@ function buildAllowedCertificationCenterAccess({
     type,
     isRelatedToManagingStudentsOrganization,
     relatedOrganizationTags,
+    habilitations,
   });
 }
 

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -72,6 +72,7 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
               'is-access-blocked-agri': false,
               'is-related-to-managing-students-organization': false,
               'related-organization-tags': [],
+              habilitations: [],
             },
           },
         ],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -12,6 +12,10 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
         type: 'PRO',
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: [],
+        habilitations: [
+          { id: 1, name: 'Certif comp 1' },
+          { id: 2, name: 'Certif comp 2' },
+        ],
       });
       const allowedCertificationCenterAccess2 = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 456,
@@ -20,6 +24,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
         type: 'SCO',
         isRelatedToManagingStudentsOrganization: true,
         relatedOrganizationTags: ['tag1'],
+        habilitations: [],
       });
       const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 789,
@@ -73,6 +78,10 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'is-access-blocked-aefe': false,
               'is-access-blocked-agri': false,
               'related-organization-tags': [],
+              habilitations: [
+                { id: 1, name: 'Certif comp 1' },
+                { id: 2, name: 'Certif comp 2' },
+              ],
             },
           },
           {
@@ -88,6 +97,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'is-access-blocked-aefe': false,
               'is-access-blocked-agri': false,
               'related-organization-tags': ['tag1'],
+              habilitations: [],
             },
           },
         ],

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -218,7 +218,7 @@
             />
           </div>
 
-          <div id="recipient-email-container" class="new-certification-candidate-details-modal__form__field">
+          <div id="recipient-email-container" class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
             <label for="result-recipient-email" class="label">E-mail du destinataire des résultats (formateur, enseignant...)</label>
             <Input
               @id="result-recipient-email"
@@ -229,7 +229,7 @@
             />
           </div>
 
-          <div id="email-container" class="new-certification-candidate-details-modal__form__field">
+          <div id="email-container" class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double">
             <label for="email" class="label">E-mail de convocation</label>
             <Input
               @id="email"
@@ -239,6 +239,28 @@
               {{on 'input' (fn @updateCandidateData @candidateData 'email')}}
             />
           </div>
+
+          {{#if this.complementaryCertifications.length}}
+            <div class="new-certification-candidate-details-modal__form__field">
+              <span class="label">Certifications complémentaires</span>
+              <div class="complementary-certifications-checkbox-list">
+                <ul>
+                  {{#each this.complementaryCertifications as |complementaryCertification index|}}
+                    <li>
+                      <label for={{concat "complementaryCertification_" index}}>
+                        <Input
+                          @type="checkbox"
+                          id={{concat "complementaryCertification_" index}}
+                          {{on "input" (fn this.addComplementaryCertification complementaryCertification)}}
+                        />
+                        {{complementaryCertification.name}}
+                      </label>
+                    </li>
+                  {{/each}}
+                </ul>
+              </div>
+            </div>
+          {{/if}}
 
           <div class="new-certification-candidate-details-modal__actions">
             <PixButton @triggerAction={{fn @closeModal}} @backgroundColor="transparent-light">

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -1,18 +1,25 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 const FRANCE_INSEE_CODE = '99100';
 const INSEE_CODE_OPTION = 'insee';
 const POSTAL_CODE_OPTION = 'postal';
 
 export default class NewCertificationCandidateModal extends Component {
+  @service currentUser;
+
   @tracked selectedBirthGeoCodeOption = INSEE_CODE_OPTION;
   @tracked selectedCountryInseeCode = FRANCE_INSEE_CODE;
   @tracked maskedBirthdate;
 
   focus(element) {
     element.focus();
+  }
+
+  get complementaryCertifications() {
+    return this.currentUser.currentAllowedCertificationCenterAccess.habilitations;
   }
 
   @action
@@ -47,6 +54,9 @@ export default class NewCertificationCandidateModal extends Component {
       this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthInseeCode', '99');
     }
   }
+
+  @action
+  addComplementaryCertification(_complementaryCertification) {}
 
   @action
   async onFormSubmit(event) {

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -10,6 +10,7 @@ export default class AllowedCertificationCenterAccess extends Model {
   @attr() isAccessBlockedAEFE;
   @attr() isAccessBlockedAgri;
   @attr() relatedOrganizationTags;
+  @attr() habilitations;
 
   get isSco() {
     return this.type === 'SCO';

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -83,7 +83,32 @@
       &-double {
         width: 248px;
       }
+
+      .complementary-certifications-checkbox-list {
+        display: flex;
+
+        ul {
+          list-style-type: none;
+          margin: 8px;
+          padding: 0;
+        }
+
+        label {
+          align-items: center;
+          display: flex;
+          height: 30px;
+        }
+
+        input {
+          width: 20px;
+          margin-right: 10px;
+        }
+      }
     }
+  }
+
+  #email-container {
+    padding-top: 18px;
   }
 
   &__actions {

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -5,9 +5,18 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import { render as renderScreen } from '@pix/ember-testing-library';
+import Service from '@ember/service';
 
 module('Integration | Component | new-certification-candidate-modal', function(hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function() {
+    const store = this.owner.lookup('service:store');
+    class CurrentUserStub extends Service {
+      currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', { habilitations: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }] });
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+  });
 
   test('it shows candidate form', async function(assert) {
     // given
@@ -50,6 +59,8 @@ module('Integration | Component | new-certification-candidate-modal', function(h
     assert.dom(screen.getByLabelText('Temps majoré (%)')).exists();
     assert.dom(screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)')).exists();
     assert.dom(screen.getByLabelText('E-mail de convocation')).exists();
+    assert.dom(screen.getByLabelText('Certif complémentaire 1')).exists();
+    assert.dom(screen.getByLabelText('Certif complémentaire 2')).exists();
   });
 
   test('it shows a countries list with France selected as default', async function(assert) {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Le passage d’une certification complémentaire en plus de la certification Pix peut engendrer des coûts supplémentaires pour les candidats ou leur prescripteur. Il faut donc qu’on s’assure qu’un candidat qui passe une certification complémentaire ait bien été inscrit en amont pour passer cette certification.

## :bat: Solution
Afficher les certifications complémentaires du centre de certification dans la modale d'ajout du candidat.

## :spider_web: Remarques
On pourrait créer un model front pour représenter les habilitations/accréditations mais cela n'a pas été fait ici.

## :ghost: Pour tester
- Se connecter à Pix Certif à un centre possédant des habilitations à faire passer des certifications complémentaires.
- Vérifier que ces certif complémentaires apparaissent bien dans la modal d'inscription d'un candidat.