### PR TITLE
[FEATURE] Sauvegarder les certifications complémentaires auxquelles un candidat est inscrit (PIX-3681).

### DIFF
--- a/api/db/migrations/20211108140716_create-table-complementary-certification-subscriptions.js
+++ b/api/db/migrations/20211108140716_create-table-complementary-certification-subscriptions.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'complementary-certification-subscriptions';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.integer('complementaryCertificationId').references('complementary-certifications.id').notNullable();
+    t.integer('certificationCandidateId').references('certification-candidates.id').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -104,9 +104,11 @@ module.exports = {
   async addCertificationCandidate(request, h) {
     const sessionId = request.params.id;
     const certificationCandidate = await certificationCandidateSerializer.deserialize(request.payload);
+    const complementaryCertifications = request.payload.data.attributes['complementary-certifications'] ?? [];
     const addedCertificationCandidate = await usecases.addCertificationCandidateToSession({
       sessionId,
       certificationCandidate,
+      complementaryCertifications,
     });
 
     return h.response(certificationCandidateSerializer.serialize(addedCertificationCandidate)).created();

--- a/api/lib/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/lib/domain/usecases/add-certification-candidate-to-session.js
@@ -6,10 +6,12 @@ const {
 module.exports = async function addCertificationCandidateToSession({
   sessionId,
   certificationCandidate,
+  complementaryCertifications,
   certificationCandidateRepository,
   certificationCpfService,
   certificationCpfCountryRepository,
   certificationCpfCityRepository,
+  complementaryCertificationSubscriptionRepository,
 }) {
   certificationCandidate.sessionId = sessionId;
 
@@ -44,8 +46,17 @@ module.exports = async function addCertificationCandidateToSession({
     certificationCandidate.updateBirthInformation(cpfBirthInformation);
   }
 
-  return certificationCandidateRepository.saveInSession({
+  const savedCertificationCandidate = await certificationCandidateRepository.saveInSession({
     certificationCandidate,
     sessionId: certificationCandidate.sessionId,
   });
+
+  for (const complementaryCertification of complementaryCertifications) {
+    await complementaryCertificationSubscriptionRepository.save({
+      complementaryCertificationId: complementaryCertification.id,
+      certificationCandidateId: savedCertificationCandidate.id,
+    });
+  }
+
+  return savedCertificationCandidate;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -58,6 +58,7 @@ const dependencies = {
   competenceTreeRepository: require('../../infrastructure/repositories/competence-tree-repository'),
   complementaryCertificationHabilitationRepository: require('../../infrastructure/repositories/complementary-certification-habilitation-repository'),
   complementaryCertificationRepository: require('../../infrastructure/repositories/complementary-certification-repository'),
+  complementaryCertificationSubscriptionRepository: require('../../infrastructure/repositories/complementary-certification-subscription-repository'),
   correctionRepository: require('../../infrastructure/repositories/correction-repository'),
   countryRepository: require('../../infrastructure/repositories/country-repository'),
   courseRepository: require('../../infrastructure/repositories/course-repository'),

--- a/api/lib/infrastructure/repositories/complementary-certification-subscription-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-subscription-repository.js
@@ -1,0 +1,7 @@
+const { knex } = require('../../../db/knex-database-connection');
+
+module.exports = {
+  async save(complementaryCertificationSubscription) {
+    return knex('complementary-certification-subscriptions').insert(complementaryCertificationSubscription);
+  },
+};

--- a/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
@@ -45,6 +45,12 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
         name: 'PARIS 15',
         INSEECode: '75115',
       });
+      const complementaryCertification1Id = databaseBuilder.factory.buildComplementaryCertification({
+        name: 'Certif complémentaire 1',
+      }).id;
+      const complementaryCertification2Id = databaseBuilder.factory.buildComplementaryCertification({
+        name: 'Certif complémentaire 2',
+      }).id;
 
       payload = {
         data: {
@@ -63,6 +69,10 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
             'birth-insee-code': certificationCandidate.birthINSEECode,
             'birth-postal-code': null,
             sex: certificationCandidate.sex,
+            'complementary-certifications': [
+              { id: complementaryCertification1Id, name: 'Certif complémentaire 1' },
+              { id: complementaryCertification2Id, name: 'Certif complémentaire 2' },
+            ],
           },
         },
       };
@@ -78,7 +88,8 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
       return databaseBuilder.commit();
     });
 
-    afterEach(function () {
+    afterEach(async function () {
+      await knex('complementary-certification-subscriptions').delete();
       return knex('certification-candidates').delete();
     });
 
@@ -118,6 +129,15 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
 
       expect(_.omit(response.result.data, 'id')).to.deep.equal(expectedData);
       expect(response.result.data.id).to.exist;
+    });
+
+    it('should save the complementary certification subscriptions', async function () {
+      // when
+      await server.inject(options);
+
+      // then
+      const complementaryCertificationRegistrationsInDB = await knex('complementary-certification-subscriptions');
+      expect(complementaryCertificationRegistrationsInDB.length).to.equal(2);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-subscription-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-subscription-repository_test.js
@@ -1,0 +1,32 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const complementaryCertificationSubscriptionRepository = require('../../../../lib/infrastructure/repositories/complementary-certification-subscription-repository');
+const { knex } = require('../../../../lib/infrastructure/bookshelf');
+
+describe('Integration | Infrastructure | Repository | complementary-certification-subscription-repository', function () {
+  context('#save', function () {
+    afterEach(function () {
+      return knex('complementary-certification-subscriptions').delete();
+    });
+
+    it('should create a complementary certification subscription', async function () {
+      // given
+      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate().id;
+      const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
+      await databaseBuilder.commit();
+
+      // when
+      await complementaryCertificationSubscriptionRepository.save({
+        certificationCandidateId,
+        complementaryCertificationId,
+      });
+
+      // then
+      const complementaryCertificationRegistration = await knex
+        .select('*')
+        .from('complementary-certification-subscriptions')
+        .where({ certificationCandidateId, complementaryCertificationId })
+        .first();
+      expect(complementaryCertificationRegistration).to.not.be.null;
+    });
+  });
+});

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -301,11 +301,20 @@ describe('Unit | Controller | sessionController', function () {
     const certificationCandidate = 'candidate';
     const addedCertificationCandidate = 'addedCandidate';
     const certificationCandidateJsonApi = 'addedCandidateJSONApi';
+    let complementaryCertifications;
 
     beforeEach(function () {
       // given
+      complementaryCertifications = Symbol('complementaryCertifications');
       request = {
         params: { id: sessionId },
+        payload: {
+          data: {
+            attributes: {
+              'complementary-certifications': complementaryCertifications,
+            },
+          },
+        },
       };
       sinon.stub(certificationCandidateSerializer, 'deserialize').resolves(certificationCandidate);
       sinon
@@ -313,6 +322,7 @@ describe('Unit | Controller | sessionController', function () {
         .withArgs({
           sessionId,
           certificationCandidate,
+          complementaryCertifications,
         })
         .resolves(addedCertificationCandidate);
       sinon

--- a/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -12,6 +12,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
   let certificationCpfService;
   let certificationCpfCountryRepository;
   let certificationCpfCityRepository;
+  let complementaryCertificationSubscriptionRepository;
 
   const sessionId = 1;
 
@@ -22,6 +23,9 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
     };
     certificationCpfService = {
       getBirthInformation: sinon.stub(),
+    };
+    complementaryCertificationSubscriptionRepository = {
+      save: sinon.stub(),
     };
     certificationCpfCountryRepository = Symbol('certificationCpfCountryRepository');
     certificationCpfCityRepository = Symbol('certificationCpfCityRepository');
@@ -39,10 +43,12 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
       const err = await catchErr(addCertificationCandidateToSession)({
         sessionId,
         certificationCandidate,
+        complementaryCertifications: [],
         certificationCandidateRepository,
         certificationCpfService,
         certificationCpfCountryRepository,
         certificationCpfCityRepository,
+        complementaryCertificationSubscriptionRepository,
       });
 
       // then
@@ -62,10 +68,12 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         const err = await catchErr(addCertificationCandidateToSession)({
           sessionId,
           certificationCandidate,
+          complementaryCertifications: [],
           certificationCandidateRepository,
           certificationCpfService,
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
+          complementaryCertificationSubscriptionRepository,
         });
 
         // then
@@ -97,10 +105,12 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         await addCertificationCandidateToSession({
           sessionId,
           certificationCandidate,
+          complementaryCertifications: [],
           certificationCandidateRepository,
           certificationCpfService,
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
+          complementaryCertificationSubscriptionRepository,
         });
 
         // then
@@ -127,10 +137,12 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         await addCertificationCandidateToSession({
           sessionId,
           certificationCandidate,
+          complementaryCertifications: [],
           certificationCandidateRepository,
           certificationCpfService,
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
+          complementaryCertificationSubscriptionRepository,
         });
 
         // then
@@ -155,10 +167,12 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         await addCertificationCandidateToSession({
           sessionId,
           certificationCandidate,
+          complementaryCertifications: [],
           certificationCandidateRepository,
           certificationCpfService,
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
+          complementaryCertificationSubscriptionRepository,
         });
 
         // then
@@ -178,15 +192,59 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           const error = await catchErr(addCertificationCandidateToSession)({
             sessionId,
             certificationCandidate,
+            complementaryCertifications: [],
             certificationCandidateRepository,
             certificationCpfService,
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
+            complementaryCertificationSubscriptionRepository,
           });
 
           // then
           expect(error).to.be.an.instanceOf(CpfBirthInformationValidationError);
           expect(error.message).to.equal(cpfBirthInformationValidation.message);
+        });
+      });
+
+      it('should save the candidate complementary certifications', async function () {
+        //given
+        const complementaryCertifications = [
+          { id: 111, name: 'Complementary certification 1' },
+          { id: 222, name: 'Complementary certification 2' },
+        ];
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: null });
+        const cpfBirthInformationValidation = CpfBirthInformationValidation.success({
+          birthCountry: 'COUNTRY',
+          birthINSEECode: 'INSEE_CODE',
+          birthPostalCode: null,
+          birthCity: 'CITY',
+        });
+        certificationCandidateRepository.findBySessionIdAndPersonalInfo.resolves([]);
+        certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
+        const savedCertificationCandidate = domainBuilder.buildCertificationCandidate({ id: 123 });
+        certificationCandidateRepository.saveInSession.resolves(savedCertificationCandidate);
+
+        // when
+        await addCertificationCandidateToSession({
+          sessionId,
+          certificationCandidate,
+          complementaryCertifications,
+          certificationCandidateRepository,
+          certificationCpfService,
+          certificationCpfCountryRepository,
+          certificationCpfCityRepository,
+          complementaryCertificationSubscriptionRepository,
+        });
+
+        // then
+        expect(complementaryCertificationSubscriptionRepository.save.callCount).to.equal(2);
+        expect(complementaryCertificationSubscriptionRepository.save.firstCall).to.have.been.calledWith({
+          complementaryCertificationId: 111,
+          certificationCandidateId: 123,
+        });
+        expect(complementaryCertificationSubscriptionRepository.save.secondCall).to.have.been.calledWith({
+          complementaryCertificationId: 222,
+          certificationCandidateId: 123,
         });
       });
     });

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -140,6 +140,7 @@ export default class EnrolledCandidates extends Component {
       email: this._trimOrUndefinedIfFalsy(certificationCandidateData.email),
       resultRecipientEmail: this._trimOrUndefinedIfFalsy(certificationCandidateData.resultRecipientEmail),
       extraTimePercentage: certificationCandidateData.extraTimePercentage,
+      complementaryCertifications: certificationCandidateData.complementaryCertifications,
     });
   }
 

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -251,7 +251,7 @@
                         <Input
                           @type="checkbox"
                           id={{concat "complementaryCertification_" index}}
