### PR TITLE
[FEATURE] Afficher la présence des candidats en session de certification (PIX-3654)

### DIFF
--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -22,6 +22,7 @@ module.exports = function buildCertificationCandidate({
   extraTimePercentage = 0.3,
   userId,
   schoolingRegistrationId,
+  authorizedToStart = false,
 } = {}) {
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -45,6 +46,7 @@ module.exports = function buildCertificationCandidate({
     createdAt,
     userId,
     schoolingRegistrationId,
+    authorizedToStart,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/database-builder/factory/build-session.js
+++ b/api/db/database-builder/factory/build-session.js
@@ -22,7 +22,7 @@ module.exports = function buildSession({
   juryComment = null,
   juryCommentAuthorId = null,
   juryCommentedAt = null,
-  supervisorPassword = null,
+  supervisorPassword = 'PIX12',
 } = {}) {
   if (_.isUndefined(certificationCenterId)) {
     const builtCertificationCenter = buildCertificationCenter();

--- a/api/db/migrations/20211029094139_add-candidate-in-session-status.js
+++ b/api/db/migrations/20211029094139_add-candidate-in-session-status.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-candidates';
+const TITLE_COLUMN = 'authorizedToStart';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(TITLE_COLUMN).notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(TITLE_COLUMN);
+  });
+};

--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -44,8 +44,10 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
 
   // A LOT of candidates for the BIG started session
   for (let i = 0; i < A_LOT_OF_CANDIDATES_COUNT; ++i) {
-    databaseBuilder.factory.buildCertificationCandidate({ sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, userId: null });
+    databaseBuilder.factory.buildCertificationCandidate({ firstName: 'Jean-Paul', lastName: _convertToRoman(i + 1), sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, userId: null });
   }
+
+  databaseBuilder.factory.buildCertificationCandidate({ sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, userId: null, authorizedToStart: true });
 
   let sessionId;
   const candidateDataSuccessWithUser = { ...CANDIDATE_DATA_SUCCESS, userId: CERTIF_SUCCESS_USER_ID };
@@ -106,3 +108,31 @@ module.exports = {
   CANDIDATE_DATA_STARTED,
   CANDIDATE_SCO_DATA_SUCCESS,
 };
+
+const romanMatrix = [
+  [1000, 'M'],
+  [900, 'CM'],
+  [500, 'D'],
+  [400, 'CD'],
+  [100, 'C'],
+  [90, 'XC'],
+  [50, 'L'],
+  [40, 'XL'],
+  [10, 'X'],
+  [9, 'IX'],
+  [5, 'V'],
+  [4, 'IV'],
+  [1, 'I'],
+];
+
+function _convertToRoman(num) {
+  if (num === 0) {
+    return '';
+  }
+  for (let i = 0; i < romanMatrix.length; i++) {
+    const [pivot, roman] = romanMatrix[i];
+    if (num >= pivot) {
+      return roman + _convertToRoman(num - pivot);
+    }
+  }
+}

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -1,12 +1,13 @@
 const isNil = require('lodash/isNil');
 
 class CertificationCandidateForSupervising {
-  constructor({ id, firstName, lastName, birthdate, extraTimePercentage } = {}) {
+  constructor({ id, firstName, lastName, birthdate, extraTimePercentage, authorizedToStart } = {}) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
     this.birthdate = birthdate;
     this.extraTimePercentage = !isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : extraTimePercentage;
+    this.authorizedToStart = authorizedToStart;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/certifications-livret-scolaire/certification-ls-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certifications-livret-scolaire/certification-ls-serializer.js
@@ -20,7 +20,7 @@ module.exports = {
   serialize(certificate) {
     return new Serializer('certificationsResults', {
       attributes: ['certifications', 'competences'],
-      certificate: {
+      certifications: {
         attributes: [...attributes],
         competenceResults: {
           attributes: ['competence-id', 'level'],

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -1,12 +1,16 @@
 const { Serializer } = require('jsonapi-serializer');
 
-const attributes = ['id', 'firstName', 'lastName', 'birthdate', 'extraTimePercentage'];
+const attributes = ['id', 'firstName', 'lastName', 'birthdate', 'extraTimePercentage', 'authorizedToStart'];
 
 module.exports = {
   serialize(sessions) {
     return new Serializer('sessionForSupervising', {
       attributes: ['room', 'examiner', 'date', 'time', 'certificationCenterName', 'certificationCandidates'],
+      typeForAttribute: (attribute) =>
+        attribute === 'certificationCandidates' ? 'certification-candidate-for-supervising' : attribute,
       certificationCandidates: {
+        included: true,
+        ref: 'id',
         attributes: [...attributes],
       },
     }).serialize(sessions);

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
@@ -33,7 +33,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.type).to.equal('sessionForSupervisings');
+      expect(response.result.data.type).to.equal('sessionForSupervising');
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -53,6 +53,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
         lastName: 'Jackson',
         firstName: 'Michael',
         sessionId: session.id,
+        authorizedToStart: true,
       });
       databaseBuilder.factory.buildCertificationCandidate({
         lastName: 'Stardust',
@@ -72,12 +73,12 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName'])
+        _.pick(item, ['sessionId', 'lastName', 'firstName', 'authorizedToStart'])
       );
       expect(actualCandidates).to.have.deep.ordered.members([
-        { lastName: 'Jackson', firstName: 'Janet' },
-        { lastName: 'Jackson', firstName: 'Michael' },
-        { lastName: 'Stardust', firstName: 'Ziggy' },
+        { lastName: 'Jackson', firstName: 'Janet', authorizedToStart: false },
+        { lastName: 'Jackson', firstName: 'Michael', authorizedToStart: true },
+        { lastName: 'Stardust', firstName: 'Ziggy', authorizedToStart: false },
       ]);
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -7,25 +7,39 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
       // given
       const expectedPayload = {
         data: {
-          type: 'sessionForSupervisings',
-          id: '12',
           attributes: {
-            room: '28D',
-            date: '2017-01-20',
-            time: '14:30',
             'certification-center-name': 'Toto',
+            date: '2017-01-20',
             examiner: 'Antoine Toutvenant',
-            'certification-candidates': [
-              {
-                id: 1234,
-                'first-name': 'toto',
-                'last-name': 'tata',
-                birthdate: '28/05/1984',
-                'extra-time-percentage': null,
-              },
-            ],
+            room: '28D',
+            time: '14:30',
           },
+          id: '12',
+          relationships: {
+            'certification-candidates': {
+              data: [
+                {
+                  id: '1234',
+                  type: 'certification-candidate-for-supervising',
+                },
+              ],
+            },
+          },
+          type: 'sessionForSupervising',
         },
+        included: [
+          {
+            attributes: {
+              birthdate: '28/05/1984',
+              'extra-time-percentage': 33,
+              'first-name': 'toto',
+              id: 1234,
+              'last-name': 'tata',
+            },
+            id: '1234',
+            type: 'certification-candidate-for-supervising',
+          },
+        ],
       };
 
       const modelSession = domainBuilder.buildSessionForSupervising({
@@ -51,7 +65,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             resultRecipientEmail: null,
             externalId: 'EXT1234',
             birthdate: '28/05/1984',
-            extraTimePercentage: null,
+            extraTimePercentage: 33,
             createdAt: '2021-02-01',
             sessionId: '456',
             userId: '747',

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -9,6 +9,7 @@
               @id={{concat "candidate-checkbox-" candidate.id}}
               class="session-supervising-candidate-list__candidate-checkbox"
               type="checkbox"
+              checked={{candidate.authorizedToStart}}
             />
             <div>
               <div class="session-supervising-candidate-list__candidate-full-name">

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -5,14 +5,23 @@
       <ul class="session-supervising-candidate-list__candidates">
         {{#each @candidates as |candidate|}}
           <li class="session-supervising-candidate-list__candidate">
-            <div class="session-supervising-candidate-list__candidate-full-name">
-              {{candidate.lastName}} {{candidate.firstName}}
-            </div>
-            <div class="session-supervising-candidate-list__candidate-details">
-              {{moment-format candidate.birthdate "DD/MM/YYYY"}}
-              {{#if candidate.extraTimePercentage}}
-                · Temps majoré : {{candidate.extraTimePercentage}}%
-              {{/if}}
+            <PixInput
+              @id={{concat "candidate-checkbox-" candidate.id}}
+              class="session-supervising-candidate-list__candidate-checkbox"
+              type="checkbox"
+            />
+            <div>
+              <div class="session-supervising-candidate-list__candidate-full-name">
+                <label for={{concat "candidate-checkbox-" candidate.id}}>
+                  {{candidate.lastName}} {{candidate.firstName}}
+                </label>
+              </div>
+              <div class="session-supervising-candidate-list__candidate-details">
+                {{moment-format candidate.birthdate "DD/MM/YYYY"}}
+                {{#if candidate.extraTimePercentage}}
+                  · Temps majoré : {{candidate.extraTimePercentage}}%
+                {{/if}}
+              </div>
             </div>
           </li>
         {{/each}}

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -1,0 +1,8 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CertificationCandidateForSupervising extends Model {
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('date-only') birthdate;
+  @attr('number') extraTimePercentage;
+}

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -5,4 +5,5 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('string') lastName;
   @attr('date-only') birthdate;
   @attr('number') extraTimePercentage;
+  @attr('boolean') authorizedToStart;
 }

--- a/certif/app/models/session-for-supervising.js
+++ b/certif/app/models/session-for-supervising.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes*/
 
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class SessionForSupervising extends Model {
 
@@ -9,5 +9,5 @@ export default class SessionForSupervising extends Model {
   @attr('string') examiner;
   @attr('string') room;
   @attr('string') certificationCenterName;
-  @attr() certificationCandidates;
+  @hasMany('certification-candidate-for-supervising') certificationCandidates;
 }

--- a/certif/app/models/session-for-supervising.js
+++ b/certif/app/models/session-for-supervising.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class SessionForSupervising extends Model {

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -41,9 +41,11 @@ $grey-85: rgb(37, 56, 88);
     }
 
     &__candidate {
-      padding: 12px 42px;
+      padding: 12px 16px;
       margin-bottom: 8px;
       border-radius: 4px;
+      display: flex;
+      align-items: center;
     }
 
     &__candidate-details {
@@ -69,6 +71,12 @@ $grey-85: rgb(37, 56, 88);
       margin: auto;
       max-width: 225px;
       text-align: center;
+    }
+
+    &__candidate-checkbox {
+      width: 32px;
+      height: 32px;
+      margin-right: 16px;
     }
   }
 }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -186,7 +186,7 @@ export default function() {
     return schema.countries.all();
   });
 
-  this.get('/sessions/:id/supervising', (schema, request) => {
+  this.get('/sessions/:id/supervising', async (schema, request) => {
     const sessionId = request.params.id;
     return schema.sessionForSupervisings.find(sessionId);
   });

--- a/certif/mirage/serializers/session-for-supervising.js
+++ b/certif/mirage/serializers/session-for-supervising.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+const include = ['certificationCandidates'];
+
+export default ApplicationSerializer.extend({
+  include,
+});

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -1,0 +1,62 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, fillIn } from '@ember/test-helpers';
+import { visit as visitScreen } from '@pix/ember-testing-library';
+import { authenticateSession } from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Session supervising', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    const certificationPointOfContact = server.create('certification-point-of-contact', {
+      firstName: 'Buffy',
+      lastName: 'Summers',
+      pixCertifTermsOfServiceAccepted: true,
+      allowedCertificationCenterAccesses: [],
+    });
+    await authenticateSession(certificationPointOfContact.id);
+  });
+
+  module('When there are candidates on the session', function() {
+    test('it should display candidates entries', async function(assert) {
+      // given
+      const sessionId = 12345;
+      this.sessionForSupervising = server.create('session-for-supervising', {
+        id: sessionId,
+        certificationCandidates: [
+          server.create('certification-candidate-for-supervising', {
+            id: 123,
+            firstName: 'Toto',
+            lastName: 'Tutu',
+            birthdate: '1984-05-28',
+            extraTimePercentage: '8',
+            authorizedToStart: true,
+          }),
+          server.create('certification-candidate-for-supervising', {
+            id: 456,
+            firstName: 'Star',
+            lastName: 'Lord',
+            birthdate: '1983-06-28',
+            extraTimePercentage: '12',
+            authorizedToStart: false,
+          }),
+        ],
+      });
+
+      const screen = await visitScreen('/connexion-espace-surveillant');
+      await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
+      await fillIn(screen.getByLabelText('Mot de passe de la session'), '6789');
+
+      // when
+      await click(screen.getByRole('button', { name: 'Surveiller la session' }));
+
+      // then
+      assert.dom(screen.getByRole('checkbox', { name: 'Tutu Toto' })).exists();
+      assert.dom(screen.getByRole('checkbox', { name: 'Lord Star' })).exists();
+    });
+  });
+});

--- a/certif/tests/acceptance/supervisor-portal-access_test.js
+++ b/certif/tests/acceptance/supervisor-portal-access_test.js
@@ -24,7 +24,7 @@ module('Acceptance | Supervisor Portal', function(hooks) {
   });
 
   module('When supervisor authentication is successful', function() {
-    test('it should redirect to ', async function(assert) {
+    test('it should redirect to supervising page', async function(assert) {
       // given
       const screen = await visitScreen('/connexion-espace-surveillant');
       await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@pix/ember-testing-library';
 
 import hbs from 'htmlbars-inline-precompile';
 
@@ -15,10 +16,10 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
 
   test('it renders the candidates information', async function(assert) {
     // given
-
     this.sessionForSupervising = store.createRecord('session-for-supervising', {
       certificationCandidates: [
         store.createRecord('certification-candidate-for-supervising', {
+          id: 123,
           firstName: 'Toto',
           lastName: 'Tutu',
           birthdate: '1984-05-28',
@@ -26,19 +27,22 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
           authorizedToStart: true,
         }),
         store.createRecord('certification-candidate-for-supervising', {
+          id: 456,
           firstName: 'Star',
           lastName: 'Lord',
           birthdate: '1983-06-28',
           extraTimePercentage: '12',
           authorizedToStart: false,
         }),
-      ] });
+      ],
+    });
 
     // when
-    await render(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}}  />`);
+    const screen = await renderScreen(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}}  />`);
 
     // then
-    assert.contains('Tutu Toto');
+    assert.dom(screen.getByRole('checkbox', { name: 'Tuto Toto' })).exists();
+    assert.contains('Tuto Toto');
     assert.contains('· Temps majoré : 8%');
     assert.contains('28/05/1984');
     assert.contains('Lord Star');

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
 import { render as renderScreen } from '@pix/ember-testing-library';
 
 import hbs from 'htmlbars-inline-precompile';
@@ -41,11 +40,12 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
     const screen = await renderScreen(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}}  />`);
 
     // then
-    assert.dom(screen.getByRole('checkbox', { name: 'Tuto Toto' })).exists();
-    assert.contains('Tuto Toto');
+    assert.dom(screen.getByRole('checkbox', { name: 'Tutu Toto' })).isChecked();
+    assert.contains('Tutu Toto');
     assert.contains('· Temps majoré : 8%');
     assert.contains('28/05/1984');
-    assert.contains('Lord Star');
+
+    assert.dom(screen.getByRole('checkbox', { name: 'Lord Star' })).isNotChecked();
     assert.contains('· Temps majoré : 12%');
     assert.contains('28/06/1983');
   });
@@ -57,7 +57,7 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
         certificationCandidates: [] });
 
       // when
-      await render(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}} />`);
+      await renderScreen(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}} />`);
 
       // then
       assert.contains('Aucun candidat inscrit à cette session');

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -18,18 +18,20 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
 
     this.sessionForSupervising = store.createRecord('session-for-supervising', {
       certificationCandidates: [
-        {
+        store.createRecord('certification-candidate-for-supervising', {
           firstName: 'Toto',
           lastName: 'Tutu',
           birthdate: '1984-05-28',
           extraTimePercentage: '8',
-        },
-        {
+          authorizedToStart: true,
+        }),
+        store.createRecord('certification-candidate-for-supervising', {
           firstName: 'Star',
           lastName: 'Lord',
           birthdate: '1983-06-28',
           extraTimePercentage: '12',
-        },
+          authorizedToStart: false,
+        }),
       ] });
 
     // when


### PR DESCRIPTION
## :jack_o_lantern: Problème
L’espace surveillant permet entre autre de ne plus avoir à contrôler la fin de test des candidats. Le surveillant puis l’utilisateur Pix Certif qui finalise la session n’aura donc plus besoin de remplir l’information “Fin de test vue ?”.

L’info sur la fin de test permettait notamment au pôle certif de s’assurer que le candidat avait bien effectué la totalité de son test sous surveillance, l’envoi de la feuille d'émargement à Pix n'étant plus obligatoire. Sans cette information, un candidat présent en salle pourrait tout à fait envoyer le code d’accès à un camarade absent qui ferait alors son test en dehors de toute surveillance.

## :bat: Solution
Permettre au surveillant depuis l’espace surveillant d’indiquer les candidats présents en salle, seuls ces candidats pourront alors lancer leur test de certification : 

- ajouter pour chaque candidat dans la liste une case à cocher

## :spider_web: Remarques
Maquettes : 

- mobile : https://share.goabstract.com/18beca74-eff3-4094-91af-86516c19a350?collectionLayerId=dc9056de-74d2-486a-8f66-7681249c330f&mode=design

- tablette : https://share.goabstract.com/18beca74-eff3-4094-91af-86516c19a350?collectionLayerId=31b92880-9a41-4b82-9a35-bff7bf247e69&mode=design

- Ordi : https://share.goabstract.com/18beca74-eff3-4094-91af-86516c19a350?collectionLayerId=ecf0a244-1c86-4f27-9316-2134d715cdf8&mode=design

## :ghost: Pour tester
- Activer le toggle  FT_END_TEST_SCREEN_REMOVAL_ENABLED
- Se connecter à pix-certif
- Rejoindre l'espace surveillant
- Se connecter à la session 3 avec le mot de passe PIX12
- Constater la présence des checkbox non cochées pour chaque candidats sauf un dont l'attribut authorizedToStart est déjà à true
