### PR TITLE
[FEATURE] Ajout de tooltip et traduction pour expliquer une campagne de collect de profiles envoi multiple dans l'onglet paramètres (Pix 3676). 

### DIFF
--- a/orga/app/components/campaign/settings.hbs
+++ b/orga/app/components/campaign/settings.hbs
@@ -7,9 +7,22 @@
       </div>
       {{#if @campaign.isTypeProfilesCollection}}
         <div class="campaign-settings-content">
-          <dt class="label-text campaign-settings-content__label">{{t
-              "pages.campaign-settings.multiple-sendings.title"
-            }}</dt>
+          <dt class="label-text campaign-settings-content__label campaign-settings-content__label--tooltip">
+            <span>{{t "pages.campaign-settings.multiple-sendings.title"}}</span>
+            <PixTooltip
+              @id="credit-info-tooltip"
+              @text={{this.multipleSendingsTooltipText}}
+              @position="top"
+              @isWide={{true}}
+            >
+              <FaIcon
+                @icon="info-circle"
+                class="campaign-settings-content__tooltip-icon"
+                tabindex="0"
+                aria-describedby={{t "pages.campaign-settings.multiple-sendings.tooltip.aria-label" htmlSafe=true}}
+              />
+            </PixTooltip>
+          </dt>
           <dd class="content-text campaign-settings-content__text">{{this.multipleSendingsText}}</dd>
         </div>
       {{/if}}

--- a/orga/app/components/campaign/settings.js
+++ b/orga/app/components/campaign/settings.js
@@ -24,6 +24,12 @@ export default class CampaignSettings extends Component {
       : this.intl.t('pages.campaign-settings.multiple-sendings.status.disabled');
   }
 
+  get multipleSendingsTooltipText() {
+    return this.args.campaign.multipleSendings
+      ? this.intl.t('pages.campaign-settings.multiple-sendings.tooltip.text-multiple-sendings-enabled')
+      : this.intl.t('pages.campaign-settings.multiple-sendings.tooltip.text-multiple-sendings-disabled');
+  }
+
   @action
   async archiveCampaign(campaignId) {
     try {

--- a/orga/app/styles/components/campaign/settings.scss
+++ b/orga/app/styles/components/campaign/settings.scss
@@ -37,6 +37,14 @@
 
   &__label {
     margin: 0 0 4px;
+
+    &--tooltip {
+      display: flex;
+
+      & span {
+        padding-right: 8px;
+      }
+    }
   }
 
   &__text {
@@ -52,6 +60,11 @@
     display: flex;
     flex-direction: row;
   }
+}
+
+.campaign-settings-content__tooltip-icon {
+  color: $grey-30;
+  margin: 0 0 4px 0;
 }
 
 .campaign-settings-buttons {

--- a/orga/tests/integration/components/campaign/settings_test.js
+++ b/orga/tests/integration/components/campaign/settings_test.js
@@ -199,22 +199,20 @@ module('Integration | Component | Campaign::Settings', function (hooks) {
     });
   });
 
-  module('display wether if a campaign is multiple sendings or not', function () {
-    module('when type is PROFILES_COLLECTION', function () {
-      test('it should display multiple sendings label', async function (assert) {
-        // given
-        this.campaign = store.createRecord('campaign', {
-          type: 'PROFILES_COLLECTION',
-        });
-
-        // when
-        await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
-
-        // then
-        assert.contains('Envoi multiple');
+  module('when type is PROFILES_COLLECTION', function () {
+    test('it should display multiple sendings label', async function (assert) {
+      // given
+      this.campaign = store.createRecord('campaign', {
+        type: 'PROFILES_COLLECTION',
       });
+      // when
+      await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+      // then
+      assert.contains('Envoi multiple');
+    });
 
-      test("it should display 'oui' when campaign is multiple sendings", async function (assert) {
+    module('when multiple sendings is true', function () {
+      test("it should display 'oui'", async function (assert) {
         // given
         this.campaign = store.createRecord('campaign', {
           type: 'PROFILES_COLLECTION',
@@ -228,7 +226,25 @@ module('Integration | Component | Campaign::Settings', function (hooks) {
         assert.contains('Oui');
       });
 
-      test("it should display 'Non' when campaign is not multiple sendings", async function (assert) {
+      test('it should display tooltip with multiple sendings explanatory text', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'PROFILES_COLLECTION',
+          multipleSendings: true,
+        });
+
+        // when
+        await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+
+        // then
+        assert.contains(
+          'Le participant peut envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez le dernier profil envoyé.'
+        );
+      });
+    });
+
+    module('when multiple sendings is false', function () {
+      test("it should display 'Non'", async function (assert) {
         // given
         this.campaign = store.createRecord('campaign', {
           type: 'PROFILES_COLLECTION',
@@ -241,20 +257,38 @@ module('Integration | Component | Campaign::Settings', function (hooks) {
         // then
         assert.contains('Non');
       });
-    });
-    module('when type is ASSESSMENT', function () {
-      test('it should not display multiple sendings label', async function (assert) {
+
+      test('it should display tooltip with a different multiple sendings explanatory text when camaign is not multiple sendings', async function (assert) {
         // given
         this.campaign = store.createRecord('campaign', {
-          type: 'ASSESSMENT',
+          type: 'PROFILES_COLLECTION',
+          multipleSendings: false,
         });
 
         // when
         await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
 
         // then
-        assert.notContains('Envoi multiple');
+        assert.contains(
+          'Si l’envoi multiple a été activé, le participant pourra envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, seul le dernier profil envoyé sera affiché.'
+        );
       });
+    });
+  });
+
+  module('when type is ASSESSMENT', function () {
+    test('it should not display multiple sendings label or tooltip', async function (assert) {
+      // given
+      this.campaign = store.createRecord('campaign', {
+        type: 'ASSESSMENT',
+      });
+
+      // when
+      await render(hbs`<Campaign::Settings @campaign={{campaign}}/>`);
+
+      // then
+      assert.notContains('Envoi multiple');
+      assert.dom('[aria-describedby=" Description de la campagne d\'envoi multiple"]').doesNotExist();
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -320,6 +320,11 @@
         "status": {
           "enabled": "Yes",
           "disabled": "No"
+        },
+        "tooltip": {
+          "aria-label": "Description of a multiple sendings campaing",
+          "text-multiple-sendings-enabled": "The participants will be able to submit their profile several times by re-entering the campaign code. Within Pix Orga you will find the latest submitted profile.",
+          "text-multiple-sendings-disabled": "If the multiple submissions is activated, the participants will be able to submit their profile several times by re-entering the campaign code. Within Pix Orga the latest submitted profile will be displayed."
         }
       },
       "personalised-test-title": "Title of the customised test",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -320,6 +320,11 @@
         "status": {
           "enabled": "Oui",
           "disabled": "Non"
+        },
+        "tooltip": {
+          "aria-label": "Description de la campagne d'envoi multiple",
+          "text-multiple-sendings-enabled": "Le participant peut envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez le dernier profil envoyé.",
+          "text-multiple-sendings-disabled": "Si l’envoi multiple a été activé, le participant pourra envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, seul le dernier profil envoyé sera affiché."
         }
       },
       "personalised-test-title": "Titre du parcours",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Il n'y a pas d'explication et de description de ce qu'est une campagne de collect de profiles envoi multiples.

## :bat: Solution
Ajouter une description dans une tooltip a fin d’expliquer ce que c'est.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Se connecter sur pix Orga
Aller sur une campagne de collect de profiles (Envoi Multiple) puis l'onglet paramètres.
Constater qu'il y a un tooltip avec une description d'une campagne d'envoi multiple devant le label 'Envoi Multiple', En Français et en Anglais.