### PR TITLE
[TECH] Amélioration des transitions dans le flux d'accès campagne (PIX-3888).

### DIFF
--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -50,7 +50,7 @@ export default class FillInCampaignCodeController extends Controller {
       const campaign = await this.store.queryRecord('campaign', {
         filter: { code: campaignCode },
       });
-      this.router.transitionTo('campaigns.entry-point', campaign);
+      this.router.transitionTo('campaigns.entry-point', campaign.code);
     } catch (error) {
       this.onStartCampaignError(error);
     }

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -7,7 +7,7 @@ export default class CampaignLandingPageRoute extends Route {
 
   afterModel(campaign) {
     if (campaign.isForAbsoluteNovice) {
-      return this.replaceWith('campaigns.start-or-resume', campaign.code);
+      this.replaceWith('campaigns.start-or-resume', campaign.code);
     }
   }
 }

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -5,7 +5,7 @@ export default class CampaignLandingPageRoute extends Route {
     return this.modelFor('campaigns');
   }
 
-  redirect(campaign) {
+  afterModel(campaign) {
     if (campaign.isForAbsoluteNovice) {
       return this.replaceWith('campaigns.start-or-resume', campaign);
     }

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -7,7 +7,7 @@ export default class CampaignLandingPageRoute extends Route {
 
   afterModel(campaign) {
     if (campaign.isForAbsoluteNovice) {
-      return this.replaceWith('campaigns.start-or-resume', campaign);
+      return this.replaceWith('campaigns.start-or-resume', campaign.code);
     }
   }
 }

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -22,9 +22,7 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
     if (this.shouldBeginCampaignParticipation(campaign)) {
       await this._beginCampaignParticipation(campaign);
     }
-  }
 
-  redirect(campaign) {
     const hasParticipated = this.campaignStorage.get(campaign.code, 'hasParticipated');
     if (!hasParticipated) {
       return;

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -10,8 +10,9 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
 
   beforeModel(transition) {
     if (!transition.from) {
-      this.replaceWith('campaigns.entry-point');
+      return this.replaceWith('campaigns.entry-point');
     }
+    super.beforeModel(...arguments);
   }
 
   model() {

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -20,7 +20,7 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
   }
 
   async afterModel(campaign) {
-    if (this.shouldBeginCampaignParticipation(campaign)) {
+    if (await this.shouldBeginCampaignParticipation(campaign)) {
       await this._beginCampaignParticipation(campaign);
     }
 
@@ -59,9 +59,14 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
     }
   }
 
-  shouldBeginCampaignParticipation(campaign) {
+  async shouldBeginCampaignParticipation(campaign) {
+    const ongoingCampaignParticipation = await this.store.queryRecord('campaignParticipation', {
+      campaignId: campaign.id,
+      userId: this.currentUser.user.id,
+    });
+    const hasParticipated = Boolean(ongoingCampaignParticipation);
+    this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
     const retry = this.campaignStorage.get(campaign.code, 'retry');
-    const hasParticipated = this.campaignStorage.get(campaign.code, 'hasParticipated');
     return !hasParticipated || (campaign.multipleSendings && retry);
   }
 }

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -30,9 +30,9 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
     }
 
     if (campaign.isProfilesCollection) {
-      this.replaceWith('campaigns.profiles-collection.start-or-resume', campaign);
+      this.replaceWith('campaigns.profiles-collection.start-or-resume', campaign.code);
     } else {
-      this.replaceWith('campaigns.assessment.start-or-resume', campaign);
+      this.replaceWith('campaigns.assessment.start-or-resume', campaign.code);
     }
   }
 
@@ -52,7 +52,7 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
 
       if (error.status == 400 && error.detail.includes('participant-external-id')) {
         this.campaignStorage.set(campaign.code, 'participantExternalId', null);
-        return this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign);
+        return this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
       }
 
       throw err;

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -34,11 +34,11 @@ export default class EntryPoint extends Route {
     }
 
     if (campaign.isArchived && !hasParticipated) {
-      this.replaceWith('campaigns.campaign-not-found', campaign);
+      this.replaceWith('campaigns.campaign-not-found', campaign.code);
     } else if (hasParticipated) {
-      this.replaceWith('campaigns.entrance', campaign);
+      this.replaceWith('campaigns.entrance', campaign.code);
     } else {
-      this.replaceWith('campaigns.campaign-landing-page', campaign);
+      this.replaceWith('campaigns.campaign-landing-page', campaign.code);
     }
   }
 }

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -11,11 +11,9 @@ export default class EntryPoint extends Route {
     return this.modelFor('campaigns');
   }
 
