### PR TITLE
[FEATURE] Afficher la liste des membres sur Pix Certif (PIX-418).

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -95,6 +95,15 @@ module.exports = {
     return certificationCenterMembershipSerializer.serialize(certificationCenterMemberships);
   },
 
+  async findCertificationCenterMemberships(request) {
+    const certificationCenterId = request.params.certificationCenterId;
+    const certificationCenterMemberships = await usecases.findCertificationCenterMembershipsByCertificationCenter({
+      certificationCenterId,
+    });
+
+    return certificationCenterMembershipSerializer.serializeMembers(certificationCenterMemberships);
+  },
+
   async createCertificationCenterMembershipByEmail(request, h) {
     const certificationCenterId = request.params.certificationCenterId;
     const { email } = request.payload;

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -164,7 +164,30 @@ exports.register = async function (server) {
             "- Récupération de tous les membres d'un centre de certification.\n" +
             '- L‘utilisateur doit avoir les droits d‘accès en tant que Pix Master',
         ],
-        tags: ['api', 'certification-center-membership'],
+        tags: ['api', 'admin', 'certification-center-membership'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/certification-centers/{certificationCenterId}/members',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
+            assign: 'isMemberOfCertificationCenter',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+        },
+        handler: certificationCenterController.findCertificationCenterMemberships,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs appartenant à un centre de certification**\n' +
+            "- Récupération de tous les membres d'un centre de certification.\n",
+        ],
+        tags: ['api', 'certification-center', 'members'],
       },
     },
     {

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -7,6 +7,7 @@ const checkUserBelongsToSupOrganizationAndManagesStudentsUseCase = require('./us
 const checkUserBelongsToOrganizationUseCase = require('./usecases/checkUserBelongsToOrganization');
 const checkUserIsAdminAndManagingStudentsForOrganization = require('./usecases/checkUserIsAdminAndManagingStudentsForOrganization');
 const checkUserIsMemberOfAnOrganizationUseCase = require('./usecases/checkUserIsMemberOfAnOrganization');
+const checkUserIsMemberOfCertificationCenterUsecase = require('./usecases/checkUserIsMemberOfCertificationCenter');
 const Organization = require('../../lib/domain/models/Organization');
 
 const JSONAPIError = require('jsonapi-serializer').Error;
@@ -70,6 +71,25 @@ function checkUserIsAdminInOrganization(request, h) {
     .execute(userId, organizationId)
     .then((isAdminInOrganization) => {
       if (isAdminInOrganization) {
+        return h.response(true);
+      }
+      return _replyForbiddenError(h);
+    })
+    .catch(() => _replyForbiddenError(h));
+}
+
+function checkUserIsMemberOfCertificationCenter(request, h) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return _replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const certificationCenterId = parseInt(request.params.certificationCenterId);
+
+  return checkUserIsMemberOfCertificationCenterUsecase
+    .execute(userId, certificationCenterId)
+    .then((isMemberInCertificationCenter) => {
+      if (isMemberInCertificationCenter) {
         return h.response(true);
       }
       return _replyForbiddenError(h);
@@ -234,4 +254,5 @@ module.exports = {
   checkUserIsAdminInSUPOrganizationManagingStudents,
   checkUserBelongsToOrganization,
   checkUserIsMemberOfAnOrganization,
+  checkUserIsMemberOfCertificationCenter,
 };

--- a/api/lib/application/usecases/checkUserIsMemberOfCertificationCenter.js
+++ b/api/lib/application/usecases/checkUserIsMemberOfCertificationCenter.js
@@ -1,0 +1,9 @@
+const certificationCenterMembershipRepository = require('../../infrastructure/repositories/certification-center-membership-repository');
+module.exports = {
+  async execute(userId, certificationCenterId) {
+    return await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
+      userId,
+      certificationCenterId,
+    });
+  },
+};

--- a/api/lib/domain/usecases/create-certification-center-membership-by-email.js
+++ b/api/lib/domain/usecases/create-certification-center-membership-by-email.js
@@ -8,10 +8,10 @@ module.exports = async function createCertificationCenterMembershipByEmail({
 }) {
   const { id: userId } = await userRepository.getByEmail(email);
 
-  const isMembershipExisting = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(
+  const isMembershipExisting = await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
     userId,
-    certificationCenterId
-  );
+    certificationCenterId,
+  });
 
   if (isMembershipExisting) {
     throw new AlreadyExistingEntityError(

--- a/api/lib/domain/usecases/create-certification-center-membership-for-sco-organization-member.js
+++ b/api/lib/domain/usecases/create-certification-center-membership-for-sco-organization-member.js
@@ -13,10 +13,10 @@ module.exports = async function createCertificationCenterMembershipForScoOrganiz
 
     if (existingCertificationCenter) {
       const isAlreadyMemberOfCertificationCenter =
-        await certificationCenterMembershipRepository.isMemberOfCertificationCenter(
-          existingMembership.user.id,
-          existingCertificationCenter.id
-        );
+        await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
+          userId: existingMembership.user.id,
+          certificationCenterId: existingCertificationCenter.id,
+        });
 
       if (!isAlreadyMemberOfCertificationCenter) {
         return await certificationCenterMembershipRepository.save({

--- a/api/lib/domain/usecases/find-certification-center-memberships-by-certification-center.js
+++ b/api/lib/domain/usecases/find-certification-center-memberships-by-certification-center.js
@@ -2,5 +2,5 @@ module.exports = function findCertificationCenterMembershipsByCertificationCente
   certificationCenterId,
   certificationCenterMembershipRepository,
 }) {
-  return certificationCenterMembershipRepository.findActiveByCertificationCenterId(certificationCenterId);
+  return certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedById({ certificationCenterId });
 };

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -62,12 +62,16 @@ module.exports = {
     }
   },
 
-  async isMemberOfCertificationCenter(userId, certificationCenterId) {
-    const certificationCenterMembership = await BookshelfCertificationCenterMembership.where({
-      userId,
-      certificationCenterId,
-    }).fetch({ require: false, columns: 'id' });
-    return Boolean(certificationCenterMembership);
+  async isMemberOfCertificationCenter({ userId, certificationCenterId }) {
+    const certificationCenterMembershipId = await knex('certification-center-memberships')
+      .select('id')
+      .where({
+        userId,
+        certificationCenterId,
+      })
+      .first();
+
+    return Boolean(certificationCenterMembershipId);
   },
 
   async disableById({ certificationCenterMembershipId }) {

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -7,6 +7,38 @@ const {
   CertificationCenterMembershipDisableError,
 } = require('../../domain/errors');
 const { knex } = require('../../../db/knex-database-connection');
+const CertificationCenter = require('../../domain/models/CertificationCenter');
+const User = require('../../domain/models/User');
+const CertificationCenterMembership = require('../../domain/models/CertificationCenterMembership');
+
+function _toDomain(certificationCenterMembershipDTO) {
+  let user, certificationCenter;
+  if (certificationCenterMembershipDTO.lastName || certificationCenterMembershipDTO.firstName) {
+    user = new User({
+      id: certificationCenterMembershipDTO.userId,
+      firstName: certificationCenterMembershipDTO.firstName,
+      lastName: certificationCenterMembershipDTO.lastName,
+      email: certificationCenterMembershipDTO.email,
+    });
+  }
+  if (certificationCenterMembershipDTO.name) {
+    certificationCenter = new CertificationCenter({
+      id: certificationCenterMembershipDTO.certificationCenterId,
+      name: certificationCenterMembershipDTO.name,
+      type: certificationCenterMembershipDTO.type,
+      externalId: certificationCenterMembershipDTO.externalId,
+      createdAt: certificationCenterMembershipDTO.certificationCenterCreatedAt,
+      updatedAt: certificationCenterMembershipDTO.certificationCenterUpdatedAt,
+    });
+  }
+  return new CertificationCenterMembership({
+    id: certificationCenterMembershipDTO.id,
+    certificationCenter,
+    user,
+    createdAt: certificationCenterMembershipDTO.createdAt,
+    updatedAt: certificationCenterMembershipDTO.updatedAt,
+  });
+}
 
 module.exports = {
   async findByUserId(userId) {
@@ -20,7 +52,36 @@ module.exports = {
     );
   },
 
-  async findActiveByCertificationCenterId(certificationCenterId) {
+  async findActiveByCertificationCenterIdSortedByNames({ certificationCenterId }) {
+    const certificationCenterMemberships = await knex
+      .select(
+        'certification-center-memberships.*',
+        'users.firstName',
+        'users.lastName',
+        'users.email',
+        'certification-centers.name',
+        'certification-centers.type',
+        'certification-centers.externalId',
+        'certification-centers.createdAt AS certificationCenterCreatedAt',
+        'certification-centers.updatedAt AS certificationCenterUpdatedAt'
+      )
+      .from('certification-center-memberships')
+      .leftJoin('users', 'users.id', 'certification-center-memberships.userId')
+      .leftJoin(
+        'certification-centers',
+        'certification-centers.id',
+        'certification-center-memberships.certificationCenterId'
+      )
+      .where({
+        certificationCenterId,
+        disabledAt: null,
+      })
+      .orderBy('lastName', 'ASC')
+      .orderBy('firstName', 'ASC');
+    return certificationCenterMemberships.map(_toDomain);
+  },
+
+  async findActiveByCertificationCenterIdSortedById({ certificationCenterId }) {
     const certificationCenterMemberships = await BookshelfCertificationCenterMembership.where({
       certificationCenterId,
       disabledAt: null,

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
@@ -29,4 +29,15 @@ module.exports = {
       },
     }).serialize(certificationCenterMemberships);
   },
+
+  serializeMembers(certificationCenterMemberships) {
+    return new Serializer('members', {
+      transform: function (record) {
+        const { id, firstName, lastName } = record.user;
+        return { id, firstName, lastName };
+      },
+      ref: 'id',
+      attributes: ['firstName', 'lastName'],
+    }).serialize(certificationCenterMemberships);
+  },
 };

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -441,39 +441,25 @@ describe('Acceptance | API | Certification Center', function () {
   });
 
   describe('GET /api/certification-centers/{id}/certification-center-memberships', function () {
-    let certificationCenter;
-    let certificationCenterMembership1;
-    let certificationCenterMembership2;
-    let user1;
-    let user2;
-
-    beforeEach(async function () {
-      certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-      user1 = databaseBuilder.factory.buildUser();
-      user2 = databaseBuilder.factory.buildUser();
-      certificationCenterMembership1 = databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: certificationCenter.id,
-        userId: user1.id,
-      });
-      certificationCenterMembership2 = databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: certificationCenter.id,
-        userId: user2.id,
-      });
-      await databaseBuilder.commit();
-
-      request = {
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(),
-        },
-        method: 'GET',
-        url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
-      };
-    });
-
     context('when certification center membership is linked to the certification center', function () {
       it('should return 200 HTTP status', async function () {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        const user1 = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: certificationCenter.id,
+          userId: user1.id,
+        });
+        await databaseBuilder.commit();
+
         // when
-        const response = await server.inject(request);
+        const response = await server.inject({
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(),
+          },
+          method: 'GET',
+          url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+        });
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -481,6 +467,39 @@ describe('Acceptance | API | Certification Center', function () {
 
       it('should return certification center memberships', async function () {
         // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        const user1 = databaseBuilder.factory.buildUser();
+        const user2 = databaseBuilder.factory.buildUser();
+        const certificationCenterMembership1 = databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: certificationCenter.id,
+          userId: user1.id,
+        });
+        const certificationCenterMembership2 = databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: certificationCenter.id,
+          userId: user2.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(),
+          },
+          method: 'GET',
+          url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+        });
+
+        // then
+        expect(response.result.data[0].id).to.equal(certificationCenterMembership1.id.toString());
+        expect(response.result.data[0].attributes['created-at']).to.deep.equal(
+          certificationCenterMembership1.createdAt
+        );
+
+        expect(response.result.data[1].id).to.equal(certificationCenterMembership2.id.toString());
+        expect(response.result.data[1].attributes['created-at']).to.deep.equal(
+          certificationCenterMembership2.createdAt
+        );
+
         const expectedIncluded = [
           {
             id: certificationCenter.id.toString(),
@@ -516,21 +535,6 @@ describe('Acceptance | API | Certification Center', function () {
             },
           },
         ];
-
-        // when
-        const response = await server.inject(request);
-
-        // then
-        expect(response.result.data[0].id).to.equal(certificationCenterMembership1.id.toString());
-        expect(response.result.data[0].attributes['created-at']).to.deep.equal(
-          certificationCenterMembership1.createdAt
-        );
-
-        expect(response.result.data[1].id).to.equal(certificationCenterMembership2.id.toString());
-        expect(response.result.data[1].attributes['created-at']).to.deep.equal(
-          certificationCenterMembership2.createdAt
-        );
-
         expect(response.result.included).to.deep.equal(expectedIncluded);
       });
     });

