### PR TITLE
[FEATURE] Ne pas poser des épreuves déjà passées dans l'algo Flash (PIX-3784).

### DIFF
--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -6,7 +6,7 @@ const STEP_OF_SAMPLES = 18 / 80;
 const END_OF_SAMPLES = 9 + STEP_OF_SAMPLES;
 const samples = _.range(START_OF_SAMPLES, END_OF_SAMPLES, STEP_OF_SAMPLES);
 
-module.exports = { getPossibleNextChallenges, getEstimatedLevel, getFilteredChallenges };
+module.exports = { getPossibleNextChallenges, getEstimatedLevel, getNonAnsweredChallenges };
 
 function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
 
@@ -85,11 +85,13 @@ function getEstimatedLevel({ allAnswers, challenges }) {
   return latestEstimatedLevel;
 }
 
-function getFilteredChallenges({ allAnswers, challenges }){
+function getNonAnsweredChallenges({ allAnswers, challenges }){
   const getAnswerSkills = (answer) => challenges.find(challenge => challenge.id === answer.challengeId).skills;
   const alreadyAnsweredSkillsIds = allAnswers.map(getAnswerSkills).flat().map(skill => skill.id);
-  const filteredChallenges = _.filter(challenges, (challenge) => !challenge.skills.some((skill) => alreadyAnsweredSkillsIds.includes(skill.id)));
-  return filteredChallenges;
+  const isSkillAlreadyAnswered = (skill) => alreadyAnsweredSkillsIds.includes(skill.id);
+  const filterNonAnsweredChallenges = (challenge) => !challenge.skills.some(isSkillAlreadyAnswered);
+  const nonAnsweredChallenges = _.filter(challenges, filterNonAnsweredChallenges);
+  return nonAnsweredChallenges;
 }
 
 function _getReward({ estimatedLevel, discriminant, difficulty }) {

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -9,8 +9,9 @@ const samples = _.range(START_OF_SAMPLES, END_OF_SAMPLES, STEP_OF_SAMPLES);
 module.exports = { getPossibleNextChallenges, getEstimatedLevel, getNonAnsweredChallenges };
 
 function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
+  const nonAnsweredChallenges = getNonAnsweredChallenges({ allAnswers, challenges });
 
-  if (challenges?.length === 0) {
+  if (nonAnsweredChallenges?.length === 0) {
     return {
       hasAssessmentEnded: true,
       possibleChallenges: [],
@@ -19,7 +20,7 @@ function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
 
   const estimatedLevel = getEstimatedLevel({ allAnswers, challenges });
 
-  const challengesWithReward = challenges.map((challenge) => {
+  const challengesWithReward = nonAnsweredChallenges.map((challenge) => {
     return {
       challenge,
       reward: _getReward({ estimatedLevel, discriminant: challenge.discriminant, difficulty: challenge.difficulty }),
@@ -85,12 +86,17 @@ function getEstimatedLevel({ allAnswers, challenges }) {
   return latestEstimatedLevel;
 }
 
-function getNonAnsweredChallenges({ allAnswers, challenges }){
-  const getAnswerSkills = (answer) => challenges.find(challenge => challenge.id === answer.challengeId).skills;
-  const alreadyAnsweredSkillsIds = allAnswers.map(getAnswerSkills).flat().map(skill => skill.id);
+function getNonAnsweredChallenges({ allAnswers, challenges }) {
+  const getAnswerSkills = (answer) => challenges.find((challenge) => challenge.id === answer.challengeId).skills;
+  const alreadyAnsweredSkillsIds = allAnswers
+    .map(getAnswerSkills)
+    .flat()
+    .map((skill) => skill.id);
+
   const isSkillAlreadyAnswered = (skill) => alreadyAnsweredSkillsIds.includes(skill.id);
   const filterNonAnsweredChallenges = (challenge) => !challenge.skills.some(isSkillAlreadyAnswered);
   const nonAnsweredChallenges = _.filter(challenges, filterNonAnsweredChallenges);
+
   return nonAnsweredChallenges;
 }
 

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -6,9 +6,10 @@ const STEP_OF_SAMPLES = 18 / 80;
 const END_OF_SAMPLES = 9 + STEP_OF_SAMPLES;
 const samples = _.range(START_OF_SAMPLES, END_OF_SAMPLES, STEP_OF_SAMPLES);
 
-module.exports = { getPossibleNextChallenges, getEstimatedLevel };
+module.exports = { getPossibleNextChallenges, getEstimatedLevel, getFilteredChallenges };
 
 function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
+
   if (challenges?.length === 0) {
     return {
       hasAssessmentEnded: true,
@@ -82,6 +83,13 @@ function getEstimatedLevel({ allAnswers, challenges }) {
   }
 
   return latestEstimatedLevel;
+}
+
+function getFilteredChallenges({ allAnswers, challenges }){
+  const getAnswerSkills = (answer) => challenges.find(challenge => challenge.id === answer.challengeId).skills;
+  const alreadyAnsweredSkillsIds = allAnswers.map(getAnswerSkills).flat().map(skill => skill.id);
+  const filteredChallenges = _.filter(challenges, (challenge) => !challenge.skills.some((skill) => alreadyAnsweredSkillsIds.includes(skill.id)));
+  return filteredChallenges;
 }
 
 function _getReward({ estimatedLevel, discriminant, difficulty }) {

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -177,4 +177,145 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       expect(result).to.be.closeTo(correctEstimatedLevel, 0.00000000001);
     });
   });
+
+  describe('#getFilteredChallenges', function() {
+    it('should return the same list of challenges if there is no answers', function () {
+      // given
+      const challenges = [
+        domainBuilder.buildChallenge({
+          id: 'ChallengeFirstAnswers',
+          discriminant: 1.86350005965093,
+          difficulty: 0.194712138508747,
+        }),
+        domainBuilder.buildChallenge({
+          id: 'ChallengeSecondAnswers',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+        }),
+      ];
+
+      const allAnswers = [];
+
+      // when
+      const result = flash.getFilteredChallenges({ allAnswers, challenges });
+
+      // then
+      expect(result).to.be.deep.equal(challenges);
+    });
+
+    it('should return the list of challenges without already answered skills', function () {
+      // given
+      const skills = [domainBuilder.buildSkill({ id: 'FirstSkill'}), domainBuilder.buildSkill({ id: 'SecondSkill'})];
+
+      const challenges = [
+        domainBuilder.buildChallenge({
+          id: 'First',
+          discriminant: 1.86350005965093,
+          difficulty: 0.194712138508747,
+          skills: [skills[0]],
+        }),
+        domainBuilder.buildChallenge({
+          id: 'Second',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+          skills: [skills[0]],
+        }),
+        domainBuilder.buildChallenge({
+          id: 'Third',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+          skills: [skills[1]],
+        }),
+      ];
+
+      const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+
+      // when
+      const result = flash.getFilteredChallenges({ allAnswers, challenges });
+
+      // then
+      expect(result).to.be.deep.equal([challenges[2]]);
+    });
+
+    it('should return the list of challenges without already answered skills with challenge containing two skills', function () {
+      // given
+      const skills = [domainBuilder.buildSkill({ id: 'FirstSkill'}), domainBuilder.buildSkill({ id: 'SecondSkill'}), domainBuilder.buildSkill({ id: 'ThirdSkill'})];
+
+      const challenges = [
+        domainBuilder.buildChallenge({
+          id: 'First',
+          discriminant: 1.86350005965093,
+          difficulty: 0.194712138508747,
+          skills: [skills[0], skills[1]],
+        }),
+        domainBuilder.buildChallenge({
+          id: 'Second',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+          skills: [skills[0]],
+        }),
+        domainBuilder.buildChallenge({
+          id: 'Third',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+          skills: [skills[1]],
+        }),
+        domainBuilder.buildChallenge({
+          id: 'Fourth',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+          skills: [skills[2]],
+        }),
+      ];
+
+      const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+
+      // when
+      const result = flash.getFilteredChallenges({ allAnswers, challenges });
+
+      // then
+      expect(result).to.be.deep.equal([challenges[3]]);
+    });
+
+    it('should return the list of challenges without already answered skills with another challenge containing two skills', function () {
+      // given
+      const skills = [domainBuilder.buildSkill({ id: 'FirstSkill'}), domainBuilder.buildSkill({ id: 'SecondSkill'}), domainBuilder.buildSkill({ id: 'ThirdSkill'})];
+
+      const challenges = [
+        domainBuilder.buildChallenge({
+          id: 'First',
+          discriminant: 1.86350005965093,
+          difficulty: 0.194712138508747,
+          skills: [skills[0]],
+        }),
+        domainBuilder.buildChallenge({
+          id: 'Second',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+          skills: [skills[1], skills[0]],
+        }),
+        domainBuilder.buildChallenge({
+          id: 'Third',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+          skills: [skills[1]],
+        }),
+        domainBuilder.buildChallenge({
+          id: 'Fourth',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+          skills: [skills[2]],
+        }),
+      ];
+
+      const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+
+      // when
+      const result = flash.getFilteredChallenges({ allAnswers, challenges });
+
+      // then
+      expect(result).to.be.deep.equal([challenges[2], challenges[3]]);
+    });
+
+  });
 });

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -178,7 +178,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
   });
 
-  describe('#getFilteredChallenges', function() {
+  describe('#getNonAnsweredChallenges', function() {
     it('should return the same list of challenges if there is no answers', function () {
       // given
       const challenges = [
@@ -197,7 +197,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       const allAnswers = [];
 
       // when
-      const result = flash.getFilteredChallenges({ allAnswers, challenges });
+      const result = flash.getNonAnsweredChallenges({ allAnswers, challenges });
 
       // then
       expect(result).to.be.deep.equal(challenges);
@@ -231,7 +231,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
       // when
-      const result = flash.getFilteredChallenges({ allAnswers, challenges });
+      const result = flash.getNonAnsweredChallenges({ allAnswers, challenges });
 
       // then
       expect(result).to.be.deep.equal([challenges[2]]);
@@ -271,7 +271,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
       // when
-      const result = flash.getFilteredChallenges({ allAnswers, challenges });
+      const result = flash.getNonAnsweredChallenges({ allAnswers, challenges });
 
       // then
       expect(result).to.be.deep.equal([challenges[3]]);
@@ -311,7 +311,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
       // when
-      const result = flash.getFilteredChallenges({ allAnswers, challenges });
+      const result = flash.getNonAnsweredChallenges({ allAnswers, challenges });
 
       // then
       expect(result).to.be.deep.equal([challenges[2], challenges[3]]);

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -57,17 +57,22 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
         it('should return every best next challenge', function () {
           // given
+          const FirstSkill = domainBuilder.buildSkill({ id: 'First' });
+          const SecondSkill = domainBuilder.buildSkill({ id: 'Second' });
           const worstNextChallenge = domainBuilder.buildChallenge({
             difficulty: -5,
             discriminant: -5,
+            skills: [FirstSkill],
           });
           const bestNextChallenge = domainBuilder.buildChallenge({
             difficulty: 1,
             discriminant: 5,
+            skills: [SecondSkill],
           });
           const anotherBestNextChallenge = domainBuilder.buildChallenge({
             difficulty: 1,
             discriminant: 5,
+            skills: [FirstSkill],
           });
           const challenges = [worstNextChallenge, bestNextChallenge, anotherBestNextChallenge];
           const allAnswers = [];
@@ -79,6 +84,45 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           expect(result).to.deep.equal({
             hasAssessmentEnded: false,
             possibleChallenges: [bestNextChallenge, anotherBestNextChallenge],
+          });
+        });
+      });
+
+      context('when there is a previous answer', function () {
+        it('should only return the best next challenge that has no previous answer', function () {
+          // given
+          const FirstSkill = domainBuilder.buildSkill({ id: 'First' });
+          const SecondSkill = domainBuilder.buildSkill({ id: 'Second' });
+          const worstNextChallenge = domainBuilder.buildChallenge({
+            id: 'recCHAL1',
+            difficulty: -5,
+            discriminant: -5,
+            skills: [FirstSkill],
+          });
+          const answeredBestNextChallenge = domainBuilder.buildChallenge({
+            id: 'recCHAL2',
+            difficulty: 1,
+            discriminant: 5,
+            skills: [SecondSkill],
+          });
+          const nonAnsweredBestNextChallenge = domainBuilder.buildChallenge({
+            id: 'recCHAL3',
+            difficulty: 1,
+            discriminant: 5,
+            skills: [FirstSkill],
+          });
+          const challenges = [worstNextChallenge, answeredBestNextChallenge, nonAnsweredBestNextChallenge];
+          const allAnswers = [
+            domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: answeredBestNextChallenge.id }),
+          ];
+
+          // when
+          const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
+
+          // then
+          expect(result).to.deep.equal({
+            hasAssessmentEnded: false,
+            possibleChallenges: [nonAnsweredBestNextChallenge],
           });
         });
       });
@@ -178,7 +222,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
   });
 
-  describe('#getNonAnsweredChallenges', function() {
+  describe('#getNonAnsweredChallenges', function () {
     it('should return the same list of challenges if there is no answers', function () {
       // given
       const challenges = [
@@ -205,7 +249,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
     it('should return the list of challenges without already answered skills', function () {
       // given
-      const skills = [domainBuilder.buildSkill({ id: 'FirstSkill'}), domainBuilder.buildSkill({ id: 'SecondSkill'})];
+      const skills = [domainBuilder.buildSkill({ id: 'FirstSkill' }), domainBuilder.buildSkill({ id: 'SecondSkill' })];
 
       const challenges = [
         domainBuilder.buildChallenge({
@@ -239,7 +283,11 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
     it('should return the list of challenges without already answered skills with challenge containing two skills', function () {
       // given
-      const skills = [domainBuilder.buildSkill({ id: 'FirstSkill'}), domainBuilder.buildSkill({ id: 'SecondSkill'}), domainBuilder.buildSkill({ id: 'ThirdSkill'})];
+      const skills = [
+        domainBuilder.buildSkill({ id: 'FirstSkill' }),
+        domainBuilder.buildSkill({ id: 'SecondSkill' }),
+        domainBuilder.buildSkill({ id: 'ThirdSkill' }),
+      ];
 
       const challenges = [
         domainBuilder.buildChallenge({
@@ -279,7 +327,11 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
     it('should return the list of challenges without already answered skills with another challenge containing two skills', function () {
       // given
-      const skills = [domainBuilder.buildSkill({ id: 'FirstSkill'}), domainBuilder.buildSkill({ id: 'SecondSkill'}), domainBuilder.buildSkill({ id: 'ThirdSkill'})];
+      const skills = [
+        domainBuilder.buildSkill({ id: 'FirstSkill' }),
+        domainBuilder.buildSkill({ id: 'SecondSkill' }),
+        domainBuilder.buildSkill({ id: 'ThirdSkill' }),
+      ];
 
       const challenges = [
         domainBuilder.buildChallenge({
@@ -316,6 +368,5 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       // then
       expect(result).to.be.deep.equal([challenges[2], challenges[3]]);
     });
-
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le choix des épreuves, dans le nouvel algo Flash, nous ne voulons pas proposer des acquis déjà passés.

## :gift: Solution
- Ajout d'une nouvelle méthode `getNonAnsweredChallenges`
- Utiliser cette méthode

## :star2: Remarques

## :santa: Pour tester
Passer la campagne et vérifier qu'on ait pas deux fois le même type d'épreuves.