### PR TITLE
[TECH] Encapsuler la logique de create-campaign dans un model (PIX-3741).

### DIFF
--- a/api/lib/domain/models/CampaignCreator.js
+++ b/api/lib/domain/models/CampaignCreator.js
@@ -1,0 +1,40 @@
+const CampaignForCreation = require('./CampaignForCreation');
+const Campaign = require('./Campaign');
+const { UserNotAuthorizedToCreateCampaignError } = require('../errors');
+
+class CampaignCreator {
+  constructor(availableTargetProfileIds, organizationCanCollectProfile) {
+    this.availableTargetProfileIds = availableTargetProfileIds;
+    this.notAllowedToCreateProfileCollectionCampaign = !organizationCanCollectProfile;
+  }
+
+  createCampaign(campaignAttributes) {
+    const { type, targetProfileId } = campaignAttributes;
+
+    if (type === Campaign.types.ASSESSMENT) {
+      _checkAssessmentCampaignCreatationAllowed(targetProfileId, this.availableTargetProfileIds);
+    } else {
+      _checkProfileCollectionCampaignCreationAllowed(this.notAllowedToCreateProfileCollectionCampaign);
+    }
+
+    return new CampaignForCreation(campaignAttributes);
+  }
+}
+
+function _checkAssessmentCampaignCreatationAllowed(targetProfileId, availableTargetProfileIds) {
+  if (targetProfileId && !availableTargetProfileIds.includes(targetProfileId)) {
+    throw new UserNotAuthorizedToCreateCampaignError(
+      `Organization does not have an access to the profile ${targetProfileId}`
+    );
+  }
+}
+
+function _checkProfileCollectionCampaignCreationAllowed(notAllowedToCreateProfileCollectionCampaign) {
+  if (notAllowedToCreateProfileCollectionCampaign) {
+    throw new UserNotAuthorizedToCreateCampaignError(
+      'Organization can not create campaign with type PROFILES_COLLECTION'
+    );
+  }
+}
+
+module.exports = CampaignCreator;

--- a/api/lib/domain/models/CampaignForCreation.js
+++ b/api/lib/domain/models/CampaignForCreation.js
@@ -1,0 +1,27 @@
+class CampaignForCreation {
+  constructor({
+                name,
+                title,
+                idPixLabel,
+                customLandingPageText,
+                type,
+                targetProfileId,
+                creatorId,
+                organizationId,
+                multipleSendings,
+                code,
+              } = {}) {
+    this.name = name;
+    this.title = title;
+    this.idPixLabel = idPixLabel;
+    this.customLandingPageText = customLandingPageText;
+    this.type = type;
+    this.targetProfileId = targetProfileId;
+    this.creatorId = creatorId;
+    this.organizationId = organizationId;
+    this.multipleSendings = multipleSendings;
+    this.code = code;
+  }
+}
+
+module.exports = CampaignForCreation;

--- a/api/lib/domain/models/CampaignForCreation.js
+++ b/api/lib/domain/models/CampaignForCreation.js
@@ -1,16 +1,17 @@
+const validate = require('../validators/campaign-creation-validator');
 class CampaignForCreation {
   constructor({
-                name,
-                title,
-                idPixLabel,
-                customLandingPageText,
-                type,
-                targetProfileId,
-                creatorId,
-                organizationId,
-                multipleSendings,
-                code,
-              } = {}) {
+    name,
+    title,
+    idPixLabel,
+    customLandingPageText,
+    type,
+    targetProfileId,
+    creatorId,
+    organizationId,
+    multipleSendings,
+    code,
+  } = {}) {
     this.name = name;
     this.title = title;
     this.idPixLabel = idPixLabel;
@@ -21,6 +22,7 @@ class CampaignForCreation {
     this.organizationId = organizationId;
     this.multipleSendings = multipleSendings;
     this.code = code;
+    validate(this);
   }
 }
 

--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const campaignCodeGenerator = require('../services/campaigns/campaign-code-generator');
+const CampaignForCreation = require('../models/CampaignForCreation');
 const campaignValidator = require('../validators/campaign-validator');
 const Campaign = require('../models/Campaign');
 const { UserNotAuthorizedToCreateCampaignError } = require('../errors');
