### PR TITLE
[TECH] Retourner une erreur du domaine quand une participation à la campagne existe déjà.

### DIFF
--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -137,6 +137,21 @@ describe('Acceptance | API | Campaign Participations', function () {
       expect(response.result.data.id).to.exist;
     });
 
+    it('should return a 412 if the user already participated to the campaign', async function () {
+      // given
+      options.payload.data.relationships.campaign.data.id = campaignId;
+
+      // when
+      await server.inject(options);
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(412);
+      expect(response.result.errors[0].detail).to.equal(
+        `User ${user.id} has already a campaign participation with campaign ${campaignId}`
+      );
+    });
+
     it('should return 404 error if the campaign related to the participation does not exist', async function () {
       // given
       options.payload.data.relationships.campaign.data.id = null;


### PR DESCRIPTION
## :christmas_tree: Problème
Une erreur 500 arrivent très régulièrement en production à la création de participation à une campagne lorsque l'utilisateur a déjà une participation pour celle-ci.

## :gift: Solution
En cas d'erreur de conflits en base de données on retourne une erreur du domain qui informe que l'entité existe déjà.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
