### PR TITLE
[FEATURE] Ne pas permettre à un utilisateur de se connecter à PixCertif si ses accès ont été désactivés (PIX-3562).

### DIFF
--- a/api/db/database-builder/factory/build-certification-center-membership.js
+++ b/api/db/database-builder/factory/build-certification-center-membership.js
@@ -8,6 +8,7 @@ module.exports = function buildCertificationCenterMembership({
   userId,
   certificationCenterId,
   createdAt = new Date('2020-01-01'),
+  disabledAt,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   certificationCenterId = _.isUndefined(certificationCenterId) ? buildCertificationCenter().id : certificationCenterId;
@@ -17,6 +18,7 @@ module.exports = function buildCertificationCenterMembership({
     userId,
     certificationCenterId,
     createdAt,
+    disabledAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-center-memberships',

--- a/api/db/migrations/20211126144130_add-disabled-at-column-in-certification-center-memberships-table.js
+++ b/api/db/migrations/20211126144130_add-disabled-at-column-in-certification-center-memberships-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-center-memberships';
+const DISABLED_AT_COLUMN = 'disabledAt';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(DISABLED_AT_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(DISABLED_AT_COLUMN);
+  });
+};

--- a/api/lib/domain/models/CertificationCenterMembership.js
+++ b/api/lib/domain/models/CertificationCenterMembership.js
@@ -1,9 +1,10 @@
 class CertificationCenterMembership {
-  constructor({ id, certificationCenter, user, createdAt } = {}) {
+  constructor({ id, certificationCenter, user, createdAt, disabledAt } = {}) {
     this.id = id;
     this.certificationCenter = certificationCenter;
     this.user = user;
     this.createdAt = createdAt;
+    this.disabledAt = disabledAt;
   }
 }
 

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -82,7 +82,9 @@ class User {
 
   hasAccessToCertificationCenter(certificationCenterId) {
     return this.certificationCenterMemberships.some(
-      (certificationCenterMembership) => certificationCenterMembership.certificationCenter.id === certificationCenterId
+      (certificationCenterMembership) =>
+        certificationCenterMembership.certificationCenter.id === certificationCenterId &&
+        _.isNil(certificationCenterMembership.disabledAt)
     );
   }
 }

--- a/api/lib/domain/usecases/find-certification-center-memberships-by-certification-center.js
+++ b/api/lib/domain/usecases/find-certification-center-memberships-by-certification-center.js
@@ -2,5 +2,5 @@ module.exports = function findCertificationCenterMembershipsByCertificationCente
   certificationCenterId,
   certificationCenterMembershipRepository,
 }) {
-  return certificationCenterMembershipRepository.findByCertificationCenterId(certificationCenterId);
+  return certificationCenterMembershipRepository.findActiveByCertificationCenterId(certificationCenterId);
 };

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -15,8 +15,11 @@ module.exports = {
     );
   },
 
