### PR TITLE
[FEATURE] Bloquer les certif complementaires si le candidat n'est pas inscrit (PIX-3684)

### DIFF
--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -1,6 +1,7 @@
 const isNil = require('lodash/isNil');
 const endsWith = require('lodash/endsWith');
 const Joi = require('joi').extend(require('@joi/date'));
+const { PIX_PLUS_DROIT } = require('./ComplementaryCertification');
 const {
   InvalidCertificationCandidate,
   CertificationCandidatePersonalInfoFieldMissingError,
@@ -125,6 +126,10 @@ class CertificationCandidate {
     this.birthINSEECode = birthINSEECode;
     this.birthPostalCode = birthPostalCode;
     this.birthCity = birthCity;
+  }
+
+  isGrantedPixPlusDroit() {
+    return this.complementaryCertifications.find((comp) => comp.name === PIX_PLUS_DROIT);
   }
 }
 

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -1,7 +1,7 @@
 const isNil = require('lodash/isNil');
 const endsWith = require('lodash/endsWith');
 const Joi = require('joi').extend(require('@joi/date'));
-const { PIX_PLUS_DROIT } = require('./ComplementaryCertification');
+const { PIX_PLUS_DROIT, CLEA } = require('./ComplementaryCertification');
 const {
   InvalidCertificationCandidate,
   CertificationCandidatePersonalInfoFieldMissingError,
@@ -130,6 +130,10 @@ class CertificationCandidate {
 
   isGrantedPixPlusDroit() {
     return this.complementaryCertifications.find((comp) => comp.name === PIX_PLUS_DROIT);
+  }
+
+  isGrantedCleA() {
+    return this.complementaryCertifications.find((comp) => comp.name === CLEA);
   }
 }
 

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -38,11 +38,12 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     throw new SessionNotAccessible();
   }
 
