### PR TITLE
[FEATURE] Proposer plusieurs épreuves à la suite pour une campagne Flash (PIX-3783).

### DIFF
--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -28,7 +28,7 @@ module.exports = function buildCampaign({
   multipleSendings = false,
   assessmentMethod,
 } = {}) {
-  if (type === Campaign.types.ASSESSMENT) {
+  if (type === Campaign.types.ASSESSMENT && !assessmentMethod) {
     targetProfileId = _.isUndefined(targetProfileId)
       ? buildTargetProfile({ ownerOrganizationId: organizationId }).id
       : targetProfileId;

--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -324,4 +324,20 @@ __Plus d'infos :)__
     multipleSendings: true,
     createdAt: new Date('2020-01-18'),
   });
+
+  databaseBuilder.factory.buildCampaign({
+    id: 19,
+    name: 'Pro - Campagne d’évaluation - Campagne FLASH',
+    code: 'FLASH1234',
+    type: 'ASSESSMENT',
+    organizationId: PRO_COMPANY_ID,
+    targetProfileId: TARGET_PROFILE_STAGES_BADGES_ID,
+    creatorId: 2,
+    idPixLabel: null,
+    title: null,
+    customLandingPageText: null,
+    createdAt: new Date('2021-11-09'),
+    assessmentMethod: 'FLASH',
+  });
+
 }

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -42,25 +42,6 @@ function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
   };
 }
 
