### PR TITLE
[BUGFIX] Forcer la taille maximale du formulaire de connexion de Pix Certif (PIX-3986).

### DIFF
--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -6,6 +6,7 @@
   background-color: $white;
   border-radius: 10px;
   padding: 20px 30px;
+  max-width: 500px;
 
   @include device-is("tablet") {
     padding: 40px 60px;

--- a/certif/app/styles/pages/login.scss
+++ b/certif/app/styles/pages/login.scss
@@ -1,7 +1,6 @@
 .login-page {
   display: flex;
   width: 100%;
-  height: 100px;
   min-height: 100vh;
   background: $pix-certif-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## :christmas_tree: Problème
On a constaté que le formulaire de connexion s'élargissait quand il y avait une erreur de connexion.

## :gift: Solution
Forcer la taille maximale du formulaire

## :santa: Pour tester
Aller sur la page de connexion 
Connectez-vous avec sco.admin@example.net
Constatez que le formulaire ne bouge pas
