### PR TITLE
[BUGFIX]  Cacher les certifications complémentaires dans la modale d'inscription d'un candidat si le FT n'est pas activé (PIX-3803).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const { Serializer } = require('jsonapi-serializer');
+const { featureToggles } = require('../../../config');
 
 module.exports = {
   serialize(certificationPointOfContact) {
@@ -38,8 +39,13 @@ module.exports = {
         transformedCertificationPointOfContact.allowedCertificationCenterAccesses = _.map(
           certificationPointOfContact.allowedCertificationCenterAccesses,
           (access) => {
+            let habilitations = access.habilitations;
+            if (!featureToggles.isComplementaryCertificationSubscriptionEnabled) {
+              habilitations = [];
+            }
             return {
               ...access,
+              habilitations,
               isAccessBlockedCollege: access.isAccessBlockedCollege(),
               isAccessBlockedLycee: access.isAccessBlockedLycee(),
               isAccessBlockedAEFE: access.isAccessBlockedAEFE(),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -1,10 +1,13 @@
-const { expect, domainBuilder } = require('../../../../test-helper');
+const { expect, domainBuilder, sinon } = require('../../../../test-helper');
 const certificationPointOfContactSerializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer');
+const { featureToggles } = require('../../../../../lib/config');
 
 describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serializer', function () {
   describe('#serialize()', function () {
     it('should convert a CertificationPointOfContact model into JSON API data', function () {
       // given
+      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(true);
+
       const allowedCertificationCenterAccess1 = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 123,
         name: 'Sunnydale Center',
@@ -101,6 +104,108 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
             },
           },
         ],
+      });
+    });
+
+    context('when isComplementaryCertificationSubscriptionEnabled is false', function () {
+      it('should not serialize the certification center habilitations', function () {
+        // given
+        sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(false);
+
+        const allowedCertificationCenterAccess1 = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 123,
+          name: 'Sunnydale Center',
+          externalId: 'BUFFY_SLAYER',
+          type: 'PRO',
+          isRelatedToManagingStudentsOrganization: false,
+          relatedOrganizationTags: [],
+          habilitations: [
+            { id: 1, name: 'Certif comp 1' },
+            { id: 2, name: 'Certif comp 2' },
+          ],
+        });
+        const allowedCertificationCenterAccess2 = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 456,
+          name: 'Hellmouth',
+          externalId: 'SPIKE',
+          type: 'SCO',
+          isRelatedToManagingStudentsOrganization: true,
+          relatedOrganizationTags: ['tag1'],
+          habilitations: [],
+        });
+        const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
+          id: 789,
+          firstName: 'Buffy',
+          lastName: 'Summers',
+          email: 'buffy.summers@example.net',
+          pixCertifTermsOfServiceAccepted: true,
+          allowedCertificationCenterAccesses: [allowedCertificationCenterAccess1, allowedCertificationCenterAccess2],
+        });
+
+        // when
+        const jsonApi = certificationPointOfContactSerializer.serialize(certificationPointOfContact);
+
+        // then
+        expect(jsonApi).to.deep.equal({
+          data: {
+            id: '789',
+            type: 'certification-point-of-contact',
+            attributes: {
+              'first-name': 'Buffy',
+              'last-name': 'Summers',
+              email: 'buffy.summers@example.net',
+              'pix-certif-terms-of-service-accepted': true,
+            },
+            relationships: {
+              'allowed-certification-center-accesses': {
+                data: [
+                  {
+                    id: '123',
+                    type: 'allowed-certification-center-access',
+                  },
+                  {
+                    id: '456',
+                    type: 'allowed-certification-center-access',
+                  },
+                ],
+              },
+            },
+          },
+          included: [
+            {
+              id: '123',
+              type: 'allowed-certification-center-access',
+              attributes: {
+                name: 'Sunnydale Center',
+                'external-id': 'BUFFY_SLAYER',
+                type: 'PRO',
+                'is-related-to-managing-students-organization': false,
+                'is-access-blocked-college': false,
+                'is-access-blocked-lycee': false,
+                'is-access-blocked-aefe': false,
+                'is-access-blocked-agri': false,
+                'related-organization-tags': [],
+                habilitations: [],
+              },
+            },
+            {
+              id: '456',
+              type: 'allowed-certification-center-access',
+              attributes: {
+                name: 'Hellmouth',
+                'external-id': 'SPIKE',
+                type: 'SCO',
+                'is-related-to-managing-students-organization': true,
+                'is-access-blocked-college': false,
+                'is-access-blocked-lycee': false,
+                'is-access-blocked-aefe': false,
+                'is-access-blocked-agri': false,
+                'related-organization-tags': ['tag1'],
+                habilitations: [],
+              },
+            },
+          ],
+        });
       });
     });
   });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les certifications complémentaires sont affichées dans la modale d'inscription d'un candidat alors que le feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED n'est pas activé.

## :bat: Solution
Ne pas retourner les habilitations lors de la sérialisation du certificationPointOfContact si le FT n'est pas activé.

## :ghost: Pour tester
- Se conneter à Pix Certif avec le compte `certifpro@example.net`
- Créer une session
- Ouvrir la modale d'ajout d'un candidat et constater que les certifications complémentaires apparaissent
- Aller sur Scalingo et désactiver le feature toggle `FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED`
- Rouvrir la modale et vérifier que les certifications complémentaires ont bien disparu.