### PR TITLE
[FEATURE] Sauvegarder le démarrage des certifications complémentaires(PIX-3689)

### DIFF
--- a/api/db/migrations/20211122131317_create-table-complementary-certification-courses.js
+++ b/api/db/migrations/20211122131317_create-table-complementary-certification-courses.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'complementary-certification-courses';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.integer('complementaryCertificationId').references('complementary-certifications.id').notNullable();
+    t.integer('certificationCourseId').references('certification-courses.id').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -99,6 +99,10 @@ function certificationCentersBuilder({ databaseBuilder }) {
     name: DROIT_CERTIF_CENTER_NAME,
     type: 'SUP',
   });
+  databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+    certificationCenterId: DROIT_CERTIF_CENTER_ID,
+    complementaryCertificationId: pixDroitComplementaryCertificationId,
+  });
 
   for (let i = 0; i < 200; i++) {
     const types = ['SCO', 'PRO', 'SUP'];

--- a/api/db/seeds/data/certification/certification-data.js
+++ b/api/db/seeds/data/certification/certification-data.js
@@ -552,6 +552,36 @@ const STRONG_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE
   { source: 'direct', skillId: 'rec7EvARki1b9t574', earnedPix: 4, status: 'validated', competenceId: 'recMiZPNl7V1hyE1d', result: 'ok', challengeId: 'recNMZX1W4lZPdyoY', timeout: null, resultDetails: 'null ' },
 ];
 
+const skillIdsForPixDroitDomain7 = [
+  'recVsrqKyTLbbDHr', 'rec1ToyUy6NRAYfsI', 'rec1EDXVReB5W6WXj', 'rec2fBbtPc8wp4KWt', 'rec1ZqFC2J4vnqMKs',
+  'rec1a0hrfPTy6Gf0t', 'recOiY1HuWVhoapW', 'rec2Q7Diqgtnz763e', 'recZKD07u0mLyujW', 'rec2N9CictMeBt1WF',
+  'rec1EXVl5Brzto10O', 'rec2vtVFViYBr0AiN', 'recNZPgcaDXajM0t', 'rec2h26SD99HTor6U', 'rec2D9DXaRKoWIi2B',
+  'rec1yUM0b5yqbJJL2', 'rec1lD19Cd9ABRiRw', 'rec1t5bLr4yky63Ta', 'rec1XGR9DqVYKdYJx', 'rec1rFg4UP2tcoari',
+  'rec1NArKsOVyN4EIk', 'recU2zsmTHLjPpk9', 'rec17oEfeJmMCUaqx', 'rec2LAaXB2PVhBtCB', 'rec1diQTFWvp6w30t',
+  'rec1UWIIBNSkSeCuL', 'rec2K9f6ZD7lxHv6j', 'recR9RgdSfG6xdcY', 'rec1HP8ydLGZQiNe3', 'rec2yo32jQUEUwaLF',
+  'rec1SfkJCdp3sz9FV', 'recVx1cQZCLOcFw4', 'rec29RWcyhULv9vqH', 'rec1489VTqc86A08u', 'recZGo5NepCfhvVn',
+  'rec1kB9mwJ5OgSVac',
+];
+
+const skillIdsForPixDroitDomain10 = [
+  'rec2N7a2V25EtOo65', 'rec2LKsFxZKznouzf', 'rec2l9DgRkwGLvypz', 'rec1hhx0ZAHDp7lbi', 'rec2HxQXDWViDqMIF',
+  'rec1WxB9xO0evkNZZ', 'rec17iburXjTGJ16I', 'rec2zRrGzUzcBGlTZ', 'rec1EIYS194JJkxvT', 'rec2Q8JYqSOHR5tXB',
+  'rec1q8EaC5p5YgH9t', 'recZZwBpFqbIrBcG', 'rec1HP5Zo3EjjkYMC', 'rec2bl04yHvkQalXp', 'rec176fBLAoLGgCik',
+  'rec2CGYVbOHJHfd3s', 'rec2UAabDUGTNPznB', 'rec2X9IfrJH2Bci4D', 'rec1742UQ2u18EvGi', 'rec1qwmvF5buKTbDr',
+  'rec1KUfQxRCM55gbC', 'rec2ooiMuIq0oUsnn', 'rec1gdjCWdJiacCjO', 'rec1euSl6Lvv6BRAj', 'rec23O6wwhi16ykUU',
+  'rec1bF7RyberJkxo8', 'rec2hdo5JKqc6W1LW', 'rec1MqaeSWF6ctGCI', 'rec1OZXpvNXccAlXH', 'rec1fP6bwoBfuSSt9',
+  'rec2Xa4FvWvA1u4EN', 'rec2Upsw0XxepV3aT', 'rec2szR4revLYvA81', 'rec2IHbKRAIatbLhR', 'rec1a3qGSOGR8ASKy',
+  'rec1Zj99pTKMJxI3b', 'rec1acCPu874VEndo', 'rec1jatQpmAIRF3zV', 'rec2owv7heER5tzB1', 'rec1iSqZ8hUYHc6k7',
+  'rec29zwatZLQvMPhb', 'rec2fkqn6Wg67b2ZA', 'rec2Kmgfh3rhMSLoS', 'rec25uNcX1RvqZmX8', 'rec2gX9NnuZdWH1ev',
+  'rec1rwutpqz9BA6uT', 'rec1kiqls8JYsVM7c', 'rec2NlK1kc6Lk5JE8', 'rec2jFSnBm3kgrLhw', 'rec1NM5bUvOaEISj7',
+  'rec2BoKMAoj65OQYc', 'rec1XXxlxvnKAzx5d',
+];
+
+const skillIdsForPixDroit = [...skillIdsForPixDroitDomain7, ...skillIdsForPixDroitDomain10];
+const PIXPLUS_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS = skillIdsForPixDroit.map((skillId) =>
+  ({ source: 'direct', skillId, earnedPix: 0.666667, status: 'validated', competenceId: null, result: 'ok', challengeId: 12395, timeout: null, resultDetails: 'null ' }))
+;
+
 const WEAK_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS = [
   { source: 'direct', skillId: 'rec9uQTL8ZFm1rSTY', earnedPix: 1.6, status: 'validated', competenceId: 'recFpYXCKcyhLI3Nu', result: 'ok', challengeId: 'recHmF7v2A4BSlzFf', timeout: null, resultDetails: 'null ' },
   { source: 'inferred', skillId: 'recH8iHKeJ5iws289', earnedPix: 1.3333334, status: 'validated', competenceId: 'recFpYXCKcyhLI3Nu', result: 'ok', challengeId: 'recHmF7v2A4BSlzFf', timeout: null, resultDetails: 'null ' },
@@ -848,6 +878,7 @@ module.exports = {
   STRONG_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
   WEAK_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
   WEAK_CERTIFIABLE_WITH_TIMED_CHALLENGE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
+  PIXPLUS_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
   CERTIFICATION_CHALLENGES_DATA,
   CERTIFICATION_FAILURE_ANSWERS_DATA,
   CERTIFICATION_SUCCESS_ANSWERS_DATA,

--- a/api/db/seeds/data/certification/partner-certification-builder.js
+++ b/api/db/seeds/data/certification/partner-certification-builder.js
@@ -1,16 +1,16 @@
 const Badge = require('../../../../lib/domain/models/Badge');
 const { CERTIFICATION_COURSE_SUCCESS_ID, CERTIFICATION_COURSE_FAILURE_ID } = require('./certification-courses-builder');
 const { PIX_DROIT_MAITRE_BADGE_ID } = require('../badges-builder');
-const { CERTIF_SUCCESS_USER_ID } = require('./user-profiles-builder');
+const { CERTIF_DROIT_USER5_ID } = require('./users');
 
 function partnerCertificationBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildBadgeAcquisition({
     badgeId: PIX_DROIT_MAITRE_BADGE_ID,
-    userId: CERTIF_SUCCESS_USER_ID,
+    userId: CERTIF_DROIT_USER5_ID,
     campaignParticipationId: null,
   });
   databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID, acquired: true, partnerKey: Badge.keys.PIX_EMPLOI_CLEA });
