### PR TITLE
[TECH] Supprimer la gestion du nom de champ et debounced des templates des filtres des tableaux (PIX-3710).

### DIFF
--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -15,14 +15,14 @@
           @value={{@lastNameFilter}}
           @placeholder={{t "pages.students-sco.table.filter.last-name.label"}}
           @ariaLabel={{t "pages.students-sco.table.filter.last-name.aria-label"}}
-          @triggerFiltering={{this.onSearchInputText}}
+          @triggerFiltering={{@onFilter}}
         />
         <Table::HeaderFilterInput
           @field="firstName"
           @value={{@firstNameFilter}}
           @placeholder={{t "pages.students-sco.table.filter.first-name.label"}}
           @ariaLabel={{t "pages.students-sco.table.filter.first-name.aria-label"}}
-          @triggerFiltering={{this.onSearchInputText}}
+          @triggerFiltering={{@onFilter}}
         />
         <Table::Header />
         <Table::Header>
@@ -38,7 +38,7 @@
           @field="connexionType"
           @options={{@connectionTypesOptions}}
           @selectedOption={{@connexionTypeFilter}}
-          @triggerFiltering={{this.onSearchInputText}}
+          @triggerFiltering={{@onFilter}}
           @ariaLabel={{t "pages.students-sco.table.filter.login-method.aria-label"}}
           @emptyOptionLabel={{t "pages.students-sco.table.filter.login-method.empty-option"}}
         />

--- a/orga/app/components/student/sco/list.js
+++ b/orga/app/components/student/sco/list.js
@@ -35,12 +35,7 @@ export default class ScoList extends Component {
   }
 
   @action
-  onSearchInputText(field, debounced, event) {
-    this.args.onFilter(field, debounced, event.target.value);
-  }
-
-  @action
   onSearchDivisions(divisions) {
-    this.args.onFilter('divisions', false, divisions);
+    this.args.onFilter('divisions', divisions);
   }
 }

--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -15,27 +15,27 @@
           @value={{@studentNumberFilter}}
           @placeholder={{t "pages.students-sup.table.filter.student-number.label"}}
           @ariaLabel={{t "pages.students-sup.table.filter.student-number.aria-label"}}
-          @triggerFiltering={{this.onFilter}}
+          @triggerFiltering={{@onFilter}}
         />
         <Table::HeaderFilterInput
           @field="lastName"
           @value={{@lastNameFilter}}
           @placeholder={{t "pages.students-sup.table.filter.last-name.label"}}
           @ariaLabel={{t "pages.students-sup.table.filter.last-name.aria-label"}}
-          @triggerFiltering={{this.onFilter}}
+          @triggerFiltering={{@onFilter}}
         />
         <Table::HeaderFilterInput
           @field="firstName"
           @value={{@firstNameFilter}}
           @placeholder={{t "pages.students-sup.table.filter.first-name.label"}}
           @ariaLabel={{t "pages.students-sup.table.filter.first-name.aria-label"}}
-          @triggerFiltering={{this.onFilter}}
+          @triggerFiltering={{@onFilter}}
         />
         <Table::Header />
         <Table::HeaderFilterMultiSelect
           @field="groups"
           @title={{t "pages.students-sup.table.column.group"}}
-          @onSelect={{this.onFilterGroup}}
+          @onSelect={{@onFilter}}
           @selectedOption={{@groupsFilter}}
           @onLoadOptions={{this.loadGroups}}
           @placeholder={{t "pages.students-sup.table.filter.group.label"}}

--- a/orga/app/components/student/sup/list.js
+++ b/orga/app/components/student/sup/list.js
@@ -31,16 +31,6 @@ export default class ListItems extends Component {
   }
 
   @action
