### PR TITLE
[BUGFIX] Supprimer les souscriptions aux certifications complémentaires (PIX-3856).

### DIFF
--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -63,10 +63,10 @@ module.exports = {
   },
 
   async delete(certificationCandidateId) {
-    const nbRowsAffected = await knex('certification-candidates').where({ id: certificationCandidateId }).del();
-    if (nbRowsAffected === 0) {
-      throw new CertificationCandidateDeletionError('An error occurred while deleting the certification candidate');
-    }
+    await knex.transaction(async (trx) => {
+      await trx('complementary-certification-subscriptions').where({ certificationCandidateId }).del();
+      return trx('certification-candidates').where({ id: certificationCandidateId }).del();
+    });
 
     return true;
   },

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -63,12 +63,12 @@ module.exports = {
   },
 
   async delete(certificationCandidateId) {
-    try {
-      await CertificationCandidateBookshelf.where({ id: certificationCandidateId }).destroy({ require: true });
-      return true;
-    } catch (err) {
+    const nbRowsAffected = await knex('certification-candidates').where({ id: certificationCandidateId }).del();
+    if (nbRowsAffected === 0) {
       throw new CertificationCandidateDeletionError('An error occurred while deleting the certification candidate');
     }
+
+    return true;
   },
 
   async isNotLinked(certificationCandidateId) {


### PR DESCRIPTION
## :christmas_tree: Problème
Sur une session de certification, lorsque l'on tente de supprime un candidat avec une souscription à une certification complémentaire, on obtient un message d'erreur.

## :gift: Solution
Supprimer la certification complémentaire du candidat dans la table `complementary-certification-subscriptions`. 
Faire les 2 suppressions dans une transaction

## :star2: Remarques
Il aurait été possible d'implémenter la solution avec une clause `CASCADE`.
Nous n'avons pas retenu cette solution pour rester expliité.

## :santa: Pour tester
Se connecter en tant que `certifpro@example.net`
Créer une session
Ajouter un candidat avec une souscriptions à a lcertif complementaire `Clea`
Supprimer le candidat
S'assurer que celui-ci n'apparait plus sur la session
