### PR TITLE
[FEATURE] Améliorer l'accessibilité des tableaux sur la page de finalisation de session (PIX-3903)

### DIFF
--- a/api/db/database-builder/factory/build-session.js
+++ b/api/db/database-builder/factory/build-session.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 module.exports = function buildSession({
   id = databaseBuffer.getNextId(),
-  accessCode = 'ACC123A',
+  accessCode = 'ACC123',
   address = '3 rue des églantines',
   certificationCenter = 'Centre de certif Pix',
   certificationCenterId,

--- a/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
@@ -48,7 +48,7 @@ describe('Integration | Repository | JurySession', function () {
           examiner: 'Ginette',
           date: '2020-01-15',
           time: '15:30:00',
-          accessCode: 'ACC123A',
+          accessCode: 'ACC123',
           description: 'La session se déroule dans le jardin',
           examinerGlobalComment: '',
           finalizedAt: null,

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -5,7 +5,9 @@
       Certification(s) terminée(s)
     </div>
   {{/if}}
-  <table>
+  <table aria-label="Certification(s) terminée(s)">
+    <caption>
+    </caption>
     <thead>
       <tr>
         <th>Nom</th>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -1,9 +1,12 @@
 <div class="table session-finalization-reports-information-step">
-  <div class="session-finalization-reports-information-step__title-uncompleted">
-    <FaIcon @icon="exclamation-triangle" class="session-finalization-reports-information-step__icon"/>
-    Ces candidats n'ont pas fini leur test de certification
-  </div>
+
   <table>
+    <caption>
+      <div class="session-finalization-reports-information-step__title-uncompleted">
+        <FaIcon @icon="exclamation-triangle" class="session-finalization-reports-information-step__icon"/>
+        Ces candidats n'ont pas fini leur test de certification
+      </div>
+    </caption>
     <thead>
     <tr>
       <th>Nom</th>

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -8,6 +8,10 @@
     color: #277848;
     font-weight: bold;
     padding: 20px 0 20px 24px;
+
+    &--hidden {
+      display: none;
+    }
   }
 
   &__title-uncompleted {
@@ -31,7 +35,7 @@
       width: 20%;
     }
 
-    th:nth-child(2){
+    th:nth-child(2) {
       width: 10%;
     }
 
@@ -58,29 +62,28 @@
     }
   }
 
-  &__header_cancel{
+  &__header_cancel {
     display: flex;
 
-    .pix-tooltip{
+    .pix-tooltip {
       padding-left: 5px;
       cursor: help;
     }
 
-    .pix-tooltip__content--wide{
+    .pix-tooltip__content--wide {
       width: 600px;
     }
 
-    ul{
+    ul {
       margin-left: 10px;
 
-      li{
+      li {
         list-style-type: disc;
 
-        li{
+        li {
           list-style-type: '- ';
         }
       }
     }
-
   }
 }

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -6,6 +6,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
+import { render as renderScreen } from '@pix/ember-testing-library';
 
 module('Integration | Component | SessionFinalization::CompletedReportsInformationStep', function(hooks) {
   setupRenderingTest(hooks);
@@ -162,6 +163,29 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
       `);
 
     // then
-    assert.notContains('Certification(s) terminée(s)');
+    assert.dom('.session-finalization-reports-information-step__title-completed').doesNotExist();
+  });
+
+  test('it has an accessible label', async function(assert) {
+    // given
+    this.certificationReports = [run(() => store.createRecord('certification-report', {
+      hasSeenEndTestScreen: null,
+    }))];
+    this.issueReportDescriptionMaxLength = 500;
+    this.toggleCertificationReportHasSeenEndTestScreen = sinon.stub().returns();
+    this.toggleAllCertificationReportsHasSeenEndTestScreen = sinon.stub().returns();
+
+    // when
+    const screen = await renderScreen(hbs`
+      <SessionFinalization::CompletedReportsInformationStep
+        @certificationReports={{this.certificationReports}}
+        @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+        @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
+        @onAllHasSeenEndTestScreenCheckboxesClicked={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
+      />
+    `);
+
+    // then
+    assert.dom(screen.getByRole('table', { name: 'Certification(s) terminée(s)' })).exists();
   });
 });

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -7,8 +7,9 @@ import { run } from '@ember/runloop';
 import sinon from 'sinon';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
+import { render as renderScreen } from '@pix/ember-testing-library';
 
-module('Integration | Component | SessionFinalization::UnUncompletedReportsInformationStep', function(hooks) {
+module('Integration | Component | SessionFinalization::UncompletedReportsInformationStep', function(hooks) {
   setupRenderingTest(hooks);
   let reportA;
   let reportB;
@@ -199,5 +200,27 @@ module('Integration | Component | SessionFinalization::UnUncompletedReportsInfor
 
     // then
     assert.contains('Retard, absence ou départ');
+  });
+
+  test('it has an accessible label', async function(assert) {
+    // given
+    this.certificationReports = [run(() => store.createRecord('certification-report', {
+      certificationCourseId: 1234,
+      certificationIssueReports: [],
+      hasSeenEndTestScreen: null,
+    }))];
+    this.abort = sinon.stub();
+
+    // when
+    const screen = await renderScreen(hbs`
+      <SessionFinalization::UncompletedReportsInformationStep
+        @certificationReports={{this.certificationReports}}
+        @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+        @onChangeAbortReason={{this.abort}}
+      />
+    `);
+
+    // then
+    assert.dom(screen.getByRole('table', { name: 'Ces candidats n\'ont pas fini leur test de certification' })).exists();
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Suite à l’audit accessibilité de Pix Certif dans le cadre duquel l’app a obtenu le score de 40%, nous cherchons à améliorer notre % de conformité à 50%. 

## :gift: Solution

Corriger le critère 5.4 : Pour chaque tableau de données ayant un titre, le titre est-il correctement associé au tableau de données ? Voir ligne 41 du tableau de l’onglet “Synthèse”

Sur la page de finalisation d’une session de certification : 
- Placer le titre du tableau “Ces candidats n'ont pas fini leur test de certification” dans des balises <caption> situées entre les balises <table> et <thead> pour en faire un titre accessible au clavier
- Placer le titre du tableau  "Certifications terminées" dans des balises <caption> situées entre les balises <table> et <thead> pour en faire un titre accessible au clavier

## :star2: Remarques

*RAS*

## :santa: Pour tester

1. Dans Pix Certif, créer une session finalisable avec au moins deux candidat·e·s
2. Dans Pix App, commencer un test avec un·e candidat·e (mais ne pas le terminer)
3. Dans Pix App, commencer un test avec un·e autre candidat·e (tout passer c’est ok)
4. Dans Pix Certif, cliquer sur Finaliser la session.
5. Sur la page de finalisation, activer le lecteur d'écran (Cmd + F5 sur Mac) puis se déplacer dans la page pour sélectionner le tableau des certifs non terminées (Ctrl + Option + flèches sur Mac)
6. Constater que le lecteur d'écran énonce bien le titre quand il est sélectionné
7. Répéter l’opération pour le tableau des certifs terminées


