### PR TITLE
[TECH] Prévenir les usages involontaires de console dans pix-certif.

### DIFF
--- a/certif/.eslintrc.js
+++ b/certif/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
   },
   rules: {
     'no-restricted-imports': ['error', { 'paths': ['lodash'] }],
+    'no-console': 'error',
   },
   overrides: [
     // node files

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -122,6 +122,7 @@ module.exports = function(environment) {
   // Warn for unknown feature toggles
   _.each(process.env, (value, key) => {
     if (key.startsWith('FT_') && _.indexOf(ACTIVE_FEATURE_TOGGLES, key) === -1) {
+      // eslint-disable-next-line no-console
       console.warn(`Unknown feature toggle ${key}. Please remove it from your environment variables.`);
     }
   });

--- a/certif/tests/helpers/extended-ember-test-helpers/click-by-label.js
+++ b/certif/tests/helpers/extended-ember-test-helpers/click-by-label.js
@@ -2,6 +2,7 @@ import { getScreen } from '@pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 
 export default function clickByLabel(labelText) {
+  // eslint-disable-next-line no-console
   console.warn(`The clickByLabel helper is deprecated. Use testing-library's click(getByRole('${labelText}')) instead.`);
   const { getByRole } = getScreen();
   const element = getByRole(/button|link|radio|checkbox/, { name: labelText });


### PR DESCRIPTION
## :christmas_tree: Problème
L'usage de `console` peut être involontaire, car utilisé en cours de développement et non retiré.
Il n'existe pas de logger comme dans l'API.

## :gift: Solution
Ajouter la règle eslint `no-console` pour que le développeur confime son usage volontaire

## :star2: Remarques
Déjà utilisé dans l'API.
Une fois effectuée dans les autres front, pourra être remonté dans la configuration du repo.

## :santa: Pour tester
Introduire un `console` et vérifier que `npm run lint` sorte en erreur