-  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID, acquired: true, partnerKey: 'PIX_DROIT_MAITRE_CERTIF' });
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID, acquired: true, partnerKey: Badge.keys.PIX_DROIT_MAITRE_CERTIF });
   databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_FAILURE_ID, acquired: false, partnerKey: Badge.keys.PIX_EMPLOI_CLEA });
 }
 

--- a/api/db/seeds/data/certification/user-profiles-builder.js
+++ b/api/db/seeds/data/certification/user-profiles-builder.js
@@ -3,11 +3,13 @@ const {
   CERTIF_SUCCESS_USER_ID, CERTIF_FAILURE_USER_ID,
   CERTIF_REGULAR_USER1_ID, CERTIF_REGULAR_USER2_ID, CERTIF_REGULAR_USER3_ID,
   CERTIF_REGULAR_USER4_ID, CERTIF_REGULAR_USER5_ID, CERTIF_SCO_STUDENT_ID, CERTIF_REGULAR_USER_WITH_TIMED_CHALLENGE_ID,
+  CERTIF_DROIT_USER5_ID,
 } = require('./users');
 const {
   STRONG_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
   WEAK_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
   WEAK_CERTIFIABLE_WITH_TIMED_CHALLENGE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
+  PIXPLUS_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS,
 } = require('./certification-data');
 const { SCO_FOREIGNER_USER_ID, SCO_FRENCH_USER_ID } = require('../organizations-sco-builder');
 
@@ -22,6 +24,12 @@ function certificationUserProfilesBuilder({ databaseBuilder }) {
     databaseBuilder.factory.buildKnowledgeElement({ ...data, createdAt, answerId, userId: CERTIF_SUCCESS_USER_ID, assessmentId: assessmentIdForSuccess });
     answerId = databaseBuilder.factory.buildAnswer({ ...data, createdAt, updatedAt, assessmentId: assessmentIdForFailure, value: 'Dummy value' }).id;
     databaseBuilder.factory.buildKnowledgeElement({ ...data, createdAt, answerId, userId: CERTIF_FAILURE_USER_ID, assessmentId: assessmentIdForFailure });
+  });
+
+  const assessmentIdForPixPlus = databaseBuilder.factory.buildAssessment({ userId: CERTIF_DROIT_USER5_ID, type: 'COMPETENCE_EVALUATION', state: 'completed' }).id;
+  _.each([...PIXPLUS_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS, ...STRONG_CERTIFIABLE_PROFILE_DATA_OBJECTS_FOR_BUILDING_ANSWERS_AND_KNOWLEDGE_ELEMENTS], (data) => {
+    const answerId = databaseBuilder.factory.buildAnswer({ ...data, createdAt, updatedAt, assessmentId: assessmentIdForPixPlus, value: 'Dummy value' }).id;
+    databaseBuilder.factory.buildKnowledgeElement({ ...data, createdAt, answerId, userId: CERTIF_DROIT_USER5_ID, assessmentId: assessmentIdForPixPlus });
   });
 
   // The rest of them just have the minimum requirements to be certifiable
