### PR TITLE
[TECH] Empêcher la double participation quand la campagne n'est pas multiple (PIX-3883).

### DIFF
--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -1,7 +1,7 @@
 const Assessment = require('../models/Assessment');
 const CampaignParticipationStarted = require('../events/CampaignParticipationStarted');
 const CampaignParticipation = require('../models/CampaignParticipation');
-const { EntityValidationError } = require('../../domain/errors');
+const { EntityValidationError, AlreadyExistingCampaignParticipationError } = require('../../domain/errors');
 
 module.exports = async function startCampaignParticipation({
   campaignParticipation,
@@ -37,6 +37,12 @@ module.exports = async function startCampaignParticipation({
         ],
       });
     }
+  }
+
+  if (hasAlreadyParticipated && !campaignToJoin.multipleSendings) {
+    throw new AlreadyExistingCampaignParticipationError(
+      `User ${userId} has already a campaign participation with campaign ${campaignToJoin.id}`
+    );
   }
 
   let createdCampaignParticipation;


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'il y a deux requêtes concurrentes de création de participation à une campagne pour un même utilisateur, il est possible de passer le check qui vérifie la possibilité participer et d'avoir le flag hasAlreadyParticipated. Dans ce cas le usecase essaye de créer une participation isImproving malgré tout.

## :gift: Solution
On s'assure avant la sauvegarde qu'on est pas dans le cas où on a déjà participé et que la campagne n'est pas à envoi multiple. Si c'est le cas on retourne une erreur pour indiquer que la participation à cette campagne existe déjà.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
On essaye de reproduire cette erreur depuis plusieurs jours/années 🤷 
