### PR TITLE
[FEATURE] Modifier un commentaire interne depuis Pix Admin (Pix-3869)

### DIFF
--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -25,7 +25,6 @@
           @value={{this.form.name}}
           required={{true}}
         />
-        <br />
         <label for="targetProfileDescription" class="form-field__label">
           Description
         </label>

--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -1,5 +1,5 @@
 <section class="page-section mb_10">
-  <div class="organization__edit-form">
+  <div class="target-profile__edit-form">
     <form class="form" {{on "submit" this.updateProfile}}>
 
       <span class="form__instructions">

--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -25,7 +25,7 @@
           @value={{this.form.name}}
           required={{true}}
         />
-
+        <br />
         <label for="targetProfileDescription" class="form-field__label">
           Description
         </label>
@@ -40,6 +40,21 @@
           @maxlength="500"
           class={{if (v-get this.form "description" "isInvalid") "form-control is-invalid" "form-control"}}
           @value={{this.form.description}}
+        />
+        <label for="targetProfileComment" class="form-field__label">
+          Commentaire (usage interne)
+        </label>
+        {{#if (v-get this.form "comment" "isInvalid")}}
+          <div class="form-field__error">
+            {{v-get this.form "comment" "message"}}
+          </div>
+        {{/if}}
+        <PixTextarea
+          id="targetProfileComment"
+          rows="4"
+          @maxlength="500"
+          class={{if (v-get this.form "comment" "isInvalid") "form-control is-invalid" "form-control"}}
+          @value={{this.form.comment}}
         />
       </div>
       <div class="form-actions">

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -28,11 +28,20 @@ const Validations = buildValidations({
       }),
     ],
   },
