### PR TITLE
[FEATURE] Ajouter une explication pour chaque type de campagne (PIX-3870)

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -19,36 +19,53 @@
   </div>
 
   {{#if this.currentUser.organization.canCollectProfiles}}
-    <div class="form__field">
-      <p class="label">{{t "pages.campaign-creation.purpose.label"}}</p>
-      <div class="form__radio-button">
-        <input
-          type="radio"
-          id="assess-participants"
-          name="campaign-goal"
-          value="assess-participants"
-          {{on "change" this.setCampaignGoal}}
-        />
-        <label for="assess-participants">{{t "pages.campaign-creation.purpose.assessment"}}</label>
-      </div>
+    <div class="form__field-with-info">
+      <div class="form__field">
+        <p class="label">{{t "pages.campaign-creation.purpose.label"}}</p>
+        <div class="form__radio-button">
+          <input
+            type="radio"
+            id="assess-participants"
+            name="campaign-goal"
+            value="assess-participants"
+            {{on "change" this.setCampaignGoal}}
+          />
+          <label for="assess-participants">{{t "pages.campaign-creation.purpose.assessment"}}</label>
+        </div>
 
-      <div class="form__radio-button">
-        <input
-          type="radio"
-          id="collect-participants-profile"
-          name="campaign-goal"
-          value="collect-participants-profile"
-          {{on "change" this.setCampaignGoal}}
-        />
-        <label for="collect-participants-profile">{{t "pages.campaign-creation.purpose.profiles-collection"}}</label>
+        <div class="form__radio-button">
+          <input
+            type="radio"
+            id="collect-participants-profile"
+            name="campaign-goal"
+            value="collect-participants-profile"
+            {{on "change" this.setCampaignGoal}}
+          />
+          <label for="collect-participants-profile">{{t "pages.campaign-creation.purpose.profiles-collection"}}</label>
+        </div>
+        {{#if @campaign.errors.type}}
+          <div class="form__error error-message">
+            {{display-campaign-errors @campaign.errors.type}}
+          </div>
+        {{/if}}
       </div>
-
-      {{#if @campaign.errors.type}}
-        <div class="form__error error-message">
-          {{display-campaign-errors @campaign.errors.type}}
+      {{#if this.isCampaignGoalAssessment}}
+        <div class="form__field-info">
+          <span class="form__field-info-title">
+            <FaIcon @icon="info-circle" class="form__field-info-icon" />
+            <span>{{t "pages.campaign-creation.purpose.assessment"}}</span>
+          </span>
+          <span class="form__field-info-message">{{t "pages.campaign-creation.purpose.assessment-info"}}</span>
+        </div>
+      {{else if this.isCampaignGoalProfileCollection}}
+        <div class="form__field-info">
+          <span class="form__field-info-title">
+            <FaIcon @icon="info-circle" class="form__field-info-icon" />
+            <span>{{t "pages.campaign-creation.purpose.profiles-collection"}}</span>
+          </span>
+          <span class="form__field-info-message">{{t "pages.campaign-creation.purpose.profiles-collection-info"}}</span>
         </div>
       {{/if}}
-
     </div>
   {{/if}}
 

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -9,7 +9,7 @@
     margin-bottom: 16px;
 
     @include device-is('desktop') {
-      max-width: 500px;
+      width: 500px;
     }
 
     &--wide > input,select,textarea {
@@ -36,6 +36,10 @@
     border-radius: 8px;
     background: $grey-15;
     height: max-content;
+
+    @include device-is('desktop') {
+      margin-bottom: min(40px);
+    }
 
     &-icon {
       color: $blue;

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -90,6 +90,25 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       assert.contains(t('pages.campaign-creation.purpose.label'));
     });
 
+    test('it should display the purpose explanation of an assessment campaign', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        organization = EmberObject.create({ canCollectProfiles: true });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.campaign = EmberObject.create({});
+
+      // when
+      await render(
+        hbs`<Campaign::CreateForm @campaign={{campaign}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}/>`
+      );
+      await clickByLabel(t('pages.campaign-creation.purpose.assessment'));
+
+      // then
+      assert.contains(t('pages.campaign-creation.purpose.assessment-info'));
+      assert.notContains(t('pages.campaign-creation.purpose.profiles-collection-info'));
+    });
+
     test('it should not display multiple sendings field', async function (assert) {
       //given
       this.campaign = EmberObject.create({});
@@ -142,6 +161,24 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // then
       assert.contains(t('pages.campaign-creation.multiple-sendings.question-label'));
       assert.contains(t('pages.campaign-creation.multiple-sendings.info'));
+    });
+    test('it should display the purpose explanation of a profiles collection campaign', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        organization = EmberObject.create({ canCollectProfiles: true });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.campaign = EmberObject.create({});
+
+      // when
+      await render(
+        hbs`<Campaign::CreateForm @campaign={{campaign}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}/>`
+      );
+      await clickByLabel(t('pages.campaign-creation.purpose.profiles-collection'));
+
+      // then
+      assert.contains(t('pages.campaign-creation.purpose.profiles-collection-info'));
+      assert.notContains(t('pages.campaign-creation.purpose.assessment-info'));
     });
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -289,8 +289,10 @@
       "no": "No",
       "purpose": {
         "assessment": "Assess participants",
+        "assessment-info": "An assessment campaign tests participants on specific topics.",
         "label": "What is the purpose of your campaign?",
-        "profiles-collection": "Collect the participants' Pix profiles"
+        "profiles-collection": "Collect the participants' Pix profiles",
+        "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score."
       },
       "target-profile-informations": "If you want more information, see <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> the corresponding documentation</a>.",
       "target-profiles-list": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -289,8 +289,11 @@
       "no": "Non",
       "purpose": {
         "assessment": "Évaluer les participants",
+        "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
         "label": "Quel est l'objectif de votre campagne ?",
-        "profiles-collection": "Collecter les profils Pix des participants"
+        "profiles-collection": "Collecter les profils Pix des participants",
+        "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix."
+
       },
       "target-profile-informations": "Si vous souhaitez avoir plus d'information, consulter <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> la documentation correspondante</a>.",
       "target-profiles-list": {


### PR DESCRIPTION
## :christmas_tree: Problème
On a décidé de faciliter la création des campagnes dans Pix Orga, notamment pour aider à choisir le type de campagne et le profile cible.

## :gift: Solution
 Pour ce faire, on a décidé d'ajouter un bloc d'info pour chaque type de campagne. Il s'affiche quand on sélectionne un type de campagne dans le formulaire de création de campagne.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Aller dans Pix Orga, créer une campagne et sélectionner un type de campagne, le bloc devrait apparaître.
