### PR TITLE
[BUGFIX] La clé requête est dupliquée dans les logs.

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -42,6 +42,8 @@ const plugins = [
       serializers: {
         req: logObjectSerializer,
       },
+      // Remove duplicated req property: https://github.com/pinojs/hapi-pino#optionsgetchildbindings-request---key-any-
+      getChildBindings: () => ({}),
       instance: require('./infrastructure/logger'),
       logQueryParams: true,
     },


### PR DESCRIPTION
## :christmas_tree: Problème
La clé `req` est dupliquée dans les logs.

## :gift: Solution
Spécifier au logger Pino un objet vide dans la propriété `getChildBindings`

## :star2: Remarques
`getChildBindings` renvoie la clé `req` par défaut et donc double son affichage
https://github.com/pinojs/hapi-pino#optionsgetchildbindings-request---key-any-

## :santa: Pour tester
- Lancer l'api
- Lancer une app
- Vérifier qu'il y a bien qu'un seul `req` dans chaque logs