+  const certificationCandidate = await certificationCandidateRepository.getBySessionIdAndUserId({
+    userId,
+    sessionId,
+  });
+
   if (featureToggles.isEndTestScreenRemovalEnabled) {
-    const certificationCandidate = await certificationCandidateRepository.getBySessionIdAndUserId({
-      userId,
-      sessionId,
-    });
     if (!certificationCandidate.isAuthorizedToStart()) {
       throw new CandidateNotAuthorizedToJoinSessionError();
     }
@@ -67,10 +68,10 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     domainTransaction,
     sessionId,
     userId,
+    certificationCandidate,
     locale,
     assessmentRepository,
     competenceRepository,
-    certificationCandidateRepository,
     certificationCourseRepository,
     certificationCenterRepository,
     certificationChallengesService,
@@ -85,9 +86,9 @@ async function _startNewCertification({
   domainTransaction,
   sessionId,
   userId,
+  certificationCandidate,
   locale,
   assessmentRepository,
-  certificationCandidateRepository,
   certificationCourseRepository,
   certificationCenterRepository,
   certificationChallengesService,
@@ -122,7 +123,6 @@ async function _startNewCertification({
   }
 
   const certificationCenter = await certificationCenterRepository.getBySessionId(sessionId);
-  const certificationCandidate = await certificationCandidateRepository.getBySessionIdAndUserId({ userId, sessionId });
 
   const complementaryCertificationIds = [];
 

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -128,7 +128,7 @@ async function _startNewCertification({
 
   const complementaryCertifications = await complementaryCertificationRepository.findAll();
 
-  if (certificationCenter.isAccreditedClea) {
+  if (certificationCenter.isAccreditedClea && certificationCandidate.isGrantedCleA()) {
     if (await certificationBadgesService.hasStillValidCleaBadgeAcquisition({ userId })) {
       const cleAComplementaryCertification = complementaryCertifications.find((comp) => comp.name === CLEA);
       complementaryCertificationIds.push(cleAComplementaryCertification.id);

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -128,14 +128,22 @@ async function _startNewCertification({
 
   const complementaryCertifications = await complementaryCertificationRepository.findAll();
 
-  if (certificationCenter.isAccreditedClea && certificationCandidate.isGrantedCleA()) {
+  if (
+    !featureToggles.isComplementaryCertificationSubscriptionEnabled ||
+    (certificationCenter.isAccreditedClea && certificationCandidate.isGrantedCleA())
+  ) {
     if (await certificationBadgesService.hasStillValidCleaBadgeAcquisition({ userId })) {
       const cleAComplementaryCertification = complementaryCertifications.find((comp) => comp.name === CLEA);
-      complementaryCertificationIds.push(cleAComplementaryCertification.id);
+      if (cleAComplementaryCertification) {
+        complementaryCertificationIds.push(cleAComplementaryCertification.id);
+      }
     }
   }
 
-  if (certificationCenter.isAccreditedPixPlusDroit && certificationCandidate.isGrantedPixPlusDroit()) {
+  if (
+    !featureToggles.isComplementaryCertificationSubscriptionEnabled ||
+    (certificationCenter.isAccreditedPixPlusDroit && certificationCandidate.isGrantedPixPlusDroit())
+  ) {
     const highestCertifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
       userId,
       domainTransaction,
@@ -145,7 +153,10 @@ async function _startNewCertification({
       const pixDroitComplementaryCertification = complementaryCertifications.find(
         (comp) => comp.name === PIX_PLUS_DROIT
       );
-      complementaryCertificationIds.push(pixDroitComplementaryCertification.id);
+      if (pixDroitComplementaryCertification) {
+        complementaryCertificationIds.push(pixDroitComplementaryCertification.id);
+      }
+
       const challengesForPixPlusCertification = await _findChallengesFromPixPlus({
         userId,
         highestCertifiableBadgeAcquisitions,

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -91,19 +91,13 @@ module.exports = {
     return !!notLinkedCandidate;
   },
 
-  getBySessionIdAndUserId({ sessionId, userId }) {
-    return CertificationCandidateBookshelf.where({ sessionId, userId })
-      .fetch()
-      .then((result) => bookshelfToDomainConverter.buildDomainObject(CertificationCandidateBookshelf, result))
-      .catch((error) => {
-        if (error instanceof CertificationCandidateBookshelf.NotFoundError) {
-          throw new NotFoundError(
-            `Candidate not found for certification session id ${sessionId} and user id ${userId}`
-          );
-        }
-
-        throw error;
-      });
+  async getBySessionIdAndUserId({ sessionId, userId }) {
+    const certificationCandidate = await knex
+      .select('certification-candidates.*')
+      .from('certification-candidates')
+      .where({ sessionId, userId })
+      .first();
+    return _toDomain(certificationCandidate);
   },
 
   async findBySessionId(sessionId) {
@@ -192,7 +186,7 @@ function _adaptModelToDb(certificationCandidateToSave) {
 
 function _toDomain(candidateData) {
   const complementaryCertifications = candidateData.complementaryCertifications
-    .filter((certificationData) => certificationData !== null)
+    ?.filter((certificationData) => certificationData !== null)
     .map((certification) => new ComplementaryCertification(certification));
 
   return new CertificationCandidate({ ...candidateData, complementaryCertifications });

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -754,6 +754,7 @@ describe('Acceptance | API | Certification Course', function () {
         // given
         certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ userId, sessionId }).id;
         databaseBuilder.factory.buildAssessment({ userId, certificationCourseId: certificationCourseId });
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId });
         await databaseBuilder.commit();
 
         // when
@@ -767,9 +768,12 @@ describe('Acceptance | API | Certification Course', function () {
 
       it('should retrieve the already existing certification course', async function () {
         // then
-        const certificationCourses = await knex('certification-courses').where({ userId, sessionId });
-        expect(certificationCourses).to.have.length(1);
-        expect(certificationCourses[0].id).to.equal(certificationCourseId);
+        const [certificationCourse, ...otherCertificationCourses] = await knex('certification-courses').where({
+          userId,
+          sessionId,
+        });
+        expect(otherCertificationCourses).to.have.length(0);
+        expect(certificationCourse.id + '').to.equal(response.result.data.id);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -520,373 +520,506 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               });
               context('when certification center has habilitation for pix plus', function () {
                 context('when user has certifiable badges with pix plus', function () {
-                  it('should save complementary certification info', async function () {
-                    // given
-                    const sessionId = 1;
-                    const accessCode = 'accessCode';
-                    const userId = 2;
-                    const domainTransaction = Symbol('someDomainTransaction');
+                  context('when user is granted for pix plus droit complementary certification', function () {
+                    it('should save complementary certification info', async function () {
+                      // given
+                      const sessionId = 1;
+                      const accessCode = 'accessCode';
+                      const userId = 2;
+                      const domainTransaction = Symbol('someDomainTransaction');
 
-                    const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
-                    sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+                      const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+                      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
 
-                    certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                      .withArgs({ userId, sessionId, domainTransaction })
-                      .resolves(null);
+                      certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                        .withArgs({ userId, sessionId, domainTransaction })
+                        .resolves(null);
 
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .onCall(0)
-                      .resolves(
-                        domainBuilder.buildCertificationCandidate({
-                          userId,
-                          sessionId,
-                          authorizedToStart: true,
-                        })
-                      );
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId, userId })
+                        .onCall(0)
+                        .resolves(
+                          domainBuilder.buildCertificationCandidate({
+                            userId,
+                            sessionId,
+                            authorizedToStart: true,
+                          })
+                        );
 
-                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
-                    certificationChallengesService.pickCertificationChallenges
-                      .withArgs(placementProfile)
-                      .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+                      const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                        _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
+                      certificationChallengesService.pickCertificationChallenges
+                        .withArgs(placementProfile)
+                        .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
-                    const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                      name: PIX_PLUS_DROIT,
-                    });
-                    const certificationCenter = domainBuilder.buildCertificationCenter({
-                      habilitations: [complementaryCertificationPixPlusDroit],
-                    });
-                    certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                    complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+                      const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                        name: PIX_PLUS_DROIT,
+                      });
+                      const certificationCenter = domainBuilder.buildCertificationCenter({
+                        habilitations: [complementaryCertificationPixPlusDroit],
+                      });
+                      certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                      complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
 
-                    const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
-                    const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                    const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                    const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
-                    const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
-                    const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({
-                      badge: certifiableBadge1,
-                    });
-                    const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
-                      badge: certifiableBadge2,
-                    });
+                      const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
+                      const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                      const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                      const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
+                      const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
+                      const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({
+                        badge: certifiableBadge1,
+                      });
+                      const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
+                        badge: certifiableBadge2,
+                      });
 
-                    certificationBadgesService.findStillValidBadgeAcquisitions
-                      .withArgs({ userId, domainTransaction })
-                      .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
+                      certificationBadgesService.findStillValidBadgeAcquisitions
+                        .withArgs({ userId, domainTransaction })
+                        .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
 
-                    certificationChallengesService.pickCertificationChallengesForPixPlus
-                      .withArgs(certifiableBadge1, userId)
-                      .resolves([challengePlus1, challengePlus2])
-                      .withArgs(certifiableBadge2, userId)
-                      .resolves([challengePlus3]);
+                      certificationChallengesService.pickCertificationChallengesForPixPlus
+                        .withArgs(certifiableBadge1, userId)
+                        .resolves([challengePlus1, challengePlus2])
+                        .withArgs(certifiableBadge2, userId)
+                        .resolves([challengePlus3]);
 
-                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                      userId,
-                      sessionId,
-                    });
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .resolves(foundCertificationCandidate);
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId,
+                        sessionId,
+                        complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                      });
 
-                    const complementaryCertificationCourse =
-                      ComplementaryCertificationCourse.fromComplementaryCertificationId(
-                        complementaryCertificationPixPlusDroit.id
-                      );
-                    const certificationCourseToSave = CertificationCourse.from({
-                      certificationCandidate: foundCertificationCandidate,
-                      challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
-                      verificationCode,
-                      maxReachableLevelOnCertificationDate: 5,
-                      complementaryCertificationCourses: [complementaryCertificationCourse],
-                    });
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId, userId })
+                        .resolves(foundCertificationCandidate);
 
-                    const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                      certificationCourseToSave.toDTO()
-                    );
-                    savedCertificationCourse._complementaryCertificationCourses = [
-                      { ...complementaryCertificationCourse, certificationCourseId: savedCertificationCourse.getId() },
-                    ];
-                    certificationCourseRepository.save
-                      .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                      .resolves(savedCertificationCourse);
-
-                    const assessmentToSave = new Assessment({
-                      userId,
-                      certificationCourseId: savedCertificationCourse.getId(),
-                      state: Assessment.states.STARTED,
-                      type: Assessment.types.CERTIFICATION,
-                      isImproving: false,
-                      method: Assessment.methods.CERTIFICATION_DETERMINED,
-                    });
-                    const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                    assessmentRepository.save
-                      .withArgs({ assessment: assessmentToSave, domainTransaction })
-                      .resolves(savedAssessment);
-
-                    // when
-                    const result = await retrieveLastOrCreateCertificationCourse({
-                      domainTransaction,
-                      sessionId,
-                      accessCode,
-                      userId,
-                      locale: 'fr',
-                      ...injectables,
-                    });
-
-                    // then
-                    expect(result).to.deep.equal({
-                      created: true,
-                      certificationCourse: new CertificationCourse({
-                        ...savedCertificationCourse.toDTO(),
-                        assessment: savedAssessment,
+                      const complementaryCertificationCourse =
+                        ComplementaryCertificationCourse.fromComplementaryCertificationId(
+                          complementaryCertificationPixPlusDroit.id
+                        );
+                      const certificationCourseToSave = CertificationCourse.from({
+                        certificationCandidate: foundCertificationCandidate,
                         challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
-                        complementaryCertificationCourses: [
-                          {
-                            certificationCourseId: savedCertificationCourse.getId(),
-                            complementaryCertificationId: complementaryCertificationPixPlusDroit.id,
-                          },
-                        ],
-                      }),
-                    });
-                  });
+                        verificationCode,
+                        maxReachableLevelOnCertificationDate: 5,
+                        complementaryCertificationCourses: [complementaryCertificationCourse],
+                      });
 
-                  it('should save all the challenges from pix and pix plus', async function () {
-                    // given
-                    const sessionId = 1;
-                    const accessCode = 'accessCode';
-                    const userId = 2;
-                    const domainTransaction = Symbol('someDomainTransaction');
-
-                    const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
-                    sessionRepository.get.withArgs(sessionId).resolves(foundSession);
-
-                    certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                      .withArgs({ userId, sessionId, domainTransaction })
-                      .resolves(null);
-
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .onCall(0)
-                      .resolves(
-                        domainBuilder.buildCertificationCandidate({
-                          userId,
-                          sessionId,
-                          authorizedToStart: true,
-                        })
+                      const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                        certificationCourseToSave.toDTO()
                       );
+                      savedCertificationCourse._complementaryCertificationCourses = [
+                        {
+                          ...complementaryCertificationCourse,
+                          certificationCourseId: savedCertificationCourse.getId(),
+                        },
+                      ];
+                      certificationCourseRepository.save
+                        .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                        .resolves(savedCertificationCourse);
 
-                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
-                    certificationChallengesService.pickCertificationChallenges
-                      .withArgs(placementProfile)
-                      .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+                      const assessmentToSave = new Assessment({
+                        userId,
+                        certificationCourseId: savedCertificationCourse.getId(),
+                        state: Assessment.states.STARTED,
+                        type: Assessment.types.CERTIFICATION,
+                        isImproving: false,
+                        method: Assessment.methods.CERTIFICATION_DETERMINED,
+                      });
+                      const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                      assessmentRepository.save
+                        .withArgs({ assessment: assessmentToSave, domainTransaction })
+                        .resolves(savedAssessment);
 
-                    const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                      name: PIX_PLUS_DROIT,
-                    });
-                    const certificationCenter = domainBuilder.buildCertificationCenter({
-                      habilitations: [complementaryCertificationPixPlusDroit],
-                    });
-                    certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                    complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+                      // when
+                      const result = await retrieveLastOrCreateCertificationCourse({
+                        domainTransaction,
+                        sessionId,
+                        accessCode,
+                        userId,
+                        locale: 'fr',
+                        ...injectables,
+                      });
 
-                    const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
-                    const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                    const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                    const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
-                    const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
-                    const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({
-                      badge: certifiableBadge1,
-                    });
-                    const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
-                      badge: certifiableBadge2,
-                    });
-
-                    certificationBadgesService.findStillValidBadgeAcquisitions
-                      .withArgs({ userId, domainTransaction })
-                      .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
-
-                    certificationChallengesService.pickCertificationChallengesForPixPlus
-                      .withArgs(certifiableBadge1, userId)
-                      .resolves([challengePlus1, challengePlus2])
-                      .withArgs(certifiableBadge2, userId)
-                      .resolves([challengePlus3]);
-
-                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                      userId,
-                      sessionId,
-                    });
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .resolves(foundCertificationCandidate);
-
-                    const complementaryCertificationCourse =
-                      ComplementaryCertificationCourse.fromComplementaryCertificationId(
-                        complementaryCertificationPixPlusDroit.id
-                      );
-                    const certificationCourseToSave = CertificationCourse.from({
-                      certificationCandidate: foundCertificationCandidate,
-                      challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
-                      verificationCode,
-                      maxReachableLevelOnCertificationDate: 5,
-                      complementaryCertificationCourses: [complementaryCertificationCourse],
+                      // then
+                      expect(result).to.deep.equal({
+                        created: true,
+                        certificationCourse: new CertificationCourse({
+                          ...savedCertificationCourse.toDTO(),
+                          assessment: savedAssessment,
+                          challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
+                          complementaryCertificationCourses: [
+                            {
+                              certificationCourseId: savedCertificationCourse.getId(),
+                              complementaryCertificationId: complementaryCertificationPixPlusDroit.id,
+                            },
+                          ],
+                        }),
+                      });
                     });
 
-                    const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                      certificationCourseToSave.toDTO()
-                    );
-                    savedCertificationCourse._complementaryCertificationCourses = [
-                      { ...complementaryCertificationCourse, certificationCourseId: savedCertificationCourse.getId() },
-                    ];
-                    certificationCourseRepository.save
-                      .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                      .resolves(savedCertificationCourse);
+                    it('should save all the challenges from pix and pix plus', async function () {
+                      // given
+                      const sessionId = 1;
+                      const accessCode = 'accessCode';
+                      const userId = 2;
+                      const domainTransaction = Symbol('someDomainTransaction');
 
-                    const assessmentToSave = new Assessment({
-                      userId,
-                      certificationCourseId: savedCertificationCourse.getId(),
-                      state: Assessment.states.STARTED,
-                      type: Assessment.types.CERTIFICATION,
-                      isImproving: false,
-                      method: Assessment.methods.CERTIFICATION_DETERMINED,
-                    });
-                    const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                    assessmentRepository.save
-                      .withArgs({ assessment: assessmentToSave, domainTransaction })
-                      .resolves(savedAssessment);
+                      const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+                      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
 
-                    // when
-                    const result = await retrieveLastOrCreateCertificationCourse({
-                      domainTransaction,
-                      sessionId,
-                      accessCode,
-                      userId,
-                      locale: 'fr',
-                      ...injectables,
-                    });
+                      certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                        .withArgs({ userId, sessionId, domainTransaction })
+                        .resolves(null);
 
-                    // then
-                    expect(result).to.deep.equal({
-                      created: true,
-                      certificationCourse: new CertificationCourse({
-                        ...savedCertificationCourse.toDTO(),
-                        assessment: savedAssessment,
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId, userId })
+                        .onCall(0)
+                        .resolves(
+                          domainBuilder.buildCertificationCandidate({
+                            userId,
+                            sessionId,
+                            authorizedToStart: true,
+                            complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                          })
+                        );
+
+                      const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                        _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
+                      certificationChallengesService.pickCertificationChallenges
+                        .withArgs(placementProfile)
+                        .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                      const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                        name: PIX_PLUS_DROIT,
+                      });
+                      const certificationCenter = domainBuilder.buildCertificationCenter({
+                        habilitations: [complementaryCertificationPixPlusDroit],
+                      });
+                      certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                      complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+
+                      const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
+                      const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                      const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                      const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
+                      const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
+                      const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({
+                        badge: certifiableBadge1,
+                      });
+                      const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
+                        badge: certifiableBadge2,
+                      });
+
+                      certificationBadgesService.findStillValidBadgeAcquisitions
+                        .withArgs({ userId, domainTransaction })
+                        .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
+
+                      certificationChallengesService.pickCertificationChallengesForPixPlus
+                        .withArgs(certifiableBadge1, userId)
+                        .resolves([challengePlus1, challengePlus2])
+                        .withArgs(certifiableBadge2, userId)
+                        .resolves([challengePlus3]);
+
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId,
+                        sessionId,
+                        complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                      });
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId, userId })
+                        .resolves(foundCertificationCandidate);
+
+                      const complementaryCertificationCourse =
+                        ComplementaryCertificationCourse.fromComplementaryCertificationId(
+                          complementaryCertificationPixPlusDroit.id
+                        );
+                      const certificationCourseToSave = CertificationCourse.from({
+                        certificationCandidate: foundCertificationCandidate,
                         challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
-                      }),
-                    });
-                  });
+                        verificationCode,
+                        maxReachableLevelOnCertificationDate: 5,
+                        complementaryCertificationCourses: [complementaryCertificationCourse],
+                      });
 
