### PR TITLE
[FEATURE] Limiter la taille de saisie d'un texte de présentation pour une campagne d'évaluation (PIX-3736)

### DIFF
--- a/admin/app/components/campaigns/update.hbs
+++ b/admin/app/components/campaigns/update.hbs
@@ -41,12 +41,14 @@
       <label for="customLandingPageText" class="form-field__label">
         Texte de la page d'accueil
       </label>
-      <Textarea
+      <PixTextarea
         id="customLandingPageText"
-        rows={{8}}
+        rows="8"
+        @maxlength="5000"
         @value={{this.form.customLandingPageText}}
         class="form-control {{if (v-get this.form "customLandingPageText" "isInvalid") "is-invalid"}}"
       />
+
       {{#if (v-get this.form "customLandingPageText" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "customLandingPageText" "message"}}
@@ -58,9 +60,9 @@
         <label for="customResultPageText" class="form-field__label">
           Texte de la page de fin de parcours
         </label>
-        <Textarea
+        <PixTextarea
           id="customResultPageText"
-          rows={{8}}
+          rows="8"
           @value={{this.form.customResultPageText}}
           class="form-control {{if (v-get this.form "customResultPageText" "isInvalid") "is-invalid"}}"
         />

--- a/admin/app/components/campaigns/update.js
+++ b/admin/app/components/campaigns/update.js
@@ -33,6 +33,8 @@ const Validations = buildValidations({
     validators: [
       validator('length', {
         min: 0,
+        max: 5000,
+        message: "La longueur du texte de la page d'accueil ne doit pas excéder 5000 caractères",
       }),
     ],
   },

--- a/admin/tests/integration/components/campaigns/update_test.js
+++ b/admin/tests/integration/components/campaigns/update_test.js
@@ -26,6 +26,7 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
     // then
     assert.dom('label[for="name"]').hasText('Nom de la campagne');
     assert.dom('label[for="customLandingPageText"]').hasText("Texte de la page d'accueil");
+    assert.dom('textarea#customLandingPageText').hasAttribute('maxLength', '5000');
     assert.dom('input#name').hasValue('Ceci est un nom');
     assert.contains('Annuler');
     assert.contains('Enregistrer');

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -80,7 +80,7 @@ exports.register = async function (server) {
               attributes: {
                 name: Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
                 title: Joi.string().required().allow(null),
-                'custom-landing-page-text': Joi.string().required().allow(null),
+                'custom-landing-page-text': Joi.string().required().allow(null).max(5000),
                 'custom-result-page-text': Joi.string().required().allow(null),
                 'custom-result-page-button-text': Joi.string().required().allow(null),
                 'custom-result-page-button-url': Joi.string().required().allow(null),
@@ -145,6 +145,19 @@ exports.register = async function (server) {
           params: Joi.object({
             id: identifiersType.campaignId,
           }),
+          payload: Joi.object({
+            data: {
+              type: 'campaigns',
+              attributes: {
+                name: Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                title: Joi.string().required().allow(null),
+                'custom-landing-page-text': Joi.string().required().allow(null).max(5000),
+              },
+            },
+          }),
+          options: {
+            allowUnknown: true,
+          },
         },
         handler: campaignController.update,
         notes: [

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -88,7 +88,16 @@ describe('Integration | Application | Route | campaignRouter', function () {
   describe('PATCH /api/campaigns/{id}', function () {
     it('should exist', async function () {
       // when
-      const response = await httpTestServer.request('PATCH', '/api/campaigns/1');
+      const response = await httpTestServer.request('PATCH', '/api/campaigns/1', {
+        data: {
+          type: 'campaigns',
+          attributes: {
+            name: 'toto',
+            title: null,
+            'custom-landing-page-text': 'toto',
+          },
+        },
+      });
 
       // then
       expect(response.statusCode).to.equal(201);

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -137,19 +137,6 @@ describe('Unit | Application | Router | campaign-router ', function () {
   });
 
   describe('PATCH /api/campaigns/{id}', function () {
-    it('should return 201', async function () {
-      // given
-      sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/campaigns/1');
-
-      // then
-      expect(response.statusCode).to.equal(201);
-    });
-
     it('should return 400 with an invalid campaign id', async function () {
       // given
       const httpTestServer = new HttpTestServer();

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -1,10 +1,10 @@
 <form {{on "submit" @onSubmit}} class="form">
 
   <div class="form__field">
-    <label for="campaign-name" class="label">{{t "pages.campaign-creation.name.label"}}</label>
-    <Input
-      id="campaign-name"
-      name="campaign-name"
+    <PixInput
+      @id="campaign-name"
+      @label={{t "pages.campaign-creation.name.label"}}
+      @name="campaign-name"
       @type="text"
       class="input"
       maxlength="255"
@@ -54,11 +54,9 @@
 
   {{#if this.isCampaignGoalAssessment}}
     <div class="form__field form__field--wide">
-      <label for="campaign-target-profile" class="label">{{t
-          "pages.campaign-creation.target-profiles-list.label"
-        }}</label>
       <PixSelect
-        id="campaign-target-profile"
+        @id="campaign-target-profile"
+        @label={{t "pages.campaign-creation.target-profiles-list.label"}}
         @onChange={{this.setSelectedTargetProfile}}
         @options={{this.targetProfilesOptions}}
         @emptyOptionLabel=""
@@ -140,14 +138,10 @@
 
   {{#if this.wantIdPix}}
     <div class="form__field">
-      <label for="external-id-label" class="label sr-only">{{t
-          "pages.campaign-creation.external-id-label.label"
-        }}</label>
-      <Input
-        id="external-id-label"
-        name="external-id-label"
-        @type="text"
-        class="input"
+      <PixInput
+        @id="external-id-label"
+        @name="external-id-label"
+        @label={{t "pages.campaign-creation.external-id-label.label"}}
         maxlength="255"
         aria-required="true"
         @value={{@campaign.idPixLabel}}
@@ -165,12 +159,10 @@
 
   {{#if this.isCampaignGoalAssessment}}
     <div class="form__field">
-      <label for="campaign-title" class="label">{{t "pages.campaign-creation.test-title.label"}}</label>
-      <Input
-        id="campaign-title"
-        name="campaign-title"
-        @type="text"
-        class="input"
+      <PixInput
+        @label={{t "pages.campaign-creation.test-title.label"}}
+        @id="campaign-title"
+        @name="campaign-title"
         maxlength="50"
         @value={{@campaign.title}}
       />
@@ -178,12 +170,12 @@
   {{/if}}
 
   <div class="form__field">
-    <label for="custom-landing-page-text" class="label">{{t "pages.campaign-creation.landing-page-text.label"}}</label>
     <PixTextarea
-      id="custom-landing-page-text"
-      maxlength={{350}}
+      @label={{t "pages.campaign-creation.landing-page-text.label"}}
+      @id="custom-landing-page-text"
+      @maxlength="5000"
       @value={{@campaign.customLandingPageText}}
-      rows={{8}}
+      rows="8"
     />
   </div>
 
@@ -191,6 +183,7 @@
     <PixButton @triggerAction={{@onCancel}} @backgroundColor="transparent-light">
       {{t "common.actions.cancel"}}
     </PixButton>
+
     <PixButton @type="submit">
       {{t "pages.campaign-creation.actions.create"}}
     </PixButton>

--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -1,11 +1,9 @@
 <form class="form" {{on "submit" @onSubmit}}>
   <div class="form__field">
-    <label for="campaign-name" class="label">{{t "pages.campaign-modification.campaign-name"}}</label>
-    <Input
-      id="campaign-name"
-      name="campaign-name"
-      @type="text"
-      class="input"
+    <PixInput
+      @id="campaign-name"
+      @name="campaign-name"
+      @label={{t "pages.campaign-modification.campaign-name"}}
       maxlength="255"
       @value={{@campaign.name}}
     />
@@ -13,12 +11,10 @@
 
   {{#if @campaign.isTypeAssessment}}
     <div class="form__field">
-      <label for="campaign-title" class="label">{{t "pages.campaign-modification.personalised-test-title"}}</label>
-      <Input
-        id="campaign-title"
-        name="campaign-title"
-        @type="text"
-        class="input"
+      <PixInput
+        @id="campaign-title"
+        @name="campaign-title"
+        @label={{t "pages.campaign-modification.personalised-test-title"}}
         maxlength="50"
         @value={{@campaign.title}}
       />
@@ -26,12 +22,10 @@
   {{/if}}
 
   <div class="form__field">
-    <label for="campaign-custom-landing-page-text" class="label">{{t
-        "pages.campaign-modification.landing-page-text"
-      }}</label>
     <PixTextarea
-      id="campaign-custom-landing-page-text"
-      maxlength={{350}}
+      @id="campaign-custom-landing-page-text"
+      @label={{t "pages.campaign-modification.landing-page-text"}}
+      @maxlength={{5000}}
       @value={{@campaign.customLandingPageText}}
       rows={{8}}
     />

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -37,7 +37,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     assert.contains(t('pages.campaign-creation.name.label'));
     assert.dom('button[type="submit"]').exists();
     assert.dom('input[type=text]').hasAttribute('maxLength', '255');
-    assert.dom('textarea').hasAttribute('maxLength', '350');
+    assert.dom('textarea').hasAttribute('maxLength', '5000');
   });
 
   module('when user cannot create campaign of type PROFILES_COLLECTION', function () {

--- a/orga/tests/integration/components/campaign/update-form_test.js
+++ b/orga/tests/integration/components/campaign/update-form_test.js
@@ -23,7 +23,7 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
     // then
     assert.dom('#campaign-custom-landing-page-text').exists();
     assert.dom('button[type="submit"]').exists();
-    assert.dom('#campaign-custom-landing-page-text').hasAttribute('maxLength', '350');
+    assert.dom('#campaign-custom-landing-page-text').hasAttribute('maxLength', '5000');
   });
 
   test('it should send campaign update action when submitted', async function (assert) {


### PR DESCRIPTION
## :jack_o_lantern: Problème
La règle de gestion sur la taille maximal du texte de présentation n'était pas en accord entre Pix Orga et Pix Admin

## :bat: Solution
Aligner les deux applications avec une marge suffisante par rapport au texte de présentation le plus long présent dans la base ( 4100 caractères )

Seuil fixé à 5000.

## :spider_web: Remarques
Vérifier que la création/modification fonctionne sur Pix Orga
Vérifier que la modification fonctionne sur Pix Admin
## :ghost: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