-function _getProbability({ estimatedLevel, discriminant, difficulty }) {
-  return 1 / (1 + Math.exp(discriminant * (difficulty - estimatedLevel)));
-}
-
-function _getReward({ estimatedLevel, discriminant, difficulty }) {
-  const probability = _getProbability({ estimatedLevel, discriminant, difficulty });
-  return probability * (1 - probability) * Math.pow(discriminant, 2);
-}
-
-function _getGaussianValue({ gaussianMean, value }) {
-  const variance = 1.5;
-  return Math.exp(Math.pow(value - gaussianMean, 2) / (-2 * variance)) / (Math.sqrt(variance) * Math.sqrt(2 * Math.PI));
-}
-
-function _normalizeDistribution(data) {
-  const sum = _.sum(data);
-  return _.map(data, (value) => value / sum);
-}
-
 function getEstimatedLevel({ allAnswers, challenges }) {
   if (allAnswers.length === 0) {
     return DEFAULT_ESTIMATED_LEVEL;
@@ -101,4 +82,23 @@ function getEstimatedLevel({ allAnswers, challenges }) {
   }
 
   return latestEstimatedLevel;
+}
+
+function _getReward({ estimatedLevel, discriminant, difficulty }) {
+  const probability = _getProbability({ estimatedLevel, discriminant, difficulty });
+  return probability * (1 - probability) * Math.pow(discriminant, 2);
+}
+
+function _getProbability({ estimatedLevel, discriminant, difficulty }) {
+  return 1 / (1 + Math.exp(discriminant * (difficulty - estimatedLevel)));
+}
+
+function _getGaussianValue({ gaussianMean, value }) {
+  const variance = 1.5;
+  return Math.exp(Math.pow(value - gaussianMean, 2) / (-2 * variance)) / (Math.sqrt(variance) * Math.sqrt(2 * Math.PI));
+}
+
+function _normalizeDistribution(data) {
+  const sum = _.sum(data);
+  return _.map(data, (value) => value / sum);
 }

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -4,7 +4,7 @@ const DEFAULT_ESTIMATED_LEVEL = 0;
 
 module.exports = { getPossibleNextChallenges, getEstimatedLevel };
 
-function getPossibleNextChallenges({ challenges } = {}) {
+function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
   if (challenges?.length === 0) {
     return {
       hasAssessmentEnded: true,
@@ -12,7 +12,7 @@ function getPossibleNextChallenges({ challenges } = {}) {
     };
   }
 
-  const estimatedLevel = DEFAULT_ESTIMATED_LEVEL;
+  const estimatedLevel = getEstimatedLevel({ allAnswers, challenges });
 
   const challengesWithReward = challenges.map((challenge) => {
     return {
@@ -56,6 +56,7 @@ function _getNormaliseData({ array }) {
   const sum = _.sum(array);
   return _.map(array, (value) => value / sum);
 }
+
 function getEstimatedLevel({ allAnswers, challenges }) {
   if (allAnswers.length === 0) {
     return DEFAULT_ESTIMATED_LEVEL;

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -1,6 +1,6 @@
 const DEFAULT_ESTIMATED_LEVEL = 0;
 
-module.exports = { getPossibleNextChallenges };
+module.exports = { getPossibleNextChallenges, getEstimatedLevel };
 
 function getPossibleNextChallenges({ challenges } = {}) {
   if (challenges?.length === 0) {
@@ -44,3 +44,10 @@ function _getReward({ estimatedLevel, discriminant, difficulty }) {
   const probability = _getProbability({ estimatedLevel, discriminant, difficulty });
   return probability * (1 - probability) * Math.pow(discriminant, 2);
 }
+
+function getEstimatedLevel({ allAnswers, challenges }) {
+  return DEFAULT_ESTIMATED_LEVEL;
+}
+
+
+

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -24,7 +24,7 @@ module.exports = async function getNextChallengeForCampaignAssessment({
       challengeRepository,
       locale,
     });
-    algoResult = flash.getPossibleNextChallenges({ ...inputValues, locale });
+    algoResult = flash.getPossibleNextChallenges({ ...inputValues });
 
     if (algoResult.hasAssessmentEnded) {
       throw new AssessmentEndedError();

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -81,7 +81,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
   });
 
-  describe('#getEstimatedLevel', function() {
+  describe('#getEstimatedLevel', function () {
     it('should return 0 when there is no answers', function () {
       // given
       const allAnswers = [];
@@ -95,35 +95,41 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
     it('should return the correct estimatedLevel when there is one answer', function () {
       // given
-      const challenges = [ domainBuilder.buildChallenge({
-        discriminant: 1.86350005965093,
-        difficulty: 0.194712138508747
-      })]
+      const challenges = [
+        domainBuilder.buildChallenge({
+          discriminant: 1.86350005965093,
+          difficulty: 0.194712138508747,
+        }),
+      ];
 
-      const allAnswers = [ domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+      const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
       const correctEstimatedLevel = 0.859419960298745;
 
       // when
       const result = flash.getEstimatedLevel({ allAnswers, challenges });
 
       // then
-      expect(result).to.equal(correctEstimatedLevel);
+      expect(result).to.be.closeTo(correctEstimatedLevel, 0.00000000001);
     });
 
     it('should return the correct estimatedLevel when there is two answers', function () {
       // given
       const challenges = [
         domainBuilder.buildChallenge({
+          id: 'ChallengeFirstAnswers',
           discriminant: 1.86350005965093,
-          difficulty: 0.194712138508747}),
+          difficulty: 0.194712138508747,
+        }),
         domainBuilder.buildChallenge({
+          id: 'ChallengeSecondAnswers',
           discriminant: 2.25422414740233,
-          difficulty: 0.823376599163319}),
-      ]
+          difficulty: 0.823376599163319,
+        }),
+      ];
 
       const allAnswers = [
         domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id })
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
       ];
       const correctEstimatedLevel = 1.802340122865396;
 
@@ -131,9 +137,40 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       const result = flash.getEstimatedLevel({ allAnswers, challenges });
 
       // then
-      expect(result).to.equal(correctEstimatedLevel);
+      expect(result).to.be.closeTo(correctEstimatedLevel, 0.00000000001);
     });
 
-  });
+    it('should return the correct estimatedLevel when there is three answers', function () {
+      // given
+      const challenges = [
+        domainBuilder.buildChallenge({
+          id: 'ChallengeFirstAnswers',
+          discriminant: 1.06665273005823,
+          difficulty: -0.030736508016524,
+        }),
+        domainBuilder.buildChallenge({
+          id: 'ChallengeSecondAnswers',
+          discriminant: 1.50948587856458,
+          difficulty: 1.62670103354638,
+        }),
+        domainBuilder.buildChallenge({
+          id: 'ChallengeThirdAnswers',
+          discriminant: 0.950709518595358,
+          difficulty: 1.90647729810166,
+        }),
+      ];
 
+      const allAnswers = [
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
+      ];
+      const correctEstimatedLevel = 2.851063556136754;
+      // when
+      const result = flash.getEstimatedLevel({ allAnswers, challenges });
+
+      // then
+      expect(result).to.be.closeTo(correctEstimatedLevel, 0.00000000001);
+    });
+  });
 });

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -96,14 +96,15 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     it('should return the correct estimatedLevel when there is one answer', function () {
       // given
       const challenges = [ domainBuilder.buildChallenge({
-        discriminant: 0.866854359282828,
-        difficulty:-1.01892585510622
+        discriminant: 1.86350005965093,
+        difficulty: 0.194712138508747
       })]
+
       const allAnswers = [ domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
-      const correctEstimatedLevel = 0.2784401326788072;
+      const correctEstimatedLevel = 0.859419960298745;
 
       // when
-      const result = flash.getEstimatedLevel({ allAnswers });
+      const result = flash.getEstimatedLevel({ allAnswers, challenges });
 
       // then
       expect(result).to.equal(correctEstimatedLevel);
@@ -113,21 +114,21 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       // given
       const challenges = [
         domainBuilder.buildChallenge({
-          discriminant: 0.866854359282828,
-          difficulty:-1.01892585510622}),
+          discriminant: 1.86350005965093,
+          difficulty: 0.194712138508747}),
         domainBuilder.buildChallenge({
-          discriminant: 1.06544675568836,
-          difficulty:2.36933312149944}),
-
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319}),
       ]
+
       const allAnswers = [
         domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
         domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id })
       ];