-                  it('should generate challenges for expert badge only if both maitre and expert badges are acquired', async function () {
-                    // given
-                    const sessionId = 1;
-                    const accessCode = 'accessCode';
-                    const userId = 2;
-                    const domainTransaction = Symbol('someDomainTransaction');
-
-                    const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
-                    sessionRepository.get.withArgs(sessionId).resolves(foundSession);
-
-                    certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                      .withArgs({ userId, sessionId, domainTransaction })
-                      .resolves(null);
-
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .onCall(0)
-                      .resolves(
-                        domainBuilder.buildCertificationCandidate({
-                          userId,
-                          sessionId,
-                          authorizedToStart: true,
-                        })
+                      const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                        certificationCourseToSave.toDTO()
                       );
+                      savedCertificationCourse._complementaryCertificationCourses = [
+                        {
+                          ...complementaryCertificationCourse,
+                          certificationCourseId: savedCertificationCourse.getId(),
+                        },
+                      ];
+                      certificationCourseRepository.save
+                        .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                        .resolves(savedCertificationCourse);
 
-                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                      _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
-                    certificationChallengesService.pickCertificationChallenges
-                      .withArgs(placementProfile)
-                      .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+                      const assessmentToSave = new Assessment({
+                        userId,
+                        certificationCourseId: savedCertificationCourse.getId(),
+                        state: Assessment.states.STARTED,
+                        type: Assessment.types.CERTIFICATION,
+                        isImproving: false,
+                        method: Assessment.methods.CERTIFICATION_DETERMINED,
+                      });
+                      const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                      assessmentRepository.save
+                        .withArgs({ assessment: assessmentToSave, domainTransaction })
+                        .resolves(savedAssessment);
 
-                    const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                      name: PIX_PLUS_DROIT,
-                    });
-                    const certificationCenter = domainBuilder.buildCertificationCenter({
-                      habilitations: [complementaryCertificationPixPlusDroit],
-                    });
-                    certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                    complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+                      // when
+                      const result = await retrieveLastOrCreateCertificationCourse({
+                        domainTransaction,
+                        sessionId,
+                        accessCode,
+                        userId,
+                        locale: 'fr',
+                        ...injectables,
+                      });
 
