### PR TITLE
[FEATURE]  Ajoute le user agent a la table feedbacks (PIX-3831)

### DIFF
--- a/api/db/migrations/20211116091730_add_user_agent_to_feedbacks.js
+++ b/api/db/migrations/20211116091730_add_user_agent_to_feedbacks.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('feedbacks', function(table) {
+    table.string('userAgent');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('feedbacks', (table) => {
+    table.dropColumn('userAgent');
+  });
+};

--- a/api/lib/application/feedbacks/feedback-controller.js
+++ b/api/lib/application/feedbacks/feedback-controller.js
@@ -4,7 +4,7 @@ const serializer = require('../../infrastructure/serializers/jsonapi/feedback-se
 
 module.exports = {
   async save(request, h) {
-    const newFeedback = await serializer.deserialize(request.payload);
+    const newFeedback = await serializer.deserialize(request.payload, request.headers['user-agent']);
 
     if (_.isBlank(newFeedback.get('content'))) {
       throw new BadRequestError('Feedback content must not be blank');

--- a/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
@@ -16,11 +16,12 @@ module.exports = {
     }).serialize(feedbacks);
   },
 
-  deserialize(json) {
+  deserialize(json, userAgent) {
     return new Deserializer()
       .deserialize(json, function (err, feedback) {
         feedback.assessmentId = json.data.relationships.assessment.data.id;
         feedback.challengeId = json.data.relationships.challenge.data.id;
+        feedback.userAgent = userAgent;
       })
       .then((deserializedFeedback) => {
         return new Feedback(deserializedFeedback);

--- a/api/tests/acceptance/application/feedback-controller_test.js
+++ b/api/tests/acceptance/application/feedback-controller_test.js
@@ -40,7 +40,7 @@ describe('Acceptance | Controller | feedback-controller', function () {
             },
           },
         },
-        headers: { authorization: generateValidRequestAuthorizationHeader() },
+        headers: { 'user-agent': 'Firefox rocks', authorization: generateValidRequestAuthorizationHeader() },
       };
     });
 
@@ -104,6 +104,7 @@ describe('Acceptance | Controller | feedback-controller', function () {
         return new Feedback().fetch().then((model) => {
           expect(model.id).to.be.a('number');
           expect(model.get('content')).to.equal(options.payload.data.attributes.content);
+          expect(model.get('userAgent')).to.equal('Firefox rocks');
           expect(model.get('assessmentId')).to.equal(options.payload.data.relationships.assessment.data.id);
           expect(model.get('challengeId')).to.equal(options.payload.data.relationships.challenge.data.id);
 


### PR DESCRIPTION
## :christmas_tree: Problème
L'équipe contenu traite beaucoup de retours d'utilisateurs. Il est parfois difficile de reproduire certains bugs sans informations sur l'appareil utilisé.

## :gift: Solution
Stocker le user agent dans la table feedbacks

## :star2: Remarques
**Firefox rocks**

## :santa: Pour tester
1. Aller sur Pix et passer une épreuve
2. Faire un signalement sur l'épreuve
3. Aller voir dans la table feedback le signalement avec le user agent
