### PR TITLE
[FEATURE] Désactive les boutons quand les champs sont vide lors du rattachement des organisations (PIX-3771).

### DIFF
--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -11,7 +11,12 @@
           aria-describedby="attach-organizations-info"
         />
         <p id="attach-organizations-info" hidden>Ids des organisations, séparés par une virgule</p>
-        <PixButton @type="submit" @size="small" aria-label="Valider le rattachement">
+        <PixButton
+          @type="submit"
+          @size="small"
+          aria-label="Valider le rattachement"
+          @isDisabled={{this.isDisabledAttachOrganizations}}
+        >
           Valider
         </PixButton>
       </div>
@@ -29,7 +34,12 @@
           aria-describedby="attach-organizations-from-existing-target-profile-info"
         />
         <p id="attach-organizations-from-existing-target-profile-info" hidden>Id du profil cible existant</p>
-        <PixButton @type="submit" @size="small" aria-label="Valider le rattachement à partir de ce profil cible">
+        <PixButton
+          @type="submit"
+          @size="small"
+          aria-label="Valider le rattachement à partir de ce profil cible"
+          @isDisabled={{this.isDisabledAttachOrganizationsFromExistingTargetProfile}}
+        >
           Valider
         </PixButton>
       </div>

--- a/admin/app/components/target-profiles/organizations.js
+++ b/admin/app/components/target-profiles/organizations.js
@@ -9,19 +9,29 @@ export default class Organizations extends Component {
   @service notifications;
   @service router;
 
-  @tracked organizationsToAttach = [];
-  @tracked existingTargetProfile = null;
+  @tracked organizationsToAttach = '';
+  @tracked existingTargetProfile = '';
+
+  get isDisabledAttachOrganizationsFromExistingTargetProfile() {
+    return this.existingTargetProfile === '';
+  }
+
+  get isDisabledAttachOrganizations() {
+    return this.organizationsToAttach === '';
+  }
 
   @action
   async attachOrganizations(e) {
     e.preventDefault();
+    if (this.isDisabledAttachOrganizations) return;
+
     const targetProfile = this.args.targetProfile;
     try {
       const response = await targetProfile.attachOrganizations({ 'organization-ids': this._getUniqueOrganizations() });
 
       const { 'attached-ids': attachedIds, 'duplicated-ids': duplicatedIds } = response.data.attributes;
 
-      this.organizationsToAttach = null;
+      this.organizationsToAttach = '';
       const hasInsertedOrganizations = attachedIds.length > 0;
       const hasDuplicatedOrgnizations = duplicatedIds.length > 0;
       const message = [];
@@ -51,12 +61,14 @@ export default class Organizations extends Component {
   @action
   async attachOrganizationsFromExistingTargetProfile(e) {
     e.preventDefault();
+    if (this.isDisabledAttachOrganizationsFromExistingTargetProfile) return;
+
     const targetProfile = this.args.targetProfile;
     try {
       await targetProfile.attachOrganizationsFromExistingTargetProfile({
         'target-profile-id': this.existingTargetProfile,
       });
-      this.existingTargetProfile = null;
+      this.existingTargetProfile = '';
       await this.notifications.success('Organisation(s) rattaché(es) avec succès.');
       return this.router.replaceWith('authenticated.target-profiles.target-profile.organizations');
     } catch (responseError) {

--- a/admin/tests/integration/components/target-profiles/organizations_test.js
+++ b/admin/tests/integration/components/target-profiles/organizations_test.js
@@ -91,4 +91,20 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
 
     assert.dom('[placeholder="1135"]').hasValue('1');
   });
+
+  test('it should disable buttons when the inputs are empty', async function (assert) {
+    // given
+    const organizations = [];
+    organizations.meta = { page: 1, pageSize: 1 };
+    this.organizations = [];
+
+    // when
+    await render(
+      hbs`<TargetProfiles::Organizations @organizations={{this.organizations}} @goToOrganizationPage={{this.goToOrganizationPage}} @triggerFiltering={{this.triggerFiltering}} />`
+    );
+
+    // then
+    assert.dom('[aria-label="Valider le rattachement"]').isDisabled();
+    assert.dom('[aria-label="Valider le rattachement à partir de ce profil cible"]').isDisabled();
+  });
 });

--- a/admin/tests/unit/components/target-profiles/organizations_test.js
+++ b/admin/tests/unit/components/target-profiles/organizations_test.js
@@ -36,7 +36,7 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
         await component.attachOrganizations(event);
 
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
-        assert.equal(component.organizationsToAttach, null);
+        assert.equal(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith('Organisation(s) rattaché(es) avec succès.', { htmlContent: true })
         );
@@ -61,7 +61,7 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
         await component.attachOrganizations(event);
 
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1] }));
-        assert.equal(component.organizationsToAttach, null);
+        assert.equal(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith(
             'Le(s) organisation(s) suivantes étai(en)t déjà rattachée(s) à ce profil cible : 1',
@@ -89,7 +89,7 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
         await component.attachOrganizations(event);
 
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
-        assert.equal(component.organizationsToAttach, null);
+        assert.equal(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith(
             'Organisation(s) rattaché(es) avec succès.<br/>Le(s) organisation(s) suivantes étai(en)t déjà rattachée(s) à ce profil cible : 1',
@@ -119,7 +119,7 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
         await component.attachOrganizations(event);
 
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2, 3] }));
-        assert.equal(component.organizationsToAttach, null);
+        assert.equal(component.organizationsToAttach, '');
         assert.ok(
           component.router.replaceWith.calledWith('authenticated.target-profiles.target-profile.organizations')
         );
@@ -224,7 +224,7 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
             'target-profile-id': 1,
           })
         );
-        assert.equal(component.existingTargetProfile, null);
+        assert.equal(component.existingTargetProfile, '');
         assert.ok(component.notifications.success.calledWith('Organisation(s) rattaché(es) avec succès.'));
         assert.ok(
           component.router.replaceWith.calledWith('authenticated.target-profiles.target-profile.organizations')


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à la PR #3659 le comportement des champs pour rattacher des organisations à des profils cible n'est pas le même en fonction de si on part de la page d'organisation ou de celle du profil cible.

## :gift: Solution
On uniforme le comportement des champs sur la page profil cible dans la section "Organisations". A présent les boutons sont disabled si les champs sont vide. Lorsqu'on utilise la touche Enter il ne se passe rien si les champs sont vides. Précédemment ça déclenchait une erreur.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter sur pix admin en RA
- Aller dans un profil cible sur l'onglet Organisations
- Constater que les boutons sont disabled
- Constater qu'il ne se passe rien si on appuie sur Enter dans les champs vides