-                    const challengesForMaitre = [
-                      domainBuilder.buildChallenge({ id: 'challenge-pixmaitre1' }),
-                      domainBuilder.buildChallenge({ id: 'challenge-pixmaitre2' }),
-                    ];
-                    const challengesForExpert = [
-                      domainBuilder.buildChallenge({ id: 'challenge-pixexpert1' }),
-                      domainBuilder.buildChallenge({ id: 'challenge-pixexpert2' }),
-                    ];
-                    const maitreBadge = domainBuilder.buildBadge({
-                      key: 'PIX_DROIT_MAITRE_CERTIF',
-                      targetProfileId: 11,
-                    });
-                    const expertBadge = domainBuilder.buildBadge({
-                      key: 'PIX_DROIT_EXPERT_CERTIF',
-                      targetProfileId: 22,
-                    });
-                    domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
-                    const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: expertBadge });
-                    certificationBadgesService.findStillValidBadgeAcquisitions
-                      .withArgs({ userId, domainTransaction })
-                      .resolves([certifiableBadgeAcquisition2]);
-
-                    certificationChallengesService.pickCertificationChallengesForPixPlus
-                      .withArgs(maitreBadge, userId)
-                      .resolves(challengesForMaitre)
-                      .withArgs(expertBadge, userId)
-                      .resolves(challengesForExpert);
-
-                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                      userId,
-                      sessionId,
-                    });
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .resolves(foundCertificationCandidate);
-                    const savedCertificationCourse = domainBuilder.buildCertificationCourse({
-                      ...foundCertificationCandidate,
-                      isV2Certification: true,
-                      challenges: [challenge1, challenge2, ...challengesForExpert],
-                    });
-                    certificationCourseRepository.save.resolves(savedCertificationCourse);
-                    const savedAssessment = domainBuilder.buildAssessment({
-                      userId,
-                      certificationCourseId: savedCertificationCourse.id,
-                      state: Assessment.states.STARTED,
-                      type: Assessment.types.CERTIFICATION,
-                      isImproving: false,
-                      method: Assessment.methods.CERTIFICATION_DETERMINED,
-                    });
-                    assessmentRepository.save.resolves(savedAssessment);
-
-                    // when
-                    const result = await retrieveLastOrCreateCertificationCourse({
-                      domainTransaction,
-                      sessionId,
-                      accessCode,
-                      userId,
-                      locale: 'fr',
-                      ...injectables,
+                      // then
+                      expect(result).to.deep.equal({
+                        created: true,
+                        certificationCourse: new CertificationCourse({
+                          ...savedCertificationCourse.toDTO(),
+                          assessment: savedAssessment,
+                          challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
+                        }),
+                      });
                     });
 
