### PR TITLE
[TECH] Supprimer le logging des query params lors des logs de requêtes Knex.

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -60,7 +60,6 @@ knex.on('query-response', function (response, obj) {
       monitoringTools.pushInContext('metrics.knexQueries', {
         id: obj.__knexQueryUid,
         sql: obj.sql,
-        params: [obj.bindings ? obj.bindings.join(',') : ''],
         duration,
       });
     }


### PR DESCRIPTION
## :christmas_tree: Problème
La variable LOG_KNEX_QUERIES permet de tracer des metrics concernant les knex queries.
Cette variable est désactivée, néanmoins on peut afficher les query params si elle est activée.

## :gift: Solution
Enlever la traçabilité des query params

## :star2: Remarques
Désactivée par défault.

## :santa: Pour tester
Activer la variable LOG_KNEX_QUERIES et vérifier que les query params ne sont pas tracées.