### PR TITLE
[FEATURE] Badge: Ajouter un critère sur un ensemble d'acquis (frontend)

### DIFF
--- a/admin/app/adapters/badge-criterion.js
+++ b/admin/app/adapters/badge-criterion.js
@@ -3,7 +3,7 @@ import ApplicationAdapter from './application';
 export default class BadgeCriterionAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  urlForCreateRecord(modelName, { adapterOptions: { badgeId } }) {
-    return `${this.host}/${this.namespace}/badges/${badgeId}/badge-criteria`;
+  urlForCreateRecord(_modelName, badgeCriterion) {
+    return `${this.host}/${this.namespace}/badges/${badgeCriterion.belongsTo('badge').id}/badge-criteria`;
   }
 }

--- a/admin/app/adapters/skill-set.js
+++ b/admin/app/adapters/skill-set.js
@@ -3,7 +3,7 @@ import ApplicationAdapter from './application';
 export default class SkillSetAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  urlForCreateRecord(_modelName, { adapterOptions: { badgeId } }) {
-    return `${this.host}/${this.namespace}/badges/${badgeId}/skill-sets`;
+  urlForCreateRecord(_modelName, skillSet) {
+    return `${this.host}/${this.namespace}/badges/${skillSet.belongsTo('badge').id}/skill-sets`;
   }
 }

--- a/admin/app/adapters/skill-set.js
+++ b/admin/app/adapters/skill-set.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class SkillSetAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForCreateRecord(_modelName, { adapterOptions: { badgeId } }) {
+    return `${this.host}/${this.namespace}/badges/${badgeId}/skill-sets`;
+  }
+}

--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -52,7 +52,24 @@
     <p>Laissez ce champ vide si la participation de campagne est non souhaitée</p>
     <div>
       <label for="campaignParticipationThreshold">Taux de réussite souhaité :</label>
-      <Input id="campaignParticipationThreshold" @type="number" @value={{this.threshold}} />
+      <Input id="campaignParticipationThreshold" @type="number" @value={{this.campaignParticipationThreshold}} />
+    </div>
+  </div>
+
+  <div>
+    <div>
+      <label for="skillSetThreshold">Taux de réussite souhaité :</label>
+      <Input id="skillSetThreshold" @type="number" @value={{this.skillSet.threshold}} />
+    </div>
+
+    <div>
+      <label for="skillSetName">Nom de la liste</label>
+      <Input id="skillSetName" @type="text" @value={{this.skillSet.name}} />
+    </div>
+
+    <div class="badge-form__text-field">
+      <label for="skillSetSkills">Message : </label>
+      <Textarea id="skillSetSkills" class="form-control" @value={{this.skillSet.skills}} rows="4" />
     </div>
   </div>
 

--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -1,91 +1,135 @@
 <form {{on "submit" this.createBadgeAndCriteria}} class="badge-form">
