### PR TITLE
[BUGFIX] Remettre le chargement entre les pages du flux d'accès campagne (PIX-3889).

### DIFF
--- a/mon-pix/app/templates/assessments/loading.hbs
+++ b/mon-pix/app/templates/assessments/loading.hbs
@@ -1,0 +1,1 @@
+<Loader @loaderText={{t "common.loading.default"}} />

--- a/mon-pix/app/templates/campaigns/invited/loading.hbs
+++ b/mon-pix/app/templates/campaigns/invited/loading.hbs
@@ -1,0 +1,1 @@
+<Loader @loaderText={{t "common.loading.default"}} />

--- a/mon-pix/app/templates/campaigns/loading.hbs
+++ b/mon-pix/app/templates/campaigns/loading.hbs
@@ -1,0 +1,1 @@
+<Loader @loaderText={{t "common.loading.default"}} />


### PR DESCRIPTION
## :christmas_tree: Problème
Visuellement, une fois qu'on était dans le flux d'accès campagne, on ne voyait plus aucun template de chargement. Le problème venait du fait que dans des transitions filles (exemple : de `campaigns.presentation` vers `campaigns.startOrResume`), Ember ne va pas chercher le template de loading général mais cherche un template de loading `campaigns.loading`. En son absence, il affiche la page d'avant jusqu'à ce que `beforeModel`, `model` et `afterModel` aient finis de s'exécuter.

cf la doc : https://guides.emberjs.com/release/routing/loading-and-error-substates/
et plus particulièrement ce texte :
![image](https://user-images.githubusercontent.com/23451175/143012218-33c55c83-96e6-41de-a30c-2c618e75bbd2.png)

## :gift: Solution
Ajouter un template de loading là où il y a des transitions entre pages filles.

## :star2: Remarques
Peut-être qu'ailleurs dans l'application il en faut également.

## :santa: Pour tester
Lancer le flux d'accès campagne, et vérifier qu'on voit le template de chargement.
