### PR TITLE
[BUGFIX] Le path de la route n'est plus journalisé.

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -10,13 +10,15 @@ function logObjectSerializer(req) {
     ...req,
     version: settings.version,
   };
-  if (!settings.hapi.enableRequestMonitoring) return enhancedReq;
 
+  if (!settings.hapi.enableRequestMonitoring) return enhancedReq;
   const context = monitoringTools.getContext();
+
   return {
     ...enhancedReq,
     user_id: monitoringTools.extractUserIdFromRequest(req),
-    metrics: context?.metrics,
+    metrics: context.metrics,
+    route: context.request.route.path,
   };
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Le pathname contenu dans les logs ne nous permet d'agréger tous les logs d'une route. C'est une régression depuis le retrait de `@hapi/good`.

## :gift: Solution
On ajoute dans le log le path de la route (ex: `campaigns/{id}`).

## :santa: Pour tester
- Lancer l'api
- Lancer une application
- Constater dans les logs la présence de la propriété route avec un path contenant des placeholders (ex: `{id}`)
