### PR TITLE
[TECH] Empêcher la suppression de BDD sur Scalingo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,8 +261,6 @@ jobs:
       - run:
           name: Install Pix API
           working_directory: ~/pix/api
-          environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npm ci
 
       - run:
@@ -339,7 +337,7 @@ jobs:
           command: npm start
 
       - run:
-          name: Test
+          name: Run tests
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npm run test:ci

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -3,6 +3,19 @@ const logger = require('../../lib/infrastructure/logger');
 const PgClient = require('../PgClient');
 const { PGSQL_NON_EXISTENT_DATABASE_ERROR } = require('../../db/pgsql-errors');
 
+function isPlatformScalingo() {
+  return Boolean(process.env.CONTAINER);
+}
+
+function preventDatabaseDropAsItCannotBeCreatedAgain() {
+  if (isPlatformScalingo()) {
+    logger.error('Database will not be dropped, as it would require to recreate the addon');
+    process.exit(1);
+  }
+}
+
+preventDatabaseDropAsItCannotBeCreatedAgain();
+
 const dbUrl = process.env.NODE_ENV === 'test' ? process.env.TEST_DATABASE_URL : process.env.DATABASE_URL;
 
 const url = new URL(dbUrl);


### PR DESCRIPTION
## :christmas_tree: Problème
Scalingo autorise la suppression de l'instance de BDD (`DROP DATABASE`) mais ne permet pas la recréation.
En effet, le nom de la BDD fait partie de la connectstring `SCALINGO_POSTGRESQL_URL` utilisée par défaut

## :gift: Solution
Ne pas supprimer la BDD lorsqu'on est sur Scalingo, voir https://github.com/1024pix/pix/pull/3730#discussion_r756264718

## :star2: Remarques
Une fois mergée, il sera possible de rajouter l'option `WITH FORCE`, voir #2164 

## :santa: Pour tester
Exécuter en local `npm run db:reset`, vérier la fin avec succès
Exécuter en local `CONTAINER=foo npm run db:reset`
Vérifier la fin avec erreur et le message
``` shell
❯ npm run db:reset

> npm run db:prepare && npm run db:seed
> npm run db:delete && npm run db:create && npm run db:migrate
> node scripts/database/drop-database

[11:51:23] ERROR: Database will not be dropped, as it cannot be created again
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! pix-api@3.130.0 db:delete: `node scripts/database/drop-database`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the pix-api@3.130.0 db:delete script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

```

Exécuter en RA ` scalingo --region osc-fr1 --app pix-api-review-pr3770 run "npm run db:reset"`
Vérifier la fin avec erreur et le message