### PR TITLE
[BUGFIX] Vérifier l'existence du contexte async local storage avant de tracer les métriques.

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -17,8 +17,8 @@ function logObjectSerializer(req) {
   return {
     ...enhancedReq,
     user_id: monitoringTools.extractUserIdFromRequest(req),
-    metrics: context.metrics,
-    route: context.request.route.path,
+    metrics: context?.metrics,
+    route: context?.request?.route?.path,
   };
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à un refacto du monitoring des métriques. On avait enlevé la vérification du contexte car il est censé être présent à chaque appel API. 

````
function logObjectSerializer(req) {
  const enhancedReq = {
    ...req,
    version: settings.version,
  };

  if (!settings.hapi.enableRequestMonitoring) return enhancedReq;
  const context = monitoringTools.getContext();

  return {
    ...enhancedReq,
    user_id: monitoringTools.extractUserIdFromRequest(req),
    metrics: context.metrics,
    route: context.request.route.path,
  };
}
````
Or en recette, on rencontre l'erreur ci-dessous:

TypeError: Cannot read property 'metrics' of undefined

https://1024pix.slack.com/archives/CPCDSA69W/p1637665318001500

## :gift: Solution
Remettre la vérification du contexte avant de tracer les métriques.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_
Sentry indique que c'est lié au démarrage du serveur.

## :santa: Pour tester
Activer la variable enableRequestMonitoring=true et verifier que l'erreur ne se reproduit plus 