### PR TITLE
[FEATURE] Permettre à un candidat de reprendre son test - Front (PIX-3962)

### DIFF
--- a/certif/app/components/dropdown/item.hbs
+++ b/certif/app/components/dropdown/item.hbs
@@ -1,3 +1,3 @@
-<li class="dropdown__item" role="button" {{on 'click' @onClick}} ...attributes>
-  {{yield}}
+<li class="dropdown__item"  ...attributes>
+  <div role="button" class="dropdown__item__button" {{on 'click' @onClick}}>{{yield}}</div>
 </li>

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -31,9 +31,17 @@
     {{/if}}
   </div>
   {{#if @candidate.hasStarted}}
-    <PixIconButton
-      @icon="ellipsis-v"
-      aria-label="Afficher les options du candidat"
-    />
+    <div class="session-supervising-candidate-in-list__menu">
+      <PixIconButton
+        @icon="ellipsis-v"
+        aria-label="Afficher les options du candidat"
+        @triggerAction={{this.toggleMenu}}
+      />
+      <Dropdown::Content @display={{this.isMenuOpen}} @close={{this.closeMenu}} aria-label="Options du candidat">
+        <Dropdown::Item @onClick={{this.allowTestResume}}>
+          Autoriser la reprise du test
+        </Dropdown::Item>
+      </Dropdown::Content>
+    </div>
   {{/if}}
 </li>

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -38,10 +38,62 @@
         @triggerAction={{this.toggleMenu}}
       />
       <Dropdown::Content @display={{this.isMenuOpen}} @close={{this.closeMenu}} aria-label="Options du candidat">
-        <Dropdown::Item @onClick={{this.allowTestResume}}>
+        <Dropdown::Item @onClick={{this.askUserToConfirmTestResume}}>
           Autoriser la reprise du test
         </Dropdown::Item>
       </Dropdown::Content>
     </div>
   {{/if}}
+
+  {{#if this.isConfirmationModalDisplayed}}
+    <AppModal @containerClass="pix-modal-dialog" @onClose={{this.closeConfirmationModal}}>
+
+      <div class="pix-modal__close-button">
+        <button
+          type="button"
+          data-test-id="finalize-session-modal__close-cross"
+          {{on "click" this.closeConfirmationModal}}
+          aria-label="Fermer la fenêtre de confirmation"
+        >
+          Fermer
+          <img src="/icons/icon-close-modal.svg" alt="" role="presentation" width="24" height="24">
+        </button>
+      </div>
+
+      <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
+        <div class="pix-modal-body pix-modal-body--with-padding">
+          <div class="app-modal-body__attention">
+            Autoriser {{@candidate.firstName}} {{@candidate.lastName}} à reprendre son test ?
+          </div>
+          <div class="app-modal-body__warning">
+            <p>
+              Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème
+              technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test
+              à l'endroit où il l'avait quitté.
+            </p>
+          </div>
+        </div>
+
+        <div class="pix-modal-footer">
+          <PixButton
+            data-test-id="finalize-session-modal__confirm-button"
+            @triggerAction={{this.authorizeTestResume}}
+            @backgroundColor="yellow"
+          >
+            Je confirme l'autorisation
+          </PixButton>
+          <PixButton
+            data-test-id="finalize-session-modal__cancel-button"
+            @triggerAction={{this.closeConfirmationModal}}
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            aria-label="Annuler et fermer la fenêtre de confirmation"
+          >
+            Annuler
+          </PixButton>
+        </div>
+      </div>
+    </AppModal>
+  {{/if}}
+
 </li>

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -1,0 +1,33 @@
+<li class="session-supervising-candidate-in-list">
+  {{#unless @candidate.hasStarted}}
+    <PixInput
+      @id={{concat "candidate-checkbox-" @candidate.id}}
+      class="session-supervising-candidate-in-list__checkbox"
+      type="checkbox"
+      checked={{@candidate.authorizedToStart}}
+      {{on 'click' (fn this.toggleCandidate @candidate)}}
+    />
+  {{/unless}}
+  <div>
+    <div class="session-supervising-candidate-in-list__full-name">
+      {{#if @candidate.hasStarted}}
+        {{@candidate.lastName}} {{@candidate.firstName}}
+      {{else}}
+        <label for={{concat "candidate-checkbox-" @candidate.id}}>
+          {{@candidate.lastName}} {{@candidate.firstName}}
+        </label>
+      {{/if}}
+    </div>
+    <div class="session-supervising-candidate-in-list__details">
+      {{moment-format @candidate.birthdate "DD/MM/YYYY"}}
+      {{#if @candidate.extraTimePercentage}}
+        · Temps majoré : {{@candidate.extraTimePercentage}}%
+      {{/if}}
+    </div>
+    {{#if @candidate.hasStarted}}
+      <span class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--started">
+        En cours
+      </span>
+    {{/if}}
+  </div>
+</li>

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -8,7 +8,7 @@
       {{on 'click' (fn this.toggleCandidate @candidate)}}
     />
   {{/unless}}
-  <div>
+  <div class="session-supervising-candidate-in-list__candidate-data">
     <div class="session-supervising-candidate-in-list__full-name">
       {{#if @candidate.hasStarted}}
         {{@candidate.lastName}} {{@candidate.firstName}}
@@ -30,4 +30,10 @@
       </span>
     {{/if}}
   </div>
+  {{#if @candidate.hasStarted}}
+    <PixIconButton
+      @icon="ellipsis-v"
+      aria-label="Afficher les options du candidat"
+    />
+  {{/if}}
 </li>

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import noop from 'lodash/noop';
+import { inject as service } from '@ember/service';
 
 export default class CandidateInList extends Component {
+  @service notifications;
+
   @tracked isMenuOpen = false;
   @tracked isConfirmationModalDisplayed = false;
 
@@ -33,7 +35,11 @@ export default class CandidateInList extends Component {
   }
 
   @action
-  authorizeTestResume() {
-    noop();
+  async authorizeTestResume() {
+    await this.args.onCandidateTestResumeAuthorization();
+    this.closeConfirmationModal();
+    this.notifications.success(
+      `Succès ! ${this.args.candidate.firstName} ${this.args.candidate.lastName} peut reprendre son test de certification.`,
+    );
   }
 }

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -5,15 +5,11 @@ import noop from 'lodash/noop';
 
 export default class CandidateInList extends Component {
   @tracked isMenuOpen = false;
+  @tracked isConfirmationModalDisplayed = false;
 
   @action
   async toggleCandidate(candidate) {
     await this.args.toggleCandidate(candidate);
-  }
-
-  @action
-  allowTestResume() {
-    noop();
   }
 
   @action
@@ -24,5 +20,20 @@ export default class CandidateInList extends Component {
   @action
   closeMenu() {
     this.isMenuOpen = false;
+  }
+
+  @action
+  askUserToConfirmTestResume() {
+    this.isConfirmationModalDisplayed = true;
+  }
+
+  @action
+  closeConfirmationModal() {
+    this.isConfirmationModalDisplayed = false;
+  }
+
+  @action
+  authorizeTestResume() {
+    noop();
   }
 }

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class CandidateInList extends Component {
+
+  @action
+  async toggleCandidate(candidate) {
+    await this.args.toggleCandidate(candidate);
+  }
+}

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -1,10 +1,28 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import noop from 'lodash/noop';
 
 export default class CandidateInList extends Component {
+  @tracked isMenuOpen = false;
 
   @action
   async toggleCandidate(candidate) {
     await this.args.toggleCandidate(candidate);
+  }
+
+  @action
+  allowTestResume() {
+    noop();
+  }
+
+  @action
+  toggleMenu() {
+    this.isMenuOpen = !this.isMenuOpen;
+  }
+
+  @action
+  closeMenu() {
+    this.isMenuOpen = false;
   }
 }

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -36,10 +36,16 @@ export default class CandidateInList extends Component {
 
   @action
   async authorizeTestResume() {
-    await this.args.onCandidateTestResumeAuthorization();
     this.closeConfirmationModal();
-    this.notifications.success(
-      `Succès ! ${this.args.candidate.firstName} ${this.args.candidate.lastName} peut reprendre son test de certification.`,
-    );
+    try {
+      await this.args.onCandidateTestResumeAuthorization();
+      this.notifications.success(
+        `Succès ! ${this.args.candidate.firstName} ${this.args.candidate.lastName} peut reprendre son test de certification.`,
+      );
+    } catch (error) {
+      this.notifications.error(
+        `Une erreur est survenue, ${this.args.candidate.firstName} ${this.args.candidate.lastName} n'a a pu être autorisé à reprendre son test.`,
+      );
+    }
   }
 }

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -5,7 +5,11 @@
       <span class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test pour l'autoriser à commencer son test de certification.</span>
       <ul class="session-supervising-candidate-list__candidates">
         {{#each @candidates as |candidate|}}
-          <SessionSupervising::CandidateInList @candidate={{candidate}} @toggleCandidate={{this.toggleCandidate}} />
+          <SessionSupervising::CandidateInList
+            @candidate={{candidate}}
+            @toggleCandidate={{this.toggleCandidate}}
+            @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
+          />
         {{/each}}
       </ul>
     </div>

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -5,39 +5,7 @@
       <span class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test pour l'autoriser à commencer son test de certification.</span>
       <ul class="session-supervising-candidate-list__candidates">
         {{#each @candidates as |candidate|}}
-          <li class="session-supervising-candidate-list__candidate" data-test-id={{concat "candidate-" candidate.id}}>
-            {{#unless candidate.hasStarted}}
-              <PixInput
-                @id={{concat "candidate-checkbox-" candidate.id}}
-                class="session-supervising-candidate-list__candidate-checkbox"
-                type="checkbox"
-                checked={{candidate.authorizedToStart}}
-                {{on 'click' (fn this.toggleCandidate candidate)}}
-              />
-            {{/unless}}
-            <div>
-              <div class="session-supervising-candidate-list__candidate-full-name">
-                {{#if candidate.hasStarted}}
-                  {{candidate.lastName}} {{candidate.firstName}}
-                {{else}}
-                  <label for={{concat "candidate-checkbox-" candidate.id}}>
-                    {{candidate.lastName}} {{candidate.firstName}}
-                  </label>
-                {{/if}}
-              </div>
-              <div class="session-supervising-candidate-list__candidate-details">
-                {{moment-format candidate.birthdate "DD/MM/YYYY"}}
-                {{#if candidate.extraTimePercentage}}
-                  · Temps majoré : {{candidate.extraTimePercentage}}%
-                {{/if}}
-              </div>
-              {{#if candidate.hasStarted}}
-                <span class="session-supervising-candidate-list__candidate-status session-supervising-candidate-list__candidate-status--started">
-                  En cours
-                </span>
-              {{/if}}
-            </div>
-          </li>
+          <SessionSupervising::CandidateInList @candidate={{candidate}} @toggleCandidate={{this.toggleCandidate}} />
         {{/each}}
       </ul>
     </div>

--- a/certif/app/components/session-supervising/candidate-list.js
+++ b/certif/app/components/session-supervising/candidate-list.js
@@ -1,10 +1,17 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import noop from 'lodash/noop';
 
 export default class CandidateList extends Component {
 
   @action
   async toggleCandidate(candidate) {
     await this.args.toggleCandidate(candidate);
+  }
+
+  @action
+  async authorizeTestResume() {
+    noop();
+    return Promise.resolve();
   }
 }

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -42,6 +42,7 @@
 @import "components/session-finalization/formbuilder-link-step";
 @import "components/session-finalization/examiner-global-comment-step";
 @import "components/session-supervising/header";
+@import "components/session-supervising/candidate-in-list";
 @import "components/session-supervising/candidate-list";
 @import "components/session-summary-list";
 @import "components/pagination-control.scss";

--- a/certif/app/styles/components/dropdown.scss
+++ b/certif/app/styles/components/dropdown.scss
@@ -21,7 +21,11 @@
     display: flex;
     font-size: 0.875rem;
     transition: background-color 0.1s linear;
-    padding: 12px 16px;
+
+    &__button {
+      padding: 12px 16px;
+      display: flex;
+    }
 
     &--link {
       padding: 0;

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -8,6 +8,7 @@ $green-70: #006134;
   border-radius: 4px;
   display: flex;
   align-items: center;
+  position: relative;
 
   &__candidate-data {
     width: calc(100% - 32px);
@@ -41,5 +42,15 @@ $green-70: #006134;
       background-color: $green-0;
       color: $green-70;
     }
+  }
+
+  &__menu {
+    position: relative;
+  }
+
+  .dropdown__content {
+    right: 0;
+    top: 32px;
+    width: 216px;
   }
 }

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -9,6 +9,10 @@ $green-70: #006134;
   display: flex;
   align-items: center;
 
+  &__candidate-data {
+    width: calc(100% - 32px);
+  }
+
   &__details {
     color: $grey-22;
     font-size: 0.75rem;

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -1,0 +1,41 @@
+$yellow-30: #FFBE00;
+$green-0: #EFFFD8;
+$green-70: #006134;
+
+.session-supervising-candidate-in-list {
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+
+  &__details {
+    color: $grey-22;
+    font-size: 0.75rem;
+  }
+
+  &__full-name {
+    color: $yellow-30;
+    margin-bottom: 4px;
+  }
+
+  &__checkbox {
+    width: 32px;
+    height: 32px;
+    margin-right: 16px;
+  }
+
+  &__status {
+    border-radius: 12px;
+    display: inline-block;
+    font-size: 0.625rem;
+    font-weight: 500;
+    margin-top: 8px;
+    padding: 4px 16px;
+
+    &--started {
+      background-color: $green-0;
+      color: $green-70;
+    }
+  }
+}

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -54,24 +54,6 @@ $green-70: #006134;
       }
     }
 
-    &__candidate {
-      padding: 12px 16px;
-      margin-bottom: 8px;
-      border-radius: 4px;
-      display: flex;
-      align-items: center;
-    }
-
-    &__candidate-details {
-      color: $grey-22;
-      font-size: 0.75rem;
-    }
-
-    &__candidate-full-name {
-      color: $yellow-30;
-      margin-bottom: 4px;
-    }
-
     &__empty-image {
       display: block;
       margin: 20px auto;
@@ -85,26 +67,6 @@ $green-70: #006134;
       margin: auto;
       max-width: 225px;
       text-align: center;
-    }
-
-    &__candidate-checkbox {
-      width: 32px;
-      height: 32px;
-      margin-right: 16px;
-    }
-
-    &__candidate-status {
-      border-radius: 12px;
-      display: inline-block;
-      font-size: 0.625rem;
-      font-weight: 500;
-      margin-top: 8px;
-      padding: 4px 16px;
-
-      &--started {
-        background-color: $green-0;
-        color: $green-70;
-      }
     }
   }
 }

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -45,11 +45,11 @@ $green-70: #006134;
       list-style: none;
       padding: 0;
 
-      li:nth-child(odd) {
+      > li:nth-child(odd) {
         background: $grey-80;
       }
 
-      li:nth-child(even) {
+      > li:nth-child(even) {
         background: $grey-90;
       }
     }

--- a/certif/app/styles/globals/app-modal.scss
+++ b/certif/app/styles/globals/app-modal.scss
@@ -100,17 +100,30 @@ $pix-modal-border-radius: 5px;
         border-bottom-left-radius: $pix-modal-border-radius;
         border-bottom-right-radius: $pix-modal-border-radius;
         padding: 8px 0 20px 0;
-        display: flex;
-        justify-content: flex-end;
 
         .pix-button {
-          margin-left: 16px;
+          margin: 8px 0;
+          width: 100%;
         }
 
         &--border {
           border-top: 1px solid $grey-20;
         }
       }
+    }
+  }
+}
+
+@include device-is('tablet') {
+
+  .pix-modal-wrapper .pix-modal-dialog .pix-modal__container .pix-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+
+    .pix-button {
+      margin: 0 0 0 16px;
+      width: auto;
     }
   }
 }

--- a/certif/app/templates/session-supervising.hbs
+++ b/certif/app/templates/session-supervising.hbs
@@ -1,6 +1,10 @@
 {{page-title "Surveiller la session n° " @model.id}}
 
-<div class="session-supervising-page">
-  <SessionSupervising::Header @session={{@model}}/>
-  <SessionSupervising::CandidateList @toggleCandidate={{this.toggleCandidate}} @candidates={{@model.certificationCandidates}}/>
+<div class="app">
+  <div class="session-supervising-page">
+    <SessionSupervising::Header @session={{@model}}/>
+    <SessionSupervising::CandidateList @toggleCandidate={{this.toggleCandidate}} @candidates={{@model.certificationCandidates}}/>
+  </div>
+
+  <NotificationContainer @position="bottom-right" />
 </div>

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -155,7 +155,7 @@ module('Acceptance | authenticated', function(hooks) {
       // when
       const screen = await visitScreen('/');
       await click(screen.getByRole('link', { name: 'Buffy Summers Bibiche (ABC123)' }));
-      await click(screen.getByRole('button', { name: 'Poupoune' }));
+      await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
       assert.contains('Poupoune (DEF456)');
@@ -188,7 +188,7 @@ module('Acceptance | authenticated', function(hooks) {
       // when
       const screen = await visitScreen('/sessions/555');
       await click(screen.getByRole('link', { name: 'Buffy Summers Bibiche (ABC123)' }));
-      await click(screen.getByRole('button', { name: 'Poupoune' }));
+      await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
       assert.equal(currentURL(), '/sessions/liste');
@@ -222,7 +222,7 @@ module('Acceptance | authenticated', function(hooks) {
       // when
       const screen = await visitScreen('/sessions/555');
       await click(screen.getByRole('link', { name: 'Buffy Summers Bibiche (ABC123)' }));
-      await click(screen.getByRole('button', { name: 'Poupoune' }));
+      await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
       assert.equal(currentURL(), '/espace-ferme');
@@ -256,7 +256,7 @@ module('Acceptance | authenticated', function(hooks) {
       // when
       const screen = await visitScreen('/');
       await click(screen.getByRole('link', { name: 'Buffy Summers Bibiche (ABC123)' }));
-      await click(screen.getByRole('button', { name: 'Poupoune' }));
+      await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
       assert.equal(currentURL(), '/sessions/liste');

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -1,0 +1,161 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render as renderScreen } from '@pix/ember-testing-library';
+
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+module('Integration | Component | SessionSupervising::CandidateInList', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(async function() {
+    store = this.owner.lookup('service:store');
+  });
+
+  test('it renders the candidates information with an unchecked checkbox', async function(assert) {
+    // given
+    this.candidate = store.createRecord('certification-candidate-for-supervising', {
+      id: 123,
+      firstName: 'Gamora',
+      lastName: 'Zen Whoberi Ben Titan',
+      birthdate: '1984-05-28',
+      extraTimePercentage: '8',
+      authorizedToStart: false,
+      assessmentStatus: null,
+    });
+    this.toggleCandidate = sinon.spy();
+
+    // when
+    const screen = await renderScreen(hbs`
+      <SessionSupervising::CandidateInList
+        @candidate={{this.candidate}}
+        @toggleCandidate={{this.toggleCandidate}}
+      />
+    `);
+
+    // then
+    assert.dom('.session-supervising-candidate-in-list').hasText('Zen Whoberi Ben Titan Gamora 28/05/1984 · Temps majoré : 8%');
+    assert.dom(screen.getByRole('checkbox', { name: 'Zen Whoberi Ben Titan Gamora' })).isNotChecked();
+  });
+
+  module('when the candidate is authorized to start', function() {
+    test('it renders the checkbox checked', async function(assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 456,
+        firstName: 'Star',
+        lastName: 'Lord',
+        birthdate: '1983-06-28',
+        extraTimePercentage: '12',
+        authorizedToStart: true,
+        assessmentStatus: null,
+      });
+      this.toggleCandidate = sinon.spy();
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList
+          @candidate={{this.candidate}}
+          @toggleCandidate={{this.toggleCandidate}}
+        />
+      `);
+
+      // then
+      assert.dom('.session-supervising-candidate-in-list').hasText('Lord Star 28/06/1983 · Temps majoré : 12%');
+      assert.dom(screen.getByRole('checkbox', { name: 'Lord Star' })).isChecked();
+    });
+  });
+
+  module('when the candidate has started the test', function() {
+    test('it renders the "en cours" label', async function(assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 789,
+        firstName: 'Rocket',
+        lastName: 'Racoon',
+        birthdate: '1982-07-28',
+        extraTimePercentage: null,
+        authorizedToStart: true,
+        assessmentStatus: 'started',
+      });
+      this.toggleCandidate = sinon.spy();
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList
+          @candidate={{this.candidate}}
+          @toggleCandidate={{this.toggleCandidate}}
+        />
+      `);
+
+      // then
+      assert.dom('.session-supervising-candidate-in-list').hasText('Racoon Rocket 28/07/1982 En cours');
+      assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
+    });
+  });
+
+  module('when the checkbox is clicked', function() {
+    module('when the candidate is already authorized', function() {
+      test('it calls the argument callback with candidate and false', async function(assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 123,
+          firstName: 'Toto',
+          lastName: 'Tutu',
+          birthdate: '1984-05-28',
+          extraTimePercentage: '8',
+          authorizedToStart: true,
+          assessmentResult: null,
+        });
+        this.toggleCandidate = sinon.spy();
+
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList
+          @candidate={{this.candidate}}
+          @toggleCandidate={{this.toggleCandidate}}
+        />`);
+        const checkbox = screen.getByRole('checkbox');
+
+        // when
+        await checkbox.click();
+
+        // then
+        sinon.assert.calledOnceWithExactly(this.toggleCandidate, this.candidate);
+        assert.ok(true);
+      });
+    });
+
+    module('when the candidate is not authorized', function() {
+      test('it calls the argument callback with candidate', async function(assert) {
+        // given
+        const candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 123,
+          firstName: 'Toto',
+          lastName: 'Tutu',
+          birthdate: '1984-05-28',
+          extraTimePercentage: '8',
+          authorizedToStart: false,
+          assessmentResult: null,
+        });
+        this.sessionForSupervising = store.createRecord('session-for-supervising', {
+          certificationCandidates: [candidate],
+        });
+        this.toggleCandidate = sinon.spy();
+
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList
+            @candidates={{this.sessionForSupervising.certificationCandidates}}
+            @toggleCandidate={{this.toggleCandidate}}
+        />`);
+        const checkbox = screen.getByRole('checkbox');
+
+        // when
+        await checkbox.click();
+
+        // then
+        sinon.assert.calledOnceWithExactly(this.toggleCandidate, this.candidate);
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render as renderScreen } from '@pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
@@ -94,6 +95,34 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom('.session-supervising-candidate-in-list').hasText('Racoon Rocket 28/07/1982 En cours');
       assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
       assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).exists();
+    });
+
+    module('when the candidate options button is clicked', function() {
+      test('it displays the "autoriser la reprise" option', async function(assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 1123,
+          firstName: 'Drax',
+          lastName: 'The Destroyer',
+          birthdate: '1928-08-27',
+          extraTimePercentage: null,
+          authorizedToStart: true,
+          assessmentStatus: 'started',
+        });
+        this.toggleCandidate = sinon.spy();
+        const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList
+            @candidate={{this.candidate}}
+            @toggleCandidate={{this.toggleCandidate}}
+          />
+        `);
+
+        // when
+        await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Autoriser la reprise du test' })).exists();
+      });
     });
   });
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -123,6 +123,95 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         // then
         assert.dom(screen.getByRole('button', { name: 'Autoriser la reprise du test' })).exists();
       });
+
+      module('when the "autoriser la reprise" option is clicked', function() {
+        test('it displays a confirmation modal', async function(assert) {
+          // given
+          this.candidate = store.createRecord('certification-candidate-for-supervising', {
+            id: 1123,
+            firstName: 'Drax',
+            lastName: 'The Destroyer',
+            birthdate: '1928-08-27',
+            extraTimePercentage: null,
+            authorizedToStart: true,
+            assessmentStatus: 'started',
+          });
+          this.toggleCandidate = sinon.spy();
+          const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList
+            @candidate={{this.candidate}}
+            @toggleCandidate={{this.toggleCandidate}}
+          />
+        `);
+
+          // when
+          await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
+          await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Je confirme l\'autorisation' })).exists();
+        });
+
+        module('when the confirmation modal "Annuler" button is clicked', function() {
+          test('it closes the confirmation modal', async function(assert) {
+            // given
+            this.candidate = store.createRecord('certification-candidate-for-supervising', {
+              id: 1123,
+              firstName: 'Drax',
+              lastName: 'The Destroyer',
+              birthdate: '1928-08-27',
+              extraTimePercentage: null,
+              authorizedToStart: true,
+              assessmentStatus: 'started',
+            });
+            this.toggleCandidate = sinon.spy();
+            const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList
+            @candidate={{this.candidate}}
+            @toggleCandidate={{this.toggleCandidate}}
+          />
+        `);
+
+            // when
+            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
+            await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+            await click(screen.getByRole('button', { name: 'Annuler et fermer la fenêtre de confirmation' }));
+
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Je confirme l\'autorisation' })).doesNotExist();
+          });
+        });
+
+        module('when the confirmation modal "Fermer" button is clicked', function() {
+          test('it closes the confirmation modal', async function(assert) {
+            // given
+            this.candidate = store.createRecord('certification-candidate-for-supervising', {
+              id: 1123,
+              firstName: 'Drax',
+              lastName: 'The Destroyer',
+              birthdate: '1928-08-27',
+              extraTimePercentage: null,
+              authorizedToStart: true,
+              assessmentStatus: 'started',
+            });
+            this.toggleCandidate = sinon.spy();
+            const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList
+            @candidate={{this.candidate}}
+            @toggleCandidate={{this.toggleCandidate}}
+          />
+        `);
+
+            // when
+            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
+            await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+            await click(screen.getByRole('button', { name: 'Fermer la fenêtre de confirmation' }));
+
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Je confirme l\'autorisation' })).doesNotExist();
+          });
+        });
+      });
     });
   });
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -69,7 +69,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
   });
 
   module('when the candidate has started the test', function() {
-    test('it renders the "en cours" label', async function(assert) {
+    test('it renders the "en cours" label and the options menu button', async function(assert) {
       // given
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: 789,
@@ -93,6 +93,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       // then
       assert.dom('.session-supervising-candidate-in-list').hasText('Racoon Rocket 28/07/1982 En cours');
       assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).exists();
     });
   });
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -211,6 +211,40 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             assert.dom(screen.queryByRole('button', { name: 'Je confirme l\'autorisation' })).doesNotExist();
           });
         });
+
+        module('when the confirmation modal "Je confirme…" button is clicked', function() {
+          module('when the authorization succeeds', function() {
+            test('it closes the modal and displays a success notification', async function(assert) {
+              // given
+              this.candidate = store.createRecord('certification-candidate-for-supervising', {
+                firstName: 'Yondu',
+                lastName: 'Undonta',
+                authorizedToStart: true,
+                assessmentStatus: 'started',
+              });
+              this.toggleCandidate = sinon.spy();
+              this.authorizeTestResume = sinon.stub().resolves();
+              const screen = await renderScreen(hbs`
+                <SessionSupervising::CandidateInList
+                  @candidate={{this.candidate}}
+                  @toggleCandidate={{this.toggleCandidate}}
+                  @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
+                />
+                <NotificationContainer @position="bottom-right" />
+              `);
+
+              // when
+              await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
+              await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+              await click(screen.getByRole('button', { name: 'Je confirme l\'autorisation' }));
+
+              // then
+              sinon.assert.calledOnce(this.authorizeTestResume);
+              assert.dom(screen.queryByRole('button', { name: 'Je confirme l\'autorisation' })).doesNotExist();
+              assert.contains('Succès ! Yondu Undonta peut reprendre son test de certification.');
+            });
+          });
+        });
       });
     });
   });

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -67,10 +67,35 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom('.session-supervising-candidate-in-list').hasText('Lord Star 28/06/1983 · Temps majoré : 12%');
       assert.dom(screen.getByRole('checkbox', { name: 'Lord Star' })).isChecked();
     });