--- a/api/tests/acceptance/application/certification-centers/certification-centers-route-get_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-centers-route-get_test.js
@@ -1,0 +1,39 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Application | Certification-centers | Routes', function () {
+  describe('GET /api/certification-centers/{certificationCenterId}/members', function () {
+    it('should return 200 http status code', async function () {
+      // given
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const certificationCenterMember = databaseBuilder.factory.buildUser();
+      const user2 = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: certificationCenterMember.id,
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: user2.id,
+      });
+      await databaseBuilder.commit();
+      const server = await createServer();
+
+      const options = {
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(certificationCenterMember.id),
+        },
+        method: 'GET',
+        url: `/api/certification-centers/${certificationCenter.id}/members`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].id).to.equal(certificationCenterMember.id.toString());
+      expect(response.result.data[1].id).to.equal(user2.id.toString());
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -202,38 +202,42 @@ describe('Integration | Repository | Certification Center Membership', function 
   });
 
   describe('#isMemberOfCertificationCenter', function () {
-    let userId;
-    let certificationCenterInId;
-    let certificationCenterNotInId;
-
-    beforeEach(async function () {
-      userId = databaseBuilder.factory.buildUser().id;
-      certificationCenterInId = databaseBuilder.factory.buildCertificationCenter().id;
-      certificationCenterNotInId = databaseBuilder.factory.buildCertificationCenter().id;
+    it('should return false if user has no membership in given certification center', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const otherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       databaseBuilder.factory.buildCertificationCenterMembership({
         userId,
-        certificationCenterId: certificationCenterInId,
+        certificationCenterId,
       });
       await databaseBuilder.commit();
-    });
 
-    it('should return false if user has no membership in given certification center', async function () {
       // when
-      const hasMembership = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(
+      const hasMembership = await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
         userId,
-        certificationCenterNotInId
-      );
+        certificationCenterId: otherCertificationCenterId,
+      });
 
       // then
       expect(hasMembership).to.be.false;
     });
 
     it('should return true if user has membership in given certification center', async function () {
-      // when
-      const hasMembership = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({
         userId,
-        certificationCenterInId
-      );
+        certificationCenterId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const hasMembership = await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
+        userId,
+        certificationCenterId,
+      });
 
       // then
       expect(hasMembership).to.be.true;

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -107,7 +107,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
   });
 
