### PR TITLE
[FEATURE] Ajout d'une URL de documentation dans les détails d'une organisation (PIX-3971).

### DIFF
--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -153,7 +153,7 @@
         {{/if}}
 
         <div class="organization-information-section__content">
-          <div>
+          <div class="organization-information-section__details">
             <p>
               Type :
               <span>{{@organization.type}}</span><br />
@@ -183,6 +183,17 @@
                 }}</span><br />
               Crédits :
               <span>{{@organization.credit}}</span>
+              <br />
+              Lien vers la documentation :
+              {{#if @organization.documentationUrl}}
+                <a
+                  href="{{@organization.documentationUrl}}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >{{@organization.documentationUrl}}</a>
+              {{else}}
+                Non spécifié
+              {{/if}}
             </p>
             <PixButton
               @backgroundColor="transparent-light"

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -15,6 +15,7 @@ export default class Organization extends Model {
   @attr() credit;
   @attr() email;
   @attr() createdBy;
+  @attr('string') documentationUrl;
 
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -38,6 +38,7 @@
 
     .organization__data {
       max-width: 100%;
+      overflow: hidden;
 
       .organization__name {
         font-size: 1.5rem;

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -4,6 +4,15 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    max-width: 600px;
+  }
+
+  &__details {
+    overflow: hidden;
+
+    p {
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
   }
 }

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -43,6 +43,30 @@ module('Integration | Component | organizations/information-section', function (
     assert.dom('.organization__canCollectProfiles').hasText('Oui');
   });
 
+  test('it should display documentation url', async function (assert) {
+    // given
+    const organization = EmberObject.create({ documentationUrl: 'https://pix.fr' });
+    this.set('organization', organization);
+
+    // when
+    await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+
+    // then
+    assert.contains('https://pix.fr');
+  });
+
+  test('it should display empty documentation link message', async function (assert) {
+    // given
+    const organization = EmberObject.create({});
+    this.set('organization', organization);
+
+    // when
+    await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+
+    // then
+    assert.contains('Non spécifié');
+  });
+
   test('it should display tags', async function (assert) {
     // given
     const organization = EmberObject.create({

--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -13,6 +13,7 @@ const buildOrganization = function buildOrganization({
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
   email = 'contact@example.net',
+  documentationUrl = null,
   createdBy,
 } = {}) {
   const values = {
@@ -26,6 +27,7 @@ const buildOrganization = function buildOrganization({
     credit,
     canCollectProfiles,
     email,
+    documentationUrl,
     createdBy,
     createdAt,
     updatedAt,

--- a/api/db/migrations/20211203133335_add_documentation_to_organization.js
+++ b/api/db/migrations/20211203133335_add_documentation_to_organization.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'documentationUrl';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.text(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -45,6 +45,7 @@ function organizationsScoBuilder({ databaseBuilder }) {
     canCollectProfiles: true,
     email: 'sco.generic.account@example.net',
     externalId: SCO_COLLEGE_EXTERNAL_ID,
+    documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
   });
 
@@ -381,4 +382,3 @@ module.exports = {
   SCO_FOREIGNER_USER_ID,
   SCO_FRENCH_USER_ID,
 };
-

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -27,6 +27,7 @@ class Organization {
     students = [],
     organizationInvitations = [],
     tags = [],
+    documentationUrl,
     createdBy,
   } = {}) {
     this.id = id;
@@ -43,6 +44,7 @@ class Organization {
     this.students = students;
     this.organizationInvitations = organizationInvitations;
     this.tags = tags;
+    this.documentationUrl = documentationUrl;
     this.createdBy = createdBy;
   }
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -23,6 +23,7 @@ function _toDomain(bookshelfOrganization) {
     credit: rawOrganization.credit,
     canCollectProfiles: Boolean(rawOrganization.canCollectProfiles),
     email: rawOrganization.email,
+    documentationUrl: rawOrganization.documentationUrl,
     createdBy: rawOrganization.createdBy,
   });
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -20,6 +20,7 @@ module.exports = {
         'targetProfiles',
         'tags',
         'createdBy',
+        'documentationUrl',
       ],
       memberships: {
         ref: 'id',

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -642,6 +642,7 @@ describe('Acceptance | Application | organization-controller', function () {
               credit: organization.credit,
               email: organization.email,
               'created-by': pixMasterUserId,
+              'documentation-url': organization.documentationUrl,
             },
             id: organization.id.toString(),
             relationships: {

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -156,6 +156,7 @@ describe('Integration | Repository | Organization', function () {
           isManagingStudents: 'true',
           canCollectProfiles: 'true',
           email: 'sco.generic.account@example.net',
+          documentationUrl: 'https://pix.fr/',
           createdBy: pixMasterUserId,
         });
 
@@ -174,6 +175,7 @@ describe('Integration | Repository | Organization', function () {
           targetProfileShares: [],
           organizationInvitations: [],
           tags: [],
+          documentationUrl: 'https://pix.fr/',
           createdBy: insertedOrganization.createdBy,
         };
 

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -58,6 +58,7 @@ buildOrganization.withSchoolingRegistrations = function ({
   createdAt = new Date('2018-01-12T01:02:03Z'),
   students = [],
   createdBy,
+  documentationUrl,
 } = {}) {
   const organization = new Organization({
     id,
@@ -72,6 +73,7 @@ buildOrganization.withSchoolingRegistrations = function ({
     createdAt,
     students,
     createdBy,
+    documentationUrl,
   });
 
   organization.students = [

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -15,6 +15,7 @@ describe('Unit | Serializer | organization-serializer', function () {
         email: 'sco.generic.account@example.net',
         tags,
         createdBy: 10,
+        documentationUrl: 'https://pix.fr/',
       });
       const meta = { some: 'meta' };
 
@@ -37,6 +38,7 @@ describe('Unit | Serializer | organization-serializer', function () {
             'can-collect-profiles': organization.canCollectProfiles,
             email: organization.email,
             'created-by': organization.createdBy,
+            'documentation-url': organization.documentationUrl,
           },
           relationships: {
             memberships: {


### PR DESCRIPTION
## :christmas_tree: Problème
La gestion de la documentation est très statique et nécessite l'intervention des développeurs lors de l'ajout de nouvelles typologies d'organisation. Les utilisateurs internes souhaiteraient avoir plus de flexibilité dans le choix de la documentation affiché pour les organisations.

## :gift: Solution
On ajoute un champ documentationUrl en base de données sur la table organizations. Dans cette PR on affiche le contenu de ce champ dans les détails d'une organisation. Si celui-ci n'est pas renseigné on affiche "Non spécifié".

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à Pix Admin
- Aller dans l'organisation "Collège The Night Watch"
- Constater la présence d'un lien de documentation vers https://pix.fr/ qui s'ouvre dans un nouvel onglet lorsqu'on clique dessus.
- Aller dans n'importe quelle autre organisation
- Constater la présence du message "Non spécifié"