@@ -43,5 +51,4 @@ function certificationUserProfilesBuilder({ databaseBuilder }) {
 
 module.exports = {
   certificationUserProfilesBuilder,
-  CERTIF_SUCCESS_USER_ID,
 };

--- a/api/lib/domain/events/handle-pix-plus-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-certifications-scoring.js
@@ -18,7 +18,7 @@ async function handlePixPlusCertificationsScoring({
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({
     certificationCourseId,
   });
-  const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgeKeysTaken();
+  const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgePixPlusKeysTaken();
   for (const certifiableBadgeKey of certifiableBadgeKeys) {
     const { certificationChallenges: pixPlusChallenges, certificationAnswers: pixPlusAnswers } =
       certificationAssessment.findAnswersAndChallengesForCertifiableBadgeKey(certifiableBadgeKey);

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -86,7 +86,7 @@ class CertificationAssessment {
     }
   }
 
-  listCertifiableBadgeKeysTaken() {
+  listCertifiableBadgePixPlusKeysTaken() {
     return _(this.certificationChallenges)
       .filter((certificationChallenge) => certificationChallenge.isPixPlus())
       .uniqBy('certifiableBadgeKey')

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -1,9 +1,8 @@
+const { PIX_PLUS_DROIT, CLEA } = require('./ComplementaryCertification');
+
 const SUP = 'SUP';
 const SCO = 'SCO';
 const PRO = 'PRO';
-
-const PIX_PLUS_DROIT = 'Pix+ Droit';
-const CLEA = 'CléA Numérique';
 
 const types = {
   SUP,

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -30,6 +30,7 @@ class CertificationCourse {
     maxReachableLevelOnCertificationDate,
     isCancelled = false,
     abortReason,
+    complementaryCertificationCourses = [],
   } = {}) {
     this._id = id;
     this._firstName = firstName;
@@ -55,9 +56,16 @@ class CertificationCourse {
     this._maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;
     this._isCancelled = isCancelled;
     this._abortReason = abortReason;
+    this._complementaryCertificationCourses = complementaryCertificationCourses;
   }
 
-  static from({ certificationCandidate, challenges, verificationCode, maxReachableLevelOnCertificationDate }) {
+  static from({
+    certificationCandidate,
+    challenges,
+    verificationCode,
+    maxReachableLevelOnCertificationDate,
+    complementaryCertificationCourses,
+  }) {
     return new CertificationCourse({
       userId: certificationCandidate.userId,
       sessionId: certificationCandidate.sessionId,
@@ -74,6 +82,7 @@ class CertificationCourse {
       challenges,
       verificationCode,
       maxReachableLevelOnCertificationDate,
+      complementaryCertificationCourses,
     });
   }
 
@@ -228,6 +237,7 @@ class CertificationCourse {
       maxReachableLevelOnCertificationDate: this._maxReachableLevelOnCertificationDate,
       isCancelled: this._isCancelled,
       abortReason: this._abortReason,
+      complementaryCertificationCourses: this._complementaryCertificationCourses,
     };
   }
 }

--- a/api/lib/domain/models/ComplementaryCertification.js
+++ b/api/lib/domain/models/ComplementaryCertification.js
@@ -1,8 +1,14 @@
+const PIX_PLUS_DROIT = 'Pix+ Droit';
+const CLEA = 'CléA Numérique';
+
 class ComplementaryCertification {
   constructor({ id, name }) {
     this.id = id;
     this.name = name;
   }
 }
+
+ComplementaryCertification.PIX_PLUS_DROIT = PIX_PLUS_DROIT;
+ComplementaryCertification.CLEA = CLEA;
 
 module.exports = ComplementaryCertification;

--- a/api/lib/domain/models/ComplementaryCertificationCourse.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourse.js
@@ -1,0 +1,14 @@
+class ComplementaryCertificationCourse {
+  constructor({ complementaryCertificationId, certificationCourseId }) {
+    this.complementaryCertificationId = complementaryCertificationId;
+    this.certificationCourseId = certificationCourseId;
+  }
+
+  static fromComplementaryCertificationId(id) {
+    return new ComplementaryCertificationCourse({
+      complementaryCertificationId: id,
+    });
+  }
+}
+
+module.exports = ComplementaryCertificationCourse;

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -126,9 +126,11 @@ async function _startNewCertification({
 
   const complementaryCertifications = await complementaryCertificationRepository.findAll();
 
-  if (await certificationBadgesService.hasStillValidCleaBadgeAcquisition({ userId })) {
-    const cleAComplementaryCertification = complementaryCertifications.find((comp) => comp.name === CLEA);
-    complementaryCertificationIds.push(cleAComplementaryCertification.id);
+  if (certificationCenter.isAccreditedClea) {
+    if (await certificationBadgesService.hasStillValidCleaBadgeAcquisition({ userId })) {
+      const cleAComplementaryCertification = complementaryCertifications.find((comp) => comp.name === CLEA);
+      complementaryCertificationIds.push(cleAComplementaryCertification.id);
+    }
   }
 
   if (certificationCenter.isAccreditedPixPlusDroit) {

--- a/api/lib/infrastructure/orm-models/CertificationCourse.js
+++ b/api/lib/infrastructure/orm-models/CertificationCourse.js
@@ -3,6 +3,7 @@ const Bookshelf = require('../bookshelf');
 require('./Assessment');
 require('./CertificationChallenge');
 require('./CertificationIssueReport');
+require('./ComplementaryCertificationCourse');
 require('./Session');
 
 const modelName = 'CertificationCourse';
@@ -35,6 +36,10 @@ module.exports = Bookshelf.model(
 
     certificationIssueReports() {
       return this.hasMany('CertificationIssueReport', 'certificationCourseId');
+    },
+
+    complementaryCertificationCourses() {
+      return this.hasMany('ComplementaryCertificationCourse', 'certificationCourseId');
     },
   },
   {

--- a/api/lib/infrastructure/orm-models/ComplementaryCertificationCourse.js
+++ b/api/lib/infrastructure/orm-models/ComplementaryCertificationCourse.js
@@ -1,0 +1,14 @@
+const Bookshelf = require('../bookshelf');
+
+const modelName = 'ComplementaryCertificationCourse';
+
+module.exports = Bookshelf.model(
+  modelName,
+  {
+    tableName: 'complementary-certification-courses',
+    hasTimestamps: ['createdAt'],
+  },
+  {
+    modelName,
+  }
+);

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -28,11 +28,9 @@ module.exports = {
         complementaryCertificationId,
         certificationCourseId: savedCertificationCourseDTO.id,
       }));
-    let savedComplementaryCertificationCourses = [];
+
     if (!_.isEmpty(complementaryCertificationCourses)) {
-      savedComplementaryCertificationCourses = await knexConn('complementary-certification-courses')
-        .insert(complementaryCertificationCourses)
-        .returning('*');
+      await knexConn('complementary-certification-courses').insert(complementaryCertificationCourses);
     }
 
     const savedChallenges = await bluebird.mapSeries(
@@ -51,7 +49,6 @@ module.exports = {
 
     const savedCertificationCourse = toDomain(savedCertificationCourseDTO);
     savedCertificationCourse._challenges = savedChallenges;
-    savedCertificationCourse._complementaryCertificationCourses = savedComplementaryCertificationCourses;
     return savedCertificationCourse;
   },
 

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -9,15 +9,31 @@ const CertificationCourse = require('../../domain/models/CertificationCourse');
 const { NotFoundError } = require('../../domain/errors');
 const certificationChallengeRepository = require('./certification-challenge-repository');
 const CertificationIssueReport = require('../../domain/models/CertificationIssueReport');
+const ComplementaryCertificationCourse = require('../../domain/models/ComplementaryCertificationCourse');
+const Bookshelf = require('../bookshelf');
 
 module.exports = {
   async save({ certificationCourse, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConn = domainTransaction.knexTransaction || Bookshelf.knex;
     const certificationCourseToSaveDTO = _adaptModelToDb(certificationCourse);
     const options = { transacting: domainTransaction.knexTransaction };
     const savedCertificationCourseDTO = await new CertificationCourseBookshelf(certificationCourseToSaveDTO).save(
       null,
       options
     );
+
+    const complementaryCertificationCourses = certificationCourse
+      .toDTO()
+      .complementaryCertificationCourses.map(({ complementaryCertificationId }) => ({
+        complementaryCertificationId,
+        certificationCourseId: savedCertificationCourseDTO.id,
+      }));
+    let savedComplementaryCertificationCourses = [];
+    if (!_.isEmpty(complementaryCertificationCourses)) {
+      savedComplementaryCertificationCourses = await knexConn('complementary-certification-courses')
+        .insert(complementaryCertificationCourses)
+        .returning('*');
+    }
 
     const savedChallenges = await bluebird.mapSeries(
       certificationCourse.toDTO().challenges,
@@ -35,6 +51,7 @@ module.exports = {
 
     const savedCertificationCourse = toDomain(savedCertificationCourseDTO);
     savedCertificationCourse._challenges = savedChallenges;
+    savedCertificationCourse._complementaryCertificationCourses = savedComplementaryCertificationCourses;
     return savedCertificationCourse;
   },
 
@@ -53,7 +70,7 @@ module.exports = {
   async get(id) {
     try {
       const certificationCourseBookshelf = await CertificationCourseBookshelf.where({ id }).fetch({
-        withRelated: ['assessment', 'challenges', 'certificationIssueReports'],
+        withRelated: ['assessment', 'challenges', 'certificationIssueReports', 'complementaryCertificationCourses'],
       });
       return toDomain(certificationCourseBookshelf);
     } catch (bookshelfError) {
@@ -136,6 +153,10 @@ function toDomain(bookshelfCertificationCourse) {
       .related('certificationIssueReports')
       .toJSON()
       .map((json) => new CertificationIssueReport(json)),
+    complementaryCertificationCourses: bookshelfCertificationCourse
+      .related('complementaryCertificationCourses')
+      .toJSON()
+      .map((json) => new ComplementaryCertificationCourse(json)),
     ..._.pick(dbCertificationCourse, [
       'id',
       'userId',
@@ -163,7 +184,13 @@ function toDomain(bookshelfCertificationCourse) {
 }
 
 function _adaptModelToDb(certificationCourse) {
-  return _.omit(certificationCourse.toDTO(), ['certificationIssueReports', 'assessment', 'challenges', 'createdAt']);
+  return _.omit(certificationCourse.toDTO(), [
+    'complementaryCertificationCourses',
+    'certificationIssueReports',
+    'assessment',
+    'challenges',
+    'createdAt',
+  ]);
 }
 
 function _pickUpdatableProperties(certificationCourse) {

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -675,6 +675,7 @@ describe('Acceptance | API | Certification Course', function () {
           await knex('answers').delete();
           await knex('assessments').delete();
           await knex('certification-challenges').delete();
+          await knex('complementary-certification-courses').delete();
           await knex('certification-courses').delete();
         });
 
@@ -732,6 +733,7 @@ describe('Acceptance | API | Certification Course', function () {
           await knex('answers').delete();
           await knex('assessments').delete();
           await knex('certification-challenges').delete();
+          await knex('complementary-certification-courses').delete();
           await knex('certification-courses').delete();
         });
 

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -60,8 +60,9 @@ describe('Integration | Repository | Certification Course', function () {
       );
 
       expect(savedCertificationChallenge).to.deep.equal(certificationChallengeToBeSaved);
+
       const [savedComplementaryCertificationCourse] =
-        savedCertificationCourse.toDTO().complementaryCertificationCourses;
+        retrievedCertificationCourse.toDTO().complementaryCertificationCourses;
       expect(_.omit(savedComplementaryCertificationCourse, ['createdAt'])).to.deep.equal({
         complementaryCertificationId,
         certificationCourseId: savedCertificationCourse.getId(),

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -24,13 +24,13 @@ function buildCertificationCourse({
   isV2Certification = false,
   isPublished = false,
   verificationCode = 'P-ABCD1234',
-  acquiredPartnerCertifications = [],
   assessment = buildAssessment({ certificationCourseId: this.id }),
   challenges = [],
   userId = 456,
   sessionId = 789,
   isCancelled = false,
   abortReason = null,
+  complementaryCertificationCourses = [],
 } = {}) {
   const certificationIssueReports = [];
   if (examinerComment && examinerComment !== '') {
@@ -63,13 +63,13 @@ function buildCertificationCourse({
     isV2Certification,
     isPublished,
     verificationCode,
-    acquiredPartnerCertifications,
     assessment,
     challenges,
     sessionId,
     userId,
     isCancelled,
     abortReason,
+    complementaryCertificationCourses,
   });
 }
 
@@ -90,13 +90,13 @@ buildCertificationCourse.unpersisted = function ({
   isV2Certification = false,
   isPublished = false,
   verificationCode = 'P-ABCD1234',
-  acquiredPartnerCertifications = [],
   assessment = buildAssessment({ certificationCourseId: this.id }),
   challenges = [],
   userId = 456,
   sessionId = 789,
   isCancelled = false,
   abortReason = null,
+  complementaryCertificationCourses = [],
 } = {}) {
   return new CertificationCourse({
     firstName,
@@ -116,13 +116,13 @@ buildCertificationCourse.unpersisted = function ({
     isV2Certification,
     isPublished,
     verificationCode,
-    acquiredPartnerCertifications,
     assessment,
     challenges,
     sessionId,
     userId,
     isCancelled,
     abortReason,
+    complementaryCertificationCourses,
   });
 };
 

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -468,7 +468,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
 
       // when
-      const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgeKeysTaken();
+      const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgePixPlusKeysTaken();
 
       // then
       expect(certifiableBadgeKeys).to.deep.include.members(['BADGE_2', 'BADGE_1']);
@@ -487,7 +487,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
 
       // when
-      const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgeKeysTaken();
+      const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgePixPlusKeysTaken();
 
       // then
       expect(certifiableBadgeKeys).to.be.empty;

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -17,17 +17,32 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
   let domainTransaction;
   let verificationCode;
 
-  let sessionRepository;
-  let assessmentRepository;
-  let competenceRepository;
-  let certificationCandidateRepository;
-  let certificationChallengeRepository;
-  let certificationChallengesService;
-  let certificationCourseRepository;
-  let certificationCenterRepository;
-  let certificationBadgesService;
-  let placementProfileService;
-  let verifyCertificateCodeService;
+  const sessionRepository = {};
+  const assessmentRepository = {};
+  const competenceRepository = {};
+  const certificationCandidateRepository = {};
+  const certificationChallengeRepository = {};
+  const certificationChallengesService = {};
+  const certificationCourseRepository = {};
+  const certificationCenterRepository = {};
+  const certificationBadgesService = {};
+  const placementProfileService = {};
+  const verifyCertificateCodeService = {};
+  const complementaryCertificationRepository = {};
+
+  const injectables = {
+    assessmentRepository,
+    competenceRepository,
+    certificationCandidateRepository,
+    certificationChallengeRepository,
+    certificationCourseRepository,
+    sessionRepository,
+    certificationCenterRepository,
+    certificationBadgesService,
+    certificationChallengesService,
+    placementProfileService,
+    verifyCertificateCodeService,
+  };
 
   beforeEach(function () {
     now = new Date('2019-01-01T05:06:07Z');
@@ -35,29 +50,21 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     domainTransaction = Symbol('someDomainTransaction');
     verificationCode = Symbol('verificationCode');
 
-    assessmentRepository = { save: sinon.stub() };
-    competenceRepository = { listPixCompetencesOnly: sinon.stub() };
-    certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
-    certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub(), update: sinon.stub() };
-    certificationChallengeRepository = { save: sinon.stub() };
-    certificationChallengesService = {
-      pickCertificationChallengesForPixPlus: sinon.stub(),
-      pickCertificationChallenges: sinon.stub(),
-    };
-    certificationCourseRepository = {
-      findOneCertificationCourseByUserIdAndSessionId: sinon.stub(),
-      save: sinon.stub(),
-    };
-    sessionRepository = { get: sinon.stub() };
-    placementProfileService = {
-      getPlacementProfile: sinon.stub(),
-    };
-    verifyCertificateCodeService = {
-      generateCertificateVerificationCode: sinon.stub().resolves(verificationCode),
-    };
-    certificationCenterRepository = {
-      getBySessionId: sinon.stub(),
-    };
+    assessmentRepository.save = sinon.stub();
+    competenceRepository.listPixCompetencesOnly = sinon.stub();
+    certificationBadgesService.findStillValidBadgeAcquisitions = sinon.stub();
+    certificationBadgesService.hasStillValidCleaBadgeAcquisition = sinon.stub();
+    certificationCandidateRepository.getBySessionIdAndUserId = sinon.stub();
+    certificationCandidateRepository.update = sinon.stub();
+    certificationChallengeRepository.save = sinon.stub();
+    certificationChallengesService.pickCertificationChallengesForPixPlus = sinon.stub();
+    certificationChallengesService.pickCertificationChallenges = sinon.stub();
+    certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId = sinon.stub();
+    certificationCourseRepository.save = sinon.stub();
+    sessionRepository.get = sinon.stub();
+    placementProfileService.getPlacementProfile = sinon.stub();
+    verifyCertificateCodeService.generateCertificateVerificationCode = sinon.stub().resolves(verificationCode);
+    certificationCenterRepository.getBySessionId = sinon.stub();
   });
 
   afterEach(function () {
@@ -81,17 +88,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
         accessCode,
         userId,
         locale: 'fr',
-        assessmentRepository,
-        competenceRepository,
-        certificationCandidateRepository,
-        certificationChallengeRepository,
-        certificationCourseRepository,
+        ...injectables,
         sessionRepository,
-        certificationCenterRepository,
-        certificationBadgesService,
-        certificationChallengesService,
-        placementProfileService,
-        verifyCertificateCodeService,
       });
 
       // then
@@ -118,17 +116,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
           accessCode,
           userId,
           locale: 'fr',
-          assessmentRepository,
-          competenceRepository,
-          certificationCandidateRepository,
-          certificationChallengeRepository,
-          certificationCourseRepository,
-          sessionRepository,
-          certificationCenterRepository,
-          certificationBadgesService,
-          certificationChallengesService,
-          placementProfileService,
-          verifyCertificateCodeService,
+          ...injectables,
         });
 
         // then
@@ -174,17 +162,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 accessCode,
                 userId,
                 locale: 'fr',
-                assessmentRepository,
-                competenceRepository,
-                certificationCandidateRepository,
-                certificationChallengeRepository,
-                certificationCourseRepository,
-                sessionRepository,
-                certificationCenterRepository,
-                certificationBadgesService,
-                certificationChallengesService,
-                placementProfileService,
-                verifyCertificateCodeService,
+                ...injectables,
               });
 
               // then
@@ -228,17 +206,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 accessCode,
                 userId,
                 locale: 'fr',
-                assessmentRepository,
-                competenceRepository,
-                certificationCandidateRepository,
-                certificationChallengeRepository,
-                certificationCourseRepository,
-                sessionRepository,
-                certificationCenterRepository,
-                certificationBadgesService,
-                certificationChallengesService,
-                placementProfileService,
-                verifyCertificateCodeService,
+                ...injectables,
               });
 
               // then
@@ -288,17 +256,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               accessCode,
               userId,
               locale: 'fr',
-              assessmentRepository,
-              competenceRepository,
-              certificationCandidateRepository,
-              certificationChallengeRepository,
-              certificationCourseRepository,
-              sessionRepository,
-              certificationCenterRepository,
-              certificationBadgesService,
-              certificationChallengesService,
-              placementProfileService,
-              verifyCertificateCodeService,
+              ...injectables,
             });
 
             // then
@@ -351,17 +309,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 accessCode,
                 userId,
                 locale: 'fr',
-                assessmentRepository,
-                competenceRepository,
-                certificationCandidateRepository,
-                certificationChallengeRepository,
-                certificationCourseRepository,
-                sessionRepository,
-                certificationCenterRepository,
-                certificationBadgesService,
-                certificationChallengesService,
-                placementProfileService,
-                verifyCertificateCodeService,
+                ...injectables,
               });
 
               // then
@@ -404,17 +352,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 accessCode,
                 userId,
                 locale: 'fr',
-                assessmentRepository,
-                competenceRepository,
-                certificationCandidateRepository,
-                certificationChallengeRepository,
-                certificationCourseRepository,
-                sessionRepository,
-                certificationCenterRepository,
-                certificationBadgesService,
-                certificationChallengesService,
-                placementProfileService,
-                verifyCertificateCodeService,
+                ...injectables,
               });
 
               // then
@@ -483,17 +421,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   accessCode,
                   userId,
                   locale: 'fr',
-                  assessmentRepository,
-                  competenceRepository,
-                  certificationCandidateRepository,
-                  certificationChallengeRepository,
-                  certificationCourseRepository,
-                  sessionRepository,
-                  certificationCenterRepository,
-                  certificationBadgesService,
-                  certificationChallengesService,
-                  placementProfileService,
-                  verifyCertificateCodeService,
+                  ...injectables,
                 });
 
                 // then
@@ -597,17 +525,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   accessCode,
                   userId,
                   locale: 'fr',
-                  assessmentRepository,
-                  competenceRepository,
-                  certificationCandidateRepository,
-                  certificationChallengeRepository,
-                  certificationCourseRepository,
-                  sessionRepository,
-                  certificationCenterRepository,
-                  certificationBadgesService,
-                  certificationChallengesService,
-                  placementProfileService,
-                  verifyCertificateCodeService,
+                  ...injectables,
                 });
 
                 // then
@@ -737,17 +655,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       accessCode,
                       userId,
                       locale: 'fr',
-                      assessmentRepository,
-                      competenceRepository,
-                      certificationCandidateRepository,
-                      certificationChallengeRepository,
-                      certificationCourseRepository,
-                      sessionRepository,
-                      certificationCenterRepository,
-                      certificationBadgesService,
-                      certificationChallengesService,
-                      placementProfileService,
-                      verifyCertificateCodeService,
+                      ...injectables,
                     });
 
                     // then
@@ -870,17 +778,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         accessCode,
                         userId,
                         locale: 'fr',
-                        assessmentRepository,
-                        competenceRepository,
-                        certificationCandidateRepository,
-                        certificationChallengeRepository,
-                        certificationCourseRepository,
-                        sessionRepository,
-                        certificationCenterRepository,
-                        certificationBadgesService,
-                        certificationChallengesService,
-                        placementProfileService,
-                        verifyCertificateCodeService,
+                        ...injectables,
                       });
 
                       // then
@@ -993,17 +891,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       accessCode,
                       userId,
                       locale: 'fr',
-                      assessmentRepository,
-                      competenceRepository,
-                      certificationCandidateRepository,
-                      certificationChallengeRepository,
-                      certificationCourseRepository,
-                      sessionRepository,
-                      certificationCenterRepository,
-                      certificationBadgesService,
-                      certificationChallengesService,
-                      placementProfileService,
-                      verifyCertificateCodeService,
+                      ...injectables,
                     });
 
                     // then
@@ -1126,17 +1014,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         accessCode,
                         userId,
                         locale: 'fr',
-                        assessmentRepository,
-                        competenceRepository,
-                        certificationCandidateRepository,
-                        certificationChallengeRepository,
-                        certificationCourseRepository,
-                        sessionRepository,
-                        certificationCenterRepository,
-                        certificationBadgesService,
-                        certificationChallengesService,
-                        placementProfileService,
-                        verifyCertificateCodeService,
+                        ...injectables,
                       });
 
                       // then
@@ -1247,17 +1125,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     accessCode,
                     userId,
                     locale: 'fr',
-                    assessmentRepository,
-                    competenceRepository,
-                    certificationCandidateRepository,
-                    certificationChallengeRepository,
-                    certificationCourseRepository,
-                    sessionRepository,
-                    certificationCenterRepository,
-                    certificationBadgesService,
-                    certificationChallengesService,
-                    placementProfileService,
-                    verifyCertificateCodeService,
+                    ...injectables,
                   });
 
                   // then

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -1409,9 +1409,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     const savedCertificationCourse = domainBuilder.buildCertificationCourse(
                       certificationCourseToSave.toDTO()
                     );
