### PR TITLE
[TECH] Simplifier le workflow d'automerge (PIX-3825)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: pascalgn/automerge-action@v0.8.3
+        uses: pascalgn/automerge-action@v0.14.3
         env:
           GITHUB_TOKEN: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
           MERGE_LABELS: ':rocket: Ready to Merge'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,23 +8,6 @@ on:
     types:
       - completed
 jobs:
-  block-autosquash-commits:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    steps:
-      - name: Block Autosquash Commits
-        uses: xt0rted/block-autosquash-commits-action@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-  verify-labels:
-    runs-on: ubuntu-latest
-    steps:
-      - name: verify labels
-        if: >
-          contains(github.event.pull_request.labels.*.name, ':earth_africa: i18n needed')
-          || contains(github.event.pull_request.labels.*.name, ':warning: Blocked')
-        run: exit 1
   automerge:
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +15,7 @@ jobs:
         uses: pascalgn/automerge-action@v0.14.3
         env:
           GITHUB_TOKEN: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
-          MERGE_LABELS: ':rocket: Ready to Merge'
+          MERGE_LABELS: ':rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed'
           MERGE_COMMIT_MESSAGE: pull-request-title
           UPDATE_LABELS: ':rocket: Ready to Merge'
           UPDATE_METHOD: rebase

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -2,15 +2,15 @@ name: commits check
 on:
   # eslint-disable-next-line yml/no-empty-mapping-value
   pull_request:
-  check_suite:
-    types:
-      - completed
 jobs:
   block-autosquash-commits:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.4.0
+
       - name: Block Autosquash Commits
         uses: xt0rted/block-autosquash-commits-action@v2
         with:


### PR DESCRIPTION
## :christmas_tree: Problème
Le workflow d'automerge comprends une verification sur les flags. Pour autant, celle ci n'est pas bloquante et ne sert donc à rien. 
Par ailleurs l'étape sur la verification des commits de merge ne fonctionne pas

## :gift: Solution
Mettre à jour la github action d'autocommit pour gérer directement les flags bloquant.

> This option can be a comma-separated list of labels that will be checked. All labels in the list need to be present, otherwise the pull request will be skipped (until all labels are present). Labels prefixed with an exclamation mark (!) will block a pull request from being merged, when present.

Pas besoin d'ajouter la verfication des commits. Il est preferable de bloquer directement le merge sur dev lorsque les commits sont KO (via un workflow spécifique).
![image](https://user-images.githubusercontent.com/3769147/141126476-ffed62ed-8dbb-41a4-80a9-38390d0cb8a4.png)


## :star2: Remarques
testé via https://github.com/1024pix/tmp-action

On ne bloque pas lorsqu'on a le flag _tech review needed_ car on peut estimer que les coches sont suffisantes.

## :santa: Pour tester