+  comment: {
+    validators: [
+      validator('length', {
+        max: 500,
+        message: 'La longueur du commentaire ne doit pas excéder 500 caractères',
+      }),
+    ],
+  },
 });
 
 class Form extends Object.extend(Validations) {
   @tracked name;
   @tracked description;
+  @tracked comment;
 }
 
 export default class UpdateTargetProfile extends Component {
@@ -43,6 +52,7 @@ export default class UpdateTargetProfile extends Component {
     this.form = Form.create(getOwner(this).ownerInjection());
     this.form.name = this.args.model.name;
     this.form.description = this.args.model.description || null;
+    this.form.comment = this.args.model.comment || null;
   }
 
   async _checkFormValidation() {
@@ -54,6 +64,7 @@ export default class UpdateTargetProfile extends Component {
     const model = this.args.model;
     model.name = this.form.name.trim();
     model.description = this.form.description ? this.form.description.trim() : null;
+    model.comment = this.form.comment ? this.form.comment.trim() : null;
     try {
       await model.save();
       await this.notifications.success('Le profil cible a bien été mis à jour.');

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -59,6 +59,7 @@
 @import 'components/sessions/list-items.scss';
 @import 'components/user-detail-personal-information-section';
 @import 'components/target-profiles/badges';
+@import 'components/target-profiles/target-profile';
 @import 'components/target-profiles/badge-form';
 @import 'components/target-profiles/create-target-profile-form';
 @import 'components/target-profiles/details';

--- a/admin/app/styles/components/target-profiles/target-profile.scss
+++ b/admin/app/styles/components/target-profiles/target-profile.scss
@@ -1,0 +1,17 @@
+.page-section {
+
+  &__container {
+    display: flex;
+  }
+
+  &__content {
+    width: 50%;
+  }
+}
+
+.target-profile__edit-form {
+
+  #targetProfileName {
+    margin-bottom: 24px;
+  }
+}

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -17,28 +17,32 @@
       <div class="page-section__header">
         <h1 class="page-section__title">{{@model.name}}</h1>
       </div>
-      <div class="page-section__content">
-        <div>ID : {{@model.id}}</div>
-        <div>Date de création : {{format-date @model.createdAt}}</div>
-        <div>Public : {{this.isPublic}}</div>
-        <div>Obsolète : {{this.isOutdated}}</div>
-        <div>Organisation de référence :
-          <LinkTo @route="authenticated.organizations.get" @model={{@model.ownerOrganizationId}}>
-            {{@model.ownerOrganizationId}}
-          </LinkTo>
+      <div class="page-section__container">
+        <div class="page-section__content">
+          <div>ID : {{@model.id}}</div>
+          <div>Date de création : {{format-date @model.createdAt}}</div>
+          <div>Public : {{this.isPublic}}</div>
+          <div>Obsolète : {{this.isOutdated}}</div>
+          <div>Organisation de référence :
+            <LinkTo @route="authenticated.organizations.get" @model={{@model.ownerOrganizationId}}>
+              {{@model.ownerOrganizationId}}
+            </LinkTo>
+          </div>
         </div>
-        {{#if @model.description}}
-          <div>
-            Description :
-            <MarkdownToHtml @markdown={{@model.description}} />
-          </div>
-        {{/if}}
-        {{#if @model.comment}}
-          <div>
-            Commentaire (usage interne) :
-            <MarkdownToHtml @markdown={{@model.comment}} />
-          </div>
-        {{/if}}
+        <div class="page-section__content">
+          {{#if @model.description}}
+            <div>
+              Description :
+              <MarkdownToHtml @markdown={{@model.description}} />
+            </div>
+          {{/if}}
+          {{#if @model.comment}}
+            <div>
+              Commentaire (usage interne) :
+              <MarkdownToHtml @markdown={{@model.comment}} />
+            </div>
+          {{/if}}
+        </div>
       </div>
       <div class="form-actions">
         <PixButton

--- a/admin/tests/unit/components/update-target-profile_test.js
+++ b/admin/tests/unit/components/update-target-profile_test.js
@@ -91,6 +91,34 @@ module('Unit | Component | update-target-profile', function (hooks) {
       assert.equal(component.args.model.description, 'Edited description');
     });
 
+    test('it should update the comment of the target profile', async function (assert) {
+      // given
+      const component = createGlimmerComponent('component:target-profiles/update-target-profile', {
+        model: {
+          name: 'Karam',
+          comment: null,
+          save: sinon.stub(),
+          rollbackAttributes: sinon.stub(),
+        },
+      });
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+      component.form.comment = 'Edited comment';
+      component.args.model = {
+        name: 'Karam',
+        comment: null,
+        save: sinon.stub(),
+        rollbackAttributes: sinon.stub(),
+      };
+      component.notifications = { success: sinon.stub(), error: sinon.stub() };
+
+      // when
+      await component.updateProfile(event);
+      // then
+      assert.equal(component.args.model.comment, 'Edited comment');
+    });
+
     test('it should do nothing when form is not valid', async function (assert) {
       // given
       const component = createGlimmerComponent('component:target-profiles/update-target-profile', {

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -225,6 +225,7 @@ exports.register = async (server) => {
               attributes: {
                 name: Joi.string().required().min(1),
                 description: Joi.string().required().allow(null).max(500),
+                comment: Joi.string().required().allow(null).max(500),
               },
             },
           }).options({ allowUnknown: true }),

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -60,8 +60,8 @@ module.exports = {
 
   async updateTargetProfile(request, h) {
     const id = request.params.id;
-    const { name, description } = request.payload.data.attributes;
-    await usecases.updateTargetProfile({ id, name, description });
+    const { name, description, comment } = request.payload.data.attributes;
+    await usecases.updateTargetProfile({ id, name, description, comment });
     return h.response({}).code(204);
   },
 

--- a/api/lib/domain/usecases/update-target-profile.js
+++ b/api/lib/domain/usecases/update-target-profile.js
@@ -1,3 +1,3 @@
-module.exports = async function updateTargetProfile({ id, name, description, targetProfileRepository }) {
-  await targetProfileRepository.update({ id, name, description });
+module.exports = async function updateTargetProfile({ id, name, description, comment, targetProfileRepository }) {
+  await targetProfileRepository.update({ id, name, description, comment });
 };

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -147,7 +147,7 @@ module.exports = {
 
   async update(targetProfile) {
     let targetProfileUpdatedRowCount;
-    const editedAttributes = _.pick(targetProfile, ['name', 'outdated', 'description']);
+    const editedAttributes = _.pick(targetProfile, ['name', 'outdated', 'description', 'comment']);
 
     try {
       targetProfileUpdatedRowCount = await knex('target-profiles')

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -272,6 +272,7 @@ describe('Acceptance | Controller | target-profile-controller', function () {
             attributes: {
               name: 'CoolPixer',
               description: 'Amazing description',
+              comment: 'Amazing comment',
             },
           },
         },

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -709,6 +709,20 @@ describe('Integration | Repository | Target-profile', function () {
       expect(description).to.equal(targetProfile.description);
     });
 
+    it('should update the target profile comment', async function () {
+      // given
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      await databaseBuilder.commit();
+
+      // when
+      targetProfile.comment = 'Je change le commentaire';
+      await targetProfileRepository.update(targetProfile);
+
+      // then
+      const { comment } = await knex('target-profiles').select('comment').where('id', targetProfile.id).first();
+      expect(comment).to.equal(targetProfile.comment);
+    });
+
     it('should outdate the target profile', async function () {
       // given
       const targetProfile = databaseBuilder.factory.buildTargetProfile({ outdated: true });

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -468,6 +468,7 @@ describe('Integration | Application | Target Profiles | Routes', function () {
           attributes: {
             name: 'test',
             description: 'description changée.',
+            comment: 'commentaire changé.',
           },
         },
       };
@@ -492,6 +493,32 @@ describe('Integration | Application | Target Profiles | Routes', function () {
           attributes: {
             name: 'test',
             description: description.repeat(26),
+            comment: null,
+          },
+        },
+      };
+      const url = '/api/admin/target-profiles/123';
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return a 400 error when comment is over than 500 characters', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      const comment = 'commentaire changé.';
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'PATCH';
+      const payload = {
+        data: {
+          attributes: {
+            name: 'test',
+            description: 'good',
+            comment: comment.repeat(27),
           },
         },
       };
@@ -533,6 +560,7 @@ describe('Integration | Application | Target Profiles | Routes', function () {
           attributes: {
             name: 'Not Pix Admin',
             description: null,
+            comment: null,
           },
         },
       };

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -19,6 +19,7 @@ describe('Unit | Controller | target-profile-controller', function () {
             attributes: {
               name: 'Pixer123',
               description: 'description changée',
+              comment: 'commentaire changée',
             },
           },
         },
@@ -37,6 +38,7 @@ describe('Unit | Controller | target-profile-controller', function () {
           id: 123,
           name: 'Pixer123',
           description: 'description changée',
+          comment: 'commentaire changée',
         });
       });
     });

--- a/api/tests/unit/domain/usecases/update-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/update-target-profile_test.js
@@ -9,13 +9,20 @@ describe('Unit | UseCase | update-target-profile', function () {
     };
 
     //when
-    await updateTargetProfile({ id: 123, name: 'Tom', description: 'description changée', targetProfileRepository });
+    await updateTargetProfile({
+      id: 123,
+      name: 'Tom',
+      description: 'description changée',
+      comment: 'commentaire changé',
+      targetProfileRepository,
+    });
 
     //then
     expect(targetProfileRepository.update).to.have.been.calledOnceWithExactly({
       id: 123,
       name: 'Tom',
       description: 'description changée',
+      comment: 'commentaire changé',
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Fait suite à cette [PR](https://github.com/1024pix/pix/pull/3757).
On cherche à simplifier la sélection des profils cibles, lors de la création des campagnes. Pour cela, on a permis d'ajouter un commentaire pour les personnes en interne. Mais on avait pas la possibilité de modifier ce commentaire.

## :gift: Solution
Permettre de modifier ce commentaire depuis pix admin

## :star2: Remarques


## :santa: Pour tester
Se connecter sur pix admin, aller voir le profil cible de la compétence 5.1 et modifier le commentaire, ou ajouter un commentaire sur un profil cible déjà existant.