### PR TITLE
[FEATURE] Permettre d'anonymiser un utilisateur peu importe sa méthode de connexion sur Pix Admin (PIX-3773).

### DIFF
--- a/admin/app/components/user-detail-personal-information.js
+++ b/admin/app/components/user-detail-personal-information.js
@@ -49,7 +49,6 @@ export default class UserDetailPersonalInformationComponent extends Component {
   @action
   async anonymizeUser() {
     await this.args.user.save({ adapterOptions: { anonymizeUser: true } });
-    await this.args.user.reload();
     this.toggleDisplayAnonymizeModal();
   }
 

--- a/admin/app/components/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/user-detail-personal-information/authentication-method.hbs
@@ -7,7 +7,11 @@
     {{#if @user.hasEmailAuthenticationMethod}}
       <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
     {{else}}
-      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      <FaIcon
+        @icon="times-circle"
+        aria-label="Méthode d'authentication par Email"
+        class="user-authentication-method-item__uncheck"
+      />
     {{/if}}
   </div>
   {{#if (and @user.hasEmailAuthenticationMethod (not @user.hasOnlyOneAuthenticationMethod))}}
@@ -26,7 +30,11 @@
     {{#if @user.hasUsernameAuthenticationMethod}}
       <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
     {{else}}
-      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      <FaIcon
+        @icon="times-circle"
+        aria-label="Méthode d'authentication par Username"
+        class="user-authentication-method-item__uncheck"
+      />
     {{/if}}
   </div>
   {{#if (and @user.hasUsernameAuthenticationMethod (not @user.hasOnlyOneAuthenticationMethod))}}
@@ -45,7 +53,11 @@
     {{#if @user.hasPoleEmploiAuthenticationMethod}}
       <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
     {{else}}
-      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      <FaIcon
+        @icon="times-circle"
+        aria-label="Méthode d'authentication par Pole Emploi"
+        class="user-authentication-method-item__uncheck"
+      />
     {{/if}}
   </div>
   {{#if (and @user.hasPoleEmploiAuthenticationMethod (not @user.hasOnlyOneAuthenticationMethod))}}
@@ -64,7 +76,11 @@
     {{#if @user.hasGARAuthenticationMethod}}
       <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
     {{else}}
-      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      <FaIcon
+        @icon="times-circle"
+        aria-label="Méthode d'authentication par GAR"
+        class="user-authentication-method-item__uncheck"
+      />
     {{/if}}
   </div>
   {{#if (and @user.hasGARAuthenticationMethod (not @user.hasOnlyOneAuthenticationMethod))}}

--- a/admin/app/components/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/user-detail-personal-information/authentication-method.hbs
@@ -9,7 +9,7 @@
     {{else}}
       <FaIcon
         @icon="times-circle"
-        aria-label="Méthode d'authentication par Email"
+        aria-label="L'utilisateur n'a pas de méthode de connexion avec adresse e-mail "
         class="user-authentication-method-item__uncheck"
       />
     {{/if}}
@@ -32,7 +32,7 @@
     {{else}}
       <FaIcon
         @icon="times-circle"
-        aria-label="Méthode d'authentication par Username"
+        aria-label="L'utilisateur n'a pas de méthode de connexion avec identifiant"
         class="user-authentication-method-item__uncheck"
       />
     {{/if}}
@@ -55,7 +55,7 @@
     {{else}}
       <FaIcon
         @icon="times-circle"
-        aria-label="Méthode d'authentication par Pole Emploi"
+        aria-label="L'utilisateur n'a pas de méthode de connexion avec Pôle Emploi"
         class="user-authentication-method-item__uncheck"
       />
     {{/if}}
@@ -78,7 +78,7 @@
     {{else}}
       <FaIcon
         @icon="times-circle"
-        aria-label="Méthode d'authentication par GAR"
+        aria-label="L'utilisateur n'a pas de méthode de connexion avec GAR"
         class="user-authentication-method-item__uncheck"
       />
     {{/if}}

--- a/admin/app/components/user-detail-personal-information/user-overview.hbs
+++ b/admin/app/components/user-detail-personal-information/user-overview.hbs
@@ -148,11 +148,9 @@
       >
         Modifier
       </PixButton>
-      {{#if this.canAdministratorAnonymizeUser}}
-        <PixButton @size="small" @backgroundColor="red" @triggerAction={{@toggleDisplayAnonymizeModal}}>
-          Anonymiser cet utilisateur
-        </PixButton>
-      {{/if}}
+      <PixButton @size="small" @backgroundColor="red" @triggerAction={{@toggleDisplayAnonymizeModal}}>
+        Anonymiser cet utilisateur
+      </PixButton>
     </div>
   </form>
 {{/if}}

--- a/admin/app/components/user-detail-personal-information/user-overview.js
+++ b/admin/app/components/user-detail-personal-information/user-overview.js
@@ -98,10 +98,6 @@ export default class UserOverview extends Component {
     return urlDashboardPrefix && urlDashboardPrefix + this.args.user.id;
   }
 
-  get canAdministratorAnonymizeUser() {
-    return this.args.user.email;
-  }
-
   get canModifyEmail() {
     return !!(this.args.user.email || this.args.user.username);
   }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -69,7 +69,6 @@ export default function () {
 
     return schema.users.find(userId);
   });
-  this.get('/admin/users/:id');
 
   this.get('/certification-centers');
   this.get('/certification-centers/:id');
@@ -123,6 +122,7 @@ export default function () {
   this.post('/admin/stages', createStage);
 
   this.get('/admin/certifications/:id');
+
   this.get('/admin/certifications/:id/certified-profile', (schema, request) => {
     const id = request.params.id;
     return schema.certifiedProfiles.find(id);
@@ -170,6 +170,8 @@ export default function () {
 
   this.patch('/organizations/:id');
 
+  this.get('/admin/users/:id');
+
   this.patch('/admin/users/:id', (schema, request) => {
     const userId = request.params.id;
     const {
@@ -185,14 +187,14 @@ export default function () {
 
   this.post('/admin/users/:id/anonymize', (schema, request) => {
     const userId = request.params.id;
-    const expectedUpdatedUser = {
+    const user = schema.users.findBy({ id: userId });
+    return user.update({
       firstName: `prenom_${userId}`,
       lastName: `nom_${userId}`,
       email: `email_${userId}@example.net`,
-    };
-
-    const user = schema.users.findBy({ id: userId });
-    return user.update(expectedUpdatedUser);
+      username: null,
+      authenticationMethods: [],
+    });
   });
 
   this.post('/admin/users/:id/remove-authentication', (schema, request) => {

--- a/admin/mirage/serializers/user.js
+++ b/admin/mirage/serializers/user.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-const _includes = ['schoolingRegistrations'];
+const _includes = ['schoolingRegistrations', 'authenticationMethods'];
 
 export default ApplicationSerializer.extend({
   include: _includes,

--- a/admin/tests/acceptance/user-details-personal-information_test.js
+++ b/admin/tests/acceptance/user-details-personal-information_test.js
@@ -5,6 +5,7 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
+import getByLabel from '../helpers/extended-ember-test-helpers/get-by-label';
 
 module('Acceptance | User details personal information', function (hooks) {
   setupApplicationTest(hooks);
@@ -79,19 +80,39 @@ module('Acceptance | User details personal information', function (hooks) {
   });
 
   module('when administrator click on anonymize button and confirm modal', function () {
-    test('should anonymize the user', async function (assert) {
+    test('should anonymize the user and remove all authentication methods', async function (assert) {
       // given
-      const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
-      await visit(`/users/${user.id}`);
+      await buildAndAuthenticateUser(this.server, {
+        email: 'john.harry@example.net',
+        username: 'john.harry121297',
+      });
+
+      const pixAuthenticationMethod = server.create('authentication-method', { identityProvider: 'PIX' });
+      const garAuthenticationMethod = server.create('authentication-method', { identityProvider: 'GAR' });
+      const userToAnonymise = server.create('user', {
+        firstName: 'Jane',
+        lastName: 'Harry',
+        email: 'jane.harry@example.net',
+        username: 'jane.harry050697',
+        isAuthenticatedFromGar: false,
+        authenticationMethods: [pixAuthenticationMethod, garAuthenticationMethod],
+      });
+
+      await visit(`/users/${userToAnonymise.id}`);
       await clickByLabel('Anonymiser cet utilisateur');
 
       // when
       await clickByLabel('Confirmer');
 
       // then
-      assert.contains(`prenom_${user.id}`);
-      assert.contains(`nom_${user.id}`);
-      assert.contains(`email_${user.id}@example.net`);
+      assert.contains(`prenom_${userToAnonymise.id}`);
+      assert.contains(`nom_${userToAnonymise.id}`);
+      assert.contains(`email_${userToAnonymise.id}@example.net`);
+
+      assert.dom(getByLabel("Méthode d'authentication par Username")).exists();
+      assert.dom(getByLabel("Méthode d'authentication par GAR")).exists();
+      assert.dom(getByLabel("Méthode d'authentication par Pole Emploi")).exists();
+      assert.dom(getByLabel("Méthode d'authentication par Email")).exists();
     });
   });
 

--- a/admin/tests/acceptance/user-details-personal-information_test.js
+++ b/admin/tests/acceptance/user-details-personal-information_test.js
@@ -109,10 +109,10 @@ module('Acceptance | User details personal information', function (hooks) {
       assert.contains(`nom_${userToAnonymise.id}`);
       assert.contains(`email_${userToAnonymise.id}@example.net`);
 
-      assert.dom(getByLabel("Méthode d'authentication par Username")).exists();
-      assert.dom(getByLabel("Méthode d'authentication par GAR")).exists();
-      assert.dom(getByLabel("Méthode d'authentication par Pole Emploi")).exists();
-      assert.dom(getByLabel("Méthode d'authentication par Email")).exists();
+      assert.dom(getByLabel("L'utilisateur n'a pas de méthode de connexion avec identifiant")).exists();
+      assert.dom(getByLabel("L'utilisateur n'a pas de méthode de connexion avec GAR")).exists();
+      assert.dom(getByLabel("L'utilisateur n'a pas de méthode de connexion avec Pôle Emploi")).exists();
+      assert.dom(getByLabel("L'utilisateur n'a pas de méthode de connexion avec adresse e-mail ")).exists();
     });
   });
 

--- a/admin/tests/helpers/extended-ember-test-helpers/query-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/query-by-label.js
@@ -9,6 +9,7 @@ export default function queryByLabel(labelText, options = {}) {
   }
 
   const labelledElement = _findElementWithLabel(labelText);
+
   if (!labelledElement) {
     return null;
   }
@@ -44,6 +45,7 @@ function _findElementWithLabel(labelText) {
     'select',
     'label[for]',
     'img',
+    'svg',
   ];
   return findAll(labellableElementSelectors.join(',')).find(_matchesLabel(labelText));
 }
@@ -57,7 +59,7 @@ function _matchesLabel(labelText) {
 }
 
 function _matchesInnerText(element, labelText) {
-  return element.innerText.includes(labelText);
+  return element.innerText?.includes(labelText);
 }
 
 function _matchesTitle(element, labelText) {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -9,6 +9,7 @@ const sharedProfileForCampaignSerializer = require('../../infrastructure/seriali
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 const emailVerificationSerializer = require('../../infrastructure/serializers/jsonapi/email-verification-serializer');
 const userDetailsForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
+const userAnonymizedDetailsForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer');
 const updateEmailSerializer = require('../../infrastructure/serializers/jsonapi/update-email-serializer');
 const authenticationMethodsSerializer = require('../../infrastructure/serializers/jsonapi/authentication-methods-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
@@ -255,8 +256,8 @@ module.exports = {
 
   async anonymizeUser(request, h) {
     const userId = request.params.id;
-    await usecases.anonymizeUser({ userId });
-    return h.response({}).code(204);
+    const user = await usecases.anonymizeUser({ userId });
+    return h.response(userAnonymizedDetailsForAdminSerializer.serialize(user)).code(200);
   },
 
   async dissociateSchoolingRegistrations(request) {

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -1,9 +1,11 @@
-module.exports = function anonymizeUser({ userId, userRepository }) {
+module.exports = async function anonymizeUser({ userId, userRepository, authenticationMethodRepository }) {
   const anonymizedUser = {
     firstName: `prenom_${userId}`,
     lastName: `nom_${userId}`,
     email: `email_${userId}@example.net`,
+    username: null,
   };
 
+  await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
   return userRepository.updateUserDetailsForAdministration(userId, anonymizedUser);
 };

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -146,6 +146,10 @@ module.exports = {
     return knex(AUTHENTICATION_METHODS_TABLE).where({ userId, identityProvider }).del();
   },
 
+  async removeAllAuthenticationMethodsByUserId({ userId }) {
+    return knex(AUTHENTICATION_METHODS_TABLE).where({ userId }).del();
+  },
+
   async updateChangedPassword({ userId, hashedPassword }, domainTransaction = DomainTransaction.emptyTransaction()) {
     const authenticationComplement = new AuthenticationMethod.PixAuthenticationComplement({
       password: hashedPassword,

--- a/api/lib/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer.js
@@ -1,0 +1,23 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(usersAnonymizedDetailsForAdmin) {
+    return new Serializer('user', {
+      attributes: [
+        'firstName',
+        'lastName',
+        'email',
+        'username',
+        'cgu',
+        'pixOrgaTermsOfServiceAccepted',
+        'pixCertifTermsOfServiceAccepted',
+        'authenticationMethods',
+      ],
+      authenticationMethods: {
+        ref: 'id',
+        includes: true,
+        attributes: ['identityProvider'],
+      },
+    }).serialize(usersAnonymizedDetailsForAdmin);
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -817,7 +817,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
-        id: 123,
         externalIdentifier: 'externalIdentifier',
         userId,
       });
@@ -830,8 +829,32 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       });
 
       // then
-      const result = await knex('authentication-methods').where({ id: 123 }).first();
+      const result = await knex('authentication-methods').where({ id: userId }).first();
       expect(result).to.be.undefined;
+    });
+  });
+
+  describe('#removeAllAuthenticationMethodsByUserId', function () {
+    it('should delete from database all the authentication methods by userId', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        externalIdentifier: 'externalIdentifier',
+        userId,
+      });
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndPassword({
+        userId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({
+        userId,
+      });
+
+      // then
+      const result = await knex('authentication-methods');
+      expect(result).to.be.empty;
     });
   });
 

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -1,25 +1,30 @@
 const { expect, sinon } = require('../../../test-helper');
 const anonymizeUser = require('../../../../lib/domain/usecases/anonymize-user');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const authenticationMethodRepository = require('../../../../lib/infrastructure/repositories/authentication-method-repository');
 
 describe('Unit | UseCase | anonymize-user', function () {
-  beforeEach(function () {
-    sinon.stub(userRepository, 'updateUserDetailsForAdministration').resolves();
-  });
-
-  it('should anonymize user', async function () {
+  it('should anonymize user and delete all authentication methods', async function () {
     // given
     const userId = 1;
     const expectedAnonymizedUser = {
       firstName: `prenom_${userId}`,
       lastName: `nom_${userId}`,
       email: `email_${userId}@example.net`,
+      username: null,
     };
 
+    sinon.stub(userRepository, 'updateUserDetailsForAdministration').resolves();
+    sinon.stub(authenticationMethodRepository, 'removeAllAuthenticationMethodsByUserId').resolves();
+
     // when
-    await anonymizeUser({ userId, userRepository });
+    await anonymizeUser({ userId, userRepository, authenticationMethodRepository });
 
     // then
+    expect(authenticationMethodRepository.removeAllAuthenticationMethodsByUserId).to.have.been.calledWithExactly({
+      userId,
+    });
+
     expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly(
       userId,
       expectedAnonymizedUser

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer_test.js
@@ -1,0 +1,53 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer');
+
+describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize user details for Pix Admin', function () {
+      // given
+      const modelObject = domainBuilder.buildUserDetailsForAdmin({
+        schoolingRegistrations: [domainBuilder.buildSchoolingRegistrationForAdmin()],
+        authenticationMethods: [{ id: 1, identityProvider: 'PIX' }],
+      });
+
+      // when
+      const json = serializer.serialize(modelObject);
+
+      // then
+      expect(json).to.be.deep.equal({
+        data: {
+          attributes: {
+            'first-name': modelObject.firstName,
+            'last-name': modelObject.lastName,
+            email: modelObject.email,
+            username: modelObject.username,
+            cgu: modelObject.cgu,
+            'pix-orga-terms-of-service-accepted': modelObject.pixOrgaTermsOfServiceAccepted,
+            'pix-certif-terms-of-service-accepted': modelObject.pixCertifTermsOfServiceAccepted,
+          },
+          relationships: {
+            'authentication-methods': {
+              data: [
+                {
+                  id: `${modelObject.authenticationMethods[0].id}`,
+                  type: 'authenticationMethods',
+                },
+              ],
+            },
+          },
+          id: `${modelObject.id}`,
+          type: 'users',
+        },
+        included: [
+          {
+            attributes: {
+              'identity-provider': modelObject.authenticationMethods[0].identityProvider,
+            },
+            id: `${modelObject.authenticationMethods[0].id}`,
+            type: 'authenticationMethods',
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Jusqu'à présent les admins pouvaient anonymiser les données utilisateurs via un bouton dans l'interface mais pour pouvoir supprimer les méthodes de connexion il fallait faire des manipulations en BDD.

Afin de rendre cette procédure plus simple, lors de l'anonymisation, les méthodes d'authentification de l'utilisateur sont supprimées automatiquement par la même occasion.

## :gift: Solution
- Nous supprimons toutes  les méthodes de l'utilisateur au moment où ses données sont anonymisées.
- Côté Pix Admin, le bouton "anonymiser" est visible quelque soit les méthodes de connexion de l'utilisateur et reste visible même une fois l'anonymisation effectuée.

## :star2: Remarques
Le DomainTransaction n'a pas été utilisé : le useCase anonymise et supprime, si l'un de ces procédures est en erreur, l'admin peut renouveler l'opération en cliquant sur le bouton anonymiser. 

## :santa: Pour tester
- Se connecter sur Pix Admin (pixmaster@example.net)
- Rechercher l'utilisateur `pro.member@example.net` et cliquer sur anonymiser dans la page de détail de l'utilisateur 
- Vérifier qu'il n'a plus de méthodes de connexion : on peut voir une icône cercle avec croix blanche en face de chaque méthode
- Le userName de l'utilisateur a été supprimé quand il existe et n'est plus visible sur la page 
- Vérifier en BDD dans `authentication-methods` que l'entrée avec un userId correspondant l'id de l'utilisateur (3) a disparu

- Il est possible de faire le test avec un utilisateur pole emploi `firstname-0.lastname-0106404@example.net` ou `john.hasleftsco@example.net` qui a un accès GAR et une adresse email


`scalingo -a pix-api-review-pr3779 --region osc-fr1 run "npm run db:seed"`