-  describe('#findActiveByCertificationCenterId', function () {
+  describe('#findActiveByCertificationCenterIdSortedById', function () {
     it('should return certification center membership associated to the certification center', async function () {
       // given
       const now = new Date('2021-01-02');
@@ -129,7 +129,9 @@ describe('Integration | Repository | Certification Center Membership', function 
 
       // when
       const foundCertificationCenterMemberships =
-        await certificationCenterMembershipRepository.findActiveByCertificationCenterId(certificationCenter.id);
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedById({
+          certificationCenterId: certificationCenter.id,
+        });
 
       // then
       expect(foundCertificationCenterMemberships).to.be.an('array');
@@ -165,7 +167,9 @@ describe('Integration | Repository | Certification Center Membership', function 
 
       // when
       const foundCertificationCenterMemberships =
-        await certificationCenterMembershipRepository.findActiveByCertificationCenterId(certificationCenter.id);
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedById({
+          certificationCenterId: certificationCenter.id,
+        });
 
       // then
       expect(foundCertificationCenterMemberships[0].id).to.equal(10);
@@ -193,11 +197,128 @@ describe('Integration | Repository | Certification Center Membership', function 
 
       // when
       const foundCertificationCenterMemberships =
-        await certificationCenterMembershipRepository.findActiveByCertificationCenterId(certificationCenter.id);
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedById({
+          certificationCenterId: certificationCenter.id,
+        });
 
       // then
       expect(foundCertificationCenterMemberships.length).to.equal(1);
       expect(foundCertificationCenterMemberships[0].id).to.equal(7);
+    });
+  });
+
+  describe('#findActiveByCertificationCenterIdSortedByNames', function () {
+    it('should return certification center membership associated to the certification center', async function () {
+      // given
+      const now = new Date('2021-01-02');
+      const clock = sinon.useFakeTimers(now);
+
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ updatedAt: now });
+      const user = databaseBuilder.factory.buildUser();
+      const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: user.id,
+      });
+      const expectedUser = {
+        id: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+      };
+      await databaseBuilder.commit();
+
+      // when
+      const foundCertificationCenterMemberships =
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedByNames({
+          certificationCenterId: certificationCenter.id,
+        });
+
+      // then
+      expect(foundCertificationCenterMemberships).to.be.an('array');
+
+      const foundCertificationCenterMembership = foundCertificationCenterMemberships[0];
+      expect(foundCertificationCenterMembership).to.be.an.instanceof(CertificationCenterMembership);
+      expect(foundCertificationCenterMembership.id).to.equal(certificationCenterMembership.id);
+
+      expect(foundCertificationCenterMembership.user).to.be.an.instanceOf(User);
+      expect(foundCertificationCenterMembership.user.lastName).to.be.equal(expectedUser.lastName);
+      expect(foundCertificationCenterMembership.user.firstName).to.be.equal(expectedUser.firstName);
+      clock.restore();
+    });
+
+    it('should return certification center memberships sorted by lastName and firstName', async function () {
+      // given
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const user1 = databaseBuilder.factory.buildUser({ lastName: 'Abba' });
+      const user4 = databaseBuilder.factory.buildUser({ lastName: 'Dodo', firstName: 'Jean' });
+      const user3 = databaseBuilder.factory.buildUser({ lastName: 'Dodo', firstName: 'Alice' });
+      const user2 = databaseBuilder.factory.buildUser({ lastName: 'Dada' });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: user1.id,
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: user4.id,
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: user3.id,
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: user2.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const foundCertificationCenterMemberships =
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedByNames({
+          certificationCenterId: certificationCenter.id,
+        });
+
+      // then
+      const certificationCenterMembershipFound1 = foundCertificationCenterMemberships[0];
+      expect(certificationCenterMembershipFound1.user.lastName).to.equal('Abba');
+
+      const certificationCenterMembershipFound2 = foundCertificationCenterMemberships[1];
+      expect(certificationCenterMembershipFound2.user.lastName).to.equal('Dada');
+
+      const certificationCenterMembershipFound3 = foundCertificationCenterMemberships[2];
+      expect(certificationCenterMembershipFound3.user.lastName).to.equal('Dodo');
+      expect(certificationCenterMembershipFound3.user.firstName).to.equal('Alice');
+
+      const certificationCenterMembershipFound4 = foundCertificationCenterMemberships[3];
+      expect(certificationCenterMembershipFound4.user.lastName).to.equal('Dodo');
+      expect(certificationCenterMembershipFound4.user.firstName).to.equal('Jean');
+    });
+
+    it('should only return active (not disabled) certification center memberships', async function () {
+      // given
+      const now = new Date();
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const user1 = databaseBuilder.factory.buildUser();
+      const user2 = databaseBuilder.factory.buildUser();
+      const activeCertificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
+        userId: user1.id,
+        certificationCenterId: certificationCenter.id,
+      }).id;
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId: user2.id,
+        certificationCenterId: certificationCenter.id,
+        disabledAt: now,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const foundCertificationCenterMemberships =
+        await certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedByNames({
+          certificationCenterId: certificationCenter.id,
+        });
+
+      // then
+      expect(foundCertificationCenterMemberships.length).to.equal(1);
+      expect(foundCertificationCenterMemberships[0].id).to.equal(activeCertificationCenterMembershipId);
     });
   });
 

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -137,6 +137,44 @@ describe('Unit | Controller | certifications-center-controller', function () {
     });
   });
 
