### PR TITLE
[BUGFIX] Afficher le détail d'un profil cible sur Pix Admin (PIX-3807).

### DIFF
--- a/admin/app/components/target-profiles/list-items.hbs
+++ b/admin/app/components/target-profiles/list-items.hbs
@@ -36,7 +36,7 @@
             <tr aria-label="Profil cible">
               <td>{{targetProfile.id}}</td>
               <td>
-                <LinkTo @route="authenticated.target-profiles.target-profile" @model={{targetProfile}}>
+                <LinkTo @route="authenticated.target-profiles.target-profile" @model={{targetProfile.id}}>
                   {{targetProfile.name}}
                 </LinkTo>
               </td>

--- a/admin/tests/acceptance/authenticated/target-profiles/list_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list_test.js
@@ -69,14 +69,27 @@ module('Acceptance | Target Profiles | List', function (hooks) {
 
     test('it should redirect to target profile details on click', async function (assert) {
       // given
-      server.create('target-profile', { id: 1, name: 'Mon Super Profil Cible' });
+      const area = server.create('area', { id: 'area1', title: 'Area 1' });
+      const competence = server.create('competence', { id: 'competence1', name: 'Competence 1', areaId: 'area1' });
+      const tube = server.create('tube', { id: 'tube1', practicalTitle: 'Tube 1', competenceId: 'competence1' });
+      const skill = server.create('skill', { id: 'skill1', name: '@web3', difficulty: 1, tubeId: 'tube1' });
+
+      server.create('target-profile', {
+        id: 1,
+        name: 'Profil Cible',
+        areas: [area],
+        competences: [competence],
+        tubes: [tube],
+        skills: [skill],
+      });
       await visit('/target-profiles/list');
 
       // when
-      await clickByLabel('Mon Super Profil Cible');
+      await clickByLabel('Profil Cible');
 
       // then
       assert.equal(currentURL(), '/target-profiles/1');
+      assert.contains('Competence 1');
     });
 
     test('it should redirect to target profile creation form on click "Nouveau profil cible', async function (assert) {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Dans Pix Admin, en arrivant depuis la liste des profils cibles, les détails ne sont pas affichés. Pourtant en rafraîchissant le navigateur, les détails s'affichent.
Il s'agit d'une regression suite à une PR pour améliorer l'accessibilité de [Pix Admin](https://github.com/1024pix/pix/commit/079392f85f6ea6ac9c5d01f292ae437b78b57440)

## :bat: Solution
Corriger le problème [à l'aide de la doc Ember](https://guides.emberjs.com/release/routing/specifying-a-routes-model/#toc_linking-to-a-dynamic-segment) sur les `LinkTo`

## :spider_web: Remarques
Ajout d'un test d'acceptance manquant.

## :ghost: Pour tester
Se connecter sur Pix Admin
Aller sur profils cibles ( dans le menu de gauche)
Cliquer sur un profil cible
Constater que les détails sont affichés.
