### PR TITLE
[FEATURE] Afficher l'url de la documentation d'une organisation quand elle en a une (PIX-3972).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -60,6 +60,7 @@ module.exports = {
             'students',
             'divisions',
             'organizationInvitations',
+            'documentationUrl',
             'groups',
           ],
           memberships: {

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -26,6 +26,7 @@ function buildOrganization({
   targetProfileShares = [],
   tags = [],
   createdBy,
+  documentationUrl = 'https://pix.fr',
 } = {}) {
   return new Organization({
     id,
@@ -42,6 +43,7 @@ function buildOrganization({
     targetProfileShares,
     tags,
     createdBy,
+    documentationUrl,
   });
 }
 

--- a/orga/app/components/layout/sidebar.js
+++ b/orga/app/components/layout/sidebar.js
@@ -6,6 +6,8 @@ export default class SidebarMenu extends Component {
   @service url;
 
   get documentationUrl() {
+    if (this.currentUser.organization.documentationUrl) return this.currentUser.organization.documentationUrl;
+
     if (!this.url.isFrenchDomainExtension) {
       return 'https://cloud.pix.fr/s/HxpfpBnY47nYBkz';
     }

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -11,6 +11,7 @@ export default class Organization extends Model {
   @attr('boolean') isAEFE;
   @attr('boolean') isMLF;
   @attr('boolean') isMediationNumerique;
+  @attr('string') documentationUrl;
 
   @hasMany('campaign') campaigns;
   @hasMany('target-profile') targetProfiles;

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -18,6 +18,20 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       this.owner.register('service:url', UrlServiceStub);
     });
 
+    test('it should display documentation url given by current organization', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, isPro: true, documentationUrl: 'https://pix.fr' });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      await render(hbs`<Layout::Sidebar />`);
+
+      // then
+      assert.dom('a[href="https://pix.fr"]').exists();
+      assert.dom('a[href="https://cloud.pix.fr/s/cwZN2GAbqSPGnw4"]').doesNotExist();
+    });
+
     test('it should display documentation for a pro organization', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, isPro: true });


### PR DESCRIPTION
## :christmas_tree: Problème
Il y a plus d'une dizaine de règles différentes pour l'affichage de la doc, nous avons décidé de rajouter pour chaque orga un champ de documentation afin de stocker une URL spécifique. Celui-ci n'est pas encore utilisé sur Pix Orga.

## :gift: Solution
Si l'url de documentation a été valorisé pour l'organisation courante on l'affiche en lieu et place de l'ancienne gestion de la documentation. Pour les organisations n'ayant pas d'url de documentation on continue d'utiliser la forêt de IF.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à Pix Orga en tant qu'admin SCO
- Utiliser l'organisation "Collège The Night Watch"
- Constater que le lien vers la documentation dans la sidebar ouvre un nouvel onglet sur pix.fr
- Utiliser n'importe quelle autre organisation
- Constater que ça renvoie toujours vers la documentation cloud