### PR TITLE
[FEATURE] Amélioration du design des liens dans les champs réponses des écrans intermédiaires (PIX-3779).

### DIFF
--- a/mon-pix/app/styles/components/_qcm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcm-solution-panel.scss
@@ -27,6 +27,11 @@ input.qcm-panel__proposal-checkbox {
 
 .qcm-proposal-label {
 
+  & a,
+  a:visited {
+    color: inherit;
+  }
+
   &__answer-details[data-goodness='good'] {
     display: inline;
     color: $green;

--- a/mon-pix/app/styles/components/_qcu-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-solution-panel.scss
@@ -1,3 +1,9 @@
+/* stylelint-disable no-descending-specificity */
+
+/* Rule added because of linter and DOM checking limitations */
+
+/* See https://stylelint.io/user-guide/rules/list/no-descending-specificity/#dom-limitations for further detail */
+
 .qcu-solution-panel {
 
   a {
@@ -8,9 +14,7 @@
       display: inline-block;
     }
 
-    &:active,
-    &:focus,
-    &:hover {
+    &:focus {
       color: $blue-hover;
     }
 
@@ -41,6 +45,10 @@
   &__proposition {
     display: inline-block;
 
+    & a {
+      color: inherit;
+    }
+
     &[data-goodness='good'] {
       color: $green;
       font-weight: $font-heavy;
@@ -48,6 +56,10 @@
 
     &[data-goodness='bad'][data-checked='yes'] {
       text-decoration: line-through;
+
+      & a {
+        text-decoration: line-through;
+      }
     }
 
     p {


### PR DESCRIPTION
## :jack_o_lantern: Problème

Si des liens apparaissent dans les solutions aux questions proposées sur les écrans intermédiaires, ceux-ci perdent la couleur verte de la bonne réponse pour être remplacée par le violet d'un lien déjà visité s'il a déjà été cliqué par l'utilisateur.

## :bat: Solution

Rajout d'une propriété CSS sur les liens

## :spider_web: Remarques

Il semble à première vue qu'il n'y ait pas ce type de réponse dans les épreuves QROC et QROM (les liens sont retranscrits en texte) , cette propriété a ainsi été ajoutée uniquement aux épreuves de types QCU et QCM.

Une règle `style-lint` a été désactivée dans le fichier `_qcu-solutions-panel.scss`. Dans ce fichier, nous sommes légèrement embêtés par le style global au fichier appliqué aux liens. (Je suis preneur de tout refacto du CSS afin de ne pas avoir à utiliser la suppression de la règle stylelint)

## :ghost: Pour tester

Sur Pix-App, répondre aux questions : 
QCM : recq1hYrUfQxM7LYw
QCU : rec1WmcP59mWZCbsn

Vérifier que les liens n'apparaissent plus avec le style visité de base sur les écrans intermédiaires.
