### PR TITLE
[TECH] Forcer l'ordre de la requête pour éviter les flaky tests (PIX-3822).

### DIFF
--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -13,7 +13,10 @@ module.exports = {
         lastName: 'users.lastName',
         email: 'users.email',
         pixCertifTermsOfServiceAccepted: 'users.pixCertifTermsOfServiceAccepted',
-        certificationCenterIds: knex.raw('array_agg(??)', 'certification-center-memberships.certificationCenterId'),
+        certificationCenterIds: knex.raw('array_agg(?? order by ?? asc)', [
+          'certificationCenterId',
+          'certificationCenterId',
+        ]),
       })
       .from('users')
       .leftJoin('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')
@@ -45,7 +48,7 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
       isRelatedToManagingStudentsOrganization: 'organizations.isManagingStudents',
       tags: knex.raw('array_agg(?? order by ??)', ['tags.name', 'tags.name']),
       habilitations: knex.raw(
-        `array_agg(json_build_object('id', "complementary-certifications".id, 'name', "complementary-certifications".name))`
+        `array_agg(json_build_object('id', "complementary-certifications".id, 'name', "complementary-certifications".name) order by "complementary-certifications".id)`
       ),
     })
     .from('certification-centers')

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -300,7 +300,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
           expectedSecondAllowedCertificationCenterAccess,
         ],
       });
-      expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
+      expect(certificationPointOfContact).to.deepEqualInstance(expectedCertificationPointOfContact);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Resultats non deterministers pour `certificationPointOfContactRepository.get`

## :gift: Solution
On utilise un sort pour s'assurer de l'ordre

## :star2: Remarques
Permet d'eviter des tests flaky

## :santa: Pour tester
Lancer les tests  jusqu'a ce que qu'on en ai marre et que ca ai toujours pas planté 