-  async findByCertificationCenterId(certificationCenterId) {
-    const certificationCenterMemberships = await BookshelfCertificationCenterMembership.where({ certificationCenterId })
+  async findActiveByCertificationCenterId(certificationCenterId) {
+    const certificationCenterMemberships = await BookshelfCertificationCenterMembership.where({
+      certificationCenterId,
+      disabledAt: null,
+    })
       .orderBy('id', 'ASC')
       .fetchAll({
         withRelated: ['certificationCenter', 'user'],

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -28,11 +28,11 @@ module.exports = {
       throw new NotFoundError(`Le référent de certification ${userId} n'existe pas.`);
     }
 
-    const autorizedCertificationCenterIds = await _removeDisabledCertificationCenterAccesses({
+    const authorizedCertificationCenterIds = await _removeDisabledCertificationCenterAccesses({
       certificationPointOfContactDTO,
     });
     const allowedCertificationCenterAccesses = await _findAllowedCertificationCenterAccesses(
-      autorizedCertificationCenterIds
+      authorizedCertificationCenterIds
     );
 
     return new CertificationPointOfContact({

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -21,6 +21,7 @@ module.exports = {
       .from('users')
       .leftJoin('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')
       .where('users.id', userId)
+      .where('certification-center-memberships.disabledAt', null)
       .groupByRaw('1, 2, 3, 4, 5')
       .first();
 

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -96,6 +96,7 @@ module.exports = {
     const session = await BookshelfSession.where({
       'sessions.id': sessionId,
       'certification-center-memberships.userId': userId,
+      'certification-center-memberships.disabledAt': null,
     })
       .query((qb) => {
         qb.innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId');

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -152,7 +152,10 @@ module.exports = {
   getWithCertificationCenterMemberships(userId) {
     return BookshelfUser.where({ id: userId })
       .fetch({
-        withRelated: ['certificationCenterMemberships.certificationCenter'],
+        withRelated: [
+          { certificationCenterMemberships: (qb) => qb.where({ disabledAt: null }) },
+          'certificationCenterMemberships.certificationCenter',
+        ],
       })
       .then(_toDomain)
       .catch((err) => {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -49,6 +49,7 @@ module.exports = {
         require: false,
         withRelated: [
           { memberships: (qb) => qb.where({ disabledAt: null }) },
+          { certificationCenterMemberships: (qb) => qb.where({ disabledAt: null }) },
           'memberships.organization',
           'pixRoles',
           'certificationCenterMemberships.certificationCenter',

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -104,7 +104,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
   });
 
-  describe('#findByCertificationCenterId', function () {
+  describe('#findActiveByCertificationCenterId', function () {
     it('should return certification center membership associated to the certification center', async function () {
       // given
       const now = new Date('2021-01-02');
@@ -126,7 +126,7 @@ describe('Integration | Repository | Certification Center Membership', function 
 
       // when
       const foundCertificationCenterMemberships =
-        await certificationCenterMembershipRepository.findByCertificationCenterId(certificationCenter.id);
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterId(certificationCenter.id);
 
       // then
       expect(foundCertificationCenterMemberships).to.be.an('array');
@@ -162,12 +162,39 @@ describe('Integration | Repository | Certification Center Membership', function 
 
       // when
       const foundCertificationCenterMemberships =
-        await certificationCenterMembershipRepository.findByCertificationCenterId(certificationCenter.id);
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterId(certificationCenter.id);
 
       // then
       expect(foundCertificationCenterMemberships[0].id).to.equal(10);
       expect(foundCertificationCenterMemberships[1].id).to.equal(20);
       expect(foundCertificationCenterMemberships[2].id).to.equal(30);
+    });
+
+    it('should only return active (not disabled) certification center memberships', async function () {
+      // given
+      const now = new Date();
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const user1 = databaseBuilder.factory.buildUser();
+      const user2 = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        id: 7,
+        userId: user1.id,
+        certificationCenterId: certificationCenter.id,
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId: user2.id,
+        certificationCenterId: certificationCenter.id,
+        disabledAt: now,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const foundCertificationCenterMemberships =
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterId(certificationCenter.id);
+
+      // then
+      expect(foundCertificationCenterMemberships.length).to.equal(1);
+      expect(foundCertificationCenterMemberships[0].id).to.equal(7);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -105,8 +105,6 @@ describe('Integration | Repository | Certification Center Membership', function 
   });
 
   describe('#findByCertificationCenterId', function () {
-    let certificationCenterMembership;
-
     it('should return certification center membership associated to the certification center', async function () {
       // given
       const now = new Date('2021-01-02');
@@ -114,7 +112,7 @@ describe('Integration | Repository | Certification Center Membership', function 
 
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ updatedAt: now });
       const user = databaseBuilder.factory.buildUser();
-      certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+      const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
         certificationCenterId: certificationCenter.id,
         userId: user.id,
       });

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -91,131 +91,125 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
       expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
     });
 
-    it('should return all the AllowedCertificationCenterAccesses of the CertificationPointOfContact if user is linked to many certification centers', async function () {
-      // given
-      databaseBuilder.factory.buildCertificationCenter({
-        id: 1,
-        name: 'Centre de certif sans orga reliée',
-        type: CertificationCenter.types.PRO,
-        externalId: 'Centre1',
-      });
-      databaseBuilder.factory.buildCertificationCenter({
-        id: 2,
-        name: 'Centre de certif reliée à une orga sans tags',
-        type: CertificationCenter.types.PRO,
-        externalId: 'Centre2',
-      });
-      databaseBuilder.factory.buildOrganization({
-        externalId: 'Centre2',
-        isManagingStudents: true,
-      });
-      databaseBuilder.factory.buildCertificationCenter({
-        id: 3,
-        name: 'Centre de certif reliée à une orga avec 1 tag',
-        type: CertificationCenter.types.SUP,
-        externalId: 'Centre3',
-      });
-      databaseBuilder.factory.buildOrganization({
-        id: 3,
-        externalId: 'Centre3',
-        isManagingStudents: false,
-      });
-      databaseBuilder.factory.buildTag({ id: 3, name: 'premier tag' });
-      databaseBuilder.factory.buildOrganizationTag({ organizationId: 3, tagId: 3 });
-      databaseBuilder.factory.buildCertificationCenter({
-        id: 4,
-        name: 'Centre de certif reliée à une orga avec 2 tags',
-        type: CertificationCenter.types.SCO,
-        externalId: 'Centre4',
-      });
-      databaseBuilder.factory.buildOrganization({
-        id: 4,
-        externalId: 'Centre4',
-        isManagingStudents: false,
-      });
-      databaseBuilder.factory.buildTag({ id: 4, name: 'deuxieme tag' });
-      databaseBuilder.factory.buildTag({ id: 5, name: 'troisieme tag' });
-      databaseBuilder.factory.buildOrganizationTag({ organizationId: 4, tagId: 4 });
-      databaseBuilder.factory.buildOrganizationTag({ organizationId: 4, tagId: 5 });
-      databaseBuilder.factory.buildUser({
-        id: 123,
-        firstName: 'Jean',
-        lastName: 'Acajou',
-        email: 'jean.acajou@example.net',
-        pixCertifTermsOfServiceAccepted: true,
-      });
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: 1,
-        userId: 123,
-      });
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: 2,
-        userId: 123,
-      });
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: 3,
-        userId: 123,
-      });
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: 4,
-        userId: 123,
-      });
-      await databaseBuilder.commit();
+    describe('when user is linked to many certification centers', function () {
+      it('should return actives and allowed certification center accesses of the CertificationPointOfContact', async function () {
+        // given
+        const now = new Date();
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'Centre de certif sans orga reliée',
+          type: CertificationCenter.types.PRO,
+          externalId: 'Centre1',
+        });
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 2,
+          name: 'Centre de certif reliée à une orga sans tags',
+          type: CertificationCenter.types.PRO,
+          externalId: 'Centre2',
+        });
+        databaseBuilder.factory.buildOrganization({
+          externalId: 'Centre2',
+          isManagingStudents: true,
+        });
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 3,
+          name: 'Centre de certif reliée à une orga avec 1 tag',
+          type: CertificationCenter.types.SUP,
+          externalId: 'Centre3',
+        });
+        databaseBuilder.factory.buildOrganization({
+          id: 3,
+          externalId: 'Centre3',
+          isManagingStudents: false,
+        });
+        databaseBuilder.factory.buildTag({ id: 3, name: 'premier tag' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: 3, tagId: 3 });
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 4,
+          name: 'Centre de certif reliée à une orga avec 2 tags',
+          type: CertificationCenter.types.SCO,
+          externalId: 'Centre4',
+        });
+        databaseBuilder.factory.buildOrganization({
+          id: 4,
+          externalId: 'Centre4',
+          isManagingStudents: false,
+        });
+        databaseBuilder.factory.buildTag({ id: 4, name: 'deuxieme tag' });
+        databaseBuilder.factory.buildTag({ id: 5, name: 'troisieme tag' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: 4, tagId: 4 });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: 4, tagId: 5 });
+        databaseBuilder.factory.buildUser({
+          id: 123,
+          firstName: 'Jean',
+          lastName: 'Acajou',
+          email: 'jean.acajou@example.net',
+          pixCertifTermsOfServiceAccepted: true,
+        });
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: 1,
+          userId: 123,
+        });
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: 2,
+          userId: 123,
+        });
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: 3,
+          userId: 123,
+        });
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: 4,
+          userId: 123,
+          disabledAt: now,
+        });
+        await databaseBuilder.commit();
 
-      // when
-      const certificationPointOfContact = await certificationPointOfContactRepository.get(123);
+        // when
+        const certificationPointOfContact = await certificationPointOfContactRepository.get(123);
 
-      // then
-      const expectedFirstAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
-        id: 1,
-        name: 'Centre de certif sans orga reliée',
-        externalId: 'Centre1',
-        type: CertificationCenter.types.PRO,
-        isRelatedToManagingStudentsOrganization: false,
-        relatedOrganizationTags: [],
-        habilitations: [],
+        // then
+        const expectedFirstAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 1,
+          name: 'Centre de certif sans orga reliée',
+          externalId: 'Centre1',
+          type: CertificationCenter.types.PRO,
+          isRelatedToManagingStudentsOrganization: false,
+          relatedOrganizationTags: [],
+          habilitations: [],
+        });
+        const expectedSecondAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 2,
+          name: 'Centre de certif reliée à une orga sans tags',
+          externalId: 'Centre2',
+          type: CertificationCenter.types.PRO,
+          isRelatedToManagingStudentsOrganization: true,
+          relatedOrganizationTags: [],
+          habilitations: [],
+        });
+        const expectedThirdAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 3,
+          name: 'Centre de certif reliée à une orga avec 1 tag',
+          externalId: 'Centre3',
+          type: CertificationCenter.types.SUP,
+          isRelatedToManagingStudentsOrganization: false,
+          relatedOrganizationTags: ['premier tag'],
+          habilitations: [],
+        });
+        const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
+          id: 123,
+          firstName: 'Jean',
+          lastName: 'Acajou',
+          email: 'jean.acajou@example.net',
+          pixCertifTermsOfServiceAccepted: true,
+          allowedCertificationCenterAccesses: [
+            expectedFirstAllowedCertificationCenterAccess,
+            expectedSecondAllowedCertificationCenterAccess,
+            expectedThirdAllowedCertificationCenterAccess,
+          ],
+        });
+        expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
       });
