### PR TITLE
[TECH] Améliorer l'accessibilité de la navigation sur Pix Orga (PIX-3894).

### DIFF
--- a/orga/app/components/dropdown/item.hbs
+++ b/orga/app/components/dropdown/item.hbs
@@ -1,10 +1,5 @@
-<li
-  class="dropdown__item"
-  role="button"
-  tabindex="0"
-  {{on "click" @onClick}}
-  {{on "keyup" this.handleKeyUp}}
-  ...attributes
->
-  {{yield}}
+<li class="dropdown__item dropdown__item--link" {{on "keyup" this.handleKeyUp}} ...attributes>
+  <button type="button" {{on "click" @onClick}}>
+    {{yield}}
+  </button>
 </li>

--- a/orga/app/styles/components/dropdown.scss
+++ b/orga/app/styles/components/dropdown.scss
@@ -14,23 +14,26 @@
   }
 
   &__item {
-    align-items: center;
-    border-radius: 4px;
-    color: $grey-60;
-    cursor: pointer;
     display: flex;
-    font-size: 0.875rem;
-    transition: background-color 0.1s linear;
-    padding: 12px 16px;
 
     &--link {
       padding: 0;
-    
-      > a {
+
+      > button {
+        border: none;
+        background-color: transparent;
+        font-family: $roboto;
+        text-align: start;
+      }
+
+      > a, > button {
         color: $grey-60;
         padding: 12px 16px;
         width: 100%;
         height: 100%;
+        font-size: 0.875rem;
+        cursor: pointer;
+        transition: background-color 0.1s linear;
 
         &:hover,
         &:active,
@@ -40,25 +43,12 @@
           text-decoration: none;
         }
 
-        &:focus {
+        &:focus, &:focus-visible {
           border-radius: 4px;
           box-shadow: inset 0px 0px 0px 1.6px $blue;
           outline: none;
         }
       }
-    }
-
-    &:hover,
-    &:active,
-    &:focus {
-      background-color: $grey-10;
-      color: $grey-60;
-    }
-
-    &:focus {
-      border-radius: 4px;
-      box-shadow: inset 0px 0px 0px 1.6px $blue;
-      outline: none;
     }
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
De nombreuses pages sur Pix Orga ne répondent pas aux critères d'accessibilité.
Une audit accessibilité sur cette application nous permet désormais de l'améliorer.

Actuellement nous ne remplissons pas le critère suivant : **Dans chaque page web, le contenu visible porteur d’information reste-t-il présent lorsque les feuilles de styles sont désactivées ?**

Lorsque les styles sont désactivés, les "boutons" du menu déroulant ne sont plus cliquables.

<img width="294" alt="Capture d’écran 2021-11-26 à 16 28 46" src="https://user-images.githubusercontent.com/58915422/143603061-450f3982-2de4-4a60-a840-4303e80ddb64.png">

## :gift: Solution
Ajouter des boutons dans le menu déroulant pour rendre les éléments cliquables.

## :star2: Remarques
L'utilisation de `role="button"` sur un `<li>` lui fait perdre sa nature d'élément de liste en plus de rendre le bouton inutilisable en mode CSS désactivé. Il faut donc intégrer un `<button>` dans un `<li>` pour éviter ce problème.

## :santa: Pour tester
- Se connecter sur Pix Orga (ex : sco.admin@example.net )
- Utiliser Wave pour retirer les feuilles de style de l'application
<img width="380" alt="Capture d’écran 2021-11-26 à 16 22 25" src="https://user-images.githubusercontent.com/58915422/143602358-0a145cba-1095-4a96-bfd5-49c2e9ac7729.png">

- Constater que la liste (les orgas et la partie "Se déconnecter) sont des boutons et sont cliquables
<img width="294" alt="Capture d’écran 2021-11-26 à 16 29 09" src="https://user-images.githubusercontent.com/58915422/143603082-b67f7233-deb2-4650-811f-e76559b30054.png">

- Vérifier le comportement au focus, lecteur d'écran etc... Vous pouvez comparer avec dev pour voir que cette ajout n'a pas impacté le rendu de base.