-                    savedCertificationCourse._complementaryCertificationCourses = [
-                      { ...complementaryCertificationCourse, certificationCourseId: savedCertificationCourse.getId() },
-                    ];
                     certificationCourseRepository.save.resolves(savedCertificationCourse);
 
                     const assessmentToSave = new Assessment({
@@ -1451,12 +1448,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         ...savedCertificationCourse.toDTO(),
                         assessment: savedAssessment,
                         challenges: [challenge1, challenge2],
-                        complementaryCertificationCourses: [
-                          {
-                            certificationCourseId: savedCertificationCourse.getId(),
-                            complementaryCertificationId: complementaryCertificationCleA.id,
-                          },
-                        ],
                       }),
                     });
                   });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -397,22 +397,11 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   .onCall(1)
                   .resolves(existingCertificationCourse);
 
-                const skill1 = domainBuilder.buildSkill();
-                const skill2 = domainBuilder.buildSkill();
-                const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                // TODO : use the domainBuilder to instanciate userCompetences
-                const placementProfile = {
-                  isCertifiable: sinon.stub().returns(true),
-                  userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                };
-                placementProfileService.getPlacementProfile
-                  .withArgs({ userId, limitDate: now })
-                  .resolves(placementProfile);
-
-                const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                const { placementProfile, userCompetencesWithChallenges } = _buildPlacementProfileWithTwoChallenges(
+                  placementProfileService,
+                  userId,
+                  now
+                );
                 certificationChallengesService.pickCertificationChallenges
                   .withArgs(placementProfile)
                   .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -463,22 +452,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     })
                   );
 