+    test('it does not display neither "en cours" label nor the options menu button', async function(assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 789,
+        firstName: 'Rocket',
+        lastName: 'Racoon',
+        birthdate: '1982-07-28',
+        extraTimePercentage: null,
+        authorizedToStart: true,
+        assessmentStatus: null,
+      });
+      this.toggleCandidate = sinon.spy();
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList
+          @candidate={{this.candidate}}
+          @toggleCandidate={{this.toggleCandidate}}
+        />
+      `);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).doesNotExist();
+      assert.notContains('En cours');
+    });
   });
 
   module('when the candidate has started the test', function() {
-    test('it renders the "en cours" label and the options menu button', async function(assert) {
+    test('it displays the "en cours" label and the options menu button', async function(assert) {
       // given
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: 789,

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -244,6 +244,38 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               assert.contains('Succès ! Yondu Undonta peut reprendre son test de certification.');
             });
           });
+
+          module('when the authorization fails', function() {
+            test('it closes the modal and displays an error notification', async function(assert) {
+              // given
+              this.candidate = store.createRecord('certification-candidate-for-supervising', {
+                firstName: 'Vance',
+                lastName: 'Astro',
+                authorizedToStart: true,
+                assessmentStatus: 'started',
+              });
+              this.toggleCandidate = sinon.spy();
+              this.authorizeTestResume = sinon.stub().rejects();
+              const screen = await renderScreen(hbs`
+                <SessionSupervising::CandidateInList
+                  @candidate={{this.candidate}}
+                  @toggleCandidate={{this.toggleCandidate}}
+                  @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
+                />
+                <NotificationContainer @position="bottom-right" />
+              `);
+
+              // when
+              await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
+              await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+              await click(screen.getByRole('button', { name: 'Je confirme l\'autorisation' }));
+
+              // then
+              sinon.assert.calledOnce(this.authorizeTestResume);
+              assert.dom(screen.queryByRole('button', { name: 'Je confirme l\'autorisation' })).doesNotExist();
+              assert.contains('Une erreur est survenue, Vance Astro n\'a a pu être autorisé à reprendre son test.');
+            });
+          });
         });
       });
     });

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render as renderScreen } from '@pix/ember-testing-library';
-import sinon from 'sinon';
 
 import hbs from 'htmlbars-inline-precompile';
 
@@ -50,86 +49,12 @@ module('Integration | Component | SessionSupervising::CandidateList', function(h
       });
 
       // when
-      const screen = await renderScreen(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}}  />`);
+      await renderScreen(hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}}  />`);
 
       // then
-      assert.dom('[data-test-id="candidate-123"]').hasText('Zen Whoberi Ben Titan Gamora 28/05/1984 · Temps majoré : 8%');
-      assert.dom(screen.getByRole('checkbox', { name: 'Zen Whoberi Ben Titan Gamora' })).isChecked();
-
-      assert.dom('[data-test-id="candidate-456"]').hasText('Lord Star 28/06/1983 · Temps majoré : 12%');
-      assert.dom(screen.getByRole('checkbox', { name: 'Lord Star' })).isNotChecked();
-
-      assert.dom('[data-test-id="candidate-789"]').hasText('Racoon Rocket 28/07/1982 En cours');
-      assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
-    });
-
-    module('when the checkbox value change', function() {
-
-      module('when the candidate is already authorized', function() {
-        test('it calls the argument callback with candidate and false', async function(assert) {
-          // given
-          const candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 123,
-            firstName: 'Toto',
-            lastName: 'Tutu',
-            birthdate: '1984-05-28',
-            extraTimePercentage: '8',
-            authorizedToStart: true,
-          });
-          this.sessionForSupervising = store.createRecord('session-for-supervising', {
-            certificationCandidates: [candidate],
-          });
-          const toggleCandidate = sinon.spy();
-          this.set('toggleCandidate', toggleCandidate);
-
-          const screen = await renderScreen(hbs`<SessionSupervising::CandidateList
-            @candidates={{this.sessionForSupervising.certificationCandidates}}
-            @toggleCandidate={{this.toggleCandidate}}
-        />`);
-          const checkbox = screen.getByRole('checkbox');
-
-          // when
-
-          await checkbox.click();
-
-          // then
-          sinon.assert.calledOnceWithExactly(toggleCandidate, candidate);
-          assert.ok(true);
-        });
-      });
-
-      module('when the candidate is not authorized', function() {
-        test('it calls the argument callback with candidate', async function(assert) {
-          // given
-          const candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 123,
-            firstName: 'Toto',
-            lastName: 'Tutu',
-            birthdate: '1984-05-28',
-            extraTimePercentage: '8',
-            authorizedToStart: false,
-          });
-          this.sessionForSupervising = store.createRecord('session-for-supervising', {
-            certificationCandidates: [candidate],
-          });
-          const toggleCandidate = sinon.spy();
-          this.set('toggleCandidate', toggleCandidate);
-
-          const screen = await renderScreen(hbs`<SessionSupervising::CandidateList
-            @candidates={{this.sessionForSupervising.certificationCandidates}}
-            @toggleCandidate={{this.toggleCandidate}}
-        />`);
-          const checkbox = screen.getByRole('checkbox');
-
-          // when
-
-          await checkbox.click();
-
-          // then
-          sinon.assert.calledOnceWithExactly(toggleCandidate, candidate);
-          assert.ok(true);
-        });
-      });
+      assert.contains('Zen Whoberi Ben Titan Gamora');
+      assert.contains('Lord Star');
+      assert.contains('Racoon Rocket');
     });
 
     module('when there is no candidate', function() {

--- a/certif/tests/integration/components/user-logged-menu_test.js
+++ b/certif/tests/integration/components/user-logged-menu_test.js
@@ -117,7 +117,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
       const allowedCertificationCenterAccessA = run(() => store.createRecord('allowed-certification-center-access', {
         id: 456,
         name: 'Torreilles',
-        externalId: 'Ca déchire',
+        externalId: 'externalId1',
       }));
       const allowedCertificationCenterAccessB = run(() => store.createRecord('allowed-certification-center-access', {
         id: 789,
@@ -136,7 +136,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
 
       // then
       assert.contains('Torreilles');
-      assert.contains('(Ca déchire)');
+      assert.contains('(externalId1)');
       assert.contains('Paris');
       assert.contains('(ILPlEUT)');
     });
@@ -149,7 +149,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
       const allowedCertificationCenterAccessA = run(() => store.createRecord('allowed-certification-center-access', {
         id: 456,
         name: 'Torreilles',
-        externalId: 'Ca déchire',
+        externalId: 'externalId1',
       }));
       certificationPointOfContact.set('allowedCertificationCenterAccesses', [
         currentAllowedCertificationCenterAccess,
@@ -160,7 +160,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
       // when
       await render(hbs`<UserLoggedMenu @onCertificationCenterAccessChanged={{this.onCertificationAccessChangedStub}}/>`);
       await clickByLabel('Buffy Summers Sunnydale');
-      await clickByLabel('Torreilles');
+      await clickByLabel('Torreilles (externalId1)');
 
       // then
       assert.dom('.fa-chevron-down').exists();
@@ -172,7 +172,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
       const allowedCertificationCenterAccessA = run(() => store.createRecord('allowed-certification-center-access', {
         id: 456,
         name: 'Torreilles',
-        externalId: 'Ca déchire',
+        externalId: 'externalId1',
       }));
       certificationPointOfContact.set('allowedCertificationCenterAccesses', [
         currentAllowedCertificationCenterAccess,
@@ -183,7 +183,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
       // when
       await render(hbs`<UserLoggedMenu @onCertificationCenterAccessChanged={{this.onCertificationAccessChangedStub}}/>`);
       await clickByLabel('Buffy Summers Sunnydale');
-      await clickByLabel('Torreilles');
+      await clickByLabel('Torreilles (externalId1)');
 
       // then
       sinon.assert.calledWithExactly(this.onCertificationAccessChangedStub, allowedCertificationCenterAccessA);


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu'un candidat accède à une session à partir de son code, son accès est consommé et il ne peut plus ré-entrer dans la session. Le surveillant doit pouvoir, depuis l'espace surveillant, ré-autoriser l'accès pour ce candidat.

## :gift: Solution

Ajouter dans la liste des candidats de l'espace surveillant une option pour ré-autoriser l'accès à la session pour un candidat.

### DONE

- [x] FRONT : afficher le menu popup avec l’option “Autoriser la reprise du test”
- [x] FRONT : afficher la modale de confirmation au clic sur l’option + bouton Annuler fermer la modale
- [x] FRONT : afficher la notification de succès + fermer la modale à la confirmation dans la modale

### TODO (dans la prochaine PR)

- FRONT : envoyer la requête au serveur à la confirmation dans la modale
- API : Réutiliser la route existante ?

## :star2: Remarques

Ce ticket n'ajoute que le front, le back viendra dans une prochaine PR.

## :santa: Pour tester

### Sans FT
 `FT_END_TEST_SCREEN_REMOVAL_ENABLED=false`

### Avec FT

1. Activer le toggle `FT_END_TEST_SCREEN_REMOVAL_ENABLED` si nécessaire
2. Se connecter à Pix Certif
3. Créer une session avec deux candidats
4. ETQ surveillant, autoriser l’accès au candidat 1
5. ETQ candidat 1, accéder à la session et constater que ça fonctionne
6. ETQ surveillant, recharger l’espace surveillant et constater l’apparition d'un menu avec l’option “Autoriser la reprise du test” pour le candidat 1
7. Cliquer sur l'option **Autoriser la reprise du test** et constater l'apparition d'une modale
8. Cliquer sur *Annuler* et constater la fermeture de la modale
9. Cliquer à nouveau sur l'option **Autoriser la reprise du test** et constater l'apparition d'une modale
10. Cliquer sur **J'autorise la reprise** et constater l'apparition d'une notification de succès et la fermeture de la modale