### PR TITLE
[BUGFIX] Les tests du pre-handler checkUserHasRolePixMaster sont fragiles.

### DIFF
--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -23,22 +23,22 @@ function _replyForbiddenError(h) {
   return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
 }
 
-function checkUserHasRolePixMaster(request, h) {
+async function checkUserHasRolePixMaster(request, h) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
 
   const userId = request.auth.credentials.userId;
 
-  return checkUserHasRolePixMasterUseCase
-    .execute(userId)
-    .then((hasRolePixMaster) => {
-      if (hasRolePixMaster) {
-        return h.response(true);
-      }
-      return _replyForbiddenError(h);
-    })
-    .catch(() => _replyForbiddenError(h));
+  try {
+    const hasRolePixMaster = await checkUserHasRolePixMasterUseCase.execute(userId);
+    if (hasRolePixMaster) {
+      return h.response(true);
+    }
+    return _replyForbiddenError(h);
+  } catch (e) {
+    return _replyForbiddenError(h);
+  }
 }
 
 function checkRequestedUserIsAuthenticatedUser(request, h) {


### PR DESCRIPTION
## :christmas_tree: Problème
Certains tests passaient en faux positifs lorsqu'ils étaient exécutés a la suite, et ne passaient pas lors de leur exécution indépendante.

## :gift: Solution
Insérer les données avant chaque test et exécuter les requêtes en async/await.

## :star2: Remarques
nous nous en sommes rendu compte lors de l'ajout d'une règle dans cette PR #3801 

## :santa: Pour tester
- Vérifier que les tests passent.
