### PR TITLE
[FEATURE] Mettre à jour le message d'erreur de session non-accessible (PIX-3902)

### DIFF
--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -199,8 +199,7 @@ describe('Integration | Component | certification-joiner', function () {
       await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
-      expect(contains("Oups ! La session est en cours de traitement par les équipes Pix et n'est plus accessible.")).to
-        .exist;
+      expect(contains("La session que vous tentez de rejoindre n'est plus accessible.")).to.exist;
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -218,7 +218,7 @@
       },
       "error-messages": {
         "generic": "Oops! We can't find you.\nPlease check your details to continue or call the invigilator.",
-        "session-not-accessible": "Oops! The session is being processed by the Pix team and is no longer available.",
+        "session-not-accessible": "The session you are trying to join is no longer available.",
         "wrong-account": "Oops! It seems that you are using the wrong Pix account to join this certification session.\nTo continue, please login to the correct Pix account or ask the invigilator for help."
       },
       "first-title": "Join a session",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -218,7 +218,7 @@
       },
       "error-messages": {
         "generic": "Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.",
-        "session-not-accessible": "Oups ! La session est en cours de traitement par les équipes Pix et n'est plus accessible.",
+        "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
         "wrong-account": "Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification.\nPour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant."
       },
       "first-title": "Rejoindre une session",


### PR DESCRIPTION
## :christmas_tree: Problème
Aujourd’hui, lorsqu’un candidat tente de rejoindre une session qui a déjà été finalisée, il voit ce message d’erreur "Oups ! La session est en cours de traitement par les équipes Pix et n'est plus accessible."

La session peut, au moment où le candidat tente de la rejoindre, déjà avoir été publiée et donc ne plus être en cours de traitement.

## :gift: Solution
Afficher un message plus générique lorsqu’un candidat tente de rejoindre une session déjà finalisée : 

“La session que vous tentez de rejoindre n'est plus accessible.”

## :santa: Pour tester
Tenter de se rendre sur une session de certification déjà finalisée.