-                    // then
-                    expect(result).to.deep.equal({
-                      created: true,
-                      certificationCourse: new CertificationCourse({
-                        ...savedCertificationCourse.toDTO(),
-                        assessment: savedAssessment,
+                    it('should generate challenges for expert badge only if both maitre and expert badges are acquired', async function () {
+                      // given
+                      const sessionId = 1;
+                      const accessCode = 'accessCode';
+                      const userId = 2;
+                      const domainTransaction = Symbol('someDomainTransaction');
+
+                      const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+                      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+                      certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                        .withArgs({ userId, sessionId, domainTransaction })
+                        .resolves(null);
+
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId, userId })
+                        .onCall(0)
+                        .resolves(
+                          domainBuilder.buildCertificationCandidate({
+                            userId,
+                            sessionId,
+                            authorizedToStart: true,
+                          })
+                        );
+
+                      const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                        _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
+                      certificationChallengesService.pickCertificationChallenges
+                        .withArgs(placementProfile)
+                        .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                      const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                        name: PIX_PLUS_DROIT,
+                      });
+                      const certificationCenter = domainBuilder.buildCertificationCenter({
+                        habilitations: [complementaryCertificationPixPlusDroit],
+                      });
+                      certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                      complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+
+                      const challengesForMaitre = [
+                        domainBuilder.buildChallenge({ id: 'challenge-pixmaitre1' }),
+                        domainBuilder.buildChallenge({ id: 'challenge-pixmaitre2' }),
+                      ];
+                      const challengesForExpert = [
+                        domainBuilder.buildChallenge({ id: 'challenge-pixexpert1' }),
+                        domainBuilder.buildChallenge({ id: 'challenge-pixexpert2' }),
+                      ];
+                      const maitreBadge = domainBuilder.buildBadge({
+                        key: 'PIX_DROIT_MAITRE_CERTIF',
+                        targetProfileId: 11,
+                      });
+                      const expertBadge = domainBuilder.buildBadge({
+                        key: 'PIX_DROIT_EXPERT_CERTIF',
+                        targetProfileId: 22,
+                      });
+                      domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
+                      const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({ badge: expertBadge });
+                      certificationBadgesService.findStillValidBadgeAcquisitions
+                        .withArgs({ userId, domainTransaction })
+                        .resolves([certifiableBadgeAcquisition2]);
+
+                      certificationChallengesService.pickCertificationChallengesForPixPlus
+                        .withArgs(maitreBadge, userId)
+                        .resolves(challengesForMaitre)
+                        .withArgs(expertBadge, userId)
+                        .resolves(challengesForExpert);
+
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId,
+                        sessionId,
+                      });
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId, userId })
+                        .resolves(foundCertificationCandidate);
+                      const savedCertificationCourse = domainBuilder.buildCertificationCourse({
+                        ...foundCertificationCandidate,
+                        isV2Certification: true,
                         challenges: [challenge1, challenge2, ...challengesForExpert],
-                      }),
+                      });
+                      certificationCourseRepository.save.resolves(savedCertificationCourse);
+                      const savedAssessment = domainBuilder.buildAssessment({
+                        userId,
+                        certificationCourseId: savedCertificationCourse.id,
+                        state: Assessment.states.STARTED,
+                        type: Assessment.types.CERTIFICATION,
+                        isImproving: false,
+                        method: Assessment.methods.CERTIFICATION_DETERMINED,
+                      });
+                      assessmentRepository.save.resolves(savedAssessment);
+
+                      // when
+                      const result = await retrieveLastOrCreateCertificationCourse({
+                        domainTransaction,
+                        sessionId,
+                        accessCode,
+                        userId,
+                        locale: 'fr',
+                        ...injectables,
+                      });
+
+                      // then
+                      expect(result).to.deep.equal({
+                        created: true,
+                        certificationCourse: new CertificationCourse({
+                          ...savedCertificationCourse.toDTO(),
+                          assessment: savedAssessment,
+                          challenges: [challenge1, challenge2, ...challengesForExpert],
+                        }),
+                      });
+                    });
+                  });
+
+                  context('when user is not granted for pix plus complementary certification', function () {
+                    it('should not save complementary certification info', async function () {
+                      // given
+                      const sessionId = 1;
+                      const accessCode = 'accessCode';
+                      const userId = 2;
+                      const domainTransaction = Symbol('someDomainTransaction');
+
+                      const foundSession = domainBuilder.buildSession.created({ id: sessionId, accessCode });
+                      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+
+                      certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                        .withArgs({ userId, sessionId, domainTransaction })
+                        .resolves(null);
+
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId, userId })
+                        .onCall(0)
+                        .resolves(
+                          domainBuilder.buildCertificationCandidate({
+                            userId,
+                            sessionId,
+                            authorizedToStart: true,
+                          })
+                        );
+
+                      const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                        _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
+                      certificationChallengesService.pickCertificationChallenges
+                        .withArgs(placementProfile)
+                        .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                      const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                        name: PIX_PLUS_DROIT,
+                      });
+                      const certificationCenter = domainBuilder.buildCertificationCenter({
+                        habilitations: [complementaryCertificationPixPlusDroit],
+                      });
+                      certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                      complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+
+                      const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
+                      const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                      const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                      const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
+                      const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
+                      const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({
+                        badge: certifiableBadge1,
+                      });
+                      const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
+                        badge: certifiableBadge2,
+                      });
+
+                      certificationBadgesService.findStillValidBadgeAcquisitions
+                        .withArgs({ userId, domainTransaction })
+                        .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
+
+                      certificationChallengesService.pickCertificationChallengesForPixPlus
+                        .withArgs(certifiableBadge1, userId)
+                        .resolves([challengePlus1, challengePlus2])
+                        .withArgs(certifiableBadge2, userId)
+                        .resolves([challengePlus3]);
+
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId,
+                        sessionId,
+                      });
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId, userId })
+                        .resolves(foundCertificationCandidate);
+
+                      const certificationCourseToSave = CertificationCourse.from({
+                        certificationCandidate: foundCertificationCandidate,
+                        challenges: [challenge1, challenge2],
+                        verificationCode,
+                        maxReachableLevelOnCertificationDate: 5,
+                        complementaryCertificationCourses: [],
+                      });
+
+                      const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                        certificationCourseToSave.toDTO()
+                      );
+                      certificationCourseRepository.save
+                        .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                        .resolves(savedCertificationCourse);
+
+                      const assessmentToSave = new Assessment({
+                        userId,
+                        certificationCourseId: savedCertificationCourse.getId(),
+                        state: Assessment.states.STARTED,
+                        type: Assessment.types.CERTIFICATION,
+                        isImproving: false,
+                        method: Assessment.methods.CERTIFICATION_DETERMINED,
+                      });
+                      const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                      assessmentRepository.save
+                        .withArgs({ assessment: assessmentToSave, domainTransaction })
+                        .resolves(savedAssessment);
+
+                      // when
+                      const result = await retrieveLastOrCreateCertificationCourse({
+                        domainTransaction,
+                        sessionId,
+                        accessCode,
+                        userId,
+                        locale: 'fr',
+                        ...injectables,
+                      });
+
+                      // then
+                      expect(result).to.deep.equal({
+                        created: true,
+                        certificationCourse: new CertificationCourse({
+                          ...savedCertificationCourse.toDTO(),
+                          assessment: savedAssessment,
+                          challenges: [challenge1, challenge2],
+                        }),
+                      });
                     });
                   });
                 });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -441,27 +441,21 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   .withArgs({ userId, sessionId, domainTransaction })
                   .resolves(null);
 