-  onFilter(fieldName, debounced, e) {
-    this.args.onFilter(fieldName, debounced, e.target.value);
-  }
-
-  @action
-  onFilterGroup(fieldName, debounced, value) {
-    this.args.onFilter(fieldName, debounced, value);
-  }
-
-  @action
   openEditStudentNumberModal(student) {
     this.selectedStudent = student;
     this.isShowingEditStudentNumberModal = true;

--- a/orga/app/components/table/header-filter-input.hbs
+++ b/orga/app/components/table/header-filter-input.hbs
@@ -5,6 +5,6 @@
     @value={{@value}}
     @placeholder={{@placeholder}}
     @ariaLabel={{@ariaLabel}}
-    @onSearch={{fn @triggerFiltering @field true}}
+    @onSearch={{this.onSearch}}
   />
 </Table::Header>

--- a/orga/app/components/table/header-filter-input.js
+++ b/orga/app/components/table/header-filter-input.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import ENV from 'pix-orga/config/environment';
+import debounce from 'lodash/debounce';
+
+export default class HeaderFilterInput extends Component {
+  constructor() {
+    super(...arguments);
+    this.debouncedTriggerFiltering = debounce(this.args.triggerFiltering, ENV.pagination.debounce);
+  }
+
+  @action
+  onSearch(event) {
+    const { field } = this.args;
+    this.debouncedTriggerFiltering(field, event.target.value);
+  }
+}

--- a/orga/app/components/table/header-filter-multi-select.hbs
+++ b/orga/app/components/table/header-filter-multi-select.hbs
@@ -7,7 +7,7 @@
     aria-label={{@ariaLabel}}
     @showOptionsOnInput={{true}}
     @isSearchable={{true}}
-    @onSelect={{fn @onSelect @field false}}
+    @onSelect={{this.onSelect}}
     @selected={{@selectedOption}}
     @options={{@options}}
     @onLoadOptions={{@onLoadOptions}}

--- a/orga/app/components/table/header-filter-multi-select.js
+++ b/orga/app/components/table/header-filter-multi-select.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class HeaderFilterMultiSelect extends Component {
+  @action
+  onSelect(value) {
+    const { onSelect, field } = this.args;
+    onSelect(field, value);
+  }
+}

--- a/orga/app/components/table/header-filter-select.hbs
+++ b/orga/app/components/table/header-filter-select.hbs
@@ -3,7 +3,7 @@
     id="select-{{@field}}"
     class="table__input"
     aria-label={{@ariaLabel}}
-    @onChange={{fn @triggerFiltering @field false}}
+    @onChange={{this.onChange}}
     @options={{@options}}
     @selectedOption={{@selectedOption}}
     @emptyOptionLabel={{@emptyOptionLabel}}

--- a/orga/app/components/table/header-filter-select.js
+++ b/orga/app/components/table/header-filter-select.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class HeaderFilterSelect extends Component {
+  @action
+  onChange(event) {
+    const { triggerFiltering, field } = this.args;
+    triggerFiltering(field, event.target.value);
+  }
+}

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -2,8 +2,6 @@ import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import ENV from 'pix-orga/config/environment';
-import debounce from 'lodash/debounce';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
@@ -34,15 +32,10 @@ export default class ListController extends Controller {
     this.pageNumber = null;
   }
 
-  debouncedUpdateFilters = debounce(this.updateFilters, ENV.pagination.debounce);
-
   @action
-  triggerFiltering(fieldName, debounced, event) {
-    if (debounced) {
-      this.debouncedUpdateFilters({ [fieldName]: event.target.value });
-    } else {
-      this.updateFilters({ [fieldName]: event.target.value });
-    }
+  triggerFiltering(fieldName, value) {
+    this[fieldName] = value;
+    this.pageNumber = null;
   }
 
   @action

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -2,9 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import ENV from 'pix-orga/config/environment';
 import { CONNECTION_TYPES } from '../../../models/student';
-import debounce from 'lodash/debounce';
 
 export default class ListController extends Controller {
   @service currentUser;
@@ -22,20 +20,10 @@ export default class ListController extends Controller {
   @tracked pageNumber = null;
   @tracked pageSize = null;
 
-  updateFilters(filters) {
-    Object.keys(filters).forEach((filterKey) => (this[filterKey] = filters[filterKey]));
-    this.pageNumber = null;
-  }
-
-  debouncedUpdateFilters = debounce(this.updateFilters, ENV.pagination.debounce);
-
   @action
-  triggerFiltering(fieldName, debounced, value) {
-    if (debounced) {
-      this.debouncedUpdateFilters({ [fieldName]: value });
-    } else {
-      this.updateFilters({ [fieldName]: value });
-    }
+  triggerFiltering(fieldName, value) {
+    this[fieldName] = value;
+    this.pageNumber = null;
   }
 
   get connectionTypesOptions() {

--- a/orga/app/controllers/authenticated/sup-students/list.js
+++ b/orga/app/controllers/authenticated/sup-students/list.js
@@ -1,8 +1,6 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import ENV from 'pix-orga/config/environment';
-import debounce from 'lodash/debounce';
 
 export default class ListController extends Controller {
   queryParams = ['lastName', 'fistName', 'studentNumber', 'groups', 'pageNumber', 'pageSize'];
@@ -14,19 +12,9 @@ export default class ListController extends Controller {
   @tracked pageNumber = null;
   @tracked pageSize = null;
 
-  updateFilters(filters) {
-    Object.keys(filters).forEach((filterKey) => (this[filterKey] = filters[filterKey]));
-    this.pageNumber = null;
-  }
-
-  debouncedUpdateFilters = debounce(this.updateFilters, ENV.pagination.debounce);
-
   @action
-  triggerFiltering(fieldName, debounced, value) {
-    if (debounced) {
-      this.debouncedUpdateFilters({ [fieldName]: value });
-    } else {
-      this.updateFilters({ [fieldName]: value });
-    }
+  triggerFiltering(fieldName, value) {
+    this[fieldName] = value;
+    this.pageNumber = null;
   }
 }

--- a/orga/tests/integration/components/students/sco/list_test.js
+++ b/orga/tests/integration/components/students/sco/list_test.js
@@ -88,8 +88,7 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'lastName');
-      assert.true(call.args[1]);
-      assert.equal(call.args[2], 'bob');
+      assert.equal(call.args[1], 'bob');
     });
 
     test('it should trigger filtering with firstname', async function (assert) {
@@ -106,8 +105,7 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'firstName');
-      assert.true(call.args[1]);
-      assert.equal(call.args[2], 'bob');
+      assert.equal(call.args[1], 'bob');
     });
 
     test('it should trigger filtering with division', async function (assert) {
@@ -124,8 +122,7 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'divisions');
-      assert.false(call.args[1]);
-      assert.deepEqual(call.args[2], ['3A']);
+      assert.deepEqual(call.args[1], ['3A']);
     });
 
     test('it should trigger filtering with connexionType', async function (assert) {
@@ -145,8 +142,7 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'connexionType');
-      assert.false(call.args[1]);
-      assert.equal(call.args[2], 'email');
+      assert.equal(call.args[1], 'email');
     });
   });
 

