### PR TITLE
[BUGFIX] Permettre l'envoi des résultats malgré une double participation non voulue à une campagne (PIX-3850).

### DIFF
--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -53,6 +53,7 @@ async function _getParticipationAttributes(userId, campaignId) {
     .join('assessments', 'campaign-participations.id', 'assessments.campaignParticipationId')
     .where({ 'campaign-participations.campaignId': campaignId })
     .andWhere({ 'campaign-participations.userId': userId })
+    .andWhere('campaign-participations.isImproved', '=', false)
     .orderBy('assessments.createdAt', 'DESC')
     .first();
 


### PR DESCRIPTION
## :christmas_tree: Problème
On a, pour une raison inconnue encore (on y a déjà passé pas mal de temps) parfois plusieurs participations à une campagne qui sont créées dans la même seconde.

Lors de l'affichage des résultats, on ne filtre pas sur les participations, on prend la première qui vient. Ce qui a pour conséquence que parfois c'est la bonne, parfois la mauvaise. L'affichage reste bon. En revanche, on se sert de l'ID récupéré pour envoyer les résultats. Lorsqu'on demande d'envoyer les résultats avec la mauvaise participation, la demande échoue car l'évaluation derrière (`assessment`) n'est pas terminée.

On redirige alors la personne en début de parcours, mais en fait elle a terminé, donc on lui affiche les résultats. Et donc cela tourne en boucle.

## :gift: Solution
Filtrer les participations pour récupérer la bonne.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier qu'on peut toujours partager ses résultats en temps normal + en cas de campagne à envois multiple.

Pour le cas précis du bug, difficile à reproduire.