### PR TITLE
[BUFGIX] Ne pas donner l'accès à Pix Certif à un administrateur dont l'organisation n'a pas d'UAI (PIX-3793).

### DIFF
--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -81,6 +81,10 @@ class Organization {
   get isScoAndManagingStudents() {
     return this.isSco && this.isManagingStudents;
   }
+
+  get isScoAndHasExternalId() {
+    return this.isSco && Boolean(this.externalId);
+  }
 }
 
 Organization.types = types;

--- a/api/lib/domain/usecases/update-membership.js
+++ b/api/lib/domain/usecases/update-membership.js
@@ -9,7 +9,7 @@ module.exports = async function updateMembership({
   membership.validateRole();
   const existingMembership = await membershipRepository.get(membership.id);
 
-  if (membership.isAdmin && existingMembership.organization.isSco) {
+  if (membership.isAdmin && existingMembership.organization.isScoAndHasExternalId) {
     const existingCertificationCenter = await certificationCenterRepository.findByExternalId({
       externalId: existingMembership.organization.externalId,
     });

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -298,4 +298,30 @@ describe('Unit | Domain | Models | Organization', function () {
       expect(organization.isScoAndManagingStudents).is.false;
     });
   });
+
+  describe('get#isScoAndHasExternalId', function () {
+    it('should return true when organization is of type SCO and has an externalId', function () {
+      // given
+      const organization = domainBuilder.buildOrganization({ type: 'SCO', externalId: '1237457A' });
+
+      // when / then
+      expect(organization.isScoAndHasExternalId).is.true;
+    });
+
+    it('should return false when organization is not of type SCO', function () {
+      // given
+      const organization = domainBuilder.buildOrganization({ type: 'SUP', externalId: '1237457A' });
+
+      // when / then
+      expect(organization.isScoAndHasExternalId).is.false;
+    });
+
+    it('should return false when organization has no external id', function () {
+      // given
+      const organization = domainBuilder.buildOrganization({ type: 'SCO', externalId: null });
+
+      // when / then
+      expect(organization.isScoAndHasExternalId).is.false;
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis Pix Orga et Pix Admin, quand le rôle d’un membre d’une organisation (de type SCO), est changé de MEMBER à ADMIN, alors ce membre est automatiquement rattaché au centre de certification correspondant (basé sur l’UAI).

Or actuellement, quand cet UAI n'existe pas (null), le membre se voit être rattaché à des centres de certification correspondant à un UAI null, qui ne correspondent pas à son organisation.

ℹ️  UAI = externalId ℹ️ 
UAI est le terme métier qui signifie [Unité Administrative Immatriculée](https://support.edulib.fr/support/solutions/articles/7000027959-qu-est-ce-que-le-code-uai-d-un-%C3%A9tablissement-scolaire-)

## :gift: Solution
Empêcher le rattachement du membre si l'UAI de l'organisation n'existe pas.

## :santa: Pour tester
Pour plus de facilité, tester en local pour voir les résultats en base. Sinon en RA, se connecter sur Adminer.

Sur Pix Admin : 
- Se connecter avec pixmaster
---

**Cas passant classique (orga SCO avec externalId fournit avec un centre de certification correspondant à cet externalId) :** 
- Choisir une orga SCO (ex: Collège The Night Watch ou en créer une)
- Vérifier qu'il existe un centre correspondant ( donc externalId similaire )
- Ajouter un membre ( ex : sco.member@example.net )
- Passer son rôle de membre à admin 
- Vérifier que ce rôle est bien changé en base, et confirmer une nouvelle entrée dans `certification-center-membership` avec l'id du user ajouté et l'id du centre de certif ).

Ici l'utilisateur à été rattaché au centre de certification correspondant et son rôle à changé.

---
**Cas bugfix (orga SCO avec externalId VIDE et centre de certif avec externalId VIDE) :** 

Même manipulation que dans le test précédent mais: 
- S'assurer que votre orga et le centre de certif ont un externalId vide

- Ici il faut toujours vérifier que le rôle est bien changé en base (on ne modifie pas ce comportement là)
- S'assurer qu'il n'y a aucune entrée dans`certification-center-membership`.

Ici le rôle de l'utilisateur à changé.

---

Sur Pix Orga : 

- Se connecter sur une organisation SCO avec un externalId ( ex: sco.member@example.net / Collège The Night Watch )
- (s'assurer qu'il existe un centre de certif correspondant)
- Dans équipe, changer le rôle d'un membre à admin