### PR TITLE
[FEATURE]  Ajouter un commentaire interne lors de la création d'un profil cible sur pix Admin(PIX-3873)

### DIFF
--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -55,6 +55,11 @@
       <p class="form__instructions create-target-profile__instructions">L'url à saisir doit être celle d'OVH. Veuillez
         vous rapprocher des équipes tech et produit pour la réalisation de celle-ci.</p>
     </div>
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="comment">Commentaire (usage interne) : </label>
+      <PixTextarea class="form-control" id="comment" @maxlength="500" row="4" @value={{@targetProfile.comment}} />
+    </div>
   </section>
 
   <section class="form-section form-actions form-section--actions">

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
@@ -20,6 +20,7 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
       imageUrl: '',
       ownerOrganizationId: '',
       isPublic: false,
+      comment: '',
     };
 
     isFileInvalid = false;
@@ -58,6 +59,7 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     assert.contains("Lien de l'image du profil cible :");
     assert.contains('Annuler');
     assert.contains('Enregistrer');
+    assert.contains('Commentaire (usage interne) :');
   });
 
   test('it should display json file error text', async function (assert) {

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -137,6 +137,7 @@ exports.register = async (server) => {
                   .optional(),
                 'image-url': Joi.string().uri().empty('').allow(null).optional(),
                 'skills-id': Joi.array().required(),
+                comment: Joi.string().optional().allow(null).max(500).empty(''),
               },
             },
           }),

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -12,7 +12,13 @@ const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = {
   async create(targetProfileData) {
-    const targetProfileRawData = _.pick(targetProfileData, ['name', 'isPublic', 'imageUrl', 'ownerOrganizationId']);
+    const targetProfileRawData = _.pick(targetProfileData, [
+      'name',
+      'isPublic',
+      'imageUrl',
+      'ownerOrganizationId',
+      'comment',
+    ]);
 
     const trx = await knex.transaction();
 

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -15,6 +15,7 @@ module.exports = {
       isPublic: json.data.attributes['is-public'],
       imageUrl: json.data.attributes['image-url'],
       skillsId: json.data.attributes['skills-id'],
+      comment: json.data.attributes['comment'],
     };
   },
 };

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -83,6 +83,7 @@ describe('Acceptance | Controller | target-profile-controller', function () {
               'is-public': false,
               'owner-organization-id': null,
               'skills-id': [skillId],
+              comment: 'comment',
             },
           },
         },

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -20,12 +20,13 @@ describe('Integration | Repository | Target-profile', function () {
         isPublic: true,
         ownerOrganizationId: null,
         skillsId: [],
+        comment: 'This is a high level target profile',
       };
       // when
       const targetProfileId = await targetProfileRepository.create(targetProfileData);
 
       const [targetProfile] = await knex('target-profiles')
-        .select(['name', 'imageUrl', 'outdated', 'isPublic', 'ownerOrganizationId'])
+        .select(['name', 'imageUrl', 'outdated', 'isPublic', 'ownerOrganizationId', 'comment'])
         .where({ id: targetProfileId });
 
       // then
@@ -34,6 +35,7 @@ describe('Integration | Repository | Target-profile', function () {
       expect(targetProfile.outdated).to.equal(false);
       expect(targetProfile.isPublic).to.equal(targetProfileData.isPublic);
       expect(targetProfile.ownerOrganizationId).to.equal(targetProfileData.ownerOrganizationId);
+      expect(targetProfile.comment).to.equal(targetProfileData.comment);
     });
 
     it('should attached each skillId once to target profile', async function () {
@@ -60,6 +62,7 @@ describe('Integration | Repository | Target-profile', function () {
         isPublic: true,
         ownerOrganizationId: null,
         skillsId: [null],
+        comment: 'This is a high level target profile',
       };
       // when
       const error = await catchErr(targetProfileRepository.create)(targetProfileData);

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -23,6 +23,7 @@ describe('Integration | Application | Target Profiles | Routes', function () {
             'image-url': null,
             'is-public': false,
             'skills-id': ['skill1', 'skill2'],
+            comment: 'comment',
           },
         },
       };
@@ -51,6 +52,7 @@ describe('Integration | Application | Target Profiles | Routes', function () {
             'image-url': null,
             'is-public': false,
             'skills-id': ['skill1', 'skill2'],
+            comment: 'comment',
           },
         },
       };
@@ -76,6 +78,7 @@ describe('Integration | Application | Target Profiles | Routes', function () {
             'image-url': null,
             'is-public': false,
             'skills-id': ['skill1', 'skill2'],
+            comment: 'comment',
           },
         },
       };


### PR DESCRIPTION
## :christmas_tree: Problème
Une création de campagne comprend le choix du profil cible, cependant il peut y avoir jusqu'au 70 profils cibles (PC) dans la drop down. L’une des améliorations sera de rajouter un commentaire interne pix pour les personnes de chez pix créant ou utilisant le profil cible. 

## :gift: Solution
Permettre l’ajout du commentaire depuis la page de création d’un profil cible.

## :star2: Remarques
Un profil cible peut posséder un commentaire ou pas (non obligatoire).

## :santa: Pour tester
- Se connectez sur pix Admin --> Profils cibles. 
- cliquez sur le bouton ' + Nouveau profile cible'.
- constatez que le champ de commentaires désormais existe.
- créez un profil cible avec un commentaire.
- retourner dans la liste des profils cibles, sélectionnez le profile qui à été créé.
- constatez qu'il contient le commentaire qui a été créé lors de la création.