+  describe('#findCertificationCenterMemberships', function () {
+    it('should return the serialized membership', async function () {
+      // given
+      const user = domainBuilder.buildUser();
+      const certificationCenter = domainBuilder.buildCertificationCenter();
+      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
+        certificationCenter,
+        user,
+      });
+      const serializedCertificationCenterMembership = Symbol('certification center membership serialized');
+
+      const request = {
+        params: {
+          certificationCenterId: certificationCenter.id,
+        },
+      };
+
+      sinon
+        .stub(usecases, 'findCertificationCenterMembershipsByCertificationCenter')
+        .withArgs({
+          certificationCenterId: certificationCenter.id,
+        })
+        .resolves(certificationCenterMembership);
+
+      sinon
+        .stub(certificationCenterMembershipSerializer, 'serializeMembers')
+        .withArgs(certificationCenterMembership)
+        .returns(serializedCertificationCenterMembership);
+
+      // when
+      const response = await certificationCenterController.findCertificationCenterMemberships(request);
+
+      // then
+      expect(usecases.findCertificationCenterMembershipsByCertificationCenter).to.have.been.calledOnce;
+      expect(response).equal(serializedCertificationCenterMembership);
+    });
+  });
+
   describe('#createCertificationCenterMembershipByEmail', function () {
     const certificationCenterId = 1;
     const email = 'user@example.net';

--- a/api/tests/unit/application/usecases/checkUserIsMemberOfCertificationCenter_test.js
+++ b/api/tests/unit/application/usecases/checkUserIsMemberOfCertificationCenter_test.js
@@ -1,0 +1,41 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const usecase = require('../../../../lib/application/usecases/checkUserIsMemberOfCertificationCenter');
+const certificationCenterMembershipRepository = require('../../../../lib/infrastructure/repositories/certification-center-membership-repository');
+
+describe('Unit | Application | Use Case | CheckUserIsMemberOfCertificationCenter', function () {
+  beforeEach(function () {
+    certificationCenterMembershipRepository.isMemberOfCertificationCenter = sinon.stub();
+  });
+
+  context('When user is member in certification center', function () {
+    it('should return true', async function () {
+      // given
+      const user = domainBuilder.buildUser();
+      const certificationCenter = domainBuilder.buildCertificationCenter();
+
+      domainBuilder.buildCertificationCenterMembership({ user, certificationCenter });
+      certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(true);
+
+      // when
+      const response = await usecase.execute(user.id, certificationCenter.id);
+
+      // then
+      expect(response).to.equal(true);
+    });
+  });
+
+  context('When user is not admin in organization', function () {
+    it('should return false', async function () {
+      // given
+      const userId = 1234;
+      const certificationCenterId = 789;
+      certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(false);
+
+      // when
+      const response = await usecase.execute(userId, certificationCenterId);
+
+      // then
+      expect(response).to.equal(false);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/create-certification-center-membership-by-email_test.js
+++ b/api/tests/unit/domain/usecases/create-certification-center-membership-by-email_test.js
@@ -37,10 +37,10 @@ describe('Unit | UseCase | create-certification-center-membership-by-email', fun
 
     // then
     expect(userRepository.getByEmail).has.been.calledWith(email);
-    expect(certificationCenterMembershipRepository.isMemberOfCertificationCenter).has.been.calledWith(
+    expect(certificationCenterMembershipRepository.isMemberOfCertificationCenter).has.been.calledWith({
       userId,
-      certificationCenterId
-    );
+      certificationCenterId,
+    });
     expect(certificationCenterMembershipRepository.save).has.been.calledWith({ userId, certificationCenterId });
   });
 

--- a/api/tests/unit/domain/usecases/create-certification-center-membership-for-sco-organization-member_test.js
+++ b/api/tests/unit/domain/usecases/create-certification-center-membership-for-sco-organization-member_test.js
@@ -43,7 +43,10 @@ describe('Unit | UseCase | create-certification-center-membership-for-sco-organi
               .withArgs({ externalId })
               .resolves(existingCertificationCenter);
             certificationCenterMembershipRepository.isMemberOfCertificationCenter
-              .withArgs(userWhoseOrganizationRoleIsToUpdate.id, existingCertificationCenter.id)
+              .withArgs({
+                userId: userWhoseOrganizationRoleIsToUpdate.id,
+                certificationCenterId: existingCertificationCenter.id,
+              })
               .resolves(true);
 
             // when

--- a/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
@@ -7,8 +7,10 @@ describe('Unit | UseCase | find-certification-center-memberships-by-certificatio
     // given
     const certificationCenterId = 1;
     const certificationCenterMemberships = [domainBuilder.buildCertificationCenterMembership()];
-    const certificationCenterMembershipRepository = { findActiveByCertificationCenterId: sinon.stub() };
-    certificationCenterMembershipRepository.findActiveByCertificationCenterId.resolves(certificationCenterMemberships);
+    const certificationCenterMembershipRepository = { findActiveByCertificationCenterIdSortedById: sinon.stub() };
+    certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedById.resolves(
+      certificationCenterMemberships
+    );
 
     // when
     const foundCertificationCenterMemberships = await usecases.findCertificationCenterMembershipsByCertificationCenter({
@@ -17,8 +19,8 @@ describe('Unit | UseCase | find-certification-center-memberships-by-certificatio
     });
 
     // then
-    expect(certificationCenterMembershipRepository.findActiveByCertificationCenterId).to.have.been.calledWith(
-      certificationCenterId
+    expect(certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedById).to.have.been.calledWith(
+      { certificationCenterId }
     );
     expect(foundCertificationCenterMemberships).to.deep.equal(certificationCenterMemberships);
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
@@ -73,4 +73,37 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
       expect(serializedCertificationCenter).to.deep.equal(expectedSerializedCertificationCenter);
     });
   });
+
+  describe('#serializeMembers', function () {
+    it('should convert into JSON API data', function () {
+      // given
+      const certificationCenter = domainBuilder.buildCertificationCenter();
+      const user = domainBuilder.buildUser();
+      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
+        certificationCenter,
+        user,
+      });
+
+      const expectedSerializedMember = {
+        data: [
+          {
+            id: user.id.toString(),
+            type: 'members',
+            attributes: {
+              'first-name': user.firstName,
+              'last-name': user.lastName,
+            },
+          },
+        ],
+      };
+
+      // when
+      const serializedMember = certificationCenterMembershipSerializer.serializeMembers([
+        certificationCenterMembership,
+      ]);
+
+      // then
+      expect(serializedMember).to.deep.equal(expectedSerializedMember);
+    });
+  });
 });

--- a/certif/app/adapters/member.js
+++ b/certif/app/adapters/member.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class MemberAdapter extends ApplicationAdapter {
+
+  urlForFindAll(modelName, { adapterOptions }) {
+    const { certificationCenterId } = adapterOptions;
+    return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/members`;
+  }
+
+}

--- a/certif/app/adapters/member.js
+++ b/certif/app/adapters/member.js
@@ -2,9 +2,7 @@ import ApplicationAdapter from './application';
 
 export default class MemberAdapter extends ApplicationAdapter {
 
-  urlForFindAll(modelName, { adapterOptions }) {
-    const { certificationCenterId } = adapterOptions;
-    return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/members`;
+  urlForQuery(query) {
+    return `${this.host}/${this.namespace}/certification-centers/${query.certificationCenterId}/members`;
   }
-
 }

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -1,0 +1,23 @@
+<div class="table--with-row-clickable" role="tabpanel">
+  <div class="panel">
+    <div class="table content-text content-text--small">
+      <table>
+        <thead>
+          <tr>
+            <th class="table__column table__column--small">Nom</th>
+            <th class="table__column table__column--small">Prénom</th>
+          </tr>
+        </thead>
+
+        <tbody>
+        {{#each @members as |member|}}
+          <tr aria-label="Membres du centre de certification">
+            <td>{{member.lastName}}</td>
+            <td>{{member.firstName}}</td>
+          </tr>
+        {{/each}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -1,4 +1,4 @@
-<div class="table--with-row-clickable" role="tabpanel">
+<div role="tabpanel">
   <div class="panel">
     <div class="table content-text content-text--small">
       <table>

--- a/certif/app/models/member.js
+++ b/certif/app/models/member.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Member extends Model {
+  @attr('string') firstName;
+  @attr('string') lastName;
+}

--- a/certif/app/router.js
+++ b/certif/app/router.js
@@ -32,6 +32,7 @@ Router.map(function() {
       });
       this.route('add-student', { path: '/:session_id/ajout-eleves' });
     });
+    this.route('team', { path: '/equipe' });
   });
 
   this.route('logout');

--- a/certif/app/routes/authenticated/team.js
+++ b/certif/app/routes/authenticated/team.js
@@ -6,6 +6,6 @@ export default class AuthenticatedTeamRoute extends Route {
 
   model() {
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
-    return this.store.findAll('member', { adapterOptions: { certificationCenterId } });
+    return this.store.query('member', { certificationCenterId });
   }
 }

--- a/certif/app/routes/authenticated/team.js
+++ b/certif/app/routes/authenticated/team.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class AuthenticatedTeamRoute extends Route {
+  @service currentUser;
+
+  model() {
+    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+    return this.store.findAll('member', { adapterOptions: { certificationCenterId } });
+  }
+}

--- a/certif/app/styles/globals/pages.scss
+++ b/certif/app/styles/globals/pages.scss
@@ -1,5 +1,6 @@
 .page {
   padding: 58px 35px;
+  flex-grow: 1;
 
   &__title {
     margin-bottom: 55px;

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -68,7 +68,7 @@
 .main-content {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: 100vh;
   overflow: auto;
 
   &__topbar {

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -26,6 +26,12 @@
           {{/if}}
         {{/if}}
         <li>
+          <LinkTo @route="authenticated.team" class="sidebar-menu__item" type="button" aria-label="Équipe">
+            <FaIcon @icon='users' @class="sidebar-menu__item-icon" />
+            Équipe
+          </LinkTo>
+        </li>
+        <li>
           <a class="sidebar-menu__item" href="{{this.documentationLink}}" target="_blank" rel="noopener noreferrer">
             <FaIcon @icon='book' @class="sidebar-menu__item-icon" />
             Documentation

--- a/certif/app/templates/authenticated/team.hbs
+++ b/certif/app/templates/authenticated/team.hbs
@@ -1,0 +1,4 @@
+{{page-title "Équipe"}}
+
+<h1 class="page__title page-title">Équipe</h1>
+<MembersList @members={{@model}}/>

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -45,6 +45,10 @@ export default function() {
     return schema.sessions.find(sessionId);
   });
 
+  this.get('/certification-centers/:id/members', function(schema) {
+    return schema.members.all();
+  });
+
   this.patch('/sessions/:id');
 
   this.get('/sessions/:id/certification-candidates', function(schema, request) {

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
-import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
+import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   createCertificationPointOfContactWithTermsOfServiceAccepted,
   authenticateSession,
+  createAllowedCertificationCenterAccess,
+  createCertificationPointOfContactWithCustomCenters,
 } from '../helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -13,19 +14,56 @@ module('Acceptance | authenticated | team', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('it should be possible to see members list', async function(assert) {
-    // given
-    const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-    server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
-    await authenticateSession(certificationPointOfContact.id);
+  module('when user go to members list', function() {
+    test('it should be possible to see members list', async function(assert) {
+      // given
+      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+      server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
+      await authenticateSession(certificationPointOfContact.id);
 
-    // when
-    await visit('/equipe');
-    await clickByLabel('Équipe');
+      // when
+      await visit('/equipe');
 
-    // then
-    assert.equal(currentURL(), '/equipe');
-    assert.contains('Lili');
-    assert.contains('Dupont');
+      // then
+      assert.equal(currentURL(), '/equipe');
+      assert.contains('Lili');
+      assert.contains('Dupont');
+    });
+
+    module('when user switch to see another certification center', function() {
+      test('it should be possible to the other members list', async function(assert) {
+        // given
+        const certificationCenterName = 'Centre de certif des Anne-atole';
+        const otherCertificationCenterName = 'Centre de certif de 7 Anne-néla';
+        const certificationPointOfContact = createAllowedCertificationCenterAccess({
+          certificationCenterName,
+          certificationCenterType: 'SCO',
+          isRelatedOrganizationManagingStudents: true,
+        });
+        const certificationPointOfContact2 = createAllowedCertificationCenterAccess({
+          certificationCenterName: otherCertificationCenterName,
+          certificationCenterType: 'SCO',
+          isRelatedOrganizationManagingStudents: true,
+        });
+        createCertificationPointOfContactWithCustomCenters({
+          pixCertifTermsOfServiceAccepted: true,
+          allowedCertificationCenterAccesses: [certificationPointOfContact, certificationPointOfContact2],
+        });
+        server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
+        const memberOfTheFirstCertificationCenter = server.create('member', { firstName: 'Jack', lastName: 'Adit' });
+        await authenticateSession(certificationPointOfContact.id);
+        await visit('/equipe');
+
+        // when
+        await click('.logged-user-summary__link');
+        await click(`li[title="${otherCertificationCenterName}"] div[role="button"]`);
+        memberOfTheFirstCertificationCenter.destroy();
+        await visit('/equipe');
+
+        // then
+        assert.notContains('Jack');
+        assert.contains('Lili');
+      });
+    });
   });
 });

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
+import { setupApplicationTest } from 'ember-qunit';
+import {
+  createCertificationPointOfContactWithTermsOfServiceAccepted,
+  authenticateSession,
+} from '../helpers/test-init';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | authenticated | team', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('it should be possible to see members list', async function(assert) {
+    // given
+    const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+    server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
+    await authenticateSession(certificationPointOfContact.id);
+
+    // when
+    await visit('/equipe');
+    await clickByLabel('Équipe');
+
+    // then
+    assert.equal(currentURL(), '/equipe');
+    assert.contains('Lili');
+    assert.contains('Dupont');
+  });
+});

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | members-list', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should show members firstName and lastName', async function(assert) {
+    // given
+    const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré' });
+    const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams' });
+    const members = [certifMember1, certifMember2];
+    this.set('members', members);
+
+    // when
+    await render(hbs`<MembersList @members={{this.members}} />`);
+
+    // then
+    assert.contains('Nom');
+    assert.contains('Prénom');
+    assert.contains('Maria');
+    assert.contains('Carré');
+    assert.contains('John');
+    assert.contains('Williams');
+  });
+});