-      const correctEstimatedLevel = 1.2135374256552827;
+      const correctEstimatedLevel = 1.802340122865396;
 
       // when
-      const result = flash.getEstimatedLevel({ allAnswers });
+      const result = flash.getEstimatedLevel({ allAnswers, challenges });
 
       // then
       expect(result).to.equal(correctEstimatedLevel);

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const flash = require('../../../../../lib/domain/services/algorithm-methods/flash');
+const AnswerStatus = require('../../../../../lib/domain/models/AnswerStatus');
 
 describe('Integration | Domain | Algorithm-methods | Flash', function () {
   beforeEach(function () {});
@@ -79,4 +80,59 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       });
     });
   });
+
+  describe('#getEstimatedLevel', function() {
+    it('should return 0 when there is no answers', function () {
+      // given
+      const allAnswers = [];
+
+      // when
+      const result = flash.getEstimatedLevel({ allAnswers });
+
+      // then
+      expect(result).to.equal(0);
+    });
+
+    it('should return the correct estimatedLevel when there is one answer', function () {
+      // given
+      const challenges = [ domainBuilder.buildChallenge({
+        discriminant: 0.866854359282828,
+        difficulty:-1.01892585510622
+      })]
+      const allAnswers = [ domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+      const correctEstimatedLevel = 0.2784401326788072;
+
+      // when
+      const result = flash.getEstimatedLevel({ allAnswers });
+
+      // then
+      expect(result).to.equal(correctEstimatedLevel);
+    });
+
+    it('should return the correct estimatedLevel when there is two answers', function () {
+      // given
+      const challenges = [
+        domainBuilder.buildChallenge({
+          discriminant: 0.866854359282828,
+          difficulty:-1.01892585510622}),
+        domainBuilder.buildChallenge({
+          discriminant: 1.06544675568836,
+          difficulty:2.36933312149944}),
+
+      ]
+      const allAnswers = [
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id })
+      ];
+      const correctEstimatedLevel = 1.2135374256552827;
+
+      // when
+      const result = flash.getEstimatedLevel({ allAnswers });
+
+      // then
+      expect(result).to.equal(correctEstimatedLevel);
+    });
+
+  });
+
 });

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -10,9 +10,10 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       it('should return hasAssessmentEnded as true and possibleChallenges is empty', function () {
         // given
         const challenges = [];
+        const allAnswers = [];
 
         // when
-        const result = flash.getPossibleNextChallenges({ challenges });
+        const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
 
         // then
         expect(result).to.deep.equal({ hasAssessmentEnded: true, possibleChallenges: [] });
@@ -24,9 +25,10 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         // given
         const challenge = domainBuilder.buildChallenge();
         const challenges = [challenge];
+        const allAnswers = [];
 
         // when
-        const result = flash.getPossibleNextChallenges({ challenges });
+        const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
 
         // then
         expect(result).to.deep.equal({ hasAssessmentEnded: false, possibleChallenges: [challenge] });
@@ -44,9 +46,10 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             discriminant: 5,
           });
           const challenges = [worstNextChallenge, bestNextChallenge];
+          const allAnswers = [];
 
           // when
-          const result = flash.getPossibleNextChallenges({ challenges });
+          const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
 
           // then
           expect(result).to.deep.equal({ hasAssessmentEnded: false, possibleChallenges: [bestNextChallenge] });
@@ -67,9 +70,10 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             discriminant: 5,
           });
           const challenges = [worstNextChallenge, bestNextChallenge, anotherBestNextChallenge];
+          const allAnswers = [];
 
           // when
-          const result = flash.getPossibleNextChallenges({ challenges });
+          const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
 
           // then
           expect(result).to.deep.equal({

--- a/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -232,7 +232,6 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
       expect(flash.getPossibleNextChallenges).to.have.been.calledWithExactly({
         allAnswers,
         challenges,
-        locale,
       });
     });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, dans l'algo de choix d'épreuves Flash, une seule épreuve est proposée. 
Il faut que l'algorithme choisisse des épreuves après la première question.

## :gift: Solution
- Ajout d'une méthode `getEstimatedLevel` capable de faire tous les calculs pour mettre à jour le niveau estimé

## :star2: Remarques
- Ajout de test venant des sorties du code d'Yvonnick.

## :santa: Pour tester