-                const skill1 = domainBuilder.buildSkill();
-                const skill2 = domainBuilder.buildSkill();
-                const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                // TODO : use the domainBuilder to instanciate userCompetences
-                const placementProfile = {
-                  isCertifiable: sinon.stub().returns(true),
-                  userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                };
-                placementProfileService.getPlacementProfile
-                  .withArgs({ userId, limitDate: now })
-                  .resolves(placementProfile);
-
-                const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                  _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                 certificationChallengesService.pickCertificationChallenges
                   .withArgs(placementProfile)
                   .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -570,22 +545,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         })
                       );
 
-                    const skill1 = domainBuilder.buildSkill();
-                    const skill2 = domainBuilder.buildSkill();
-                    const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                    const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                    // TODO : use the domainBuilder to instanciate userCompetences
-                    const placementProfile = {
-                      isCertifiable: sinon.stub().returns(true),
-                      userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                    };
-                    placementProfileService.getPlacementProfile
-                      .withArgs({ userId, limitDate: now })
-                      .resolves(placementProfile);
-
-                    const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                    userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                    userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                     certificationChallengesService.pickCertificationChallenges
                       .withArgs(placementProfile)
                       .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -716,22 +677,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         })
                       );
 
-                    const skill1 = domainBuilder.buildSkill();
-                    const skill2 = domainBuilder.buildSkill();
-                    const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                    const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                    // TODO : use the domainBuilder to instanciate userCompetences
-                    const placementProfile = {
-                      isCertifiable: sinon.stub().returns(true),
-                      userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                    };
-                    placementProfileService.getPlacementProfile
-                      .withArgs({ userId, limitDate: now })
-                      .resolves(placementProfile);
-
-                    const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                    userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                    userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                     certificationChallengesService.pickCertificationChallenges
                       .withArgs(placementProfile)
                       .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -856,22 +803,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         })
                       );
 
