### PR TITLE
[FEATURE] Ajout du taux de réussite d'un résultat thématique sur Pix-Admin (PIX-3507).

### DIFF
--- a/admin/app/adapters/badge-criterion.js
+++ b/admin/app/adapters/badge-criterion.js
@@ -1,6 +1,6 @@
 import ApplicationAdapter from './application';
 
-export default class BadgeAdapter extends ApplicationAdapter {
+export default class BadgeCriterionAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
   urlForCreateRecord(modelName, { adapterOptions: { badgeId } }) {

--- a/admin/app/adapters/badge-criterion.js
+++ b/admin/app/adapters/badge-criterion.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class BadgeAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForCreateRecord(modelName, { adapterOptions: { badgeId } }) {
+    return `${this.host}/${this.namespace}/badges/${badgeId}/badge-criteria`;
+  }
+}

--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -1,4 +1,4 @@
-<form {{on "submit" this.createBadge}} class="badge-form">
+<form {{on "submit" this.createBadgeAndCriteria}} class="badge-form">
   <div class="badge-form__text-field">
     <label for="title">Nom du badge : </label>
     <Input id="title" class="form-control" @type="text" @value={{this.badge.title}} />
@@ -43,7 +43,7 @@
     <p>Laissez ce champ vide si la participation de campagne est non souhaitée</p>
     <div>
       <label for="campaignParticipationThreshold">Taux de réussite souhaité :</label>
-      <Input id="campaignParticipationThreshold" @type="text" />
+      <Input id="campaignParticipationThreshold" @type="number" @value={{this.threshold}} />
     </div>
   </div>
 

--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -38,6 +38,15 @@
     />
   </div>
 
+  <div>
+    <h3>Réussite sur la participation de campagne</h3>
+    <p>Laissez ce champ vide si la participation de campagne est non souhaitée</p>
+    <div>
+      <label for="campaignParticipationThreshold">Taux de réussite souhaité :</label>
+      <Input id="campaignParticipationThreshold" @type="text" />
+    </div>
+  </div>
+
   <div class="badge-form__action-buttons">
     <PixButtonLink
       data-test="badge-form-cancel-button"

--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -32,21 +32,25 @@ export default class BadgeForm extends Component {
         await this._createThresholdBadgeCriterion(badge.id);
       }
 
-      this.notifications.success('Le badge est créé.');
       this.router.transitionTo('authenticated.target-profiles.target-profile.insights');
     } catch (error) {
       console.error(error);
-      this.notifications.error('Erreur lors de la création du résultat thématique.');
     }
   }
 
   async _createBadge() {
-    const badge = this.store.createRecord('badge', this.badge);
-    await badge.save({
-      adapterOptions: { targetProfileId: this.args.targetProfileId },
-    });
+    try {
+      const badge = this.store.createRecord('badge', this.badge);
+      await badge.save({
+        adapterOptions: { targetProfileId: this.args.targetProfileId },
+      });
 
-    return badge;
+      this.notifications.success('Le résultat thématique a été créé.');
+      return badge;
+    } catch (error) {
+      console.error(error);
+      this.notifications.error('Erreur lors de la création du résultat thématique.');
+    }
   }
 
   async _createThresholdBadgeCriterion(badgeId) {
@@ -60,6 +64,7 @@ export default class BadgeForm extends Component {
         threshold: this.threshold,
       });
       await badgeCriterion.save({ adapterOptions: { badgeId } });
