### PR TITLE
[FEATURE] Notifier que le rôle du membre à été modifié à l'utilisateur sur Pix Orga (PIX-3951).

### DIFF
--- a/orga/app/components/team/members-list-item.js
+++ b/orga/app/components/team/members-list-item.js
@@ -63,10 +63,14 @@ export default class MembersListItem extends Component {
     if (!this.selectedNewRole) return false;
 
     membership.organizationRole = this.selectedNewRole;
-
     membership.organization = this.currentUser.organization;
 
-    return membership.save();
+    try {
+      await membership.save();
+      this.notifications.success(this.intl.t('pages.team-members.notifications.change-member-role.success'));
+    } catch (e) {
+      this.notifications.error(this.intl.t('pages.team-members.notifications.change-member-role.error'));
+    }
   }
 
   @action
@@ -94,10 +98,10 @@ export default class MembersListItem extends Component {
 
       await this.args.onRemoveMember(membership);
       this.notifications.success(
-        this.intl.t('pages.team-members.notifications.success', { memberFirstName, memberLastName })
+        this.intl.t('pages.team-members.notifications.remove-membership.success', { memberFirstName, memberLastName })
       );
     } catch (e) {
-      this.notifications.error(this.intl.t('pages.team-members.notifications.error'));
+      this.notifications.error(this.intl.t('pages.team-members.notifications.remove-membership.error'));
     } finally {
       this.closeRemoveMembershipModal();
     }

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { click, fillIn, render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { clickByLabel } from '../../../helpers/testing-library';
+import { clickByLabel, fillInByLabel } from '../../../helpers/testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Team::MembersListItem', function (hooks) {
@@ -77,7 +77,7 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
       await clickByLabel('Modifier le rôle');
 
       // when
-      await click('#cancel-update-organization-role');
+      await clickByLabel('Annuler');
 
       // then
       assert.equal(memberMembership.organizationRole, 'MEMBER');
@@ -93,8 +93,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
       await clickByLabel('Modifier le rôle');
 
       // when
-      await fillIn('select', 'ADMIN');
-      await click('#save-organization-role');
+      await fillInByLabel('Sélectionner un rôle', 'ADMIN');
+      await clickByLabel('Enregistrer');
 
       // then
       assert.equal(memberMembership.organizationRole, 'ADMIN');
@@ -110,8 +110,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
       await clickByLabel('Modifier le rôle');
 
       // when
-      await fillIn('select', 'MEMBER');
-      await click('#save-organization-role');
+      await fillInByLabel('Sélectionner un rôle', 'MEMBER');
+      await clickByLabel('Enregistrer');
 
       // then
       assert.equal(adminMembership.organizationRole, 'MEMBER');

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { clickByLabel, fillInByLabel } from '../../../helpers/testing-library';
+import { fillByLabel, clickByText, render, clickByName } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Team::MembersListItem', function (hooks) {
@@ -58,8 +57,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
       await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
 
       // when
-      await clickByLabel('Gérer');
-      await clickByLabel('Modifier le rôle');
+      await clickByName('Gérer');
+      await clickByText('Modifier le rôle');
 
       // then
       assert.dom('.zone-save-cancel-role').exists({ count: 1 });
@@ -73,11 +72,11 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
 
       await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
 
-      await clickByLabel('Gérer');
-      await clickByLabel('Modifier le rôle');
+      await clickByName('Gérer');
+      await clickByText('Modifier le rôle');
 
       // when
-      await clickByLabel('Annuler');
+      await clickByName('Annuler');
 
       // then
       assert.equal(memberMembership.organizationRole, 'MEMBER');
@@ -89,12 +88,12 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
       this.set('membership', memberMembership);
 
       await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
-      await clickByLabel('Gérer');
-      await clickByLabel('Modifier le rôle');
+      await clickByName('Gérer');
+      await clickByText('Modifier le rôle');
 
       // when
-      await fillInByLabel('Sélectionner un rôle', 'ADMIN');
-      await clickByLabel('Enregistrer');
+      await fillByLabel('Sélectionner un rôle', 'ADMIN');
+      await clickByText('Enregistrer');
 
       // then
       assert.equal(memberMembership.organizationRole, 'ADMIN');
@@ -106,16 +105,61 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
       this.set('membership', adminMembership);
 
       await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
-      await clickByLabel('Gérer');
-      await clickByLabel('Modifier le rôle');
+      await clickByName('Gérer');
+      await clickByText('Modifier le rôle');
 
       // when
-      await fillInByLabel('Sélectionner un rôle', 'MEMBER');
-      await clickByLabel('Enregistrer');
+      await fillByLabel('Sélectionner un rôle', 'MEMBER');
+      await clickByText('Enregistrer');
 
       // then
       assert.equal(adminMembership.organizationRole, 'MEMBER');
       sinon.assert.called(adminMembership.save);
+    });
+
+    test('it should display success message when updating a member role', async function (assert) {
+      // given
+      const notifications = this.owner.lookup('service:notifications');
+      sinon.stub(notifications, 'success');
+      this.set('membership', adminMembership);
+
+      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+      await clickByName('Gérer');
+      await clickByText('Modifier le rôle');
+
+      // when
+      await fillByLabel('Sélectionner un rôle', 'MEMBER');
+      await clickByText('Enregistrer');
+
+      // then
+      sinon.assert.calledWith(
+        notifications.success,
+        this.intl.t('pages.team-members.notifications.change-member-role.success')
+      );
+      assert.ok(true);
+    });
+
+    test('it should display error message when updating a member role fails', async function (assert) {
+      // given
+      adminMembership.save.rejects();
+      this.set('membership', adminMembership);
+      const notifications = this.owner.lookup('service:notifications');
+      sinon.stub(notifications, 'error');
+
+      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+      await clickByName('Gérer');
+      await clickByText('Modifier le rôle');
+
+      // when
+      await fillByLabel('Sélectionner un rôle', 'MEMBER');
+      await clickByText('Enregistrer');
+
+      // then
+      sinon.assert.calledWith(
+        notifications.error,
+        this.intl.t('pages.team-members.notifications.change-member-role.error')
+      );
+      assert.ok(true);
     });
   });
 
