### PR TITLE
[TECH] Faciliter la lecture des logs API par des humains.

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -70,6 +70,7 @@ module.exports = (function () {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: false,
       logLevel: process.env.LOG_LEVEL || 'info',
+      logForHumans: isFeatureEnabled(process.env.LOG_FOR_HUMANS),
       enableLogKnexQueries: isFeatureEnabled(process.env.LOG_KNEX_QUERIES),
       enableLogStartingEventDispatch: isFeatureEnabled(process.env.LOG_STARTING_EVENT_DISPATCH),
       enableLogEndingEventDispatch: isFeatureEnabled(process.env.LOG_ENDING_EVENT_DISPATCH),

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -1,13 +1,29 @@
 const pino = require('pino');
 const settings = require('../config');
 
-const nullDestination = { write() {} };
+const nullDestination = {
+  write() {},
+};
+
+let pinoPrettyOptions;
+
+if (settings.logging.logForHumans) {
+  const omitDay = 'h:MM:ss';
+
+  pinoPrettyOptions = {
+    colorize: true,
+    translateTime: omitDay,
+    ignore: 'pid,hostname',
+  };
+} else {
+  pinoPrettyOptions = false;
+}
 
 const logger = pino(
   {
     level: settings.logging.logLevel,
     redact: ['req.headers.authorization'],
-    prettyPrint: !settings.isProduction,
+    prettyPrint: pinoPrettyOptions,
   },
   settings.logging.enabled ? pino.destination() : nullDestination
 );

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -23,6 +23,7 @@ const schema = Joi.object({
   LCMS_API_URL: Joi.string().uri().required(),
   LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
+  LOG_FOR_HUMANS: Joi.string().optional().valid('true', 'false'),
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   CACHE_RELOAD_TIME: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -305,14 +305,6 @@ LOG_ENDING_EVENT_DISPATCH=true
 # default: "info"
 # LOG_LEVEL=debug
 
-# Enable or disable the logging of the 5XX error traces. Always true in
-# development. Doesn't log if logging is disabled.
-#
-# presence: optional
-# type: Boolean
-# default: `false`
-# SHOULD_LOG_5XX_ERRORS=true
-
 # Enable OPS logging
 # If 'production', will log core container metrics
 # Sample output: {"event":"ops","timestamp":1630419363680,"host":"pix-api-production-web-2","pid":22,"os":{"load":[2.16,1.97,1.85],"mem":{"total":42185723904,"free":6782152704},"uptime":8208319.46},"proc":{"uptime":81367.686662047,"mem":{"rss":196128768,"heapTotal":109948928,"heapUsed":104404328,"external":6004718,"arrayBuffers":4416211},"delay":0.11345672607421875},"load":{"requests":{"21344":{"total":55,"disconnects":0,"statusCodes":{"200":43,"201":10,"204":1,"401":1}}},"responseTimes":{"21344":{"avg":19.472727272727273,"max":64}},"sockets":{"http":{"total":0},"https":{"total":0}}}}

--- a/api/sample.env
+++ b/api/sample.env
@@ -320,6 +320,19 @@ LOG_ENDING_EVENT_DISPATCH=true
 # type: String
 # NODE_ENV=production
 
+# Log for humans
+#
+# Make log human-friendly:
+# - color logs
+# - display time of the day in HH:MM:SS format
+# - skip process id and hostname
+#
+# Do NOT use if logs are to be processed by a log processing pipeline
+#
+# Sample output: [8:27:12] INFO: Connected to server
+# presence: optional
+# type: String
+# LOG_FOR_HUMANS=true
 
 
 # =================


### PR DESCRIPTION
## :jack_o_lantern: Problème
L'affichage des logs est colorisé si `NODE_ENV` <> production (développement en local).
Cependant, il reste verbeux. 

## :bat: Solution
L'approche classiques est d'utiliser un CLI, par exemple [pino-ppretty]( https://github.com/pinojs/pino-pretty).
Pour le moment, on garde la solution basée sur la variable d'environnement.

Ajouter une variable d'environnement `LOG_FOR_HUMANS`, activable en local (machine du développeur) qui positionne les options `prettyPrint` de pino

Supprimer :
- le PID 
- le hostname
- la date

Avant
![image](https://user-images.githubusercontent.com/56302715/140286934-970ba6e9-fca5-4a40-8c76-c96b94380333.png)

Après
![image](https://user-images.githubusercontent.com/56302715/140286560-8a654783-1fc5-44c5-8f47-901370d50ea1.png)

Il existe un autre moyen dans la [nouvelle version 7 de pino](https://github.com/pinojs/pino/releases), les `transport`
>Deprecation of prettyPrint option
The prettyPrint option has been deprecated in favor of the new transport system.

Je préfère merger cette PR et faire une PR de montée de version séparée.

## :spider_web: Remarques
La variable `NODE_ENV` reste utilisée pour d'autres usages, mais ça va dans le sens de réduire ses usages ([voir cette PR](https://github.com/1024pix/pix/pull/3429)).

Si `LOG_FOR_HUMANS` est à true en production, cela cassera l'utilisation des logs dans Datadog.
Comme c'est une action intentionelle, et que cet impact est documenté dans le `sample.env`, je considère que ce risque est suffisament mitigé.

Suppression de la doc obsolète de `SHOULD_LOG_5XX_ERRORS` non supprimée par bb5836f3d99b0e1b74c66a3703eada6d89f8263e

## :ghost: Pour tester
Vérifier [en RA que les logs](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr3690/logs/) gardent leur format habituel pour pouvoir êtrre ingérés par Datadog.

` scalingo --region osc-fr1 --app pix-api-review-pr3690 logs --lines 10000`

```
2021-11-04 10:08:52.897956154 +0100 CET [manager] Documentation: https://doc.scalingo.com/platform/getting-started
2021-11-04 10:12:39.486308708 +0100 CET [manager] container [web-1] (6183a3e0164b6e02a4927467) started with the command 'exec node bin/www'
2021-11-04 10:12:39.607877798 +0100 CET [web-1] {"level":10,"time":1636017159607,"pid":23,"hostname":"pix-api-review-pr3690-web-1","msg":"TRACE logs enabled"}
2021-11-04 10:12:39.607852378 +0100 CET [web-1] {"level":20,"time":1636017159607,"pid":23,"hostname":"pix-api-review-pr3690-web-1","msg":"DEBUG logs enabled
```
