### PR TITLE
[FEAT] Ajout d'une colonne 'Lacune' dans le tableau d'affichage des RT (PIX-3574).

### DIFF
--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -8,6 +8,7 @@
           <th class="badges-table__key">Clé</th>
           <th class="badges-table__name">Nom</th>
           <th>Message</th>
+          <th>Toujours visible</th>
           <th class="badges-table__actions">Actions</th>
         </tr>
       </thead>
@@ -19,6 +20,7 @@
             <td>{{badge.key}}</td>
             <td>{{badge.title}}</td>
             <td>{{badge.message}}</td>
+            <td>{{if badge.isAlwaysVisible "Oui" "Non"}}</td>
             <td>
               <PixButtonLink
                 @backgroundColor="transparent-light"

--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -8,7 +8,7 @@
           <th class="badges-table__key">Clé</th>
           <th class="badges-table__name">Nom</th>
           <th>Message</th>
-          <th>Toujours visible</th>
+          <th class="badges-table__shortcoming">Lacune</th>
           <th class="badges-table__actions">Actions</th>
         </tr>
       </thead>
@@ -20,7 +20,9 @@
             <td>{{badge.key}}</td>
             <td>{{badge.title}}</td>
             <td>{{badge.message}}</td>
-            <td>{{if badge.isAlwaysVisible "Oui" "Non"}}</td>
+            <td>
+              <Common::TickOrCross @isTrue={{badge.isAlwaysVisible}} />
+            </td>
             <td>
               <PixButtonLink
                 @backgroundColor="transparent-light"

--- a/admin/app/styles/components/target-profiles/badges.scss
+++ b/admin/app/styles/components/target-profiles/badges.scss
@@ -20,7 +20,8 @@
     }
   }
 
-  &__actions {
+  &__actions,
+  &__shortcoming {
     width: 140px;
   }
 }

--- a/admin/tests/integration/components/target-profiles/badges_test.js
+++ b/admin/tests/integration/components/target-profiles/badges_test.js
@@ -16,6 +16,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
       message: 'My message',
       imageUrl: 'data:,',
       altMessage: 'My alt message',
+      isAlwaysVisible: true,
     });
     this.set('badges', [badge]);
 
@@ -31,6 +32,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
     assert.contains('Clé');
     assert.contains('Nom');
     assert.contains('Message');
+    assert.contains('Toujours visible');
     assert.contains('Actions');
     assert.dom('tbody tr').exists({ count: 1 });
     assert.equal(find('tbody tr td:first-child').textContent, '1');
@@ -40,6 +42,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
     assert.contains('My key');
     assert.contains('My title');
     assert.contains('My message');
+    assert.contains('Oui');
     assert.contains('Voir détail');
     assert.notContains('Aucun résultat thématique associé');
   });

--- a/admin/tests/integration/components/target-profiles/badges_test.js
+++ b/admin/tests/integration/components/target-profiles/badges_test.js
@@ -16,7 +16,6 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
       message: 'My message',
       imageUrl: 'data:,',
       altMessage: 'My alt message',
-      isAlwaysVisible: true,
     });
     this.set('badges', [badge]);
 
@@ -32,7 +31,6 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
     assert.contains('Clé');
     assert.contains('Nom');
     assert.contains('Message');
-    assert.contains('Toujours visible');
     assert.contains('Actions');
     assert.dom('tbody tr').exists({ count: 1 });
     assert.equal(find('tbody tr td:first-child').textContent, '1');
@@ -42,7 +40,6 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
     assert.contains('My key');
     assert.contains('My title');
     assert.contains('My message');
-    assert.contains('Oui');
     assert.contains('Voir détail');
     assert.notContains('Aucun résultat thématique associé');
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Nous souhaitons savoir si un RT est une lacune ou non.

## :gift: Solution

Ajout d'une colonne dans le tableau d'affichage des RT dans la catégorie `profil cible` de l'application.

## :star2: Remarques

Nous divergeons au niveau du nommage entre `isAlwaysVisible` et `Lacune` (que je me suis tenté à traduire par `deficiency`, ouvert aux propositions)
Je propose de renommer la propriété isAlwaysVisible en BDD dans une PR ulterieure afin de s'aligner sur les termes.

Dans le deuxieme commit, des modifications de style ont été apportées avec l'arrivée de `tick` et `croix` en lieu et place de `Oui` et `Non` dans les cellules du tableau, rendant les tests moins aisés. Preneur d'aide sur ce sujet.

## :santa: Pour tester

Se rendre sur le profil cible Pix+Droit, vérifier des deux résultats dans la nouvelle colonne en fonction de la propriété `isAlwaysVisible` du RT en BDD.
