### PR TITLE
[TECH]  Supprimer les occurences d'accreditations de certification (PIX-3743)

### DIFF
--- a/admin/app/components/certification-centers/form.hbs
+++ b/admin/app/components/certification-centers/form.hbs
@@ -65,19 +65,19 @@
     </div>
 
     <section>
-      <h1 class="accreditations-title">Habilitations aux certifications complémentaires</h1>
-      <div class="form-field accreditations-checkbox-list">
+      <h1 class="habilitations-title">Habilitations aux certifications complémentaires</h1>
+      <div class="form-field habilitations-checkbox-list">
         <ul>
-          {{#each @accreditations as |accreditation index|}}
+          {{#each @habilitations as |habilitation index|}}
             <li>
-              <label class="form-field__label" for={{concat "accreditation_" index}}>
+              <label class="form-field__label" for={{concat "habilitation_" index}}>
                 <Input
                   @type="checkbox"
-                  id={{concat "accreditation_" index}}
-                  @checked={{contains accreditation @certificationCenter.accreditations}}
-                  {{on "input" (fn this.updateGrantedAccreditation accreditation)}}
+                  id={{concat "habilitation_" index}}
+                  @checked={{contains habilitation @certificationCenter.habilitations}}
+                  {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
                 />
-                {{accreditation.name}}
+                {{habilitation.name}}
               </label>
             </li>
           {{/each}}

--- a/admin/app/components/certification-centers/form.js
+++ b/admin/app/components/certification-centers/form.js
@@ -11,12 +11,12 @@ export default class CertificationCenterForm extends Component {
   }
 
   @action
-  updateGrantedAccreditation(accreditation) {
-    const accreditations = this.args.certificationCenter.accreditations;
-    if (accreditations.includes(accreditation)) {
-      accreditations.removeObject(accreditation);
+  updateGrantedHabilitation(habilitation) {
+    const habilitations = this.args.certificationCenter.habilitations;
+    if (habilitations.includes(habilitation)) {
+      habilitations.removeObject(habilitation);
     } else {
-      accreditations.addObject(accreditation);
+      habilitations.addObject(habilitation);
     }
   }
 }

--- a/admin/app/components/certification-centers/information.hbs
+++ b/admin/app/components/certification-centers/information.hbs
@@ -104,12 +104,12 @@
             <ul class="accreditations-list-ul">
               {{#each this.availableAccreditations as |accreditation|}}
                 {{#if (contains accreditation @certificationCenter.accreditations)}}
-                  <li aria-label={{concat "Accrédité pour " accreditation.name}}>
+                  <li aria-label={{concat "Habilité pour " accreditation.name}}>
                     <FaIcon class="granted-accreditation-icon" @icon="check-circle" />
                     {{accreditation.name}}
                   </li>
                 {{else}}
-                  <li aria-label={{concat "Non-accrédité pour " accreditation.name}}>
+                  <li aria-label={{concat "Non-habilité pour " accreditation.name}}>
                     <FaIcon class="not-granted-accreditation-icon" @icon="times-circle" />
                     {{accreditation.name}}
                   </li>

--- a/admin/app/components/certification-centers/information.hbs
+++ b/admin/app/components/certification-centers/information.hbs
@@ -55,20 +55,20 @@
               @value={{this.form.externalId}}
             />
           </div>
-          <div class="form-field certification-center-information__edit-form__accreditations-checkbox-list">
+          <div class="form-field certification-center-information__edit-form__habilitations-checkbox-list">
             <h2 class="field__label">Habilitations aux certifications complémentaires</h2>
-            <ul class="accreditations-list-ul">
-              {{#each this.availableAccreditations as |accreditation|}}
+            <ul class="habilitations-list-ul">
+              {{#each this.availableHabilitations as |habilitation|}}
                 <li>
-                  <div class="accreditation-entry">
+                  <div class="habilitation-entry">
                     <Input
-                      id="accreditation-checkbox__{{accreditation.id}}"
+                      id="habilitation-checkbox__{{habilitation.id}}"
                       @type="checkbox"
-                      @checked={{contains accreditation @certificationCenter.accreditations}}
-                      {{on "input" (fn this.updateGrantedAccreditation accreditation)}}
+                      @checked={{contains habilitation @certificationCenter.habilitations}}
+                      {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
                     />
-                    <label class="field__label" for="accreditation-checkbox__{{accreditation.id}}">
-                      {{accreditation.name}}
+                    <label class="field__label" for="habilitation-checkbox__{{habilitation.id}}">
+                      {{habilitation.name}}
                     </label>
                   </div>
                 </li>
@@ -100,18 +100,18 @@
         </div>
         <div class="property">
           <h2 class="field__label">Habilitations aux certifications complémentaires</h2>
-          <div class="certification-center-information__display__accreditations-list">
-            <ul class="accreditations-list-ul">
-              {{#each this.availableAccreditations as |accreditation|}}
-                {{#if (contains accreditation @certificationCenter.accreditations)}}
-                  <li aria-label={{concat "Habilité pour " accreditation.name}}>
-                    <FaIcon class="granted-accreditation-icon" @icon="check-circle" />
-                    {{accreditation.name}}
+          <div class="certification-center-information__display__habilitations-list">
+            <ul class="habilitations-list-ul">
+              {{#each this.availableHabilitations as |habilitation|}}
+                {{#if (contains habilitation @certificationCenter.habilitations)}}
+                  <li aria-label={{concat "Habilité pour " habilitation.name}}>
+                    <FaIcon class="granted-habilitation-icon" @icon="check-circle" />
+                    {{habilitation.name}}
                   </li>
                 {{else}}
-                  <li aria-label={{concat "Non-habilité pour " accreditation.name}}>
-                    <FaIcon class="not-granted-accreditation-icon" @icon="times-circle" />
-                    {{accreditation.name}}
+                  <li aria-label={{concat "Non-habilité pour " habilitation.name}}>
+                    <FaIcon class="not-granted-habilitation-icon" @icon="times-circle" />
+                    {{habilitation.name}}
                   </li>
                 {{/if}}
               {{/each}}

--- a/admin/app/components/certification-centers/information.js
+++ b/admin/app/components/certification-centers/information.js
@@ -45,7 +45,7 @@ class Form extends Object.extend(Validations) {
   @tracked name;
   @tracked externalId;
   @tracked type;
-  @tracked accreditations;
+  @tracked habilitations;
 }
 
 export default class Information extends Component {
@@ -53,9 +53,9 @@ export default class Information extends Component {
 
   certificationCenterTypes = types;
 
-  @computed('args.availableAccreditations.@each.id')
-  get availableAccreditations() {
-    return this.args.availableAccreditations?.sortBy('id');
+  @computed('args.availableHabilitations.@each.id')
+  get availableHabilitations() {
+    return this.args.availableHabilitations?.sortBy('id');
   }
 
   constructor() {
@@ -92,7 +92,7 @@ export default class Information extends Component {
       name: this.form.name.trim(),
       externalId: !this.form.externalId ? null : this.form.externalId.trim(),
       type: this.form.type.trim(),
-      accreditations: this.form.accreditations,
+      habilitations: this.form.habilitations,
     };
 
     await this.args.updateCertificationCenter(certificationCenterData);
@@ -100,25 +100,25 @@ export default class Information extends Component {
   }
 
   @action
-  updateGrantedAccreditation(accreditation) {
-    const accreditations = this.form.accreditations;
-    if (accreditations.includes(accreditation)) {
-      this.form.accreditations.removeObject(accreditation);
+  updateGrantedHabilitation(habilitation) {
+    const habilitations = this.form.habilitations;
+    if (habilitations.includes(habilitation)) {
+      this.form.habilitations.removeObject(habilitation);
     } else {
-      this.form.accreditations.addObject(accreditation);
+      this.form.habilitations.addObject(habilitation);
     }
   }
 
   _initForm() {
-    const { accreditations, name, externalId, type } = this.args.certificationCenter.getProperties(
-      'accreditations',
+    const { habilitations, name, externalId, type } = this.args.certificationCenter.getProperties(
+      'habilitations',
       'name',
       'externalId',
       'type'
     );
 
     this.form.name = name;
-    this.form.accreditations = accreditations ? accreditations.toArray() : [];
+    this.form.habilitations = habilitations ? habilitations.toArray() : [];
     this.form.externalId = externalId;
     this.form.type = type;
   }

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -63,7 +63,7 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
     this.model.certificationCenter.name = certificationCenterData.name;
     this.model.certificationCenter.externalId = certificationCenterData.externalId;
     this.model.certificationCenter.type = certificationCenterData.type;
-    this.model.certificationCenter.accreditations = certificationCenterData.accreditations;
+    this.model.certificationCenter.habilitations = certificationCenterData.habilitations;
 
     try {
       await this.model.certificationCenter.save();

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -11,7 +11,7 @@ export default class CertificationCenter extends Model {
   @attr() type;
   @attr() externalId;
 
-  @hasMany('accreditation') accreditations;
+  @hasMany('habilitation') habilitations;
 
   get typeLabel() {
     return types.find((type) => type.value === this.type).label;

--- a/admin/app/models/habilitation.js
+++ b/admin/app/models/habilitation.js
@@ -1,5 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
-export default class Accreditation extends Model {
+export default class Habilitation extends Model {
   @attr() name;
 }

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -13,12 +13,12 @@ export default class CertificationCentersGetRoute extends Route {
         certificationCenterId: certificationCenter.id,
       },
     });
-    const accreditations = await this.store.findAll('accreditation');
+    const habilitations = await this.store.findAll('habilitation');
 
     return RSVP.hash({
       certificationCenterMemberships,
       certificationCenter,
-      accreditations,
+      habilitations,
     });
   }
 

--- a/admin/app/routes/authenticated/certification-centers/new.js
+++ b/admin/app/routes/authenticated/certification-centers/new.js
@@ -5,7 +5,7 @@ export default class NewRoute extends Route {
   model() {
     return RSVP.hash({
       certificationCenter: this.store.createRecord('certification-center'),
-      accreditations: this.store.findAll('accreditation'),
+      habilitations: this.store.findAll('habilitation'),
     });
   }
 }

--- a/admin/app/serializers/certification-center.js
+++ b/admin/app/serializers/certification-center.js
@@ -2,6 +2,6 @@ import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class CertificationCenter extends JSONAPISerializer {
   attrs = {
-    accreditations: { serialize: true },
+    habilitations: { serialize: true },
   };
 }

--- a/admin/app/styles/components/certification-center-form.scss
+++ b/admin/app/styles/components/certification-center-form.scss
@@ -11,13 +11,13 @@
     width: 100%;
   }
 
-  .accreditations-title {
+  .habilitations-title {
     color: $grey-70;
     font-size: 0.875rem;
     font-weight: normal;
   }
 
-  .accreditations-checkbox-list {
+  .habilitations-checkbox-list {
     display: flex;
 
     ul {

--- a/admin/app/styles/components/certification-centers/information.scss
+++ b/admin/app/styles/components/certification-centers/information.scss
@@ -8,7 +8,7 @@
       margin-bottom: 20px;
     }
 
-    &__accreditations-list {
+    &__habilitations-list {
       background-color: #F4F5F7;
       border-radius: 16px;
       padding: 8px;
@@ -17,11 +17,11 @@
         width: 200px;
       }
 
-      .granted-accreditation-icon {
+      .granted-habilitation-icon {
         color: $green;
       }
 
-      .not-granted-accreditation-icon {
+      .not-granted-habilitation-icon {
         color: $grey-35;
       }
     }
@@ -44,15 +44,15 @@
   &__edit-form {
     width: 500px;
 
-    .accreditations-list-ul {
+    .habilitations-list-ul {
       flex-direction: column;
     }
 
-    &__accreditations-checkboxes {
+    &__habilitations-checkboxes {
       display: flex;
     }
 
-    .accreditation-entry {
+    .habilitation-entry {
       display: block;
       padding-bottom: 8px;
     }
@@ -70,7 +70,7 @@
     font-size: 0.85rem;
   }
 
-  .accreditations-list-ul {
+  .habilitations-list-ul {
     list-style-type: none;
     display: flex;
     margin: 8px 0;

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -11,7 +11,7 @@
 
 <main class="page-body" id="certification-center-get-page">
   <CertificationCenters::Information
-    @availableAccreditations={{this.model.accreditations}}
+    @availableHabilitations={{this.model.habilitations}}
     @certificationCenter={{this.model.certificationCenter}}
     @updateCertificationCenter={{this.updateCertificationCenter}}
   />

--- a/admin/app/templates/authenticated/certification-centers/new.hbs
+++ b/admin/app/templates/authenticated/certification-centers/new.hbs
@@ -9,7 +9,7 @@
   <section class="page-section">
     <CertificationCenters::Form
       @certificationCenter={{@model.certificationCenter}}
-      @accreditations={{@model.accreditations}}
+      @habilitations={{@model.habilitations}}
       @onSubmit={{this.addCertificationCenter}}
       @onCancel={{this.goBackToCertificationCentersList}}
     />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -260,8 +260,8 @@ export default function () {
     return schema.countries.all();
   });
 
-  this.get('/accreditations', (schema, _) => {
-    return schema.accreditations.all();
+  this.get('/habilitations', (schema) => {
+    return schema.habilitations.all();
   });
 
   this.put('/admin/sessions/:id/comment', (schema, request) => {
@@ -290,10 +290,6 @@ export default function () {
     certificationToUpdate.update({ status: 'validated' });
 
     return new Response(200);
-  });
-
-  this.get('/accreditations', (schema) => {
-    return schema.accreditations.all();
   });
 
   this.post('/admin/assessment-results/', () => {

--- a/admin/mirage/serializers/certification-center.js
+++ b/admin/mirage/serializers/certification-center.js
@@ -1,6 +1,6 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
-const include = ['accreditations'];
+const include = ['habilitations'];
 
 export default JSONAPISerializer.extend({
   include,

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -18,8 +18,8 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
 
   test('it should create a certification center', async function (assert) {
     // given
-    this.server.create('accreditation', { name: 'Pix+ Droit' });
-    this.server.create('accreditation', { name: 'CléA Numérique' });
+    this.server.create('habilitation', { name: 'Pix+ Droit' });
+    this.server.create('habilitation', { name: 'CléA Numérique' });
 
     const name = 'name';
     const type = { label: 'Organisation professionnelle', value: 'PRO' };

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -45,7 +45,7 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     assert.contains(type.label);
     assert.contains(externalId);
 
-    assert.dom(screen.getByRole('listitem', { name: 'Non-accrédité pour CléA Numérique' })).exists();
-    assert.dom(screen.getByRole('listitem', { name: 'Accrédité pour Pix+ Droit' })).exists();
+    assert.dom(screen.getByRole('listitem', { name: 'Non-habilité pour CléA Numérique' })).exists();
+    assert.dom(screen.getByRole('listitem', { name: 'Habilité pour Pix+ Droit' })).exists();
   });
 });

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -92,9 +92,9 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
     const screen = await visitScreen(`/certification-centers/${certificationCenter.id}`);
 
     // then
-    assert.dom(screen.getByLabelText('Accrédité pour Pix+Edu')).exists();
-    assert.dom(screen.getByLabelText('Accrédité pour Pix+Surf')).exists();
-    assert.dom(screen.getByLabelText('Non-accrédité pour Pix+Autre')).exists();
+    assert.dom(screen.getByLabelText('Habilité pour Pix+Edu')).exists();
+    assert.dom(screen.getByLabelText('Habilité pour Pix+Surf')).exists();
+    assert.dom(screen.getByLabelText('Non-habilité pour Pix+Autre')).exists();
   });
 
   test('should display Certification center memberships', async function (assert) {
@@ -329,8 +329,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       await clickByLabel('Enregistrer');
 
       // then
-      assert.dom(screen.getByLabelText('Accrédité pour Pix+Surf')).exists();
-      assert.dom(screen.getByLabelText('Non-accrédité pour Pix+Autre')).exists();
+      assert.dom(screen.getByLabelText('Habilité pour Pix+Surf')).exists();
+      assert.dom(screen.getByLabelText('Non-habilité pour Pix+Autre')).exists();
       assert.contains('Habilitations aux certifications complémentaires');
       assert.contains('Centre des réussites');
       assert.contains('Centre de certification mis à jour avec succès.');

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -52,17 +52,17 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
     assert.contains('Établissement scolaire');
   });
 
-  test('should display Certification center accreditations', async function (assert) {
+  test('should display Certification center habilitations', async function (assert) {
     // given
     const currentUser = server.create('user');
     await createAuthenticateSession({ userId: currentUser.id });
-    const accreditation1 = server.create('accreditation', { name: 'Pix+Edu' });
-    const accreditation2 = server.create('accreditation', { name: 'Pix+Surf' });
+    const habilitation1 = server.create('habilitation', { name: 'Pix+Edu' });
+    const habilitation2 = server.create('habilitation', { name: 'Pix+Surf' });
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
       externalId: 'ABCDEF',
       type: 'SCO',
-      accreditations: [accreditation1, accreditation2],
+      habilitations: [habilitation1, habilitation2],
     });
 
     // when
@@ -73,20 +73,20 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
     assert.contains('Pix+Surf');
   });
 
-  test('should highlight the accreditations of the current certification center', async function (assert) {
+  test('should highlight the habilitations of the current certification center', async function (assert) {
     // given
     const currentUser = server.create('user');
     await createAuthenticateSession({ userId: currentUser.id });
-    const accreditation1 = server.create('accreditation', { name: 'Pix+Edu' });
-    const accreditation2 = server.create('accreditation', { name: 'Pix+Surf' });
+    const habilitation1 = server.create('habilitation', { name: 'Pix+Edu' });
+    const habilitation2 = server.create('habilitation', { name: 'Pix+Surf' });
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
       externalId: 'ABCDEF',
       type: 'SCO',
-      accreditations: [accreditation1, accreditation2],
+      habilitations: [habilitation1, habilitation2],
     });
 
-    server.create('accreditation', { name: 'Pix+Autre' });
+    server.create('habilitation', { name: 'Pix+Autre' });
 
     // when
     const screen = await visitScreen(`/certification-centers/${certificationCenter.id}`);
@@ -316,8 +316,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         externalId: 'ABCDEF',
         type: 'SCO',
       });
-      server.create('accreditation', { name: 'Pix+Surf' });
-      server.create('accreditation', { name: 'Pix+Autre' });
+      server.create('habilitation', { name: 'Pix+Surf' });
+      server.create('habilitation', { name: 'Pix+Autre' });
 
       const screen = await visitScreen(`/certification-centers/${certificationCenter.id}`);
       await clickByLabel('Editer');

--- a/admin/tests/integration/components/certification-centers/form_test.js
+++ b/admin/tests/integration/components/certification-centers/form_test.js
@@ -44,47 +44,47 @@ module('Integration | Component | certification-centers/form', function (hooks) 
     });
   });
 
-  module('#updateGrantedAccreditation', function () {
-    test('should add accreditation to certification center on checked checkbox', async function (assert) {
+  module('#updateGrantedHabilitation', function () {
+    test('should add habilitation to certification center on checked checkbox', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const accreditation1 = store.createRecord('accreditation', { name: 'accreditation 1' });
-      const accreditation2 = store.createRecord('accreditation', { name: 'accreditation 2' });
+      const habilitation1 = store.createRecord('habilitation', { name: 'habilitation 1' });
+      const habilitation2 = store.createRecord('habilitation', { name: 'habilitation 2' });
       this.certificationCenter = store.createRecord('certification-center');
-      this.accreditations = EmberArray([accreditation1, accreditation2]);
+      this.habilitations = EmberArray([habilitation1, habilitation2]);
       this.stub = () => {};
 
       await render(
-        hbs`<CertificationCenters::Form @certificationCenter={{this.certificationCenter}} @accreditations={{this.accreditations}} @onSubmit={{this.stub}} @onCancel={{this.stub}} />`
+        hbs`<CertificationCenters::Form @certificationCenter={{this.certificationCenter}} @habilitations={{this.habilitations}} @onSubmit={{this.stub}} @onCancel={{this.stub}} />`
       );
 
       // when
-      await clickByLabel('accreditation 2');
+      await clickByLabel('habilitation 2');
 
       // then
-      assert.ok(this.certificationCenter.accreditations.includes(accreditation2));
+      assert.ok(this.certificationCenter.habilitations.includes(habilitation2));
     });
 
-    test('should remove accreditation to certification center on unchecked checkbox', async function (assert) {
+    test('should remove habilitation to certification center on unchecked checkbox', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const accreditation1 = store.createRecord('accreditation', { name: 'accreditation 1' });
-      const accreditation2 = store.createRecord('accreditation', { name: 'accreditation 2' });
+      const habilitation1 = store.createRecord('habilitation', { name: 'habilitation 1' });
+      const habilitation2 = store.createRecord('habilitation', { name: 'habilitation 2' });
       this.certificationCenter = store.createRecord('certification-center', {
-        accreditations: [accreditation2],
+        habilitations: [habilitation2],
       });
-      this.accreditations = EmberArray([accreditation1, accreditation2]);
+      this.habilitations = EmberArray([habilitation1, habilitation2]);
       this.stub = () => {};
 
       await render(
-        hbs`<CertificationCenters::Form @certificationCenter={{this.certificationCenter}} @accreditations={{this.accreditations}} @onSubmit={{this.stub}} @onCancel={{this.stub}} />`
+        hbs`<CertificationCenters::Form @certificationCenter={{this.certificationCenter}} @habilitations={{this.habilitations}} @onSubmit={{this.stub}} @onCancel={{this.stub}} />`
       );
 
       // when
-      await clickByLabel('accreditation 2');
+      await clickByLabel('habilitation 2');
 
       // then
-      assert.notOk(this.certificationCenter.accreditations.includes(accreditation2));
+      assert.notOk(this.certificationCenter.habilitations.includes(habilitation2));
     });
   });
 });

--- a/admin/tests/integration/components/certification-centers/information_test.js
+++ b/admin/tests/integration/components/certification-centers/information_test.js
@@ -10,7 +10,7 @@ import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-
 import repeat from 'lodash/repeat';
 import sinon from 'sinon';
 
-function _createEmberDataAccreditations() {
+function _createEmberDataHabilitations() {
   return ArrayProxy.create({
     content: [EmberObject.create({ id: 0, name: 'Pix+Droit' }), EmberObject.create({ id: 1, name: 'Cléa' })],
   });
@@ -21,21 +21,21 @@ module('Integration | Component | certification-centers/information', function (
 
   test('it should display label and values in read mode', async function (assert) {
     // given
-    const availableAccreditations = _createEmberDataAccreditations();
-    this.availableAccreditations = availableAccreditations;
+    const availableHabilitations = _createEmberDataHabilitations();
+    this.availableHabilitations = availableHabilitations;
 
     const certificationCenter = EmberObject.create({
       name: 'Centre SCO',
       type: 'SCO',
       externalId: 'AX129',
-      accreditations: [availableAccreditations.firstObject],
+      habilitations: [availableHabilitations.firstObject],
     });
     this.certificationCenter = certificationCenter;
 
     // when
     const screen = await renderScreen(
       hbs`<CertificationCenters::Information
-      @availableAccreditations={{this.availableAccreditations}}
+      @availableHabilitations={{this.availableHabilitations}}
       @certificationCenter={{this.certificationCenter}} />`
     );
 
@@ -122,20 +122,20 @@ module('Integration | Component | certification-centers/information', function (
 
   test('it renders the certification center information component in edit mode', async function (assert) {
     // given
-    const availableAccreditations = _createEmberDataAccreditations();
-    this.availableAccreditations = availableAccreditations;
+    const availableHabilitations = _createEmberDataHabilitations();
+    this.availableHabilitations = availableHabilitations;
 
     const certificationCenter = EmberObject.create({
       name: 'Centre SCO',
       type: 'SCO',
       externalId: 'AX129',
-      accreditations: [availableAccreditations.firstObject],
+      habilitations: [availableHabilitations.firstObject],
     });
     this.set('certificationCenter', certificationCenter);
 
     // when
     const screen = await renderScreen(
-      hbs`<CertificationCenters::Information @availableAccreditations={{this.availableAccreditations}} @certificationCenter={{this.certificationCenter}} />`
+      hbs`<CertificationCenters::Information @availableHabilitations={{this.availableHabilitations}} @certificationCenter={{this.certificationCenter}} />`
     );
     await clickByLabel('Editer');
 
@@ -207,20 +207,20 @@ module('Integration | Component | certification-centers/information', function (
 
   test('it should call updateCertificationCenter with certification center data on save', async function (assert) {
     // given
-    const availableAccreditations = _createEmberDataAccreditations();
-    this.availableAccreditations = availableAccreditations;
+    const availableHabilitations = _createEmberDataHabilitations();
+    this.availableHabilitations = availableHabilitations;
     const certificationCenter = EmberObject.create({
       name: 'Centre SCO',
       type: 'SCO',
       externalId: 'AX129',
-      accreditations: [],
+      habilitations: [],
     });
 
     this.set('certificationCenter', certificationCenter);
     this.updateCertificationCenter = sinon.stub();
     await renderScreen(
       hbs`<CertificationCenters::Information
-        @availableAccreditations={{this.availableAccreditations}}
+        @availableHabilitations={{this.availableHabilitations}}
         @updateCertificationCenter={{this.updateCertificationCenter}}
         @certificationCenter={{this.certificationCenter}} />`
     );
@@ -236,7 +236,7 @@ module('Integration | Component | certification-centers/information', function (
 
     // then
     sinon.assert.calledWithExactly(this.updateCertificationCenter, {
-      accreditations: [availableAccreditations.firstObject],
+      habilitations: [availableHabilitations.firstObject],
       externalId: 'externalId',
       name: 'Centre SUP',
       type: 'SUP',
@@ -246,13 +246,13 @@ module('Integration | Component | certification-centers/information', function (
 
   test('it should not call updateCertificationCenter and discard user input on cancel', async function (assert) {
     // given
-    const availableAccreditations = _createEmberDataAccreditations();
-    this.availableAccreditations = availableAccreditations;
+    const availableHabilitations = _createEmberDataHabilitations();
+    this.availableHabilitations = availableHabilitations;
     const certificationCenter = EmberObject.create({
       name: 'Centre SCO',
       type: 'SCO',
       externalId: 'AX129',
-      accreditations: [availableAccreditations.firstObject],
+      habilitations: [availableHabilitations.firstObject],
     });
     this.set('certificationCenter', certificationCenter);
     this.updateCertificationCenter = sinon.stub();
@@ -261,7 +261,7 @@ module('Integration | Component | certification-centers/information', function (
     const screen = await renderScreen(
       hbs`<CertificationCenters::Information
         @certificationCenter={{this.certificationCenter}}
-        @availableAccreditations={{this.availableAccreditations}}
+        @availableHabilitations={{this.availableHabilitations}}
         @updateCertificationCenter={{this.updateCertificationCenter}} />`
     );
 

--- a/admin/tests/integration/components/certification-centers/information_test.js
+++ b/admin/tests/integration/components/certification-centers/information_test.js
@@ -45,8 +45,8 @@ module('Integration | Component | certification-centers/information', function (
     assert.contains('Centre SCO');
     assert.contains('SCO');
     assert.contains('AX129');
-    assert.dom(screen.getByLabelText('Accrédité pour Pix+Droit')).exists();
-    assert.dom(screen.getByLabelText('Non-accrédité pour Cléa')).exists();
+    assert.dom(screen.getByLabelText('Habilité pour Pix+Droit')).exists();
+    assert.dom(screen.getByLabelText('Non-habilité pour Cléa')).exists();
   });
 
   test('it enters edition mode when click on Edit button', async function (assert) {
@@ -277,7 +277,7 @@ module('Integration | Component | certification-centers/information', function (
     assert.contains('Centre SCO');
     assert.contains('SCO');
     assert.contains('AX129');
-    assert.dom(screen.getByLabelText('Accrédité pour Pix+Droit')).exists();
-    assert.dom(screen.getByLabelText('Non-accrédité pour Cléa')).exists();
+    assert.dom(screen.getByLabelText('Habilité pour Pix+Droit')).exists();
+    assert.dom(screen.getByLabelText('Non-habilité pour Cléa')).exists();
   });
 });

--- a/admin/tests/unit/components/certification-centers/information_test.js
+++ b/admin/tests/unit/components/certification-centers/information_test.js
@@ -9,37 +9,37 @@ module('Unit | Component | certification-center informations', function (hooks) 
 
   hooks.beforeEach(function () {
     component = createGlimmerComponent('component:certification-centers/information', {
-      availableAccreditations: [],
+      availableHabilitations: [],
       certificationCenter: {},
       updateCertificationCenter: () => {},
     });
   });
 
-  module('#updateGrantedAccreditation', function () {
-    test('it should add the accreditation to the certification center', function (assert) {
+  module('#updateGrantedHabilitation', function () {
+    test('it should add the habilitation to the certification center', function (assert) {
       // given
-      const cleaAccreditation = { name: 'Pix+clea' };
+      const cleaHabilitation = { name: 'Pix+clea' };
 
-      component.form.accreditations = [];
+      component.form.habilitations = [];
 
       // when
-      component.updateGrantedAccreditation(cleaAccreditation);
+      component.updateGrantedHabilitation(cleaHabilitation);
 
       // then
-      assert.true(component.form.accreditations.includes(cleaAccreditation));
+      assert.true(component.form.habilitations.includes(cleaHabilitation));
     });
 
-    test('it should remove the accreditation from the certification center', function (assert) {
+    test('it should remove the habilitation from the certification center', function (assert) {
       // given
-      const pixSurfAccreditation = { name: 'Pix+Surf' };
+      const pixSurfHabilitation = { name: 'Pix+Surf' };
 
-      component.form.accreditations = [pixSurfAccreditation];
+      component.form.habilitations = [pixSurfHabilitation];
 
       // when
-      component.updateGrantedAccreditation(pixSurfAccreditation);
+      component.updateGrantedHabilitation(pixSurfHabilitation);
 
       // then
-      assert.false(component.form.accreditations.includes(pixSurfAccreditation));
+      assert.false(component.form.habilitations.includes(pixSurfHabilitation));
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get_test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get_test.js
@@ -25,14 +25,14 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
       save: saveStub,
     });
 
-    const testAccreditation = store.createRecord('accreditation', { name: 'Accreditation test' });
+    const testHabilitation = store.createRecord('habilitation', { name: 'Habilitation test' });
 
     certificationCenter = store.createRecord('certification-center', {
       id: 1,
       name: 'Centre des Anne-Etoiles',
       type: 'PRO',
       externalId: 'ex123',
-      accreditations: [testAccreditation],
+      habilitations: [testHabilitation],
     });
 
     store.createRecord = createRecordStub;

--- a/api/db/migrations/20211208080142_drop-granted-accreditations-table.js
+++ b/api/db/migrations/20211208080142_drop-granted-accreditations-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'granted-accreditations';
+
+exports.up = function(knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+exports.down = function(knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.integer('accreditationId').references('accreditations.id').notNullable();
+    t.integer('certificationCenterId').references('certification-centers.id').notNullable();
+  });
+};

--- a/api/db/migrations/20211208080513_drop-accreditated-badges-table.js
+++ b/api/db/migrations/20211208080513_drop-accreditated-badges-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'accredited-badges';
+
+exports.up = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+exports.down = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('accreditationId').references('accreditations.id').notNullable();
+    t.integer('badgeId').references('badges.id').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};

--- a/api/db/migrations/20211208080645_drop-accreditations-table.js
+++ b/api/db/migrations/20211208080645_drop-accreditations-table.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'accreditations';
+
+exports.up = function(knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+exports.down = function(knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.string('name').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -12,20 +12,20 @@ const map = require('lodash/map');
 module.exports = {
   async create(request) {
     const certificationCenter = certificationCenterSerializer.deserialize(request.payload);
-    const accreditationIds = map(request.payload.data.relationships?.accreditations?.data, 'id');
+    const complementaryCertificationIds = map(request.payload.data.relationships?.habilitations?.data, 'id');
     const createdCertificationCenter = await usecases.createCertificationCenter({
       certificationCenter,
-      accreditationIds,
+      complementaryCertificationIds,
     });
     return certificationCenterSerializer.serialize(createdCertificationCenter);
   },
 
   async update(request) {
     const certificationCenter = certificationCenterSerializer.deserialize(request.payload);
-    const accreditationIds = map(request.payload.data.relationships?.accreditations?.data, 'id');
+    const complementaryCertificationIds = map(request.payload.data.relationships?.habilitations?.data, 'id');
     const updatedCertificationCenter = await usecases.updateCertificationCenter({
       certificationCenter,
-      accreditationIds,
+      complementaryCertificationIds,
     });
     return certificationCenterSerializer.serialize(updatedCertificationCenter);
   },

--- a/api/lib/application/complementary-certifications/index.js
+++ b/api/lib/application/complementary-certifications/index.js
@@ -5,7 +5,7 @@ exports.register = async function (server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/accreditations',
+      path: '/api/habilitations',
       config: {
         pre: [
           {

--- a/api/lib/domain/events/handle-clea-certification-rescoring.js
+++ b/api/lib/domain/events/handle-clea-certification-rescoring.js
@@ -13,7 +13,7 @@ async function handleCleaCertificationRescoring({
   const { certificationCourseId } = event;
 
   const certificationCenter = await certificationCenterRepository.getByCertificationCourseId(certificationCourseId);
-  if (!certificationCenter.isAccreditedClea) {
+  if (!certificationCenter.isHabilitatedClea) {
     return;
   }
   const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -17,7 +17,7 @@ async function handleCleaCertificationScoring({
   const { certificationCourseId, userId, reproducibilityRate } = event;
 
   const certificationCenter = await certificationCenterRepository.getByCertificationCourseId(certificationCourseId);
-  if (!certificationCenter.isAccreditedClea) {
+  if (!certificationCenter.isHabilitatedClea) {
     return;
   }
 

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -25,11 +25,11 @@ class CertificationCenter {
     return this.type === types.SCO;
   }
 
-  get isAccreditedPixPlusDroit() {
+  get isHabilitatedPixPlusDroit() {
     return this.habilitations.some((habilitation) => habilitation.name === PIX_PLUS_DROIT);
   }
 
-  get isAccreditedClea() {
+  get isHabilitatedClea() {
     return this.habilitations.some((habilitation) => habilitation.name === CLEA);
   }
 }

--- a/api/lib/domain/usecases/create-certification-center.js
+++ b/api/lib/domain/usecases/create-certification-center.js
@@ -3,16 +3,16 @@ const certificationCenterCreationValidator = require('../validators/certificatio
 
 module.exports = async function createCertificationCenter({
   certificationCenter,
-  accreditationIds,
+  complementaryCertificationIds,
   complementaryCertificationHabilitationRepository,
   certificationCenterRepository,
 }) {
   certificationCenterCreationValidator.validate(certificationCenter);
   const createdCertificationCenter = await certificationCenterRepository.save(certificationCenter);
 
-  for (const accreditationId of accreditationIds) {
+  for (const complementaryCertificationId of complementaryCertificationIds) {
     const complementaryCertificationHabilitation = new ComplementaryCertificationHabilitation({
-      complementaryCertificationId: parseInt(accreditationId),
+      complementaryCertificationId: parseInt(complementaryCertificationId),
       certificationCenterId: createdCertificationCenter.id,
     });
 

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -130,7 +130,7 @@ async function _startNewCertification({
 
   if (
     !featureToggles.isComplementaryCertificationSubscriptionEnabled ||
-    (certificationCenter.isAccreditedClea && certificationCandidate.isGrantedCleA())
+    (certificationCenter.isHabilitatedClea && certificationCandidate.isGrantedCleA())
   ) {
     if (await certificationBadgesService.hasStillValidCleaBadgeAcquisition({ userId })) {
       const cleAComplementaryCertification = complementaryCertifications.find((comp) => comp.name === CLEA);
@@ -142,7 +142,7 @@ async function _startNewCertification({
 
   if (
     !featureToggles.isComplementaryCertificationSubscriptionEnabled ||
-    (certificationCenter.isAccreditedPixPlusDroit && certificationCandidate.isGrantedPixPlusDroit())
+    (certificationCenter.isHabilitatedPixPlusDroit && certificationCandidate.isGrantedPixPlusDroit())
   ) {
     const highestCertifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
       userId,

--- a/api/lib/domain/usecases/update-certification-center.js
+++ b/api/lib/domain/usecases/update-certification-center.js
@@ -3,7 +3,7 @@ const ComplementaryCertificationHabilitation = require('../../domain/models/Comp
 
 module.exports = async function updateCertificationCenter({
   certificationCenter,
-  accreditationIds,
+  complementaryCertificationIds,
   certificationCenterRepository,
   complementaryCertificationHabilitationRepository,
 }) {
@@ -11,11 +11,11 @@ module.exports = async function updateCertificationCenter({
   if (certificationCenter.id) {
     await complementaryCertificationHabilitationRepository.deleteByCertificationCenterId(certificationCenter.id);
   }
-  if (accreditationIds) {
+  if (complementaryCertificationIds) {
     await Promise.all(
-      accreditationIds.map((accreditationId) => {
+      complementaryCertificationIds.map((complementaryCertificationId) => {
         const complementaryCertificationHabilitation = new ComplementaryCertificationHabilitation({
-          complementaryCertificationId: parseInt(accreditationId),
+          complementaryCertificationId: parseInt(complementaryCertificationId),
           certificationCenterId: certificationCenter.id,
         });
         return complementaryCertificationHabilitationRepository.save(complementaryCertificationHabilitation);

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
@@ -5,12 +5,7 @@ const CertificationCenter = require('../../../domain/models/CertificationCenter'
 module.exports = {
   serialize(certificationCenters, meta) {
     return new Serializer('certification-center', {
-      transform: (certificationCenter) => {
-        certificationCenter.accreditations = certificationCenter.habilitations;
-        delete certificationCenter.habilitations;
-        return certificationCenter;
-      },
-      attributes: ['name', 'type', 'externalId', 'createdAt', 'certificationCenterMemberships', 'accreditations'],
+      attributes: ['name', 'type', 'externalId', 'createdAt', 'certificationCenterMemberships', 'habilitations'],
       certificationCenterMemberships: {
         ref: 'id',
         ignoreRelationshipData: true,
@@ -21,7 +16,7 @@ module.exports = {
           },
         },
       },
-      accreditations: {
+      habilitations: {
         include: true,
         ref: 'id',
         attributes: ['name'],

--- a/api/lib/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
@@ -2,10 +2,10 @@ const { Serializer } = require('jsonapi-serializer');
 const ComplementaryCertification = require('../../../domain/models/ComplementaryCertification');
 
 module.exports = {
-  serialize(accreditation) {
-    return new Serializer('accreditation', {
+  serialize(habilitation) {
+    return new Serializer('habilitation', {
       attributes: ['name'],
-    }).serialize(accreditation);
+    }).serialize(habilitation);
   },
 
   deserialize(jsonAPI) {

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -74,11 +74,11 @@ describe('Acceptance | API | Certification Center', function () {
                 type: 'SUP',
               },
               relationships: {
-                accreditations: {
+                habilitations: {
                   data: [
                     {
                       id: '12',
-                      type: 'accreditations',
+                      type: 'habilitations',
                     },
                   ],
                 },
@@ -99,7 +99,7 @@ describe('Acceptance | API | Certification Center', function () {
                 type: 'SCO',
               },
               relationships: {
-                accreditations: {
+                habilitations: {
                   data: [],
                 },
                 'certification-center-memberships': {
@@ -113,7 +113,7 @@ describe('Acceptance | API | Certification Center', function () {
           included: [
             {
               id: '12',
-              type: 'accreditations',
+              type: 'habilitations',
               attributes: {
                 name: 'Pix+Edu',
               },
@@ -168,10 +168,10 @@ describe('Acceptance | API | Certification Center', function () {
               type: 'SCO',
             },
             relationships: {
-              accreditations: {
+              habilitations: {
                 data: [
                   {
-                    type: 'accreditations',
+                    type: 'habilitations',
                     id: `${complementaryCertification.id}`,
                   },
                 ],

--- a/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
@@ -13,13 +13,13 @@ describe('Acceptance | API | complementary-certification-controller', function (
     server = await createServer();
   });
 
-  describe('GET /api/accreditations/', function () {
+  describe('GET /api/habilitations/', function () {
     it('should return 200 HTTP status code', async function () {
       // given
       const pixMaster = await insertUserWithRolePixMaster();
       const options = {
         method: 'GET',
-        url: '/api/accreditations',
+        url: '/api/habilitations',
         headers: {
           authorization: generateValidRequestAuthorizationHeader(pixMaster.id),
         },
@@ -42,14 +42,14 @@ describe('Acceptance | API | complementary-certification-controller', function (
       expect(response.result).to.deep.equal({
         data: [
           {
-            type: 'accreditations',
+            type: 'habilitations',
             id: '1',
             attributes: {
               name: 'Pix+Edu',
             },
           },
           {
-            type: 'accreditations',
+            type: 'habilitations',
             id: '2',
             attributes: {
               name: 'Cléa Numérique',

--- a/api/tests/unit/application/complementary-certifications/index_test.js
+++ b/api/tests/unit/application/complementary-certifications/index_test.js
@@ -4,7 +4,7 @@ const complementaryCertificationController = require('../../../../lib/applicatio
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 
 describe('Unit | Application | Router | complementary-certifications-router', function () {
-  describe('GET /api/accreditations', function () {
+  describe('GET /api/habilitations', function () {
     it('should return 403 HTTP status code when the user authenticated is not PixMaster', async function () {
       // given
       sinon
@@ -15,7 +15,7 @@ describe('Unit | Application | Router | complementary-certifications-router', fu
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('GET', '/api/accreditations');
+      const response = await httpTestServer.request('GET', '/api/habilitations');
 
       // then
       expect(response.statusCode).to.equal(403);

--- a/api/tests/unit/domain/events/handle-clea-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-rescoring_test.js
@@ -109,7 +109,7 @@ describe('Unit | Domain | Events | handle-clea-certification-rescoring', functio
       });
     });
 
-    context('when certification center is not accredited', function () {
+    context('when certification center is not habilitated', function () {
       it('should not save the re-scored cleA certification', async function () {
         // given
         const certificationRescoringCompletedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -267,7 +267,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
       });
     });
 
-    context('when certification center is not accredited', function () {
+    context('when certification center is not habilitated', function () {
       it('should not save a certif partner', async function () {
         // given
         const userId = 1234;

--- a/api/tests/unit/domain/models/CertificationCenter_test.js
+++ b/api/tests/unit/domain/models/CertificationCenter_test.js
@@ -25,7 +25,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
       const certificationCenter = domainBuilder.buildCertificationCenter({ habilitations: [] });
 
       // then
-      expect(certificationCenter.isAccreditedPixPlusDroit).to.be.false;
+      expect(certificationCenter.isHabilitatedPixPlusDroit).to.be.false;
     });
 
     it('should return true when the certification center has Pix+ Droit complementary certification', function () {
@@ -38,7 +38,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
       });
 
       // then
-      expect(certificationCenter.isAccreditedPixPlusDroit).to.be.true;
+      expect(certificationCenter.isHabilitatedPixPlusDroit).to.be.true;
     });
   });
 
@@ -48,7 +48,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
       const certificationCenter = domainBuilder.buildCertificationCenter({ habilitations: [] });
 
       // then
-      expect(certificationCenter.isAccreditedClea).to.be.false;
+      expect(certificationCenter.isHabilitatedClea).to.be.false;
     });
 
     it('should return true when the certification center has Cléa numérique complementary certification', function () {
@@ -61,7 +61,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
       });
 
       // then
-      expect(certificationCenter.isAccreditedClea).to.be.true;
+      expect(certificationCenter.isHabilitatedClea).to.be.true;
     });
   });
 });

--- a/api/tests/unit/domain/usecases/create-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/create-certification-center_test.js
@@ -12,7 +12,7 @@ describe('Unit | UseCase | create-certification-center', function () {
       // when
       const createdCertificationCenter = await createCertificationCenter({
         certificationCenter,
-        accreditationIds: [],
+        complementaryCertificationIds: [],
         certificationCenterRepository,
         complementaryCertificationHabilitationRepository,
       });
@@ -25,7 +25,7 @@ describe('Unit | UseCase | create-certification-center', function () {
     it('should save the complementary certification habilitations', async function () {
       // given
       const certificationCenter = domainBuilder.buildCertificationCenter();
-      const accreditationIds = ['1234', '4567'];
+      const complementaryCertificationIds = ['1234', '4567'];
       const certificationCenterRepository = { save: sinon.stub().returns(certificationCenter) };
       const complementaryCertificationHabilitationRepository = {
         save: sinon.stub(),
@@ -34,7 +34,7 @@ describe('Unit | UseCase | create-certification-center', function () {
       // when
       await createCertificationCenter({
         certificationCenter,
-        accreditationIds,
+        complementaryCertificationIds,
         certificationCenterRepository,
         complementaryCertificationHabilitationRepository,
       });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -528,9 +528,9 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(false);
                     });
                     context(
-                      'when certificationCenter has no accreditation and user is not granted for complementary certification',
+                      'when certificationCenter has no habilitation and user is not granted for complementary certification',
                       function () {
-                        context('when user is elligible for cleA and Pix+ droit', function () {
+                        context('when user is eligible for cleA and Pix+ droit', function () {
                           it('should save complementary certification info for cleA and Pix+ droit', async function () {
                             // given
                             const sessionId = 1;

--- a/api/tests/unit/domain/usecases/update-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/update-certification-center_test.js
@@ -33,7 +33,7 @@ describe('Unit | UseCase | update-certification-center', function () {
       it('should reset existing complementary certitification habilitation and create new ones', async function () {
         // given
         const certificationCenter = domainBuilder.buildCertificationCenter();
-        const accreditationIds = ['1234', '5678'];
+        const complementaryCertificationIds = ['1234', '5678'];
         const complementaryCertificationHabilitation1 = domainBuilder.buildComplementaryCertificationHabilitation({
           complementaryCertificationId: 1234,
           certificationCenterId: certificationCenter.id,
@@ -54,7 +54,7 @@ describe('Unit | UseCase | update-certification-center', function () {
         // when
         const savedCertificationCenter = await updateCertificationCenter({
           certificationCenter,
-          accreditationIds,
+          complementaryCertificationIds,
           certificationCenterRepository,
           complementaryCertificationHabilitationRepository,
         });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
@@ -34,11 +34,11 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
                 related: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
               },
             },
-            accreditations: {
+            habilitations: {
               data: [
                 {
                   id: '1',
-                  type: 'accreditations',
+                  type: 'habilitations',
                 },
               ],
             },
@@ -47,7 +47,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
         included: [
           {
             id: '1',
-            type: 'accreditations',
+            type: 'habilitations',
             attributes: {
               name: 'Pix+surf',
             },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/complementary-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/complementary-certification-serializer_test.js
@@ -24,14 +24,14 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
         data: [
           {
             id: '11',
-            type: 'accreditations',
+            type: 'habilitations',
             attributes: {
               name: 'Pix+Edu',
             },
           },
           {
             id: '22',
-            type: 'accreditations',
+            type: 'habilitations',
             attributes: {
               name: 'Cléa Numérique',
             },


### PR DESCRIPTION
## :christmas_tree: Problème
[La PR d'ajout des tables d'habilitation](https://github.com/1024pix/pix/pull/3657) à permis d'utiliser le terme habilitation au lieu d'accreditation.
Pour ne pas allourdir la PR on a decidé de ne pas supprimer les tables et renommer coté front

## :gift: Solution
Suppression des tables et refacto coté pix-admin

## :star2: Remarques
L'affichage dans les centre de certification (2nd commit) passe de accreditation à habilitation

## :santa: Pour tester
Creer un centre de certification avec des habilitations et s'assurer que les habilitations sont bien ajoutés
Mettre à jour les habilitations du centre de certif
Ajouter un candidat à une session en s'assurant qu'il peut etre inscrit à une certif complementaire pour laquel le centre est habilité
