### PR TITLE
[FEATURE] Permettre à un surveillant de quitter la session qu'il surveille (PIX-3752).

### DIFF
--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -1,4 +1,14 @@
 <div class="session-supervising-header">
+  <PixButtonLink
+    aria-label="Quitter la surveillance de la session {{@session.id}}"
+    @route="login-session-supervisor"
+    @size="small"
+    @backgroundColor="transparent-light"
+    @isBorderVisible="true"
+    class="session-supervising-header__quit"
+  >
+    <FaIcon @icon="sign-out-alt" />Quitter
+  </PixButtonLink>
   <h1 class="session-supervising-header__title">Session {{@session.id}}</h1>
   <time class="session-supervising-header__date">
     {{moment-format @session.date "DD/MM/YYYY"}} ·

--- a/certif/app/styles/components/session-supervising/header.scss
+++ b/certif/app/styles/components/session-supervising/header.scss
@@ -11,6 +11,14 @@
     width: 672px;
   }
 
+  &__quit {
+    float: right;
+
+    svg {
+      margin-right: 8px;
+    }
+  }
+
   &__title {
     font-family: $open-sans;
     font-size: 1.75rem;

--- a/certif/tests/acceptance/supervisor-portal-access_test.js
+++ b/certif/tests/acceptance/supervisor-portal-access_test.js
@@ -27,11 +27,11 @@ module('Acceptance | Supervisor Portal', function(hooks) {
     test('it should redirect to ', async function(assert) {
       // given
       const screen = await visitScreen('/connexion-espace-surveillant');
-      await fillIn(screen.getByLabelText('Numéro de la session'), '12345');
+      await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
       await fillIn(screen.getByLabelText('Mot de passe de la session'), '6789');
 
       // when
-      await click(screen.getByText('Surveiller la session'));
+      await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // then
       assert.equal(currentURL(), '/sessions/12345/surveiller');
@@ -43,9 +43,9 @@ module('Acceptance | Supervisor Portal', function(hooks) {
       test('it should redirect to the supervisor authentication page', async function(assert) {
         // given
         const screen = await visitScreen('/connexion-espace-surveillant');
-        await fillIn(screen.getByLabelText('Numéro de la session'), '12345');
+        await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
         await fillIn(screen.getByLabelText('Mot de passe de la session'), '6789');
-        await click(screen.getByText('Surveiller la session'));
+        await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
         // when
         await click(screen.getByText('Quitter'));

--- a/certif/tests/acceptance/supervisor-portal-access_test.js
+++ b/certif/tests/acceptance/supervisor-portal-access_test.js
@@ -37,4 +37,22 @@ module('Acceptance | Supervisor Portal', function(hooks) {
       assert.equal(currentURL(), '/sessions/12345/surveiller');
     });
   });
+
+  module('When supervisor is supervising a session', function() {
+    module('When quit button is clicked', function() {
+      test('it should redirect to the supervisor authentication page', async function(assert) {
+        // given
+        const screen = await visitScreen('/connexion-espace-surveillant');
+        await fillIn(screen.getByLabelText('Numéro de la session'), '12345');
+        await fillIn(screen.getByLabelText('Mot de passe de la session'), '6789');
+        await click(screen.getByText('Surveiller la session'));
+
+        // when
+        await click(screen.getByText('Quitter'));
+
+        // then
+        assert.equal(currentURL(), '/connexion-espace-surveillant');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Un surveillant doit pouvoir sortir d'une session qu'il est en train de surveiller (ex: s'il est entré dans la mauvaise) et pouvoir ré-entrer dans une autre session sans avoir à se ré-authentifier.

## :bat: Solution
Ajouter un bouton quitter dans l'espace surveillant afin de renvoyer sur la page permettant de surveiller une session de certification.

## :ghost: Pour tester
- Se connecter à Pix Certif avec le compte `certif-success@example.net`
- Aller sur la session 3 (mot de passe surveillant: 1234)
- Cliquer sur `Quitter`
- Vérifier que l'on retourne bien sur la page d'accès à une session à surveiller 