### PR TITLE
[BUGFIX] Utiliser un `alt` vide par défaut pour les illustrations d'épreuves (PIX-3987)

### DIFF
--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -13,7 +13,7 @@ export default class Challenge extends Model {
   @attr('string') format;
   @attr('string', {
     defaultValue() {
-      return "Illustration de l'épreuve";
+      return '';
     },
   })
   illustrationAlt;


### PR DESCRIPTION
## :christmas_tree: Problème
Le  `alt` par défaut est génant pour l'accessibilité.

## :gift: Solution
Comme conseillé par Tanaguru : utilisation d'un alt vide.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier sur un challenge avec illustration sans alt custom que le `alt` est précisé ET vide (ex : premier challenge de la campagne `AZERTY123`) https://app-pr3808.review.pix.fr/assessments/10000000/challenges/0).