--- a/certif/tests/unit/adapters/member_test.js
+++ b/certif/tests/unit/adapters/member_test.js
@@ -4,16 +4,15 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Adapter | member', function(hooks) {
   setupTest(hooks);
 
-  module('#urlForFindAll', function() {
+  module('#urlForQuery', function() {
 
     test('should call the right url', async function(assert) {
       // given
       const adapter = this.owner.lookup('adapter:member');
       const certificationCenterId = 1;
-      const adapterOptions = { certificationCenterId };
 
       // when
-      const url = await adapter.urlForFindAll('member', { adapterOptions });
+      const url = await adapter.urlForQuery({ certificationCenterId });
 
       // then
       assert.true(url.endsWith(`certification-centers/${certificationCenterId}/members`));

--- a/certif/tests/unit/adapters/member_test.js
+++ b/certif/tests/unit/adapters/member_test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | member', function(hooks) {
+  setupTest(hooks);
+
+  module('#urlForFindAll', function() {
+
+    test('should call the right url', async function(assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:member');
+      const certificationCenterId = 1;
+      const adapterOptions = { certificationCenterId };
+
+      // when
+      const url = await adapter.urlForFindAll('member', { adapterOptions });
+
+      // then
+      assert.true(url.endsWith(`certification-centers/${certificationCenterId}/members`));
+    });
+  });
+});

--- a/certif/tests/unit/routes/authenticated/team_test.js
+++ b/certif/tests/unit/routes/authenticated/team_test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | authenticated/team', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const route = this.owner.lookup('route:authenticated/team');
+    assert.ok(route);
+  });
+});