-                          {{on "input" (fn this.addComplementaryCertification complementaryCertification)}}
+                          {{on "input" (fn this.updateComplementaryCertifications complementaryCertification)}}
                         />
                         {{complementaryCertification.name}}
                       </label>

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -56,7 +56,17 @@ export default class NewCertificationCandidateModal extends Component {
   }
 
   @action
-  addComplementaryCertification(_complementaryCertification) {}
+  updateComplementaryCertifications(complementaryCertification) {
+    if (!this.args.candidateData.complementaryCertifications) {
+      this.args.candidateData.complementaryCertifications = [];
+    }
+    const complementaryCertifications = this.args.candidateData.complementaryCertifications;
+    if (complementaryCertifications.includes(complementaryCertification)) {
+      complementaryCertifications.removeObject(complementaryCertification);
+    } else {
+      complementaryCertifications.addObject(complementaryCertification);
+    }
+  }
 
   @action
   async onFormSubmit(event) {

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -16,6 +16,7 @@ export default class CertificationCandidate extends Model {
   @attr('boolean') isLinked;
   @attr('string') schoolingRegistrationId;
   @attr('string') sex;
+  @attr complementaryCertifications;
 
   get sexLabel() {
     if (this.sex === 'M') {

--- a/certif/tests/unit/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/unit/components/new-certification-candidate-modal_test.js
@@ -263,4 +263,33 @@ module('Unit | Component | new-certification-candidate-modal', function(hooks) {
       ]);
     });
   });
