### PR TITLE
[FEATURE] Afficher dans Pix App les certification complémentaires que va passer un candidat (PIX-3688).

### DIFF
--- a/api/lib/application/certification-candidates/certification-candidates-controller.js
+++ b/api/lib/application/certification-candidates/certification-candidates-controller.js
@@ -1,6 +1,7 @@
 const usecases = require('../../domain/usecases');
 const { featureToggles } = require('../../config');
 const { NotFoundError } = require('../http-errors');
+const certificationCandidateSubscriptionSerializer = require('../../infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer');
 
 module.exports = {
   async authorizeToStart(request, h) {
@@ -29,5 +30,13 @@ module.exports = {
     });
 
     return h.response().code(204);
+  },
+
+  async getSubscriptions(request) {
+    const certificationCandidateId = request.params.id;
+    const certificationCandidateSubscription = await usecases.getCertificationCandidateSubscription({
+      certificationCandidateId,
+    });
+    return certificationCandidateSubscriptionSerializer.serialize(certificationCandidateSubscription);
   },
 };

--- a/api/lib/application/certification-candidates/index.js
+++ b/api/lib/application/certification-candidates/index.js
@@ -41,6 +41,23 @@ exports.register = async function (server) {
         tags: ['api', 'certification-candidates'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/certification-candidates/{id}/subscriptions',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCandidateId,
+          }),
+        },
+        handler: certificationCandidatesController.getSubscriptions,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Renvoie les informations d'inscription et d'élligibilité au passage de certification complémentaires d'un candidat",
+        ],
+        tags: ['api', 'certification-candidates'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/models/ComplementaryCertification.js
+++ b/api/lib/domain/models/ComplementaryCertification.js
@@ -6,6 +6,14 @@ class ComplementaryCertification {
     this.id = id;
     this.name = name;
   }
+
+  isClea() {
+    return this.name === CLEA;
+  }
+
+  isPixPlusDroit() {
+    return this.name === PIX_PLUS_DROIT;
+  }
 }
 
 ComplementaryCertification.PIX_PLUS_DROIT = PIX_PLUS_DROIT;

--- a/api/lib/domain/read-models/CertificationCandidateSubscription.js
+++ b/api/lib/domain/read-models/CertificationCandidateSubscription.js
@@ -1,0 +1,8 @@
+module.exports = class CertificationCandidateSubscription {
+  constructor({ id, sessionId, eligibleSubscriptions, nonEligibleSubscriptions }) {
+    this.id = id;
+    this.sessionId = sessionId;
+    this.eligibleSubscriptions = eligibleSubscriptions;
+    this.nonEligibleSubscriptions = nonEligibleSubscriptions;
+  }
+};

--- a/api/lib/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/lib/domain/usecases/get-certification-candidate-subscription.js
@@ -1,0 +1,62 @@
+const CertificationCandidateSubscription = require('../read-models/CertificationCandidateSubscription');
+const Badge = require('../models/Badge');
+const _ = require('lodash');
+
+function _hasStillValidPixPlusDroit(badgeAcquisitions) {
+  return badgeAcquisitions.some(
+    (badgeAcquisition) =>
+      badgeAcquisition.badgeKey === Badge.keys.PIX_DROIT_MAITRE_CERTIF ||
+      badgeAcquisition.badgeKey === Badge.keys.PIX_DROIT_EXPERT_CERTIF
+  );
+}
+
+module.exports = async function getCertificationCandidateSubscription({
+  certificationCandidateId,
+  certificationBadgesService,
+  certificationCandidateRepository,
+}) {
+  const certificationCandidate = await certificationCandidateRepository.getWithComplementaryCertifications(
+    certificationCandidateId
+  );
+
+  if (_.isEmpty(certificationCandidate.complementaryCertifications)) {
+    return new CertificationCandidateSubscription({
+      id: certificationCandidateId,
+      sessionId: certificationCandidate.sessionId,
+      eligibleSubscriptions: [],
+      nonEligibleSubscriptions: [],
+    });
+  }
+
+  const eligibleSubscriptions = [];
+  const nonEligibleSubscriptions = [];
+  for (const complementaryCertification of certificationCandidate.complementaryCertifications) {
+    if (complementaryCertification.isPixPlusDroit()) {
+      const stillValidCertifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
+        userId: certificationCandidate.userId,
+      });
+      if (_hasStillValidPixPlusDroit(stillValidCertifiableBadgeAcquisitions)) {
+        eligibleSubscriptions.push(complementaryCertification);
+      } else {
+        nonEligibleSubscriptions.push(complementaryCertification);
+      }
+    }
+    if (complementaryCertification.isClea()) {
+      const hasStillValidCleaBadge = await certificationBadgesService.hasStillValidCleaBadgeAcquisition({
+        userId: certificationCandidate.userId,
+      });
+      if (hasStillValidCleaBadge) {
+        eligibleSubscriptions.push(complementaryCertification);
+      } else {
+        nonEligibleSubscriptions.push(complementaryCertification);
+      }
+    }
+  }
+
+  return new CertificationCandidateSubscription({
+    id: certificationCandidateId,
+    sessionId: certificationCandidate.sessionId,
+    eligibleSubscriptions,
+    nonEligibleSubscriptions,
+  });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -261,6 +261,7 @@ module.exports = injectDependencies(
     getCertificationAttestation: require('./certificate/get-certification-attestation'),
     findCertificationAttestationsForDivision: require('./certificate/find-certification-attestations-for-division'),
     getCertificationCandidate: require('./get-certification-candidate'),
+    getCertificationCandidateSubscription: require('./get-certification-candidate-subscription'),
     getCertificationCenter: require('./get-certification-center'),
     getCertificationCourse: require('./get-certification-course'),
     getCertificationDetails: require('./get-certification-details'),

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -185,6 +185,26 @@ module.exports = {
 
     await knex('certification-candidates').where({ sessionId }).del();
   },
+
+  async getWithComplementaryCertifications(id) {
+    const candidateData = await knex('certification-candidates')
+      .select('certification-candidates.*')
+      .select({ complementaryCertifications: knex.raw('json_agg("complementary-certifications".*)') })
+      .leftJoin(
+        'complementary-certification-subscriptions',
+        'complementary-certification-subscriptions.certificationCandidateId',
+        'certification-candidates.id'
+      )
+      .leftJoin(
+        'complementary-certifications',
+        'complementary-certifications.id',
+        'complementary-certification-subscriptions.complementaryCertificationId'
+      )
+      .where('certification-candidates.id', id)
+      .groupBy('certification-candidates.id')
+      .first();
+    return _toDomain(candidateData);
+  },
 };
 
 function _adaptModelToDb(certificationCandidateToSave) {

--- a/api/lib/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer.js
@@ -1,0 +1,9 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(certificationCandidateSubscription) {
+    return new Serializer('certification-candidate-subscription', {
+      attributes: ['sessionId', 'eligibleSubscriptions', 'nonEligibleSubscriptions'],
+    }).serialize(certificationCandidateSubscription);
+  },
+};

