### PR TITLE
[FEATURE] Ne pas sauvegarder les KE lors de campagnes Flash (PIX-2781).

### DIFF
--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -124,11 +124,15 @@ class Assessment {
   }
 
   hasKnowledgeElements() {
-    return this.isCompetenceEvaluation() || this.isForCampaign();
+    return this.isCompetenceEvaluation() || (this.isForCampaign() && this.isSmartRandom());
   }
 
   isFlash() {
     return this.method === methods.FLASH;
+  }
+
+  isSmartRandom() {
+    return this.method === methods.SMART_RANDOM;
   }
 
   static computeMethodFromType(type) {

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -240,12 +240,26 @@ describe('Unit | Domain | Models | Assessment', function () {
       expect(assessment.hasKnowledgeElements()).to.be.true;
     });
 
-    it('should return true when the assessment is a Campaign assessment', function () {
+    it('should return true when the assessment is a Campaign assessment with Smart Random Method', function () {
       // given
-      const assessment = domainBuilder.buildAssessment({ type: Assessment.types.CAMPAIGN });
+      const assessment = domainBuilder.buildAssessment({
+        type: Assessment.types.CAMPAIGN,
+        method: Assessment.methods.SMART_RANDOM,
+      });
 
       // when/then
       expect(assessment.hasKnowledgeElements()).to.be.true;
+    });
+
+    it('should return false when the assessment is a Campaign assessment with Flash Method', function () {
+      // given
+      const assessment = domainBuilder.buildAssessment({
+        type: Assessment.types.CAMPAIGN,
+        method: Assessment.methods.FLASH,
+      });
+
+      // when/then
+      expect(assessment.hasKnowledgeElements()).to.be.false;
     });
 
     it('should return false when the assessment is not a CompetenceEvaluation nor Campaign', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Les Campagnes Flash n'utilisent pas les KE, et actuellement on les enregistre comme pour toute campagne

## :gift: Solution
Ne plus considérer que les Campagnes d'évaluation avec la méthode Flash sont des évaluations avec KE.

## :star2: Remarques

## :santa: Pour tester
Passer une campagne Flash.
Voir que la table KE ne se remplit pas