### PR TITLE
[FEATURE] Bloquer l'accès à une session pour un candidat qui a déjà accédé à la session (PIX-3846)

### DIFF
--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -43,6 +43,8 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     if (!certificationCandidate.isAuthorizedToStart()) {
       throw new CandidateNotAuthorizedToJoinSessionError();
     }
+    certificationCandidate.authorizedToStart = false;
+    certificationCandidateRepository.update(certificationCandidate);
   }
 
   const existingCertificationCourse =

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -35,6 +35,16 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     throw new SessionNotAccessible();
   }
 
+  if (featureToggles.isEndTestScreenRemovalEnabled) {
+    const certificationCandidate = await certificationCandidateRepository.getBySessionIdAndUserId({
+      userId,
+      sessionId,
+    });
+    if (!certificationCandidate.isAuthorizedToStart()) {
+      throw new CandidateNotAuthorizedToJoinSessionError();
+    }
+  }
+
   const existingCertificationCourse =
     await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({
       userId,
@@ -46,16 +56,6 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
       created: false,
       certificationCourse: existingCertificationCourse,
     };
-  }
-
-  if (featureToggles.isEndTestScreenRemovalEnabled) {
-    const certificationCandidate = await certificationCandidateRepository.getBySessionIdAndUserId({
-      userId,
-      sessionId,
-    });
-    if (!certificationCandidate.isAuthorizedToStart()) {
-      throw new CandidateNotAuthorizedToJoinSessionError();
-    }
   }
 
   return _startNewCertification({

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -172,6 +172,16 @@ module.exports = {
 
     return anyLinkedCandidateInSession !== null;
   },
+
+  async update(certificationCandidate) {
+    const result = await knex('certification-candidates')
+      .where({ id: certificationCandidate.id })
+      .update({ authorizedToStart: certificationCandidate.authorizedToStart });
+
+    if (result === 0) {
+      throw new NotFoundError('Aucun candidat trouvé');
+    }
+  },
 };
 
 function _adaptModelToDb(certificationCandidateToSave) {

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -38,7 +38,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     assessmentRepository = { save: sinon.stub() };
     competenceRepository = { listPixCompetencesOnly: sinon.stub() };
     certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
-    certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub() };
+    certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub(), update: sinon.stub() };
     certificationChallengeRepository = { save: sinon.stub() };
     certificationChallengesService = {
       pickCertificationChallengesForPixPlus: sinon.stub(),
@@ -253,7 +253,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
         });
 
         context('when a certification course with provided userId and sessionId already exists', function () {
-          it('should return it with flag created marked as false', async function () {
+          it('should allow access and block future access', async function () {
             // given
             const sessionId = 1;
             const accessCode = 'accessCode';
@@ -276,6 +276,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
             certificationCandidateRepository.getBySessionIdAndUserId
               .withArgs({ sessionId, userId })
               .resolves(foundCertificationCandidate);
+            certificationCandidateRepository.update.withArgs({
+              ...foundCertificationCandidate,
+              authorizedToStart: false,
+            });
 
             // when
             const result = await retrieveLastOrCreateCertificationCourse({
@@ -305,6 +309,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
             expect(certificationCourseRepository.save).not.to.have.been.called;
             expect(verifyCertificateCodeService.generateCertificateVerificationCode).not.to.have.been.called;
+            expect(certificationCandidateRepository.update).to.have.been.calledOnce;
           });
         });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Si un candidat accède à une session, il ne doit pas pouvoir ré-accéder à cette même session depuis un autre ordinateur, sans que le surveillant ne l'ait explicitement autorisé.

## :gift: Solution

Si le toggle est activé, lorsque le candidat accède à la session, passer le champ `authorizedToStart` à `false`.
:warning: Cela veut dire que le surveillant verra la case décochée alors que le candidat est présent

## :star2: Remarques

- Cette PR hérite de #3727 et doit être fusionnée après. Edit : rebase fait.

## :santa: Pour tester

### Avec le toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED activé

1. Se connecter à Pix App
2. Accéder à une session de certification et commencer un test
3. Fermer la fenêtre de navigateur
4. Tenter de ré-accéder à la même session de certification et constater qu'un message d'erreur s'affiche

### Avec le toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED désactivé

1. Se connecter à Pix App
2. Accéder à une session de certification et commencer un test3
3. Fermer la fenêtre de navigateur
4. Tenter de ré-accéder à la même session de certification et constater que ça fonctionne
