### PR TITLE
[BUGFIX] Cacher les certifications complémentaires si le FT est désactivé (PIX-3854).

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -92,12 +92,14 @@
               {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
             </span>
           </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Certifications complémentaires</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="complementary-certifications-row">
-              {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}
-            </span>
-          </li>
+          {{#if @displayComplementaryCertification}}
+            <li class="certification-candidate-details-modal__row">
+              <span class="certification-candidate-details-modal__row__label">Certifications complémentaires</span>
+              <span class="certification-candidate-details-modal__row__value" data-test-id="complementary-certifications-row">
+                {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}
+              </span>
+            </li>
+          {{/if}}
         </ul>
 
         <div class="certification-candidate-details-modal__actions">

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -139,6 +139,7 @@
   <CertificationCandidateDetailsModal
     @closeModal={{this.closeCertificationCandidateDetailsModal}}
     @candidate={{this.certificationCandidateInDetailsModal}}
+    @displayComplementaryCertification={{@displayComplementaryCertification}}
   />
 {{/if}}
 

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -51,7 +51,9 @@
               <th class="certification-candidates-table__external-id">Identifiant externe</th>
             {{/unless}}
             <th class="certification-candidates-table__column-time">Temps majoré</th>
-            <th>Certifications complémentaires</th>
+            {{#if @displayComplementaryCertification}}
+              <th>Certifications complémentaires</th>
+            {{/if }}
           </tr>
           </thead>
           <tbody>
@@ -71,9 +73,11 @@
                 <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
               {{/unless}}
               <td data-test-id='panel-candidate__extraTimePercentage__{{candidate.id}}'>{{format-percentage candidate.extraTimePercentage}}</td>
+              {{#if @displayComplementaryCertification}}
               <td data-test-id='panel-candidate__complementaryCertifications__{{candidate.id}}'>
                 {{if candidate.complementaryCertifications candidate.complementaryCertificationsList "-"}}
               </td>
+              {{/if}}
               <td>
                 <div class="certification-candidates-actions">
                   {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -42,4 +42,8 @@ export default class CertificationCandidatesController extends Controller {
   async reloadCertificationCandidateInController() {
     await this.reloadCertificationCandidate();
   }
+
+  get displayComplementaryCertification() {
+    return this.featureToggles.featureToggles.isComplementaryCertificationSubscriptionEnabled;
+  }
 }

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('boolean') isManageUncompletedCertifEnabled;
   @attr('boolean') isEndTestScreenRemovalEnabled;
+  @attr('boolean') isComplementaryCertificationSubscriptionEnabled;
 }

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -10,6 +10,7 @@
         @certificationCandidates={{this.certificationCandidates}}
         @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
         @countries={{this.countries}}
+        @displayComplementaryCertification={{this.displayComplementaryCertification}}
   />
   {{/if}}
 {{else}}
@@ -24,5 +25,6 @@
           @certificationCandidates={{this.certificationCandidates}}
           @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
           @countries={{this.countries}}
+          @displayComplementaryCertification={{this.displayComplementaryCertification}}
   />
 {{/if}}

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -115,7 +115,6 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
         // then
         assert.dom('table tbody tr').exists({ count: 3 });
-        assert.dom('table thead tr th').exists({ count: 7 });
         assert.contains(`${aCandidate.lastName}`);
         assert.contains(`${aCandidate.firstName}`);
         assert.contains(`${moment(aCandidate.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -10,106 +10,173 @@ import { render as renderScreen } from '@pix/ember-testing-library';
 module('Integration | Component | certification-candidate-details-modal', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it shows candidate details', async function(assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const candidate = store.createRecord('certification-candidate', {
-      firstName: 'Jean-Paul',
-      lastName: 'Candidat',
-      birthCity: 'Eu',
-      birthCountry: 'France',
-      email: 'jeanpauldeu@pix.fr',
-      resultRecipientEmail: 'suric@animal.fr',
-      externalId: '12345',
-      birthdate: '2000-12-25',
-      extraTimePercentage: 0.10,
-      birthInseeCode: 76255,
-      birthPostalCode: 76260,
-      sex: 'F',
-      complementaryCertifications: [
-        {
-          id: 1,
-          name: 'Pix+Edu',
-        },
-        {
-          id: 2,
-          name: 'Pix+Droit',
-        },
-      ],
-    });
-
-    const closeModalStub = sinon.stub();
-    this.set('closeModal', closeModalStub);
-    this.set('candidate', candidate);
-
-    // when
-    await render(hbs`
-      <CertificationCandidateDetailsModal
-        @closeModal={{this.closeModal}}
-        @candidate={{this.candidate}}
-      />
-    `);
-
-    // then
-    assert.contains('Détail du candidat');
-    assert.contains('Jean-Paul');
-    assert.contains('Candidat');
-    assert.contains('Eu');
-    assert.contains('76260');
-    assert.contains('76255');
-    assert.contains('Femme');
-    assert.contains('France');
-    assert.contains('jeanpauldeu@pix.fr');
-    assert.contains('suric@animal.fr');
-    assert.contains('12345');
-    assert.contains('25/12/2000');
-    assert.contains('10 %');
-    assert.contains('Pix+Edu, Pix+Droit');
-  });
-
-  module('when candidate has missing data', () => {
-    test('it displays a dash', async function(assert) {
+  module('when feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is enabled', function() {
+    test('it shows candidate details with complementary certification', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
       const candidate = store.createRecord('certification-candidate', {
-        firstName: undefined,
-        lastName: undefined,
-        birthCountry: undefined,
-        birthdate: undefined,
-        sex: undefined,
-        email: undefined,
-        resultRecipientEmail: undefined,
-        externalId: undefined,
-        extraTimePercentage: undefined,
-        complementaryCertifications: [],
+        firstName: 'Jean-Paul',
+        lastName: 'Candidat',
+        birthCity: 'Eu',
+        birthCountry: 'France',
+        email: 'jeanpauldeu@pix.fr',
+        resultRecipientEmail: 'suric@animal.fr',
+        externalId: '12345',
+        birthdate: '2000-12-25',
+        extraTimePercentage: 0.10,
+        birthInseeCode: 76255,
+        birthPostalCode: 76260,
+        sex: 'F',
+        complementaryCertifications: [
+          {
+            id: 1,
+            name: 'Pix+Edu',
+          },
+          {
+            id: 2,
+            name: 'Pix+Droit',
+          },
+        ],
       });
 
       const closeModalStub = sinon.stub();
       this.set('closeModal', closeModalStub);
       this.set('candidate', candidate);
+      this.set('displayComplementaryCertification', true);
 
       // when
       await render(hbs`
+      <CertificationCandidateDetailsModal
+        @closeModal={{this.closeModal}}
+        @candidate={{this.candidate}}
+        @displayComplementaryCertification={{this.displayComplementaryCertification}}
+      />
+    `);
+
+      // then
+      assert.contains('Détail du candidat');
+      assert.contains('Jean-Paul');
+      assert.contains('Candidat');
+      assert.contains('Eu');
+      assert.contains('76260');
+      assert.contains('76255');
+      assert.contains('Femme');
+      assert.contains('France');
+      assert.contains('jeanpauldeu@pix.fr');
+      assert.contains('suric@animal.fr');
+      assert.contains('12345');
+      assert.contains('25/12/2000');
+      assert.contains('10 %');
+      assert.contains('Pix+Edu, Pix+Droit');
+    });
+
+    module('when candidate has missing data', () => {
+      test('it displays a dash', async function(assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const candidate = store.createRecord('certification-candidate', {
+          firstName: undefined,
+          lastName: undefined,
+          birthCountry: undefined,
+          birthdate: undefined,
+          sex: undefined,
+          email: undefined,
+          resultRecipientEmail: undefined,
+          externalId: undefined,
+          extraTimePercentage: undefined,
+          complementaryCertifications: [],
+        });
+
+        const closeModalStub = sinon.stub();
+        this.set('closeModal', closeModalStub);
+        this.set('candidate', candidate);
+        this.set('displayComplementaryCertification', true);
+
+        // when
+        await render(hbs`
         <CertificationCandidateDetailsModal
           @closeModal={{this.closeModal}}
           @candidate={{this.candidate}}
+          @displayComplementaryCertification={{this.displayComplementaryCertification}}
         />
       `);
 
+        // then
+        assert.dom('[data-test-id="birth-postal-code-row"]').hasText('-');
+        assert.dom('[data-test-id="birth-insee-code-row"]').hasText('-');
+        assert.dom('[data-test-id="birth-city-row"]').hasText('-');
+        assert.dom('[data-test-id="result-recipient-email-row"]').hasText('-');
+        assert.dom('[data-test-id="email-row"]').hasText('-');
+        assert.dom('[data-test-id="external-id-row"]').hasText('-');
+        assert.dom('[data-test-id="extra-time-row"]').hasText('-');
+        assert.dom('[data-test-id="sex-label-row"]').hasText('-');
+        assert.dom('[data-test-id="birth-date-row"]').hasText('-');
+        assert.dom('[data-test-id="first-name-row"]').hasText('-');
+        assert.dom('[data-test-id="last-name-row"]').hasText('-');
+        assert.dom('[data-test-id="birth-country-row"]').hasText('-');
+        assert.dom('[data-test-id="complementary-certifications-row"]').hasText('-');
+      });
+    });
+  });
+
+  module('when feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is disabled', function() {
+    test('it shows candidate details without complementary certifications', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const candidate = store.createRecord('certification-candidate', {
+        firstName: 'Jean-Paul',
+        lastName: 'Candidat',
+        birthCity: 'Eu',
+        birthCountry: 'France',
+        email: 'jeanpauldeu@pix.fr',
+        resultRecipientEmail: 'suric@animal.fr',
+        externalId: '12345',
+        birthdate: '2000-12-25',
+        extraTimePercentage: 0.10,
+        birthInseeCode: 76255,
+        birthPostalCode: 76260,
+        sex: 'F',
+        complementaryCertifications: [
+          {
+            id: 1,
+            name: 'Pix+Edu',
+          },
+          {
+            id: 2,
+            name: 'Pix+Droit',
+          },
+        ],
+      });
+
+      const closeModalStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('candidate', candidate);
+      this.set('displayComplementaryCertification', false);
+
+      // when
+      await render(hbs`
+      <CertificationCandidateDetailsModal
+        @closeModal={{this.closeModal}}
+        @candidate={{this.candidate}}
+        @displayComplementaryCertification={{this.displayComplementaryCertification}}
+      />
+    `);
+
       // then
-      assert.dom('[data-test-id="birth-postal-code-row"]').hasText('-');
-      assert.dom('[data-test-id="birth-insee-code-row"]').hasText('-');
-      assert.dom('[data-test-id="birth-city-row"]').hasText('-');
-      assert.dom('[data-test-id="result-recipient-email-row"]').hasText('-');
-      assert.dom('[data-test-id="email-row"]').hasText('-');
-      assert.dom('[data-test-id="external-id-row"]').hasText('-');
-      assert.dom('[data-test-id="extra-time-row"]').hasText('-');
-      assert.dom('[data-test-id="sex-label-row"]').hasText('-');
-      assert.dom('[data-test-id="birth-date-row"]').hasText('-');
-      assert.dom('[data-test-id="first-name-row"]').hasText('-');
-      assert.dom('[data-test-id="last-name-row"]').hasText('-');
-      assert.dom('[data-test-id="birth-country-row"]').hasText('-');
-      assert.dom('[data-test-id="complementary-certifications-row"]').hasText('-');
+      assert.contains('Détail du candidat');
+      assert.contains('Jean-Paul');
+      assert.contains('Candidat');
+      assert.contains('Eu');
+      assert.contains('76260');
+      assert.contains('76255');
+      assert.contains('Femme');
+      assert.contains('France');
+      assert.contains('jeanpauldeu@pix.fr');
+      assert.contains('suric@animal.fr');
+      assert.contains('12345');
+      assert.contains('25/12/2000');
+      assert.contains('10 %');
+      assert.notContains('Pix+Edu, Pix+Droit');
     });
   });
 

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -30,64 +30,100 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  test('it displays candidates information', async function(assert) {
-    // given
-    const candidate = _buildCertificationCandidate({
-      birthdate: new Date('2019-04-28'),
-    });
+  module('when feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is enabled', ()=> {
+    test('it displays candidate information', async function(assert) {
+      // given
+      this.set('displayComplementaryCertification', true);
+      const candidate = _buildCertificationCandidate({
+        birthdate: new Date('2019-04-28'),
+      });
 
-    const certificationCandidate = store.createRecord('certification-candidate', candidate);
+      const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
-    const certificationCandidates = [certificationCandidate];
+      const certificationCandidates = [certificationCandidate];
 
-    this.set('certificationCandidates', certificationCandidates);
+      this.set('certificationCandidates', certificationCandidates);
 
-    // when
-    await render(hbs`
+      // when
+      await render(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
+          @displayComplementaryCertification={{displayComplementaryCertification}}
           >
         </EnrolledCandidates>
       `);
 
-    // then
-    assert.dom(`[data-test-id=${EXTERNAL_ID_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.externalId);
-    assert.dom(`[data-test-id=${BIRTHDATE_COLUMN_SELECTOR}${candidate.id}]`).hasText('28/04/2019');
-    assert.dom(`[data-test-id=${LAST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.lastName);
-    assert.dom(`[data-test-id=${FIRST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.firstName);
-    assert.dom(`[data-test-id=${RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.resultRecipientEmail);
-    assert.dom(`[data-test-id=${EXTRA_TIME_SELECTOR}${candidate.id}]`).hasText('3000 %');
-    assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).hasText('Pix+Edu, Pix+Droit');
-    assert.dom(`[data-test-id=${BIRTH_CITY_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
-    assert.dom(`[data-test-id=${BIRTH_PROVINCE_CODE_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
-    assert.dom(`[data-test-id=${BIRTH_COUNTRY_SELECTOR}${candidate.id}]`).doesNotExist();
-    assert.dom(`[data-test-id=${EMAIL_SELECTOR}${candidate.id}]`).doesNotExist();
+      // then
+      assert.dom(`[data-test-id=${EXTERNAL_ID_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.externalId);
+      assert.dom(`[data-test-id=${BIRTHDATE_COLUMN_SELECTOR}${candidate.id}]`).hasText('28/04/2019');
+      assert.dom(`[data-test-id=${LAST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.lastName);
+      assert.dom(`[data-test-id=${FIRST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.firstName);
+      assert.dom(`[data-test-id=${RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.resultRecipientEmail);
+      assert.dom(`[data-test-id=${EXTRA_TIME_SELECTOR}${candidate.id}]`).hasText('3000 %');
+      assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).hasText('Pix+Edu, Pix+Droit');
+      assert.dom(`[data-test-id=${BIRTH_CITY_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(`[data-test-id=${BIRTH_PROVINCE_CODE_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(`[data-test-id=${BIRTH_COUNTRY_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(`[data-test-id=${EMAIL_SELECTOR}${candidate.id}]`).doesNotExist();
+    });
+    test('it displays a dash where there is no certification', async function(assert) {
+      // given
+      this.set('displayComplementaryCertification', true);
+      const candidate = _buildCertificationCandidate({
+        complementaryCertifications: null,
+      });
+
+      const certificationCandidate = store.createRecord('certification-candidate', candidate);
+
+      const certificationCandidates = [certificationCandidate];
+
+      this.set('certificationCandidates', certificationCandidates);
+
+      // when
+      await render(hbs`
+        <EnrolledCandidates
+          @sessionId="1"
+          @certificationCandidates={{certificationCandidates}}
+          @displayComplementaryCertification={{displayComplementaryCertification}}
+          >
+        </EnrolledCandidates>
+      `);
+
+      // then
+      assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).hasText('-');
+    });
   });
 
-  test('it displays a dash where there is no certification', async function(assert) {
-    // given
-    const candidate = _buildCertificationCandidate({
-      complementaryCertifications: null,
-    });
+  module('when feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is disabled', ()=> {
+    test('it display candidate information without complementary certification', async function(assert) {
+      // given
+      this.set('displayComplementaryCertification', false);
 
-    const certificationCandidate = store.createRecord('certification-candidate', candidate);
+      const candidate = _buildCertificationCandidate({
+        birthdate: new Date('2019-04-28'),
+      });
 
-    const certificationCandidates = [certificationCandidate];
+      const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
-    this.set('certificationCandidates', certificationCandidates);
+      const certificationCandidates = [certificationCandidate];
 
-    // when
-    await render(hbs`
+      this.set('certificationCandidates', certificationCandidates);
+
+      // when
+      await render(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
+          @displayComplementaryCertification={{displayComplementaryCertification}}
           >
         </EnrolledCandidates>
       `);
 
-    // then
-    assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).hasText('-');
+      // then
+      assert.notContains('Certifications complémentaires');
+      assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).doesNotExist();
+    });
   });
 
   test('it should display details button', async function(assert) {


### PR DESCRIPTION
## :christmas_tree: Problème
Les certifications complémentaires apparaissent même si le feature toggle `FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED` est désactivé :

- dans la liste des candidats
- dans la détails de modale

## :gift: Solution
Ne pas afficher les certifications complémentaires lorsque le feature toggle `FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED` est désactivé.

## :star2: Remarques
On a rajouté des tests qui manquaient :notes: 

## :santa: Pour tester
Se connecter en SUP ou PRO voir que la colonne ne s'affiche pas avec le FT desactivé