--- a/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
@@ -1,6 +1,7 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, sinon } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const { featureToggles } = require('../../../../lib/config');
+const ComplementaryCertification = require('../../../../lib/domain/models/ComplementaryCertification');
 
 describe('Acceptance | API | Certifications candidates', function () {
   describe('POST /api/certification-candidates/:id/authorize-to-start', function () {
@@ -60,6 +61,65 @@ describe('Acceptance | API | Certifications candidates', function () {
           // then
           expect(response.statusCode).to.equal(204);
         });
+      });
+    });
+  });
+
+  describe('GET /api/certification-candidates/:id/subscriptions', function () {
+    it('should return the certification candidate subscriptions', async function () {
+      // given
+      const server = await createServer();
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const session = databaseBuilder.factory.buildSession();
+      const candidate = databaseBuilder.factory.buildCertificationCandidate({
+        sessionId: session.id,
+      });
+
+      const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        name: ComplementaryCertification.CLEA,
+      });
+      const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        name: ComplementaryCertification.PIX_PLUS_DROIT,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        certificationCandidateId: candidate.id,
+        complementaryCertificationId: cleaComplementaryCertification.id,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        certificationCandidateId: candidate.id,
+        complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
+      });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/certification-candidates/${candidate.id}/subscriptions`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId, 'pix-certif') },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal({
+        id: `${candidate.id}`,
+        type: 'certification-candidate-subscriptions',
+        attributes: {
+          'session-id': session.id,
+          'eligible-subscriptions': [],
+          'non-eligible-subscriptions': [
+            {
+              id: cleaComplementaryCertification.id,
+              name: 'CléA Numérique',
+            },
+            {
+              id: pixPlusDroitComplementaryCertification.id,
+              name: 'Pix+ Droit',
+            },
+          ],
+        },
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -782,4 +782,63 @@ describe('Integration | Repository | CertificationCandidate', function () {
       expect(certificationCandidateInDB).to.deep.equal([]);
     });
   });
+
+  describe('#getWithComplementaryCertifications', function () {
+    context('when the candidate has no complementary certification subscriptions', function () {
+      it('should return the candidate with empty complementary certifications', async function () {
+        // given
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCandidateWithComplementaryCertifications =
+          await certificationCandidateRepository.getWithComplementaryCertifications(certificationCandidate.id);
+
+        // then
+        expect(certificationCandidateWithComplementaryCertifications).to.deep.equal(
+          domainBuilder.buildCertificationCandidate({
+            ...certificationCandidate,
+            complementaryCertifications: [],
+          })
+        );
+      });
+    });
+
+    context('when the candidate complementary certification subscriptions', function () {
+      it('should return the candidate with his complementary certifications', async function () {
+        // given
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
+        const complementaryCertification1 = databaseBuilder.factory.buildComplementaryCertification({
+          name: 'Complementary certification 1',
+        });
+        const complementaryCertification2 = databaseBuilder.factory.buildComplementaryCertification({
+          name: 'Complementary certification 2',
+        });
+        databaseBuilder.factory.buildComplementaryCertificationSubscription({
+          complementaryCertificationId: complementaryCertification1.id,
+          certificationCandidateId: certificationCandidate.id,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationSubscription({
+          complementaryCertificationId: complementaryCertification2.id,
+          certificationCandidateId: certificationCandidate.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCandidateWithComplementaryCertifications =
+          await certificationCandidateRepository.getWithComplementaryCertifications(certificationCandidate.id);
+
+        // then
+        expect(certificationCandidateWithComplementaryCertifications).to.deep.equal(
+          domainBuilder.buildCertificationCandidate({
+            ...certificationCandidate,
+            complementaryCertifications: [
+              domainBuilder.buildComplementaryCertification(complementaryCertification1),
+              domainBuilder.buildComplementaryCertification(complementaryCertification2),
+            ],
+          })
+        );
+      });
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-subscription.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-subscription.js
@@ -1,0 +1,15 @@
+const CertificationCandidateSubscription = require('../../../../lib/domain/read-models/CertificationCandidateSubscription');
+
+module.exports = function buildCertificationCandidateSubscription({
+  id = 1234,
+  sessionId = 1234,
+  eligibleSubscriptions = [],
+  nonEligibleSubscriptions = [],
+} = {}) {
+  return new CertificationCandidateSubscription({
+    id,
+    sessionId,
+    eligibleSubscriptions,
+    nonEligibleSubscriptions,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -24,6 +24,7 @@ module.exports = {
   buildCertificationAssessmentScore: require('./build-certification-assessment-score'),
   buildCertificationCandidate: require('./build-certification-candidate'),
   buildCertificationCandidateForSupervising: require('./build-certification-candidate-for-supervising'),
+  buildCertificationCandidateSubscription: require('./build-certification-candidate-subscription'),
   buildCertificationEligibility: require('./build-certification-eligibility'),
   buildCertificationIssueReport: require('./build-certification-issue-report'),
   buildCertificationOfficer: require('./build-certification-officer'),

--- a/api/tests/unit/domain/models/ComplementaryCertification_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertification_test.js
@@ -1,0 +1,60 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+const ComplementaryCertification = require('../../../../lib/domain/models/ComplementaryCertification');
+
+describe('Unit | Domain | Models | ComplementaryCertification', function () {
+  describe('#isClea', function () {
+    it('should return true id name equals CléA Numérique', function () {
+      // given
+      const complementaryCertification = domainBuilder.buildComplementaryCertification({
+        name: ComplementaryCertification.CLEA,
+      });
+
+      // when
+      const isClea = complementaryCertification.isClea();
+
+      // then
+      expect(isClea).to.be.true;
+    });
+
+    it('should return false otherwise', function () {
+      // given
+      const complementaryCertification = domainBuilder.buildComplementaryCertification({
+        name: 'Not cléa',
+      });
+
+      // when
+      const isClea = complementaryCertification.isClea();
+
+      // then
+      expect(isClea).to.be.false;
+    });
+  });
+
+  describe('#isPixPlusDroit', function () {
+    it('should return true id name equals Pix+ Droit', function () {
+      // given
+      const complementaryCertification = domainBuilder.buildComplementaryCertification({
+        name: ComplementaryCertification.PIX_PLUS_DROIT,
+      });
+
+      // when
+      const isPixPlusDroit = complementaryCertification.isPixPlusDroit();
+
+      // then
+      expect(isPixPlusDroit).to.be.true;
+    });
+
+    it('should return false otherwise', function () {
+      // given
+      const complementaryCertification = domainBuilder.buildComplementaryCertification({
+        name: 'Not pix+ droit',
+      });
+
+      // when
+      const isPixPlusDroit = complementaryCertification.isPixPlusDroit();
+
+      // then
+      expect(isPixPlusDroit).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -1,0 +1,198 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const getCertificationCandidateSubscription = require('../../../../lib/domain/usecases/get-certification-candidate-subscription');
+const ComplementaryCertification = require('../../../../lib/domain/models/ComplementaryCertification');
+const Badge = require('../../../../lib/domain/models/Badge');
+
+describe('Unit | UseCase | get-certification-candidate-subscription', function () {
+  let certificationBadgesService;
+  let certificationCandidateRepository;
+
+  beforeEach(function () {
+    certificationBadgesService = {
+      findStillValidBadgeAcquisitions: sinon.stub(),
+      hasStillValidCleaBadgeAcquisition: sinon.stub(),
+    };
+    certificationCandidateRepository = {
+      getWithComplementaryCertifications: sinon.stub(),
+    };
+  });
+
+  context('when the candidate is registered and eligible to both Pix+ Droit and CléA', function () {
+    it('should return the candidate with both Pix+ Droit and CléA as eligible complementary certifications', async function () {
+      // given
+      const certificationCandidateId = 123;
+      const userId = 456;
+      const sessionId = 789;
+
+      const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
+        name: ComplementaryCertification.PIX_PLUS_DROIT,
+      });
+      const cleaComplementaryCertifications = domainBuilder.buildComplementaryCertification({
+        name: ComplementaryCertification.CLEA,
+      });
+      const candidateWithComplementaryCertifications = domainBuilder.buildCertificationCandidate({
+        id: certificationCandidateId,
+        userId,
+        sessionId,
+        complementaryCertifications: [pixPlusDroitComplementaryCertification, cleaComplementaryCertifications],
+      });
+      certificationCandidateRepository.getWithComplementaryCertifications
+        .withArgs(certificationCandidateId)
+        .resolves(candidateWithComplementaryCertifications);
+
+      const pixPlusDroitExpertBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
+        badge: domainBuilder.buildBadge({ key: Badge.keys.PIX_DROIT_EXPERT_CERTIF }),
+      });
+      certificationBadgesService.findStillValidBadgeAcquisitions
+        .withArgs({ userId })
+        .resolves([pixPlusDroitExpertBadgeAcquisition]);
+
+      certificationBadgesService.hasStillValidCleaBadgeAcquisition.withArgs({ userId }).resolves(true);
+
+      // when
+      const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+        certificationCandidateId,
+        certificationBadgesService,
+        certificationCandidateRepository,
+      });
+
+      // then
+      expect(certificationCandidateSubscription).to.deep.equal(
+        domainBuilder.buildCertificationCandidateSubscription({
+          id: certificationCandidateId,
+          sessionId,
+          eligibleSubscriptions: [pixPlusDroitComplementaryCertification, cleaComplementaryCertifications],
+          nonEligibleSubscriptions: [],
+        })
+      );
+    });
+  });
+
+  context('when the candidate is registered to both Pix+ Droit and CléA but he is not eligible to both', function () {
+    it('should return the candidate with both Pix+ Droit and CléA as non eligible complementary certifications', async function () {
+      // given
+      const certificationCandidateId = 123;
+      const userId = 456;
+      const sessionId = 789;
+
+      const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
+        name: ComplementaryCertification.PIX_PLUS_DROIT,
+      });
+      const cleaComplementaryCertifications = domainBuilder.buildComplementaryCertification({
+        name: ComplementaryCertification.CLEA,
+      });
+      const candidateWithComplementaryCertifications = domainBuilder.buildCertificationCandidate({
+        id: certificationCandidateId,
+        userId,
+        sessionId,
+        complementaryCertifications: [pixPlusDroitComplementaryCertification, cleaComplementaryCertifications],
+      });
+      certificationCandidateRepository.getWithComplementaryCertifications
+        .withArgs(certificationCandidateId)
+        .resolves(candidateWithComplementaryCertifications);
+
+      certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId }).resolves([]);
+
+      certificationBadgesService.hasStillValidCleaBadgeAcquisition.withArgs({ userId }).resolves(false);
+
+      // when
+      const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+        certificationCandidateId,
+        certificationBadgesService,
+        certificationCandidateRepository,
+      });
+
+      // then
+      expect(certificationCandidateSubscription).to.deep.equal(
+        domainBuilder.buildCertificationCandidateSubscription({
+          id: certificationCandidateId,
+          sessionId,
+          eligibleSubscriptions: [],
+          nonEligibleSubscriptions: [pixPlusDroitComplementaryCertification, cleaComplementaryCertifications],
+        })
+      );
+    });
+  });
+
+  context('when the candidate is not registered to both Pix+ Droit and CléA but he is eligible to both', function () {
+    it('should return the candidate without complementary certifications', async function () {
+      // given
+      const certificationCandidateId = 123;
+      const userId = 456;
+      const sessionId = 789;
+
+      const candidateWithoutComplementaryCertifications = domainBuilder.buildCertificationCandidate({
+        id: certificationCandidateId,
+        userId,
+        sessionId,
+        complementaryCertifications: [],
+      });
+      certificationCandidateRepository.getWithComplementaryCertifications
+        .withArgs(certificationCandidateId)
+        .resolves(candidateWithoutComplementaryCertifications);
+
+      // when
+      const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+        certificationCandidateId,
+        certificationBadgesService,
+        certificationCandidateRepository,
+      });
+
+      // then
+      expect(certificationCandidateSubscription).to.deep.equal(
+        domainBuilder.buildCertificationCandidateSubscription({
+          id: certificationCandidateId,
+          sessionId,
+          eligibleSubscriptions: [],
+          nonEligibleSubscriptions: [],
+        })
+      );
+    });
+  });
+
+  context('when the candidate is registered to both Pix+ Droit and CléA but he is eligible to only one', function () {
+    it('should return the candidate with Pix+ Droit as non eligible and CléA as eligible', async function () {
+      // given
+      const certificationCandidateId = 123;
+      const userId = 456;
+      const sessionId = 789;
+
+      const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
+        name: ComplementaryCertification.PIX_PLUS_DROIT,
+      });
+      const cleaComplementaryCertifications = domainBuilder.buildComplementaryCertification({
+        name: ComplementaryCertification.CLEA,
+      });
+      const candidateWithComplementaryCertifications = domainBuilder.buildCertificationCandidate({
+        id: certificationCandidateId,
+        userId,
+        sessionId,
+        complementaryCertifications: [pixPlusDroitComplementaryCertification, cleaComplementaryCertifications],
+      });
+      certificationCandidateRepository.getWithComplementaryCertifications
+        .withArgs(certificationCandidateId)
+        .resolves(candidateWithComplementaryCertifications);
+
+      certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId }).resolves([]);
+
+      certificationBadgesService.hasStillValidCleaBadgeAcquisition.withArgs({ userId }).resolves(true);
+
+      // when
+      const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+        certificationCandidateId,
+        certificationBadgesService,
+        certificationCandidateRepository,
+      });
+
+      // then
+      expect(certificationCandidateSubscription).to.deep.equal(
+        domainBuilder.buildCertificationCandidateSubscription({
+          id: certificationCandidateId,
+          sessionId,
+          eligibleSubscriptions: [cleaComplementaryCertifications],
+          nonEligibleSubscriptions: [pixPlusDroitComplementaryCertification],
+        })
+      );
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer_test.js
@@ -1,0 +1,43 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer');
+
+describe('Unit | Serializer | JSONAPI | certification-candidate-subscription-serializer', function () {
+  describe('#serialize', function () {
+    it('should return a serialized JSON data object', function () {
+      const certificationCandidateSubscription = domainBuilder.buildCertificationCandidateSubscription({
+        id: 123,
+        sessionId: 456,
+        eligibleSubscriptions: [domainBuilder.buildComplementaryCertification({ name: 'Comp 1' })],
+        nonEligibleSubscriptions: [domainBuilder.buildComplementaryCertification({ name: 'Comp 2' })],
+      });
+
+      const expectedSerializedResult = {
+        data: {
+          id: '123',
+          type: 'certification-candidate-subscriptions',
+          attributes: {
+            'eligible-subscriptions': [
+              {
+                id: 1,
+                name: 'Comp 1',
+              },
+            ],
+            'non-eligible-subscriptions': [
+              {
+                id: 1,
+                name: 'Comp 2',
+              },
+            ],
+            'session-id': 456,
+          },
+        },
+      };
+
+      // when
+      const result = serializer.serialize(certificationCandidateSubscription);
+
+      // then
+      expect(result).to.deep.equal(expectedSerializedResult);
+    });
+  });
+});

--- a/mon-pix/app/adapters/certification-candidate-subscription.js
+++ b/mon-pix/app/adapters/certification-candidate-subscription.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class AccountRecoveryDemandAdapter extends ApplicationAdapter {
+  urlForFindRecord(id) {
+    return `${this.host}/${this.namespace}/certification-candidates/${id}/subscriptions`;
+  }
+}

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -81,7 +81,7 @@ export default class CertificationJoiner extends Component {
     try {
       currentCertificationCandidate = this.createCertificationCandidate();
       await currentCertificationCandidate.save({ adapterOptions: { joinSession: true, sessionId: this.sessionId } });
-      this.args.onStepChange(this.sessionId);
+      this.args.onStepChange(currentCertificationCandidate.id);
     } catch (err) {
       if (currentCertificationCandidate) {
         currentCertificationCandidate.deleteRecord();

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -18,9 +18,22 @@ export default class CertificationJoiner extends Component {
     return this.inputAccessCode.toUpperCase();
   }
 
+  get allComplementaryCertificationsLength() {
+    return (
+      this.args.certificationCandidateSubscription.eligibleSubscriptions.length +
+      this.args.certificationCandidateSubscription.nonEligibleSubscriptions.length
+    );
+  }
+
   get nonEligibleSubscriptionNames() {
     return this.args.certificationCandidateSubscription.nonEligibleSubscriptions
       .map((nonEligibleSubscription) => nonEligibleSubscription.name)
+      .join(', ');
+  }
+
+  get eligibleSubscriptionNames() {
+    return this.args.certificationCandidateSubscription.eligibleSubscriptions
+      .map((eligibleSubscription) => eligibleSubscription.name)
       .join(', ');
   }
 

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -18,6 +18,12 @@ export default class CertificationJoiner extends Component {
     return this.inputAccessCode.toUpperCase();
   }
 
+  get nonEligibleSubscriptionNames() {
+    return this.args.certificationCandidateSubscription.nonEligibleSubscriptions
+      .map((nonEligibleSubscription) => nonEligibleSubscription.name)
+      .join(', ');
+  }
+
   @action
   async submit(e) {
     e.preventDefault();
@@ -29,7 +35,7 @@ export default class CertificationJoiner extends Component {
 
     const newCertificationCourse = this.store.createRecord('certification-course', {
       accessCode: this.accessCode,
-      sessionId: this.args.sessionId,
+      sessionId: this.args.certificationCandidateSubscription.sessionId,
     });
     try {
       await newCertificationCourse.save();

--- a/mon-pix/app/controllers/certifications/join.js
+++ b/mon-pix/app/controllers/certifications/join.js
@@ -19,7 +19,7 @@ export default class JoinCertificationController extends Controller {
   }
 
   @action
-  changeStep(sessionId) {
-    this.router.transitionTo('certifications.start', sessionId);
+  changeStep(certificationCandidateId) {
+    this.router.transitionTo('certifications.start', certificationCandidateId);
   }
 }

--- a/mon-pix/app/controllers/certifications/join.js
+++ b/mon-pix/app/controllers/certifications/join.js
@@ -3,15 +3,14 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class StartCertificationController extends Controller {
+export default class JoinCertificationController extends Controller {
   @service currentUser;
+  @service router;
 
   @tracked displayCongratulationsBanner = true;
-  @tracked currentStep = 'join';
-  @tracked sessionId = null;
 
   get showCongratulationsBanner() {
-    return this.displayCongratulationsBanner && this.currentStep === 'join';
+    return this.displayCongratulationsBanner;
   }
 
   @action
@@ -21,7 +20,6 @@ export default class StartCertificationController extends Controller {
 
   @action
   changeStep(sessionId) {
-    this.sessionId = sessionId;
-    this.currentStep = 'start';
+    this.router.transitionTo('certifications.start', sessionId);
   }
 }

--- a/mon-pix/app/models/certification-candidate-subscription.js
+++ b/mon-pix/app/models/certification-candidate-subscription.js
@@ -1,7 +1,12 @@
 import Model, { attr } from '@ember-data/model';
+import isEmpty from 'lodash/isEmpty';
 
 export default class CertificationCandidateSubscription extends Model {
   @attr sessionId;
   @attr eligibleSubscriptions;
   @attr nonEligibleSubscriptions;
+
+  get hasSubscriptions() {
+    return !isEmpty(this.eligibleSubscriptions) || !isEmpty(this.nonEligibleSubscriptions);
+  }
 }

--- a/mon-pix/app/models/certification-candidate-subscription.js
+++ b/mon-pix/app/models/certification-candidate-subscription.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CertificationCandidateSubscription extends Model {
+  @attr sessionId;
+  @attr eligibleSubscriptions;
+  @attr nonEligibleSubscriptions;
+}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -56,7 +56,8 @@ Router.map(function () {
 
   this.route('update-expired-password', { path: '/mise-a-jour-mot-de-passe-expire' });
   this.route('certifications', function () {
-    this.route('start', { path: '/' });
+    this.route('join', { path: '/' });
+    this.route('start', { path: '/commencer/:session_id' });
     this.route('resume', { path: '/:certification_course_id' });
     this.route('results', { path: '/:certification_number/results' });
   });

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -57,7 +57,7 @@ Router.map(function () {
   this.route('update-expired-password', { path: '/mise-a-jour-mot-de-passe-expire' });
   this.route('certifications', function () {
     this.route('join', { path: '/' });
-    this.route('start', { path: '/commencer/:session_id' });
+    this.route('start', { path: '/candidat/:certification_candidate_id' });
     this.route('resume', { path: '/:certification_course_id' });
     this.route('results', { path: '/:certification_number/results' });
   });

--- a/mon-pix/app/routes/certifications/join.js
+++ b/mon-pix/app/routes/certifications/join.js
@@ -1,8 +1,12 @@
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 export default class StartRoute extends Route.extend(SecuredRouteMixin) {
-  model(params) {
-    return { sessionId: params.session_id };
+  @service currentUser;
+
+  model() {
+    const user = this.currentUser.user;
+    return user.belongsTo('isCertifiable').reload();
   }
 }

--- a/mon-pix/app/routes/certifications/start.js
+++ b/mon-pix/app/routes/certifications/start.js
@@ -3,6 +3,6 @@ import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 export default class StartRoute extends Route.extend(SecuredRouteMixin) {
   model(params) {
-    return { sessionId: params.session_id };
+    return this.store.findRecord('certification-candidate-subscription', params.certification_candidate_id);
   }
 }

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -35,12 +35,18 @@
     font-size: 1rem;
   }
 
-  &__eligible-item {
+  &__eligible-item,
+  &__non-eligible-item {
     font-weight: 500;
   }
 
   &__eligible-icon {
     color: $green;
+  }
+
+  &__non-eligible-item,
+  &__non-eligible-icon {
+    color: $grey-50;
   }
 
   &__non-eligible {
@@ -51,7 +57,7 @@
     padding: 10px 16px;
   }
 
-  &__non-eligible-icon {
+  &__info-icon {
     margin-right: 10px;
   }
 }

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -20,6 +20,42 @@
   margin-bottom: 20px;
 }
 
+.certification-starter-subscriptions {
+  color: $grey-90;
+  font-size: 0.875rem;
+  margin-bottom: 32px;
+
+  &__eligible {
+    background-color: $grey-10;
+    padding: 16px 0;
+    text-align: center;
+  }
+
+  &__eligible-title {
+    font-size: 1rem;
+  }
+
+  &__eligible-item {
+    font-weight: 500;
+  }
+
+  &__eligible-icon {
+    color: $green;
+  }
+
+  &__non-eligible {
+    align-items: center;
+    background-color: $yellow-alert-light;
+    color: $yellow-alert-dark;
+    display: flex;
+    padding: 10px 16px;
+  }
+
+  &__non-eligible-icon {
+    margin-right: 10px;
+  }
+}
+
 .certification-course-page__order {
   color: $grey-80;
   font-family: $font-open-sans;

--- a/mon-pix/app/styles/globals/_colors.scss
+++ b/mon-pix/app/styles/globals/_colors.scss
@@ -25,6 +25,8 @@ $purple: #8845FF;
 // extended
 $blue-10: #C4E6FF;
 $blue-60: #0D25B3;
+$yellow-alert-light: #FFF1C5;
+$yellow-alert-dark: #A95800;
 
 // gradients
 $default-gradient: linear-gradient(135deg, $blue 0%, $purple 100%);

--- a/mon-pix/app/templates/certifications/join.hbs
+++ b/mon-pix/app/templates/certifications/join.hbs
@@ -1,0 +1,30 @@
+{{page-title (t "pages.certification-start.title")}}
+<BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
+  <burger.outlet>
+
+    <NavbarHeader @burger={{burger}} />
+    <main class="main">
+      <PixBackgroundHeader id="main">
+
+        {{#if this.model.isCertifiable}}
+          <PixBlock @shadow="heavy" class="certification-start-page__block">
+            {{#if this.showCongratulationsBanner}}
+              <CongratulationsCertificationBanner
+                @certificationEligibility={{this.model}}
+                @fullName={{this.currentUser.user.fullName}}
+                @closeBanner={{this.closeBanner}}
+              />
+            {{/if}}
+            <CertificationJoiner @onStepChange={{this.changeStep}} />
+          </PixBlock>
+        {{else}}
+          <CertificationNotCertifiable />
+        {{/if}}
+
+      </PixBackgroundHeader>
+    </main>
+
+    <Footer />
+
+  </burger.outlet>
+</BurgerMenu>

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -6,7 +6,7 @@
     <main class="main">
       <PixBackgroundHeader id="main">
         <PixBlock @shadow="heavy" class="certification-start-page__block">
-          <CertificationStarter @sessionId={{@model.sessionId}} />
+          <CertificationStarter @certificationCandidateSubscription={{@model}} />
         </PixBlock>
       </PixBackgroundHeader>
     </main>

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -5,26 +5,9 @@
     <NavbarHeader @burger={{burger}} />
     <main class="main">
       <PixBackgroundHeader id="main">
-
-        {{#if this.model.isCertifiable}}
-          <PixBlock @shadow="heavy" class="certification-start-page__block">
-            {{#if this.showCongratulationsBanner}}
-              <CongratulationsCertificationBanner
-                @certificationEligibility={{this.model}}
-                @fullName={{this.currentUser.user.fullName}}
-                @closeBanner={{this.closeBanner}}
-              />
-            {{/if}}
-            {{#if (eq this.currentStep "join")}}
-              <CertificationJoiner @onStepChange={{this.changeStep}} />
-            {{else}}
-              <CertificationStarter @sessionId={{this.sessionId}} />
-            {{/if}}
-          </PixBlock>
-        {{else}}
-          <CertificationNotCertifiable />
-        {{/if}}
-
+        <PixBlock @shadow="heavy" class="certification-start-page__block">
+          <CertificationStarter @sessionId={{@model.sessionId}} />
+        </PixBlock>
       </PixBackgroundHeader>
     </main>
 

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -2,6 +2,34 @@
 <section class="certification-starter">
   <h2 class="certification-start-page__title">{{t "pages.certification-start.first-title"}}</h2>
 
+  {{#if @certificationCandidateSubscription.hasSubscriptions}}
+    <div class="certification-starter-subscriptions">
+      {{#if @certificationCandidateSubscription.eligibleSubscriptions.length}}
+        <div class="certification-starter-subscriptions__eligible" data-test-id="eligible-subscriptions">
+          <p class="certification-starter-subscriptions__eligible-title">{{t
+              "pages.certification-start.eligible-subscriptions"
+              itemCount=@certificationCandidateSubscription.eligibleSubscriptions.length
+            }}</p>
+          {{#each @certificationCandidateSubscription.eligibleSubscriptions as |eligibleSubscription|}}
+            <span class="certification-starter-subscriptions__eligible-item">
+              <FaIcon @icon="check-circle" class="certification-starter-subscriptions__eligible-icon" />
+              {{eligibleSubscription.name}}
+            </span>
+          {{/each}}
+        </div>
+      {{/if}}
+      {{#if this.nonEligibleSubscriptionNames.length}}
+        <div class="certification-starter-subscriptions__non-eligible" data-test-id="non-eligible-subscriptions">
+          <FaIcon @icon="exclamation-circle" class="certification-starter-subscriptions__non-eligible-icon" />
+          <span>{{t
+              "pages.certification-start.non-eligible-subscriptions"
+              subscriptions=this.nonEligibleSubscriptionNames
+              itemCount=@certificationCandidateSubscription.nonEligibleSubscriptions.length
+            }}<br />{{t "pages.certification-start.non-eligible-subscriptions2"}}</span>
+        </div>
+      {{/if}}
+    </div>
+  {{/if}}
   <p class="certification-course-page__order">
     {{t "pages.certification-start.access-code"}}
   </p>

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -4,11 +4,11 @@
 
   {{#if @certificationCandidateSubscription.hasSubscriptions}}
     <div class="certification-starter-subscriptions">
-      {{#if @certificationCandidateSubscription.eligibleSubscriptions.length}}
+      {{#if (gt this.allComplementaryCertificationsLength 0)}}
         <div class="certification-starter-subscriptions__eligible" data-test-id="eligible-subscriptions">
           <p class="certification-starter-subscriptions__eligible-title">{{t
               "pages.certification-start.eligible-subscriptions"
-              itemCount=@certificationCandidateSubscription.eligibleSubscriptions.length
+              itemCount=this.allComplementaryCertificationsLength
             }}</p>
           {{#each @certificationCandidateSubscription.eligibleSubscriptions as |eligibleSubscription|}}
             <span class="certification-starter-subscriptions__eligible-item">
@@ -16,16 +16,25 @@
               {{eligibleSubscription.name}}
             </span>
           {{/each}}
+          {{#each @certificationCandidateSubscription.nonEligibleSubscriptions as |nonEligibleSubscription|}}
+            <span class="certification-starter-subscriptions__non-eligible-item">
+              <FaIcon @icon="check-circle" class="certification-starter-subscriptions__non-eligible-icon" />
+              {{nonEligibleSubscription.name}}
+            </span>
+          {{/each}}
         </div>
       {{/if}}
       {{#if this.nonEligibleSubscriptionNames.length}}
         <div class="certification-starter-subscriptions__non-eligible" data-test-id="non-eligible-subscriptions">
-          <FaIcon @icon="exclamation-circle" class="certification-starter-subscriptions__non-eligible-icon" />
+          <FaIcon @icon="exclamation-circle" class="certification-starter-subscriptions__info-icon" />
           <span>{{t
               "pages.certification-start.non-eligible-subscriptions"
-              subscriptions=this.nonEligibleSubscriptionNames
+              nonEligibleSubscription=this.nonEligibleSubscriptionNames
+              eligibleSubscription=this.eligibleSubscriptionNames
+              eligibleSubscriptionLength=this.eligibleSubscriptionNames.length
               itemCount=@certificationCandidateSubscription.nonEligibleSubscriptions.length
-            }}<br />{{t "pages.certification-start.non-eligible-subscriptions2"}}</span>
+            }}
+          </span>
         </div>
       {{/if}}
     </div>

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -110,4 +110,9 @@ export default function () {
   });
 
   this.post('/shared-certifications', postSharedCertifications);
+
+  this.get('/certification-candidates/:id/subscriptions', (schema, request) => {
+    const certificationCandidateId = request.params.id;
+    return schema.certificationCandidateSubscriptions.find(certificationCandidateId);
+  });
 }

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -184,13 +184,13 @@ describe('Acceptance | Certification | Start Certification Course', function () 
             });
           });
 
-          it('should render the component to provide the access code', function () {
+          it('should redirect to certification start route', function () {
             // then
-            expect(find('.certification-start-page__title')).to.exist;
+            expect(currentURL()).to.equal('/certifications/commencer/1');
           });
         });
 
-        context('when user is successfuly linked to the candidate', function () {
+        context('when user is successfully linked to the candidate', function () {
           beforeEach(async function () {
             // when
             await fillCertificationJoiner({
@@ -204,9 +204,9 @@ describe('Acceptance | Certification | Start Certification Course', function () 
             });
           });
 
-          it('should render the component to provide the access code', function () {
+          it('should redirect to certification start route', function () {
             // then
-            expect(find('.certification-start-page__title')).to.exist;
+            expect(currentURL()).to.equal('/certifications/commencer/1');
           });
         });
 

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -172,6 +172,12 @@ describe('Acceptance | Certification | Start Certification Course', function () 
               sessionId: 1,
               birthdate: '1990-01-04',
             });
+            this.server.create('certification-candidate-subscription', {
+              id: 1,
+              sessionId: 1,
+              eligibleSubscriptions: [],
+              nonEligibleSubscriptions: [],
+            });
             // when
             await fillCertificationJoiner({
               sessionId: '1',
@@ -186,12 +192,20 @@ describe('Acceptance | Certification | Start Certification Course', function () 
 
           it('should redirect to certification start route', function () {
             // then
-            expect(currentURL()).to.equal('/certifications/commencer/1');
+            expect(currentURL()).to.equal('/certifications/candidat/1');
           });
         });
 
         context('when user is successfully linked to the candidate', function () {
           beforeEach(async function () {
+            // given
+            this.server.create('certification-candidate-subscription', {
+              id: 2,
+              sessionId: 1,
+              eligibleSubscriptions: [],
+              nonEligibleSubscriptions: [],
+            });
+
             // when
             await fillCertificationJoiner({
               sessionId: '1',
@@ -206,7 +220,7 @@ describe('Acceptance | Certification | Start Certification Course', function () 
 
           it('should redirect to certification start route', function () {
             // then
-            expect(currentURL()).to.equal('/certifications/commencer/1');
+            expect(currentURL()).to.equal('/certifications/candidat/2');
           });
         });
 
@@ -227,6 +241,13 @@ describe('Acceptance | Certification | Start Certification Course', function () 
               lastName: 'Bravo',
             });
             assessment = certificationCourse.assessment;
+
+            this.server.create('certification-candidate-subscription', {
+              id: 2,
+              sessionId: 1,
+              eligibleSubscriptions: [],
+              nonEligibleSubscriptions: [],
+            });
           });
 
           context('when user enter a correct code session', function () {

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -85,7 +85,7 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
 
         // then
         expect(contains('156')).to.exist;
-        expect(contains('Area_1_title')).to.exist;
+        expect(contains('AREA_1_TITLE')).to.exist;
         expect(contains('Area_1_Competence_1_name')).to.exist;
       });
     });

--- a/mon-pix/tests/helpers/contains.js
+++ b/mon-pix/tests/helpers/contains.js
@@ -2,6 +2,6 @@ import { getRootElement } from '@ember/test-helpers';
 
 export function contains(text) {
   const element = getRootElement();
-  if (element.textContent.match(text)) return element;
+  if (element.innerText.includes(text)) return element;
   return null;
 }

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/archived_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/archived_test.js
@@ -35,8 +35,8 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         // then
         expect(contains('My organization')).to.exist;
         expect(contains('My campaign')).to.exist;
-        expect(contains("Parcours archivé par votre organisation.Vos résultats n'ont pas pu être envoyés.")).to.exist;
-        expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.archived'))).to.exist;
+        expect(contains("Parcours archivé par votre organisation.\nVos résultats n'ont pas pu être envoyés.")).to.exist;
+        expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.archived').toUpperCase())).to.exist;
         expect(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' })))
           .to.exist;
       });

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ongoing_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ongoing_test.js
@@ -30,7 +30,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Ongoi
     // then
     expect(contains('My organization')).to.exist;
     expect(contains('My campaign')).to.exist;
-    expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.started'))).to.exist;
+    expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.started').toUpperCase())).to.exist;
     expect(contains(this.intl.t('pages.campaign-participation-overview.card.resume'))).to.exist;
     expect(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '10/12/2020' }))).to
       .exist;

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/to-share_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/to-share_test.js
@@ -30,7 +30,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | ToSha
     // then
     expect(contains('My organization')).to.exist;
     expect(contains('My campaign')).to.exist;
-    expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.completed'))).to.exist;
+    expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.completed').toUpperCase())).to.exist;
     expect(contains(this.intl.t('pages.campaign-participation-overview.card.send'))).to.exist;
     expect(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '10/12/2020' }))).to
       .exist;

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card_test.js
@@ -25,7 +25,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card', funct
       this.set('campaignParticipationOverview', campaignParticipationOverview);
 
       await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
-      expect(contains('En cours')).to.exist;
+      expect(contains('EN COURS')).to.exist;
     });
   });
 
@@ -42,7 +42,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card', funct
       this.set('campaignParticipationOverview', campaignParticipationOverview);
 
       await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
-      expect(contains('À envoyer')).to.exist;
+      expect(contains('À ENVOYER')).to.exist;
     });
   });
 
@@ -60,7 +60,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card', funct
       this.set('campaignParticipationOverview', campaignParticipationOverview);
 
       await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
-      expect(contains('Terminé')).to.exist;
+      expect(contains('TERMINÉ')).to.exist;
     });
   });
 
@@ -78,7 +78,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card', funct
       this.set('campaignParticipationOverview', campaignParticipationOverview);
 
       await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
-      expect(contains('Archivé')).to.exist;
+      expect(contains('ARCHIVÉ')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -79,14 +79,17 @@ describe('Integration | Component | certification-joiner', function () {
       await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
       const store = this.owner.lookup('service:store');
       const createRecordMock = sinon.mock();
-      createRecordMock.returns({ save: function () {} });
+      createRecordMock.returns({
+        save: function () {},
+        id: '112233',
+      });
       store.createRecord = createRecordMock;
 
       // when
       await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
-      sinon.assert.calledWith(stepChangeStub, '123456');
+      sinon.assert.calledWith(stepChangeStub, '112233');
     });
 
     it('should display an error message if session id contains letters', async function () {

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -144,7 +144,7 @@ describe('Integration | Component | certification-joiner', function () {
       // then
       expect(
         contains(
-          'Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification.\nPour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant.'
+          'Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification. Pour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant.'
         )
       ).to.exist;
     });
@@ -174,7 +174,7 @@ describe('Integration | Component | certification-joiner', function () {
       // then
       expect(
         contains(
-          'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.'
+          'Oups ! Nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez le surveillant.'
         )
       ).to.exist;
     });

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -11,12 +11,172 @@ import { clickByLabel } from '../../helpers/click-by-label';
 describe('Integration | Component | certification-starter', function () {
   setupIntlRenderingTest();
 
+  describe('when the candidate has no complementary certification subscriptions', function () {
+    it('should not display subscriptions panel', async function () {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.set(
+        'certificationCandidateSubscription',
+        store.createRecord('certification-candidate-subscription', {
+          eligibleSubscriptions: [],
+          nonEligibleSubscriptions: [],
+        })
+      );
+      this.set('certificationCandidateSubscription', { eligibleSubscriptions: [], nonEligibleSubscriptions: [] });
+
+      // when
+      await render(
+        hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+      );
+
+      // expect
+      expect(
+        contains(
+          'Vous êtes inscrit aux certification(s) complémentaire(s) suivante(s) en plus de la certification Pix :'
+        )
+      ).to.not.exist;
+      expect(
+        contains(
+          "Vous avez été inscrit à/aux certification(s) complémentaire(s) suivantes : mais vous n'y êtes pas éligible.\n"
+        )
+      ).to.not.exist;
+    });
+  });
+
+  describe('when the candidate has complementary certification subscriptions', function () {
+    describe('when the candidate is eligible', function () {
+      it('should display subscription eligible panel', async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        this.set(
+          'certificationCandidateSubscription',
+          store.createRecord('certification-candidate-subscription', {
+            eligibleSubscriptions: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+            nonEligibleSubscriptions: [],
+          })
+        );
+
+        // when
+        await render(
+          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+        );
+
+        // then
+        expect(
+          contains(
+            'Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :\n\n Certif complémentaire 1  Certif complémentaire 2'
+          )
+        ).to.exist;
+      });
+
+      it('should not display subscription non eligible panel', async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        this.set(
+          'certificationCandidateSubscription',
+          store.createRecord('certification-candidate-subscription', {
+            eligibleSubscriptions: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+            nonEligibleSubscriptions: [],
+          })
+        );
+
+        // when
+        await render(
+          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+        );
+
+        // expect
+        expect(
+          contains(
+            "Vous avez été inscrit aux certifications complémentaires suivantes : mais vous n'y êtes pas éligible."
+          )
+        ).to.not.exist;
+      });
+    });
+
+    describe('when the candidate is not eligible', function () {
+      it('should display subscription non eligible panel for 1 complementary certification', async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        this.set(
+          'certificationCandidateSubscription',
+          store.createRecord('certification-candidate-subscription', {
+            eligibleSubscriptions: [],
+            nonEligibleSubscriptions: [{ name: 'Certif complémentaire 1' }],
+          })
+        );
+
+        // when
+        await render(
+          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+        );
+
+        // expect
+        expect(
+          contains(
+            "Vous avez été inscrit à la certification complémentaire suivante : Certif complémentaire 1 mais vous n'y êtes pas éligible.\nVous pouvez néanmoins passer votre certification Pix si vous le souhaitez."
+          )
+        ).to.exist;
+      });
+
+      it('should display subscription non eligible panel for 2 complementary certifications', async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        this.set(
+          'certificationCandidateSubscription',
+          store.createRecord('certification-candidate-subscription', {
+            eligibleSubscriptions: [],
+            nonEligibleSubscriptions: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+          })
+        );
+
+        // when
+        await render(
+          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+        );
+
+        // expect
+        expect(
+          contains(
+            "Vous avez été inscrit aux certifications complémentaires suivantes : Certif complémentaire 1, Certif complémentaire 2 mais vous n'y êtes pas éligible.\nVous pouvez néanmoins passer votre certification Pix si vous le souhaitez."
+          )
+        ).to.exist;
+      });
+
+      it('should not display subscription eligible panel', async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        this.set(
+          'certificationCandidateSubscription',
+          store.createRecord('certification-candidate-subscription', {
+            eligibleSubscriptions: [],
+            nonEligibleSubscriptions: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+          })
+        );
+
+        // when
+        await render(
+          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+        );
+
+        // expect
+        expect(
+          contains(
+            'Vous êtes inscrit aux certification(s) complémentaire(s) suivante(s) en plus de la certification Pix :'
+          )
+        ).to.not.exist;
+      });
+    });
+  });
+
   describe('#submit', function () {
     context('when no access code is provided', function () {
       it('should display an appropriated error message', async function () {
         // given
-        this.set('sessionId', '123');
-        await render(hbs`<CertificationStarter @sessionId={{this.sessionId}}/>`);
+        this.set('certificationCandidateSubscription', { sessionId: 123 });
+        await render(
+          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+        );
 
         // when
         await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
@@ -46,8 +206,10 @@ describe('Integration | Component | certification-starter', function () {
             deleteRecord: sinon.stub(),
           };
           createRecordStub.returns(certificationCourse);
-          this.set('sessionId', '123');
-          await render(hbs`<CertificationStarter @sessionId={{this.sessionId}}/>`);
+          this.set('certificationCandidateSubscription', { sessionId: 123 });
+          await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+          );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
           replaceWithStub.returns('ok');
 
@@ -57,7 +219,7 @@ describe('Integration | Component | certification-starter', function () {
           // then
           sinon.assert.calledWithExactly(createRecordStub, 'certification-course', {
             accessCode: 'ABC123',
-            sessionId: '123',
+            sessionId: 123,
           });
           sinon.assert.calledOnce(certificationCourse.save);
           sinon.assert.calledWithExactly(replaceWithStub, 'certifications.resume', 456);
@@ -83,8 +245,10 @@ describe('Integration | Component | certification-starter', function () {
             deleteRecord: sinon.stub(),
           };
           createRecordStub.returns(certificationCourse);
-          this.set('sessionId', '123');
-          await render(hbs`<CertificationStarter @sessionId={{this.sessionId}}/>`);
+          this.set('certificationCandidateSubscription', { sessionId: 123 });
+          await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+          );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
           certificationCourse.save.rejects({ errors: [{ status: '404' }] });
 
@@ -113,8 +277,10 @@ describe('Integration | Component | certification-starter', function () {
             deleteRecord: sinon.stub(),
           };
           createRecordStub.returns(certificationCourse);
-          this.set('sessionId', '123');
-          await render(hbs`<CertificationStarter @sessionId={{this.sessionId}}/>`);
+          this.set('certificationCandidateSubscription', { sessionId: 123 });
+          await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+          );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
           certificationCourse.save.rejects({ errors: [{ status: '412' }] });
 
@@ -143,8 +309,10 @@ describe('Integration | Component | certification-starter', function () {
             deleteRecord: sinon.stub(),
           };
           createRecordStub.returns(certificationCourse);
-          this.set('sessionId', '123');
-          await render(hbs`<CertificationStarter @sessionId={{this.sessionId}}/>`);
+          this.set('certificationCandidateSubscription', { sessionId: 123 });
+          await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+          );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
           certificationCourse.save.rejects({
             errors: [{ status: '403', detail: "Message d'erreur envoyé par l 'API" }],
@@ -175,8 +343,10 @@ describe('Integration | Component | certification-starter', function () {
             deleteRecord: sinon.stub(),
           };
           createRecordStub.returns(certificationCourse);
-          this.set('sessionId', '123');
-          await render(hbs`<CertificationStarter @sessionId={{this.sessionId}}/>`);
+          this.set('certificationCandidateSubscription', { sessionId: 123 });
+          await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+          );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
           certificationCourse.save.rejects({ errors: [{ status: 'other' }] });
 

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -114,7 +114,7 @@ describe('Integration | Component | certification-starter', function () {
         // expect
         expect(
           contains(
-            "Vous avez été inscrit à la certification complémentaire suivante : Certif complémentaire 1 mais vous n'y êtes pas éligible.\nVous pouvez néanmoins passer votre certification Pix si vous le souhaitez."
+            'Vous n’êtes pas éligible à Certif complémentaire 1. Vous pouvez néanmoins passer votre certification Pix'
           )
         ).to.exist;
       });
@@ -138,12 +138,12 @@ describe('Integration | Component | certification-starter', function () {
         // expect
         expect(
           contains(
-            "Vous avez été inscrit aux certifications complémentaires suivantes : Certif complémentaire 1, Certif complémentaire 2 mais vous n'y êtes pas éligible.\nVous pouvez néanmoins passer votre certification Pix si vous le souhaitez."
+            'Vous n’êtes pas éligible à Certif complémentaire 1, Certif complémentaire 2. Vous pouvez néanmoins passer votre certification Pix'
           )
         ).to.exist;
       });
 
-      it('should not display subscription eligible panel', async function () {
+      it('should display subscription panel', async function () {
         // given
         const store = this.owner.lookup('service:store');
         this.set(
@@ -161,10 +161,8 @@ describe('Integration | Component | certification-starter', function () {
 
         // expect
         expect(
-          contains(
-            'Vous êtes inscrit aux certification(s) complémentaire(s) suivante(s) en plus de la certification Pix :'
-          )
-        ).to.not.exist;
+          contains('Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :')
+        ).to.exist;
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -267,7 +267,7 @@
     },
     "certification-start": {
       "title": "Join a certification session",
-      "access-code": "Enter the access code sent by the invigilator",
+      "access-code": "Access code sent by the invigilator",
       "eligible-subscriptions": "You are registered for the following additional {itemCount, plural, one {certification}  other {certification(s)}} in combination with the Pix Certification:",
       "non-eligible-subscriptions": "You have been registered for the following additional {itemCount, plural, one {certification}  other {certification(s)}}: {subscriptions} but you are not eligible.",
       "non-eligible-subscriptions2": "However, you can still take your Pix Certification if you want to.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -268,6 +268,9 @@
     "certification-start": {
       "title": "Join a certification session",
       "access-code": "Enter the access code sent by the invigilator",
+      "eligible-subscriptions": "You are registered for the following additional {itemCount, plural, one {certification}  other {certification(s)}} in combination with the Pix Certification:",
+      "non-eligible-subscriptions": "You have been registered for the following additional {itemCount, plural, one {certification}  other {certification(s)}}: {subscriptions} but you are not eligible.",
+      "non-eligible-subscriptions2": "However, you can still take your Pix Certification if you want to.",
       "actions": {
         "submit": "Start my test"
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -269,8 +269,7 @@
       "title": "Join a certification session",
       "access-code": "Access code sent by the invigilator",
       "eligible-subscriptions": "You are registered for the following additional {itemCount, plural, one {certification}  other {certification(s)}} in combination with the Pix Certification:",
-      "non-eligible-subscriptions": "You have been registered for the following additional {itemCount, plural, one {certification}  other {certification(s)}}: {subscriptions} but you are not eligible.",
-      "non-eligible-subscriptions2": "However, you can still take your Pix Certification if you want to.",
+      "non-eligible-subscriptions": "You are not eligible to {nonEligibleSubscription}. However, you can still take your Pix Certification{eligibleSubscriptionLength, plural, =0 {} other { and }}{eligibleSubscription}.",
       "actions": {
         "submit": "Start my test"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -267,6 +267,9 @@
     },
     "certification-start": {
       "title": "Rejoindre une session de certification",
+      "eligible-subscriptions": "Vous êtes inscrit {itemCount, plural, one {à la certification complémentaire suivante}  other {aux certifications complémentaires suivantes}} en plus de la certification Pix :",
+      "non-eligible-subscriptions": "Vous avez été inscrit {itemCount, plural, one {à la certification complémentaire suivante}  other {aux certifications complémentaires suivantes}} : {subscriptions} mais vous n'y êtes pas éligible.",
+      "non-eligible-subscriptions2": "Vous pouvez néanmoins passer votre certification Pix si vous le souhaitez.",
       "access-code": "Saisissez le code d'accès communiqué par le surveillant",
       "actions": {
         "submit": "Commencer mon test"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -270,7 +270,7 @@
       "eligible-subscriptions": "Vous êtes inscrit {itemCount, plural, one {à la certification complémentaire suivante}  other {aux certifications complémentaires suivantes}} en plus de la certification Pix :",
       "non-eligible-subscriptions": "Vous avez été inscrit {itemCount, plural, one {à la certification complémentaire suivante}  other {aux certifications complémentaires suivantes}} : {subscriptions} mais vous n'y êtes pas éligible.",
       "non-eligible-subscriptions2": "Vous pouvez néanmoins passer votre certification Pix si vous le souhaitez.",
-      "access-code": "Saisissez le code d'accès communiqué par le surveillant",
+      "access-code": "Code d'accès communiqué par le surveillant",
       "actions": {
         "submit": "Commencer mon test"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -268,8 +268,7 @@
     "certification-start": {
       "title": "Rejoindre une session de certification",
       "eligible-subscriptions": "Vous êtes inscrit {itemCount, plural, one {à la certification complémentaire suivante}  other {aux certifications complémentaires suivantes}} en plus de la certification Pix :",
-      "non-eligible-subscriptions": "Vous avez été inscrit {itemCount, plural, one {à la certification complémentaire suivante}  other {aux certifications complémentaires suivantes}} : {subscriptions} mais vous n'y êtes pas éligible.",
-      "non-eligible-subscriptions2": "Vous pouvez néanmoins passer votre certification Pix si vous le souhaitez.",
+      "non-eligible-subscriptions": "Vous n’êtes pas éligible à {nonEligibleSubscription}. Vous pouvez néanmoins passer votre certification Pix{eligibleSubscriptionLength, plural, =0 {} other { et }}{eligibleSubscription}.",
       "access-code": "Code d'accès communiqué par le surveillant",
       "actions": {
         "submit": "Commencer mon test"


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis la nécessité d'inscrire un candidat en certification complémentaire avant de lui permettre de la passer, certains candidats qui pouvaient auparavant la/les passer ne seront plus en mesure de le faire. Il faudrait donc pouvoir avertir le candidat, avant son entrée en test de certification, quant aux certifications complémentaires qu'il sera amené à passer.

## :gift: Solution
Ajouter, dans la page permettant d'entrer le code d'accès à une session de certifications, deux encarts:
- Le premier listant les certifications complémentaires pour lesquelles le candidat est inscrit et habilité à les passer.
- Le deuxième listant les certifications complémentaires pour lesquelles le candidat est inscrit mais n'est pas habilité à les passer.

## :santa: Pour tester
- Créer une session sur Pix Certif
- Ajouter deux candidat et les inscrire aux certifications Pix+Droit et CléA Numérique
- Se connecter à Pix App avec le compte `anne-success@example.net` et vérifier l'inscription et l'éligibilité à CléA et le non éligibilité à Pix+ Droit
- Se connecter à Pix App avec le compte `certifdroit@example.net` et vérifier l'inscription et l'éligibilité à Pix+Droit et la non éligibilité à CléA.
- Tester avec un candidat non inscrit aux certifications complémentaires et vérifier que rien n'apparaît pour un compte éligible à une ou plusieurs certifications complémentaires.  