+                const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                  userId,
+                  sessionId,
+                  authorizedToStart: true,
+                });
+
                 certificationCandidateRepository.getBySessionIdAndUserId
                   .withArgs({ sessionId, userId })
-                  .onCall(0)
-                  .resolves(
-                    domainBuilder.buildCertificationCandidate({
-                      userId,
-                      sessionId,
-                      authorizedToStart: true,
-                    })
-                  );
+                  .resolves(foundCertificationCandidate);
 
                 const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                   _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                 certificationChallengesService.pickCertificationChallenges
                   .withArgs(placementProfile)
                   .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({ userId, sessionId });
-                certificationCandidateRepository.getBySessionIdAndUserId
-                  .withArgs({ sessionId, userId })
-                  .resolves(foundCertificationCandidate);
 
                 const certificationCourseToSave = CertificationCourse.from({
                   certificationCandidate: foundCertificationCandidate,
@@ -535,16 +529,16 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .withArgs({ userId, sessionId, domainTransaction })
                         .resolves(null);
 
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId,
+                        sessionId,
+                        authorizedToStart: true,
+                        complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                      });
+
                       certificationCandidateRepository.getBySessionIdAndUserId
                         .withArgs({ sessionId, userId })
-                        .onCall(0)
-                        .resolves(
-                          domainBuilder.buildCertificationCandidate({
-                            userId,
-                            sessionId,
-                            authorizedToStart: true,
-                          })
-                        );
+                        .resolves(foundCertificationCandidate);
 
                       const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                         _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
