### PR TITLE
[FEATURE] Afficher un message d'erreur pour les invitations d'organisation annulées (PIX-1316)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -168,6 +168,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CertificationCandidateForbiddenDeletionError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.CancelledOrganizationInvitationError) {
+    return new HttpErrors.ForbiddenError(error.message);
+  }
   if (error instanceof DomainErrors.SendingEmailToResultRecipientError) {
     return new HttpErrors.ServiceUnavailableError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -133,6 +133,12 @@ class AlreadySharedCampaignParticipationError extends DomainError {
   }
 }
 
+class CancelledOrganizationInvitationError extends DomainError {
+  constructor(message = "L'invitation à cette organisation a été annulée.") {
+    super(message);
+  }
+}
+
 class CantImproveCampaignParticipationError extends DomainError {
   constructor(message = 'Une campagne de collecte de profils ne peut pas être retentée.') {
     super(message);
@@ -938,6 +944,7 @@ module.exports = {
   AssessmentResultNotCreatedError,
   AuthenticationMethodNotFoundError,
   AuthenticationKeyForPoleEmploiTokenExpired,
+  CancelledOrganizationInvitationError,
   CampaignCodeError,
   CertificateVerificationCodeGenerationTooManyTrials,
   NoCertificationAttestationForDivisionError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -134,8 +134,11 @@ class AlreadySharedCampaignParticipationError extends DomainError {
 }
 
 class CancelledOrganizationInvitationError extends DomainError {
-  constructor(message = "L'invitation à cette organisation a été annulée.") {
-    super(message);
+  constructor(
+    message = "L'invitation à cette organisation a été annulée.",
+    code = 'CANCELLED_ORGANIZATION_INVITATION_CODE'
+  ) {
+    super(message, code);
   }
 }
 

--- a/api/lib/domain/models/OrganizationInvitation.js
+++ b/api/lib/domain/models/OrganizationInvitation.js
@@ -4,6 +4,7 @@ const { validateEntity } = require('../validators/entity-validator');
 const statuses = {
   PENDING: 'pending',
   ACCEPTED: 'accepted',
+  CANCELLED: 'cancelled',
 };
 
 const roles = {
@@ -59,6 +60,10 @@ class OrganizationInvitation {
 
   get isAccepted() {
     return this.status === statuses.ACCEPTED;
+  }
+
+  get isCancelled() {
+    return this.status === statuses.CANCELLED;
   }
 }
 

--- a/api/lib/domain/usecases/get-organization-invitation.js
+++ b/api/lib/domain/usecases/get-organization-invitation.js
@@ -1,4 +1,7 @@
-const { AlreadyExistingOrganizationInvitationError } = require('../../domain/errors');
+const {
+  AlreadyExistingOrganizationInvitationError,
+  CancelledOrganizationInvitationError,
+} = require('../../domain/errors');
 
 module.exports = async function getOrganizationInvitation({
   organizationInvitationId,
@@ -10,6 +13,10 @@ module.exports = async function getOrganizationInvitation({
     id: organizationInvitationId,
     code: organizationInvitationCode,
   });
+
+  if (foundOrganizationInvitation.isCancelled) {
+    throw new CancelledOrganizationInvitationError(`Invitation was cancelled`);
+  }
 
   if (foundOrganizationInvitation.isAccepted) {
     throw new AlreadyExistingOrganizationInvitationError(

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -433,6 +433,15 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('The scope is not allowed.');
       expect(responseTitle(response)).to.equal('Forbidden');
     });
+
+    it('responds Forbidden when a CancelledOrganizationInvitationError error occurs', async function () {
+      routeHandler.throws(new DomainErrors.CancelledOrganizationInvitationError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
+      expect(responseDetail(response)).to.equal("L'invitation à cette organisation a été annulée.");
+      expect(responseTitle(response)).to.equal('Forbidden');
+    });
   });
 
   context('400 Bad Request', function () {

--- a/api/tests/unit/domain/models/OrganizationInvitation_test.js
+++ b/api/tests/unit/domain/models/OrganizationInvitation_test.js
@@ -97,4 +97,28 @@ describe('Unit | Domain | Models | OrganizationInvitation', function () {
       expect(result).to.be.false;
     });
   });
+
+  describe('isCancelled', function () {
+    it('should return true if status is cancelled', function () {
+      // given
+      const invitation = new OrganizationInvitation({ status: 'cancelled' });
+
+      // when
+      const result = invitation.isCancelled;
+
+      // /then
+      expect(result).to.be.true;
+    });
+
+    it('should return false if status is different than cancelled', function () {
+      // given
+      const invitation = new OrganizationInvitation({ status: 'pending' });
+
+      // when
+      const result = invitation.isCancelled;
+
+      // /then
+      expect(result).to.be.false;
+    });
+  });
 });

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -8,6 +8,10 @@
     <div class="login-form__invitation-error">{{t "pages.login-form.invitation-already-accepted"}}</div>
   {{/if}}
 
+  {{#if @isInvitationCancelled}}
+    <p class="login-form__invitation-error">{{t "pages.login-form.invitation-was-cancelled"}}</p>
+  {{/if}}
+
   {{#if this.isErrorMessagePresent}}
     <div id="login-form-error-message" class="login-form__error-message error-message" role="alert">
       {{this.errorMessage}}

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -4,7 +4,7 @@
     <div class="login-form__information">{{t "pages.login-form.is-only-accessible"}}</div>
   {{/unless}}
 
-  {{#if @hasInvitationError}}
+  {{#if @hasInvitationAlreadyBeenAccepted}}
     <div class="login-form__invitation-error">{{t "pages.login-form.invitation-already-accepted"}}</div>
   {{/if}}
 

--- a/orga/app/controllers/login.js
+++ b/orga/app/controllers/login.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
 
 export default class LoginController extends Controller {
-  queryParams = ['hasInvitationError'];
+  queryParams = ['hasInvitationError', 'isInvitationCancelled'];
 }

--- a/orga/app/controllers/login.js
+++ b/orga/app/controllers/login.js
@@ -1,5 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class LoginController extends Controller {
-  queryParams = ['hasInvitationError'];
-}

--- a/orga/app/controllers/login.js
+++ b/orga/app/controllers/login.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
 
 export default class LoginController extends Controller {
-  queryParams = ['hasInvitationError', 'isInvitationCancelled'];
+  queryParams = ['hasInvitationError'];
 }

--- a/orga/app/routes/join.js
+++ b/orga/app/routes/join.js
@@ -19,6 +19,9 @@ export default class JoinRoute extends Route {
       })
       .catch((errorResponse) => {
         errorResponse.errors.forEach((error) => {
+          if (error.status === '403') {
+            this.router.replaceWith('login', { queryParams: { isInvitationCancelled: true } });
+          }
           if (error.status === '412') {
             this.router.replaceWith('login', { queryParams: { hasInvitationError: true } });
           }

--- a/orga/app/routes/join.js
+++ b/orga/app/routes/join.js
@@ -24,7 +24,8 @@ export default class JoinRoute extends Route {
             transition.data['isInvitationCancelled'] = true;
           }
           if (error.status === '412') {
-            this.router.replaceWith('login', { queryParams: { hasInvitationError: true } });
+            const transition = this.router.replaceWith('login');
+            transition.data['hasInvitationAlreadyBeenAccepted'] = true;
           }
         });
         this.router.replaceWith('login');

--- a/orga/app/routes/join.js
+++ b/orga/app/routes/join.js
@@ -20,7 +20,8 @@ export default class JoinRoute extends Route {
       .catch((errorResponse) => {
         errorResponse.errors.forEach((error) => {
           if (error.status === '403') {
-            this.router.replaceWith('login', { queryParams: { isInvitationCancelled: true } });
+            const transition = this.router.replaceWith('login');
+            transition.data['isInvitationCancelled'] = true;
           }
           if (error.status === '412') {
             this.router.replaceWith('login', { queryParams: { hasInvitationError: true } });

--- a/orga/app/routes/login.js
+++ b/orga/app/routes/login.js
@@ -7,4 +7,10 @@ export default class LoginRoute extends Route {
   beforeModel() {
     this.session.prohibitAuthentication('authenticated');
   }
+
+  setupController(controller, model, transition) {
+    if (transition?.data?.isInvitationCancelled) {
+      controller.set('isInvitationCancelled', true);
+    }
+  }
 }

--- a/orga/app/routes/login.js
+++ b/orga/app/routes/login.js
@@ -12,5 +12,8 @@ export default class LoginRoute extends Route {
     if (transition?.data?.isInvitationCancelled) {
       controller.set('isInvitationCancelled', true);
     }
+    if (transition?.data?.hasInvitationAlreadyBeenAccepted) {
+      controller.set('hasInvitationAlreadyBeenAccepted', true);
+    }
   }
 }

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -5,6 +5,10 @@
       <img src="/pix-orga.svg" alt="Pix Orga" />
     </div>
     <h1 class="form-title">{{t "pages.login.title"}}</h1>
-    <Auth::LoginForm @isWithInvitation={{false}} @hasInvitationError={{this.hasInvitationError}} />
+    <Auth::LoginForm
+      @isWithInvitation={{false}}
+      @hasInvitationError={{this.hasInvitationError}}
+      @isInvitationCancelled={{this.isInvitationCancelled}}
+    />
   </div>
 </main>

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -7,7 +7,7 @@
     <h1 class="form-title">{{t "pages.login.title"}}</h1>
     <Auth::LoginForm
       @isWithInvitation={{false}}
-      @hasInvitationError={{this.hasInvitationError}}
+      @hasInvitationAlreadyBeenAccepted={{this.hasInvitationAlreadyBeenAccepted}}
       @isInvitationCancelled={{this.isInvitationCancelled}}
     />
   </div>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -134,6 +134,9 @@ export default function () {
     if (organizationInvitation.status === 'accepted') {
       return new Response(412, {}, { errors: [{ status: '412', detail: '' }] });
     }
+    if (organizationInvitation.status === 'cancelled') {
+      return new Response(403, {}, { errors: [{ status: '403', detail: '' }] });
+    }
 
     return organizationInvitation;
   });

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -69,7 +69,7 @@ module('Acceptance | join', function (hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
-      assert.equal(currentURL(), '/connexion?hasInvitationError=true');
+      assert.equal(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
       assert.dom('.login-form__invitation-error').exists();
       assert.dom('.login-form__invitation-error').hasText(expectedErrorMessage);

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -74,6 +74,26 @@ module('Acceptance | join', function (hooks) {
       assert.dom('.login-form__invitation-error').exists();
       assert.dom('.login-form__invitation-error').hasText(expectedErrorMessage);
     });
+
+    test('it should redirect user to login page when organization-invitation has been cancelled', async function (assert) {
+      // given
+      const code = 'ABCDEFGH01';
+      const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+      const organizationInvitationId = server.create('organizationInvitation', {
+        organizationId,
+        email: 'random@email.com',
+        status: 'cancelled',
+        code,
+      }).id;
+
+      // when
+      await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+
+      // then
+      assert.equal(currentURL(), '/connexion?isInvitationCancelled=true');
+      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+      assert.contains(this.intl.t('pages.login-form.invitation-was-cancelled'));
+    });
   });
 
   module('Login', function (hooks) {

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -90,7 +90,7 @@ module('Acceptance | join', function (hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
-      assert.equal(currentURL(), '/connexion?isInvitationCancelled=true');
+      assert.equal(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
       assert.contains(this.intl.t('pages.login-form.invitation-was-cancelled'));
     });

--- a/orga/tests/unit/routes/join_test.js
+++ b/orga/tests/unit/routes/join_test.js
@@ -15,6 +15,8 @@ module('Unit | Route | join', function (hooks) {
       sinon.stub(store, 'queryRecord');
       const forbiddenError = { status: '403' };
       store.queryRecord.rejects({ errors: [forbiddenError] });
+      const transition = { data: { isInvitationCancelled: false } };
+      route.router.replaceWith.returns(transition);
 
       const params = {
         invitationId: 2,
@@ -25,7 +27,8 @@ module('Unit | Route | join', function (hooks) {
       await route.model(params);
 
       // then
-      assert.ok(route.router.replaceWith.calledWith('login', { queryParams: { isInvitationCancelled: true } }));
+      assert.ok(route.router.replaceWith.calledWith('login'));
+      assert.true(transition.data['isInvitationCancelled']);
     });
   });
 });

--- a/orga/tests/unit/routes/join_test.js
+++ b/orga/tests/unit/routes/join_test.js
@@ -1,11 +1,31 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | join', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function (assert) {
-    const route = this.owner.lookup('route:join');
-    assert.ok(route);
+  module('when invitation was cancelled', function () {
+    test('should redirect to login route with isInvitationCancelled true', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:join');
+      const store = this.owner.lookup('service:store');
+
+      sinon.stub(route.router, 'replaceWith');
+      sinon.stub(store, 'queryRecord');
+      const forbiddenError = { status: '403' };
+      store.queryRecord.rejects({ errors: [forbiddenError] });
+
+      const params = {
+        invitationId: 2,
+        code: 'ABCDEF',
+      };
+
+      // when
+      await route.model(params);
+
+      // then
+      assert.ok(route.router.replaceWith.calledWith('login', { queryParams: { isInvitationCancelled: true } }));
+    });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -500,6 +500,7 @@
       "forgot-password": "Forgot your password?",
       "forgotten-password-url": "https://app.pix.org/mot-de-passe-oublie?lang=en",
       "invitation-already-accepted": "This invitation has already been accepted. Please log in or contact the administrator of your Pix Orga space.",
+      "invitation-was-cancelled": "This invitation is no longer valid. Please contact the administrator of your Pix Orga space.",
       "is-only-accessible": "Pix Orga is only accessible to invited members. Please contact your Pix Orga administrator in order to be invited.",
       "login": "Log in",
       "only-for-admin": "only for school administrations",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -500,6 +500,7 @@
       "forgot-password": "Mot de passe oublié ?",
       "forgotten-password-url": "https://app.pix.fr/mot-de-passe-oublie",
       "invitation-already-accepted": "Cette invitation a déjà été acceptée. Connectez-vous ou contactez l'administrateur de votre espace Pix Orga.",
+      "invitation-was-cancelled": "Cette invitation n’est plus valide. Contactez l’administrateur de votre espace Pix Orga.",
       "is-only-accessible": "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.",
       "login": "Je me connecte",
       "only-for-admin": "Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Aujourd'hui les admin des organisations peuvent inviter des personnes à rejoindre leur organisation via leur email.
Cependant lorsque le formulaire est remplis et l'invitation envoyée il n'existe aucun moyen actuellement pour annuler l'invitation. Cela peut poser soucis lorsque l'utilisateur se trompe d'email et invite une personne qui n'est pas destinée à rejoindre l'organisation.

## :bat: Solution
Rediriger vers la page de login et afficher un message d'erreur lorsque l'utilisateur essaie de cliquer sur une invitation qui a été annulée.

## :spider_web: Remarques
On s'était dit qu'il serait pas mal de ne pas mettre de queryParams lorsqu'on redirige vers la page de login avec l'erreur.

Après quelques recherches pour ne pas passer `isInvitationCancelled=true` dans l'url je suis tombée sur : https://stackoverflow.com/questions/43302439/how-to-remove-a-query-parameter-from-url-without-refresh-the-router-in-ember-js.

Et me suis appuyée sur la proposition suivante pour ne pas passer par les queryParams et quand même afficher une erreur sur la page de login après la transition : 
> storing the params in transition object or storing the value in a service.

Toute la magie pour ne pas passer de queryParams se fait donc de cette manière :
```
const transition = this.router.replaceWith('login');
transition.data['isInvitationCancelled'] = true;
```

Il suffit ensuite de passer par le hook `setupController` pour donner la valeur de `isInvitationCancelled` à la route login. Et voilà 🎉 

## :ghost: Pour tester
Lancer l'API et PixOrga :
- Se connecter sur PixOrga avec un administrateur (par ex : `sup.admin@example.net`)
- Aller dans Equipe (`/equipe/membres`)
- Cliquer sur "Inviter un membre" 
- Rentrez un email auquel vous avez accès

En BDD modifiez la colonne "status" de l'`organization-invitation` précédemment crée pour qu'elle ait la valeur `cancelled`. 

Dans vos emails copier le lien pour rejoindre l'organisation. 
Remplacez le début de l'url par votre environnement.

_Par exemple :  `https://orga.pix.org/rejoindre?invitationId=10000000&code=G4T6GXJ0YR` devient `localhost:4201/rejoindre?invitationId=10000000&code=G4T6GXJ0YR`._

- Constatez que vous arrivez sur la page de login de PixOrga avec un message d'erreur : 
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/38167520/140044148-43a33733-6d32-4cd3-a67a-e995fa9e7fae.png">

