### PR TITLE
[FEATURE] Rattacher un membre au centre de certification correspondant lorsqu'il accepte l'invitation à rejoindre une organisation (PIX-3852).

### DIFF
--- a/api/lib/application/organization-invitations/organization-invitation-controller.js
+++ b/api/lib/application/organization-invitations/organization-invitation-controller.js
@@ -11,7 +11,8 @@ module.exports = {
     const organizationInvitationId = request.params.id;
     const { code, email } = request.payload.data.attributes;
 
-    await usecases.acceptOrganizationInvitation({ organizationInvitationId, code, email });
+    const membership = await usecases.acceptOrganizationInvitation({ organizationInvitationId, code, email });
+    await usecases.createCertificationCenterMembershipForScoOrganizationMember({ membership });
     return null;
   },
 

--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -32,6 +32,8 @@ module.exports = async function acceptOrganizationInvitation({
     const existingMembership = memberships.find((membership) => membership.user.id === userFound.id);
 
     if (existingMembership && !invitationRole) {
+      await organizationInvitationRepository.markAsAccepted(organizationInvitationId);
+
       throw new AlreadyExistingMembershipError(`User is already member of organisation ${organizationId}`);
     }
 
@@ -49,7 +51,7 @@ module.exports = async function acceptOrganizationInvitation({
 
     await userOrgaSettingsRepository.createOrUpdate({ userId: userFound.id, organizationId });
 
-    organizationInvitationRepository.markAsAccepted(organizationInvitationId);
+    await organizationInvitationRepository.markAsAccepted(organizationInvitationId);
 
     return membership;
   }

--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -35,18 +35,22 @@ module.exports = async function acceptOrganizationInvitation({
       throw new AlreadyExistingMembershipError(`User is already member of organisation ${organizationId}`);
     }
 
+    let membership;
+
     if (existingMembership) {
-      await membershipRepository.updateById({
+      membership = await membershipRepository.updateById({
         id: existingMembership.id,
         membership: { organizationRole: invitationRole },
       });
     } else {
       const organizationRole = invitationRole || _pickDefaultRole(memberships);
-      await membershipRepository.create(userFound.id, organizationId, organizationRole);
+      membership = await membershipRepository.create(userFound.id, organizationId, organizationRole);
     }
 
     await userOrgaSettingsRepository.createOrUpdate({ userId: userFound.id, organizationId });
 
-    return organizationInvitationRepository.markAsAccepted(organizationInvitationId);
+    organizationInvitationRepository.markAsAccepted(organizationInvitationId);
+
+    return membership;
   }
 };

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -21,6 +21,7 @@ describe('Integration | Application | Organization-invitations | organization-in
     sandbox = sinon.createSandbox();
     sandbox.stub(usecases, 'acceptOrganizationInvitation');
     sandbox.stub(usecases, 'sendScoInvitation');
+    sandbox.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationMember');
     sandbox.stub(scoOrganizationInvitationSerializer, 'serialize');
 
     httpTestServer = new HttpTestServer();
@@ -47,6 +48,7 @@ describe('Integration | Application | Organization-invitations | organization-in
       it('should return an HTTP response with status code 204', async function () {
         // given
         usecases.acceptOrganizationInvitation.resolves();
+        usecases.createCertificationCenterMembershipForScoOrganizationMember.resolves();
 
         // when
         const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);

--- a/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
@@ -6,8 +6,6 @@ const usecases = require('../../../../lib/domain/usecases');
 const organizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-invitation-serializer');
 
 describe('Unit | Application | Organization-Invitations | organization-invitation-controller', function () {
-  let request;
-
   describe('#acceptOrganizationInvitation', function () {
     it('should call acceptOrganizationInvitation usecase to accept invitation with organizationInvitationId and code', async function () {
       // given
@@ -68,23 +66,17 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
   });
 
   describe('#getOrganizationInvitation', function () {
-    const organizationInvitationId = 1;
-    const organizationInvitationCode = 'ABCDEFGH01';
-
-    beforeEach(function () {
-      request = {
+    it('should call the usecase to get invitation with organizationInvitationId, organizationInvitationCode', async function () {
+      // given
+      const organizationInvitationId = 1;
+      const organizationInvitationCode = 'ABCDEFGH01';
+      const request = {
         params: { id: organizationInvitationId },
         query: { code: organizationInvitationCode },
       };
 
-      sinon.stub(usecases, 'getOrganizationInvitation');
-      sinon.stub(organizationInvitationSerializer, 'serialize');
-    });
-
-    it('should call the usecase to get invitation with organizationInvitationId, organizationInvitationCode', async function () {
-      // given
-      usecases.getOrganizationInvitation.resolves();
-      organizationInvitationSerializer.serialize.returns();
+      sinon.stub(usecases, 'getOrganizationInvitation').resolves();
+      sinon.stub(organizationInvitationSerializer, 'serialize').returns();
 
       // when
       await organizationInvitationController.getOrganizationInvitation(request);
@@ -98,7 +90,11 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
 
     it('should throw a MissingQueryParamError when code is not defined', async function () {
       // given
-      request.query.code = undefined;
+      const organizationInvitationId = 1;
+      const request = {
+        params: { id: organizationInvitationId },
+        query: { code: undefined },
+      };
 
       // when
       const errorCatched = await catchErr(organizationInvitationController.getOrganizationInvitation)(request);

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -178,22 +178,25 @@ describe('Unit | UseCase | accept-organization-invitation', function () {
           .resolves([membership]);
       });
 
-      it('should throw an AlreadyExistingMembershipError', async function () {
-        // given
-        const { id: organizationInvitationId, code } = pendingOrganizationInvitation;
+      context('when no role is defined in the invitation', function () {
+        it('should mark invitation as accepted and throw an AlreadyExistingMembershipError', async function () {
+          // given
+          const { id: organizationInvitationId, code } = pendingOrganizationInvitation;
 
-        // when
-        const err = await catchErr(acceptOrganizationInvitation)({
-          organizationInvitationId,
-          code,
-          email,
-          userRepository,
-          membershipRepository,
-          organizationInvitationRepository,
+          // when
+          const err = await catchErr(acceptOrganizationInvitation)({
+            organizationInvitationId,
+            code,
+            email,
+            userRepository,
+            membershipRepository,
+            organizationInvitationRepository,
+          });
+
+          // then
+          expect(organizationInvitationRepository.markAsAccepted).to.have.been.calledWith(organizationInvitationId);
+          expect(err).to.be.instanceOf(AlreadyExistingMembershipError);
         });
-
-        // then
-        expect(err).to.be.instanceOf(AlreadyExistingMembershipError);
       });
 
       context('when the role is already defined in the invitation', function () {

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -3,7 +3,6 @@ const acceptOrganizationInvitation = require('../../../../lib/domain/usecases/ac
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const Membership = require('../../../../lib/domain/models/Membership');
 const {
-  NotFoundError,
   AlreadyExistingOrganizationInvitationError,
   AlreadyExistingMembershipError,
 } = require('../../../../lib/domain/errors');
@@ -30,23 +29,6 @@ describe('Unit | UseCase | accept-organization-invitation', function () {
     userOrgaSettingsRepository = {
       createOrUpdate: sinon.stub(),
     };
-  });
-
-  context('when invitation with id and code does not exist', function () {
-    it('should throw a NotFoundError', async function () {
-      // given
-      organizationInvitationRepository.getByIdAndCode.rejects(new NotFoundError());
-
-      // when
-      const error = await catchErr(acceptOrganizationInvitation)({
-        organizationInvitationId: 1,
-        code: 'codeNotExist',
-        organizationInvitationRepository,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(NotFoundError);
-    });
   });
 
   context('when invitation is already accepted', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Dernière étape du rattachement à un centre de certif ([PR précédente](https://github.com/1024pix/pix/pull/3744))

Aujourd'hui, lorsqu'un utilisateur accepte l'invitation à rejoindre une organisation SCO, il n'est pas automatiquement rattaché au centre de certification correspondant (même UAI)

## :gift: Solution
Rattacher automatiquement le membre au centre de certif lorsqu'il accepte l'invitation.

## :star2: Remarques
- Suppression d'un test unitaire coté usecase, qui testait l'erreur généré par le repository. Cette erreur étant déjà testé coté repository, ce test unitaire coté usecase peut être supprimé.
- Coté usecase, on renvoie une erreur quand le membre existe déjà et qu'aucun rôle n'est définit dans l'invitation mais on ne  passait pas l'invitation comme accepté, il restait donc en pending et s'affichait toujours dans les invitations en attente. => Désormais on marque l'invitation comme accepté.

## :santa: Pour tester

ℹ️ il faut une orga SCO avec un centre de certification correspondant (UAI)
 
Organisation : Collège The Night Watch
Centre de certification correspondant : Centre SCO Collège des Anne-Étoiles

Pour tester le rattachement ou non au centre de certif avec un même utilisateur, supprimer le `certification-center-membership` en base à chaque nouveau scénario.

---

**Scénario 1 : User qui n'est pas membre de cette organisation**

- Se connecter sur Pix Admin (pixmaster@example.net)
- Aller dans l'organisation Collège The Night Watch
- Inviter un utilisateur en lui donnant un rôle admin (votre adresse pour recevoir le mail)
- Cliquer sur le lien du mail ( cliquer direct en RA, copier l'url du lien en local pour passer en localhost dans l'url )
- Dans la double mire de Pix Orga, créer un compte ou se connecter directement ( avec un utilisateur qui n'est pas déjà membre de l'orga)
- Ce scénario va créer le `membership` à l'orga ( implem existante, rien n'a changé ) ET un `certification-center-membership` au centre de certification correspondant. Il marque l'invitation comme accepté ( implem existante, rien n'a changé ).

---

**Scénario 2 : User déjà membre de cette orga dont l'invitation _ne change pas_ son rôle**

- Se connecter sur Pix Admin (pixmaster@example.net)
- Aller dans l'organisation Collège The Night Watch
- Inviter un utilisateur en lui donnant un rôle automatique (null)
- Cliquer sur le lien du mail
- Dans la double mire, se connecter directement avec l'utilisateur créé dans le scenario 1
- Ce scénario va uniquement marquer l'invitation comme accepté (ce qu'il ne faisait pas avant), pas de création de `certification-center-membership` au centre de certification correspondant.
- Constater que l'invitation n'apparaît plus dans le tableau des invitations en attente ( ou vérifier juste qu'il est passé en accepted coté base )

---

**Scénario 3 : User déjà membre de cette orga dont l'invitation _change_ son rôle**

- Se connecter sur Pix Admin (pixmaster@example.net)
- Aller dans l'organisation Collège The Night Watch
- Inviter un utilisateur en lui donnant un rôle admin
- Cliquer sur le lien du mail
- Dans la double mire, se connecter directement avec un utilisateur déjà membre et pas encore rattaché coté certif
- Ce scénario va mettre à jour le `membership` de l'utilisateur ( implem existante, rien n'a changé ) ET un `certification-center-membership` au centre de certification correspondant. Il marque l'invitation comme accepté ( implem existante, rien n'a changé ).