### PR TITLE
[FEATURE] Afficher les candidats ayant démarré leur test dans l'espace surveillant (PIX-3657)

### DIFF
--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -16,6 +16,7 @@ const {
   CERTIF_REGULAR_USER5_ID,
   CERTIF_SCO_STUDENT_ID,
 } = require('./users');
+const Assessment = require('../../../../lib/domain/models/Assessment');
 
 const A_LOT_OF_CANDIDATES_COUNT = 150;
 const SUCCESS_CANDIDATE_IN_SESSION_TO_FINALIZE_ID = 1;
@@ -48,7 +49,34 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
     databaseBuilder.factory.buildCertificationCandidate({ firstName: 'Jean-Paul', lastName: _convertToRoman(i + 1), sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, userId: null });
   }
 
-  databaseBuilder.factory.buildCertificationCandidate({ sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, userId: null, authorizedToStart: true });
+  // A candidate that is authorized to start
+  databaseBuilder.factory.buildCertificationCandidate({
+    firstName: 'Jean-François',
+    lastName: 'Ananas',
+    sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
+    userId: null,
+    authorizedToStart: true,
+  });
+
+  // A candidate that has started the session
+  const userId = databaseBuilder.factory.buildUser().id;
+  const candidateWithStartedTest = {
+    firstName: 'Jean-Pierre',
+    lastName: 'Arbuste',
+    userId,
+    sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
+  };
+  databaseBuilder.factory.buildCertificationCandidate({
+    ...candidateWithStartedTest,
+    authorizedToStart: true,
+  });
+  const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+    ...candidateWithStartedTest,
+  });
+  databaseBuilder.factory.buildAssessment({
+    certificationCourseId: certificationCourse.id,
+    state: Assessment.states.STARTED,
+  });
 
   let sessionId;
   const candidateDataSuccessWithUser = { ...CANDIDATE_DATA_SUCCESS, userId: CERTIF_SUCCESS_USER_ID };

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -1,13 +1,14 @@
 const isNil = require('lodash/isNil');
 
 class CertificationCandidateForSupervising {
-  constructor({ id, firstName, lastName, birthdate, extraTimePercentage, authorizedToStart } = {}) {
+  constructor({ id, firstName, lastName, birthdate, extraTimePercentage, authorizedToStart, assessmentStatus } = {}) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
     this.birthdate = birthdate;
     this.extraTimePercentage = !isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : extraTimePercentage;
     this.authorizedToStart = authorizedToStart;
+    this.assessmentStatus = assessmentStatus;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -1,6 +1,14 @@
 const { Serializer } = require('jsonapi-serializer');
 
-const attributes = ['id', 'firstName', 'lastName', 'birthdate', 'extraTimePercentage', 'authorizedToStart'];
+const attributes = [
+  'id',
+  'firstName',
+  'lastName',
+  'birthdate',
+  'extraTimePercentage',
+  'authorizedToStart',
+  'assessmentStatus',
+];
 
 module.exports = {
   serialize(sessions) {

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const { NotFoundError } = require('../../../../../lib/domain/errors');
 const SessionForSupervising = require('../../../../../lib/domain/read-models/SessionForSupervising');
 const sessionForSupervisingRepository = require('../../../../../lib/infrastructure/repositories/sessions/session-for-supervising-repository');
+const Assessment = require('../../../../../lib/domain/models/Assessment');
 
 describe('Integration | Repository | SessionForSupervising', function () {
   describe('#get', function () {
@@ -65,6 +66,24 @@ describe('Integration | Repository | SessionForSupervising', function () {
         firstName: 'Janet',
         sessionId: session.id,
       });
+      databaseBuilder.factory.buildUser({ id: 12345 });
+      databaseBuilder.factory.buildCertificationCandidate({
+        lastName: 'Joplin',
+        firstName: 'Janis',
+        sessionId: session.id,
+        userId: 12345,
+        authorizedToStart: true,
+      });
+
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        userId: 12345,
+        sessionId: session.id,
+      });
+
+      databaseBuilder.factory.buildAssessment({
+        certificationCourseId: certificationCourse.id,
+        state: Assessment.states.STARTED,
+      });
       databaseBuilder.factory.buildCertificationCandidate();
       await databaseBuilder.commit();
 
@@ -73,12 +92,18 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName', 'authorizedToStart'])
+        _.pick(item, ['sessionId', 'lastName', 'firstName', 'authorizedToStart', 'assessmentStatus'])
       );
       expect(actualCandidates).to.have.deep.ordered.members([
-        { lastName: 'Jackson', firstName: 'Janet', authorizedToStart: false },
-        { lastName: 'Jackson', firstName: 'Michael', authorizedToStart: true },
-        { lastName: 'Stardust', firstName: 'Ziggy', authorizedToStart: false },
+        { lastName: 'Jackson', firstName: 'Janet', authorizedToStart: false, assessmentStatus: null },
+        { lastName: 'Jackson', firstName: 'Michael', authorizedToStart: true, assessmentStatus: null },
+        {
+          lastName: 'Joplin',
+          firstName: 'Janis',
+          authorizedToStart: true,
+          assessmentStatus: Assessment.states.STARTED,
+        },
+        { lastName: 'Stardust', firstName: 'Ziggy', authorizedToStart: false, assessmentStatus: null },
       ]);
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer');
+const Assessment = require('../../../../../lib/domain/models/Assessment');
 
 describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', function () {
   describe('#serialize()', function () {
@@ -35,6 +36,8 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'first-name': 'toto',
               id: 1234,
               'last-name': 'tata',
+              'authorized-to-start': true,
+              'assessment-status': Assessment.states.STARTED,
             },
             id: '1234',
             type: 'certification-candidate-for-supervising',
@@ -55,21 +58,10 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             id: 1234,
             firstName: 'toto',
             lastName: 'tata',
-            sex: 'M',
-            birthPostalCode: '75000',
-            birthInseeCode: null,
-            birthCity: 'Paris',
-            birthProvinceCode: null,
-            birthCountry: 'France',
-            email: 'toto@example.net',
-            resultRecipientEmail: null,
-            externalId: 'EXT1234',
             birthdate: '28/05/1984',
             extraTimePercentage: 33,
-            createdAt: '2021-02-01',
-            sessionId: '456',
-            userId: '747',
-            schoolingRegistrationId: null,
+            authorizedToStart: true,
+            assessmentStatus: Assessment.states.STARTED,
           },
         ],
       });

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -5,19 +5,25 @@
       <span class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test pour l'autoriser à commencer son test de certification.</span>
       <ul class="session-supervising-candidate-list__candidates">
         {{#each @candidates as |candidate|}}
-          <li class="session-supervising-candidate-list__candidate">
-            <PixInput
-              @id={{concat "candidate-checkbox-" candidate.id}}
-              class="session-supervising-candidate-list__candidate-checkbox"
-              type="checkbox"
-              checked={{candidate.authorizedToStart}}
-              {{on 'click' (fn this.toggleCandidate candidate)}}
-            />
+          <li class="session-supervising-candidate-list__candidate" data-test-id={{concat "candidate-" candidate.id}}>
+            {{#unless candidate.hasStarted}}
+              <PixInput
+                @id={{concat "candidate-checkbox-" candidate.id}}
+                class="session-supervising-candidate-list__candidate-checkbox"
+                type="checkbox"
+                checked={{candidate.authorizedToStart}}
+                {{on 'click' (fn this.toggleCandidate candidate)}}
+              />
+            {{/unless}}
             <div>
               <div class="session-supervising-candidate-list__candidate-full-name">
-                <label for={{concat "candidate-checkbox-" candidate.id}}>
+                {{#if candidate.hasStarted}}
                   {{candidate.lastName}} {{candidate.firstName}}
-                </label>
+                {{else}}
+                  <label for={{concat "candidate-checkbox-" candidate.id}}>
+                    {{candidate.lastName}} {{candidate.firstName}}
+                  </label>
+                {{/if}}
               </div>
               <div class="session-supervising-candidate-list__candidate-details">
                 {{moment-format candidate.birthdate "DD/MM/YYYY"}}
@@ -25,6 +31,11 @@
                   · Temps majoré : {{candidate.extraTimePercentage}}%
                 {{/if}}
               </div>
+              {{#if candidate.hasStarted}}
+                <span class="session-supervising-candidate-list__candidate-status session-supervising-candidate-list__candidate-status--started">
+                  En cours
+                </span>
+              {{/if}}
             </div>
           </li>
         {{/each}}

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -7,6 +7,11 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('date-only') birthdate;
   @attr('number') extraTimePercentage;
   @attr('boolean') authorizedToStart;
+  @attr('string') assessmentStatus;
+
+  get hasStarted() {
+    return this.assessmentStatus === 'started';
+  }
 
   updateAuthorizedToStart = memberAction({
     type: 'patch',

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -1,5 +1,7 @@
 $yellow-30: #FFBE00;
 $grey-85: rgb(37, 56, 88);
+$green-0: #EFFFD8;
+$green-70: #006134;
 
 .session-supervising-candidate-list-background {
   background: $grey-100;
@@ -25,7 +27,7 @@ $grey-85: rgb(37, 56, 88);
       font-size: 12px;
       font-weight: normal;
       height: 14px;
-      letter-spacing: 0px;
+      letter-spacing: 0;
       padding: 0 8px;
       margin-bottom: 2rem;
     }
@@ -89,6 +91,20 @@ $grey-85: rgb(37, 56, 88);
       width: 32px;
       height: 32px;
       margin-right: 16px;
+    }
+
+    &__candidate-status {
+      border-radius: 12px;
+      display: inline-block;
+      font-size: 0.625rem;
+      font-weight: 500;
+      margin-top: 8px;
+      padding: 4px 16px;
+
+      &--started {
+        background-color: $green-0;
+        color: $green-70;
+      }
     }
   }
 }

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -21,11 +21,12 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
         certificationCandidates: [
           store.createRecord('certification-candidate-for-supervising', {
             id: 123,
-            firstName: 'Toto',
-            lastName: 'Tutu',
+            firstName: 'Gamora',
+            lastName: 'Zen Whoberi Ben Titan',
             birthdate: '1984-05-28',
             extraTimePercentage: '8',
             authorizedToStart: true,
+            assessmentStatus: null,
           }),
           store.createRecord('certification-candidate-for-supervising', {
             id: 456,
@@ -34,6 +35,16 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
             birthdate: '1983-06-28',
             extraTimePercentage: '12',
             authorizedToStart: false,
+            assessmentStatus: null,
+          }),
+          store.createRecord('certification-candidate-for-supervising', {
+            id: 789,
+            firstName: 'Rocket',
+            lastName: 'Racoon',
+            birthdate: '1982-07-28',
+            extraTimePercentage: null,
+            authorizedToStart: true,
+            assessmentStatus: 'started',
           }),
         ],
       });
@@ -42,15 +53,14 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
       const screen = await renderScreen(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}}  />`);
 
       // then
-      assert.dom(screen.getByRole('checkbox', { name: 'Tutu Toto' })).isChecked();
+      assert.dom('[data-test-id="candidate-123"]').hasText('Zen Whoberi Ben Titan Gamora 28/05/1984 · Temps majoré : 8%');
+      assert.dom(screen.getByRole('checkbox', { name: 'Zen Whoberi Ben Titan Gamora' })).isChecked();
 
-      assert.contains('· Temps majoré : 8%');
-      assert.contains('28/05/1984');
-
+      assert.dom('[data-test-id="candidate-456"]').hasText('Lord Star 28/06/1983 · Temps majoré : 12%');
       assert.dom(screen.getByRole('checkbox', { name: 'Lord Star' })).isNotChecked();
 
-      assert.contains('· Temps majoré : 12%');
-      assert.contains('28/06/1983');
+      assert.dom('[data-test-id="candidate-789"]').hasText('Racoon Rocket 28/07/1982 En cours');
+      assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
     });
 
     module('when the checkbox value change', function() {

--- a/certif/tests/unit/models/certification-candidate-for-supervising_test.js
+++ b/certif/tests/unit/models/certification-candidate-for-supervising_test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import pick from 'lodash/pick';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | certification-candidate-for-supervising', function(hooks) {
+  setupTest(hooks);
+
+  test('it creates a CertificationCandidateForSupervising', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const data = {
+      firstName: 'Jean-Paul',
+      lastName: 'Candidat',
+      birthdate: '2000-12-25',
+      extraTimePercentage: 10,
+      authorizedToStart: true,
+      assessmentStatus: 'started',
+    };
+
+    // when
+    const model = store.createRecord('certification-candidate-for-supervising', data);
+
+    // then
+    assert.deepEqual(_pickModelData(data), _pickModelData(model));
+  });
+
+  module('#get hasStarted', () => {
+    test('returns false if assessmentStatus is not started', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: null };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.false(model.hasStarted);
+    });
+
+    test('returns true if assessmentStatus is started', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: 'started' };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.true(model.hasStarted);
+    });
+  });
+
+  function _pickModelData(certificationCandidate) {
+    return pick(certificationCandidate, [
+      'firstName',
+      'lastName',
+      'birthdate',
+      'extraTimePercentage',
+      'authorizedToStart',
+      'assessmentStatus',
+    ]);
+  }
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Les surveillants ont la possibilité depuis le portail surveillant d’autoriser ou non le lancement du test de certification des candidats en indiquant leur présence dans la salle de test. Il s’agit maintenant de permettre au surveillant de suivre quels candidats ont bien démarré leur test de certification depuis le portail.

## :gift: Solution

Lorsqu’un candidat dans une session de certification lance son test : 
- afficher le statut “Test en cours” dans le portail surveillant
- ne PLUS afficher la case à cocher qui permet au surveillant de cocher sa présence dans la salle de test

Maquettes : 
- mobile : https://share.goabstract.com/18beca74-eff3-4094-91af-86516c19a350?collectionLayerId=1dcaf551-de1c-449f-8866-c5b3a71ca266&mode=design
- tablette : https://share.goabstract.com/18beca74-eff3-4094-91af-86516c19a350?collectionLayerId=725bc691-1e5d-4d8c-aa6d-6d094687e1f3&mode=design
- ordi : https://share.goabstract.com/18beca74-eff3-4094-91af-86516c19a350?collectionLayerId=a2306f4f-8437-4cc8-aca4-d3fa26b38e6d&mode=design

## :star2: Remarques

*RAS*

## :santa: Pour tester

1. Activer le toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED
2. Se connecter à Pix Certif
2. Accéder à l'espace surveillant
3. Accéder à une session avec au moins un candidat ayant commencé son test (par exemple la 3)
4. Constater que, pour ce candidat, la case à cocher n'apparaît plus et que la pilule "En cours" apparaît