--- a/mon-pix/tests/unit/adapters/user_test.js
+++ b/mon-pix/tests/unit/adapters/user_test.js
@@ -63,7 +63,6 @@ describe('Unit | Adapters | user', function () {
       // when
       const snapshot = { adapterOptions: { tooltipChallengeType: 'focused' } };
       const url = await adapter.urlForUpdateRecord(123, 'user', snapshot);
-      console.log(url);
 
       // then
       expect(url.endsWith('/users/123/has-seen-challenge-tooltip/focused')).to.be.true;


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, tous les membres Pix Certif voient et peuvent modifier toutes les infos de toutes les sessions et de tous les candidats sans restriction (nom, prénom, date de naissance, lieu de naissance). Or, pour des questions de protection des données, il est souhaitable de ne pas donner cette possibilité à tous les membres Pix Certif.
Aujourd'hui on différencie au moins 3 types de personnes différentes qui ont besoin des accès à Pix Certif mais dont les activités varient (le référent, le suppléant et le surveillant).

Ainsi dans le cadre de la création de ces futurs rôles dans Pix Certif, il est souhaitable que les membres d'un centre de certification aient accès à la liste des membres du même centre de certification qu'eux. Or, actuellement, un membre d'un centre de certification sur Pix Certif n'a pas accès à la liste des autres membres du même espace que lui.

## :gift: Solution
Afficher la liste des membres du centre de certification, accessible depuis l'onglet "Equipe" dans le menu.

## ☃️ Remarques
- `findAll` a pour but de récupérer TOUS les records du modèle qu'on lui passe en paramètre. Du coup, Ember ne va charger les données que renvoie l'API UNIQUEMENT si elles sont nouvelles / elles n'ont pas encore été mise dans le store (si elles sont dans le store il ne va pas les enlever + remettre dedans).
_Ca paraît sympa comme ça, mais du coup si au premier appel du `findAll` on trouve 2 résultats (2 membres par exemple) et qu'au deuxième appel on ne trouve plus qu'1 résultat (1 seul membre si on a changé de centre de certification par exemple)... et bien le model renverra quand même le résultat avec les 2 résultats (et affichera donc 2 membres au lieu d'1 pour le deuxième coup)._
Normalement on peut mettre l'option `{ reload: true }` au `findAll` pour lui dire explicitement de se fier uniquement au retour API (et pas au store) mais je n'ai pas réussi à le faire fonctionner dans cette PR 😢 ... si quelqu'un sait pourquoi je suis preneuse.
=> voir https://emberigniter.com/force-store-reload-data-api-backend/  +  https://api.emberjs.com/ember-data/release/classes/Store/methods/query?anchor=findAll

- `query` a été designé pour demander à l'API à chaque fois le ce qui est attendu. Il est souvent utilisé dans les cas de paggination, filtre etc.
_Dans notre cas c'est pour ca que `query` marche mieux que `findAll`... on a besoin à chaque changement de centre de certif de faire confiance au retour d'API et pas du contenu du store ember._
=> voir la première réponse dans https://stackoverflow.com/questions/56791227/ember-store-findall-is-reloading-view-and-store-query-is-not

## :santa: Pour tester
- Se connecter sur PixCertif (certifsco@example.net)
- Cliquer sur l'onglet "Equipe" 
- Constater qu'on voit la liste des membres du même centre de certification (comparer en base avec la table "certification-center-memberships")
- Restez connecté et changer de centre de certification (clic sur le menu en haut à droite et choisir un autre centre)
- Cliquer sur l'onglet "Equipe" 
- Constater que la liste des membres a changé et comparer avec les résultats de la BDD
