### PR TITLE
[BUGFIX] Upgrade pix-ui to fix select element on firefox (PIX-3810)

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -8108,355 +8108,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@pix/ember-testing-library": {
-      "version": "https://github.com/1024pix/ember-testing-library/tarball/v0.1.0",
-      "integrity": "sha512-EkzLKV3+P3mRR2BTGf5dTd5MGTqMqjMsqtJGX4aD7RdyvaFrxAn4yI7dy93OCtfmZpJlK7wxjWXRKrvr/LLZ9g==",
-      "dev": true,
-      "requires": {
-        "@testing-library/dom": "^8.9.0",
-        "broccoli-funnel": "^3.0.8",
-        "ember-auto-import": "^1.11.3",
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.7.1"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.14.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
-        "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@testing-library/dom": {
-          "version": "8.10.1",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.10.1.tgz",
-          "integrity": "sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^4.2.0",
-            "aria-query": "^5.0.0",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^27.0.2"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "aria-query": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
-          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
-          "dev": true
-        },
-        "broccoli-funnel": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
-          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "broccoli-plugin": "^4.0.7",
-            "debug": "^4.1.1",
-            "fs-tree-diff": "^2.0.1",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "walk-sync": "^2.0.2"
-          }
-        },
-        "broccoli-output-wrapper": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.5.tgz",
-          "integrity": "sha512-bQAtwjSrF4Nu0CK0JOy5OZqw9t5U0zzv2555EA/cF8/a8SLDTIetk9UgrtMVw7qKLKdSpOZ2liZNeZZDaKgayw==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^8.1.0",
-            "heimdalljs-logger": "^0.1.10",
-            "symlink-or-copy": "^1.2.0"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-              "dev": true
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "dom-accessibility-api": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz",
-          "integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "fs-merger": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.2.1.tgz",
-          "integrity": "sha512-AN6sX12liy0JE7C2evclwoo0aCG3PFulLjrTLsJpWh/2mM+DinhpSGqYLbHBBbIW1PLRNcFhJG8Axtz8mQW3ug==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-node-info": "^2.1.0",
-            "fs-extra": "^8.0.1",
-            "fs-tree-diff": "^2.0.1",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "dev": true,
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.3.1.tgz",
-          "integrity": "sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.2.5",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "promise-map-series": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
-      }
-    },
     "@simple-dom/interface": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
@@ -20454,6 +20105,16 @@
         "ember-cli-babel": "^7.22.1"
       }
     },
+    "ember-prop-modifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-prop-modifier/-/ember-prop-modifier-1.0.1.tgz",
+      "integrity": "sha512-IbWHOY1MtEFwA5oMC+54CiTh0TuhMDIE6Z+QyX9pYvIOpr+BJsDphujPw9697Dt/0EK3PE41ZWllI8G4Butd/w==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-modifier": "^2.1.1"
+      }
+    },
     "ember-qunit": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",
@@ -26907,8 +26568,8 @@
       }
     },
     "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v9.1.0",
-      "integrity": "sha512-VRj+TPEleSrKw3bVV9+/Vda1xT3UJrkfzl2GsAx/jojyT91kY4h3rhpANnsTTo0DSPP76wE3nqSc4qKRHrpoew==",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v10.0.2",
+      "integrity": "sha512-XxPUsV4+nLUY15rCML2RrzLvC8LrvGXXbwNZ0wTCIhPVEi1uSk+X1gT3bjy6TOsKe6XPNntzm3gjBUr2Jzy6Ag==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
@@ -26916,6 +26577,7 @@
         "ember-cli-sass": "^10.0.1",
         "ember-cli-string-utils": "^1.1.0",
         "ember-click-outside": "^2.0.0",
+        "ember-prop-modifier": "^1.0.1",
         "ember-truth-helpers": "^3.0.0"
       }
     },

--- a/orga/package.json
+++ b/orga/package.json
@@ -99,7 +99,7 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v9.1.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v10.0.2",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",


### PR DESCRIPTION
## :christmas_tree: Problème
Le comportement du select sur firefox ne fonctionnait pas correctement. le `selected` n'était pas toujours affiché.

## :gift: Solution
La correction a été apporté sur pix-ui. il suffit maintenant de monté de version sur Pix-Orga

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Vérifier sur campagne avec des résultats que le filtres select sur le status fonctionne sur Firefox.