### PR TITLE
[FEATURE] Afficher les sujets sur la page de selection des profils cibles dans Pix Orga (PIX-3949).

### DIFF
--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -6,6 +6,7 @@ const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('./us
 const checkUserBelongsToSupOrganizationAndManagesStudentsUseCase = require('./usecases/checkUserBelongsToSupOrganizationAndManagesStudents');
 const checkUserBelongsToOrganizationUseCase = require('./usecases/checkUserBelongsToOrganization');
 const checkUserIsAdminAndManagingStudentsForOrganization = require('./usecases/checkUserIsAdminAndManagingStudentsForOrganization');
+const checkUserIsMemberOfAnOrganizationUseCase = require('./usecases/checkUserIsMemberOfAnOrganization');
 const Organization = require('../../lib/domain/models/Organization');
 
 const JSONAPIError = require('jsonapi-serializer').Error;
@@ -201,6 +202,26 @@ async function checkUserBelongsToOrganization(request, h) {
   return _replyForbiddenError(h);
 }
 
+async function checkUserIsMemberOfAnOrganization(request, h) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return _replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+
+  let isMemberOfAnOrganization;
+  try {
+    isMemberOfAnOrganization = await checkUserIsMemberOfAnOrganizationUseCase.execute(userId);
+  } catch (err) {
+    return _replyForbiddenError(h);
+  }
+
+  if (isMemberOfAnOrganization) {
+    return h.response(true);
+  }
+  return _replyForbiddenError(h);
+}
+
 module.exports = {
   checkRequestedUserIsAuthenticatedUser,
   checkUserBelongsToOrganizationOrHasRolePixMaster,
@@ -212,4 +233,5 @@ module.exports = {
   checkUserIsAdminInSCOOrganizationManagingStudents,
   checkUserIsAdminInSUPOrganizationManagingStudents,
   checkUserBelongsToOrganization,
+  checkUserIsMemberOfAnOrganization,
 };

--- a/api/lib/application/tubes/index.js
+++ b/api/lib/application/tubes/index.js
@@ -1,4 +1,5 @@
 const TubesController = require('./tubes-controller');
+const securityPreHandlers = require('../security-pre-handlers');
 
 exports.register = async function (server) {
   server.route([
@@ -7,9 +8,10 @@ exports.register = async function (server) {
       path: '/api/framework/tubes',
       config: {
         handler: TubesController.getTubes,
+        pre: [{ method: securityPreHandlers.checkUserIsMemberOfAnOrganization }],
         tags: ['api', 'framework', 'tubes'],
         notes: [
-          'Cette route est restreinte aux utilisateurs authentifiés',
+          "Cette route est restreinte aux utilisateurs authentifiés membre d'une organisation",
           'Elle permet de demander de récupérer tous les sujets du référentiel',
         ],
       },

--- a/api/lib/application/tubes/index.js
+++ b/api/lib/application/tubes/index.js
@@ -1,0 +1,20 @@
+const TubesController = require('./tubes-controller');
+
+exports.register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/framework/tubes',
+      config: {
+        handler: TubesController.getTubes,
+        tags: ['api', 'framework', 'tubes'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle permet de demander de récupérer tous les sujets du référentiel',
+        ],
+      },
+    },
+  ]);
+};
+
+exports.name = 'tubes-api';

--- a/api/lib/application/tubes/tubes-controller.js
+++ b/api/lib/application/tubes/tubes-controller.js
@@ -1,0 +1,9 @@
+const usecases = require('../../domain/usecases');
+const tubeSerializer = require('../../infrastructure/serializers/jsonapi/tube-serializer');
+
+module.exports = {
+  async getTubes(request, h) {
+    const tubes = await usecases.getTubes();
+    return h.response(tubeSerializer.serialize(tubes)).code(200);
+  },
+};

--- a/api/lib/application/tubes/tubes-controller.js
+++ b/api/lib/application/tubes/tubes-controller.js
@@ -1,9 +1,11 @@
 const usecases = require('../../domain/usecases');
 const tubeSerializer = require('../../infrastructure/serializers/jsonapi/tube-serializer');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
   async getTubes(request, h) {
-    const tubes = await usecases.getTubes();
+    const locale = extractLocaleFromRequest(request);
+    const tubes = await usecases.getTubesFromPixFramework(locale);
     return h.response(tubeSerializer.serialize(tubes)).code(200);
   },
 };