@@ -16,7 +17,8 @@ module.exports = async function createCampaign({
   await _checkIfUserCanCreateCampaign(campaign, userRepository, organizationRepository, organizationService);
 
   const generatedCampaignCode = await campaignCodeGenerator.generate(campaignRepository);
-  return campaignRepository.create({ ...campaign, code: generatedCampaignCode });
+  const campaignForCreation = new CampaignForCreation({ ...campaign, code: generatedCampaignCode });
+  return campaignRepository.create(campaignForCreation);
 };
 
 async function _checkIfUserCanCreateCampaign(campaign, userRepository, organizationRepository, organizationService) {

--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -6,5 +6,5 @@ module.exports = async function createCampaign({ campaign, campaignRepository, c
 
   const campaignForCreation = campaignCreator.createCampaign({ ...campaign, code: generatedCampaignCode });
 
-  return campaignRepository.create(campaignForCreation);
+  return campaignRepository.save(campaignForCreation);
 };

--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -1,8 +1,6 @@
 const _ = require('lodash');
 const campaignCodeGenerator = require('../services/campaigns/campaign-code-generator');
 const CampaignForCreation = require('../models/CampaignForCreation');
-const campaignValidator = require('../validators/campaign-validator');
-
 const Campaign = require('../models/Campaign');
 const { UserNotAuthorizedToCreateCampaignError } = require('../errors');
 
@@ -15,7 +13,6 @@ module.exports = async function createCampaign({
 }) {
   const generatedCampaignCode = await campaignCodeGenerator.generate(campaignRepository);
   const campaignForCreation = new CampaignForCreation({ ...campaign, code: generatedCampaignCode });
-  campaignValidator.validate(campaignForCreation);
 
   await _checkIfUserCanCreateCampaign(campaignForCreation, userRepository, organizationRepository, organizationService);
 

--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -1,75 +1,10 @@
-const _ = require('lodash');
 const campaignCodeGenerator = require('../services/campaigns/campaign-code-generator');
-const CampaignForCreation = require('../models/CampaignForCreation');
-const Campaign = require('../models/Campaign');
-const { UserNotAuthorizedToCreateCampaignError } = require('../errors');
 
-module.exports = async function createCampaign({
-  campaign,
-  campaignRepository,
-  userRepository,
-  organizationRepository,
-  organizationService,
-}) {
+module.exports = async function createCampaign({ campaign, campaignRepository, campaignCreatorRepository }) {
   const generatedCampaignCode = await campaignCodeGenerator.generate(campaignRepository);
-  const campaignForCreation = new CampaignForCreation({ ...campaign, code: generatedCampaignCode });
+  const campaignCreator = await campaignCreatorRepository.get(campaign.creatorId, campaign.organizationId);
 
-  await _checkIfUserCanCreateCampaign(campaignForCreation, userRepository, organizationRepository, organizationService);
+  const campaignForCreation = campaignCreator.createCampaign({ ...campaign, code: generatedCampaignCode });
 
   return campaignRepository.create(campaignForCreation);
 };
-
-async function _checkIfUserCanCreateCampaign(
-  campaignForCreation,
-  userRepository,
-  organizationRepository,
-  organizationService
-) {
-  if (
-    !(await _hasCreatorAccessToCampaignOrganization(
-      campaignForCreation.creatorId,
-      campaignForCreation.organizationId,
-      userRepository
-    ))
-  ) {
-    throw new UserNotAuthorizedToCreateCampaignError(
-      `User does not have an access to the organization ${campaignForCreation.organizationId}`
-    );
-  }
-
-  if (
-    campaignForCreation.type === Campaign.types.PROFILES_COLLECTION &&
-    !(await _canOrganizationCollectProfiles(campaignForCreation.organizationId, organizationRepository))
-  ) {
-    throw new UserNotAuthorizedToCreateCampaignError(
-      'Organization can not create campaign with type PROFILES_COLLECTION'
-    );
-  }
-  if (
-    campaignForCreation.type === Campaign.types.ASSESSMENT &&
-    !(await _hasOrganizationAccessToTargetProfile(
-      campaignForCreation.targetProfileId,
-      campaignForCreation.organizationId,
-      organizationService
-    ))
-  ) {
-    throw new UserNotAuthorizedToCreateCampaignError(
-      `Organization does not have an access to the profile ${campaignForCreation.targetProfileId}`
-    );
-  }
-}
-
-async function _hasCreatorAccessToCampaignOrganization(userId, organizationId, userRepository) {
-  const user = await userRepository.getWithMemberships(userId);
-  return user.hasAccessToOrganization(organizationId);
-}
-
-async function _hasOrganizationAccessToTargetProfile(targetProfileId, organizationId, organizationService) {
-  const targetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(organizationId);
-  return _.find(targetProfiles, (targetProfile) => targetProfile.id === targetProfileId);
-}
-
-async function _canOrganizationCollectProfiles(organizationId, organizationRepository) {
-  const organization = await organizationRepository.get(organizationId);
-  return organization.canCollectProfiles;
-}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -13,6 +13,7 @@ const dependencies = {
   campaignAssessmentParticipationRepository: require('../../infrastructure/repositories/campaign-assessment-participation-repository'),
   campaignAssessmentParticipationResultListRepository: require('../../infrastructure/repositories/campaign-assessment-participation-result-list-repository'),
   campaignAssessmentParticipationResultRepository: require('../../infrastructure/repositories/campaign-assessment-participation-result-repository'),
+  campaignCreatorRepository: require('../../infrastructure/repositories/campaign-creator-repository'),
   campaignParticipantActivityRepository: require('../../infrastructure/repositories/campaign-participant-activity-repository'),
   campaignCollectiveResultRepository: require('../../infrastructure/repositories/campaign-collective-result-repository'),
   campaignManagementRepository: require('../../infrastructure/repositories/campaign-management-repository'),

--- a/api/lib/domain/validators/campaign-creation-validator.js
+++ b/api/lib/domain/validators/campaign-creation-validator.js
@@ -1,0 +1,72 @@
+const Joi = require('joi');
+const { first } = require('lodash');
+const { EntityValidationError } = require('../errors');
+const Campaign = require('../models/Campaign');
+
+const schema = Joi.object({
+  type: Joi.string()
+    .valid(Campaign.types.ASSESSMENT, Campaign.types.PROFILES_COLLECTION)
+    .required()
+    .error((errors) => first(errors))
+    .messages({
+      'any.required': 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+      'string.base': 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+      'any.only': 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+    }),
+
+  name: Joi.string().required().messages({
+    'string.base': 'CAMPAIGN_NAME_IS_REQUIRED',
+    'string.empty': 'CAMPAIGN_NAME_IS_REQUIRED',
+  }),
+
+  creatorId: Joi.number().integer().required().messages({
+    'any.required': 'MISSING_CREATOR',
+    'number.base': 'MISSING_CREATOR',
+  }),
+
+  organizationId: Joi.number().integer().required().messages({
+    'any.required': 'MISSING_ORGANIZATION',
+    'number.base': 'MISSING_ORGANIZATION',
+  }),
+
+  targetProfileId: Joi.number()
+    .when('type', {
+      switch: [
+        {
+          is: Joi.string().required().valid(Campaign.types.PROFILES_COLLECTION),
+          then: Joi.valid(null).optional(),
+        },
+        {
+          is: Joi.string().required().valid(Campaign.types.ASSESSMENT),
+          then: Joi.required(),
+        },
+      ],
+    })
+    .integer()
+    .messages({
+      'any.required': 'TARGET_PROFILE_IS_REQUIRED',
+      'number.base': 'TARGET_PROFILE_IS_REQUIRED',
+      'any.only': 'TARGET_PROFILE_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
+    }),
+
+  title: Joi.string()
+    .allow(null)
+    .when('type', {
+      is: Joi.string().required().valid(Campaign.types.PROFILES_COLLECTION),
+      then: Joi.valid(null),
+      otherwise: Joi.optional(),
+    })
+    .messages({
+      'any.only': 'TITLE_OF_PERSONALISED_TEST_IS_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
+    }),
+});
+
+function validate(campaign) {
+  const { error } = schema.validate(campaign, { abortEarly: false, allowUnknown: true });
+  if (error) {
+    throw EntityValidationError.fromJoiErrors(error.details);
+  }
+  return true;
+}
+
+module.exports = validate;

--- a/api/lib/infrastructure/repositories/campaign-creator-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-creator-repository.js
@@ -1,0 +1,30 @@
+const { knex } = require('../../../db/knex-database-connection');
+const CampaignCreator = require('../../../lib/domain/models/CampaignCreator');
+const organizationService = require('../../domain/services/organization-service');
+const { UserNotAuthorizedToCreateCampaignError } = require('../../domain/errors');
+
+async function get(userId, organizationId) {
+  await _checkUserIsAMemberOfOrganization(organizationId, userId);
+  const { canCollectProfiles } = await knex('organizations')
+    .where({ id: organizationId })
+    .select('canCollectProfiles')
+    .first();
+  const availableTargetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(
+    organizationId
+  );
+  const availableTargetProfilesIds = availableTargetProfiles.map(({ id }) => id);
+  return new CampaignCreator(availableTargetProfilesIds, canCollectProfiles);
+}
+
+module.exports = {
+  get,
+};
+
+async function _checkUserIsAMemberOfOrganization(organizationId, userId) {
+  const membership = await knex('memberships').where({ organizationId, userId }).first();
+  if (!membership) {
+    throw new UserNotAuthorizedToCreateCampaignError(
+      `User does not have an access to the organization ${organizationId}`
+    );
+  }
+}

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -37,7 +37,7 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfCampaign, bookshelfCampaign);
   },
 
-  async create(campaign) {
+  async save(campaign) {
     const campaignAttributes = _.pick(campaign, [
       'name',
       'code',

--- a/api/tests/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/integration/domain/usecases/create-campaign_test.js
@@ -2,9 +2,7 @@ const { expect, databaseBuilder, mockLearningContent, knex } = require('../../..
 const _ = require('lodash');
 
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
-const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
-const organizationService = require('../../../../lib/domain/services/organization-service');
+const campaignCreatorRepository = require('../../../../lib/infrastructure/repositories/campaign-creator-repository');
 
 const createCampaign = require('../../../../lib/domain/usecases/create-campaign');
 
@@ -58,9 +56,7 @@ describe('Integration | UseCases | create-campaign', function () {
     const result = await createCampaign({
       campaign,
       campaignRepository,
-      userRepository,
-      organizationRepository,
-      organizationService,
+      campaignCreatorRepository,
     });
 
     // then
@@ -89,9 +85,7 @@ describe('Integration | UseCases | create-campaign', function () {
     const result = await createCampaign({
       campaign,
       campaignRepository,
-      userRepository,
-      organizationRepository,
-      organizationService,
+      campaignCreatorRepository,
     });
 
     // then

--- a/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
@@ -1,18 +1,9 @@
-const { expect, databaseBuilder, catchErr, mockLearningContent } = require('../../../test-helper');
+const { expect, databaseBuilder, catchErr } = require('../../../test-helper');
 const campaignCreatorRepository = require('../../../../lib/infrastructure/repositories/campaign-creator-repository');
 const { UserNotAuthorizedToCreateCampaignError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Repository | CampaignCreatorRepository', function () {
   describe('#get', function () {
-    let skillId;
-    beforeEach(function () {
-      skillId = 'skillId';
-
-      mockLearningContent({
-        skills: [{ id: skillId }],
-      });
-    });
-
     it('returns the creator for the given organization and user id', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
@@ -26,47 +17,92 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
       expect(creator.notAllowedToCreateProfileCollectionCampaign).to.equal(false);
     });
 
-    it('returns the creator and the targetProfileId list for available targetProfileId', async function () {
-      const { id: userId } = databaseBuilder.factory.buildUser();
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
-      databaseBuilder.factory.buildMembership({ organizationId, userId });
+    context('when there are target profiles', function () {
+      context('when target profiles are public', function () {
+        it('returns the public target profiles', async function () {
+          const { id: userId } = databaseBuilder.factory.buildUser();
+          const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
+          databaseBuilder.factory.buildMembership({ organizationId, userId });
 
-      const { id: targetProfilePublicId } = databaseBuilder.factory.buildTargetProfile({
-        isPublic: true,
-        outdated: false,
-      });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfilePublicId, skillId });
-      const { id: organizationTargetProfileId } = databaseBuilder.factory.buildTargetProfile({
-        isPublic: false,
-        outdated: false,
-        ownerOrganizationId: organizationId,
-      });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: organizationTargetProfileId, skillId });
-      const { id: targetProfileSharedId } = databaseBuilder.factory.buildTargetProfile({
-        isPublic: false,
-        outdated: false,
-      });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileSharedId, skillId });
-      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileSharedId, organizationId });
-      const { id: targetProfilePrivateId } = databaseBuilder.factory.buildTargetProfile({
-        isPublic: false,
-        outdated: false,
-      });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfilePrivateId, skillId });
-      const { id: targetProfileOutdatedId } = databaseBuilder.factory.buildTargetProfile({
-        isPublic: true,
-        outdated: true,
-      });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileOutdatedId, skillId });
+          const { id: targetProfilePublicId } = databaseBuilder.factory.buildTargetProfile({
+            isPublic: true,
+            outdated: false,
+          });
 
-      await databaseBuilder.commit();
+          await databaseBuilder.commit();
 
-      const creator = await campaignCreatorRepository.get(userId, organizationId);
-      expect(creator.availableTargetProfileIds).to.exactlyContain([
-        targetProfilePublicId,
-        targetProfileSharedId,
-        organizationTargetProfileId,
-      ]);
+          const creator = await campaignCreatorRepository.get(userId, organizationId);
+          expect(creator.availableTargetProfileIds).to.exactlyContain([targetProfilePublicId]);
+        });
+      });
+
+      context('when the target profiles are private', function () {
+        it('returns the shared target profiles', async function () {
+          const { id: userId } = databaseBuilder.factory.buildUser();
+          const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
+          databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+          const { id: targetProfileSharedId } = databaseBuilder.factory.buildTargetProfile({
+            isPublic: false,
+            outdated: false,
+          });
+          databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileSharedId, organizationId });
+          databaseBuilder.factory.buildTargetProfile({
+            isPublic: false,
+            outdated: false,
+          });
+
+          await databaseBuilder.commit();
+
+          const creator = await campaignCreatorRepository.get(userId, organizationId);
+          expect(creator.availableTargetProfileIds).to.exactlyContain([targetProfileSharedId]);
+        });
+
+        it('returns the target profiles is owned by the organization', async function () {
+          const { id: userId } = databaseBuilder.factory.buildUser();
+          const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
+          databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+          const { id: organizationTargetProfileId } = databaseBuilder.factory.buildTargetProfile({
+            isPublic: false,
+            outdated: false,
+            ownerOrganizationId: organizationId,
+          });
+
+          await databaseBuilder.commit();
+
+          const creator = await campaignCreatorRepository.get(userId, organizationId);
+          expect(creator.availableTargetProfileIds).to.exactlyContain([organizationTargetProfileId]);
+        });
+      });
+
+      context('when target profiles are outdated', function () {
+        it('does not return target profiles', async function () {
+          const { id: userId } = databaseBuilder.factory.buildUser();
+          const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
+          databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+          databaseBuilder.factory.buildTargetProfile({
+            isPublic: true,
+            outdated: true,
+          });
+          databaseBuilder.factory.buildTargetProfile({
+            isPublic: false,
+            outdated: true,
+            ownerOrganizationId: organizationId,
+          });
+          const { id: targetProfileSharedId } = databaseBuilder.factory.buildTargetProfile({
+            isPublic: false,
+            outdated: true,
+          });
+          databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileSharedId, organizationId });
+
+          await databaseBuilder.commit();
+
+          const creator = await campaignCreatorRepository.get(userId, organizationId);
+          expect(creator.availableTargetProfileIds).to.be.empty;
+        });
+      });
     });
 
     context('when the user is not a member the organization', function () {

--- a/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
@@ -1,0 +1,88 @@
+const { expect, databaseBuilder, catchErr, mockLearningContent } = require('../../../test-helper');
+const campaignCreatorRepository = require('../../../../lib/infrastructure/repositories/campaign-creator-repository');
+const { UserNotAuthorizedToCreateCampaignError } = require('../../../../lib/domain/errors');
+
+describe('Integration | Repository | CampaignCreatorRepository', function () {
+  describe('#get', function () {
+    let skillId;
+    beforeEach(function () {
+      skillId = 'skillId';
+
+      mockLearningContent({
+        skills: [{ id: skillId }],
+      });
+    });
+
+    it('returns the creator for the given organization and user id', async function () {
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
+      const { id: otherOrganizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: false });
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      databaseBuilder.factory.buildMembership({ organizationId: otherOrganizationId, userId });
+      await databaseBuilder.commit();
+
+      const creator = await campaignCreatorRepository.get(userId, organizationId);
+
+      expect(creator.notAllowedToCreateProfileCollectionCampaign).to.equal(false);
+    });
+
+    it('returns the creator and the targetProfileId list for available targetProfileId', async function () {
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+      const { id: targetProfilePublicId } = databaseBuilder.factory.buildTargetProfile({
+        isPublic: true,
+        outdated: false,
+      });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfilePublicId, skillId });
+      const { id: organizationTargetProfileId } = databaseBuilder.factory.buildTargetProfile({
+        isPublic: false,
+        outdated: false,
+        ownerOrganizationId: organizationId,
+      });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: organizationTargetProfileId, skillId });
+      const { id: targetProfileSharedId } = databaseBuilder.factory.buildTargetProfile({
+        isPublic: false,
+        outdated: false,
+      });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileSharedId, skillId });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileSharedId, organizationId });
+      const { id: targetProfilePrivateId } = databaseBuilder.factory.buildTargetProfile({
+        isPublic: false,
+        outdated: false,
+      });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfilePrivateId, skillId });
+      const { id: targetProfileOutdatedId } = databaseBuilder.factory.buildTargetProfile({
+        isPublic: true,
+        outdated: true,
+      });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileOutdatedId, skillId });
+
+      await databaseBuilder.commit();
+
+      const creator = await campaignCreatorRepository.get(userId, organizationId);
+      expect(creator.availableTargetProfileIds).to.exactlyContain([
+        targetProfilePublicId,
+        targetProfileSharedId,
+        organizationTargetProfileId,
+      ]);
+    });
+
+    context('when the user is not a member the organization', function () {
+      it('throws an error', async function () {
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        const { id: organizationMemberId } = databaseBuilder.factory.buildUser();
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
+        databaseBuilder.factory.buildMembership({ organizationId, userId: organizationMemberId });
+
+        await databaseBuilder.commit();
+
+        const error = await catchErr(campaignCreatorRepository.get)(userId, organizationId);
+
+        expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
+        expect(error.message).to.equal(`User does not have an access to the organization ${organizationId}`);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -110,7 +110,7 @@ describe('Integration | Repository | Campaign', function () {
       };
 
       // when
-      savedCampaign = await campaignRepository.create(campaignToSave);
+      savedCampaign = await campaignRepository.save(campaignToSave);
 
       // then
       expect(savedCampaign).to.be.instanceof(Campaign);
@@ -136,7 +136,7 @@ describe('Integration | Repository | Campaign', function () {
       campaignToSave = { ...campaignAttributes, type: Campaign.types.PROFILES_COLLECTION };
 
       // when
-      savedCampaign = await campaignRepository.create(campaignToSave);
+      savedCampaign = await campaignRepository.save(campaignToSave);
 
       // then
       expect(savedCampaign).to.be.instanceof(Campaign);

--- a/api/tests/unit/domain/models/CampaignCreator_test.js
+++ b/api/tests/unit/domain/models/CampaignCreator_test.js
@@ -1,0 +1,91 @@
+const CampaignCreator = require('../../../../lib/domain/models/CampaignCreator');
+const { expect, catchErr } = require('../../../test-helper');
+const Campaign = require('../../../../lib/domain/models/Campaign');
+const CampaignForCreation = require('../../../../lib/domain/models/CampaignForCreation');
+const { UserNotAuthorizedToCreateCampaignError, EntityValidationError } = require('../../../../lib/domain/errors');
+
+describe('Unit | Domain | Models | CampaignCreator', function () {
+  describe('#createCampaign', function () {
+    describe('when the creator is allowed to create the campaign', function () {
+      it('creates the campaign', function () {
+        const availableTargetProfileIds = [1, 2];
+        const creator = new CampaignCreator(availableTargetProfileIds, false);
+        const campaignData = {
+          name: 'campagne utilisateur',
+          type: Campaign.types.ASSESSMENT,
+          creatorId: 1,
+          organizationId: 2,
+          targetProfileId: 2,
+        };
+        const expectedCampaignForCreation = new CampaignForCreation(campaignData);
+
+        const campaignForCreation = creator.createCampaign(campaignData);
+
+        expect(campaignForCreation).to.deep.equal(expectedCampaignForCreation);
+      });
+    });
+
+    describe('when the campaign to create is an assessment campaign', function () {
+      describe('when the creator cannot use the targetProfileId', function () {
+        it('throws an error', async function () {
+          const availableTargetProfileIds = [1, 2];
+          const creator = new CampaignCreator(availableTargetProfileIds, false);
+          const campaignData = {
+            name: 'campagne utilisateur',
+            type: Campaign.types.ASSESSMENT,
+            creatorId: 1,
+            organizationId: 2,
+            targetProfileId: 5,
+          };
+          const error = await catchErr(creator.createCampaign, creator)(campaignData);
+
+          expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
+          expect(error.message).to.equal(
+            `Organization does not have an access to the profile ${campaignData.targetProfileId}`
+          );
+        });
+      });
+
+      describe('when the targetProfileId is not given', function () {
+        it('throws an error', async function () {
+          const availableTargetProfileIds = [1, 2];
+          const creator = new CampaignCreator(availableTargetProfileIds, false);
+          const campaignData = {
+            name: 'campagne utilisateur',
+            type: Campaign.types.ASSESSMENT,
+            creatorId: 1,
+            organizationId: 2,
+            targetProfileId: null,
+          };
+          const error = await catchErr(creator.createCampaign, creator)(campaignData);
+
+          expect(error).to.be.an.instanceof(EntityValidationError);
+          expect(error.message).to.equal("Échec de validation de l'entité.");
+          expect(error.invalidAttributes).to.deep.equal([
+            { attribute: 'targetProfileId', message: 'TARGET_PROFILE_IS_REQUIRED' },
+          ]);
+        });
+      });
+    });
+
+    describe('when the campaign to create is an profile collection campaign', function () {
+      describe('when the prescriber cannot create profile collection campaign', function () {
+        it('creates the campaign', async function () {
+          const canCollectProfile = false;
+          const creator = new CampaignCreator([], canCollectProfile);
+          const campaignData = {
+            name: 'campagne utilisateur',
+            type: Campaign.types.PROFILES_COLLECTION,
+            creatorId: 1,
+            organizationId: 2,
+          };
+
+          const error = await catchErr(creator.createCampaign, creator)(campaignData);
+
+          expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
+          expect(error.message).to.equal('Organization can not create campaign with type PROFILES_COLLECTION');
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/CampaignForCreation_test.js
+++ b/api/tests/unit/domain/models/CampaignForCreation_test.js
@@ -1,0 +1,181 @@
+const { expect, catchErr } = require('../../../test-helper');
+const CampaignForCreation = require('../../../../lib/domain/models/CampaignForCreation');
+const Campaign = require('../../../../lib/domain/models/Campaign');
+
+describe('Unit | Domain | Models | CampaignForCreation', function () {
+  describe('#create', function () {
+    context('when the campaign type is ASSESSEMENT', function () {
+      context('when the every required field is present', function () {
+        it('creates the campaign', function () {
+          const attributes = {
+            name: 'CampaignName',
+            type: Campaign.types.ASSESSMENT,
+            targetProfileId: 1,
+            creatorId: 2,
+            organizationId: 3,
+          };
+
+          expect(() => new CampaignForCreation(attributes)).to.not.throw();
+        });
+      });
+
+      context('when attributes are invalid', function () {
+        let attributes;
+        beforeEach(function () {
+          attributes = {
+            name: 'CampaignName',
+            type: Campaign.types.ASSESSMENT,
+            targetProfileId: 1,
+            creatorId: 2,
+            organizationId: 3,
+          };
+        });
+
+        context('name is missing', function () {
+          it('throws an error', async function () {
+            attributes.name = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'name', message: '"name" is required' }]);
+          });
+        });
+
+        context('creatorId is missing', function () {
+          it('throws an error', async function () {
+            attributes.creatorId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'creatorId', message: 'MISSING_CREATOR' }]);
+          });
+        });
+
+        context('organizationId is missing', function () {
+          it('throws an error', async function () {
+            attributes.organizationId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'organizationId', message: 'MISSING_ORGANIZATION' },
+            ]);
+          });
+        });
+
+        context('targetProfileId is missing', function () {
+          it('throws an error', async function () {
+            attributes.targetProfileId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'targetProfileId', message: 'TARGET_PROFILE_IS_REQUIRED' },
+            ]);
+          });
+        });
+      });
+    });
+
+    context('when the campaign type is PROFILE_COLLECTION', function () {
+      context('when the every required field is present', function () {
+        it('should create the campaign', function () {
+          const attributes = {
+            name: 'CampaignName',
+            type: Campaign.types.PROFILES_COLLECTION,
+            creatorId: 2,
+            organizationId: 3,
+          };
+
+          expect(() => new CampaignForCreation(attributes)).to.not.throw();
+        });
+      });
+
+      context('when attributes are invalid', function () {
+        let attributes;
+        beforeEach(function () {
+          attributes = {
+            name: 'CampaignName',
+            type: Campaign.types.PROFILES_COLLECTION,
+            creatorId: 2,
+            organizationId: 3,
+          };
+        });
+
+        context('name is missing', function () {
+          it('throws an error', async function () {
+            attributes.name = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'name', message: '"name" is required' }]);
+          });
+        });
+
+        context('creatorId is missing', function () {
+          it('throws an error', async function () {
+            attributes.creatorId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([{ attribute: 'creatorId', message: 'MISSING_CREATOR' }]);
+          });
+        });
+
+        context('organizationId is missing', function () {
+          it('throws an error', async function () {
+            attributes.organizationId = undefined;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'organizationId', message: 'MISSING_ORGANIZATION' },
+            ]);
+          });
+        });
+
+        context('targetProfileId is provided', function () {
+          it('throws an error', async function () {
+            attributes.targetProfileId = 1;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'targetProfileId', message: 'TARGET_PROFILE_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN' },
+            ]);
+          });
+        });
+
+        context('title is provided', function () {
+          it('throws an error', async function () {
+            attributes.title = 'Title';
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              {
+                attribute: 'title',
+                message: 'TITLE_OF_PERSONALISED_TEST_IS_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
+              },
+            ]);
+          });
+        });
+      });
+    });
+
+    context('when the campaign type is something else', function () {
+      it('throws an error', async function () {
+        const attributes = {
+          name: 'CampaignName',
+          type: 'BAD TYPE',
+          creatorId: 2,
+          organizationId: 3,
+        };
+
+        const error = await catchErr(() => new CampaignForCreation(attributes))();
+        expect(error.message).to.equal("Échec de validation de l'entité.");
+        expect(error.invalidAttributes).to.deep.equal([{ attribute: 'type', message: 'CAMPAIGN_PURPOSE_IS_REQUIRED' }]);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -3,6 +3,7 @@ const createCampaign = require('../../../../lib/domain/usecases/create-campaign'
 const campaignCodeGenerator = require('../../../../lib/domain/services/campaigns/campaign-code-generator');
 const { EntityValidationError, UserNotAuthorizedToCreateCampaignError } = require('../../../../lib/domain/errors');
 const Campaign = require('../../../../lib/domain/models/Campaign');
+const CampaignForCreation = require('../../../../lib/domain/models/CampaignForCreation');
 
 describe('Unit | UseCase | create-campaign', function () {
   let campaignRepository;
@@ -156,6 +157,8 @@ describe('Unit | UseCase | create-campaign', function () {
         targetProfileId,
         organizationId,
       };
+      const campaignForCreation = new CampaignForCreation({ ...campaignData, code})
+
 
       const organization = domainBuilder.buildOrganization({ id: organizationId });
       const organizationMember = _createOrganizationMember(creatorId, organization);
@@ -176,10 +179,7 @@ describe('Unit | UseCase | create-campaign', function () {
       });
 
       // then
-      expect(campaignRepository.create).to.have.been.calledWith({
-        ...campaignData,
-        code,
-      });
+      expect(campaignRepository.create).to.have.been.calledWith(campaignForCreation);
     });
 
     it('should save a profile collection campaign', async function () {
@@ -194,6 +194,7 @@ describe('Unit | UseCase | create-campaign', function () {
         organizationId,
       };
 
+      const campaignForCreation = new CampaignForCreation({ ...campaignData, code})
       const organization = domainBuilder.buildOrganization({ id: organizationId, canCollectProfiles: true });
       const organizationMember = _createOrganizationMember(creatorId, organization);
       userRepository.getWithMemberships.withArgs(creatorId).resolves(organizationMember);
@@ -212,10 +213,7 @@ describe('Unit | UseCase | create-campaign', function () {
       });
 
       // then
-      expect(campaignRepository.create).to.have.been.calledWith({
-        ...campaignData,
-        code,
-      });
+      expect(campaignRepository.create).to.have.been.calledWith(campaignForCreation);
     });
 
     it('should generate a new code to the campaign', async function () {
@@ -253,7 +251,7 @@ describe('Unit | UseCase | create-campaign', function () {
       });
 
       // then
-      expect(campaignRepository.create).to.have.been.calledWithMatch({ code });
+      expect(campaignRepository.create).to.have.been.deep.calledWithMatch({ code });
     });
 
     it('should return the newly created campaign', async function () {

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -1,285 +1,81 @@
-const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const createCampaign = require('../../../../lib/domain/usecases/create-campaign');
 const campaignCodeGenerator = require('../../../../lib/domain/services/campaigns/campaign-code-generator');
-const { UserNotAuthorizedToCreateCampaignError } = require('../../../../lib/domain/errors');
 const Campaign = require('../../../../lib/domain/models/Campaign');
+const CampaignCreator = require('../../../../lib/domain/models/CampaignCreator');
 const CampaignForCreation = require('../../../../lib/domain/models/CampaignForCreation');
 
 describe('Unit | UseCase | create-campaign', function () {
   let campaignRepository;
-  let userRepository;
-  let organizationRepository;
-  let organizationService;
+  let campaignCreatorRepository;
 
   beforeEach(function () {
     campaignRepository = { create: sinon.stub() };
-    userRepository = { getWithMemberships: sinon.stub() };
-    organizationRepository = { get: sinon.stub() };
-    organizationService = { findAllTargetProfilesAvailableForOrganization: sinon.stub() };
+    campaignCreatorRepository = { get: sinon.stub() };
     sinon.stub(campaignCodeGenerator, 'generate');
   });
 
-  context('When user do not have an access to the campaign organization', function () {
-    it('should throw an error', async function () {
-      // given
-      const code = 'ABCDEF123';
-      const creatorId = 13;
-      const campaignData = {
-        name: 'campagne utilisateur',
-        type: Campaign.types.PROFILES_COLLECTION,
-        creatorId,
-        organizationId: 12,
-      };
+  it('should save the campaign', async function () {
+    // given
+    const code = 'ABCDEF123';
+    const targetProfileId = 12;
+    const creatorId = 13;
+    const organizationId = 14;
+    const campaignData = {
+      name: 'campagne utilisateur',
+      type: Campaign.types.ASSESSMENT,
+      creatorId,
+      targetProfileId,
+      organizationId,
+    };
+    const campaignForCreation = new CampaignForCreation({ ...campaignData, code });
 
-      const user = domainBuilder.buildUser({ id: creatorId });
-      userRepository.getWithMemberships.withArgs(creatorId).resolves(user);
+    const campaignCreator = new CampaignCreator([targetProfileId], false);
+    campaignCreatorRepository.get.withArgs(creatorId, organizationId).resolves(campaignCreator);
 
-      campaignCodeGenerator.generate.resolves(code);
-      campaignRepository.create.resolves();
-      // when
-      const error = await catchErr(createCampaign)({
-        campaign: campaignData,
-        campaignRepository,
-        userRepository,
-        organizationRepository,
-        organizationService,
-      });
+    campaignCodeGenerator.generate.resolves(code);
+    campaignRepository.create.resolves();
 
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
-      expect(error.message).to.equal(
-        `User does not have an access to the organization ${campaignData.organizationId}`
-      );
+    // when
+    await createCampaign({
+      campaign: campaignData,
+      campaignRepository,
+      campaignCreatorRepository,
     });
+
+    // then
+    expect(campaignRepository.create).to.have.been.calledWith(campaignForCreation);
   });
 
-  context('When this is a profiles collection campaign and the organization cannot collect profiles', function () {
-    it('should throw an error', async function () {
-      // given
-      const code = 'ABCDEF123';
-      const creatorId = 13;
-      const organizationId = 12;
-      const campaignData = {
-        name: 'campagne utilisateur',
-        type: Campaign.types.PROFILES_COLLECTION,
-        creatorId,
-        organizationId,
-      };
-      const organization = domainBuilder.buildOrganization({ id: organizationId, canCollectProfiles: false });
-      organizationRepository.get.withArgs(organization.id).resolves(organization);
+  it('should return the newly created campaign', async function () {
+    // given
+    const code = 'ABCDEF123';
+    const targetProfileId = 12;
+    const creatorId = 13;
+    const organizationId = 14;
+    const campaignData = {
+      name: 'campagne utilisateur',
+      type: Campaign.types.ASSESSMENT,
+      creatorId,
+      targetProfileId,
+      organizationId,
+    };
+    const campaignCreator = new CampaignCreator([targetProfileId], false);
+    campaignCreatorRepository.get.withArgs(creatorId, organizationId).resolves(campaignCreator);
 
-      const organizationMember = _createOrganizationMember(creatorId, organization);
-      userRepository.getWithMemberships.withArgs(creatorId).resolves(organizationMember);
+    campaignCodeGenerator.generate.resolves(code);
+    const savedCampaign = Symbol('a saved campaign');
 
-      // when
-      const error = await catchErr(createCampaign)({
-        campaign: campaignData,
-        campaignRepository,
-        userRepository,
-        organizationRepository,
-        organizationService,
-      });
+    campaignRepository.create.resolves(savedCampaign);
 
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
-      expect(error.message).to.equal('Organization can not create campaign with type PROFILES_COLLECTION');
-    });
-  });
-
-  context('When the target profile cannot be used by the organization', function () {
-    it('should save an assessment campaign', async function () {
-      // given
-      const code = 'ABCDEF123';
-      const targetProfileId = 12;
-      const creatorId = 13;
-      const organizationId = 14;
-      const campaignData = {
-        name: 'campagne utilisateur',
-        type: Campaign.types.ASSESSMENT,
-        creatorId,
-        targetProfileId,
-        organizationId,
-      };
-
-      const organization = domainBuilder.buildOrganization({ id: organizationId });
-      const organizationMember = _createOrganizationMember(creatorId, organization);
-      userRepository.getWithMemberships.withArgs(creatorId).resolves(organizationMember);
-      organizationService.findAllTargetProfilesAvailableForOrganization.resolves([]);
-
-      campaignCodeGenerator.generate.resolves(code);
-      campaignRepository.create.resolves();
-
-      // when
-      const error = await catchErr(createCampaign)({
-        campaign: campaignData,
-        campaignRepository,
-        userRepository,
-        organizationRepository,
-        organizationService,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
-      expect(error.message).to.equal(`Organization does not have an access to the profile ${campaignData.targetProfileId}`);
-    });
-  });
-
-  context('When the campaign is valid', function () {
-    it('should save an assessment campaign', async function () {
-      // given
-      const code = 'ABCDEF123';
-      const targetProfileId = 12;
-      const creatorId = 13;
-      const organizationId = 14;
-      const campaignData = {
-        name: 'campagne utilisateur',
-        type: Campaign.types.ASSESSMENT,
-        creatorId,
-        targetProfileId,
-        organizationId,
-      };
-      const campaignForCreation = new CampaignForCreation({ ...campaignData, code})
-
-
-      const organization = domainBuilder.buildOrganization({ id: organizationId });
-      const organizationMember = _createOrganizationMember(creatorId, organization);
-      userRepository.getWithMemberships.withArgs(creatorId).resolves(organizationMember);
-      const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId, isPublic: true });
-      organizationService.findAllTargetProfilesAvailableForOrganization.resolves([targetProfile]);
-
-      campaignCodeGenerator.generate.resolves(code);
-      campaignRepository.create.resolves();
-
-      // when
-      await createCampaign({
-        campaign: campaignData,
-        campaignRepository,
-        userRepository,
-        organizationRepository,
-        organizationService,
-      });
-
-      // then
-      expect(campaignRepository.create).to.have.been.calledWith(campaignForCreation);
+    // when
+    const campaign = await createCampaign({
+      campaign: campaignData,
+      campaignRepository,
+      campaignCreatorRepository,
     });
 
-    it('should save a profile collection campaign', async function () {
-      // given
-      const code = 'ABCDEF123';
-      const creatorId = 13;
-      const organizationId = 14;
-      const campaignData = {
-        name: 'campagne utilisateur',
-        type: Campaign.types.PROFILES_COLLECTION,
-        creatorId,
-        organizationId,
-      };
-
-      const campaignForCreation = new CampaignForCreation({ ...campaignData, code})
-      const organization = domainBuilder.buildOrganization({ id: organizationId, canCollectProfiles: true });
-      const organizationMember = _createOrganizationMember(creatorId, organization);
-      userRepository.getWithMemberships.withArgs(creatorId).resolves(organizationMember);
-      organizationRepository.get.resolves(organization);
-
-      campaignCodeGenerator.generate.resolves(code);
-      campaignRepository.create.resolves();
-
-      // when
-      await createCampaign({
-        campaign: campaignData,
-        campaignRepository,
-        userRepository,
-        organizationRepository,
-        organizationService,
-      });
-
-      // then
-      expect(campaignRepository.create).to.have.been.calledWith(campaignForCreation);
-    });
-
-    it('should generate a new code to the campaign', async function () {
-      // given
-      const code = 'ABCDEF123';
-      const creatorId = 13;
-      const organizationId = 14;
-      const targetProfileId = 11;
-
-      const campaignData = {
-        name: 'campagne utilisateur',
-        type: Campaign.types.ASSESSMENT,
-        creatorId,
-        targetProfileId,
-        organizationId,
-      };
-
-      const organization = domainBuilder.buildOrganization({ id: campaignData.organizationId });
-      const organizationMember = _createOrganizationMember(creatorId, organization);
-      userRepository.getWithMemberships.withArgs(creatorId).resolves(organizationMember);
-
-      const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId });
-      organizationService.findAllTargetProfilesAvailableForOrganization.resolves([targetProfile]);
-
-      campaignCodeGenerator.generate.resolves(code);
-      campaignRepository.create.resolves();
-
-      // when
-      await createCampaign({
-        campaign: campaignData,
-        campaignRepository,
-        userRepository,
-        organizationRepository,
-        organizationService,
-      });
-
-      // then
-      expect(campaignRepository.create).to.have.been.deep.calledWithMatch({ code });
-    });
-
-    it('should return the newly created campaign', async function () {
-      // given
-      const code = 'ABCDEF123';
-      const targetProfileId = 12;
-      const creatorId = 13;
-      const organizationId = 14;
-      const campaignData = {
-        name: 'campagne utilisateur',
-        type: Campaign.types.ASSESSMENT,
-        creatorId,
-        targetProfileId,
-        organizationId,
-      };
-
-      const organization = domainBuilder.buildOrganization({ id: campaignData.organizationId });
-      const organizationMember = _createOrganizationMember(creatorId, organization);
-      userRepository.getWithMemberships.withArgs(creatorId).resolves(organizationMember);
-      const targetProfile = domainBuilder.buildTargetProfile({ id: targetProfileId, isPublic: true });
-      organizationService.findAllTargetProfilesAvailableForOrganization.resolves([targetProfile]);
-
-      campaignCodeGenerator.generate.resolves(code);
-      const savedCampaign = Symbol('a saved campaign');
-
-      campaignRepository.create.resolves(savedCampaign);
-
-      // when
-      const campaign = await createCampaign({
-        campaign: campaignData,
-        campaignRepository,
-        userRepository,
-        organizationRepository,
-        organizationService,
-      });
-
-      // then
-      expect(campaign).to.deep.equal(savedCampaign);
-    });
+    // then
+    expect(campaign).to.deep.equal(savedCampaign);
   });
 });
-
-function _createOrganizationMember(userId, organization) {
-  const organizationMember = domainBuilder.buildUser({ id: userId, memberships: [] });
-
-  const membership = domainBuilder.buildMembership({ organization: organization });
-  organizationMember.memberships.push(membership);
-
-  return organizationMember;
-}

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -4,7 +4,6 @@ const campaignCodeGenerator = require('../../../../lib/domain/services/campaigns
 const campaignValidator = require('../../../../lib/domain/validators/campaign-validator');
 const { EntityValidationError, UserNotAuthorizedToCreateCampaignError } = require('../../../../lib/domain/errors');
 const Campaign = require('../../../../lib/domain/models/Campaign');
-const _ = require('lodash');
 
 describe('Unit | UseCase | create-campaign', function () {
   const availableCampaignCode = 'ABCDEF123';
@@ -160,10 +159,10 @@ describe('Unit | UseCase | create-campaign', function () {
     });
 
     // then
-    const [campaignToCreateWithCode] = campaignRepository.create.firstCall.args;
-
-    expect(campaignToCreateWithCode).to.deep.include({
-      ..._.pick(campaignToCreate, ['name', 'userId', 'type', 'organizationId']),
+    expect(campaignRepository.create).to.have.been.calledWith({
+      creatorId,
+      targetProfileId,
+      organizationId,
       code: availableCampaignCode,
     });
   });

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | create-campaign', function () {
   let campaignCreatorRepository;
 
   beforeEach(function () {
-    campaignRepository = { create: sinon.stub() };
+    campaignRepository = { save: sinon.stub() };
     campaignCreatorRepository = { get: sinon.stub() };
     sinon.stub(campaignCodeGenerator, 'generate');
   });
@@ -34,7 +34,7 @@ describe('Unit | UseCase | create-campaign', function () {
     campaignCreatorRepository.get.withArgs(creatorId, organizationId).resolves(campaignCreator);
 
     campaignCodeGenerator.generate.resolves(code);
-    campaignRepository.create.resolves();
+    campaignRepository.save.resolves();
 
     // when
     await createCampaign({
@@ -44,7 +44,7 @@ describe('Unit | UseCase | create-campaign', function () {
     });
 
     // then
-    expect(campaignRepository.create).to.have.been.calledWith(campaignForCreation);
+    expect(campaignRepository.save).to.have.been.calledWith(campaignForCreation);
   });
 
   it('should return the newly created campaign', async function () {
@@ -66,7 +66,7 @@ describe('Unit | UseCase | create-campaign', function () {
     campaignCodeGenerator.generate.resolves(code);
     const savedCampaign = Symbol('a saved campaign');
 
-    campaignRepository.create.resolves(savedCampaign);
+    campaignRepository.save.resolves(savedCampaign);
 
     // when
     const campaign = await createCampaign({

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const createCampaign = require('../../../../lib/domain/usecases/create-campaign');
 const campaignCodeGenerator = require('../../../../lib/domain/services/campaigns/campaign-code-generator');
-const { EntityValidationError, UserNotAuthorizedToCreateCampaignError } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToCreateCampaignError } = require('../../../../lib/domain/errors');
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const CampaignForCreation = require('../../../../lib/domain/models/CampaignForCreation');
 
@@ -17,25 +17,6 @@ describe('Unit | UseCase | create-campaign', function () {
     organizationRepository = { get: sinon.stub() };
     organizationService = { findAllTargetProfilesAvailableForOrganization: sinon.stub() };
     sinon.stub(campaignCodeGenerator, 'generate');
-  });
-
-  context('When the campaign is not valid', function () {
-    it('should throw an EntityValidationError', async function () {
-      // given
-      const invalidCampaign = {};
-
-      // when
-      const error = await catchErr(createCampaign)({
-        campaign: invalidCampaign,
-        campaignRepository,
-        userRepository,
-        organizationRepository,
-        organizationService,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(EntityValidationError);
-    });
   });
 
   context('When user do not have an access to the campaign organization', function () {

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -127,7 +127,7 @@ describe('Unit | UseCase | create-campaign', function () {
     });
 
     // then
-    expect(campaignCodeGenerator.generate).to.have.been.called;
+    expect(campaignRepository.create).to.have.been.calledWithMatch({ code: availableCampaignCode });
   });
 
   it('should save the campaign with name, type, userId, organizationId and generated code', async function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
La logique de création de campagne fuite dans le use case.
En conséquence de quoi le use ne case ne fait plus uniquement de l'orchestration et le code et les tests deviennent plus complexe à comprendre et à maintenir.


## :bat: Solution
Essayer de sortir la logique de création de la campagne du use case.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester

Essayer de créer des campagnes.