### PR TITLE
[TECH] Séparer les usecases d'invitation à une orga pour un admin Pix et un admin Orga

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -254,9 +254,9 @@ module.exports = {
     const invitationInformation =
       await organizationInvitationSerializer.deserializeForCreateOrganizationInvitationAndSendEmail(request.payload);
 
-    const [organizationInvitation] = await usecases.createOrganizationInvitations({
+    const organizationInvitation = await usecases.createOrganizationInvitationByAdmin({
       organizationId,
-      emails: [invitationInformation.email],
+      email: invitationInformation.email,
       locale: invitationInformation.lang,
       role: invitationInformation.role,
     });

--- a/api/lib/domain/usecases/create-organization-invitation-by-admin.js
+++ b/api/lib/domain/usecases/create-organization-invitation-by-admin.js
@@ -1,0 +1,19 @@
+const organizationInvitationService = require('../services/organization-invitation-service');
+
+module.exports = async function createOrganizationInvitationByAdmin({
+  organizationId,
+  email,
+  locale,
+  role,
+  organizationRepository,
+  organizationInvitationRepository,
+}) {
+  return organizationInvitationService.createOrganizationInvitation({
+    organizationId,
+    email,
+    locale,
+    role,
+    organizationInvitationRepository,
+    organizationRepository,
+  });
+};

--- a/api/lib/domain/usecases/create-organization-invitations.js
+++ b/api/lib/domain/usecases/create-organization-invitations.js
@@ -3,12 +3,11 @@ const bluebird = require('bluebird');
 const organizationInvitationService = require('../../domain/services/organization-invitation-service');
 
 module.exports = async function createOrganizationInvitations({
-  organizationRepository,
-  organizationInvitationRepository,
   organizationId,
   emails,
   locale,
-  role,
+  organizationRepository,
+  organizationInvitationRepository,
 }) {
   const trimmedEmails = emails.map((email) => email.trim());
   const uniqueEmails = [...new Set(trimmedEmails)];
@@ -20,7 +19,6 @@ module.exports = async function createOrganizationInvitations({
       organizationId,
       email,
       locale,
-      role,
     });
   });
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -177,6 +177,7 @@ module.exports = injectDependencies(
     createMembership: require('./create-membership'),
     createOrUpdateUserOrgaSettings: require('./create-or-update-user-orga-settings'),
     createOrganization: require('./create-organization'),
+    createOrganizationInvitationByAdmin: require('./create-organization-invitation-by-admin'),
     createOrganizationInvitations: require('./create-organization-invitations'),
     createPasswordResetDemand: require('./create-password-reset-demand'),
     createProOrganizations: require('./create-pro-organizations-with-tags'),

--- a/api/lib/infrastructure/serializers/jsonapi/organization-invitation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-invitation-serializer.js
@@ -12,7 +12,7 @@ module.exports = {
       return {
         role: record.role,
         lang: record.lang,
-        email: record.email.toLowerCase(),
+        email: record.email?.trim().toLowerCase(),
       };
     });
   },

--- a/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
@@ -1,0 +1,43 @@
+const { expect, sinon } = require('../../../test-helper');
+
+const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
+const Membership = require('../../../../lib/domain/models/Membership');
+
+const createOrganizationInvitationByAdmin = require('../../../../lib/domain/usecases/create-organization-invitation-by-admin');
+
+describe('Unit | UseCase | create-organization-invitation-by-admin', function () {
+  describe('#createOrganizationInvitationByAdmin', function () {
+    it('should create one organization-invitation with organizationId, role and email', async function () {
+      // given
+      const organizationId = 1;
+      const email = 'member@organization.org';
+      const locale = 'fr-fr';
+      const role = Membership.roles.MEMBER;
+
+      const organizationInvitationRepository = sinon.stub();
+      const organizationRepository = sinon.stub();
+      sinon.stub(organizationInvitationService, 'createOrganizationInvitation').resolves();
+
+      // when
+      await createOrganizationInvitationByAdmin({
+        organizationId,
+        email,
+        locale,
+        role,
+        organizationRepository,
+        organizationInvitationRepository,
+      });
+
+      // then
+      expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledOnce;
+      expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledWith({
+        organizationId,
+        email,
+        locale,
+        role,
+        organizationRepository,
+        organizationInvitationRepository,
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/create-organization-invitations_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitations_test.js
@@ -1,7 +1,6 @@
 const { expect, sinon } = require('../../../test-helper');
 
 const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
-const Membership = require('../../../../lib/domain/models/Membership');
 
 const createOrganizationInvitations = require('../../../../lib/domain/usecases/create-organization-invitations');
 
@@ -14,32 +13,29 @@ describe('Unit | UseCase | create-organization-invitations', function () {
   });
 
   describe('#createOrganizationInvitations', function () {
-    it('should create one organization-invitation with organizationId, role and email', async function () {
+    it('should create one organization-invitation with organizationId and email', async function () {
       // given
       const organizationId = 1;
       const emails = ['member@organization.org'];
       const locale = 'fr-fr';
-      const role = Membership.roles.MEMBER;
 
       // when
       await createOrganizationInvitations({
-        organizationRepository,
-        organizationInvitationRepository,
         organizationId,
         emails,
         locale,
-        role,
+        organizationRepository,
+        organizationInvitationRepository,
       });
 
       // then
       expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledOnce;
       expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledWith({
-        organizationRepository,
-        organizationInvitationRepository,
         organizationId,
         email: emails[0],
         locale,
-        role,
+        organizationRepository,
+        organizationInvitationRepository,
       });
     });
 
@@ -50,10 +46,10 @@ describe('Unit | UseCase | create-organization-invitations', function () {
 
       // when
       await createOrganizationInvitations({
-        organizationRepository,
-        organizationInvitationRepository,
         organizationId,
         emails,
+        organizationRepository,
+        organizationInvitationRepository,
       });
 
       // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-invitation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-invitation-serializer_test.js
@@ -37,7 +37,7 @@ describe('Unit | Serializer | JSONAPI | organization-invitation-serializer', fun
           type: 'organization-invitations',
           attributes: {
             lang: 'fr-fr',
-            email: 'EMAIL@example.net',
+            email: 'email@example.net',
             role: null,
           },
         },
@@ -53,6 +53,26 @@ describe('Unit | Serializer | JSONAPI | organization-invitation-serializer', fun
         role: null,
       };
       expect(json).to.deep.equal(expectedJsonApi);
+    });
+
+    it('should trim and lower case email from payload', async function () {
+      //given
+      const payload = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            lang: 'fr-fr',
+            email: '    EMAIL@example.net    ',
+            role: null,
+          },
+        },
+      };
+
+      // when
+      const json = await serializer.deserializeForCreateOrganizationInvitationAndSendEmail(payload);
+
+      // then
+      expect(json.email).to.deep.equal('email@example.net');
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
La fonctionnalité d'ajouter une invitation unique, avec un rôle et une langue est spécifique à un Pix Admin.Côté Pix Orga, les administrateurs des organizations (différent d'un Pix Admin) peuvent eux, inviter plusieurs personnes d'un coup.

Ces deux fonctionnalités, bien que ressemblante, commencent à différer et il est probable que ça continue par la suite.

Il est donc nécessaire de séparer ces fonctionnalités en deux usecases différents (ce qui n'est pas le cas aujourd'hui).

## :gift: Solution
Créer un nouveau usecase : `createOrganizationInvitationByAdmin`.

## :star2: Remarques
Voir le thread sur le sujets de la ré-utilisation de usecase : https://1024pix.slack.com/archives/CFVNK8QQJ/p1636365278009400?thread_ts=1636118972.005000&cid=CFVNK8QQJ 

## :santa: Pour tester
- Tester l'envoie d'invitation avec un rôle dans PixAdmin (voir la PR d'introduction à l'ajout du rôle pour plus de détail https://github.com/1024pix/pix/pull/3618) 