-  <div class="badge-form__text-field">
-    <label for="title">Nom du badge : </label>
-    <Input id="title" class="form-control" @type="text" @value={{this.badge.title}} />
-  </div>
-  <div class="badge-form__text-field">
-    <label for="image-url">Nom de l'image (svg) :
-      <a href="https://images.pix.fr/index.html" target="_blank" rel="noopener noreferrer"> Voir la liste des badges</a>
-    </label>
-    <Input
-      id="image-name"
-      required="true"
-      class="form-control"
-      @type="text"
-      @value={{this.imageName}}
-      placeholder="exemple: clea_num.svg"
-    />
-  </div>
-  <div class="badge-form__text-field">
-    <label for="alt-message">Texte alternatif pour l'image : </label>
-    <Input id="alt-message" required="true" class="form-control" @type="text" @value={{this.badge.altMessage}} />
-  </div>
-  <div class="badge-form__text-field">
-    <label for="message">Message : </label>
-    <Textarea id="message" class="form-control" @value={{this.badge.message}} rows="4" />
-  </div>
-  <div class="badge-form__text-field">
-    <label for="badge-key">Clé (texte unique , vérifier qu'il n'existe pas) : </label>
-    <Input id="badge-key" class="form-control" maxlength="255" @type="text" required="true" @value={{this.badge.key}} />
-  </div>
-  <div class="badge-form__check-field">
-    <label for="isCertifiable">Certifiable : </label>
-    <Input
-      class="badge-form-check-field__control"
-      @type="checkbox"
-      @checked={{this.badge.isCertifiable}}
-      id="isCertifiable"
-    />
-  </div>
-  <div class="badge-form__check-field">
-    <label for="isAlwaysVisible">Lacunes : </label>
-    <Input
-      class="badge-form-check-field__control"
-      @type="checkbox"
-      @checked={{this.badge.isAlwaysVisible}}
-      id="isAlwaysVisible"
-    />
-  </div>
-
-  <div>
-    <h3>Réussite sur la participation de campagne</h3>
-    <p>Laissez ce champ vide si la participation de campagne est non souhaitée</p>
-    <div>
-      <label for="campaignParticipationThreshold">Taux de réussite souhaité :</label>
-      <Input id="campaignParticipationThreshold" @type="number" @value={{this.campaignParticipationThreshold}} />
-    </div>
-  </div>
-
-  <div>
-    <div>
-      <label for="skillSetThreshold">Taux de réussite souhaité :</label>
-      <Input id="skillSetThreshold" @type="number" @value={{this.skillSet.threshold}} />
-    </div>
-
-    <div>
-      <label for="skillSetName">Nom de la liste</label>
-      <Input id="skillSetName" @type="text" @value={{this.skillSet.name}} />
-    </div>
-
+  <section class="page-section">
+    <h2>Création d'un résultat thématique</h2>
     <div class="badge-form__text-field">
-      <label for="skillSetSkills">Message : </label>
-      <Textarea id="skillSetSkills" class="form-control" @value={{this.skillSet.skills}} rows="4" />
+      <label for="title">Nom du badge : </label>
+      <Input id="title" class="form-control" @type="text" @value={{this.badge.title}} />
     </div>
-  </div>
+    <div class="badge-form__text-field">
+      <label for="image-url">Nom de l'image (svg) :
+        <a href="https://images.pix.fr/index.html" target="_blank" rel="noopener noreferrer">
+          Voir la liste des badges</a>
+      </label>
+      <Input
+        id="image-name"
+        required="true"
+        class="form-control"
+        @type="text"
+        @value={{this.imageName}}
+        placeholder="exemple: clea_num.svg"
+      />
+    </div>
+    <div class="badge-form__text-field">
+      <label for="alt-message">Texte alternatif pour l'image : </label>
+      <Input id="alt-message" required="true" class="form-control" @type="text" @value={{this.badge.altMessage}} />
+    </div>
+    <div class="badge-form__text-field">
+      <label for="message">Message : </label>
+      <Textarea id="message" class="form-control" @value={{this.badge.message}} rows="4" />
+    </div>
+    <div class="badge-form__text-field">
+      <label for="badge-key">Clé (texte unique , vérifier qu'il n'existe pas) : </label>
+      <Input
+        id="badge-key"
+        class="form-control"
+        maxlength="255"
+        @type="text"
+        required="true"
+        @value={{this.badge.key}}
+      />
+    </div>
+    <div class="badge-form__check-field">
+      <label for="isCertifiable">Certifiable : </label>
+      <Input
+        class="badge-form-check-field__control"
+        @type="checkbox"
+        @checked={{this.badge.isCertifiable}}
+        id="isCertifiable"
+      />
+    </div>
+    <div class="badge-form__check-field">
+      <label for="isAlwaysVisible">Lacunes : </label>
+      <Input
+        class="badge-form-check-field__control"
+        @type="checkbox"
+        @checked={{this.badge.isAlwaysVisible}}
+        id="isAlwaysVisible"
+      />
+    </div>
+  </section>
 
