### PR TITLE
[FEATURE] Embed + focus = :heavy_check_mark:  (PIX-3041)

### DIFF
--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -4,7 +4,7 @@
   data-challenge-id="{{@challenge.id}}"
   {{on "mouseenter" this.hideOutOfFocusBorder}}
   {{on "mouseleave" this.showOutOfFocusBorder}}
-  {{will-destroy this.clearOnBlurMethod}}
+  {{will-destroy this.clearFocusOutEventListener}}
 >
   <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -3,6 +3,8 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'mon-pix/config/environment';
 
+const FOCUSEDOUT_EVENT_NAME = 'focusedout';
+
 export default class Item extends Component {
   @service currentUser;
 
@@ -38,7 +40,7 @@ export default class Item extends Component {
   }
 
   _setFocusOutEventListener() {
-    document.addEventListener('hasFocusOut', this._hasFocusOutListener);
+    document.addEventListener(FOCUSEDOUT_EVENT_NAME, this._focusedoutListener);
 
     this._previousFocus = document.hasFocus();
     this._pollHasFocusInterval = setInterval(this._pollHasFocus, 1000);
@@ -47,20 +49,20 @@ export default class Item extends Component {
   _pollHasFocus = () => {
     const hasFocus = document.hasFocus();
     if (!hasFocus && this._previousFocus) {
-      const hasFocusOutEvent = new CustomEvent('hasFocusOut');
+      const hasFocusOutEvent = new CustomEvent(FOCUSEDOUT_EVENT_NAME);
       document.dispatchEvent(hasFocusOutEvent);
     }
     this._previousFocus = hasFocus;
   };
 
-  _hasFocusOutListener = () => {
+  _focusedoutListener = () => {
     this.args.onFocusOutOfWindow();
     this.clearFocusOutEventListener();
   };
 
   clearFocusOutEventListener = () => {
     clearInterval(this._pollHasFocusInterval);
-    document.removeEventListener('hasFocusOut', this._hasFocusOutListener);
+    document.removeEventListener(FOCUSEDOUT_EVENT_NAME, this._focusedoutListener);
   };
 
   get isFocusedChallenge() {

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -42,17 +42,17 @@ export default class Item extends Component {
   _setFocusOutEventListener() {
     document.addEventListener(FOCUSEDOUT_EVENT_NAME, this._focusedoutListener);
 
-    this._previousFocus = document.hasFocus();
+    this._hadFocus = document.hasFocus();
     this._pollHasFocusInterval = setInterval(this._pollHasFocus, 1000);
   }
 
   _pollHasFocus = () => {
     const hasFocus = document.hasFocus();
-    if (!hasFocus && this._previousFocus) {
+    if (!hasFocus && this._hadFocus) {
       const hasFocusOutEvent = new CustomEvent(FOCUSEDOUT_EVENT_NAME);
       document.dispatchEvent(hasFocusOutEvent);
     }
-    this._previousFocus = hasFocus;
+    this._hadFocus = hasFocus;
   };
 
   _focusedoutListener = () => {

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -39,7 +39,19 @@ export default class Item extends Component {
 
   _setFocusOutEventListener() {
     document.addEventListener('hasFocusOut', this._hasFocusOutListener);
+
+    this._previousFocus = document.hasFocus();
+    this._pollHasFocusInterval = setInterval(this._pollHasFocus, 1000);
   }
+
+  _pollHasFocus = () => {
+    const hasFocus = document.hasFocus();
+    if (!hasFocus && this._previousFocus) {
+      const hasFocusOutEvent = new CustomEvent('hasFocusOut');
+      document.dispatchEvent(hasFocusOutEvent);
+    }
+    this._previousFocus = hasFocus;
+  };
 
   _hasFocusOutListener = () => {
     this.args.onFocusOutOfWindow();
@@ -47,6 +59,7 @@ export default class Item extends Component {
   };
 
   clearFocusOutEventListener = () => {
+    clearInterval(this._pollHasFocusInterval);
     document.removeEventListener('hasFocusOut', this._hasFocusOutListener);
   };
 

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -9,7 +9,7 @@ export default class Item extends Component {
   constructor() {
     super(...arguments);
     if (this.isFocusedChallenge && !this.args.answer) {
-      this._setOnBlurEventToWindow();
+      this._setFocusOutEventListener();
     }
   }
 
@@ -37,16 +37,18 @@ export default class Item extends Component {
     return event.relatedTarget === null;
   }
 
-  _setOnBlurEventToWindow() {
-    window.onblur = () => {
-      this.args.onFocusOutOfWindow();
-      this.clearOnBlurMethod();
-    };
+  _setFocusOutEventListener() {
+    document.addEventListener('hasFocusOut', this._hasFocusOutListener);
   }
 
-  clearOnBlurMethod() {
-    window.onblur = null;
-  }
+  _hasFocusOutListener = () => {
+    this.args.onFocusOutOfWindow();
+    this.clearFocusOutEventListener();
+  };
+
+  clearFocusOutEventListener = () => {
+    document.removeEventListener('hasFocusOut', this._hasFocusOutListener);
+  };
 
   get isFocusedChallenge() {
     return ENV.APP.FT_FOCUS_CHALLENGE_ENABLED && this.args.challenge.focused;

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import ENV from 'mon-pix/config/environment';
 
 const FOCUSEDOUT_EVENT_NAME = 'focusedout';
+const FOCUSEDOUT_INTERVAL = 1000;
 
 export default class Item extends Component {
   @service currentUser;
@@ -43,7 +44,7 @@ export default class Item extends Component {
     document.addEventListener(FOCUSEDOUT_EVENT_NAME, this._focusedoutListener);
 
     this._hadFocus = document.hasFocus();
-    this._pollHasFocusInterval = setInterval(this._pollHasFocus, 1000);
+    this._pollHasFocusInterval = setInterval(this._pollHasFocus, FOCUSEDOUT_INTERVAL);
   }
 
   _pollHasFocus = () => {

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -86,7 +86,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
               it('should display a warning alert', async function () {
                 // when
-                await triggerEvent(document, 'hasFocusOut');
+                await triggerEvent(document, 'focusedout');
 
                 // then
                 expect(find('[data-test="alert-message-focused-out-of-window"]')).to.exist;
@@ -113,7 +113,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
                 expect(find('.challenge__focused-out-overlay')).to.exist;
 
                 // when
-                await triggerEvent(document, 'hasFocusOut');
+                await triggerEvent(document, 'focusedout');
 
                 // then
                 expect(find('.challenge__info-alert--could-show')).to.not.exist;
@@ -202,7 +202,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await visit(`/assessments/${assessment.id}/challenges/0`);
 
               // when
-              await triggerEvent(document, 'hasFocusOut');
+              await triggerEvent(document, 'focusedout');
             });
 
             it('should display the certification warning alert', async function () {
@@ -226,7 +226,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await visit(`/assessments/${assessment.id}/challenges/0`);
 
               // when
-              await triggerEvent(document, 'hasFocusOut');
+              await triggerEvent(document, 'focusedout');
             });
 
             it('should display the default warning alert', async function () {
@@ -414,7 +414,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
             it('should not display a warning alert', async function () {
               // when
-              await triggerEvent(document, 'hasFocusOut');
+              await triggerEvent(document, 'focusedout');
               // then
               expect(find('.challenge-actions__focused-out-of-window')).to.not.exist;
             });

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -86,7 +86,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
               it('should display a warning alert', async function () {
                 // when
-                await triggerEvent(window, 'blur');
+                await triggerEvent(document, 'hasFocusOut');
 
                 // then
                 expect(find('[data-test="alert-message-focused-out-of-window"]')).to.exist;
@@ -113,7 +113,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
                 expect(find('.challenge__focused-out-overlay')).to.exist;
 
                 // when
-                await triggerEvent(window, 'blur');
+                await triggerEvent(document, 'hasFocusOut');
 
                 // then
                 expect(find('.challenge__info-alert--could-show')).to.not.exist;
@@ -202,7 +202,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await visit(`/assessments/${assessment.id}/challenges/0`);
 
               // when
-              await triggerEvent(window, 'blur');
+              await triggerEvent(document, 'hasFocusOut');
             });
 
             it('should display the certification warning alert', async function () {
@@ -226,7 +226,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await visit(`/assessments/${assessment.id}/challenges/0`);
 
               // when
-              await triggerEvent(window, 'blur');
+              await triggerEvent(document, 'hasFocusOut');
             });
 
             it('should display the default warning alert', async function () {
@@ -414,7 +414,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
             it('should not display a warning alert', async function () {
               // when
-              await triggerEvent(window, 'blur');
+              await triggerEvent(document, 'hasFocusOut');
               // then
               expect(find('.challenge-actions__focused-out-of-window')).to.not.exist;
             });


### PR DESCRIPTION
Reprise de #3344 

## :unicorn: Problème
L'implémentation actuelle des épreuves focus ne permet pas l'utilisation des embeds.

## :robot: Solution
Utiliser la méthode `document.hasFocus()` qui renvoit true si une iframe contenu dans le document a le focus. 

## :rainbow: Remarques
Nous n'avons pas trouvé d'événements qui nous permettrait de ne pas interroger périodiquement le résultat de `document.hasFocus()`
L'implémentation proposée, dans le but de la rendre testable, décorrèle le polling de `document.hasFocus` de ses conséquences via un événement custom.

## :100: Pour tester
1. Aller sur un challenge qroc + focus + embed: `rec1Y3cL4enp1lZ97`
2. Lancer le simulateur
3. Constater qu'il n'y a aucun message de sortie de la page
4. Sortir de la page
5. Constater qu'il y a un message de sortie de la page

Deux épreuves : `rec2mZPQeLyz6jiaR` `rec2zZCdSTvyLLJcS`
