### PR TITLE
[FEATURE] Afficher les certifications complémentaires auxquelles sont inscrits les candidats dans Pix Certif (PIX-3686)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification-subscription.js
+++ b/api/db/database-builder/factory/build-complementary-certification-subscription.js
@@ -1,0 +1,27 @@
+const _ = require('lodash');
+const buildCertificationCandidate = require('./build-certification-candidate');
+const buildComplementaryCertification = require('./build-complementary-certification');
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildComplementaryCertificationSubscription({
+  certificationCandidateId,
+  complementaryCertificationId,
+  createdAt = new Date('2020-01-01'),
+} = {}) {
+  certificationCandidateId = _.isNull(certificationCandidateId)
+    ? buildCertificationCandidate().id
+    : certificationCandidateId;
+  complementaryCertificationId = _.isNull(complementaryCertificationId)
+    ? buildComplementaryCertification().id
+    : complementaryCertificationId;
+
+  const values = {
+    certificationCandidateId,
+    complementaryCertificationId,
+    createdAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'complementary-certification-subscriptions',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -33,6 +33,7 @@ module.exports = {
   buildComplementaryCertification: require('./build-complementary-certification'),
   buildComplementaryCertificationBadge: require('./build-complementary-certification-badge'),
   buildComplementaryCertificationHabilitation: require('./build-complementary-certification-habilitation'),
+  buildComplementaryCertificationSubscription: require('./build-complementary-certification-subscription'),
   buildCorrectAnswersAndKnowledgeElementsForLearningContent: require('./build-correct-answers-and-knowledge-elements-for-learning-content'),
   buildCorrectAnswerAndKnowledgeElement: require('./build-correct-answer-and-knowledge-element'),
   buildFinalizedSession: require('./build-finalized-session'),

--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -8,6 +8,7 @@ const {
   PUBLISHED_SESSION_ID,
   PUBLISHED_SCO_SESSION_ID,
   PIX_DROIT_SESSION_ID,
+  COMPLEMENTARY_CERTIFICATIONS_SESSION_ID,
 } = require('./certification-sessions-builder');
 const {
   CERTIF_SUCCESS_USER_ID,
@@ -89,6 +90,18 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildCertificationCandidate({ ...CANDIDATE_DROIT_1, sessionId, userId: null });
   databaseBuilder.factory.buildCertificationCandidate({ ...CANDIDATE_DROIT_2, sessionId, userId: null });
 
+  // Candidates for a session with complementary certification subscriptions
+  sessionId = COMPLEMENTARY_CERTIFICATIONS_SESSION_ID;
+  const pixPlusRock = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+Rock' });
+  const pixPlusJazz = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+Jazz' });
+  const john = databaseBuilder.factory.buildCertificationCandidate({ firstName: 'John', lastName: 'Lennon', sessionId, userId: null });
+  databaseBuilder.factory.buildComplementaryCertificationSubscription({ certificationCandidateId: john.id, complementaryCertificationId: pixPlusRock.id });
+  const herbie = databaseBuilder.factory.buildCertificationCandidate({ firstName: 'Herbie', lastName: 'Hancock', sessionId, userId: null });
+  databaseBuilder.factory.buildComplementaryCertificationSubscription({ certificationCandidateId: herbie.id, complementaryCertificationId: pixPlusJazz.id });
+  const frank = databaseBuilder.factory.buildCertificationCandidate({ firstName: 'Frank', lastName: 'Zappa', sessionId, userId: null });
+  databaseBuilder.factory.buildComplementaryCertificationSubscription({ certificationCandidateId: frank.id, complementaryCertificationId: pixPlusRock.id });
+  databaseBuilder.factory.buildComplementaryCertificationSubscription({ certificationCandidateId: frank.id, complementaryCertificationId: pixPlusJazz.id });
+  databaseBuilder.factory.buildCertificationCandidate({ firstName: 'Britney', lastName: 'Spears', sessionId, userId: null });
 }
 
 module.exports = {

--- a/api/db/seeds/data/certification/certification-sessions-builder.js
+++ b/api/db/seeds/data/certification/certification-sessions-builder.js
@@ -1,4 +1,4 @@
-const { SCO_COLLEGE_CERTIF_CENTER_ID, SCO_COLLEGE_CERTIF_CENTER_NAME, DROIT_CERTIF_CENTER_ID, DROIT_CERTIF_CENTER_NAME } = require('./certification-centers-builder');
+const { SCO_COLLEGE_CERTIF_CENTER_ID, SCO_COLLEGE_CERTIF_CENTER_NAME, DROIT_CERTIF_CENTER_ID, DROIT_CERTIF_CENTER_NAME, SUP_CERTIF_CENTER_NAME, SUP_CERTIF_CENTER_ID } = require('./certification-centers-builder');
 const { PIX_MASTER_ID } = require('./../users-builder');
 const EMPTY_SESSION_ID = 1;
 const STARTED_SESSION_ID = 2;
@@ -10,6 +10,7 @@ const NO_CERTIF_CENTER_SESSION_ID = 7;
 const PUBLISHED_SESSION_ID = 8;
 const PIX_DROIT_SESSION_ID = 9;
 const PUBLISHED_SCO_SESSION_ID = 10;
+const COMPLEMENTARY_CERTIFICATIONS_SESSION_ID = 11;
 
 function certificationSessionsBuilder({ databaseBuilder }) {
   const certificationCenter = SCO_COLLEGE_CERTIF_CENTER_NAME;
@@ -138,6 +139,14 @@ function certificationSessionsBuilder({ databaseBuilder }) {
     publishedAt: new Date('2020-06-05T15:00:34Z'),
   });
 
+  databaseBuilder.factory.buildSession({
+    id: COMPLEMENTARY_CERTIFICATIONS_SESSION_ID,
+    certificationCenterName: SUP_CERTIF_CENTER_NAME,
+    certificationCenterId: SUP_CERTIF_CENTER_ID,
+    date, time,
+    description: 'Candidats avec des certifications complémentaires',
+  });
+
   // Some sessions to illustrate paginated sessions list order in PixAdmin
   databaseBuilder.factory.buildSession({
     certificationCenter, certificationCenterId, address, room, examiner: `${examiner}-1`, date, time,
@@ -183,4 +192,5 @@ module.exports = {
   PUBLISHED_SESSION_ID,
   PUBLISHED_SCO_SESSION_ID,
   PIX_DROIT_SESSION_ID,
+  COMPLEMENTARY_CERTIFICATIONS_SESSION_ID,
 };

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -96,9 +96,8 @@ module.exports = {
   async getCertificationCandidates(request) {
     const sessionId = request.params.id;
 
-    return usecases
-      .getSessionCertificationCandidates({ sessionId })
-      .then((certificationCandidates) => certificationCandidateSerializer.serialize(certificationCandidates));
+    const certificationCandidates = await usecases.getSessionCertificationCandidates({ sessionId });
+    return certificationCandidateSerializer.serialize(certificationCandidates);
   },
 
   async addCertificationCandidate(request, h) {

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -55,6 +55,7 @@ const certificationCandidateParticipationJoiSchema = Joi.object({
   sessionId: Joi.number().required(),
   userId: Joi.any().allow(null).optional(),
   schoolingRegistrationId: Joi.any().allow(null).optional(),
+  complementaryCertifications: Joi.array(),
 });
 
 class CertificationCandidate {
@@ -77,6 +78,7 @@ class CertificationCandidate {
     sessionId,
     userId,
     schoolingRegistrationId = null,
+    complementaryCertifications = [],
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -96,6 +98,7 @@ class CertificationCandidate {
     this.sessionId = sessionId;
     this.userId = userId;
     this.schoolingRegistrationId = schoolingRegistrationId;
+    this.complementaryCertifications = complementaryCertifications;
   }
 
   validate(version = '1.4') {

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -12,6 +12,7 @@ const {
 } = require('../../domain/errors');
 const { knex } = require('../../../db/knex-database-connection');
 const CertificationCandidate = require('../../domain/models/CertificationCandidate');
+const ComplementaryCertification = require('../../domain/models/ComplementaryCertification');
 
 module.exports = {
   async linkToUser({ id, userId }) {
@@ -97,11 +98,23 @@ module.exports = {
   async findBySessionId(sessionId) {
     const results = await knex
       .select('certification-candidates.*')
+      .select({ complementaryCertifications: knex.raw(`json_agg("complementary-certifications".*)`) })
       .from('certification-candidates')
       .where({ 'certification-candidates.sessionId': sessionId })
+      .leftJoin(
+        'complementary-certification-subscriptions',
+        'certification-candidates.id',
+        'complementary-certification-subscriptions.certificationCandidateId'
+      )
+      .leftJoin(
+        'complementary-certifications',
+        'complementary-certification-subscriptions.complementaryCertificationId',
+        'complementary-certifications.id'
+      )
+      .groupBy('certification-candidates.id')
       .orderByRaw('LOWER("certification-candidates"."lastName") asc')
       .orderByRaw('LOWER("certification-candidates"."firstName") asc');
-    return results.map((candidateData) => new CertificationCandidate(candidateData));
+    return results.map(_toDomain);
   },
 
   async findBySessionIdAndPersonalInfo({ sessionId, firstName, lastName, birthdate }) {
@@ -163,4 +176,12 @@ module.exports = {
 
 function _adaptModelToDb(certificationCandidateToSave) {
   return _.omit(certificationCandidateToSave, ['createdAt', 'certificationCourse', 'complementaryCertifications']);
+}
+
+function _toDomain(candidateData) {
+  const complementaryCertifications = candidateData.complementaryCertifications
+    .filter((certificationData) => certificationData !== null)
+    .map((certification) => new ComplementaryCertification(certification));
+
+  return new CertificationCandidate({ ...candidateData, complementaryCertifications });
 }

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -162,5 +162,5 @@ module.exports = {
 };
 
 function _adaptModelToDb(certificationCandidateToSave) {
-  return _.omit(certificationCandidateToSave, ['createdAt', 'certificationCourse']);
+  return _.omit(certificationCandidateToSave, ['createdAt', 'certificationCourse', 'complementaryCertifications']);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
@@ -29,6 +29,7 @@ module.exports = {
         'sex',
         'birthINSEECode',
         'birthPostalCode',
+        'complementaryCertifications',
       ],
     }).serialize(certificationCandidates);
   },

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -140,6 +140,7 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
                 'result-recipient-email': null,
                 'schooling-registration-id': student.id,
                 sex: 'M',
+                'complementary-certifications': [],
               },
               id: sinon.match.string,
               type: 'certification-candidates',

--- a/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
@@ -70,6 +70,7 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
           sex: certificationCandidateA.sex,
           'birth-insee-code': certificationCandidateA.birthINSEECode,
           'birth-postal-code': certificationCandidateA.birthPostalCode,
+          'complementary-certifications': [],
         };
         expectedCertificationCandidateBAttributes = {
           'first-name': certificationCandidateB.firstName,
@@ -87,6 +88,7 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
           sex: certificationCandidateB.sex,
           'birth-insee-code': certificationCandidateB.birthINSEECode,
           'birth-postal-code': certificationCandidateB.birthPostalCode,
+          'complementary-certifications': [],
         };
         userId = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });

--- a/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
@@ -124,6 +124,7 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
           'birth-insee-code': certificationCpfCity.INSEECode,
           'birth-postal-code': null,
           sex: certificationCandidate.sex,
+          'complementary-certifications': [],
         },
       };
 

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -51,7 +51,7 @@ describe('Integration | Repository | CertificationCandidate', function () {
         const [firstCertificationCandidatesInSession] = await certificationCandidateRepository.findBySessionId(
           sessionId
         );
-        const attributesToOmit = ['createdAt', 'sessionId', 'userId', 'id'];
+        const attributesToOmit = ['createdAt', 'sessionId', 'userId', 'id', 'complementaryCertifications'];
         expect(_.omit(firstCertificationCandidatesInSession, attributesToOmit)).to.deep.equal(
           _.omit(certificationCandidate, attributesToOmit)
         );
@@ -298,6 +298,7 @@ describe('Integration | Repository | CertificationCandidate', function () {
           extraTimePercentage: null,
           userId: null,
           schoolingRegistrationId: null,
+          complementaryCertifications: [],
         });
         databaseBuilder.factory.buildCertificationCandidate(certificationCandidate);
         await databaseBuilder.commit();
@@ -339,6 +340,7 @@ describe('Integration | Repository | CertificationCandidate', function () {
           extraTimePercentage: null,
           userId: null,
           schoolingRegistrationId: null,
+          complementaryCertifications: [],
         });
         databaseBuilder.factory.buildCertificationCandidate(certificationCandidate);
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -218,7 +218,7 @@ describe('Integration | Repository | CertificationCandidate', function () {
     });
   });
 
-  describe('#findBySessionIdWithCertificationCourse', function () {
+  describe('#findBySessionId', function () {
     let sessionId;
 
     beforeEach(async function () {

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -7,6 +7,7 @@ const {
   CertificationCandidateDeletionError,
   CertificationCandidateMultipleUserLinksWithinSessionError,
 } = require('../../../../lib/domain/errors');
+const ComplementaryCertification = require('../../../../lib/domain/models/ComplementaryCertification');
 const _ = require('lodash');
 
 describe('Integration | Repository | CertificationCandidate', function () {
@@ -253,6 +254,76 @@ describe('Integration | Repository | CertificationCandidate', function () {
         expect(actualCandidates[2].firstName).to.equal('Michael');
         expect(actualCandidates[3].firstName).to.equal('Freddy');
         expect(actualCandidates).to.have.lengthOf(4);
+      });
+    });
+
+    context('when some returned candidates have complementary certification subscriptions', function () {
+      it('return ordered candidates with associated subscriptions', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession().id;
+        const rockCertification = databaseBuilder.factory.buildComplementaryCertification({
+          name: 'Pix+Rock',
+        });
+        const jazzCertification = databaseBuilder.factory.buildComplementaryCertification({
+          name: 'Pix+Jazz',
+        });
+        const matthieuChedid = databaseBuilder.factory.buildCertificationCandidate({
+          lastName: 'Chedid',
+          firstName: 'Matthieu',
+          sessionId,
+        });
+        const louisChedid = databaseBuilder.factory.buildCertificationCandidate({
+          lastName: 'Chedid',
+          firstName: 'Louis',
+          sessionId,
+        });
+        databaseBuilder.factory.buildCertificationCandidate({
+          lastName: 'Herbie',
+          firstName: 'Hancock',
+          sessionId,
+        });
+
+        databaseBuilder.factory.buildComplementaryCertificationSubscription({
+          complementaryCertificationId: rockCertification.id,
+          certificationCandidateId: matthieuChedid.id,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationSubscription({
+          complementaryCertificationId: rockCertification.id,
+          certificationCandidateId: louisChedid.id,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationSubscription({
+          complementaryCertificationId: jazzCertification.id,
+          certificationCandidateId: louisChedid.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const candidates = await certificationCandidateRepository.findBySessionId(sessionId);
+
+        // then
+        const firstCandidate = candidates[0];
+        const secondCandidate = candidates[1];
+        const thirdCandidate = candidates[2];
+
+        //        expect(firstCandidate);
+        expect(firstCandidate.firstName).to.equal('Louis');
+        expect(firstCandidate.lastName).to.equal('Chedid');
+        expect(firstCandidate.complementaryCertifications[0]).to.deepEqualInstance(
+          new ComplementaryCertification({ id: rockCertification.id, name: 'Pix+Rock' })
+        );
+        expect(firstCandidate.complementaryCertifications[1]).to.deepEqualInstance(
+          new ComplementaryCertification({ id: jazzCertification.id, name: 'Pix+Jazz' })
+        );
+        expect(secondCandidate.firstName).to.equal('Matthieu');
+        expect(secondCandidate.lastName).to.equal('Chedid');
+        expect(secondCandidate.complementaryCertifications[0]).to.deepEqualInstance(
+          new ComplementaryCertification({ id: rockCertification.id, name: 'Pix+Rock' })
+        );
+
+        expect(thirdCandidate.firstName).to.equal('Hancock');
+        expect(thirdCandidate.lastName).to.equal('Herbie');
+        expect(thirdCandidate.complementaryCertifications).to.deep.equal([]);
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
@@ -1,3 +1,4 @@
+const buildComplementaryCertification = require('./build-complementary-certification');
 const CertificationCandidate = require('../../../../lib/domain/models/CertificationCandidate');
 
 module.exports = function buildCertificationCandidate({
@@ -20,6 +21,7 @@ module.exports = function buildCertificationCandidate({
   sessionId = 456,
   userId = 789,
   schoolingRegistrationId,
+  complementaryCertifications = [buildComplementaryCertification()],
 } = {}) {
   return new CertificationCandidate({
     id,
@@ -41,5 +43,6 @@ module.exports = function buildCertificationCandidate({
     createdAt,
     userId,
     schoolingRegistrationId,
+    complementaryCertifications,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
@@ -9,6 +9,12 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
   beforeEach(function () {
     certificationCandidate = domainBuilder.buildCertificationCandidate({
       schoolingRegistrationId: 1,
+      complementaryCertifications: [
+        domainBuilder.buildComplementaryCertification({
+          id: 2,
+          name: 'Pix+Patisserie',
+        }),
+      ],
     });
   });
 
@@ -35,6 +41,12 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
             'is-linked': !_.isNil(certificationCandidate.userId),
             'schooling-registration-id': 1,
             sex: certificationCandidate.sex,
+            'complementary-certifications': [
+              {
+                id: 2,
+                name: 'Pix+Patisserie',
+              },
+            ],
           },
         },
       };

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -92,6 +92,12 @@
               {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
             </span>
           </li>
+          <li class="certification-candidate-details-modal__row">
+            <span class="certification-candidate-details-modal__row__label">Certifications complémentaires</span>
+            <span class="certification-candidate-details-modal__row__value" data-test-id="complementary-certifications-row">
+              {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}
+            </span>
+          </li>
         </ul>
 
         <div class="certification-candidate-details-modal__actions">

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -51,6 +51,7 @@
               <th class="certification-candidates-table__external-id">Identifiant externe</th>
             {{/unless}}
             <th class="certification-candidates-table__column-time">Temps majoré</th>
+            <th>Certifications complémentaires</th>
           </tr>
           </thead>
           <tbody>
@@ -70,6 +71,9 @@
                 <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
               {{/unless}}
               <td data-test-id='panel-candidate__extraTimePercentage__{{candidate.id}}'>{{format-percentage candidate.extraTimePercentage}}</td>
+              <td data-test-id='panel-candidate__complementaryCertifications__{{candidate.id}}'>
+                {{if candidate.complementaryCertifications candidate.complementaryCertificationsList "-"}}
+              </td>
               <td>
                 <div class="certification-candidates-actions">
                   {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -27,4 +27,8 @@ export default class CertificationCandidate extends Model {
     }
     return null;
   }
+
+  get complementaryCertificationsList() {
+    return this.complementaryCertifications.map(({ name }) => name).join(', ');
+  }
 }

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -115,7 +115,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
         // then
         assert.dom('table tbody tr').exists({ count: 3 });
-        assert.dom('table thead tr th').exists({ count: 6 });
+        assert.dom('table thead tr th').exists({ count: 7 });
         assert.contains(`${aCandidate.lastName}`);
         assert.contains(`${aCandidate.firstName}`);
         assert.contains(`${moment(aCandidate.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -26,6 +26,16 @@ module('Integration | Component | certification-candidate-details-modal', functi
       birthInseeCode: 76255,
       birthPostalCode: 76260,
       sex: 'F',
+      complementaryCertifications: [
+        {
+          id: 1,
+          name: 'Pix+Edu',
+        },
+        {
+          id: 2,
+          name: 'Pix+Droit',
+        },
+      ],
     });
 
     const closeModalStub = sinon.stub();
@@ -54,6 +64,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
     assert.contains('12345');
     assert.contains('25/12/2000');
     assert.contains('10 %');
+    assert.contains('Pix+Edu, Pix+Droit');
   });
 
   module('when candidate has missing data', () => {
@@ -70,6 +81,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
         resultRecipientEmail: undefined,
         externalId: undefined,
         extraTimePercentage: undefined,
+        complementaryCertifications: [],
       });
 
       const closeModalStub = sinon.stub();
@@ -97,6 +109,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       assert.dom('[data-test-id="first-name-row"]').hasText('-');
       assert.dom('[data-test-id="last-name-row"]').hasText('-');
       assert.dom('[data-test-id="birth-country-row"]').hasText('-');
+      assert.dom('[data-test-id="complementary-certifications-row"]').hasText('-');
     });
   });
 

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -22,13 +22,23 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
   const BIRTH_COUNTRY_SELECTOR = 'panel-candidate__birthCountry__';
   const EMAIL_SELECTOR = 'panel-candidate__email__';
   const EXTRA_TIME_SELECTOR = 'panel-candidate__extraTimePercentage__';
+  const COMPLEMENTARY_CERTIFICATIONS_SELECTOR = 'panel-candidate__complementaryCertifications__';
+
+  let store;
+
+  hooks.beforeEach(async function() {
+    store = this.owner.lookup('service:store');
+  });
 
   test('it displays candidates information', async function(assert) {
     // given
     const candidate = _buildCertificationCandidate({
       birthdate: new Date('2019-04-28'),
     });
-    const certificationCandidates = [candidate];
+
+    const certificationCandidate = store.createRecord('certification-candidate', candidate);
+
+    const certificationCandidates = [certificationCandidate];
 
     this.set('certificationCandidates', certificationCandidates);
 
@@ -48,10 +58,36 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
     assert.dom(`[data-test-id=${FIRST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.firstName);
     assert.dom(`[data-test-id=${RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.resultRecipientEmail);
     assert.dom(`[data-test-id=${EXTRA_TIME_SELECTOR}${candidate.id}]`).hasText('3000 %');
+    assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).hasText('Pix+Edu, Pix+Droit');
     assert.dom(`[data-test-id=${BIRTH_CITY_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
     assert.dom(`[data-test-id=${BIRTH_PROVINCE_CODE_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
     assert.dom(`[data-test-id=${BIRTH_COUNTRY_SELECTOR}${candidate.id}]`).doesNotExist();
     assert.dom(`[data-test-id=${EMAIL_SELECTOR}${candidate.id}]`).doesNotExist();
+  });
+
+  test('it displays a dash where there is no certification', async function(assert) {
+    // given
+    const candidate = _buildCertificationCandidate({
+      complementaryCertifications: null,
+    });
+
+    const certificationCandidate = store.createRecord('certification-candidate', candidate);
+
+    const certificationCandidates = [certificationCandidate];
+
+    this.set('certificationCandidates', certificationCandidates);
+
+    // when
+    await render(hbs`
+        <EnrolledCandidates
+          @sessionId="1"
+          @certificationCandidates={{certificationCandidates}}
+          >
+        </EnrolledCandidates>
+      `);
+
+    // then
+    assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).hasText('-');
   });
 
   test('it should display details button', async function(assert) {
@@ -194,6 +230,16 @@ function _buildCertificationCandidate({
   externalId = 'an external id',
   extraTimePercentage = 30,
   isLinked = false,
+  complementaryCertifications = [
+    {
+      id: 1,
+      name: 'Pix+Edu',
+    },
+    {
+      id: 2,
+      name: 'Pix+Droit',
+    },
+  ],
 }) {
   return {
     id,
@@ -208,5 +254,6 @@ function _buildCertificationCandidate({
     externalId,
     extraTimePercentage,
     isLinked,
+    complementaryCertifications,
   };
 }

--- a/certif/tests/unit/models/certification-candidate_test.js
+++ b/certif/tests/unit/models/certification-candidate_test.js
@@ -6,6 +6,7 @@ module('Unit | Model | certification-candidate', function(hooks) {
   setupTest(hooks);
 
   test('it creates a CertificationCandidate', function(assert) {
+    // given
     const store = this.owner.lookup('service:store');
     const data = {
       firstName: 'Jean-Paul',
@@ -21,41 +22,68 @@ module('Unit | Model | certification-candidate', function(hooks) {
       birthPostalCode: 76260,
       sex: 1,
     };
-
+    // when
     const model = store.createRecord('certification-candidate', data);
+    // then
     assert.deepEqual(_pickModelData(data), _pickModelData(model));
   });
 
   module('#get sexLabel', () => {
     test('it get "Homme" for sex code "M"', function(assert) {
+      // given
       const store = this.owner.lookup('service:store');
       const data = {
         sex: 'M',
       };
-
+      // when
       const model = store.createRecord('certification-candidate', data);
-
+      // then
       assert.equal(model.sexLabel, 'Homme');
     });
 
     test('it get "Femme" for sex code "F"', function(assert) {
+      // given
       const store = this.owner.lookup('service:store');
       const data = {
         sex: 'F',
       };
-
+      // when
       const model = store.createRecord('certification-candidate', data);
-
+      // then
       assert.equal(model.sexLabel, 'Femme');
     });
 
     test('it get nothing if no sex code', function(assert) {
+      // given
       const store = this.owner.lookup('service:store');
       const data = {};
-
+      // when
       const model = store.createRecord('certification-candidate', data);
-
+      // then
       assert.equal(model.sexLabel, null);
+    });
+  });
+
+  module('#get complementaryCertificationsList', () => {
+    test('returns the complementary certification names as a string', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = {
+        complementaryCertifications: [
+          {
+            id: 1,
+            name: 'Pix+Edu',
+          },
+          {
+            id: 2,
+            name: 'Pix+Droit',
+          },
+        ],
+      };
+      // when
+      const model = store.createRecord('certification-candidate', data);
+      // then
+      assert.equal(model.complementaryCertificationsList, 'Pix+Edu, Pix+Droit');
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Nous allons permettre aux utilisateurs Pix certif d’inscrire leurs candidats en certifications complémentaires depuis la modale d’ajout d’un candidat, ou via un import ods. Il faut donc également leur permettre de visualiser cette information une fois ajoutée.

## :gift: Solution

Sur la page de détails d’une session dans Pix Certif, ajouter un champ “Certification(s) complémentaire(s)” :

1. sur la modale de détails des candidats - Maquette : https://share.goabstract.com/cfe96cd5-793a-4413-a4b5-2646e407d709?collectionLayerId=9bd59e80-c0c6-4d2f-a896-b4e3fcdf012e&mode=design
2. sur la liste des candidats - Maquette : https://share.goabstract.com/cfe96cd5-793a-4413-a4b5-2646e407d709?collectionLayerId=7ca56cb4-b139-4d70-b6a4-1012c2f2e231&mode=design

## :star2: Remarques

*RAS*

## :santa: Pour tester
- Activer le feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
- Se connecter à Pix Certif et accéder à une session *
- Si besoin, ajouter des candidats inscrits à des certifications complémentaires et d'autres candidats sans certifications complémentaires
- Constater que les certifications complémentaires apparaissent dans la listes des candidats
- Ouvrir la modale de détails pour un candidat inscrit à des certifs complémentaires et constater qu'elles apparaissent
- Ouvrir la modale de détails pour un candidat sans certifs complémentaires et constater qu'elles n'apparaissent pas

\* Astuce : la session 11 de certifsup@example.net dans les seeds a des candidats inscrits à des certifs complémentaires