### PR TITLE
[FEAT] Limiter le nombre de questions dans un assessment flash (PIX-3785).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -152,6 +152,7 @@ module.exports = (function () {
       garAccessV2: isFeatureEnabled(process.env.GAR_ACCESS_V2),
       maxReachableLevel: _getNumber(process.env.MAX_REACHABLE_LEVEL, 5),
       newYearSchoolingRegistrationsImportDate: _getDate(process.env.NEW_YEAR_SCHOOLING_REGISTRATIONS_IMPORT_DATE),
+      numberOfChallengesForFlashMethod: _getNumber(process.env.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD),
       pixCertifScoBlockedAccessWhitelist: _getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
@@ -250,6 +251,7 @@ module.exports = (function () {
     config.features.dayBeforeImproving = 4;
     config.features.dayBeforeCompetenceResetV2 = 7;
     config.features.garAccessV2 = false;
+    config.features.numberOfChallengesForFlashMethod = 10;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 
+const config = require('../../../config');
+
 const DEFAULT_ESTIMATED_LEVEL = 0;
 const START_OF_SAMPLES = -9;
 const STEP_OF_SAMPLES = 18 / 80;
@@ -11,7 +13,7 @@ module.exports = { getPossibleNextChallenges, getEstimatedLevel, getNonAnsweredC
 function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
   const nonAnsweredChallenges = getNonAnsweredChallenges({ allAnswers, challenges });
 
-  if (nonAnsweredChallenges?.length === 0) {
+  if (nonAnsweredChallenges?.length === 0 || allAnswers.length >= config.features.numberOfChallengesForFlashMethod) {
     return {
       hasAssessmentEnded: true,
       possibleChallenges: [],

--- a/api/sample.env
+++ b/api/sample.env
@@ -518,3 +518,10 @@ ENABLE_REQUEST_MONITORING=true
 # default: false
 # note: Enabled in demand in production
 LOG_KNEX_QUERIES=true
+
+# ========
+# FLASH METHOD CHALLENGES
+# ========
+
+# Number of challenges given to the user during a flash test.
+NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD=48


### PR DESCRIPTION
## :christmas_tree: Problème

On veut limiter le nombre de questions posées aux utilisateurs.

## :gift: Solution

Ajout d'une variable d'environnement.

## :star2: Remarques
N/A

## :santa: Pour tester

Passer un test de campagne et voir qu'on ne répond qu'à 48 questions. (FLASH123)