### PR TITLE
[BUGFIX] Liens vers le support Pix (PIX-3981)

### DIFF
--- a/mon-pix/tests/acceptance/user-logged-menu_test.js
+++ b/mon-pix/tests/acceptance/user-logged-menu_test.js
@@ -39,13 +39,13 @@ describe('Acceptance | User account', function () {
       expect(currentURL()).to.equal('/mes-certifications');
     });
 
-    it('should contain link to pix.fr/aide', async function () {
+    it('should contain link to support.pix.org/fr/support/home', async function () {
       // when
       await click('.logged-user-name');
       const helplink = findByLabel('Aide').getAttribute('href');
 
       // then
-      expect(helplink).to.equal('https://pix.fr/aide');
+      expect(helplink).to.equal('https://support.pix.org/fr/support/home');
     });
 
     it('should open My account page when click on menu', async function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -73,7 +73,7 @@
       "code": "I have a code",
       "dashboard": "Home",
       "help": "Help",
-      "link-help": "https://pix.org/en-gb/faq-pix",
+      "link-help": "https://support.pix.org/en/support/home",
       "skills": "Competences",
       "start-certification": "Certification",
       "tutorials": "My tutorials"
@@ -210,7 +210,7 @@
         "clea-eligibility": "You are also eligible for the CléA numérique certification.",
         "link": {
           "text": "How do I certify my digital skills?",
-          "url": "https://support.pix.fr/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
+          "url": "https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
         },
         "message": "Well done, {fullName},'<br>'your profile can now be certified.",
         "pix-plus-droit-expert-eligibility": "You are also eligible for the Pix+ Droit Expert certification.",
@@ -489,7 +489,7 @@
           },
           "description": "Pix lets you choose which format of file to download. If you do not know which option to use, select the default option. This is the file format that is the most commonly used.",
           "file-type": "file .{fileExtension}",
-          "help": "Need help to '<a href=\"https://support.pix.fr/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\">'open, edit or find this file'</a>'?"
+          "help": "Need help to '<a href=\"https://support.pix.org/en/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\">'open, edit or find this file'</a>'?"
         },
         "tooltip": {
           "aria-label": "Show question's warning",
@@ -987,10 +987,10 @@
           "warning": "Par précaution nous devons vérifier vos données ensemble."
         },
         "confirmation-step": {
-          "good-news" : "Bonne nouvelle { firstName } !",
+          "good-news": "Bonne nouvelle { firstName } !",
           "found-account": "Nous avons trouvé votre compte :",
           "contact-support": "Si vous constatez une erreur ou si ces données ne sont pas les vôtres, ",
-          "fields" : {
+          "fields": {
             "last-name": "Votre nom",
             "first-name": "Votre prénom",
             "username": "Votre identifiant",
@@ -998,7 +998,7 @@
           },
           "certify-account": "J’atteste sur l’honneur que le compte associé à ces données m’appartient.",
           "buttons": {
-            "cancel":"Annuler",
+            "cancel": "Annuler",
             "confirm": "Je confirme"
           }
         },
@@ -1015,12 +1015,12 @@
               "submit": "C'est parti",
               "cancel": "Annuler"
             },
-            "error":  {
+            "error": {
               "empty-email": "Le champ adresse e-mail est obligatoire.",
               "wrong-email-format": "Votre adresse e-mail n’est pas valide.",
               "email-already-exist": {
                 "existing-email": "Vous possédez déjà cette adresse e-mail. Si elle est valide,",
-                "init-password":" réinitialisez votre mot de passe",
+                "init-password": " réinitialisez votre mot de passe",
                 "new-email": ", sinon saisissez une nouvelle."
               },
               "new-backup-email": "Veuillez saisir un e-mail valide pour récupérer votre compte",
@@ -1134,7 +1134,7 @@
           "and": "and ",
           "cgu": "Pix terms of use",
           "data-protection-policy": "personal data protection policy",
-          "pix" : "",
+          "pix": "",
           "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
           "label": "Agree Pix terms of use and personal data protection policy"
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -73,7 +73,7 @@
       "code": "J'ai un code",
       "dashboard": "Accueil",
       "help": "Aide",
-      "link-help": "https://pix.fr/aide",
+      "link-help": "https://support.pix.org/fr/support/home",
       "skills": "Compétences",
       "start-certification": "Certification",
       "tutorials": "Mes tutos"
@@ -210,7 +210,7 @@
         "clea-eligibility": "Vous êtes également éligible à la certification CléA numérique.",
         "link": {
           "text": "Comment se certifier ?",
-          "url": "https://support.pix.fr/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
+          "url": "https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
         },
         "message": "Bravo {fullName},'<br>'votre profil est certifiable.",
         "pix-plus-droit-expert-eligibility": "Vous êtes également éligible à la certification Pix+ Droit Expert.",
@@ -489,7 +489,7 @@
           },
           "description": "Pix vous laisse le choix du format de fichier à télécharger. Si vous ne savez pas quelle option retenir, conservez le choix par défaut. Il correspond au format de fichier pris en charge par le plus grand nombre de logiciels.",
           "file-type": "fichier .{fileExtension}",
-          "help": "Besoin d'aide pour '<a href=\"https://support.pix.fr/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\">'ouvrir, modifier ou retrouver ce fichier'</a>' ?"
+          "help": "Besoin d'aide pour '<a href=\"https://support.pix.org/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\">'ouvrir, modifier ou retrouver ce fichier'</a>' ?"
         },
         "tooltip": {
           "aria-label": "Afficher l'indication sur l'épreuve.",
@@ -987,10 +987,10 @@
           "warning": "Par précaution nous devons vérifier vos données ensemble."
         },
         "confirmation-step": {
-          "good-news" : "Bonne nouvelle { firstName } !",
+          "good-news": "Bonne nouvelle { firstName } !",
           "found-account": "Nous avons trouvé votre compte :",
           "contact-support": "Si vous constatez une erreur ou si ces données ne sont pas les vôtres, ",
-          "fields" : {
+          "fields": {
             "last-name": "Votre nom",
             "first-name": "Votre prénom",
             "username": "Votre identifiant",
@@ -998,7 +998,7 @@
           },
           "certify-account": "J’atteste sur l’honneur que le compte associé à ces données m’appartient.",
           "buttons": {
-            "cancel":"Annuler",
+            "cancel": "Annuler",
             "confirm": "Je confirme"
           }
         },
@@ -1015,12 +1015,12 @@
               "submit": "C'est parti",
               "cancel": "Annuler"
             },
-            "error":  {
+            "error": {
               "empty-email": "Le champ adresse e-mail est obligatoire.",
               "wrong-email-format": "Votre adresse e-mail n’est pas valide.",
               "email-already-exist": {
                 "existing-email": "Vous possédez déjà cette adresse e-mail. Si elle est valide,",
-                "init-password":" réinitialisez votre mot de passe",
+                "init-password": " réinitialisez votre mot de passe",
                 "new-email": ", sinon saisissez une nouvelle."
               },
               "new-backup-email": "Veuillez saisir un e-mail valide pour récupérer votre compte",
@@ -1134,7 +1134,7 @@
           "and": "et la ",
           "cgu": "conditions d'utilisation",
           "data-protection-policy": "politique de confidentialité",
-          "pix" : " de Pix",
+          "pix": " de Pix",
           "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
           "label": "Accepter les conditions d’utilisation de Pix et la politique de confidentialité"
         },


### PR DESCRIPTION
## :christmas_tree: Problème
Les liens vers le support ne sont plus à jour. Sur app.pix.org en anglais, le lien vers l'aide dans la navigation envoie sur une page 404.

## :gift: Solution
Remplacer par des liens corrects.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que les liens d'aide sont toujours OK.