### PR TITLE
[BUGFIX] Vérifier que l'utilisateur est membre de l'organisation afin de pouvoir filtrer sur les groupes (PIX-3832)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -178,8 +178,7 @@ exports.register = async (server) => {
       config: {
         pre: [
           {
-            method: securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents,
-            assign: 'isAdminInOrganizationManagingStudents',
+            method: securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents,
           },
         ],
         validate: {
@@ -199,7 +198,7 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/organizations/{id}/groups',
       config: {
-        pre: [{ method: securityPreHandlers.checkUserIsAdminInOrganization }],
+        pre: [{ method: securityPreHandlers.checkUserBelongsToSupOrganizationAndManagesStudents }],
         validate: {
           params: Joi.object({
             id: identifiersType.organizationId,

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -3,6 +3,7 @@ const checkUserHasRolePixMasterUseCase = require('./usecases/checkUserHasRolePix
 const checkUserIsAdminInOrganizationUseCase = require('./usecases/checkUserIsAdminInOrganization');
 const checkUserBelongsToOrganizationManagingStudentsUseCase = require('./usecases/checkUserBelongsToOrganizationManagingStudents');
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('./usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
+const checkUserBelongsToSupOrganizationAndManagesStudentsUseCase = require('./usecases/checkUserBelongsToSupOrganizationAndManagesStudents');
 const checkUserBelongsToOrganizationUseCase = require('./usecases/checkUserBelongsToOrganization');
 const checkUserIsAdminAndManagingStudentsForOrganization = require('./usecases/checkUserIsAdminAndManagingStudentsForOrganization');
 const Organization = require('../../lib/domain/models/Organization');
@@ -137,6 +138,29 @@ async function checkUserBelongsToScoOrganizationAndManagesStudents(request, h) {
   return _replyForbiddenError(h);
 }
 
+async function checkUserBelongsToSupOrganizationAndManagesStudents(request, h) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return _replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const organizationId = parseInt(request.params.id) || parseInt(request.payload.data.attributes['organization-id']);
+
+  let belongsToSupOrganizationAndManageStudents;
+  try {
+    belongsToSupOrganizationAndManageStudents =
+      await checkUserBelongsToSupOrganizationAndManagesStudentsUseCase.execute(userId, organizationId);
+  } catch (err) {
+    return _replyForbiddenError(h);
+  }
+
+  if (belongsToSupOrganizationAndManageStudents) {
+    return h.response(true);
+  }
+
+  return _replyForbiddenError(h);
+}
+
 async function checkUserIsAdminInSCOOrganizationManagingStudents(request, h) {
   const userId = request.auth.credentials.userId;
   const organizationId = parseInt(request.params.id);
@@ -182,6 +206,7 @@ module.exports = {
   checkUserBelongsToOrganizationOrHasRolePixMaster,
   checkUserBelongsToOrganizationManagingStudents,
   checkUserBelongsToScoOrganizationAndManagesStudents,
+  checkUserBelongsToSupOrganizationAndManagesStudents,
   checkUserHasRolePixMaster,
   checkUserIsAdminInOrganization,
   checkUserIsAdminInSCOOrganizationManagingStudents,

--- a/api/lib/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents.js
+++ b/api/lib/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents.js
@@ -9,7 +9,7 @@ module.exports = {
     });
 
     return memberships.some(
-      (membership) => membership.organization.isManagingStudents && membership.organization.isSco
+      (membership) => membership.organization.isManagingStudents && membership.organization.isSup
     );
   },
 };

--- a/api/tests/unit/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents_test.js
@@ -1,0 +1,74 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const useCase = require('../../../../lib/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents');
+const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+
+describe('Unit | Application | Use Case | checkUserBelongsToSupOrganizationAndManagesStudents', function () {
+  beforeEach(function () {
+    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+  });
+
+  context('When user is in a SUP organization', function () {
+    it('should return true', async function () {
+      // given
+      const userId = 1234;
+
+      const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
+      const membership = domainBuilder.buildMembership({ organization });
+      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+
+      // when
+      const response = await useCase.execute(userId, organization.id);
+
+      // then
+      expect(response).to.equal(true);
+    });
+
+    it('should return true when there are several memberships', async function () {
+      // given
+      const userId = 1234;
+
+      const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
+      const membership1 = domainBuilder.buildMembership({ organization });
+      const membership2 = domainBuilder.buildMembership({ organization });
+      membershipRepository.findByUserIdAndOrganizationId.resolves([membership1, membership2]);
+
+      // when
+      const response = await useCase.execute(userId, organization.id);
+
+      // then
+      expect(response).to.equal(true);
+    });
+  });
+
+  context('When user is not in a SUP organization', function () {
+    it('should return false', async function () {
+      // given
+      const userId = 1234;
+      const organization = domainBuilder.buildOrganization({ type: 'PRO', isManagingStudents: true });
+      const membership = domainBuilder.buildMembership({ organization });
+      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+
+      // when
+      const response = await useCase.execute(userId, organization.id);
+
+      // then
+      expect(response).to.equal(false);
+    });
+  });
+
+  context('When user is in a SUP organization but does not manage students', function () {
+    it('should return false', async function () {
+      // given
+      const userId = 1234;
+      const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: false });
+      const membership = domainBuilder.buildMembership({ organization });
+      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+
+      // when
+      const response = await useCase.execute(userId, organization.id);
+
+      // then
+      expect(response).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Des utilisateurs de Pix Orga (non admin) nous on remonté que le fitre des classes était constamment en chargement

## :gift: Solution
Remplacer la vérification sur `/api/organizations/{id}/groups` par `checkUserBelongsToSupOrganizationAndManagesStudents` au lieu de `checkUserIsAdminInOrganization`  

Remplacer la vérification sur `/api/organizations/{id}/divisions` par `checkUserBelongsToScoOrganizationAndManagesStudents` au lieu de `checkUserIsAdminInSCOOrganizationManagingStudents`  
## :star2: Remarques

## :santa: Pour tester
Vérifier qu'un utilisateur classique sur Pix Orga puisse filtrer sur les classes/groupes dans la liste éléves/etudiants