### PR TITLE
[FEATURE] Avoir uniquement les épreuves dans la locale de l'utilisateur pour l'algo Flash (PIX-3782).

### DIFF
--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -74,10 +74,10 @@ async function fetchForCompetenceEvaluations({
   };
 }
 
-async function fetchForFlashCampaigns({ assessment, answerRepository, challengeRepository }) {
+async function fetchForFlashCampaigns({ assessment, answerRepository, challengeRepository, locale }) {
   const [allAnswers, challenges] = await Promise.all([
     answerRepository.findByAssessment(assessment.id),
-    challengeRepository.findFlashCompatible(),
+    challengeRepository.findFlashCompatible(locale),
   ]);
 
   return {

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -18,7 +18,12 @@ module.exports = async function getNextChallengeForCampaignAssessment({
   let algoResult;
 
   if (assessment.isFlash()) {
-    const inputValues = await dataFetcher.fetchForFlashCampaigns({ assessment, answerRepository, challengeRepository });
+    const inputValues = await dataFetcher.fetchForFlashCampaigns({
+      assessment,
+      answerRepository,
+      challengeRepository,
+      locale,
+    });
     algoResult = flash.getPossibleNextChallenges({ ...inputValues, locale });
 
     if (algoResult.hasAssessmentEnded) {

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -35,12 +35,13 @@ module.exports = datasource.extend({
     return challenges.filter((challengeData) => _.includes(VALIDATED_CHALLENGES, challengeData.status));
   },
 
-  async findFlashCompatible() {
+  async findFlashCompatible(locale) {
     const challenges = await this.list();
     return challenges.filter(
       (challengeData) =>
         _.includes(VALIDATED_CHALLENGES, challengeData.status) &&
         !_.isEmpty(challengeData.skillIds) &&
+        _.includes(challengeData.locales, locale) &&
         challengeData.alpha != null &&
         challengeData.delta != null
     );

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -56,8 +56,8 @@ module.exports = {
     return _toDomainCollection({ challengeDataObjects, skills: operativeSkills });
   },
 
-  async findFlashCompatible() {
-    const challengeDataObjects = await challengeDatasource.findFlashCompatible();
+  async findFlashCompatible(locale) {
+    const challengeDataObjects = await challengeDatasource.findFlashCompatible(locale);
     const activeSkills = await skillDatasource.findActive();
     return _toDomainCollection({ challengeDataObjects, skills: activeSkills });
   },

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
@@ -37,7 +37,7 @@ const learningContent = [
               {
                 id: skillWeb2Id,
                 nom: '@web2',
-                challenges: [{ id: firstChallengeId, alpha: 2.8, delta: 1.1 }],
+                challenges: [{ id: firstChallengeId, alpha: 2.8, delta: 1.1, langues: ['Franco Français'] }],
               },
               {
                 id: skillWeb3Id,
@@ -48,8 +48,8 @@ const learningContent = [
                 id: skillWeb1Id,
                 nom: '@web1',
                 challenges: [
-                  { id: thirdChallengeId, alpha: -0.2, delta: 2.7 },
-                  { id: otherChallengeId, alpha: -0.2, delta: -0.4 },
+                  { id: thirdChallengeId, alpha: -0.2, delta: 2.7, langues: ['Franco Français'] },
+                  { id: otherChallengeId, alpha: -0.2, delta: -0.4, langues: ['Franco Français'] },
                 ],
               },
             ],

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -343,6 +343,7 @@ describe('Integration | Repository | challenge-repository', function () {
       const flashCompatibleChallenge = domainBuilder.buildChallenge({
         skills: [skill],
         status: 'validé',
+        locales: ['fr-fr'],
       });
       const nonFlashCompatibleChallenge = domainBuilder.buildChallenge({ skills: [skill], status: 'PAS validé' });
       const learningContent = {
@@ -353,9 +354,10 @@ describe('Integration | Repository | challenge-repository', function () {
         ],
       };
       mockLearningContent(learningContent);
+      const locale = 'fr-fr';
 
       // when
-      const actualChallenges = await challengeRepository.findFlashCompatible();
+      const actualChallenges = await challengeRepository.findFlashCompatible(locale);
 
       // then
       expect(actualChallenges).to.have.lengthOf(1);

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -56,7 +56,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
         assessment.method = 'FLASH';
         sinon.stub(flash, 'getPossibleNextChallenges').returns({ possibleChallenges: [], hasAssessmentEnded: false });
         sinon.stub(dataFetcher, 'fetchForFlashCampaigns').resolves({});
-
+        const locale = 'fr-fr';
         // when
         await getNextChallengeForCampaignAssessment({
           knowledgeElementRepository,
@@ -65,6 +65,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           answerRepository,
           pickChallengeService,
           assessment,
+          locale,
         });
 
         // then
@@ -73,6 +74,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           assessment,
           answerRepository,
           challengeRepository,
+          locale,
         });
       });
     });

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -16,7 +16,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     challenge_competence2,
     challenge_web1,
     challenge_web1_notValidated,
-    challenge_web2,
+    challenge_web2_en,
     challenge_web3,
     challenge_web3_archived;
 
@@ -31,6 +31,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       competenceId: competence1.id,
       skillIds: [web1.id],
       status: 'validé',
+      locales: ['fr', 'fr-fr'],
       alpha: 2.11,
       delta: -3.56,
     };
@@ -39,6 +40,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       competenceId: competence1.id,
       skillIds: undefined,
       status: 'validé',
+      locales: ['fr', 'fr-fr'],
       alpha: 8.11,
       delta: 0.95,
     };
@@ -46,6 +48,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       id: 'challenge-competence1-notValidated',
       competenceId: competence1.id,
       skillIds: [web1.id],
+      locales: ['fr', 'fr-fr'],
       status: 'proposé',
       alpha: -0,
       delta: 0,
@@ -55,6 +58,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       competenceId: competence2.id,
       skillIds: [web1.id],
       status: 'validé',
+      locales: ['fr', 'fr-fr'],
       alpha: 8.21,
       delta: -4.23,
     };
@@ -72,7 +76,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       alpha: -1.9,
       delta: 2.34,
     };
-    challenge_web2 = {
+    challenge_web2_en = {
       id: 'challenge-web2',
       skillIds: [web2.id],
       locales: ['en'],
@@ -84,6 +88,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       id: 'challenge-web3',
       skillIds: [web3.id],
       status: 'validé',
+      locales: ['fr', 'fr-fr'],
       alpha: 1.83,
       delta: 0.27,
     };
@@ -103,7 +108,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     beforeEach(function () {
       sinon
         .stub(lcms, 'getLatestRelease')
-        .resolves({ challenges: [challenge_web1, challenge_web1_notValidated, challenge_web2, challenge_web3] });
+        .resolves({ challenges: [challenge_web1, challenge_web1_notValidated, challenge_web2_en, challenge_web3] });
     });
 
     it('should resolve an array of matching Challenges from learning content', async function () {
@@ -147,7 +152,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
   describe('#findOperative', function () {
     beforeEach(function () {
       sinon.stub(lcms, 'getLatestRelease').resolves({
-        challenges: [challenge_web1, challenge_web1_notValidated, challenge_web2, challenge_web3_archived],
+        challenges: [challenge_web1, challenge_web1_notValidated, challenge_web2_en, challenge_web3_archived],
       });
     });
 
@@ -166,7 +171,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       // given
       const locale = 'fr-fr';
       sinon.stub(lcms, 'getLatestRelease').resolves({
-        challenges: [challenge_web1, challenge_web1_notValidated, challenge_web2, challenge_web3_archived],
+        challenges: [challenge_web1, challenge_web1_notValidated, challenge_web2_en, challenge_web3_archived],
       });
 
       // when
@@ -180,7 +185,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
   describe('#findValidated', function () {
     beforeEach(function () {
       sinon.stub(lcms, 'getLatestRelease').resolves({
-        challenges: [challenge_web1, challenge_web1_notValidated, challenge_web2, challenge_web3_archived],
+        challenges: [challenge_web1, challenge_web1_notValidated, challenge_web2_en, challenge_web3_archived],
       });
     });
 
@@ -203,7 +208,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
           challenge_competence2,
           challenge_web1,
           challenge_web1_notValidated,
-          challenge_web2,
+          challenge_web2_en,
           challenge_web3,
           challenge_web3_archived,
         ],
@@ -212,14 +217,14 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
 
     it('should resolve an array of matching Challenges from learning content', async function () {
       // when
-      const result = await challengeDatasource.findFlashCompatible();
+      const locale = 'fr-fr';
+      const result = await challengeDatasource.findFlashCompatible(locale);
 
       // then
       expect(lcms.getLatestRelease).to.have.been.called;
       expect(_.map(result, 'id')).to.deep.equal([
         'challenge-competence1',
         'challenge-competence2',
-        'challenge-web2',
         'challenge-web3',
       ]);
     });

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -222,11 +222,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
 
       // then
       expect(lcms.getLatestRelease).to.have.been.called;
-      expect(_.map(result, 'id')).to.deep.equal([
-        'challenge-competence1',
-        'challenge-competence2',
-        'challenge-web3',
-      ]);
+      expect(_.map(result, 'id')).to.deep.equal(['challenge-competence1', 'challenge-competence2', 'challenge-web3']);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, dans l'algorithme Flash, toutes les épreuves valides avec les paramètres pour le flash sont récupérés, quelque soit la langue.

## :gift: Solution
Remonter uniquement les épreuves de la bonne locale.

## :star2: Remarques
Aucune

## :santa: Pour tester
Ne pas avoir d'épreuves en anglais