+
+  module('#updateComplementaryCertifications', function() {
+    test('it should add the complementary certification to the candidate data', function(assert) {
+      // given
+      modal.args.candidateData = {};
+      const complementaryCertification = Symbol('complementaryCertification');
+
+      // when
+      modal.updateComplementaryCertifications(complementaryCertification);
+
+      // then
+      assert.deepEqual(modal.args.candidateData.complementaryCertifications, [complementaryCertification]);
+    });
+
+    test('it should remove the complementary certification if it is already present', function(assert) {
+      // given
+      const complementaryCertificationToRemove = Symbol('complementaryCertification');
+      const anotherComplementaryCertification = Symbol('complementaryCertification');
+      modal.args.candidateData = {
+        complementaryCertifications: [complementaryCertificationToRemove, anotherComplementaryCertification],
+      };
+
+      // when
+      modal.updateComplementaryCertifications(complementaryCertificationToRemove);
+
+      // then
+      assert.deepEqual(modal.args.candidateData.complementaryCertifications, [anotherComplementaryCertification]);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Les utilisateurs pix certif vont pouvoir inscrire leur candidats en certification complémentaire. C’est cette inscription (ou non) qui conditionnera la possibilité pour un candidat de passer une certif complémentaire (s’il est éligible) le jour de la session. Il faut donc enregistrer l’information des certification(s) complémentaire(s) auxquelles un candidat est inscrit pour pouvoir vérifier cette information au lancement du test.

## :gift: Solution
Sauvegarder les certifications complémentaires sélectionnées lors de l'inscription d'un candidat.

## :santa: Pour tester
- Se connecter à[ Pix Certif ](https://certif-pr3713.review.pix.fr/connexion)avec le compte `certifsup@example.net`
- Créer une session de certification
- Inscrire un candidat et lui ajouter une ou des certifications complémentaires
- Vérifier en base que la table `complementary-certification-subscriptions` a bien été alimentée
