### PR TITLE
[FEATURE] Passer en "résolu" les signalements des anciennes sessions (PIX-2641).

### DIFF
--- a/api/db/migrations/20211123133135_resole-existing-certification-issue-reports.js
+++ b/api/db/migrations/20211123133135_resole-existing-certification-issue-reports.js
@@ -1,0 +1,15 @@
+exports.up = async function(knex) {
+  await knex.raw(`UPDATE "certification-issue-reports"
+                  SET  "resolvedAt" = NOW()
+                  WHERE id IN
+                  (
+                      SELECT r.id FROM "certification-issue-reports" r
+                          INNER JOIN "certification-courses" c ON c.id = r."certificationCourseId"
+                          INNER JOIN "sessions" s ON s.id = c."sessionId"
+                      WHERE 1=1
+                        AND s."finalizedAt" IS NOT NULL
+                        AND r."resolvedAt" IS NULL
+                  )`);
+};
+
+exports.down = function() {};


### PR DESCRIPTION
## :christmas_tree: Problème
Le champ "certification-issue-reports"."resolvedAt" est alimenté pour les sessions finalisées (dans quelle PR ?).
Or, cette fonctionnalité a été introduite alors que des données étaient déjà présentes, pour lesquelles "resolvedAt" est NULL  
La volumétrie est d'environ 10 000 enregistrements en production.

## :gift: Solution
Alimenter ces données par migration ( < 20 minutes, sujette à deadlock)

## :star2: Remarques
Testés en `datawarehouse-production` avec ROLLBACK: < 5 secondes

## :santa: Pour tester

### Exécuter la migration
Se positionner sur la dernière version
` git checkout v3.131.0 `

Créer la BDD et les seeds
`npm run db:reset`

L'instruction SQL doit renvoyer des enregistrements
```sql
SELECT COUNT(1)
FROM "certification-issue-reports" r
	INNER JOIN "certification-courses" c ON c.id = r."certificationCourseId"
	INNER JOIN "sessions" s ON s.id = c."sessionId"
WHERE 1=1 
	AND s."finalizedAt" IS NOT NULL 
	AND r."resolvedAt" IS NULL;
```

Se positionner sur la branche
`git checkout pix-2641-resolve-existing-sessions-reports `

Exécuter la migratiobn
`npm run db:migrate`

L'instruction SQL ne doit rien renvoyer
```sql
SELECT COUNT(1)
FROM "certification-issue-reports" r
	INNER JOIN "certification-courses" c ON c.id = r."certificationCourseId"
	INNER JOIN "sessions" s ON s.id = c."sessionId"
WHERE 1=1 
	AND s."finalizedAt" IS NOT NULL 
	AND r."resolvedAt" IS NULL;
```