--- a/api/lib/application/usecases/checkUserIsMemberOfAnOrganization.js
+++ b/api/lib/application/usecases/checkUserIsMemberOfAnOrganization.js
@@ -1,0 +1,8 @@
+const _ = require('lodash');
+const membershipRepository = require('../../infrastructure/repositories/membership-repository');
+
+module.exports = {
+  execute(userId) {
+    return membershipRepository.findByUserId({ userId }).then((memberships) => !_.isEmpty(memberships));
+  },
+};

--- a/api/lib/domain/usecases/get-tubes-from-pix-framework.js
+++ b/api/lib/domain/usecases/get-tubes-from-pix-framework.js
@@ -1,0 +1,3 @@
+module.exports = function getTubes({ locale, tubeRepository }) {
+  return tubeRepository.findActivesFromPixFramework(locale);
+};

--- a/api/lib/domain/usecases/get-tubes.js
+++ b/api/lib/domain/usecases/get-tubes.js
@@ -1,0 +1,3 @@
+module.exports = function getTubes({ tubeRepository }) {
+  return tubeRepository.list();
+};

--- a/api/lib/domain/usecases/get-tubes.js
+++ b/api/lib/domain/usecases/get-tubes.js
@@ -1,3 +1,0 @@
-module.exports = function getTubes({ tubeRepository }) {
-  return tubeRepository.list();
-};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -298,6 +298,7 @@ module.exports = injectDependencies(
     getShareableCertificate: require('./certificate/get-shareable-certificate'),
     getStageDetails: require('./get-stage-details'),
     getTargetProfileDetails: require('./get-target-profile-details'),
+    getTubes: require('./get-tubes'),
     getAccountRecoveryDetails: require('./account-recovery/get-account-recovery-details'),
     getParticipationsCountByMasteryRate: require('./get-participations-count-by-mastery-rate'),
     findUserAuthenticationMethods: require('./find-user-authentication-methods'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -298,7 +298,7 @@ module.exports = injectDependencies(
     getShareableCertificate: require('./certificate/get-shareable-certificate'),
     getStageDetails: require('./get-stage-details'),
     getTargetProfileDetails: require('./get-target-profile-details'),
-    getTubes: require('./get-tubes'),
+    getTubesFromPixFramework: require('./get-tubes-from-pix-framework'),
     getAccountRecoveryDetails: require('./account-recovery/get-account-recovery-details'),
     getParticipationsCountByMasteryRate: require('./get-participations-count-by-mastery-rate'),
     findUserAuthenticationMethods: require('./find-user-authentication-methods'),

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -1,6 +1,9 @@
 const _ = require('lodash');
+const bluebird = require('bluebird');
 const Tube = require('../../domain/models/Tube');
 const tubeDatasource = require('../datasources/learning-content/tube-datasource');
+const skillDatasource = require('../datasources/learning-content/skill-datasource');
+const competenceRepository = require('./competence-repository');
 
 const { getTranslatedText } = require('../../domain/services/get-translated-text');
 
@@ -25,6 +28,29 @@ function _toDomain({ tubeData, locale }) {
   });
 }
 
+function _findFromPixFramework(tubeDatas, pixCompetences) {
+  return pixCompetences.flatMap(({ id }) => {
+    return tubeDatas.filter(({ competenceId }) => id === competenceId);
+  });
+}
+
+async function _findActive(tubesFromPixFramework) {
+  const skillsByTube = await bluebird.mapSeries(tubesFromPixFramework, ({ id }) =>
+    skillDatasource.findActiveByTubeId(id)
+  );
+
+  const activeTubes = skillsByTube.reduce((accumulator, activeSkills) => {
+    if (activeSkills.length > 0) {
+      const tube = tubesFromPixFramework.find((tubeFromPixFramework) => {
+        return tubeFromPixFramework.id === activeSkills[0].tubeId;
+      });
+      accumulator.push(tube);
+    }
+    return accumulator;
+  }, []);
+  return activeTubes;
+}
+
 module.exports = {
   async get(id) {
     const tubeData = await tubeDatasource.get(id);
@@ -40,6 +66,18 @@ module.exports = {
   async findByNames({ tubeNames, locale }) {
     const tubeDatas = await tubeDatasource.findByNames(tubeNames);
     const tubes = _.map(tubeDatas, (tubeData) => _toDomain({ tubeData, locale }));
+    return _.orderBy(tubes, (tube) => tube.name.toLowerCase());
+  },
+
+  async findActivesFromPixFramework(locale) {
+    const tubeDatas = await tubeDatasource.list();
+    const pixCompetences = await competenceRepository.listPixCompetencesOnly();
+
+    const tubesFromPixFramework = _findFromPixFramework(tubeDatas, pixCompetences);
+
+    const activeTubes = await _findActive(tubesFromPixFramework);
+
+    const tubes = _.map(activeTubes, (tubeData) => _toDomain({ tubeData, locale }));
     return _.orderBy(tubes, (tube) => tube.name.toLowerCase());
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/tube-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/tube-serializer.js
@@ -1,0 +1,10 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(tube) {
+    return new Serializer('tube', {
+      ref: 'id',
+      attributes: ['practicalTitle', 'practicalDescription', 'competenceId'],
+    }).serialize(tube);
+  },
+};

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -42,6 +42,7 @@ module.exports = [
   require('./application/stages'),
   require('./application/tags'),
   require('./application/target-profiles'),
+  require('./application/tubes'),
   require('./application/tutorial-evaluations'),
   require('./application/user-orga-settings'),
   require('./application/user-tutorials'),

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -332,4 +332,22 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
       expect(response.result).to.deep.equal(jsonApiError403);
     });
   });
+
+  describe('#checkUserIsMemberOfAnOrganization', function () {
+    it('should return a well formed JSON API error when user is not authorized', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/framework/tubes',
+        headers: { authorization: generateValidRequestAuthorizationHeader() },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError403);
+    });
+  });
 });