@@ -582,16 +576,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .resolves([challengePlus1, challengePlus2])
                         .withArgs(certifiableBadge2, userId)
                         .resolves([challengePlus3]);
-
-                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                        userId,
-                        sessionId,
-                        complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
-                      });
-
-                      certificationCandidateRepository.getBySessionIdAndUserId
-                        .withArgs({ sessionId, userId })
-                        .resolves(foundCertificationCandidate);
 
                       const complementaryCertificationCourse =
                         ComplementaryCertificationCourse.fromComplementaryCertificationId(
@@ -672,17 +656,16 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .withArgs({ userId, sessionId, domainTransaction })
                         .resolves(null);
 
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId,
+                        sessionId,
+                        authorizedToStart: true,
+                        complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                      });
+
                       certificationCandidateRepository.getBySessionIdAndUserId
                         .withArgs({ sessionId, userId })
-                        .onCall(0)
-                        .resolves(
-                          domainBuilder.buildCertificationCandidate({
-                            userId,
-                            sessionId,
-                            authorizedToStart: true,
-                            complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
-                          })
-                        );
+                        .resolves(foundCertificationCandidate);
 
                       const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                         _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
@@ -720,15 +703,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .resolves([challengePlus1, challengePlus2])
                         .withArgs(certifiableBadge2, userId)
                         .resolves([challengePlus3]);
-
-                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                        userId,
-                        sessionId,
-                        complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
-                      });
-                      certificationCandidateRepository.getBySessionIdAndUserId
-                        .withArgs({ sessionId, userId })
-                        .resolves(foundCertificationCandidate);
 
                       const complementaryCertificationCourse =
                         ComplementaryCertificationCourse.fromComplementaryCertificationId(
@@ -803,16 +777,15 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .withArgs({ userId, sessionId, domainTransaction })
                         .resolves(null);
 
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId,
+                        sessionId,
+                        authorizedToStart: true,
+                      });
+
                       certificationCandidateRepository.getBySessionIdAndUserId
                         .withArgs({ sessionId, userId })
-                        .onCall(0)
-                        .resolves(
-                          domainBuilder.buildCertificationCandidate({
-                            userId,
-                            sessionId,
-                            authorizedToStart: true,
-                          })
-                        );
+                        .resolves(foundCertificationCandidate);
 
                       const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                         _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
@@ -857,13 +830,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .withArgs(expertBadge, userId)
                         .resolves(challengesForExpert);
 
-                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                        userId,
-                        sessionId,
-                      });
-                      certificationCandidateRepository.getBySessionIdAndUserId
-                        .withArgs({ sessionId, userId })
-                        .resolves(foundCertificationCandidate);
                       const savedCertificationCourse = domainBuilder.buildCertificationCourse({
                         ...foundCertificationCandidate,
                         isV2Certification: true,
@@ -917,16 +883,15 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .withArgs({ userId, sessionId, domainTransaction })
                         .resolves(null);
 
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId,
+                        authorizedToStart: true,
+                        sessionId,
+                      });
+
                       certificationCandidateRepository.getBySessionIdAndUserId
                         .withArgs({ sessionId, userId })
-                        .onCall(0)
-                        .resolves(
-                          domainBuilder.buildCertificationCandidate({
-                            userId,
-                            sessionId,
-                            authorizedToStart: true,
-                          })
-                        );
+                        .resolves(foundCertificationCandidate);
 
                       const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                         _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
@@ -964,14 +929,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .resolves([challengePlus1, challengePlus2])
                         .withArgs(certifiableBadge2, userId)
                         .resolves([challengePlus3]);
-
-                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                        userId,
-                        sessionId,
-                      });
-                      certificationCandidateRepository.getBySessionIdAndUserId
-                        .withArgs({ sessionId, userId })
-                        .resolves(foundCertificationCandidate);
 
                       const certificationCourseToSave = CertificationCourse.from({
                         certificationCandidate: foundCertificationCandidate,
@@ -1039,16 +996,15 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       .withArgs({ userId, sessionId, domainTransaction })
                       .resolves(null);
 
+                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                      userId,
+                      sessionId,
+                      authorizedToStart: true,
+                    });
+
                     certificationCandidateRepository.getBySessionIdAndUserId
                       .withArgs({ sessionId, userId })
-                      .onCall(0)
-                      .resolves(
-                        domainBuilder.buildCertificationCandidate({
-                          userId,
-                          sessionId,
-                          authorizedToStart: true,
-                        })
-                      );
+                      .resolves(foundCertificationCandidate);
 
                     const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                       _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
@@ -1068,14 +1024,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     certificationBadgesService.findStillValidBadgeAcquisitions
                       .withArgs({ userId, domainTransaction })
                       .resolves([]);
-
-                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                      userId,
-                      sessionId,
-                    });
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .resolves(foundCertificationCandidate);
 
                     const certificationCourseToSave = CertificationCourse.from({
                       certificationCandidate: foundCertificationCandidate,
@@ -1139,16 +1087,15 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       .withArgs({ userId, sessionId, domainTransaction })
                       .resolves(null);
 
+                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                      userId,
+                      sessionId,
+                      authorizedToStart: true,
+                    });
+
                     certificationCandidateRepository.getBySessionIdAndUserId
                       .withArgs({ sessionId, userId })
-                      .onCall(0)
-                      .resolves(
-                        domainBuilder.buildCertificationCandidate({
-                          userId,
-                          sessionId,
-                          authorizedToStart: true,
-                        })
-                      );
+                      .resolves(foundCertificationCandidate);
 
                     const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                       _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
@@ -1193,13 +1140,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       .withArgs(expertBadge, userId)
                       .resolves(challengesForExpert);
 