-                    const skill1 = domainBuilder.buildSkill();
-                    const skill2 = domainBuilder.buildSkill();
-                    const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                    const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                    // TODO : use the domainBuilder to instanciate userCompetences
-                    const placementProfile = {
-                      isCertifiable: sinon.stub().returns(true),
-                      userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                    };
-                    placementProfileService.getPlacementProfile
-                      .withArgs({ userId, limitDate: now })
-                      .resolves(placementProfile);
-
-                    const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                    userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                    userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                     certificationChallengesService.pickCertificationChallenges
                       .withArgs(placementProfile)
                       .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -984,22 +917,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         })
                       );
 
-                    const skill1 = domainBuilder.buildSkill();
-                    const skill2 = domainBuilder.buildSkill();
-                    const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                    const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                    // TODO : use the domainBuilder to instanciate userCompetences
-                    const placementProfile = {
-                      isCertifiable: sinon.stub().returns(true),
-                      userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                    };
-                    placementProfileService.getPlacementProfile
-                      .withArgs({ userId, limitDate: now })
-                      .resolves(placementProfile);
-
-                    const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                    userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                    userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                     certificationChallengesService.pickCertificationChallenges
                       .withArgs(placementProfile)
                       .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -1098,22 +1017,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         })
                       );
 
-                    const skill1 = domainBuilder.buildSkill();
-                    const skill2 = domainBuilder.buildSkill();
-                    const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                    const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                    // TODO : use the domainBuilder to instanciate userCompetences
-                    const placementProfile = {
-                      isCertifiable: sinon.stub().returns(true),
-                      userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                    };
-                    placementProfileService.getPlacementProfile
-                      .withArgs({ userId, limitDate: now })
-                      .resolves(placementProfile);
-
-                    const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                    userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                    userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                     certificationChallengesService.pickCertificationChallenges
                       .withArgs(placementProfile)
                       .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -1227,22 +1132,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       })
                     );
 