-  <div class="badge-form__action-buttons">
-    <PixButtonLink
-      data-test="badge-form-cancel-button"
-      class="badge-form-action-buttons__cancel"
-      @backgroundColor="transparent-light"
-      @isBorderVisible={{true}}
-      @size="small"
-      @route="authenticated.target-profiles.target-profile.insights"
-    >
-      Annuler
-    </PixButtonLink>
-    <PixButton data-test="badge-form-submit-button" @backgroundColor="green" @size="small" @type="submit">
-      Créer le badge
-    </PixButton>
-  </div>
+  <section class="page-section">
+    <h3>Définir un ou plusieurs critères</h3>
+
+    <p>
+      Vous pouvez définir un critère de réussite du RT sur une liste d’acquis ET/OU sur l’ensemble du profil cible.
+      Toutes les conditions devront être remplies pour obtenir le badge. Laissez vide les critères qui ne sont pas
+      souhaités.
+    </p>
+
+    <div>
+      <h4>Sur une liste d'acquis</h4>
+
+      <div class="badge-form-criteria">
+        <div class="badge-form__text-field badge-form-criteria__threshold">
+          <label for="skillSetThreshold">Taux de réussite :</label>
+          <Input
+            id="skillSetThreshold"
+            class="form-control"
+            @type="number"
+            min="1"
+            max="100"
+            @value={{this.skillSet.threshold}}
+          />
+        </div>
+
+        <div class="badge-form-criteria__skill-set">
+          <div class="badge-form__text-field">
+            <label for="skillSetName">Nom de la liste :</label>
+            <Input id="skillSetName" class="form-control" @type="text" @value={{this.skillSet.name}} />
+          </div>
+
+          <div class="badge-form__text-field">
+            <label for="skillSetSkills">Liste des acquis :</label>
+            <Textarea id="skillSetSkills" class="form-control" @value={{this.skillSet.skills}} rows="4" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <h4>Sur l'ensemble du profil cible</h4>
+
+      <div class="badge-form-criteria">
+        <div class="badge-form__text-field badge-form-criteria__threshold">
+          <label for="campaignParticipationThreshold">Taux de réussite :</label>
+          <Input
+            id="campaignParticipationThreshold"
+            class="form-control"
+            @type="number"
+            min="1"
+            max="100"
+            @value={{this.campaignParticipationThreshold}}
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="badge-form__action-buttons">
+      <PixButtonLink
+        data-test="badge-form-cancel-button"
+        class="badge-form-action-buttons__cancel"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @size="small"
+        @route="authenticated.target-profiles.target-profile.insights"
+      >
+        Annuler
+      </PixButtonLink>
+      <PixButton data-test="badge-form-submit-button" @backgroundColor="green" @size="small" @type="submit">
+        Créer le badge
+      </PixButton>
+    </div>
+  </section>
+
 </form>

--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -32,7 +32,7 @@ export default class BadgeForm extends Component {
       const badge = await this._createBadge();
 
       if (this.threshold) {
-        await this._createThresholdBadgeCriterion(badge.id);
+        await this._createThresholdBadgeCriterion(badge);
       }
 
       this.router.transitionTo('authenticated.target-profiles.target-profile.insights');
@@ -60,7 +60,7 @@ export default class BadgeForm extends Component {
     }
   }
 