--- a/api/tests/acceptance/application/tubes/tubes-controller_test.js
+++ b/api/tests/acceptance/application/tubes/tubes-controller_test.js
@@ -1,0 +1,88 @@
+const {
+  expect,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  mockLearningContent,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | tubes-controller', function () {
+  let server;
+
+  const learningContent = {
+    tubes: [
+      {
+        id: 'tubeId',
+        title: '@tube',
+        description: 'Description tube',
+        practicalTitleFrFr: 'Titre pratique',
+        practicalDescriptionFrFr: 'description pratique',
+        competenceId: 'recCOMP123',
+      },
+    ],
+  };
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/framework/tubes', function () {
+    describe('User is authenticated', function () {
+      beforeEach(async function () {
+        await databaseBuilder.factory.buildUser({
+          id: 4444,
+          firstName: 'Classic',
+          lastName: 'Papa',
+          email: 'classic.papa@example.net',
+          password: 'abcd1234',
+        });
+        await databaseBuilder.commit();
+        mockLearningContent(learningContent);
+      });
+      it('should return response code 200', async function () {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/framework/tubes`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(4444),
+          },
+        };
+
+        const expectedResult = [
+          {
+            id: 'tubeId',
+            type: 'tubes',
+            attributes: {
+              'practical-title': 'Titre pratique',
+              'practical-description': 'description pratique',
+              'competence-id': 'recCOMP123',
+            },
+          },
+        ];
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.deep.equal(expectedResult);
+      });
+    });
+    describe('User is not authenticated', function () {
+      it('should return response code 401', async function () {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/framework/tubes`,
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/tubes/tubes-controller_test.js
+++ b/api/tests/acceptance/application/tubes/tubes-controller_test.js
@@ -17,7 +17,20 @@ describe('Acceptance | Controller | tubes-controller', function () {
         description: 'Description tube',
         practicalTitleFrFr: 'Titre pratique',
         practicalDescriptionFrFr: 'description pratique',
-        competenceId: 'recCOMP123',
+        competenceId: 'competenceId',
+      },
+    ],
+    skills: [
+      {
+        id: 'skillId',
+        status: 'actif',
+        tubeId: 'tubeId',
+      },
+    ],
+    competences: [
+      {
+        id: 'competenceId',
+        origin: 'Pix',
       },
     ],
   };
@@ -56,7 +69,7 @@ describe('Acceptance | Controller | tubes-controller', function () {
             attributes: {
               'practical-title': 'Titre pratique',
               'practical-description': 'description pratique',
-              'competence-id': 'recCOMP123',
+              'competence-id': 'competenceId',
             },
           },
         ];

--- a/api/tests/acceptance/application/tubes/tubes-controller_test.js
+++ b/api/tests/acceptance/application/tubes/tubes-controller_test.js
@@ -41,14 +41,14 @@ describe('Acceptance | Controller | tubes-controller', function () {
 
   describe('GET /api/framework/tubes', function () {
     describe('User is authenticated', function () {
+      let userId;
+
       beforeEach(async function () {
-        await databaseBuilder.factory.buildUser({
-          id: 4444,
-          firstName: 'Classic',
-          lastName: 'Papa',
-          email: 'classic.papa@example.net',
-          password: 'abcd1234',
-        });
+        userId = databaseBuilder.factory.buildUser().id;
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildMembership({ userId, organizationId: organization.id });
+
         await databaseBuilder.commit();
         mockLearningContent(learningContent);
       });
@@ -58,7 +58,7 @@ describe('Acceptance | Controller | tubes-controller', function () {
           method: 'GET',
           url: `/api/framework/tubes`,
           headers: {
-            authorization: generateValidRequestAuthorizationHeader(4444),
+            authorization: generateValidRequestAuthorizationHeader(userId),
           },
         };
 

--- a/api/tests/integration/application/security-pre-handlers_test.js
+++ b/api/tests/integration/application/security-pre-handlers_test.js
@@ -68,4 +68,65 @@ describe('Integration | Application | SecurityPreHandlers', function () {
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('#checkUserIsMemberOfAnOrganization', function () {
+    let httpServerTest;
+
+    beforeEach(async function () {
+      const moduleUnderTest = {
+        name: 'security-test',
+        register: async function (server) {
+          server.route([
+            {
+              method: 'GET',
+              path: '/framework/tubes',
+              handler: (r, h) => h.response().code(200),
+              config: {
+                pre: [
+                  {
+                    method: securityPreHandlers.checkUserIsMemberOfAnOrganization,
+                  },
+                ],
+              },
+            },
+          ]);
+        },
+      };
+      httpServerTest = new HttpTestServer();
+      await httpServerTest.register(moduleUnderTest);
+      httpServerTest.setupAuthentication();
+    });
+
+    it('returns 403 when user is not a member of an organization', async function () {
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/framework/tubes',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      const response = await httpServerTest.requestObject(options);
+
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('returns 200 when the user is a member of an organization', async function () {
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildMembership({ userId, organizationId });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/framework/tubes',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      const response = await httpServerTest.requestObject(options);
+
+      expect(response.statusCode).to.equal(200);
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -218,4 +218,118 @@ describe('Integration | Repository | tube-repository', function () {
       });
     });
   });
+
+  describe('#findActivesFromFramework', function () {
+    it('should return the active tubes from pix framework', async function () {
+      // given
+      const tube0 = new Tube({
+        id: 'recTube0',
+        name: 'tubeName0',
+        competenceId: 'recCompetence0',
+      });
+
+      const learningContentSkill0 = {
+        id: 'recSkill0',
+        status: 'actif',
+        tubeId: 'recTube0',
+      };
+
+      const learningContentSkill1 = {
+        id: 'recSkill1',
+        status: 'archivé',
+        tubeId: 'recTube1',
+      };
+
+      const learningContentSkill2 = {
+        id: 'recSkill2',
+        status: 'actif',
+        tubeId: 'recTube2',
+      };
+
+      const learningContentTube0 = {
+        id: 'recTube0',
+        name: 'tubeName0',
+        competenceId: 'recCompetence0',
+      };
+
+      const learningContentTube1 = {
+        id: 'recTube1',
+        name: '@tubeName1',
+        competenceId: 'recCompetence0',
+      };
+
+      const learningContentTube2 = {
+        id: 'recTube2',
+        name: '@tubeName1',
+        competenceId: 'recCompetence1',
+      };
+
+      const learningContentCompetence0 = {
+        id: 'recCompetence0',
+        origin: 'Pix',
+      };
+
+      const learningContentCompetence1 = {
+        id: 'recCompetence1',
+        origin: 'Pix plus',
+      };
+
+      mockLearningContent({
+        tubes: [learningContentTube0, learningContentTube1, learningContentTube2],
+        skills: [learningContentSkill0, learningContentSkill1, learningContentSkill2],
+        competences: [learningContentCompetence0, learningContentCompetence1],
+      });
+
+      // when
+      const tubes = await tubeRepository.findActivesFromPixFramework();
+
+      // then
+      expect(tubes.length).to.equal(1);
+      expect(tubes[0]).to.deep.equal(tube0);
+    });
+
+    it('should return tubes in the specified locale', async function () {
+      // given
+      const tube0 = new Tube({
+        id: 'recTube0',
+        name: 'tubeName0',
+        practicalTitle: 'translatedPracticalTitle1',
+        practicalDescription: 'translatedPracticalDescription1',
+        competenceId: 'recCompetence0',
+      });
+
+      const learningContentSkill0 = {
+        id: 'recSkill0',
+        status: 'actif',
+        tubeId: 'recTube0',
+      };
+
+      const learningContentTube0 = {
+        id: 'recTube0',
+        name: 'tubeName0',
+        practicalTitleEnUs: 'translatedPracticalTitle1',
+        practicalDescriptionEnUs: 'translatedPracticalDescription1',
+        competenceId: 'recCompetence0',
+      };
+
+      const learningContentCompetence0 = {
+        id: 'recCompetence0',
+        origin: 'Pix',
+      };
+
+      mockLearningContent({
+        tubes: [learningContentTube0],
+        skills: [learningContentSkill0],
+        competences: [learningContentCompetence0],
+      });
+      const locale = 'en';
+
+      // when
+      const tubes = await tubeRepository.findActivesFromPixFramework(locale);
+
+      // then
+      expect(tubes.length).to.equal(1);
+      expect(tubes[0]).to.deep.equal(tube0);
+    });
+  });
 });

--- a/api/tests/unit/application/tubes/tubes-controller_test.js
+++ b/api/tests/unit/application/tubes/tubes-controller_test.js
@@ -1,0 +1,50 @@
+const { expect, hFake, sinon, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const tubeSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/tube-serializer');
+const tubesController = require('../../../../lib/application/tubes/tubes-controller');
+
+describe('Unit | Controller | tubes-controller', function () {
+  beforeEach(function () {
+    sinon.stub(usecases, 'getTubesFromPixFramework');
+    sinon.stub(tubeSerializer, 'serialize');
+  });
+
+  describe('#getTubes', function () {
+    it('should fetch and return tubes, serialized as JSONAPI', async function () {
+      // given
+      const userId = 42;
+      const request = {
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        pre: { userId },
+      };
+
+      // when
+      await tubesController.getTubes(request, hFake);
+
+      // then
+      expect(usecases.getTubesFromPixFramework).to.have.been.called;
+      expect(usecases.getTubesFromPixFramework).to.have.been.calledWithExactly('fr-fr');
+      expect(tubeSerializer.serialize).to.have.been.called;
+    });
+
+    it('should extract the locale and pass it to the usecases', async function () {
+      // given
+      const userId = 42;
+      const request = {
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+          'accept-language': 'en',
+        },
+        pre: { userId },
+      };
+
+      // when
+      await tubesController.getTubes(request, hFake);
+
+      // then
+      expect(usecases.getTubesFromPixFramework).to.have.been.called;
+      expect(usecases.getTubesFromPixFramework).to.have.been.calledWithExactly('en');
+      expect(tubeSerializer.serialize).to.have.been.called;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-tubes-from-pix-framework_test.js
+++ b/api/tests/unit/domain/usecases/get-tubes-from-pix-framework_test.js
@@ -2,19 +2,21 @@ const { expect, sinon } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 
 describe('Unit | UseCase | get-tubes', function () {
-  it('should get tubes', async function () {
+  it('should get tubes from framework', async function () {
     // given
     const expectedResult = Symbol('tubes');
 
     const tubeRepository = {
-      list: sinon.stub().resolves(expectedResult),
+      findActivesFromPixFramework: sinon.stub().resolves(expectedResult),
     };
 
     // when
-    const response = await usecases.getTubes({
+    const response = await usecases.getTubesFromPixFramework({
+      locale: 'fr',
       tubeRepository,
     });
 
     expect(response).to.equal(expectedResult);
+    expect(tubeRepository.findActivesFromPixFramework).to.have.been.calledWithExactly('fr');
   });
 });

--- a/api/tests/unit/domain/usecases/get-tubes_test.js
+++ b/api/tests/unit/domain/usecases/get-tubes_test.js
@@ -1,0 +1,20 @@
+const { expect, sinon } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+
+describe('Unit | UseCase | get-tubes', function () {
+  it('should get tubes', async function () {
+    // given
+    const expectedResult = Symbol('tubes');
+
+    const tubeRepository = {
+      list: sinon.stub().resolves(expectedResult),
+    };
+
+    // when
+    const response = await usecases.getTubes({
+      tubeRepository,
+    });
+
+    expect(response).to.equal(expectedResult);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/tube-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/tube-serializer_test.js
@@ -1,0 +1,33 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/tube-serializer');
+
+describe('Unit | Serializer | JSONAPI | tube-serializer', function () {
+  describe('#serialize', function () {
+    it('should return a serialized JSON data object', function () {
+      // given
+      const tubeId = 456;
+
+      const tube = domainBuilder.buildTube({
+        id: tubeId,
+      });
+
+      const expectedSerializedResult = {
+        data: {
+          id: tubeId.toString(),
+          type: 'tubes',
+          attributes: {
+            'practical-title': 'titre pratique',
+            'practical-description': 'description pratique',
+            'competence-id': 'recCOMP123',
+          },
+        },
+      };
+
+      // when
+      const result = serializer.serialize(tube);
+
+      // then
+      expect(result).to.deep.equal(expectedSerializedResult);
+    });
+  });
+});

--- a/orga/app/adapters/tube.js
+++ b/orga/app/adapters/tube.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class TubeAdapter extends ApplicationAdapter {
+  namespace = 'api/framework';
+}

--- a/orga/app/components/tube/list.hbs
+++ b/orga/app/components/tube/list.hbs
@@ -1,0 +1,23 @@
+<section>
+  <div class="panel">
+    <table class="table content-text content-text--small">
+      <thead>
+        <tr>
+          <Table::Header @size="wide">{{t "pages.preselect-target-profile.table.column.name"}}</Table::Header>
+        </tr>
+      </thead>
+
+      <tbody>
+        {{#each @tubes as |tube|}}
+          <tr class="row-tube" aria-label={{t "pages.preselect-target-profile.table.row-title"}}>
+            <td class="table__column">
+              {{tube.practicalTitle}}
+              :
+              {{tube.practicalDescription}}
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/orga/app/models/tube.js
+++ b/orga/app/models/tube.js
@@ -1,5 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class Tube extends Model {
-  @attr('string') name;
+  @attr('string') practicalTitle;
+  @attr('string') practicalDescription;
 }

--- a/orga/app/models/tube.js
+++ b/orga/app/models/tube.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Tube extends Model {
+  @attr('string') name;
+}

--- a/orga/app/routes/authenticated/preselect-target-profile.js
+++ b/orga/app/routes/authenticated/preselect-target-profile.js
@@ -1,11 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default class PreselectTargetProfileRoute extends Route {
-  model(params) {
-    return this.store.query('tube', {
-      filter: {
-        name: params.name,
-      },
-    });
+  model() {
+    return this.store.query('tube', {});
   }
 }

--- a/orga/app/routes/authenticated/preselect-target-profile.js
+++ b/orga/app/routes/authenticated/preselect-target-profile.js
@@ -1,3 +1,11 @@
 import Route from '@ember/routing/route';
 
-export default class PreselectTargetProfileRoute extends Route {}
+export default class PreselectTargetProfileRoute extends Route {
+  model(params) {
+    return this.store.query('tube', {
+      filter: {
+        name: params.name,
+      },
+    });
+  }
+}

--- a/orga/app/templates/authenticated/preselect-target-profile.hbs
+++ b/orga/app/templates/authenticated/preselect-target-profile.hbs
@@ -1,1 +1,5 @@
-{{page-title (t "pages.preselectTargetProfile.title")}}
+{{page-title (t "pages.preselect-target-profile.title")}}
+
+<article>
+  <Tube::List @tubes={{@model}} />
+</article>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -425,4 +425,8 @@ export default function () {
 
     return new Response(204);
   });
+
+  this.get('/framework/tubes', (schema) => {
+    return schema.tubes.all();
+  });
 }

--- a/orga/tests/acceptance/preselect-target-profile_test.js
+++ b/orga/tests/acceptance/preselect-target-profile_test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
+import authenticateSession from '../helpers/authenticate-session';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | preselect-target-profile', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async () => {
+    const user = createUserWithMembershipAndTermsOfServiceAccepted();
+    createPrescriberByUser(user);
+    await authenticateSession(user.id);
+  });
+
+  test('it should display tubes', async function (assert) {
+    // when
+    await visit('/selection-sujets');
+
+    // then
+    assert.dom('.tube-select').exists({ count: 3 });
+  });
+});

--- a/orga/tests/acceptance/preselect-target-profile_test.js
+++ b/orga/tests/acceptance/preselect-target-profile_test.js
@@ -16,10 +16,15 @@ module('Acceptance | preselect-target-profile', function (hooks) {
   });
 
   test('it should display tubes', async function (assert) {
+    // given
+    server.create('tube', { name: 'Tube 1' });
+    server.create('tube', { name: 'Tube 2' });
+    server.create('tube', { name: 'Tube 3' });
+
     // when
     await visit('/selection-sujets');
 
     // then
-    assert.dom('.tube-select').exists({ count: 3 });
+    assert.dom('.row-tube').exists({ count: 3 });
   });
 });

--- a/orga/tests/integration/components/tube/list_test.js
+++ b/orga/tests/integration/components/tube/list_test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | tube:list', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should display a list of tubes', async function (assert) {
+    // given
+    const tubes = [
+      {
+        id: 'tubeId1',
+        practicalTitle: 'Titre 1',
+        practicalDescription: 'Description 1',
+      },
+      {
+        id: 'tubeId2',
+        practicalTitle: 'Titre 2',
+        practicalDescription: 'Description 2',
+      },
+    ];
+    this.set('tubes', tubes);
+
+    // when
+    await render(hbs`<Tube::list @tubes={{this.tubes}}/>`);
+
+    // then
+    assert.dom('.row-tube').exists({ count: 2 });
+    assert.dom(this.element.querySelector('.row-tube')).hasText('Titre 1 : Description 1');
+  });
+});

--- a/orga/tests/unit/adapters/tube-test.js
+++ b/orga/tests/unit/adapters/tube-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | tube', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    const adapter = this.owner.lookup('adapter:tube');
+    assert.ok(adapter);
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -562,7 +562,13 @@
       }
     },
     "preselect-target-profile": {
-      "title": "Topic selection"
+      "title": "Topic selection",
+      "table": {
+        "column" : {
+          "name": "Topic name"
+        },
+        "row-title": "Topic"
+      }
     },
     "profiles-individual-results": {
       "title": "Profile of {firstName} {lastName}",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -563,7 +563,13 @@
       }
     },
     "preselect-target-profile": {
-      "title": "Sélection des sujets"
+      "title": "Sélection des sujets",
+      "table": {
+        "column" : {
+          "name": "Nom du sujet"
+        },
+        "row-title": "Sujet"
+      }
     },
     "profiles-individual-results": {
       "title": "Profil de {firstName} {lastName}",


### PR DESCRIPTION
## :christmas_tree: Problème
les sujets ne sont pas affichés sur la page de sélection.

## :gift: Solution
Afficher les sujets sur la page de sélection des profils cible.

## :star2: Remarques
R.A.S

## :santa: Pour tester
Se rendre sur /selection-sujets et vérifier que les sujets sont bien affichés.