-                  const skill1 = domainBuilder.buildSkill();
-                  const skill2 = domainBuilder.buildSkill();
-                  const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                  const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                  // TODO : use the domainBuilder to instanciate userCompetences
-                  const placementProfile = {
-                    isCertifiable: sinon.stub().returns(true),
-                    userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                  };
-                  placementProfileService.getPlacementProfile
-                    .withArgs({ userId, limitDate: now })
-                    .resolves(placementProfile);
-
-                  const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                  userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                  userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                  const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                    _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                   certificationChallengesService.pickCertificationChallenges
                     .withArgs(placementProfile)
                     .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -1342,22 +1233,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         })
                       );
 
-                    const skill1 = domainBuilder.buildSkill();
-                    const skill2 = domainBuilder.buildSkill();
-                    const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                    const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                    // TODO : use the domainBuilder to instanciate userCompetences
-                    const placementProfile = {
-                      isCertifiable: sinon.stub().returns(true),
-                      userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                    };
-                    placementProfileService.getPlacementProfile
-                      .withArgs({ userId, limitDate: now })
-                      .resolves(placementProfile);
-
-                    const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
-                    userCompetencesWithChallenges[0].challenges[0].testedSkill = skill1;
-                    userCompetencesWithChallenges[1].challenges[0].testedSkill = skill2;
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                     certificationChallengesService.pickCertificationChallenges
                       .withArgs(placementProfile)
                       .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -1480,19 +1357,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           authorizedToStart: true,
                         })
                       );