-                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                      userId,
-                      sessionId,
-                    });
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .resolves(foundCertificationCandidate);
                     const savedCertificationCourse = domainBuilder.buildCertificationCourse({
                       ...foundCertificationCandidate,
                       isV2Certification: true,
@@ -1254,16 +1194,15 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     .withArgs({ userId, sessionId, domainTransaction })
                     .resolves(null);
 
+                  const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                    userId,
+                    sessionId,
+                    authorizedToStart: true,
+                  });
+
                   certificationCandidateRepository.getBySessionIdAndUserId
                     .withArgs({ sessionId, userId })
-                    .onCall(0)
-                    .resolves(
-                      domainBuilder.buildCertificationCandidate({
-                        userId,
-                        sessionId,
-                        authorizedToStart: true,
-                      })
-                    );
+                    .resolves(foundCertificationCandidate);
 
                   const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                     _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
@@ -1283,11 +1222,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   certificationBadgesService.findStillValidBadgeAcquisitions
                     .withArgs({ userId, domainTransaction })
                     .resolves([]);
-
-                  const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({ userId, sessionId });
-                  certificationCandidateRepository.getBySessionIdAndUserId
-                    .withArgs({ sessionId, userId })
-                    .resolves(foundCertificationCandidate);
 
                   const certificationCourseToSave = CertificationCourse.from({
                     certificationCandidate: foundCertificationCandidate,
@@ -1355,16 +1289,15 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       .withArgs({ userId, sessionId, domainTransaction })
                       .resolves(null);
 
+                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                      userId,
+                      sessionId,
+                      authorizedToStart: true,
+                    });
+
                     certificationCandidateRepository.getBySessionIdAndUserId
                       .withArgs({ sessionId, userId })
-                      .onCall(0)
-                      .resolves(
-                        domainBuilder.buildCertificationCandidate({
-                          userId,
-                          sessionId,
-                          authorizedToStart: true,
-                        })
-                      );
+                      .resolves(foundCertificationCandidate);
 
                     const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                       _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
@@ -1395,14 +1328,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
 
                     certificationChallengesService.pickCertificationChallengesForPixPlus.resolves([]);
-
-                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                      userId,
-                      sessionId,
-                    });
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .resolves(foundCertificationCandidate);
 
                     const complementaryCertificationCourse =
                       ComplementaryCertificationCourse.fromComplementaryCertificationId(
@@ -1480,16 +1405,16 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       .withArgs({ userId, sessionId, domainTransaction })
                       .resolves(null);
 
+                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                      userId,
+                      sessionId,
+                      authorizedToStart: true,
+                    });
+
                     certificationCandidateRepository.getBySessionIdAndUserId
                       .withArgs({ sessionId, userId })
-                      .onCall(0)
-                      .resolves(
-                        domainBuilder.buildCertificationCandidate({
-                          userId,
-                          sessionId,
-                          authorizedToStart: true,
-                        })
-                      );
+                      .resolves(foundCertificationCandidate);
+
                     const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
                       _buildPlacementProfileWithTwoChallenges(placementProfileService, userId, now);
                     certificationChallengesService.pickCertificationChallenges
@@ -1502,14 +1427,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     const certificationCenter = domainBuilder.buildCertificationCenter();
                     certificationCenterRepository.getBySessionId.resolves(certificationCenter);
                     complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
-
-                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                      userId,
-                      sessionId,
-                    });
-                    certificationCandidateRepository.getBySessionIdAndUserId
-                      .withArgs({ sessionId, userId })
-                      .resolves(foundCertificationCandidate);
 
                     const certificationCourseToSave = CertificationCourse.from({
                       certificationCandidate: foundCertificationCandidate,


### PR DESCRIPTION
## :christmas_tree: Problème
L'epix 3649 à introduit l'inscription d'un candidat aux certifications complémentaires. Cette inscription n'a pour le moment pas d'impact sur le passage des certifications complémentaires.

## :gift: Solution
Ne permettre de passer une certification complémentaire que si le candidat y est autorisé

## :star2: Remarques
Un peu de refacto
sous toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED

## :santa: Pour tester

### Avec le toggle `FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED`

1. Créer une session sur un centre de certif autorisé Pix+Droit et Cléa
2. Ajouter un candidat 1 sans inscription complémentaire 
3. Ajouter un candidat 2 avec une inscription complémentaire Pix+Droit
4. Ajouter un candidat 3 avec une inscription complémentaire Cléa
5. Ajouter un candidat 4 sans inscription complémentaire

5. Se connecter à Mon Pix avec un utilisateur qui a un badge Pix+Droit ou Cléa
6. Commencer le test de certification en tant que candidat 1 (pas la peine de le finir)
7. Verifier en base que rien n'a été ajouté dans la table `complementary-certification-courses` pour ce candidat

8. Se connecter à Mon Pix avec un utilisateur qui a un badge Pix+Droit
9. Commencer le test de certification en tant que candidat 2 (pas la peine de le finir)
10. Verifier en base qu'une ligne a été créé dans la table `complementary-certification-courses` pour Pix+Droit

11. Se connecter à Mon Pix avec un utilisateur qui a un badge Cléa
12. Commencer le test de certification en tant que candidat 3 (pas la peine de le finir)
13. Verifier en base qu'une ligne a été créé dans la table `complementary-certification-courses` pour Cléa

### Sans toggle `FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED`

11. Se connecter à Mon Pix avec un utilisateur qui a un badge Cléa ou Pix+Droit
12. Commencer le test de certification en tant que candidat 4 (pas la peine de le finir)
7. Verifier en base que rien n'a été ajouté dans la table `complementary-certification-courses` pour ce candidat

Notes: 
Pour ajouter le badge cléA a pixCertifDroit:
`update "badge-acquisitions" set "userId"=111 where "badgeId" = 118;`
Pour recuperer le code d'acces surveillant:
`select "supervisorPassword" from sessions order by id desc limit 1;`