### PR TITLE
[FEATURE]: Ajout d'un feature toggle pour le Net Promoter Score dans Pix App (PIX-3969 PIX-3967)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -165,6 +165,7 @@ module.exports = (function () {
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
       ),
+      isNetPromoterScoreEnabled: isFeatureEnabled(process.env.FT_NET_PROMOTER_SCORE_ENABLED),
     },
 
     infra: {

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -31,6 +31,7 @@ const schema = Joi.object({
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
   FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
   FT_END_TEST_SCREEN_REMOVAL_ENABLED: Joi.string().optional().valid('true', 'false'),
+  FT_NET_PROMOTER_SCORE_ENABLED: Joi.string().optional().valid('true', 'false'),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -36,6 +36,13 @@ FT_VALIDATE_EMAIL=false
 # default: false
 FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED=false
 
+# Enable Net Promoter Score in Pix App
+#
+# type: boolean
+# presence: optionnal
+# default: false
+FT_NET_PROMOTER_SCORE_ENABLED=false
+
 # =======
 # CACHING
 # =======

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -25,6 +25,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-email-validation-enabled': false,
             'is-end-test-screen-removal-enabled': false,
             'is-complementary-certification-subscription-enabled': false,
+            'is-net-promoter-score-enabled': false,
           },
           type: 'feature-toggles',
         },

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -132,6 +132,12 @@
   </PixBlock>
 {{/if}}
 
+{{#if this.featureToggles.featureToggles.isNetPromoterScoreEnabled}}
+  <PixBlock class="skill-review__net-promoter-score">
+    {{t "pages.skill-review.net-promoter-score.title"}}
+  </PixBlock>
+{{/if}}
+
 <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
   {{#if this.showBadges}}
     {{#unless this.hideBadgesTitle}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -134,7 +134,12 @@
 
 {{#if this.featureToggles.featureToggles.isNetPromoterScoreEnabled}}
   <PixBlock class="skill-review__net-promoter-score">
-    {{t "pages.skill-review.net-promoter-score.title"}}
+    <div class="skill-review-net-promoter-score__container">
+      <p>{{t "pages.skill-review.net-promoter-score.title"}}</p>
+      <PixButtonLink @href="{{t "pages.skill-review.net-promoter-score.link.href"}}" target="_blank">
+        {{t "pages.skill-review.net-promoter-score.link.label"}}
+      </PixButtonLink>
+    </div>
   </PixBlock>
 {{/if}}
 

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -12,6 +12,7 @@ export default class SkillReview extends Component {
   @service currentUser;
   @service url;
   @service store;
+  @service featureToggles;
 
   @tracked displayErrorMessage = false;
 

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isEmailValidationEnabled;
+  @attr('boolean') isNetPromoterScoreEnabled;
 }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -90,6 +90,12 @@
   &__improvement-button {
     height: 50px;
   }
+
+  &-net-promoter-score__container {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+  }
 }
 
 .skill-review-retry {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1220,6 +1220,9 @@
       "stage": {
         "masteryPercentage": "Success rate: {rate, number, ::percent}",
         "starsAcquired": "{acquired, plural, =0 {no star} other {# stars}} acquired over {total}"
+      },
+      "net-promoter-score": {
+        "title": "This is the Net Promoter Score!"
       }
     },
     "terms-of-service": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1222,7 +1222,11 @@
         "starsAcquired": "{acquired, plural, =0 {no star} other {# stars}} acquired over {total}"
       },
       "net-promoter-score": {
-        "title": "This is the Net Promoter Score!"
+        "title": "Your opinion counts! Take a few minutes to tell us what you thought of this test and help us improve it.",
+        "link": {
+          "label": "Give my feedback",
+          "href": "https://pix.org/en-gb"
+        }
       }
     },
     "terms-of-service": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1222,7 +1222,11 @@
         "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} other {# étoiles acquises}} sur {total}"
       },
       "net-promoter-score": {
-        "title": "C'est le Net Promoter Score !"
+        "title": "Votre avis compte ! Prenez quelques minutes pour nous dire ce que vous avez pensé de ce test et nous aider à l'améliorer.",
+        "link": {
+          "label": "Je donne mon avis",
+          "href": "https://pix.fr"
+        }
       }
     },
     "terms-of-service": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1220,6 +1220,9 @@
       "stage": {
         "masteryPercentage": "{rate, number, ::percent} de réussite",
         "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} other {# étoiles acquises}} sur {total}"
+      },
+      "net-promoter-score": {
+        "title": "C'est le Net Promoter Score !"
       }
     },
     "terms-of-service": {


### PR DESCRIPTION
## :christmas_tree: Problème
Pour voir le NPS en integration et recette, créer un FT pour que le NPS soit visible en permanence sur les environnements de test.

## :gift: Solution
Ajout d'un nouveau FT avec la variable d'environnement associée `FT_NET_PROMOTER_SCORE_ENABLED`.

## :star2: Remarques
N/A

## :santa: Pour tester
Terminer une campagne, vérifier que le bloc NPS s'affiche bien à la fin.