### PR TITLE
[BUGFIX] Interdire l'import des fichiers SIECLE avec un mime-type non autorisé.

### DIFF
--- a/orga/app/adapters/students-import.js
+++ b/orga/app/adapters/students-import.js
@@ -1,6 +1,8 @@
 import ApplicationAdapter from './application';
 
 export default class StudentImportsAdapter extends ApplicationAdapter {
+  static FORMAT_NOT_SUPPORTED_ERROR = 'format-not-supported-error';
+
   addStudentsCsv(organizationId, files) {
     if (!files || files.length === 0) return;
 
@@ -15,10 +17,16 @@ export default class StudentImportsAdapter extends ApplicationAdapter {
     return this.ajax(url, 'POST', { data: files[0] });
   }
 
-  importStudentsSiecle(organizationId, files, format) {
+  importStudentsSiecle(organizationId, files, acceptedFormat) {
     if (!files || files.length === 0) return;
 
-    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/schooling-registrations/import-siecle?format=${format}`;
-    return this.ajax(url, 'POST', { data: files[0] });
+    const fileToUpload = files[0];
+    const fileToUploadMimeType = fileToUpload.type;
+    if (!fileToUploadMimeType?.includes(acceptedFormat)) {
+      throw new Error(StudentImportsAdapter.FORMAT_NOT_SUPPORTED_ERROR);
+    }
+
+    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/schooling-registrations/import-siecle?format=${acceptedFormat}`;
+    return this.ajax(url, 'POST', { data: fileToUpload });
   }
 }

--- a/orga/app/adapters/students-import.js
+++ b/orga/app/adapters/students-import.js
@@ -1,8 +1,7 @@
 import ApplicationAdapter from './application';
+import ENV from 'pix-orga/config/environment';
 
 export default class StudentImportsAdapter extends ApplicationAdapter {
-  static FORMAT_NOT_SUPPORTED_ERROR = 'format-not-supported-error';
-
   addStudentsCsv(organizationId, files) {
     if (!files || files.length === 0) return;
 
@@ -23,7 +22,7 @@ export default class StudentImportsAdapter extends ApplicationAdapter {
     const fileToUpload = files[0];
     const fileToUploadMimeType = fileToUpload.type;
     if (!fileToUploadMimeType?.includes(acceptedFormat)) {
-      throw new Error(StudentImportsAdapter.FORMAT_NOT_SUPPORTED_ERROR);
+      throw new Error(ENV.APP.ERRORS.FILE_UPLOAD.FORMAT_NOT_SUPPORTED_ERROR);
     }
 
     const url = `${this.host}/${this.namespace}/organizations/${organizationId}/schooling-registrations/import-siecle?format=${acceptedFormat}`;

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { CONNECTION_TYPES } from '../../../models/student';
-import StudentImportsAdapter from '../../../adapters/students-import';
+import ENV from 'pix-orga/config/environment';
 
 export default class ListController extends Controller {
   @service currentUser;
@@ -13,7 +13,6 @@ export default class ListController extends Controller {
   @service store;
 
   @tracked isLoading = false;
-
   @tracked lastName = null;
   @tracked firstName = null;
   @tracked divisions = [];
@@ -56,7 +55,7 @@ export default class ListController extends Controller {
   }
 
   _handleError(errorResponse, acceptedFormat) {
-    if (errorResponse.message === StudentImportsAdapter.FORMAT_NOT_SUPPORTED_ERROR) {
+    if (errorResponse.message === ENV.APP.ERRORS.FILE_UPLOAD.FORMAT_NOT_SUPPORTED_ERROR) {
       return this.notifications.sendError(
         this.intl.t('pages.students-sco.import.invalid-mimetype', { format: acceptedFormat, htmlSafe: true })
       );

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -39,10 +39,10 @@ export default class ListController extends Controller {
   async importStudents(files) {
     const adapter = this.store.adapterFor('students-import');
     const organizationId = this.currentUser.organization.id;
-    const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
+    const acceptedFormat = this.currentUser.isAgriculture ? 'csv' : 'xml';
     const fileToUploadMimeType = files[0]?.type;
-    if (!fileToUploadMimeType?.includes(format)) {
-      const message = this.intl.t('pages.students-sco.import.invalid-mimetype', { format });
+    if (!fileToUploadMimeType?.includes(acceptedFormat)) {
+      const message = this.intl.t('pages.students-sco.import.invalid-mimetype', { format: acceptedFormat });
       this.notifications.sendError(this.intl.t('pages.students-sco.import.error-wrapper', { message }));
       return;
     }
@@ -50,7 +50,7 @@ export default class ListController extends Controller {
     this.isLoading = true;
     this.notifications.clearAll();
     try {
-      await adapter.importStudentsSiecle(organizationId, files, format);
+      await adapter.importStudentsSiecle(organizationId, files, acceptedFormat);
       this.refresh();
       this.isLoading = false;
       this.notifications.sendSuccess(this.intl.t('pages.students-sco.import.global-success'));

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -42,7 +42,8 @@ export default class ListController extends Controller {
     const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
     const fileToUploadMimeType = files[0]?.type;
     if (!fileToUploadMimeType?.includes(format)) {
-      this.notifications.sendError(this.intl.t('pages.students-sco.import.invalid-mimetype', { format }));
+      const message = this.intl.t('pages.students-sco.import.invalid-mimetype', { format });
+      this.notifications.sendError(this.intl.t('pages.students-sco.import.error-wrapper', { message }));
       return;
     }
 

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -57,9 +57,8 @@ export default class ListController extends Controller {
 
   _handleError(errorResponse, acceptedFormat) {
     if (errorResponse.message === StudentImportsAdapter.FORMAT_NOT_SUPPORTED_ERROR) {
-      const message = this.intl.t('pages.students-sco.import.invalid-mimetype', { format: acceptedFormat });
       return this.notifications.sendError(
-        this.intl.t('pages.students-sco.import.error-wrapper', { message, htmlSafe: true })
+        this.intl.t('pages.students-sco.import.invalid-mimetype', { format: acceptedFormat, htmlSafe: true })
       );
     }
 

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -40,6 +40,11 @@ export default class ListController extends Controller {
     const adapter = this.store.adapterFor('students-import');
     const organizationId = this.currentUser.organization.id;
     const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
+    const fileToUploadMimeType = files[0]?.type;
+    if (!fileToUploadMimeType?.includes(format)) {
+      this.notifications.sendError(this.intl.t('pages.students-sco.import.invalid-mimetype', { format }));
+      return;
+    }
 
     this.isLoading = true;
     this.notifications.clearAll();

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -45,6 +45,11 @@ module.exports = function (environment) {
         minValue: 1,
       }),
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
+      ERRORS: {
+        FILE_UPLOAD: {
+          FORMAT_NOT_SUPPORTED_ERROR: 'format-not-supported-error',
+        },
+      },
     },
 
     googleFonts: [

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -248,7 +248,7 @@ export default function () {
           )
         );
       });
-    } else if (type === 'valid-file') {
+    } else if (type === 'valid-file' || type === 'xml') {
       const organizationId = request.params.id;
       return schema.students.create({ organizationId: organizationId, firstName: 'Harry', lastName: 'Cover' });
     }

--- a/orga/tests/acceptance/sco-student-list_test.js
+++ b/orga/tests/acceptance/sco-student-list_test.js
@@ -114,11 +114,7 @@ module('Acceptance | Sco Student List', function (hooks) {
         test('it should display invalid mime-type message when uploading a file with a wrong mime-type', async function (assert) {
           // given
           await visit('/eleves');
-          const expectedMimeTypeFormatWhenUserIsNotAGRI = 'xml';
           const fileWithWrongMimeType = new Blob(['foo'], { type: 'text/csv' });
-          const expectedMsg = this.intl.t('pages.students-sco.import.invalid-mimetype', {
-            format: expectedMimeTypeFormatWhenUserIsNotAGRI,
-          });
 
           // when
           const input = find('#students-file-upload');
@@ -126,7 +122,11 @@ module('Acceptance | Sco Student List', function (hooks) {
 
           // then
           assert.dom('[data-test-notification-message="error"]').exists();
-          assert.dom('[data-test-notification-message="error"]').hasText(expectedMsg);
+          assert
+            .dom('[data-test-notification-message="error"]')
+            .hasText(
+              "Aucun élève n’a été importé.Le type de fichier n'est pas accepté, veuillez importer un fichier xml Veuillez vérifier ou modifier votre base élèves et importer à nouveau."
+            );
         });
       });
 

--- a/orga/tests/acceptance/sco-student-list_test.js
+++ b/orga/tests/acceptance/sco-student-list_test.js
@@ -125,7 +125,7 @@ module('Acceptance | Sco Student List', function (hooks) {
           assert
             .dom('[data-test-notification-message="error"]')
             .hasText(
-              "Aucun élève n’a été importé.Le type de fichier n'est pas accepté, veuillez importer un fichier xml Veuillez vérifier ou modifier votre base élèves et importer à nouveau."
+              "Aucun élève n’a été importé.Le type de fichier n'est pas accepté, veuillez importer un fichier xml."
             );
         });
       });

--- a/orga/tests/helpers/catch-err.js
+++ b/orga/tests/helpers/catch-err.js
@@ -1,0 +1,10 @@
+export default function catchErr(promiseFn, ctx) {
+  return async (...args) => {
+    try {
+      await promiseFn.call(ctx, ...args);
+      return 'should have thrown an error';
+    } catch (err) {
+      return err;
+    }
+  };
+}

--- a/orga/tests/unit/adapters/students-import_test.js
+++ b/orga/tests/unit/adapters/students-import_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import catchErr from '../../helpers/catch-err';
-import StudentImportsAdapter from '../../../app/adapters/students-import';
+import ENV from 'pix-orga/config/environment';
 
 module('Unit | Adapters | Students import', function (hooks) {
   setupTest(hooks);
@@ -45,7 +45,7 @@ module('Unit | Adapters | Students import', function (hooks) {
     test('should throw an error if format is not handled', async function (assert) {
       const error = await catchErr(adapter.importStudentsSiecle)(1, [zipFile], acceptedFormat);
       sinon.assert.notCalled(adapter.ajax);
-      assert.equal(error.message, StudentImportsAdapter.FORMAT_NOT_SUPPORTED_ERROR);
+      assert.equal(error.message, ENV.APP.ERRORS.FILE_UPLOAD.FORMAT_NOT_SUPPORTED_ERROR);
     });
 
     test('should build importStudentsSiecle url from organizationId and format', async function (assert) {

--- a/orga/tests/unit/adapters/students-import_test.js
+++ b/orga/tests/unit/adapters/students-import_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import catchErr from '../../helpers/catch-err';
 import StudentImportsAdapter from '../../../app/adapters/students-import';
 
 module('Unit | Adapters | Students import', function (hooks) {
@@ -42,17 +43,9 @@ module('Unit | Adapters | Students import', function (hooks) {
     const acceptedFormat = 'csv';
 
     test('should throw an error if format is not handled', async function (assert) {
-      assert.expect(1);
-
-      try {
-        // when
-        await adapter.importStudentsSiecle(1, [zipFile], acceptedFormat);
-        assert.fail('It should not be possible to upload a zip');
-      } catch (error) {
-        // then
-        sinon.assert.notCalled(adapter.ajax);
-        assert.equals(error.message, StudentImportsAdapter.FORMAT_NOT_SUPPORTED_ERROR);
-      }
+      const error = await catchErr(adapter.importStudentsSiecle)(1, [zipFile], acceptedFormat);
+      sinon.assert.notCalled(adapter.ajax);
+      assert.equal(error.message, StudentImportsAdapter.FORMAT_NOT_SUPPORTED_ERROR);
     });
 
     test('should build importStudentsSiecle url from organizationId and format', async function (assert) {

--- a/orga/tests/unit/adapters/students-import_test.js
+++ b/orga/tests/unit/adapters/students-import_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import StudentImportsAdapter from '../../../app/adapters/students-import';
 
 module('Unit | Adapters | Students import', function (hooks) {
   setupTest(hooks);
@@ -36,9 +37,27 @@ module('Unit | Adapters | Students import', function (hooks) {
   });
 
   module('#importStudentsSiecle', function () {
+    const zipFile = new File([''], 'archive.zip', { type: 'application/zip' });
+    const csvFile = new File([''], 'file.csv', { type: 'text/csv' });
+    const acceptedFormat = 'csv';
+
+    test('should throw an error if format is not handled', async function (assert) {
+      assert.expect(1);
+
+      try {
+        // when
+        await adapter.importStudentsSiecle(1, [zipFile], acceptedFormat);
+        assert.fail('It should not be possible to upload a zip');
+      } catch (error) {
+        // then
+        sinon.assert.notCalled(adapter.ajax);
+        assert.equals(error.message, StudentImportsAdapter.FORMAT_NOT_SUPPORTED_ERROR);
+      }
+    });
+
     test('should build importStudentsSiecle url from organizationId and format', async function (assert) {
       // when
-      await adapter.importStudentsSiecle(1, [Symbol()], 'csv');
+      await adapter.importStudentsSiecle(1, [csvFile], acceptedFormat);
 
       // then
       assert.ok(

--- a/orga/tests/unit/controllers/authenticated/sco-students/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-students/list_test.js
@@ -4,10 +4,11 @@ import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
   setupTest(hooks);
-  const files = Symbol('files');
   const currentUser = { organization: { id: 1 } };
   let controller;
   let importStudentStub;
+  const filesWithXmlMimeType = [{ type: 'text/xml' }];
+  const filesWithCsvMimeType = [{ type: 'text/csv' }];
 
   hooks.beforeEach(function () {
     this.owner.lookup('service:intl').setLocale('fr');
@@ -25,9 +26,9 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
       test('it sends the chosen csv file to the API', async function (assert) {
         currentUser.isAgriculture = true;
 
-        await controller.importStudents(files);
+        await controller.importStudents(filesWithCsvMimeType);
 
-        assert.ok(importStudentStub.calledWith(1, files, 'csv'));
+        assert.ok(importStudentStub.calledWith(1, filesWithCsvMimeType, 'csv'));
       });
     });
 
@@ -35,9 +36,9 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
       test('it sends the chosen xml file to the API', async function (assert) {
         currentUser.isAgriculture = false;
 
-        await controller.importStudents(files);
+        await controller.importStudents(filesWithXmlMimeType);
 
-        assert.ok(importStudentStub.calledWith(1, files, 'xml'));
+        assert.ok(importStudentStub.calledWith(1, filesWithXmlMimeType, 'xml'));
       });
     });
 
@@ -50,7 +51,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
         importStudentStub.rejects({ errors: [{ status: '401' }] });
 
         // when
-        await controller.importStudents(files);
+        await controller.importStudents(filesWithXmlMimeType);
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
@@ -64,7 +65,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
         importStudentStub.rejects({ errors: [{ status: '412', detail: 'Error message' }] });
 
         // when
-        await controller.importStudents(files);
+        await controller.importStudents(filesWithXmlMimeType);
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
@@ -78,7 +79,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
         importStudentStub.rejects({ errors: [{ status: '413', detail: 'Error message' }] });
 
         // when
-        await controller.importStudents(files);
+        await controller.importStudents(filesWithXmlMimeType);
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
@@ -92,7 +93,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
         importStudentStub.rejects({ errors: [{ status: '422', detail: 'Error message' }] });
 
         // when
-        await controller.importStudents(files);
+        await controller.importStudents(filesWithXmlMimeType);
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -647,6 +647,7 @@
       "import": {
         "error-wrapper": "<div>Import has failed.<br/><strong>{message}</strong><br/> Please check or edit your file and try to import it again.</div>",
         "global-error": "<div>Import has failed.<br/>Please try again or contact us through <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">the help form</a>.</div>",
+        "invalid-mimetype": "The file type is not allowed, please upload {format} file",
         "global-success": "The list has been successfully imported."
       },
       "manage-authentication-method-modal": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -385,7 +385,7 @@
             "empty": "All statuses"
           },
           "stages": "Success rate",
-          "groups":  {
+          "groups": {
             "title": "Groups",
             "empty": "No group"
           }
@@ -647,7 +647,7 @@
       "import": {
         "error-wrapper": "<div>Import has failed.<br/><strong>{message}</strong><br/> Please check or edit your file and try to import it again.</div>",
         "global-error": "<div>Import has failed.<br/>Please try again or contact us through <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">the help form</a>.</div>",
-        "invalid-mimetype": "The file type is not allowed, please upload {format} file",
+        "invalid-mimetype": "<div>Import has failed.<br/><strong>The file type is not allowed, please upload a {format} file.</strong>",
         "global-success": "The list has been successfully imported."
       },
       "manage-authentication-method-modal": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -640,6 +640,7 @@
       "import": {
         "error-wrapper": "<div>Aucun élève n’a été importé.<br/><strong>{message}</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>",
         "global-error": "<div>Aucun élève n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">le formulaire du centre d’aide</a>.</div>",
+        "invalid-mimetype": "Le type de fichier n'est pas accepté, veuillez importer un fichier {format}",
         "global-success": "La liste a été importée avec succès."
       },
       "manage-authentication-method-modal": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -640,7 +640,7 @@
       "import": {
         "error-wrapper": "<div>Aucun élève n’a été importé.<br/><strong>{message}</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>",
         "global-error": "<div>Aucun élève n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">le formulaire du centre d’aide</a>.</div>",
-        "invalid-mimetype": "Le type de fichier n'est pas accepté, veuillez importer un fichier {format}",
+        "invalid-mimetype": "<div>Aucun élève n’a été importé.<br/><strong>Le type de fichier n'est pas accepté, veuillez importer un fichier {format}.</strong>",
         "global-success": "La liste a été importée avec succès."
       },
       "manage-authentication-method-modal": {


### PR DESCRIPTION
## :christmas_tree: Problème
Un grand nombre d'erreurs tracées dans Datadog liées au parsing de fichier SIECLE invalide via la lib SAX qui polluent la prod. > 70000 errors dans les deux dernières semaines. 
[https://app.datadoghq.eu/logs?query=status%3Aerror%20service%3Apix-api-production%20%40msg%3AText%3Fdata%3Foutside%3Fof%3Froot%3Fnode.%2A&agg_m=count&agg_q=&agg_t=count&index=&sort_m=&sort_t=&stream_sort=time%2Casc&top_n=&top_o=&viz=stream&from_ts=1634984489947&to_ts=1637576489947&live=true]()
L'erreur de la lib en question
https://github.com/isaacs/sax-js/blob/5aee2163d55cff24b817bbf550bac44841f9df45/lib/sax.js#L1035

Le problème a été reproduit en local en important un fichier CSV alors que le type fichier attendu est en XML.

![image](https://user-images.githubusercontent.com/10045497/143596840-27de6258-4bb4-40f1-b295-67c8fc587310.png)

Le problème vient du fait qu'on détermine le type de fichier à upload via la règle de gestion ci-dessous.
`const format = this.currentUser.isAgriculture ? 'csv' : 'xml';`
Du coup on se retrouve avec des déphasages entre le vrai mime type du fichier et celui calculé avec la règle de gestion.
Le parsing du fichier en streaming 


## :gift: Solution
Quick Fix: 1- Rajouter un check entre le mime-type du fichier et celui autorisé. Le but est d'éviter l'appel à l'API en cas de mime-type non autorisé. 
2- On pourrait rajouter la règle de gestion coté backend pour protéger l'API. ( Sera faite dans une PR )
3- On pourrait aussi blinder par la suite le parsing en s'arrêtant à la première erreur.  ( Sera faite dans une PR )

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Se connecter à Pix Orga avec un utilisateur SCO qui n'est pas AGRI.
Importer un fichier csv au lieu d'un fichier Xml.
Vérifier qu'il n'y a pas d'erreur coté API et qu'on a bien un message d'erreur.
Faire une non régression de l'import du fichier