@@ -133,8 +177,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
 
       // when
       await render(hbs`<Team::MembersListItem @membership={{membership}} @onRemoveMember={{removeMembership}} />`);
-      await clickByLabel('Gérer');
-      await clickByLabel('Supprimer');
+      await clickByName('Gérer');
+      await clickByText('Supprimer');
     });
 
     test('should display a confirmation modal', function (assert) {
@@ -152,7 +196,7 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
 
     test('should close the modal by clicking on cancel button', async function (assert) {
       // when
-      await clickByLabel('Annuler');
+      await clickByName('Annuler');
 
       // then
       assert.notContains("Supprimer de l'équipe");
@@ -160,7 +204,7 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
 
     test('should call removeMembership and close modal by clicking on remove button', async function (assert) {
       // when
-      await click('button[data-test-modal-remove-button]');
+      await clickByText('Oui, supprimer le membre');
 
       // then
       sinon.assert.calledWith(removeMembershipStub, memberMembership);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -799,8 +799,14 @@
         }
       },
       "notifications": {
-        "error": "An error occurred while removing this member.",
-        "success": "{memberFirstName} {memberLastName} has successfully been removed from your Pix Orga team."
+        "remove-membership": {
+          "error": "An error occurred while removing this member.",
+          "success": "{memberFirstName} {memberLastName} has successfully been removed from your Pix Orga team."
+        },
+        "change-member-role": {
+          "success": "The role has been changed.",
+          "error": "An error occurred while changing this member's role."
+        }
       },
       "remove-membership-modal": {
         "title": "Are you sure you want to remove this member?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -799,8 +799,14 @@
         }
       },
       "notifications": {
-        "error": "Une erreur est survenue lors de la désactivation du membre.",
-        "success": "{memberFirstName} {memberLastName} a été supprimé avec succès de votre équipe Pix Orga."
+        "remove-membership": {
+          "error": "Une erreur est survenue lors de la désactivation du membre.",
+          "success": "{memberFirstName} {memberLastName} a été supprimé avec succès de votre équipe Pix Orga."
+        },
+        "change-member-role": {
+          "success": "Le rôle a bien été changé.",
+          "error": "Une erreur est survenue lors de la modification du rôle du membre."
+        }
       },
       "remove-membership-modal": {
         "title": "Confirmez-vous la suppression ?",


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement sur Pix, lorsqu'un administrateur modifie le rôle d'un des membres de son équipe, il n'a aucune information visuelle confirmant que le rôle à bien été modifié.

## :gift: Solution
Afficher une notification lorsque le rôle a bien été modifié

## :star2: Remarques
Ajout d'une notification d'erreur si la modification n'a pas été effectué, que l'api retourne une erreur.

## :santa: Pour tester
- Aller sur Pix Orga
- Se connecter avec un administrateur (ex:`sco.admin@example.net`)
- Aller dans la page Équipe
- Changer le rôle d'un membre > Gérer (les trois points) > Sélectionner un rôle > Enregistrer
- Constater que la notification s'affiche `Le rôle a bien été changé.`

Tester l'affichage de la notification d'erreur. ( par exemple, bidouiller le controller coté API, elle retournera une erreur)
- Constater que la notification s'affiche `Une erreur est survenue lors de la modification du rôle du membre.`

Tester en français et anglais