-      const expectedSecondAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
-        id: 2,
-        name: 'Centre de certif reliée à une orga sans tags',
-        externalId: 'Centre2',
-        type: CertificationCenter.types.PRO,
-        isRelatedToManagingStudentsOrganization: true,
-        relatedOrganizationTags: [],
-        habilitations: [],
-      });
-      const expectedThirdAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
-        id: 3,
-        name: 'Centre de certif reliée à une orga avec 1 tag',
-        externalId: 'Centre3',
-        type: CertificationCenter.types.SUP,
-        isRelatedToManagingStudentsOrganization: false,
-        relatedOrganizationTags: ['premier tag'],
-        habilitations: [],
-      });
-      const expectedFourthAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
-        id: 4,
-        name: 'Centre de certif reliée à une orga avec 2 tags',
-        externalId: 'Centre4',
-        type: CertificationCenter.types.SCO,
-        isRelatedToManagingStudentsOrganization: false,
-        relatedOrganizationTags: ['deuxieme tag', 'troisieme tag'],
-        habilitations: [],
-      });
-      const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
-        id: 123,
-        firstName: 'Jean',
-        lastName: 'Acajou',
-        email: 'jean.acajou@example.net',
-        pixCertifTermsOfServiceAccepted: true,
-        allowedCertificationCenterAccesses: [
-          expectedFirstAllowedCertificationCenterAccess,
-          expectedSecondAllowedCertificationCenterAccess,
-          expectedThirdAllowedCertificationCenterAccess,
-          expectedFourthAllowedCertificationCenterAccess,
-        ],
-      });
-      expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
     });
 
     it('should return all the certification center habilitations', async function () {

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -366,29 +366,23 @@ describe('Integration | Repository | Session', function () {
   });
 
   describe('#doesUserHaveCertificationCenterMembershipForSession', function () {
-    let userId, userIdNotAllowed, sessionId, certificationCenterId, certificationCenterNotAllowedId;
-
-    beforeEach(async function () {
+    it('should return true if user has membership in the certification center that originated the session', async function () {
       // given
-      userId = 1;
-      userIdNotAllowed = 2;
+      const userId = 1;
+      const userIdNotAllowed = 2;
       databaseBuilder.factory.buildUser({ id: userId });
       databaseBuilder.factory.buildUser({ id: userIdNotAllowed });
-      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      certificationCenterNotAllowedId = databaseBuilder.factory.buildCertificationCenter().id;
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const certificationCenterNotAllowedId = databaseBuilder.factory.buildCertificationCenter().id;
       databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
       databaseBuilder.factory.buildCertificationCenterMembership({
         userId: userIdNotAllowed,
         certificationCenterId: certificationCenterNotAllowedId,
       });
-
-      // when
-      sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
 
       await databaseBuilder.commit();
-    });
 
-    it('should return true if user has membership in the certification center that originated the session', async function () {
       // when
       const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(
         userId,
@@ -400,6 +394,22 @@ describe('Integration | Repository | Session', function () {
     });
 
     it('should return false if user has no membership in the certification center that originated the session', async function () {
+      //given
+      const userId = 1;
+      const userIdNotAllowed = 2;
+      databaseBuilder.factory.buildUser({ id: userId });
+      databaseBuilder.factory.buildUser({ id: userIdNotAllowed });
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const certificationCenterNotAllowedId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId: userIdNotAllowed,
+        certificationCenterId: certificationCenterNotAllowedId,
+      });
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+
+      await databaseBuilder.commit();
+
       // when
       const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(
         userIdNotAllowed,

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -393,6 +393,27 @@ describe('Integration | Repository | Session', function () {
       expect(hasMembership).to.be.true;
     });
 
+    it('should return false if user has a disabled membership in the certification center that originated the session', async function () {
+      //given
+      const userId = 1;
+      const now = new Date();
+      databaseBuilder.factory.buildUser({ id: userId });
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, disabledAt: now });
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(
+        userId,
+        sessionId
+      );
+
+      // then
+      expect(hasMembership).to.be.false;
+    });
+
     it('should return false if user has no membership in the certification center that originated the session', async function () {
       //given
       const userId = 1;

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -486,12 +486,9 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
     });
 
     describe('#getWithCertificationCenterMemberships', function () {
-      beforeEach(async function () {
-        await _insertUserWithOrganizationsAndCertificationCenterAccesses();
-      });
-
       it('should return user for the given id', async function () {
         // given
+        await _insertUserWithOrganizationsAndCertificationCenterAccesses();
         const expectedUser = new User(userInDB);
 
         // when
@@ -507,8 +504,9 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         expect(user.cgu).to.equal(expectedUser.cgu);
       });
 
-      it('should return certification center membership associated to the user', async function () {
+      it('should return actives certification center membership associated to the user', async function () {
         // when
+        await _insertUserWithOrganizationsAndCertificationCenterAccesses();
         const user = await userRepository.getWithCertificationCenterMemberships(userInDB.id);
 
         // then
@@ -526,6 +524,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
       it('should reject with a UserNotFound error when no user was found with the given id', async function () {
         // given
+        await _insertUserWithOrganizationsAndCertificationCenterAccesses();
         const unknownUserId = 666;
 
         // when

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -551,7 +551,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         // when
         const user = await userRepository.getWithCertificationCenterMemberships(userInDB.id);
 
-        // then:
+        // then
         expect(user.certificationCenterMemberships.length).to.equal(1);
 
         const foundCertificationCenterMembership = user.certificationCenterMemberships[0];

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
@@ -16,11 +16,13 @@ module.exports = function buildCertificationCenterMembership({
   certificationCenter = buildCertificationCenter(),
   user = _buildUser(),
   createdAt = new Date('2020-01-01'),
+  disabledAt,
 } = {}) {
   return new CertificationCenterMembership({
     id,
     certificationCenter,
     user,
     createdAt,
+    disabledAt,
   });
 };

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -211,6 +211,25 @@ describe('Unit | Domain | Models | User', function () {
       //then
       expect(hasAccess).to.be.true;
     });
+
+    it('should be false if the user has a disabled access to the given CertificationCenterId ', function () {
+      // given
+      const certificationCenterId = 12345;
+      const now = new Date();
+      const user = domainBuilder.buildUser();
+      user.certificationCenterMemberships = [
+        domainBuilder.buildCertificationCenterMembership({
+          certificationCenter: { id: certificationCenterId },
+          disabledAt: now,
+        }),
+      ];
+
+      // when
+      const hasAccess = user.hasAccessToCertificationCenter(certificationCenterId);
+
+      //then
+      expect(hasAccess).to.be.false;
+    });
   });
 
   describe('#email', function () {

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -212,7 +212,7 @@ describe('Unit | Domain | Models | User', function () {
       expect(hasAccess).to.be.true;
     });
 
-    it('should be false if the user has a disabled access to the given CertificationCenterId ', function () {
+    it('should be false if the user has a disabled access to the given CertificationCenterId', function () {
       // given
       const certificationCenterId = 12345;
       const now = new Date();

--- a/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
@@ -7,8 +7,8 @@ describe('Unit | UseCase | find-certification-center-memberships-by-certificatio
     // given
     const certificationCenterId = 1;
     const certificationCenterMemberships = [domainBuilder.buildCertificationCenterMembership()];
-    const certificationCenterMembershipRepository = { findByCertificationCenterId: sinon.stub() };
-    certificationCenterMembershipRepository.findByCertificationCenterId.resolves(certificationCenterMemberships);
+    const certificationCenterMembershipRepository = { findActiveByCertificationCenterId: sinon.stub() };
+    certificationCenterMembershipRepository.findActiveByCertificationCenterId.resolves(certificationCenterMemberships);
 
     // when
     const foundCertificationCenterMemberships = await usecases.findCertificationCenterMembershipsByCertificationCenter({
@@ -17,7 +17,7 @@ describe('Unit | UseCase | find-certification-center-memberships-by-certificatio
     });
 
     // then
-    expect(certificationCenterMembershipRepository.findByCertificationCenterId).to.have.been.calledWith(
+    expect(certificationCenterMembershipRepository.findActiveByCertificationCenterId).to.have.been.calledWith(
       certificationCenterId
     );
     expect(foundCertificationCenterMemberships).to.deep.equal(certificationCenterMemberships);

--- a/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
@@ -3,22 +3,12 @@ const { domainBuilder, expect, sinon } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 
 describe('Unit | UseCase | find-certification-center-memberships-by-certification-center', function () {
-  const certificationCenterId = 1;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certificationCenterMemberships = [domainBuilder.buildCertificationCenterMembership()];
-
-  let certificationCenterMembershipRepository;
-
-  beforeEach(function () {
-    certificationCenterMembershipRepository = {
-      findByCertificationCenterId: sinon.stub(),
-    };
-    certificationCenterMembershipRepository.findByCertificationCenterId.resolves(certificationCenterMemberships);
-  });
-
   it('should result certification-center-memberships by certification center id', async function () {
     // given
+    const certificationCenterId = 1;
+    const certificationCenterMemberships = [domainBuilder.buildCertificationCenterMembership()];
+    const certificationCenterMembershipRepository = { findByCertificationCenterId: sinon.stub() };
+    certificationCenterMembershipRepository.findByCertificationCenterId.resolves(certificationCenterMemberships);
 
     // when
     const foundCertificationCenterMemberships = await usecases.findCertificationCenterMembershipsByCertificationCenter({


### PR DESCRIPTION
## :christmas_tree: Problème
Aujourd'hui les personnes gérant les espaces Pix Certif demandent parfois au support de désactiver l'accès d'une personne à leur centre de certification car ils ne peuvent pas le faire eux même via l'application.
Cette demande de support est ensuite envoyée à notre PO pour supprimer ces accès directement en base car même sur Pix Admin il n'existe pas de moyen de désactiver l'accès d'une personne de Pix Certif.

## :gift: Solution
Ajouter un état `disabledAt` aux accès PixCertif (donc dans la table `certification-center-memberships`).
Ne plus permettre aux utilisateurs de se connecter à un centre de certif si leur accès est `disabled`.

## :star2: Remarques
Cette PR ne permet pas encore de rendre les admin Pix d'être autonome, cela sera possible dans le ticket suivant  qui consiste à rajouter un bouton pour désactiver un accès PixCertif (https://1024pix.atlassian.net/browse/PIX-3563).

Pour éviter les incohérences au moments de la désactivation d'un membre PixCertif, j'ai rajouté côté API quelques protections pour ne pas permettre des actions sur les centres de certif de la part d'un membre disabled : 
- [x] création de session
- [x] finalization de session
- [x] modification de session
- [x] ajout de candidats

Cependant je ne suis pas sûre de tous les cas de figure à protéger pour PixCertif et nous n'avons pas de pré-handler commun à toutes les routes Pix certif. Vu avec Emmy et Anne-So : on ne protège que les cas listé juste au-dessus.

## :santa: Pour tester
- Faire la migration de la BDD ` npm run db:migrate` si vous êtes en local
- Connectez vous avec `certifsco@example.net` sur PixCertif
- Constatez que vous avez accès à 4 centre de certif (menu déroulant en haut à droite)
- Changer en base la colonne `disabledAt` de la table `certification-center-memberships` où  l'`userId`=100 et le `certificationCenterId`=1 
- Rafraichissez la page PixCertif
- Constatez que vous n'avez plus accès au "Centre SCO Collège des Anne-Étoiles" 
- Supprimez de la même manière tous les autres accès de l'`userId` = 100
- Déconnectez-vous
- Constatez que vous ne pouvez plus vous connecter avec `certifsco@example.net` 

Pour aller plus loin : 
- tester le cas où l'utilisateur passe disabled au moment où il créée une session / il finalise une session / il modifie la session / il ajoute des candidats
- dans tous ces cas on attend que l'API ne change rien en BDD et renvoie une erreur (mais qui n'est pas pour autant affiché côté front, à voir avec Emmy si besoin ? )
