### PR TITLE
[TECH] Corriger les valeurs de l'autocomplete dans le formulaire de création de compte sur Pix Orga (PIX-3896).

### DIFF
--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -11,7 +11,7 @@
         @type="firstName"
         class="input {{if this.validation.firstName.hasError "input--error"}}"
         @value={{this.user.firstName}}
-        autocomplete="firstname"
+        autocomplete="given-name"
         {{on "focusout" (fn this.validateInput "firstName" this.user.firstName)}}
       />
       {{#if this.validation.firstName.hasError}}
@@ -32,7 +32,7 @@
         @type="lastName"
         class="input {{if this.validation.lastName.hasError "input--error"}}"
         @value={{this.user.lastName}}
-        autocomplete="lastname"
+        autocomplete="family-name"
         {{on "focusout" (fn this.validateInput "lastName" this.user.lastName)}}
       />
       {{#if this.validation.lastName.hasError}}
@@ -51,7 +51,7 @@
         @type="email"
         class="input {{if this.validation.email.hasError "input--error"}}"
         @value={{this.user.email}}
-        autocomplete="username"
+        autocomplete="email"
         {{on "focusout" (fn this.validateInput "email" this.user.email)}}
       />
       {{#if this.validation.email.hasError}}


### PR DESCRIPTION
## :christmas_tree: Problème
De nombreuses pages sur Pix Orga ne répondent pas aux critères d'accessibilité.
Une audit accessibilité sur cette application nous permet désormais de l'améliorer.

Actuellement nous ne remplissons pas le critère suivant : Chaque champ de formulaire dont l'objet se rapporte à une information concernant l'utilisateur vérifie-t-il ces conditions ?

## :gift: Solution

Ce critère concerne le formulaire de création de compte dans la double mire de Pix Orga.

Remplacer les valeurs non autorisées par les valeurs suivantes : 
- "given-name" pour le prénom 
- "family-name" pour le nom de famille 
- "email" pour l'adresse e-mail

## :star2: Remarques
Les valeurs "firstname" et "lastname" ne sont pas des valeurs autorisées pour l'attribut "autocomplete". 

MDN sur les valeurs autorisées : https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/autocomplete

