### PR TITLE
[FEATURE] Modification de l'enregistrement de l'image d'un RT dans Pix-Admin (PIX-3481).

### DIFF
--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -4,7 +4,9 @@
     <Input id="title" class="form-control" @type="text" @value={{this.badge.title}} />
   </div>
   <div class="badge-form__text-field">
-    <label for="image-url">Url de l'image : </label>
+    <label for="image-url">Nom de l'image (svg) :
+      <a href="https://images.pix.fr/index.html" target="_blank" rel="noopener noreferrer"> Voir la liste des badges</a>
+    </label>
     <Input id="image-url" required="true" class="form-control" @type="text" @value={{this.badge.imageUrl}} />
   </div>
   <div class="badge-form__text-field">

--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -25,7 +25,7 @@
     <Textarea id="message" class="form-control" @value={{this.badge.message}} rows="4" />
   </div>
   <div class="badge-form__text-field">
-    <label for="badge-key">Clé : </label>
+    <label for="badge-key">Clé (texte unique , vérifier qu'il n'existe pas) : </label>
     <Input id="badge-key" class="form-control" maxlength="255" @type="text" required="true" @value={{this.badge.key}} />
   </div>
   <div class="badge-form__check-field">

--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -7,7 +7,14 @@
     <label for="image-url">Nom de l'image (svg) :
       <a href="https://images.pix.fr/index.html" target="_blank" rel="noopener noreferrer"> Voir la liste des badges</a>
     </label>
-    <Input id="image-url" required="true" class="form-control" @type="text" @value={{this.badge.imageUrl}} />
+    <Input
+      id="image-name"
+      required="true"
+      class="form-control"
+      @type="text"
+      @value={{this.imageName}}
+      placeholder="exemple: clea_num.svg"
+    />
   </div>
   <div class="badge-form__text-field">
     <label for="alt-message">Texte alternatif pour l'image : </label>

--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -7,15 +7,18 @@ export default class BadgeForm extends Component {
   @service store;
   @service router;
 
+  BASE_URL = 'https://images.pix.fr/badges/';
+
   badge = {
     key: '',
     altMessage: '',
-    imageUrl: '',
     message: '',
     title: '',
     isCertifiable: false,
     isAlwaysVisible: false,
   };
+
+  imageName = '';
   threshold = null;
 
   constructor(...args) {
@@ -40,7 +43,11 @@ export default class BadgeForm extends Component {
 
   async _createBadge() {
     try {
-      const badge = this.store.createRecord('badge', this.badge);
+      const badgeWithFormattedImageUrl = {
+        ...this.badge,
+        imageUrl: this.BASE_URL + this.imageName,
+      };
+      const badge = this.store.createRecord('badge', badgeWithFormattedImageUrl);
       await badge.save({
         adapterOptions: { targetProfileId: this.args.targetProfileId },
       });

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -67,7 +67,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
 
       // when
       await fillIn('input#badge-key', 'clé_du_badge');
-      await fillIn('input#image-url', 'https://image-url.pix.fr');
+      await fillIn('input#image-name', 'nom_de_limage');
       await fillIn('input#alt-message', 'texte alternatif à l‘image');
       await fillIn('input#campaignParticipationThreshold', '65');
       await click('[data-test="badge-form-submit-button"]');

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -54,7 +54,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
 
       // when
       await fillIn('input#badge-key', 'clé_du_badge');
-      await fillIn('input#image-url', 'https://image-url.pix.fr');
+      await fillIn('input#image-name', 'nom_de_limage.svg');
       await fillIn('input#alt-message', 'texte alternatif à l‘image');
       await click('button[data-test="badge-form-submit-button"]');
 
@@ -62,7 +62,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
       sinon.assert.calledWith(createRecordStub, 'badge', {
         key: 'clé_du_badge',
         altMessage: 'texte alternatif à l‘image',
-        imageUrl: 'https://image-url.pix.fr',
+        imageUrl: 'https://images.pix.fr/badges/nom_de_limage.svg',
         message: '',
         title: '',
         isCertifiable: false,
@@ -88,7 +88,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
 
       // when
       await fillIn('input#badge-key', 'clé_du_badge');
-      await fillIn('input#image-url', 'https://image-url.pix.fr');
+      await fillIn('input#image-name', 'nom_de_limage.svg');
       await fillIn('input#alt-message', 'texte alternatif à l‘image');
       await fillIn('input#campaignParticipationThreshold', '65');
       await click('button[data-test="badge-form-submit-button"]');


### PR DESCRIPTION
## :christmas_tree: Problème

Dans Pix-Admin, les personnes s'occupant d'enregistrer les résultats thématiques doivent rentrer l'URL des images de Pix à chaque fois qu'ils souhaitent créer un nouveau RT.

## :gift: Solution

Ajout d'un `base_url` afin de n'avoir à enregistrer que le nom de l'image lors de la création du RT.

## :star2: Remarques

La propriété `imageUrl` a été supprimée dans l'initialisation du badge pour être remplacée par la variable `imageName` afin de davantage correspondre à la valeur associée à l'input.

## :santa: Pour tester

Créer un nouveau RT en n'enregistrant que le nom d'une image hébergée chez Pix.
Vérifier en base que l'image a bien été enregistrée.