-  afterModel(campaign) {
+  async afterModel(campaign, transition) {
     this.campaignStorage.clear(campaign.code);
-  }
 
-  async redirect(campaign, transition) {
     const queryParams = transition.to.queryParams;
     if (queryParams.participantExternalId) {
       this.campaignStorage.set(campaign.code, 'participantExternalId', transition.to.queryParams.participantExternalId);

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -7,8 +7,9 @@ export default class InvitedRoute extends Route.extend(SecuredRouteMixin) {
 
   beforeModel(transition) {
     if (!transition.from) {
-      this.replaceWith('campaigns.entry-point');
+      return this.replaceWith('campaigns.entry-point');
     }
+    super.beforeModel(...arguments);
   }
 
   model() {

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -15,7 +15,7 @@ export default class InvitedRoute extends Route.extend(SecuredRouteMixin) {
     return this.modelFor('campaigns');
   }
 
-  redirect(campaign) {
+  afterModel(campaign) {
     if (this.shouldAssociateWithScoInformation(campaign)) {
       return this.replaceWith('campaigns.invited.student-sco', campaign);
     }

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -18,14 +18,12 @@ export default class InvitedRoute extends Route.extend(SecuredRouteMixin) {
 
   afterModel(campaign) {
     if (this.shouldAssociateWithScoInformation(campaign)) {
-      return this.replaceWith('campaigns.invited.student-sco', campaign.code);
+      this.replaceWith('campaigns.invited.student-sco', campaign.code);
+    } else if (this.shouldAssociateWithSupInformation(campaign)) {
+      this.replaceWith('campaigns.invited.student-sup', campaign.code);
+    } else {
+      this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
-
-    if (this.shouldAssociateWithSupInformation(campaign)) {
-      return this.replaceWith('campaigns.invited.student-sup', campaign.code);
-    }
-
-    return this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
   }
 
   shouldAssociateWithScoInformation(campaign) {

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -18,14 +18,14 @@ export default class InvitedRoute extends Route.extend(SecuredRouteMixin) {
 
   afterModel(campaign) {
     if (this.shouldAssociateWithScoInformation(campaign)) {
-      return this.replaceWith('campaigns.invited.student-sco', campaign);
+      return this.replaceWith('campaigns.invited.student-sco', campaign.code);
     }
 
     if (this.shouldAssociateWithSupInformation(campaign)) {
-      return this.replaceWith('campaigns.invited.student-sup', campaign);
+      return this.replaceWith('campaigns.invited.student-sup', campaign.code);
     }
 
-    return this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign);
+    return this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
   }
 
   shouldAssociateWithScoInformation(campaign) {

--- a/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -11,7 +11,7 @@ export default class FillInParticipantExternalIdRoute extends Route.extend(Secur
 
   afterModel(campaign) {
     if (!this.shouldProvideExternalId(campaign)) {
-      return this.replaceWith('campaigns.entrance', campaign.code);
+      this.replaceWith('campaigns.entrance', campaign.code);
     }
   }
 

--- a/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -9,7 +9,7 @@ export default class FillInParticipantExternalIdRoute extends Route.extend(Secur
     return this.modelFor('campaigns');
   }
 
-  redirect(campaign) {
+  afterModel(campaign) {
     if (!this.shouldProvideExternalId(campaign)) {
       return this.replaceWith('campaigns.entrance', campaign);
     }

--- a/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -11,7 +11,7 @@ export default class FillInParticipantExternalIdRoute extends Route.extend(Secur
 
   afterModel(campaign) {
     if (!this.shouldProvideExternalId(campaign)) {
-      return this.replaceWith('campaigns.entrance', campaign);
+      return this.replaceWith('campaigns.entrance', campaign.code);
     }
   }
 

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -121,17 +121,17 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
 
   _redirectToPoleEmploiLoginPage(transition) {
     this.session.set('attemptedTransition', transition);
-    return this.transitionTo('login-pe');
+    return this.replaceWith('login-pe');
   }
 
   _redirectToTermsOfServicesBeforeAccessingToCampaign(transition) {
     this.session.set('attemptedTransition', transition);
-    return this.transitionTo('terms-of-service');
+    return this.replaceWith('terms-of-service');
   }
 
   _redirectToLoginBeforeAccessingToCampaign(transition, campaign, displayRegisterForm) {
     this.session.set('attemptedTransition', transition);
-    return this.transitionTo('campaigns.restricted.login-or-register-to-access', campaign.code, {
+    return this.replaceWith('campaigns.restricted.login-or-register-to-access', campaign.code, {
       queryParams: { displayRegisterForm },
     });
   }

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -67,9 +67,10 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
 
     if (hasParticipated) {
-      return this.replaceWith('campaigns.entrance', campaign.code);
+      this.replaceWith('campaigns.entrance', campaign.code);
+    } else {
+      this.replaceWith('campaigns.invited', campaign.code);
     }
-    return this.replaceWith('campaigns.invited', campaign.code);
   }
 
   _resetState() {

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -54,7 +54,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     super.beforeModel(...arguments);
   }
 
-  async model() {
+  model() {
     return this.modelFor('campaigns');
   }
 
@@ -65,10 +65,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     });
     const hasParticipated = Boolean(ongoingCampaignParticipation);
     this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
-  }
 
-  redirect(campaign) {
-    const hasParticipated = this.campaignStorage.get(campaign.code, 'hasParticipated');
     if (hasParticipated) {
       return this.replaceWith('campaigns.entrance', campaign);
     }

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -37,7 +37,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     }
 
     if (this._shouldJoinFromMediacentre) {
-      return this.replaceWith('campaigns.restricted.join-from-mediacentre', campaign);
+      return this.replaceWith('campaigns.restricted.join-from-mediacentre', campaign.code);
     }
 
     if (this._shouldDisconnectAnonymousUser) {
@@ -67,9 +67,9 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
 
     if (hasParticipated) {
-      return this.replaceWith('campaigns.entrance', campaign);
+      return this.replaceWith('campaigns.entrance', campaign.code);
     }
-    return this.replaceWith('campaigns.invited', campaign);
+    return this.replaceWith('campaigns.invited', campaign.code);
   }
 
   _resetState() {

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
@@ -27,7 +27,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
   });
 
   describe('#startCampaign', () => {
-    it('should call start-or-resume', async () => {
+    it('should call entry-point', async () => {
       // given
       const campaignCode = 'azerty1';
       const campaign = Symbol('someCampaign');
@@ -44,7 +44,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       await controller.actions.startCampaign.call(controller, eventStub);
 
       // then
-      sinon.assert.calledWith(controller.router.transitionTo, 'campaigns.entry-point', campaign);
+      sinon.assert.calledWith(controller.router.transitionTo, 'campaigns.entry-point', campaign.code);
     });
 
     it('should set error when campaign code is empty', async () => {

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -129,7 +129,7 @@ describe('Unit | Route | Entrance', function () {
 
       //then
       sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', null);
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign);
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign.code);
     });
 
     it('should redirect to profiles-collection when campaign is of type PROFILES COLLECTION', async function () {

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -47,7 +47,8 @@ describe('Unit | Route | Entrance', function () {
     let campaignParticipationStub;
     beforeEach(function () {
       campaignParticipationStub = { save: sinon.stub(), deleteRecord: sinon.stub() };
-      route.store = { createRecord: sinon.stub().returns(campaignParticipationStub) };
+      route.store = { createRecord: sinon.stub().returns(campaignParticipationStub), queryRecord: sinon.stub() };
+      route.currentUser = { user: {} };
     });
 
     it('should save new campaign participation', async function () {
@@ -85,7 +86,7 @@ describe('Unit | Route | Entrance', function () {
       campaign = EmberObject.create({
         code: 'SOMECODE',
       });
-      route.campaignStorage.get.withArgs(campaign.code, 'hasParticipated').returns(true);
+      route.store.queryRecord.resolves({});
 
       //when
       await route.afterModel(campaign);

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -130,9 +130,7 @@ describe('Unit | Route | Entrance', function () {
       sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', null);
       sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign);
     });
-  });
 
-  describe('#redirect', function () {
     it('should redirect to profiles-collection when campaign is of type PROFILES COLLECTION', async function () {
       //given
       campaign = EmberObject.create({
@@ -142,7 +140,7 @@ describe('Unit | Route | Entrance', function () {
       route.campaignStorage.get.withArgs(campaign.code, 'hasParticipated').returns(true);
 
       //when
-      await route.redirect(campaign);
+      await route.afterModel(campaign);
 
       //then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.profiles-collection.start-or-resume');
@@ -157,7 +155,7 @@ describe('Unit | Route | Entrance', function () {
       route.campaignStorage.get.withArgs(campaign.code, 'hasParticipated').returns(true);
 
       //when
-      await route.redirect(campaign);
+      await route.afterModel(campaign);
 
       //then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.assessment.start-or-resume');

--- a/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
@@ -32,19 +32,17 @@ describe('Unit | Route | Entry Point', function () {
   });
 
   describe('#afterModel', function () {
-    it('should erase campaign storage', async function () {
-      //given/when
-      await route.afterModel({ code: 'CODE' });
-
-      //then
-      sinon.assert.calledWith(route.campaignStorage.clear, 'CODE');
-    });
-  });
-
-  describe('#redirect', function () {
     let transition;
     beforeEach(function () {
       transition = { to: { queryParams: {} } };
+    });
+
+    it('should erase campaign storage', async function () {
+      //given/when
+      await route.afterModel({ code: 'CODE' }, transition);
+
+      //then
+      sinon.assert.calledWith(route.campaignStorage.clear, 'CODE');
     });
 
     describe('user not connected', function () {
@@ -55,7 +53,7 @@ describe('Unit | Route | Entry Point', function () {
 
       it('should not call queryRecord to retrieve campaignParticipation', async function () {
         //when
-        await route.redirect(campaign, transition);
+        await route.afterModel(campaign, transition);
 
         //then
         sinon.assert.notCalled(route.store.queryRecord);
@@ -63,7 +61,7 @@ describe('Unit | Route | Entry Point', function () {
 
       it('should redirect to landing page', async function () {
         //when
-        await route.redirect(campaign, transition);
+        await route.afterModel(campaign, transition);
 
         //then
         sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-landing-page');
@@ -76,7 +74,7 @@ describe('Unit | Route | Entry Point', function () {
 
         it('should redirect to not-found page', async function () {
           //when
-          await route.redirect(campaign, transition);
+          await route.afterModel(campaign, transition);
 
           //then
           sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-not-found');
@@ -92,7 +90,7 @@ describe('Unit | Route | Entry Point', function () {
 
       it('should call queryRecord to retrieve campaignParticipation', async function () {
         //when
-        await route.redirect(campaign, transition);
+        await route.afterModel(campaign, transition);
 
         //then
         sinon.assert.calledWith(route.store.queryRecord, 'campaignParticipation', {
@@ -111,7 +109,7 @@ describe('Unit | Route | Entry Point', function () {
           .resolves(null);
 
         //when
-        await route.redirect(campaign, transition);
+        await route.afterModel(campaign, transition);
 
         //then
         sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-landing-page');
@@ -127,7 +125,7 @@ describe('Unit | Route | Entry Point', function () {
           .resolves('Ma Participation');
 
         //when
-        await route.redirect(campaign, transition);
+        await route.afterModel(campaign, transition);
 
         //then
         sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance');
@@ -148,7 +146,7 @@ describe('Unit | Route | Entry Point', function () {
             .resolves(null);
 
           //when
-          await route.redirect(campaign, transition);
+          await route.afterModel(campaign, transition);
 
           //then
           sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-not-found');
@@ -164,7 +162,7 @@ describe('Unit | Route | Entry Point', function () {
             .resolves('Ma Participation');
 
           //when
-          await route.redirect(campaign, transition);
+          await route.afterModel(campaign, transition);
 
           //then
           sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance');
@@ -184,7 +182,7 @@ describe('Unit | Route | Entry Point', function () {
           };
 
           //when
-          await route.redirect(campaign, transition);
+          await route.afterModel(campaign, transition);
 
           //then
           sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', 'externalId');
@@ -202,7 +200,7 @@ describe('Unit | Route | Entry Point', function () {
           };
 
           //when
-          await route.redirect(campaign, transition);
+          await route.afterModel(campaign, transition);
 
           //then
           sinon.assert.notCalled(route.campaignStorage.set);
@@ -222,7 +220,7 @@ describe('Unit | Route | Entry Point', function () {
           };
 
           //when
-          await route.redirect(campaign, transition);
+          await route.afterModel(campaign, transition);
 
           //then
           sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'retry', 'true');
@@ -240,7 +238,7 @@ describe('Unit | Route | Entry Point', function () {
           };
 
           //when
-          await route.redirect(campaign, transition);
+          await route.afterModel(campaign, transition);
 
           //then
           sinon.assert.notCalled(route.campaignStorage.set);

--- a/mon-pix/tests/unit/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -25,7 +25,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
     });
   });
 
-  describe('#redirect', function () {
+  describe('#afterModel', function () {
     it('should redirect to entrance page if an external id is already set', async function () {
       //given
       campaign = EmberObject.create({
@@ -34,7 +34,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
       route.campaignStorage.get.withArgs(campaign.code, 'participantExternalId').returns('someID');
 
       //when
-      await route.redirect(campaign);
+      await route.afterModel(campaign);
 
       //then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance', campaign);
@@ -48,7 +48,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
       route.campaignStorage.get.withArgs(campaign.code, 'participantExternalId').returns(null);
 
       //when
-      await route.redirect(campaign);
+      await route.afterModel(campaign);
 
       //then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance', campaign);
@@ -62,7 +62,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
       route.campaignStorage.get.withArgs(campaign.code, 'participantExternalId').returns(null);
 
       //when
-      await route.redirect(campaign);
+      await route.afterModel(campaign);
 
       //then
       sinon.assert.notCalled(route.replaceWith);

--- a/mon-pix/tests/unit/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -37,7 +37,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance', campaign);
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance', campaign.code);
     });
 
     it('should redirect to entrance page if an external id is not required', async function () {
@@ -51,7 +51,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance', campaign);
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance', campaign.code);
     });
 
     it('should not redirect if an external id is required and not already set', async function () {

--- a/mon-pix/tests/unit/routes/campaigns/invited_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited_test.js
@@ -56,7 +56,7 @@ describe('Unit | Route | Invited', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.student-sco', campaign);
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.student-sco', campaign.code);
     });
 
     it('should redirect to student sup invited page when association is needed', async function () {
@@ -71,7 +71,7 @@ describe('Unit | Route | Invited', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.student-sup', campaign);
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.student-sup', campaign.code);
     });
 
     it('should redirect to fill in participant external otherwise', async function () {
@@ -85,7 +85,7 @@ describe('Unit | Route | Invited', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign);
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign.code);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/invited_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited_test.js
@@ -43,7 +43,7 @@ describe('Unit | Route | Invited', function () {
     });
   });
 
-  describe('#redirect', function () {
+  describe('#afterModel', function () {
     it('should redirect to student sco invited page when association is needed', async function () {
       //given
       campaign = EmberObject.create({
@@ -53,7 +53,7 @@ describe('Unit | Route | Invited', function () {
       route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
 
       //when
-      await route.redirect(campaign);
+      await route.afterModel(campaign);
 
       //then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.student-sco', campaign);
@@ -68,7 +68,7 @@ describe('Unit | Route | Invited', function () {
       route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
 
       //when
-      await route.redirect(campaign);
+      await route.afterModel(campaign);
 
       //then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.student-sup', campaign);
@@ -82,7 +82,7 @@ describe('Unit | Route | Invited', function () {
       route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
 
       //when
-      await route.redirect(campaign);
+      await route.afterModel(campaign);
 
       //then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign);


### PR DESCRIPTION
## :christmas_tree: Problème
La gestion de redirection avec ember est compliquée. Il existe de nombreux cas particuliers à prendre en compte. Le tunnel d'accès aux campagnes est compliqué et l'utilisation de certaines features de ember rendent compliqué la compréhension de ce qui se passe réellement.

## :gift: Solution
On souhaite reposer sur des fonctionnalités de Ember qui aide à rendre le code plus prédictible : 
- Déplacement du code des hooks **redirect** vers **afterModel** lorsqu'il n'est pas néccessaire d'attendre que la transition soit complétée.
- Ajout de l'appel à super.beforeModel lorsqu'on hérite de la mixin d'authentification et que le hook beforeModel est surchargé
- Récupération du model de campagne participation lorsqu'on en a besoin plutôt que de la reposer sur le store (au risque d'avoir une information périmée)
- Remplacement des transitionTo par des replaceWith lorsqu'il n'est pas pertinent de garder une page dans l'historique de navigation (potentiellement source d'erreur si un utilisateur navigue dans son historique)
- Suppression des return dans les hooks qui peuvent provoquer une attente non désiré lors d'une nouvelle transition

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Tester l'ensemble des cas d'accès aux campagnes