-
-                    const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-                    const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
-                    // TODO : use the domainBuilder to instanciate userCompetences
-                    const placementProfile = {
-                      isCertifiable: sinon.stub().returns(true),
-                      userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
-                    };
-                    placementProfileService.getPlacementProfile
-                      .withArgs({ userId, limitDate: now })
-                      .resolves(placementProfile);
-
-                    const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                     certificationChallengesService.pickCertificationChallenges
                       .withArgs(placementProfile)
                       .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
@@ -1574,3 +1440,19 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     });
   });
 });
+
+function _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now) {
+  const challenge1 = domainBuilder.buildChallenge({ id: 'challenge1' });
+  const challenge2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+  // TODO : use the domainBuilder to instanciate userCompetences
+  const placementProfile = {
+    isCertifiable: sinon.stub().returns(true),
+    userCompetences: [{ challenges: [challenge1] }, { challenges: [challenge2] }],
+  };
+  placementProfileService.getPlacementProfile.withArgs({ userId, limitDate: now }).resolves(placementProfile);
+
+  const userCompetencesWithChallenges = _.clone(placementProfile.userCompetences);
+  userCompetencesWithChallenges[0].challenges[0].testedSkill = domainBuilder.buildSkill();
+  userCompetencesWithChallenges[1].challenges[0].testedSkill = domainBuilder.buildSkill();
+  return { challenge1, challenge2, placementProfile, userCompetencesWithChallenges };
+}


### PR DESCRIPTION
## :christmas_tree: Problème
Le passage des certifications complémentaire est soumis à différentes contraintes. Il depend du centre de certification, de l'inscription du candidat et de ses badges/acquis. On ne souhaite pas refaire le calcul à chaque fois que c'est nécessaire

## :gift: Solution
Sauvegarder l'information lors de l'enregistrement du certification course

## :star2: Remarques
Ajout de seeds pour que 'certifdroit@example.net' soit élligible à la certification Pix+Droit

## :santa: Pour tester
1) Pix+
- Créer une session de certif sur un centre de certif agréé Pix+Droit
- Ajouter le candidat `certifdroit@example.net` à la session
- L'autoriser à démarrer la certif (via le portail surveillant)
- Demarrer la certif (pas besoin de répondre au questions)
- Verifier qu'il y a bien une ligne dans la table `complementary-certification-courses` pour la certification donnée et la certification complementaire Pix+

2) CléA
- Refaire les même étapes avec un centre agréé CleA et `certif-success@example.net`
- Verifier qu'il y a bien une ligne dans la table `complementary-certification-courses` pour la certification donnée et la certification complementaire CléA