### PR TITLE
[TECH] Supprimer la BDD locale sans attendre la fermeture des connexions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,8 +261,6 @@ jobs:
       - run:
           name: Install Pix API
           working_directory: ~/pix/api
-          environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npm ci
 
       - run:
@@ -339,7 +337,7 @@ jobs:
           command: npm start
 
       - run:
-          name: Test
+          name: Run tests
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npm run test:ci

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -4,6 +4,7 @@ const schema = Joi.object({
   REDIS_URL: Joi.string().uri().optional(),
   DATABASE_URL: Joi.string().uri().optional(),
   TEST_DATABASE_URL: Joi.string().optional(),
+  ALLOW_DATABASE_DROP: Joi.string().valid('true', 'false').optional(),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   DATABASE_CONNECTION_POOL_MAX_SIZE: Joi.number().integer().min(0).optional(),
   MAILING_ENABLED: Joi.string().optional().valid('true', 'false'),

--- a/api/sample.env
+++ b/api/sample.env
@@ -122,7 +122,9 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # sample: KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=1000000
 # KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=
 
+# ALLOW_DATABASE_DROP
 # Enable database instance removal (DROP DATABASE) in npm `db:delete` task
+# If NODE_ENV=test, database will be dropped anyway
 #
 # presence: optional
 # type: String

--- a/api/sample.env
+++ b/api/sample.env
@@ -122,6 +122,14 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # sample: KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=1000000
 # KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=
 
+# Enable database instance removal (DROP DATABASE) in npm `db:delete` task
+#
+# presence: optional
+# type: String
+# default: false
+# sample: ALLOW_DATABASE_DROP=true
+ALLOW_DATABASE_DROP=true
+
 # ========
 # EMAILING
 # ========

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -11,6 +11,11 @@ const DB_TO_DELETE_NAME = url.pathname.slice(1);
 
 url.pathname = '/postgres';
 
+if (!process.env.ALLOW_DATABASE_DROP || process.env.ALLOW_DATABASE_DROP !== 'true') {
+  logger.error(`Database has not been dropped as 'ALLOW_DATABASE_DROP' is disabled`);
+  process.exit(1);
+}
+
 PgClient.getClient(url.href).then(async (client) => {
   try {
     await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME} WITH (FORCE);`);

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -13,7 +13,7 @@ url.pathname = '/postgres';
 
 PgClient.getClient(url.href).then(async (client) => {
   try {
-    await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME};`);
+    await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME} WITH (FORCE);`);
     logger.info('Database dropped');
     await client.end();
     process.exit(0);

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -11,9 +11,16 @@ const DB_TO_DELETE_NAME = url.pathname.slice(1);
 
 url.pathname = '/postgres';
 
-if (!process.env.ALLOW_DATABASE_DROP || process.env.ALLOW_DATABASE_DROP !== 'true') {
-  logger.error(`Database has not been dropped as 'ALLOW_DATABASE_DROP' is disabled`);
-  process.exit(1);
+const databaseInstanceCanBeDropped = () => {
+  if (process.env.NODE_ENV === 'test') {
+    return true;
+  }
+  return process.env.ALLOW_DATABASE_DROP === 'true';
+};
+
+if (!databaseInstanceCanBeDropped()) {
+  logger.info(`Database will not be dropped (check environment variables NODE_ENV and ALLOW_DATABASE_DROP)`);
+  process.exit(0);
 }
 
 PgClient.getClient(url.href).then(async (client) => {


### PR DESCRIPTION
## :unicorn: Problème
En local ou en RA, quand le script `npm run db:reset` est lancé pour générer des JDD, le message suivant est parfois affiché

```
> pix-api@2.219.0 db:delete /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api
> node scripts/database/drop-database
query: DROP DATABASE pix;
(node:15695) UnhandledPromiseRejectionWarning: error: database "pix" is being accessed by other users
```

## :robot: Solution
Les déconnecter avec `DROP DATABASE foo WITH (FORCE);`
https://www.postgresql.org/docs/13/sql-dropdatabase.html

Suite à [échange lors de la PR](https://github.com/1024pix/pix/pull/3730#issuecomment-968683313), pour éviter que cela soit exécuté manuellement et par erreur  en production, ne pas supprimer la BDD dans tous les cas. 

### Implémentation
- ajout d'une variable d'environnement `ALLOW_DATABASE_DROP`
- activée en local (décommenté dans `sample.env`)
- le script ne supprime pas la BDD si `database-drop` est lancé alors que `ALLOW_DATABASE_DROP` n'est pas actif (mais ne sort pas en erreur)

### Motivations

Comme la tâche `test` (utilisée en local et sur la CI) utilise `db:delete`, `ALLOW_DATABASE_DROP` ne sera pas prise en compte si `NODE_ENV=test`, c'est à dire que l'instance sera supprimée. 

Comme la tâche `test:ci` des tests E2E utilise `db:delete` (via`cy:run:ci`), le traitement ne doit pas sortir en erreur si `db:delete` est invoqué avec `NODE_ENV <> test` et `ALLOW_DATABASE_DROP` n'est pas présent. Le but des tests E2E est d'exécuter l'API en conditions réelles, donc de ne pas non plus supprimer la BDD.

## :rainbow: Remarques

Il reste à [traiter cette remarque ](https://github.com/1024pix/pix/pull/2164#discussion_r526167602)de @jonathanperret (gestion des erreurs) , mais ce sera dans une autre PR

## :100: Pour tester

### Déconnexion
Etapes
- se connecter avec un client BDD `psql postgres://postgres@localhost:5432/pix`
- lancer l'API `npm start`
- lancer les seeds `npm run db:seed`
- vérifier qu'on obtient `Ran 1 seed files`

### Non-suppression de l'instance
Etapes
- passer la variable `ALLOW_DATABASE_DROP` à `false` 
- lancer les seeds `npm run db:reset`
- vérifier que le traitement finit avec succès
- vérifier le message suivant
```bash
❯ npm run db:reset

> pix-api@3.127.0 db:reset /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api
> npm run db:prepare && npm run db:seed

> pix-api@3.127.0 db:prepare /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api
> npm run db:delete && npm run db:create && npm run db:migrate

> pix-api@3.127.0 db:delete /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api
> node scripts/database/drop-database
[10:09:35] INFO: Database will not be dropped (check environment variables NODE_ENV and ALLOW_DATABASE_DROP)

```