### PR TITLE
[TECH] Enrichir la documentation des variables d'environnement du monitoring.

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -504,3 +504,17 @@ MAX_REACHABLE_LEVEL=
 # default: false
 # note: Enabled in production
 ENABLE_REQUEST_MONITORING=true
+
+# ========
+# LOG KNEX QUERIES
+# ========
+
+# Enable knex log queries metrics
+# duration: to calculate the response time of the query
+# sql: sql queries
+# knexQueryCount: le nombre de queries par API
+# presence: optional
+# type: boolean
+# default: false
+# note: Enabled in demand in production
+LOG_KNEX_QUERIES=true

--- a/api/sample.env
+++ b/api/sample.env
@@ -490,3 +490,17 @@ TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS=
 # default: 5
 # note: Pay attention to sync it whit prod
 MAX_REACHABLE_LEVEL=
+
+# ========
+# ENABLE REQUEST MONITORING
+# ========
+
+# Enable monitoring request by adding metrics to hapi response using AsyncLocalStorage API.
+# The AsyncLocalStorage creates stores that stays coherent through asynchronous operations.
+# When this env is enabled, we install a patch present in monitoring-tools file that wrap all API calls by async local storage method.
+# The logger use this context to add this metrics to hapi request.
+# presence: optional
+# type: boolean
+# default: false
+# note: Enabled in production
+ENABLE_REQUEST_MONITORING=true


### PR DESCRIPTION
## :christmas_tree: Problème
Les variables de monitoring ENABLE_REQUEST_MONITORING, LOG_KNEX_QUERIES ne sont pas documentées.

## :gift: Solution
Rajouter de la documentation dans le sample.env

## :santa: Pour tester
Vérifier que la documentation est claire.
