### PR TITLE
[TECH] Journaliser  la version de l'application.

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -48,6 +48,8 @@ module.exports = (function () {
 
     logOpsMetrics: isFeatureEnabled(process.env.LOG_OPS_METRICS),
 
+    version: process.env.CONTAINER_VERSION || 'development',
+
     hapi: {
       options: {},
       enableRequestMonitoring: isFeatureEnabled(process.env.ENABLE_REQUEST_MONITORING),

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -36,6 +36,7 @@ const schema = Joi.object({
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),
   POLE_EMPLOI_SENDING_URL: Joi.string().uri().optional(),
+  CONTAINER_VERSION: Joi.string().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -3,20 +3,21 @@ const settings = require('./config');
 const Blipp = require('blipp');
 const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
-const { get } = require('lodash');
 const monitoringTools = require('./infrastructure/monitoring-tools');
 
-function logObjectSerializer(obj) {
-  if (settings.hapi.enableRequestMonitoring) {
-    const context = monitoringTools.getContext();
-    return {
-      ...obj,
-      user_id: get(context, 'request') ? monitoringTools.extractUserIdFromRequest(context.request) : '-',
-      metrics: get(context, 'metrics'),
-    };
-  } else {
-    return { ...obj };
-  }
+function logObjectSerializer(req) {
+  const enhancedReq = {
+    ...req,
+    version: settings.version,
+  };
+  if (!settings.hapi.enableRequestMonitoring) return enhancedReq;
+
+  const context = monitoringTools.getContext();
+  return {
+    ...enhancedReq,
+    user_id: monitoringTools.extractUserIdFromRequest(req),
+    metrics: context?.metrics,
+  };
 }
 
 const plugins = [


### PR DESCRIPTION
## :christmas_tree: Problème
La version de l'app n'est pas spécifiée dans les logs.

## :gift: Solution
Ajouter dans les logs l'information du commit déployé. cette version est contenue dans la variable d'environnement scalingo: `CONTAINER_VERSION`.

## :star2: Remarques
La doc relative a la variable est est dispo ici:
https://doc.scalingo.com/platform/app/environment

Lorsque la version n'est pas spécifiée on indique: `development`.
## :santa: Pour tester
- Faire un export `ENABLE_REQUEST_MONITORING=true`
- Faire un `export CONTAINER_VERSION=3.172` 
- Lancer l'api dans le même terminal
- Lancer une app
- Vérifier qu'il y a bien `version: 3.172` dans chaque logs
