### PR TITLE
[BUGFIX] Corriger l'affichage de la liste déroulante des sous-catégories de signalements (PIX-3735)

### DIFF
--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -97,25 +97,8 @@
         margin-bottom: 4px;
       }
 
-      .pix-select {
-        background: $white;
-        border: 1.2px solid $grey-45;
-        border-radius: 4px;
-
-        select[id^="subcategory-for-category"] {
-          height: 35px;
-          font-size: 14px;
-          color: $grey-90;
-        }
-
-        svg {
-          width: 14px;
-          height: 16px;
-          color: $blue-zodiac;
-          font-size: 16px;
-          font-weight: normal;
-          letter-spacing: 0;
-        }
+      .pix-select select {
+        width: 100%;
       }
 
       label[for^="text-area-for-category"] {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -22038,8 +22038,8 @@
       }
     },
     "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v9.2.0",
-      "integrity": "sha512-9c2fNL/ceGlssOHeE8z83OJq4PBZuGoZMQLImN+fWfrbSMHVhfzUXemaHZP7yuaP9VW16VOYcvJne2L+uubLLQ==",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v10.0.1",
+      "integrity": "sha512-s70SrvH6pvou93/p09FecOg7veMQi/nUDmzdc4Kt01pApoZ9muhgAM5wItK7M0hmtqTnnrajxzIqE1rP3O+aHA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/certif/package.json
+++ b/certif/package.json
@@ -90,7 +90,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.3.0",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v9.2.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v10.0.1",
     "qunit-dom": "^1.6.0",
     "sass": "^1.32.8",
     "stylelint": "^13.12.0",


### PR DESCRIPTION
## :unicorn: Problème

La liste déroulante des sous-catégories de signalements de type "Problème sur une question" s'affiche mal : elle déborde de la modale

![Capture d’écran 2021-11-03 à 10 36 51](https://user-images.githubusercontent.com/5627688/140037486-37d3e206-7dbc-4ec0-aa8f-40c25d72a343.png)

## 🤖  Solution

Tronquer le texte pour empêcher le débordement du champ si le libellé est plus long que le parent :

![Capture d’écran 2021-11-03 à 09 54 48](https://user-images.githubusercontent.com/5627688/140038332-db3657b6-ae24-48ec-90d3-d712f0b704c5.png)

## :rainbow: Remarques

- La solution a été implémentée côté Pix UI, cette PR se contente de mettre à jour Pix UI dans Pix Certif
- Le libellé entier reste lisible lorsqu'on ouvre le PixSelect pour afficher toutes les options.

![Capture d’écran 2021-11-03 à 09 54 54](https://user-images.githubusercontent.com/5627688/140038554-05612318-475f-4d5b-a9d9-cbe19424e9e7.png)

## :100: Pour tester

1. Se connecter à Pix Certif (avec certifsco@example.net)
2. Se rendre sur une session finalisable (exemple : la 4) et cliquer sur **Finaliser**
3. Cliquer sur **Ajouter ?** dans la colonne signalement d'un candidat
4. Sélectionner la catégorie **E1-E9 Problème technique sur une question**
5. Constater que la liste déroulante "Sélectionnez une sous-catégorie :" ne déborde pas de la modale
6. Sélectionner l'option "E8 Le candidat bénéficie d'un temps majoré et n'a pas pu répondre à la question dans le temps imparti"
7. Constater que le texte de l'option est tronqué