### PR TITLE
[FEATURE] Ajout d'une page de sélection des sujets dans pix-orga (PIX-3734).

### DIFF
--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -59,6 +59,7 @@ Router.map(function () {
       });
     });
     this.route('certifications');
+    this.route('preselect-target-profile', { path: '/selection-sujets' });
   });
 
   this.route('logout');

--- a/orga/app/routes/authenticated/preselect-target-profile.js
+++ b/orga/app/routes/authenticated/preselect-target-profile.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class PreselectTargetProfileRoute extends Route {}

--- a/orga/app/templates/authenticated/preselect-target-profile.hbs
+++ b/orga/app/templates/authenticated/preselect-target-profile.hbs
@@ -1,0 +1,1 @@
+{{page-title (t "pages.preselectTargetProfile.title")}}

--- a/orga/tests/unit/routes/authenticated/preselect-target-profile-test.js
+++ b/orga/tests/unit/routes/authenticated/preselect-target-profile-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | authenticated/preselect-target-profile', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:authenticated/preselect-target-profile');
+    assert.ok(route);
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -554,6 +554,9 @@
         "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr."
       }
     },
+    "preselect-target-profile": {
+      "title": "Topic selection"
+    },
     "profiles-individual-results": {
       "title": "Profile of {firstName} {lastName}",
       "certifiable": "Eligible for certification",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -554,6 +554,9 @@
         "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr."
       }
     },
+    "preselect-target-profile": {
+      "title": "Sélection des sujets"
+    },
     "profiles-individual-results": {
       "title": "Profil de {firstName} {lastName}",
       "certifiable": "Certifiable",


### PR DESCRIPTION
## :christmas_tree: Problème
Nous souhaitons permettre au membre de pix-orga la possibilité de sélectionner les sujets d'un profile cible.

## :gift: Solution
Créer une page authentifié où l'on intègrera un sélecteur de sujet d'un profile cible.

## :star2: Remarques
RAS

## :santa: Pour tester
Se rendre sur [/selection-sujet](https://orga-pr3791.review.pix.fr/selection-sujet) et vérifier que : 
1. elle existe
2. elle n'est accessible que lorsque l'on est connecté