-  async _createThresholdBadgeCriterion(badgeId) {
+  async _createThresholdBadgeCriterion(badge) {
     try {
       if (this.threshold < 0 || this.threshold > 100) {
         this.notifications.error('Le taux de réussite doit être compris entre 0 et 100.');
@@ -69,8 +69,9 @@ export default class BadgeForm extends Component {
       const badgeCriterion = this.store.createRecord('badge-criterion', {
         scope: 'CampaignParticipation',
         threshold: this.threshold,
+        badge,
       });
-      await badgeCriterion.save({ adapterOptions: { badgeId } });
+      await badgeCriterion.save();
       this.notifications.success('Le critère du résultat thématique a été créé.');
     } catch (error) {
       console.error(error);

--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -95,7 +95,7 @@ export default class BadgeForm extends Component {
         this.notifications.error('Le taux de réussite doit être compris entre 0 et 100.');
         return;
       }
-      const skillIds = this.skillSet.skills.split(',');
+      const skillIds = this.skillSet.skills.replace(/\s/g, '').split(',');
       const skillSet = this.store.createRecord('skill-set', {
         badge,
         name: this.skillSet.name,

--- a/admin/app/models/badge-criterion.js
+++ b/admin/app/models/badge-criterion.js
@@ -5,5 +5,5 @@ export default class BadgeCriterion extends Model {
   @attr('number') threshold;
 
   @belongsTo('badge') badge;
-  @hasMany('skillSet') skillSets;
+  @hasMany('skill-set') skillSets;
 }

--- a/admin/app/models/skill-set.js
+++ b/admin/app/models/skill-set.js
@@ -1,10 +1,10 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class SkillSet extends Model {
   @attr('string') name;
   @attr('array') skillIds;
 
   @belongsTo('badge') badge;
-  //   @belongsTo('badge-criterion') criterion;
-  //   @hasMany('skill') skillIds;
+  @belongsTo('badge-criterion') criterion;
+  @hasMany('skill') skills;
 }

--- a/admin/app/models/skill-set.js
+++ b/admin/app/models/skill-set.js
@@ -1,9 +1,10 @@
-import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class SkillSet extends Model {
   @attr('string') name;
+  @attr('array') skillIds;
 
   @belongsTo('badge') badge;
-  @belongsTo('badge-criterion') criterion;
-  @hasMany('skill') skills;
+  //   @belongsTo('badge-criterion') criterion;
+  //   @hasMany('skill') skillIds;
 }

--- a/admin/app/serializers/badge-criterion.js
+++ b/admin/app/serializers/badge-criterion.js
@@ -1,9 +1,12 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class BadgeCriterionSerializer extends JSONAPISerializer {
-  serialize(snapshot, options) {
-    const json = super.serialize(snapshot, options);
-    delete json.data.relationships?.badge;
-    return json;
-  }
+  attrs = {
+    skillSets: {
+      serialize: true,
+    },
+    badge: {
+      serialize: false,
+    },
+  };
 }

--- a/admin/app/serializers/badge-criterion.js
+++ b/admin/app/serializers/badge-criterion.js
@@ -1,0 +1,9 @@
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+
+export default class BadgeCriterionSerializer extends JSONAPISerializer {
+  serialize(snapshot, options) {
+    const json = super.serialize(snapshot, options);
+    delete json.data.relationships?.badge;
+    return json;
+  }
+}

--- a/admin/app/serializers/skill-set.js
+++ b/admin/app/serializers/skill-set.js
@@ -1,9 +1,9 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class SkillSetSerializer extends JSONAPISerializer {
-  serialize(snapshot, options) {
-    const json = super.serialize(snapshot, options);
-    delete json.data.relationships;
-    return json;
-  }
+  attrs = {
+    badge: {
+      serialize: false,
+    },
+  };
 }

--- a/admin/app/serializers/skill-set.js
+++ b/admin/app/serializers/skill-set.js
@@ -3,7 +3,7 @@ import JSONAPISerializer from '@ember-data/serializer/json-api';
 export default class SkillSetSerializer extends JSONAPISerializer {
   serialize(snapshot, options) {
     const json = super.serialize(snapshot, options);
-    delete json.data.relationships?.badge;
+    delete json.data.relationships;
     return json;
   }
 }

--- a/admin/app/serializers/skill-set.js
+++ b/admin/app/serializers/skill-set.js
@@ -1,0 +1,9 @@
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+
+export default class SkillSetSerializer extends JSONAPISerializer {
+  serialize(snapshot, options) {
+    const json = super.serialize(snapshot, options);
+    delete json.data.relationships?.badge;
+    return json;
+  }
+}

--- a/admin/app/styles/components/target-profiles/badge-form.scss
+++ b/admin/app/styles/components/target-profiles/badge-form.scss
@@ -1,5 +1,4 @@
 .badge-form {
-
   label {
     font-weight: $font-semi-bold;
   }
@@ -7,11 +6,15 @@
   &__text-field {
     display: flex;
     flex-direction: column;
+  }
+
+  &__text-field:not(:last-child),
+  &__check-field:not(:last-child) {
     margin-bottom: 16px;
   }
 
-  &__check-field {
-    margin-bottom: 16px;
+  &-check-field__control {
+    margin: 0 8px;
   }
 
   &__action-buttons {
@@ -19,20 +22,27 @@
     padding-top: 24px;
     border-top: 1px solid $grey-22;
   }
-}
 
-.badge-form-check-field__control {
-  margin: 0 8px;
-}
-
-.badge-form-action-buttons {
-
-  &__cancel {
+  &-action-buttons__cancel {
     margin-right: 8px;
 
     &:hover {
       text-decoration: none;
       color: inherit;
+    }
+  }
+
+  &-criteria {
+    display: flex;
+    gap: 32px;
+    margin-bottom: 16px;
+
+    &__threshold {
+      width: 160px;
+    }
+
+    &__skill-set {
+      flex: 1;
     }
   }
 }

--- a/admin/app/styles/components/target-profiles/badge-form.scss
+++ b/admin/app/styles/components/target-profiles/badge-form.scss
@@ -1,4 +1,5 @@
 .badge-form {
+
   label {
     font-weight: $font-semi-bold;
   }

--- a/admin/app/styles/components/target-profiles/badge-form.scss
+++ b/admin/app/styles/components/target-profiles/badge-form.scss
@@ -46,4 +46,8 @@
       flex: 1;
     }
   }
+
+  h4 {
+    margin-top: 37px;
+  }
 }

--- a/admin/app/styles/components/target-profiles/target-profile.scss
+++ b/admin/app/styles/components/target-profiles/target-profile.scss
@@ -1,4 +1,5 @@
 .page-section {
+
   &__container {
     display: flex;
   }
@@ -13,6 +14,7 @@
 }
 
 .target-profile__edit-form {
+
   #targetProfileName {
     margin-bottom: 24px;
   }

--- a/admin/app/styles/components/target-profiles/target-profile.scss
+++ b/admin/app/styles/components/target-profiles/target-profile.scss
@@ -1,5 +1,4 @@
 .page-section {
-
   &__container {
     display: flex;
   }
@@ -7,10 +6,13 @@
   &__content {
     width: 50%;
   }
+
+  &:not(:first-of-type) {
+    margin-top: 20px;
+  }
 }
 
 .target-profile__edit-form {
-
   #targetProfileName {
     margin-bottom: 24px;
   }

--- a/admin/app/templates/authenticated/target-profiles/target-profile/badges/new.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/badges/new.hbs
@@ -1,9 +1,3 @@
-<header class="page-header">
-  <div class="page-title">Création de résultat thématique et de ses critères</div>
-</header>
-
 <main>
-  <section class="page-section">
-    <TargetProfiles::BadgeForm @targetProfileId={{this.model.targetProfileId}} />
-  </section>
+  <TargetProfiles::BadgeForm @targetProfileId={{this.model.targetProfileId}} />
 </main>

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -18,8 +18,8 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
 
   test('it should display the expected number of inputs', async function (assert) {
     // given
-    const expectedNumberOfInputsInForm = 8;
-    const expectedNumberOfTextareasInForm = 1;
+    const expectedNumberOfInputsInForm = 11;
+    const expectedNumberOfTextareasInForm = 2;
     const expectedNumberOfCheckboxesInForm = 2;
 
     // when
@@ -50,7 +50,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
       store.createRecord = createRecordStub;
       this.targetProfileId = 123;
 
-      await render(hbs`<TargetProfiles::BadgeForm @targetProfileId={{"targetProfileId"}} />`);
+      await render(hbs`<TargetProfiles::BadgeForm @targetProfileId={{targetProfileId}} />`);
 
       // when
       await fillIn('input#badge-key', 'clé_du_badge');
@@ -110,11 +110,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
     const findStub = sinon.stub();
-    const targetProfile = {
-      hasMany() {
-        return [{ id: 'skillId1' }, { id: 'skillId2' }, { id: 'skillId3' }, { id: 'skillId4' }];
-      },
-    };
+    const targetProfile = {};
     findStub.onFirstCall().returns(targetProfile);
     const createRecordStub = sinon.stub();
     const saveStub = sinon.stub();
@@ -126,7 +122,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
     store.createRecord = createRecordStub;
     store.find = findStub;
 
-    await render(hbs`<TargetProfiles::BadgeForm @targetProfileId={{"targetProfileId"}} />`);
+    await render(hbs`<TargetProfiles::BadgeForm @targetProfileId={{targetProfileId}} />`);
 
     // when
     await fillIn('input#badge-key', 'clé_du_badge');
@@ -134,16 +130,16 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
     await fillIn('input#alt-message', 'texte alternatif à l‘image');
     await fillIn('input#skillSetThreshold', '75');
     await fillIn('input#skillSetName', 'nom du skill set');
-    await fillIn('input#skillSetSkills', 'skillId1,skillId2,skillId3,skillId4');
+    await fillIn('textarea#skillSetSkills', 'skillId1,skillId3,skillId4');
     await click('button[data-test="badge-form-submit-button"]');
 
     // then
-    sinon.assert.calledWith(createRecordStub.secondcall, 'skill-set', {
+    sinon.assert.calledWith(createRecordStub.secondCall, 'skill-set', {
       name: 'nom du skill set',
       badge,
-      skills: [{ id: 'skillId1' }, { id: 'skillId2' }, { id: 'skillId3' }, { id: 'skillId4' }],
+      skillIds: ['skillId1', 'skillId3', 'skillId4'],
     });
-    sinon.assert.calledWith(saveStub.secondcall);
+    sinon.assert.calledWith(saveStub.secondCall);
     sinon.assert.calledWith(createRecordStub.thirdCall, 'badge-criterion', {
       threshold: '75',
       scope: 'SkillSet',

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -81,7 +81,9 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
       const store = this.owner.lookup('service:store');
       const createRecordStub = sinon.stub();
       const saveStub = sinon.stub();
-      createRecordStub.returns({ save: saveStub, id: 123 });
+      const badge = { id: 'badgeId', save: saveStub };
+      createRecordStub.onFirstCall().returns(badge);
+      createRecordStub.onSecondCall().returns({ save: saveStub });
       store.createRecord = createRecordStub;
 
       await render(hbs`<TargetProfiles::BadgeForm @targetProfileId={{targetProfileId}} />`);
@@ -97,12 +99,9 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
       sinon.assert.calledWith(createRecordStub.secondCall, 'badge-criterion', {
         threshold: '65',
         scope: 'CampaignParticipation',
+        badge,
       });
-      sinon.assert.calledWith(saveStub.secondCall, {
-        adapterOptions: {
-          badgeId: 123,
-        },
-      });
+      sinon.assert.calledWith(saveStub.secondCall);
       assert.ok(true);
     });
   });

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -130,7 +130,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
     await fillIn('input#alt-message', 'texte alternatif à l‘image');
     await fillIn('input#skillSetThreshold', '75');
     await fillIn('input#skillSetName', 'nom du skill set');
-    await fillIn('textarea#skillSetSkills', 'skillId1,skillId3,skillId4');
+    await fillIn('textarea#skillSetSkills', 'skillId1, skillId3, skillId4');
     await click('button[data-test="badge-form-submit-button"]');
 
     // then

--- a/admin/tests/unit/adapters/badge-criterion_test.js
+++ b/admin/tests/unit/adapters/badge-criterion_test.js
@@ -13,8 +13,13 @@ module('Unit | Adapters | badge-criterion', function (hooks) {
   module('#urlForCreateRecord', function () {
     test('should build create url from badgeId', async function (assert) {
       // when
-      const options = { adapterOptions: { badgeId: 90 } };
-      const url = await adapter.urlForCreateRecord('badge-criterion', options);
+      const badgeCriterion = {
+        belongsTo(relationship) {
+          if (relationship !== 'badge') return null;
+          return { id: 90 };
+        },
+      };
+      const url = await adapter.urlForCreateRecord('badge-criterion', badgeCriterion);
 
       // then
       assert.true(url.endsWith('/api/admin/badges/90/badge-criteria'));

--- a/admin/tests/unit/adapters/skill-set_test.js
+++ b/admin/tests/unit/adapters/skill-set_test.js
@@ -13,8 +13,13 @@ module('Unit | Adapters | skill-set', function (hooks) {
   module('#urlForCreateRecord', function () {
     test('should build create url from badgeId', async function (assert) {
       // when
-      const options = { adapterOptions: { badgeId: 66 } };
-      const url = await adapter.urlForCreateRecord('skill-set', options);
+      const skillSet = {
+        belongsTo(relationship) {
+          if (relationship !== 'badge') return null;
+          return { id: 66 };
+        },
+      };
+      const url = await adapter.urlForCreateRecord('skill-set', skillSet);
 
       // then
       assert.true(url.endsWith('/api/admin/badges/66/skill-sets'));

--- a/admin/tests/unit/adapters/skill-set_test.js
+++ b/admin/tests/unit/adapters/skill-set_test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapters | skill-set', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:skill-set');
+  });
+
+  module('#urlForCreateRecord', function () {
+    test('should build create url from badgeId', async function (assert) {
+      // when
+      const options = { adapterOptions: { badgeId: 66 } };
+      const url = await adapter.urlForCreateRecord('skill-set', options);
+
+      // then
+      assert.true(url.endsWith('/api/admin/badges/66/skill-sets'));
+    });
+  });
+});

--- a/admin/tests/unit/serializers/badge-criterion_test.js
+++ b/admin/tests/unit/serializers/badge-criterion_test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Serializer | BadgeCriterion', function (hooks) {
+  setupTest(hooks);
+
+  test('it serializes records', function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const record = run(() => {
+      store.push({
+        data: [
+          {
+            id: 'badgeId',
+            type: 'badge',
+          },
+          {
+            id: 'skillSetId',
+            type: 'skill-set',
+          },
+        ],
+      });
+
+      return store.createRecord('badge-criterion', {
+        scope: 'SkillSet',
+        threshold: 86,
+        badge: store.peekRecord('badge', 'badgeId'),
+        skillSets: [store.peekRecord('skill-set', 'skillSetId')],
+      });
+    });
+
+    // when
+    const serializedRecord = record.serialize();
+
+    // then
+    assert.deepEqual(serializedRecord, {
+      data: {
+        type: 'badge-criteria',
+        attributes: {
+          scope: 'SkillSet',
+          threshold: 86,
+        },
+        relationships: {
+          'skill-sets': {
+            data: [
+              {
+                id: 'skillSetId',
+                type: 'skill-sets',
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+});

--- a/admin/tests/unit/serializers/skill-set_test.js
+++ b/admin/tests/unit/serializers/skill-set_test.js
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Serializer | SkillSet', function (hooks) {
+  setupTest(hooks);
+
+  test('it serializes records', function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const record = run(() => {
+      store.push({
+        data: [
+          {
+            id: 'badgeId',
+            type: 'badge',
+          },
+        ],
+      });
+
+      return store.createRecord('skill-set', {
+        name: 'SkillSet name',
+        skillIds: ['skillId1', 'skillId2'],
+        badge: store.peekRecord('badge', 'badgeId'),
+      });
+    });
+
+    // when
+    const serializedRecord = record.serialize();
+
+    // then
+    assert.deepEqual(serializedRecord, {
+      data: {
+        type: 'skill-sets',
+        attributes: {
+          name: 'SkillSet name',
+          'skill-ids': ['skillId1', 'skillId2'],
+        },
+      },
+    });
+  });
+});

--- a/api/lib/application/badges/badges-controller.js
+++ b/api/lib/application/badges/badges-controller.js
@@ -14,13 +14,13 @@ module.exports = {
     const badgeId = request.params.id;
     const badgeCriterion = badgeCriteriaSerializer.deserialize(request.payload);
     const savedBadgeCriterion = await usecases.createBadgeCriterion({ badgeId, badgeCriterion });
-    return h.response(badgeCriteriaSerializer.serialize(savedBadgeCriterion));
+    return h.response(badgeCriteriaSerializer.serialize(savedBadgeCriterion)).created();
   },
 
   async createSkillSet(request, h) {
     const badgeId = request.params.id;
     const skillSet = skillSetSerializer.deserialize(request.payload);
     const savedSkillSet = await usecases.createSkillSet({ badgeId, skillSet });
-    return h.response(skillSetSerializer.serialize(savedSkillSet));
+    return h.response(skillSetSerializer.serialize(savedSkillSet)).created();
   },
 };

--- a/api/lib/application/badges/index.js
+++ b/api/lib/application/badges/index.js
@@ -88,7 +88,7 @@ exports.register = async function (server) {
             data: Joi.object({
               attributes: Joi.object({
                 name: Joi.string().required(),
-                skillIds: Joi.array().items(Joi.string()).required(),
+                'skill-ids': Joi.array().items(Joi.string()).required(),
               }).required(),
               type: Joi.string().required(),
             }).required(),

--- a/api/lib/domain/usecases/create-skill-set.js
+++ b/api/lib/domain/usecases/create-skill-set.js
@@ -1,5 +1,5 @@
-module.exports = async function createSkillSet({ badgeId, skillSet, skillSetRepository }) {
-  await skillSetRepository.save({
+module.exports = function createSkillSet({ badgeId, skillSet, skillSetRepository }) {
+  return skillSetRepository.save({
     skillSet: {
       ...skillSet,
       badgeId,

--- a/api/lib/infrastructure/serializers/jsonapi/skill-set-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/skill-set-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
   },
 
   deserialize(skillSetJson) {
-    const { name, skillIds } = skillSetJson.data.attributes;
+    const { name, 'skill-ids': skillIds } = skillSetJson.data.attributes;
     return {
       name,
       skillIds,

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -271,7 +271,7 @@ describe('Acceptance | API | Badges', function () {
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(201);
     });
 
     it('should create a SkillSet criterion and add it to an existing badge', async function () {
@@ -305,7 +305,7 @@ describe('Acceptance | API | Badges', function () {
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(201);
     });
   });
 
@@ -335,7 +335,7 @@ describe('Acceptance | API | Badges', function () {
       // given
       const skillSet = {
         name: 'Mon skillSet',
-        skillIds: ['recSkill1', 'recSkill2'],
+        'skill-ids': ['recSkill1', 'recSkill2'],
       };
 
       options = {
@@ -354,7 +354,7 @@ describe('Acceptance | API | Badges', function () {
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(201);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/badge-criteria-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-criteria-repository_test.js
@@ -10,7 +10,7 @@ describe('Integration | Repository | Badge Criteria Repository', function () {
   });
 
   describe('#save', function () {
-    it('should save badge-criterion', async function () {
+    it('should save CampaignParticipation badge-criterion', async function () {
       // given
       const { id: badgeId } = databaseBuilder.factory.buildBadge();
       await databaseBuilder.commit();

--- a/api/tests/unit/infrastructure/serializers/jsonapi/skill-set-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/skill-set-serializer_test.js
@@ -37,7 +37,7 @@ describe('Unit | Serializer | JSONAPI | skill-set-serializer', function () {
           type: 'skill-sets',
           attributes: {
             name: 'Mon SkillSet',
-            skillIds: ['recSkill1', 'recSkill2'],
+            'skill-ids': ['recSkill1', 'recSkill2'],
           },
         },
       };


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix Admin, sur la création d'un badge, je dois pouvoir créer un nouvel ensemble d'acquis :

 - Pouvoir ajouter une ligne dans la table Skills-set avec une liste d'acquis.
 - Ne pas avoir à saisir les {} à la main…

## :gift: Solution
Adapter l'écran pour permettre l'ajout d'un criteria de type SkillSets avec un seul SkillSet pour le moment.
https://share.goabstract.com/c6eaea93-f791-403e-b407-ff4a5d7cac0e?collectionLayerId=dd8aac4c-9078-43aa-a950-6aeafdcacd0f&mode=design

## :star2: Remarques
Non

## :santa: Pour tester
Se rendre dans pix admin et créer un badge avec un critère sur un ensemble d'acquis.
Vérifier que tout est OK en BdD.
