### PR TITLE
[FEATURE] Mises à jour d'affiche mineur sur certif (PIX-3780)

### DIFF
--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -6,7 +6,7 @@
         {{#each @candidates as |candidate|}}
           <li class="session-supervising-candidate-list__candidate">
             <div class="session-supervising-candidate-list__candidate-full-name">
-              {{candidate.firstName}} {{candidate.lastName}}
+              {{candidate.lastName}} {{candidate.firstName}}
             </div>
             <div class="session-supervising-candidate-list__candidate-details">
               {{moment-format candidate.birthdate "DD/MM/YYYY"}}

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -4,6 +4,12 @@
   min-width: 576px;
   max-width: 576px;
 
+  fieldset {
+    margin: 0;
+    border: 0;
+    padding: 0;
+  }
+
   &__title {
     font-family: $open-sans;
     padding: 12px 32px;

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -53,6 +53,7 @@ $grey-85: rgb(37, 56, 88);
 
     &__candidate-full-name {
       color: $yellow-30;
+      margin-bottom: 4px;
     }
 
     &__empty-image {

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -32,7 +32,7 @@ $grey-85: rgb(37, 56, 88);
       padding: 0;
 
       li:nth-child(odd) {
-        background: $grey-70;
+        background: $grey-80;
       }
 
       li:nth-child(even) {

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -36,10 +36,10 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
     await render(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}}  />`);
 
     // then
-    assert.contains('Toto Tutu');
+    assert.contains('Tutu Toto');
     assert.contains('· Temps majoré : 8%');
     assert.contains('28/05/1984');
-    assert.contains('Star Lord');
+    assert.contains('Lord Star');
     assert.contains('· Temps majoré : 12%');
     assert.contains('28/06/1983');
   });


### PR DESCRIPTION
## :jack_o_lantern: Problème + solution
Certification, espace surveillant:
- ajouter 4 pixels entre les lignes:  nom/prénom et la DDN
- le gris clair des lignes pairs est à modifier: doit être grey 80
- inverser les nom/prénom (car liste triée sur le nom de famille)

Certification, pop-in d'ajout de candidat sur une session pro
- supprimer le style spécifique des fieldset

🕸️ Remarques
~~Ajout des mots de passe de supervision par defaut dans le database builder (et donc dans les seeds)~~
fait dans une autre PR

## :ghost: Pour tester
Verifier les styles sur l'espace surveillant: 
Se connecter avec certifsco@example.net puis aller sur l'espace surveillant avec l'id de session `4` et le code d'acces `12345`
