### PR TITLE
[TECH] Expliciter la journalisation des métriques OPS.

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -46,7 +46,7 @@ module.exports = (function () {
 
     environment: process.env.NODE_ENV || 'development',
 
-    isProduction: 'production' === process.env.NODE_ENV,
+    logOpsMetrics: isFeatureEnabled(process.env.LOG_OPS_METRICS),
 
     hapi: {
       options: {},

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -24,6 +24,7 @@ const schema = Joi.object({
   LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
   LOG_FOR_HUMANS: Joi.string().optional().valid('true', 'false'),
+  LOG_OPS_METRICS: Joi.string().optional().valid('true', 'false'),
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   CACHE_RELOAD_TIME: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -305,12 +305,14 @@ LOG_ENDING_EVENT_DISPATCH=true
 # default: "info"
 # LOG_LEVEL=debug
 
-# Enable OPS logging
-# If 'production', will log core container metrics
+# Log operations metrics
+#
+# Log core container metrics: CPU, memory, load-average, http calls...
 # Sample output: {"event":"ops","timestamp":1630419363680,"host":"pix-api-production-web-2","pid":22,"os":{"load":[2.16,1.97,1.85],"mem":{"total":42185723904,"free":6782152704},"uptime":8208319.46},"proc":{"uptime":81367.686662047,"mem":{"rss":196128768,"heapTotal":109948928,"heapUsed":104404328,"external":6004718,"arrayBuffers":4416211},"delay":0.11345672607421875},"load":{"requests":{"21344":{"total":55,"disconnects":0,"statusCodes":{"200":43,"201":10,"204":1,"401":1}}},"responseTimes":{"21344":{"avg":19.472727272727273,"max":64}},"sockets":{"http":{"total":0},"https":{"total":0}}}}
+#
 # presence: optional
 # type: String
-# NODE_ENV=production
+# LOG_OPS_METRICS=true
 
 # Log for humans
 #

--- a/api/sample.env
+++ b/api/sample.env
@@ -65,6 +65,17 @@ REDIS_URL=redis://localhost:6379
 # DATABASES
 # =========
 
+# Environment
+#
+# Developement: will persist data in DATABASE_URL, allocate 1 to 4 connexion in pool
+# Test: will persist data in TEST_DATABASE_URL, allocate 1 to 4 connexion in pool
+# Production: will persist data in DATABASE_URL, allocate 1 to DATABASE_CONNECTION_POOL_MAX_SIZE connexion in pool
+#
+# presence: optional
+# type: string (any of 'development', 'test', 'production' )
+# default: development in npm start task, test in npm test task
+# NODE_ENV=development
+
 # URL of the PostgreSQL database used for storing users data (filled-in or
 # generated).
 #

--- a/api/server.js
+++ b/api/server.js
@@ -22,7 +22,7 @@ const setupServer = async () => {
 
   const server = await createServer();
 
-  if (settings.isProduction) await enableOpsMetrics(server);
+  if (settings.logOpsMetrics) await enableOpsMetrics(server);
 
   setupErrorHandling(server);
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite de la [PR](https://github.com/1024pix/pix/pull/3429) qui réduisait les dépendances à `NODE_ENV` 
Décorréler le log des métriques OPS de l'environnement

## :bat: Solution
Création de la variable d'environnement `LOG_OPS_METRICS`

## :spider_web: Remarques
- [x] Créer cette variable à `true` avant la MEP

Il ne reste plus qu'un seul usage de `NODE_ENV` , il a été documenté

## :ghost: Pour tester
Activer sur la RA et vérifier la présence de logs tagguées `ops`

` scalingo --region osc-fr1 --app pix-api-review-pr3699 logs --lines 10000 | grep ops`

```
2021-11-05 18:22:09.299229257 +0100 CET [web-1] {"level":30,"time":1636132929298,"pid":23,"hostname":"pix-api-review-pr3699-web-1","tags":["ops"],"data":{"host":"pix-api-review-pr3699-web-1","osload":[1.49,1.66,1.89],"osmem":{"total":42185732096,"free":5883691008},"osup":12125736.32,"psup":16.834622979,"psmem":{"rss":142684160,"heapTotal":77766656,"heapUsed":71899808,"external":5673565,"arrayBuffers":4111606},"pscpu":{"user":3358598,"system":313105},"psdelay":0.9337272644042969,"requests":{},"responseTimes":{},"sockets":{"http":{"total":0},"https":{"total":0}}}}
```
