### PR TITLE
[A11Y] Suppression de phrases pour lecteurs d'écrans entravant l'UX (PIX-3914).

### DIFF
--- a/mon-pix/app/templates/components/qcu-proposals.hbs
+++ b/mon-pix/app/templates/components/qcu-proposals.hbs
@@ -15,7 +15,6 @@
     />
 
     <label for="radio_{{inc index}}" class="qcu-proposals__label">
-      <span class="sr-only">{{t "pages.proposals.answer.qcu"}}</span>
       <MarkdownToHtml @class="qcu-panel__text proposal-text" @markdown={{get labeledRadio 0}} />
     </label>
   </p>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -922,11 +922,6 @@
         "message": "{organization} encourages you to resubmit your profile to measure your progress."
       }
     },
-    "proposals": {
-      "answer": {
-        "qcu": "The answer to the question is: "
-      }
-    },
     "reset-password": {
       "title": "Change my password",
       "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -922,11 +922,6 @@
         "message": "{organization} vous invite à renvoyer votre profil pour mesurer votre progression."
       }
     },
-    "proposals": {
-      "answer": {
-        "qcu": "La réponse à la question est : "
-      }
-    },
     "reset-password": {
       "title": "Changer mon mot de passe",
       "actions": {


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu'un utilisateur ayant besoin d'avoir recours à un lecteur d'écran arrive sur un QCU, il lui est répété autant de fois qu'il y a de réponses : `La réponse à la question est :`, entravant son expérience.

## :gift: Solution

Retirer le texte uniquement accessible pour les lecteurs d'écrans.

## :star2: Remarques

N/A

## :santa: Pour tester

Se rendre sur un QCM et constater de la disparition de l'élément concerné (DOM et/ou avec Voice Over)