+      this.notifications.success('Le critère du résultat thématique a été créé.');
     } catch (error) {
       console.error(error);
       this.notifications.error('Erreur lors de la création du critère du résultat thématique.');

--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -16,22 +16,53 @@ export default class BadgeForm extends Component {
     isCertifiable: false,
     isAlwaysVisible: false,
   };
+  threshold = null;
 
   constructor(...args) {
     super(...args);
   }
 
   @action
-  async createBadge(event) {
+  async createBadgeAndCriteria(event) {
     event.preventDefault();
     try {
-      const result = await this.store.createRecord('badge', this.badge);
-      await result.save({ adapterOptions: { targetProfileId: this.args.targetProfileId } });
+      const badge = await this._createBadge();
+
+      if (this.threshold) {
+        await this._createThresholdBadgeCriterion(badge.id);
+      }
+
       this.notifications.success('Le badge est créé.');
       this.router.transitionTo('authenticated.target-profiles.target-profile.insights');
     } catch (error) {
       console.error(error);
-      this.notifications.error('Erreur lors de la création du badge.');
+      this.notifications.error('Erreur lors de la création du résultat thématique.');
+    }
+  }
+
+  async _createBadge() {
+    const badge = this.store.createRecord('badge', this.badge);
+    await badge.save({
+      adapterOptions: { targetProfileId: this.args.targetProfileId },
+    });
+
+    return badge;
+  }
+
+  async _createThresholdBadgeCriterion(badgeId) {
+    try {
+      if (this.threshold < 0 || this.threshold > 100) {
+        this.notifications.error('Le taux de réussite doit être compris entre 0 et 100.');
+        return;
+      }
+      const badgeCriterion = this.store.createRecord('badge-criterion', {
+        scope: 'CampaignParticipation',
+        threshold: this.threshold,
+      });
+      await badgeCriterion.save({ adapterOptions: { badgeId } });
+    } catch (error) {
+      console.error(error);
+      this.notifications.error('Erreur lors de la création du critère du résultat thématique.');
     }
   }
 }

--- a/admin/app/templates/authenticated/target-profiles/target-profile/badges/new.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/badges/new.hbs
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <div class="page-title">Création de badge</div>
+  <div class="page-title">Création de résultat thématique et de ses critères</div>
 </header>
 
 <main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -9,6 +9,7 @@ import {
   outdate,
   updateTargetProfileName,
   createBadge,
+  createBadgeCriterion,
 } from './handlers/target-profiles';
 
 import { Response } from 'ember-cli-mirage';
@@ -106,6 +107,7 @@ export default function () {
   this.post('/organizations/:id/target-profiles', attachTargetProfiles);
   this.get('/admin/organizations/:id/invitations', getOrganizationInvitations);
   this.get('/admin/badges/:id', getBadge);
+  this.post('/admin/badges/:id/badge-criteria', createBadgeCriterion);
   this.post('/admin/target-profiles');
   this.get('/admin/target-profiles');
   this.get('/admin/target-profiles/:id');

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -96,11 +96,16 @@ function createBadge(schema) {
   return schema.create('badge', {});
 }
 
+function createBadgeCriterion(schema) {
+  return schema.create('badge-criterion', {});
+}
+
 export {
   attachOrganizationsFromExistingTargetProfile,
   attachTargetProfiles,
   attachTargetProfileToOrganizations,
   createBadge,
+  createBadgeCriterion,
   getOrganizationTargetProfiles,
   findPaginatedTargetProfileOrganizations,
   findTargetProfileBadges,

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -69,6 +69,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       await fillIn('input#badge-key', 'clé_du_badge');
       await fillIn('input#image-url', 'https://image-url.pix.fr');
       await fillIn('input#alt-message', 'texte alternatif à l‘image');
+      await fillIn('input#campaignParticipationThreshold', '65');
       await click('[data-test="badge-form-submit-button"]');
 
       // then

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -40,23 +40,26 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
     assert.dom('button[data-test="badge-form-submit-button"]').exists();
   });
 
-  test('should send badge creation request to api', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const createRecordMock = sinon.mock();
-    createRecordMock.returns({ save: function () {} });
-    store.createRecord = createRecordMock;
+  module('#createBadge', function () {
+    test('should send badge creation request to api', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const createRecordStub = sinon.stub();
+      const saveStub = sinon.stub().resolves();
+      createRecordStub.returns({ save: saveStub });
+      store.createRecord = createRecordStub;
+      this.targetProfileId = 123;
 
-    await render(hbs`<TargetProfiles::BadgeForm />`);
+      await render(hbs`<TargetProfiles::BadgeForm @targetProfileId={{targetProfileId}} />`);
 
-    // when
-    await fillIn('input#badge-key', 'clé_du_badge');
-    await fillIn('input#image-url', 'https://image-url.pix.fr');
-    await fillIn('input#alt-message', 'texte alternatif à l‘image');
-    await click('button[data-test="badge-form-submit-button"]');
+      // when
+      await fillIn('input#badge-key', 'clé_du_badge');
+      await fillIn('input#image-url', 'https://image-url.pix.fr');
+      await fillIn('input#alt-message', 'texte alternatif à l‘image');
+      await click('button[data-test="badge-form-submit-button"]');
 
-    assert.ok(
-      createRecordMock.calledWith('badge', {
+      // then
+      sinon.assert.calledWith(createRecordStub, 'badge', {
         key: 'clé_du_badge',
         altMessage: 'texte alternatif à l‘image',
         imageUrl: 'https://image-url.pix.fr',
@@ -64,7 +67,43 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
         title: '',
         isCertifiable: false,
         isAlwaysVisible: false,
-      })
-    );
+      });
+      sinon.assert.calledWith(saveStub, {
+        adapterOptions: {
+          targetProfileId: this.targetProfileId,
+        },
+      });
+      assert.ok(true);
+    });
+
+    test('should send badgeCriteria creation request to api', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const createRecordStub = sinon.stub();
+      const saveStub = sinon.stub();
+      createRecordStub.returns({ save: saveStub, id: 123 });
+      store.createRecord = createRecordStub;
+
+      await render(hbs`<TargetProfiles::BadgeForm @targetProfileId={{targetProfileId}} />`);
+
+      // when
+      await fillIn('input#badge-key', 'clé_du_badge');
+      await fillIn('input#image-url', 'https://image-url.pix.fr');
+      await fillIn('input#alt-message', 'texte alternatif à l‘image');
+      await fillIn('input#campaignParticipationThreshold', '65');
+      await click('button[data-test="badge-form-submit-button"]');
+
+      // then
+      sinon.assert.calledWith(createRecordStub.secondCall, 'badge-criterion', {
+        threshold: '65',
+        scope: 'CampaignParticipation',
+      });
+      sinon.assert.calledWith(saveStub.secondCall, {
+        adapterOptions: {
+          badgeId: 123,
+        },
+      });
+      assert.ok(true);
+    });
   });
 });

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -18,7 +18,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
 
   test('it should display the expected number of inputs', async function (assert) {
     // given
-    const expectedNumberOfInputsInForm = 7;
+    const expectedNumberOfInputsInForm = 8;
     const expectedNumberOfTextareasInForm = 1;
     const expectedNumberOfCheckboxesInForm = 2;
 

--- a/admin/tests/unit/adapters/badge-criterion_test.js
+++ b/admin/tests/unit/adapters/badge-criterion_test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapters | badge-criterion', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:badge-criterion');
+  });
+
+  module('#urlForCreateRecord', function () {
+    test('should build create url from badgeId', async function (assert) {
+      // when
+      const options = { adapterOptions: { badgeId: 90 } };
+      const url = await adapter.urlForCreateRecord('badge-criterion', options);
+
+      // then
+      assert.true(url.endsWith('/api/admin/badges/90/badge-criteria'));
+    });
+  });
+});

