### PR TITLE
[BUGFIX][ORGA] Correctly display create or modify campaign button (pix-3792)

### DIFF
--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -37,10 +37,6 @@
     background: $grey-15;
     height: max-content;
 
-    @include device-is('desktop') {
-      max-width: 500px;
-    }
-
     &-icon {
       color: $blue;
       margin-right: 8px;
@@ -65,6 +61,10 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+
+    @include device-is('desktop') {
+      max-width: 500px;
+    }
   }
 
   &__error {


### PR DESCRIPTION
## :christmas_tree: Problème
Récemment nous avons ajouté une bulle de descriptif dans la page de création de campagne pour expliquer ce qu'est une campagne d’envoi multiple, cet ajout à introduit un décalage au niveau de CSS qui a fait que les boutons valider et modifier sont pas afficher correctement. de plus, la bulle de descriptif ne prendre pas la totalité de l’espace. 

## :gift: Solution
Corriger le placement de bouton Valider/modifier dans le formulaire de création de campagne dans pix orga + modifié l'affichage de la bulle pour que elle prenne la largeur de droite

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Se connectez à pix Orga --> crée une campagne
- constater que le bouton 'Créer la campagne' ne dépasse pas la taille du champ de texte de la page d'accueil
- Dans le formulaire de création de campagne , sélectionnez une campagne de collect puis 'oui' pour l'option envoi multiple puis constater que la bulle prendre bien la largeur de droit de l’écran   