### PR TITLE
[BUGFIX] Empêcher le débordement de l'en-tête de colonne "Temps majoré" (PIX-3804). 

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -187,6 +187,7 @@
 
 .certification-candidates-table__column-time {
   width: 50px;
+  box-sizing: content-box;
 }
 
 .certification-candidates-actions {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les images parlent d'elles-mêmes :sweat_smile: 

![image](https://user-images.githubusercontent.com/56302715/140717713-8a07375a-0f3d-4ead-949c-a5e4e015928f.png)

## :bat: Solution
Ajouter la propriété `box-sizing: content-box;`

## :spider_web: Remarques
Cela est lié à une régression PIX-UI qui passe tous les éléments à `border-box`

## :ghost: Pour tester

1. Créer une session de certification
2. Ajouter un candidat avec temps majoré
3. Vérifier l'affichage