--- a/orga/tests/integration/components/students/sup/list_test.js
+++ b/orga/tests/integration/components/students/sup/list_test.js
@@ -91,7 +91,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       await fillInByLabel('Entrer un nom', 'bob');
 
       // then
-      sinon.assert.calledWithExactly(triggerFiltering, 'lastName', true, 'bob');
+      sinon.assert.calledWithExactly(triggerFiltering, 'lastName', 'bob');
       assert.ok(true);
     });
 
@@ -107,7 +107,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       await fillInByLabel('Entrer un prénom', 'bob');
 
       // then
-      sinon.assert.calledWithExactly(triggerFiltering, 'firstName', true, 'bob');
+      sinon.assert.calledWithExactly(triggerFiltering, 'firstName', 'bob');
       assert.ok(true);
     });
 
@@ -123,7 +123,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       await fillInByLabel('Entrer un numéro étudiant', 'LATERREURGIGI123');
 
       // then
-      sinon.assert.calledWithExactly(triggerFiltering, 'studentNumber', true, 'LATERREURGIGI123');
+      sinon.assert.calledWithExactly(triggerFiltering, 'studentNumber', 'LATERREURGIGI123');
       assert.ok(true);
     });
 
@@ -143,7 +143,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
       await clickByLabel('L1');
 
       // then
-      sinon.assert.calledWithExactly(triggerFiltering, 'groups', false, ['L1']);
+      sinon.assert.calledWithExactly(triggerFiltering, 'groups', ['L1']);
       assert.ok(true);
     });
   });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Dans chaque template d'un filtre de header de tableau on dois passer en paramètre de la fonction qui filtre le nom du champ et un booléen pour savoir si le filtre doit utiliser le debounce.

## :bat: Solution
Laisser le composant faire un debounce sur la fonction si nécessaire et gérer le nom du champ en dehors du template.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Dans PixOrga tester les filtres sur :
- La liste des élèves
- La liste des étudiants
- La liste des campagnes
