### PR TITLE
[BUGFIX] Ne PAS afficher le champ "Certifications complémentaires" pour un centre non habilité (PIX-3855)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -43,7 +43,7 @@ export default class CertificationCandidatesController extends Controller {
     await this.reloadCertificationCandidate();
   }
 
-  get displayComplementaryCertification() {
+  get shouldDisplayComplementaryCertifications() {
     return this.featureToggles.featureToggles.isComplementaryCertificationSubscriptionEnabled;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -44,6 +44,6 @@ export default class CertificationCandidatesController extends Controller {
   }
 
   get shouldDisplayComplementaryCertifications() {
-    return this.featureToggles.featureToggles.isComplementaryCertificationSubscriptionEnabled;
+    return this.featureToggles.featureToggles.isComplementaryCertificationSubscriptionEnabled && this.currentUser.currentAllowedCertificationCenterAccess.hasHabilitations;
   }
 }

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -23,4 +23,8 @@ export default class AllowedCertificationCenterAccess extends Model {
   get isAccessRestricted() {
     return this.isAccessBlockedCollege || this.isAccessBlockedLycee || this.isAccessBlockedAEFE || this.isAccessBlockedAgri;
   }
+
+  get hasHabilitations() {
+    return this.habilitations.length > 0;
+  }
 }

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -25,6 +25,6 @@
           @certificationCandidates={{this.certificationCandidates}}
           @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
           @countries={{this.countries}}
-          @displayComplementaryCertification={{this.displayComplementaryCertification}}
+          @displayComplementaryCertification={{this.shouldDisplayComplementaryCertifications}}
   />
 {{/if}}

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
 
 module('Unit | Controller | authenticated/sessions/details/certification-candidates', function(hooks) {
   setupTest(hooks);
@@ -31,4 +32,39 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
       assert.false(shouldDisplayStudentList);
     });
   });
+
+  module('#get displayComplementaryCertification', function() {
+    test('should return false if feature toggle is false', function(assert) {
+      // given
+      _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', false);
+      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
+
+      // when
+      const displayComplementaryCertification = controller.displayComplementaryCertification;
+
+      // then
+      assert.false(displayComplementaryCertification);
+    });
+
+    test('should return true if feature toggle is true', function(assert) {
+      // given
+      _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', true);
+      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
+
+      // when
+      const displayComplementaryCertification = controller.displayComplementaryCertification;
+
+      // then
+      assert.true(displayComplementaryCertification);
+    });
+  });
 });
+
+function _stubFeatureToggle(controller, featureToggleName, featureToggleValue) {
+  const featureToggles = {};
+  featureToggles[featureToggleName] = featureToggleValue;
+  class FeatureTogglesStub extends Service {
+    featureToggles = featureToggles;
+  }
+  controller.owner.register('service:feature-toggles', FeatureTogglesStub);
+}

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
@@ -33,17 +33,17 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
     });
   });
 
-  module('#get displayComplementaryCertification', function() {
+  module('#get shouldDisplayComplementaryCertifications', function() {
     test('should return false if feature toggle is false', function(assert) {
       // given
       _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', false);
       const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
 
       // when
-      const displayComplementaryCertification = controller.displayComplementaryCertification;
+      const shouldDisplayComplementaryCertifications = controller.shouldDisplayComplementaryCertifications;
 
       // then
-      assert.false(displayComplementaryCertification);
+      assert.false(shouldDisplayComplementaryCertifications);
     });
 
     test('should return true if feature toggle is true', function(assert) {
@@ -52,10 +52,10 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
       const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
 
       // when
-      const displayComplementaryCertification = controller.displayComplementaryCertification;
+      const shouldDisplayComplementaryCertifications = controller.shouldDisplayComplementaryCertifications;
 
       // then
-      assert.true(displayComplementaryCertification);
+      assert.true(shouldDisplayComplementaryCertifications);
     });
   });
 });

--- a/certif/tests/unit/models/allowed-certification-center-access_test.js
+++ b/certif/tests/unit/models/allowed-certification-center-access_test.js
@@ -148,4 +148,26 @@ module('Unit | Model | allowed-certification-center-access', function(hooks) {
       assert.true(model.isAccessRestricted);
     });
   });
+
+  module('#get hasHabilitations', function() {
+    test('should return true when the certification center has habilitations', function(assert) {
+      // given
+      const model = store.createRecord('allowed-certification-center-access', {
+        habilitations: ['Pix+Droit'],
+      });
+
+      // then
+      assert.true(model.hasHabilitations);
+    });
+
+    test('should return false when the certification center has no habilitations', function(assert) {
+      // given
+      const model = store.createRecord('allowed-certification-center-access', {
+        habilitations: [],
+      });
+
+      // then
+      assert.false(model.hasHabilitations);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Aujourd’hui : lorsque le toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED est activé, le champ “Certifications complémentaires” est visible sur la liste des candidats ET sur la modale de détails des candidats

Attendu : ce champ ne devrait être visible QUE pour les centres avec au moins une certification complémentaire, sinon il ne doivent pas être visibles.

## :gift: Solution
Ajouter une condition à l'affichage de ces éléments afin de ne pas les afficher quand la liste des habilitations du centre est vide.

## :santa: Pour tester
Avec le toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED activé
Se connecter à Pix Certif à un centre qui a des certifs complémentaires

1 - Se rendre dans une session avec des candidats
2 - Se rendre sur la liste des candidats et constater que la colonne Certifications complémentaires apparaît
3 - Ouvrir la modale de détails et constater que la ligne Certifications complémentaires apparaît
4 - Se connecter à Pix Certif à un centre qui n'a pas des certifs complémentaires
5 - Se rendre dans une session avec des candidats
6 - Se rendre sur la liste des candidats et constater que la colonne Certifications complémentaires n’apparaît pas
7 - Ouvrir la modale de détails et constater que la ligne Certifications complémentaires n'apparaît pas

Avec le toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED désactivé
Se connecter à Pix Certif à un centre qui a des certifs complémentaires

1 - Se rendre dans une session avec des candidats
2 - Se rendre sur la liste des candidats et constater que la colonne Certifications complémentaires n’apparaît pas
3 - Ouvrir la modale de détails et constater que la ligne Certifications complémentaires n’apparaît pas
4 - Se connecter à Pix Certif à un centre qui n'a pas des certifs complémentaires
5 - Se rendre dans une session avec des candidats
6 - Se rendre sur la liste des candidats et constater que la colonne Certifications complémentaires n’apparaît pas
7 - Ouvrir la modale de détails et constater que la ligne Certifications complémentaires n'apparaît pas
