### PR TITLE
[TECH] Bloquer le merge pour les commits de fixup

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   block-autosquash-commits:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Block Autosquash Commits
         uses: xt0rted/block-autosquash-commits-action@v2

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,6 +8,13 @@ on:
     types:
       - completed
 jobs:
+  block-autosquash-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block Autosquash Commits
+        uses: xt0rted/block-autosquash-commits-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
   verify-labels:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,7 @@ on:
     types:
       - completed
 jobs:
-  automerge:
+  verify-labels:
     runs-on: ubuntu-latest
     steps:
       - name: verify labels
@@ -16,6 +16,9 @@ jobs:
           contains(github.event.pull_request.labels.*.name, ':earth_africa: i18n needed')
           || contains(github.event.pull_request.labels.*.name, ':warning: Blocked')
         run: exit 1
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
       - name: automerge
         uses: pascalgn/automerge-action@v0.8.3
         env:

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   block-autosquash-commits:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Block Autosquash Commits
         uses: xt0rted/block-autosquash-commits-action@v2

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -1,5 +1,6 @@
 name: commits check
 on:
+  # eslint-disable-next-line yml/no-empty-mapping-value
   pull_request:
   check_suite:
     types:

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -1,0 +1,14 @@
+name: commits check
+on:
+  pull_request:
+  check_suite:
+    types:
+      - completed
+jobs:
+  block-autosquash-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block Autosquash Commits
+        uses: xt0rted/block-autosquash-commits-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :jack_o_lantern: Problème
On retravail souvent les commits et parfois ou oublie d'automerge les commits `!fixup
`
## :bat: Solution
Ajouter un étape de github action pour bloquer ces commits basé sur https://github.com/xt0rted/block-autosquash-commits-action
On ajoute en fait 2 etapes
1) pour chaque push
2) avant l'automerge

> If any commit message in the pull request starts with fixup! or squash! the check status will be set to error.
> 
> ⚠️ GitHub's API only returns the first 250 commits of a PR so if you're working on a really large PR your fixup commits might not be detected


## :ghost: Pour tester
Creer un commit fixup, voir que le merge est bloqué pour la PR (mais on ne peux pas le faire tant que la PR n'est mergé!)
Sur push:
![image](https://user-images.githubusercontent.com/3769147/140095977-592c471c-17d0-4ed0-8f04-3f67eab728c3.png)

Lors de l'automerge:
![image](https://user-images.githubusercontent.com/3769147/140063818-4b92cd8e-a5de-4097-a857-5a8c0af1fbd4.png)