--- a/api/lib/application/badges/badges-controller.js
+++ b/api/lib/application/badges/badges-controller.js
@@ -1,10 +1,18 @@
 const usecases = require('../../domain/usecases');
 const badgeWithLearningContentSerializer = require('../../infrastructure/serializers/jsonapi/badge-with-learning-content-serializer');
+const badgeCriteriaSerializer = require('../../infrastructure/serializers/jsonapi/badge-criteria-serializer');
 
 module.exports = {
   async getBadge(request) {
     const badgeId = request.params.id;
     const badgeWithLearningContent = await usecases.getBadgeDetails({ badgeId });
     return badgeWithLearningContentSerializer.serialize(badgeWithLearningContent);
+  },
+
+  async createBadgeCriterion(request, h) {
+    const badgeId = request.params.id;
+    const badgeCriterion = badgeCriteriaSerializer.deserialize(request.payload);
+    const savedBadgeCriterion = await usecases.createBadgeCriteria({ badgeId, badgeCriterion });
+    return h.response(badgeCriteriaSerializer.serialize(savedBadgeCriterion));
   },
 };

--- a/api/lib/application/badges/badges-controller.js
+++ b/api/lib/application/badges/badges-controller.js
@@ -12,7 +12,7 @@ module.exports = {
   async createBadgeCriterion(request, h) {
     const badgeId = request.params.id;
     const badgeCriterion = badgeCriteriaSerializer.deserialize(request.payload);
-    const savedBadgeCriterion = await usecases.createBadgeCriteria({ badgeId, badgeCriterion });
+    const savedBadgeCriterion = await usecases.createBadgeCriterion({ badgeId, badgeCriterion });
     return h.response(badgeCriteriaSerializer.serialize(savedBadgeCriterion));
   },
 };

