### PR TITLE
[BUGFIX] Corriger l'affichage de la page de login à Pix Certif (PIX-3952).

### DIFF
--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -8,9 +8,9 @@
 
     <h1 class="login-form__title">Connectez-vous</h1>
 
-    <div class="login-form__information paragraph">
+    <p class="login-form__information paragraph">
       L'accès à Pix Certif est limité aux centres de certification Pix.
-    </div>
+    </p>
 
     {{#if this.isErrorMessagePresent}}
       <div id="login-form-error-message" class="login-form__error-message error-message">

--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -1,7 +1,7 @@
 <div class="login-form">
 
   <div>
-    <img src="/pix-certif-logo.svg" alt="Pix Certif">
+    <img src="/pix-certif-logo.svg" alt="Pix Certif" />
   </div>
 
   <div>
@@ -13,46 +13,37 @@
     </p>
 
     {{#if this.isErrorMessagePresent}}
-      <div id="login-form-error-message" class="login-form__error-message error-message">
+      <div
+        id="login-form-error-message"
+        class="login-form__error-message error-message"
+      >
         {{this.errorMessage}}
       </div>
     {{/if}}
 
-    <form {{on 'submit' this.authenticate}} >
+    <form {{on "submit" this.authenticate}}>
 
       <div class="login-form__input-container">
-        <label for="login-email" class="label">Adresse e-mail</label>
-        <Input
+        <PixInput
           @id="login-email"
-          @name="login"
-          @type="email"
-          @class="input"
+          name="login"
+          @label="Adresse e-mail"
           @value={{this.email}}
-          @autocomplete="username"
-          @required="true"
+          autocomplete="email"
+          type="email"
+          required="true"
         />
       </div>
 
       <div class="login-form__input-container">
-        <label for="login-password" class="label">Mot de passe</label>
-        <div class="login-form__input-field">
-          <Input
-            @id="login-password"
-            @name="password"
-            @type={{this.passwordInputType}}
-            @class="input"
-            @value={{this.password}}
-            @autocomplete="current-password"
-            @required="true"
-          />
-          <button type="button" aria-label="rendre le mot de passe lisible" class="login-form__icon" {{on 'click' this.togglePasswordVisibility}} >
-            {{#if this.isPasswordVisible}}
-              <div tabindex="-1" onmousedown={{this.togglePasswordVisibility}}><FaIcon @icon='eye' class="fa-fw login-form-icon__eye" /></div>
-            {{else}}
-              <div tabindex="-1" onmousedown={{this.togglePasswordVisibility}}><FaIcon @icon='eye-slash' class="fa-fw login-form-icon__eye" /></div>
-            {{/if}}
-          </button>
-        </div>
+        <PixInputPassword
+          @id="login-password"
+          name="password"
+          @label="Mot de passe"
+          @value={{this.password}}
+          autocomplete="current-password"
+          required="true"
+        />
       </div>
 
       <div class="login-form__input-container">
@@ -62,11 +53,15 @@
       </div>
 
       <div class="login-form__forgotten-password one-line-text">
-        <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer" >Mot de passe oublié ?</a>
+        <a
+          href="https://app.pix.fr/mot-de-passe-oublie"
+          target="_blank"
+          rel="noopener noreferrer"
+        >Mot de passe oublié ?</a>
       </div>
 
     </form>
 
-    </div>
+  </div>
 
 </div>

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -65,3 +65,7 @@ body > .ember-view {
 input:invalid {
   box-shadow: none;
 }
+
+* {
+  box-sizing: border-box;
+}

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -3,11 +3,13 @@
   flex-direction: column;
   margin: auto;
   align-items: center;
-  background-color: white;
+  background-color: $white;
   border-radius: 10px;
-  padding: 40px 60px;
-  max-width: 400px;
-  width: 100%;
+  padding: 20px 8px;
+
+  @include device-is('tablet') {
+    padding: 40px 60px;
+  }
 
   &__title {
     text-align: center;
@@ -72,7 +74,7 @@
     height: 42px;
     border-radius: 3px;
     align-items: center;
-    background-color: white;
+    background-color: $white;
     border: 2px solid $grey-20;
 
     &:focus-within {

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -5,9 +5,9 @@
   align-items: center;
   background-color: $white;
   border-radius: 10px;
-  padding: 20px 8px;
+  padding: 20px 30px;
 
-  @include device-is('tablet') {
+  @include device-is("tablet") {
     padding: 40px 60px;
   }
 

--- a/certif/app/styles/pages/login.scss
+++ b/certif/app/styles/pages/login.scss
@@ -6,4 +6,5 @@
   background: $pix-certif-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
   align-items: center;
+  padding: 8px;
 }

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -2,7 +2,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn, render } from '@ember/test-helpers';
+import { fillIn, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { reject, resolve } from 'rsvp';
@@ -155,41 +155,5 @@ module('Integration | Component | login-form', function(hooks) {
     // then
     assert.dom('#login-form-error-message').exists();
     assert.dom('#login-form-error-message').hasText(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
-  });
-
-  module('when password is hidden', function(hooks) {
-
-    hooks.beforeEach(async function() {
-      // given
-      await render(hbs`{{login-form}});`);
-    });
-
-    test('it should display password when user click', async function(assert) {
-      // when
-      await click('.login-form__icon');
-
-      // then
-      assert.dom('#login-password').hasAttribute('type', 'text');
-    });
-
-    test('it should change icon when user click on it', async function(assert) {
-      // when
-      await click('.login-form__icon');
-
-      // then
-      assert.dom('.fa-eye').exists();
-    });
-
-    test('it should not change icon when user keeps typing his password', async function(assert) {
-      // given
-      await fillIn('#login-password', 'début du mot de passe');
-
-      // when
-      await click('.login-form__icon');
-      await fillIn('#login-password', 'fin du mot de passe');
-
-      // then
-      assert.dom('.fa-eye').exists();
-    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis une mise à jour de Pix-UI la page de login de Pix Certif n'est plus pareil à cause du `box-sizing: border-box;`. 
En effet le formulaire pour se connecter est plus petit ce qui n'est pas terrible quand on est sur un grand écran.

<img width="905" alt="image" src="https://user-images.githubusercontent.com/38167520/144029534-8219c276-da75-4560-a7bc-dbe231d55966.png">

## :gift: Solution
Mettre la propriété CSS box-sizing: border-box; est une bonne pratique CSS en règle générale (cela évite pas mal de problématiques de débordement etc.). Voir les mini conventions de CSS du site alsacreations.. Un autre site qui recommande le box-sizing: border-box..

Du coup, je propose d'adapter le style de pix certif plutôt que d'essayer d'enlever la règle `box-sizing`.

## :star2: Remarques
Une PR similaire : https://github.com/1024pix/pix/pull/3748. 


## :santa: Pour tester
Aller sur la page de login de pix certif, et vérifier le responsive.