--- a/api/lib/application/badges/index.js
+++ b/api/lib/application/badges/index.js
@@ -28,6 +28,38 @@ exports.register = async function (server) {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/badges/{id}/badge-criteria',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRolePixMaster,
+            assign: 'hasRolePixMaster',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.badgeId,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                scope: Joi.string().required(),
+                threshold: Joi.number().min(0).max(100).required(),
+              }).required(),
+              type: Joi.string().required(),
+            }).required(),
+          }).required(),
+        },
+        handler: badgesController.createBadgeCriterion,
+        tags: ['api', 'badges'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+            "- Elle permet de créer un critère et de l'ajouter au badge référencé par {id}.",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/models/BadgeCriterion.js
+++ b/api/lib/domain/models/BadgeCriterion.js
@@ -1,9 +1,10 @@
 class BadgeCriterion {
-  constructor({ id, scope, threshold, skillSetIds } = {}) {
+  constructor({ id, scope, threshold, skillSetIds, badgeId } = {}) {
     this.id = id;
     this.scope = scope;
     this.threshold = threshold;
     this.skillSetIds = skillSetIds;
+    this.badgeId = badgeId;
   }
 }
 

--- a/api/lib/domain/usecases/create-badge-criteria.js
+++ b/api/lib/domain/usecases/create-badge-criteria.js
@@ -1,0 +1,3 @@
+module.exports = async function createBadgeCriteria() {
+
+};

--- a/api/lib/domain/usecases/create-badge-criteria.js
+++ b/api/lib/domain/usecases/create-badge-criteria.js
@@ -1,3 +1,8 @@
-module.exports = async function createBadgeCriteria() {
-
+module.exports = async function createBadgeCriteria({ badgeId, badgeCriterion, badgeCriteriaRepository }) {
+  await badgeCriteriaRepository.save({
+    badgeCriterion: {
+      ...badgeCriterion,
+      badgeId,
+    },
+  });
 };

--- a/api/lib/domain/usecases/create-badge-criterion.js
+++ b/api/lib/domain/usecases/create-badge-criterion.js
@@ -1,4 +1,4 @@
-module.exports = async function createBadgeCriteria({ badgeId, badgeCriterion, badgeCriteriaRepository }) {
+module.exports = async function createBadgeCriterion({ badgeId, badgeCriterion, badgeCriteriaRepository }) {
   await badgeCriteriaRepository.save({
     badgeCriterion: {
       ...badgeCriterion,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -164,6 +164,7 @@ module.exports = injectDependencies(
     correctCandidateIdentityInCertificationCourse: require('./correct-candidate-identity-in-certification-course'),
     createAndReconcileUserToSchoolingRegistration: require('./create-and-reconcile-user-to-schooling-registration'),
     createBadge: require('./create-badge'),
+    createBadgeCriteria: require('./create-badge-criteria'),
     createCampaign: require('./create-campaign'),
     createCertificationCenter: require('./create-certification-center'),
     createCertificationCenterMembership: require('./create-certification-center-membership'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -165,7 +165,7 @@ module.exports = injectDependencies(
     correctCandidateIdentityInCertificationCourse: require('./correct-candidate-identity-in-certification-course'),
     createAndReconcileUserToSchoolingRegistration: require('./create-and-reconcile-user-to-schooling-registration'),
     createBadge: require('./create-badge'),
-    createBadgeCriteria: require('./create-badge-criteria'),
+    createBadgeCriterion: require('./create-badge-criterion'),
     createCampaign: require('./create-campaign'),
     createCertificationCenter: require('./create-certification-center'),
     createCertificationCenterMembership: require('./create-certification-center-membership'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -7,6 +7,7 @@ const dependencies = {
   authenticationService: require('../../domain/services/authentication-service'),
   badgeAcquisitionRepository: require('../../infrastructure/repositories/badge-acquisition-repository'),
   badgeCriteriaService: require('../../domain/services/badge-criteria-service'),
+  badgeCriteriaRepository: require('../../infrastructure/repositories/badge-criteria-repository'),
   badgeRepository: require('../../infrastructure/repositories/badge-repository'),
   campaignAnalysisRepository: require('../../infrastructure/repositories/campaign-analysis-repository'),
   campaignAssessmentParticipationRepository: require('../../infrastructure/repositories/campaign-assessment-participation-repository'),

--- a/api/lib/infrastructure/repositories/badge-criteria-repository.js
+++ b/api/lib/infrastructure/repositories/badge-criteria-repository.js
@@ -1,0 +1,11 @@
+const { knex } = require('../bookshelf');
+const BadgeCriterion = require('../../../lib/domain/models/BadgeCriterion');
+
+const TABLE_NAME = 'badge-criteria';
+
+module.exports = {
+  async save({ badgeCriterion }) {
+    const savedBadgeCriterion = await knex(TABLE_NAME).insert(badgeCriterion).returning('*');
+    return new BadgeCriterion(savedBadgeCriterion[0]);
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/badge-criteria-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-criteria-serializer.js
@@ -1,0 +1,18 @@
+const { Serializer } = require('jsonapi-serializer');
+module.exports = {
+  serialize(badgeCriterion = {}) {
+    return new Serializer('badge-criteria', {
+      ref: 'id',
+      attributes: ['scope', 'threshold', 'skill'],
+    }).serialize(badgeCriterion);
+  },
+
+  deserialize(badgeCriterionJson) {
+    const { scope, threshold } = badgeCriterionJson.data.attributes;
+    return {
+      scope,
+      threshold,
+      skillSetIds: [],
+    };
+  },
+};

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -6,6 +6,7 @@ const {
   insertUserWithRolePixMaster,
   learningContentBuilder,
   mockLearningContent,
+  knex,
 } = require('../../../test-helper');
 
 describe('Acceptance | API | Badges', function () {
@@ -237,6 +238,11 @@ describe('Acceptance | API | Badges', function () {
       });
 
       await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('badge-criteria').delete();
+      await knex('badges').delete();
     });
 
     it('should create a criterion and add it to an existing badge', async function () {

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -221,4 +221,48 @@ describe('Acceptance | API | Badges', function () {
       expect(response.result).to.deep.equal(expectedBadge);
     });
   });
+
+  describe('POST /api/admin/badges/{id}/badge-criteria', function () {
+    beforeEach(async function () {
+      userId = (await insertUserWithRolePixMaster()).id;
+
+      badge = databaseBuilder.factory.buildBadge({
+        id: 1,
+        altMessage: 'Message alternatif',
+        imageUrl: 'url_image',
+        message: 'Bravo',
+        title: 'titre du badge',
+        key: 'clef du badge',
+        isCertifiable: false,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should create a criterion and add it to an existing badge', async function () {
+      // given
+      const badgeCriterion = {
+        scope: 'CampaignParticipation',
+        threshold: 65,
+      };
+
+      options = {
+        method: 'POST',
+        url: `/api/admin/badges/${badge.id}/badge-criteria`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            type: 'badge-criteria',
+            attributes: badgeCriterion,
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
 });

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -90,6 +90,7 @@ describe('Integration | Service | Certification-Badges Service', function () {
           scope: badgeCriterion.scope,
           threshold: badgeCriterion.threshold,
           skillSetIds: badgeCriterion.skillSetIds,
+          badgeId: badge.id,
         },
       ];
 

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -382,6 +382,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
           scope: badgePartnerCriterion.scope,
           threshold: badgePartnerCriterion.threshold,
           skillSetIds: badgePartnerCriterion.skillSetIds,
+          badgeId: badgeCertifiable.id,
         },
       ];
 

--- a/api/tests/integration/infrastructure/repositories/badge-criteria-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-criteria-repository_test.js
@@ -1,0 +1,38 @@
+const { knex, expect, databaseBuilder } = require('../../../test-helper');
+const badgeCriteriaRepository = require('../../../../lib/infrastructure/repositories/badge-criteria-repository');
+const omit = require('lodash/omit');
+const BadgeCriterion = require('../../../../lib/domain/models/BadgeCriterion');
+
+describe('Integration | Repository | Badge Criteria Repository', function () {
+  afterEach(async function () {
+    await knex('badge-criteria').delete();
+    await knex('badges').delete();
+  });
+
+  describe('#save', function () {
+    it('should save badge-criteria', async function () {
+      // given
+      const { id: badgeId } = databaseBuilder.factory.buildBadge();
+      await databaseBuilder.commit();
+      const badgeCriterion = {
+        threshold: 90,
+        scope: 'CampaignParticipation',
+        badgeId,
+      };
+
+      const expectedBadgeCriterion = {
+        threshold: 90,
+        scope: 'CampaignParticipation',
+        badgeId,
+        skillSetIds: null,
+      };
+
+      // when
+      const result = await badgeCriteriaRepository.save({ badgeCriterion });
+
+      // then
+      expect(result).to.be.instanceOf(BadgeCriterion);
+      expect(omit(result, 'id')).to.deep.equal(expectedBadgeCriterion);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -56,11 +56,11 @@ describe('Integration | Repository | Badge', function () {
       scope: BadgeCriterion.SCOPES.SKILL_SET,
       threshold: 53,
       skillSetIds: [1, 2],
+      badgeId: badgeWithSkillSets.id,
     };
 
     databaseBuilder.factory.buildBadgeCriterion({
       ...badgeCriterionForBadgeWithSkillSets,
-      badgeId: badgeWithSkillSets.id,
     });
     databaseBuilder.factory.buildSkillSet({
       ...skillSet_1,
@@ -87,10 +87,10 @@ describe('Integration | Repository | Badge', function () {
       scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
       threshold: 88,
       skillSetIds: [],
+      badgeId: badgeWithSameTargetProfile_1.id,
     };
     databaseBuilder.factory.buildBadgeCriterion({
       ...badgeCriterionForBadgeWithSameTargetProfile_1,
-      badgeId: badgeWithSameTargetProfile_1.id,
     });
 
     badgeWithSameTargetProfile_2 = databaseBuilder.factory.buildBadge({
@@ -105,10 +105,10 @@ describe('Integration | Repository | Badge', function () {
       scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
       threshold: 35,
       skillSetIds: [],
+      badgeId: badgeWithSameTargetProfile_2.id,
     };
     databaseBuilder.factory.buildBadgeCriterion({
       ...badgeCriterionForBadgeWithSameTargetProfile_2,
-      badgeId: badgeWithSameTargetProfile_2.id,
     });
   }
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -20,8 +20,10 @@ async function _buildDomainAndDatabaseBadge(key, targetProfileId) {
   badge.skillSets = [skillSet1, skillSet2];
 
   badge.id = databaseBuilder.factory.buildBadge({ ...badge }).id;
-  badgeCriterion1.id = databaseBuilder.factory.buildBadgeCriterion({ ...badgeCriterion1, badgeId: badge.id }).id;
-  badgeCriterion2.id = databaseBuilder.factory.buildBadgeCriterion({ ...badgeCriterion2, badgeId: badge.id }).id;
+  badgeCriterion1.badgeId = badge.id;
+  badgeCriterion2.badgeId = badge.id;
+  badgeCriterion1.id = databaseBuilder.factory.buildBadgeCriterion({ ...badgeCriterion1 }).id;
+  badgeCriterion2.id = databaseBuilder.factory.buildBadgeCriterion({ ...badgeCriterion2 }).id;
   skillSet1.id = databaseBuilder.factory.buildSkillSet({
     ...skillSet1,
     badgeId: badge.id,

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -292,6 +292,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
                   scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
                   threshold: 54,
                   skillSetIds: [],
+                  badgeId: undefined,
                 },
               ],
               skillSets: [
@@ -434,6 +435,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
                   scope: BadgeCriterion.SCOPES.SKILL_SET,
                   threshold: 54,
                   skillSetIds: [42],
+                  badgeId: undefined,
                 },
               ],
               skillSets: [
@@ -473,6 +475,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
                   scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
                   threshold: 54,
                   skillSetIds: [],
+                  badgeId: undefined,
                 },
               ],
               skillSets: [],
@@ -604,6 +607,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
                   scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
                   threshold: 54,
                   skillSetIds: [],
+                  badgeId: undefined,
                 },
               ],
               skillSets: [
@@ -643,6 +647,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
                   scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
                   threshold: 54,
                   skillSetIds: [],
+                  badgeId: undefined,
                 }),
               ],
               skillSets: [
@@ -773,6 +778,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
                   scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
                   threshold: 54,
                   skillSetIds: [],
+                  badgeId: undefined,
                 },
               ],
               skillSets: [],
@@ -795,6 +801,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
                   scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
                   threshold: 54,
                   skillSetIds: [],
+                  badgeId: undefined,
                 },
               ],
               skillSets: [],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-criteria-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-criteria-serializer_test.js
@@ -1,0 +1,59 @@
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/badge-criteria-serializer');
+const { expect } = require('../../../../test-helper');
+const BadgeCriterion = require('../../../../../lib/domain/models/BadgeCriterion');
+
+describe('Unit | Serializer | JSONAPI | badge-criteria-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert a BadgeCriterion model object into JSON API data', function () {
+      // given
+      const badgeCriterion = new BadgeCriterion({
+        scope: 'CampaignParticipation',
+        threshold: 65,
+        skillSetIds: [],
+      });
+
+      // when
+      const badgeCriteria = serializer.serialize(badgeCriterion);
+
+      // then
+      const expectedBadgeCriterion = {
+        data: {
+          type: 'badge-criteria',
+          attributes: {
+            scope: 'CampaignParticipation',
+            threshold: 65,
+          },
+        },
+      };
+
+      expect(badgeCriteria).to.deep.equal(expectedBadgeCriterion);
+    });
+  });
+
+  describe('#deserialize', function () {
+    it('should convert JSON API data into a BadgeCriterion model object', function () {
+      // given
+      const badgeCriterionPayload = {
+        data: {
+          type: 'badge-criteria',
+          attributes: {
+            scope: 'CampaignParticipation',
+            threshold: 65,
+          },
+        },
+      };
+
+      // when
+      const badgeCriteria = serializer.deserialize(badgeCriterionPayload);
+
+      // then
+      const expectedBadgeCriterion = {
+        scope: 'CampaignParticipation',
+        threshold: 65,
+        skillSetIds: [],
+      };
+
+      expect(badgeCriteria).to.deep.equal(expectedBadgeCriterion);
+    });
+  });
+});


### PR DESCRIPTION
## :jack_o_lantern: Problème

A l'heure actuelle, afin de créer les critères associés aux résultats thématiques, il faut passer par Adminer.

## :bat: Solution

Ajout d'un champ dans le formulaire de création de résultat thématique dans `pix-admin` avec la route API associée à cette nouvelle entrée.

## :spider_web: Remarques

Le dernier commit de renommage a été réalisé afin de correspondre davantage à l'implémentation actuelle, à savoir l'existence d'un seul critère de résultat thématique.

## :ghost: Pour tester

Se rendre sur Pix-admin
Profil Cible -> choisir un profil
Clés de lecture -> Nouveau résultat thématique

Lors de la création, vérifier que:
- Il est pas possible de créer un badge sans taux de réussite
- Si taux de réussite, le nombre doit être compris entre 0 et 100
