### PR TITLE
[FEATURE] Permettre aux utilisateurs ayant un rôle "membre" sur Pix Orga d'accéder à la liste des membres de l'organisation (PIX-531).

### DIFF
--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -36,14 +36,12 @@
         {{t "navigation.main.students-sup"}}
       </LinkTo>
     {{/if}}
-    {{#if this.currentUser.isAdminInOrganization}}
-      <LinkTo @route="authenticated.team" class="sidebar-nav__item">
-        <span class="sidebar-nav__item-icon">
-          <img src="{{this.rootURL}}/icons/users-light.svg" alt="" role="none" />
-        </span>
-        {{t "navigation.main.team"}}
-      </LinkTo>
-    {{/if}}
+    <LinkTo @route="authenticated.team" class="sidebar-nav__item">
+      <span class="sidebar-nav__item-icon">
+        <img src="{{this.rootURL}}/icons/users-light.svg" alt="" role="none" />
+      </span>
+      {{t "navigation.main.team"}}
+    </LinkTo>
     {{#if this.documentationUrl}}
       <a class="sidebar-nav__item" href={{this.documentationUrl}} target="_blank" rel="noopener noreferrer">
         <span class="sidebar-nav__item-icon">

--- a/orga/app/components/team/member-list.js
+++ b/orga/app/components/team/member-list.js
@@ -1,0 +1,6 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class MembersList extends Component {
+  @service currentUser;
+}

--- a/orga/app/components/team/members-list-item.hbs
+++ b/orga/app/components/team/members-list-item.hbs
@@ -4,24 +4,26 @@
 
   {{#unless this.isEditionMode}}
     <td>{{this.displayRole}}</td>
-    {{#if (not-eq @membership.user.id this.currentUser.prescriber.id)}}
-      <td class="zone-edit-role hide-on-mobile">
-        <Dropdown::IconTrigger
-          @icon="ellipsis-v"
-          @dropdownButtonClass="zone-edit-role__dropdown-button"
-          @dropdownContentClass="zone-edit-role__dropdown-content"
-          @ariaLabel={{t "pages.team-members.actions.manage"}}
-        >
-          <Dropdown::Item @onClick={{fn this.editRoleOfMember @membership}}>
-            {{t "pages.team-members.actions.edit-organization-membership-role"}}
-          </Dropdown::Item>
-          <Dropdown::Item @onClick={{fn this.displayRemoveMembershipModal @membership}}>
-            {{t "pages.team-members.actions.remove-membership"}}
-          </Dropdown::Item>
-        </Dropdown::IconTrigger>
-      </td>
-    {{else}}
-      <td class="hide-on-mobile"></td>
+    {{#if this.currentUser.isAdminInOrganization}}
+      {{#if this.isNotCurrentUserMembership}}
+        <td class="zone-edit-role hide-on-mobile">
+          <Dropdown::IconTrigger
+            @icon="ellipsis-v"
+            @dropdownButtonClass="zone-edit-role__dropdown-button"
+            @dropdownContentClass="zone-edit-role__dropdown-content"
+            @ariaLabel={{t "pages.team-members.actions.manage"}}
+          >
+            <Dropdown::Item @onClick={{fn this.editRoleOfMember @membership}}>
+              {{t "pages.team-members.actions.edit-organization-membership-role"}}
+            </Dropdown::Item>
+            <Dropdown::Item @onClick={{fn this.displayRemoveMembershipModal @membership}}>
+              {{t "pages.team-members.actions.remove-membership"}}
+            </Dropdown::Item>
+          </Dropdown::IconTrigger>
+        </td>
+      {{else}}
+        <td class="hide-on-mobile"></td>
+      {{/if}}
     {{/if}}
   {{/unless}}
 
@@ -40,7 +42,12 @@
     </td>
     <td>
       <div class="zone-save-cancel-role">
-        <PixButton id="save-organization-role" @triggerAction={{fn this.updateRoleOfMember @membership}} @size="small">
+        <PixButton
+          id="save-organization-role"
+          @triggerAction={{fn this.updateRoleOfMember @membership}}
+          @size="small"
+          aria-label={{t "pages.team-members.actions.save"}}
+        >
           {{t "pages.team-members.actions.save"}}
         </PixButton>
         <PixIconButton

--- a/orga/app/components/team/members-list-item.js
+++ b/orga/app/components/team/members-list-item.js
@@ -43,6 +43,10 @@ export default class MembersListItem extends Component {
     return this.displayRoleByOrganizationRole[this.args.membership.organizationRole];
   }
 
+  get isNotCurrentUserMembership() {
+    return this.currentUser.prescriber.id !== this.args.membership.user.get('id');
+  }
+
   @action
   setRoleSelection(event) {
     this.selectedNewRole = event.target.value;

--- a/orga/app/components/team/members-list.hbs
+++ b/orga/app/components/team/members-list.hbs
@@ -6,7 +6,9 @@
           <th>{{t "pages.team-members.table.column.last-name"}}</th>
           <th>{{t "pages.team-members.table.column.first-name"}}</th>
           <th>{{t "pages.team-members.table.column.organization-membership-role"}}</th>
-          <th class="hide-on-mobile"></th>
+          {{#if this.currentUser.isAdminInOrganization}}
+            <th class="hide-on-mobile"></th>
+          {{/if}}
         </tr>
       </thead>
       {{#if @members}}

--- a/orga/app/controllers/authenticated/team/list.js
+++ b/orga/app/controllers/authenticated/team/list.js
@@ -1,9 +1,11 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
+  @service currentUser;
   queryParams = ['pageNumber', 'pageSize'];
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;

--- a/orga/app/routes/authenticated/team.js
+++ b/orga/app/routes/authenticated/team.js
@@ -1,13 +1,3 @@
-import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 
-export default class TeamRoute extends Route {
-  @service currentUser;
-
-  beforeModel() {
-    super.beforeModel(...arguments);
-    if (!this.currentUser.isAdminInOrganization) {
-      return this.replaceWith('application');
-    }
-  }
-}
+export default class TeamRoute extends Route {}

--- a/orga/app/routes/authenticated/team/new.js
+++ b/orga/app/routes/authenticated/team/new.js
@@ -5,6 +5,13 @@ export default class NewRoute extends Route {
   @service store;
   @service currentUser;
 
+  beforeModel() {
+    super.beforeModel(...arguments);
+    if (!this.currentUser.isAdminInOrganization) {
+      return this.replaceWith('application');
+    }
+  }
+
   model() {
     const organization = this.currentUser.organization;
     return this.store.createRecord('organizationInvitation', { organizationId: organization.id });

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -23,13 +23,10 @@ $margin-right: 32px;
   }
 }
 
-.list-team-page-header {
-
-  &__add-member-button {
-    margin-top: 20px;
+.list-team-page-header__add-member-button {
     margin-left: auto;
+    margin-bottom: 14px;
   }
-}
 
 .list-team-page-invitations {
   margin-bottom: 35px;

--- a/orga/app/templates/authenticated/team/list.hbs
+++ b/orga/app/templates/authenticated/team/list.hbs
@@ -2,23 +2,23 @@
 
 <div class="list-team-page">
   <div class="list-team-page__header">
-    <div class="page__title page-title">{{t "pages.team-list.title"}}</div>
-    <div class="list-team-page-header__add-member-button">
-      <PixButtonLink @route="authenticated.team.new">
-        {{t "pages.team-list.add-member-button"}}
-      </PixButtonLink>
-    </div>
+    <h1 class="page__title page-title">{{t "pages.team-list.title"}}</h1>
   </div>
 
-  <nav class="panel navbar list-team-page__tabs">
-    <LinkTo @route="authenticated.team.list.members" class="navbar-item">
-      {{t "pages.team-list.tabs.member" count=@model.memberships.meta.rowCount}}
-    </LinkTo>
+  {{#if this.currentUser.isAdminInOrganization}}
+    <PixButtonLink @route="authenticated.team.new" class="list-team-page-header__add-member-button">
+      {{t "pages.team-list.add-member-button"}}
+    </PixButtonLink>
+    <nav class="panel navbar list-team-page__tabs">
+      <LinkTo @route="authenticated.team.list.members" class="navbar-item">
+        {{t "pages.team-list.tabs.member" count=@model.memberships.meta.rowCount}}
+      </LinkTo>
 
-    <LinkTo @route="authenticated.team.list.invitations" class="navbar-item">
-      {{t "pages.team-list.tabs.invitation" count=@model.organization.organizationInvitations.length}}
-    </LinkTo>
-  </nav>
+      <LinkTo @route="authenticated.team.list.invitations" class="navbar-item">
+        {{t "pages.team-list.tabs.invitation" count=@model.organization.organizationInvitations.length}}
+      </LinkTo>
+    </nav>
+  {{/if}}
 
   {{outlet}}
 </div>

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -307,7 +307,8 @@ module('Acceptance | authentication', function (hooks) {
         await visit('/');
 
         // then
-        assert.dom('.sidebar-nav a').exists({ count: 2 });
+
+        assert.dom('.sidebar-nav a').exists({ count: 3 });
         assert.dom('.sidebar-nav').containsText('Campagnes');
         assert.dom('.sidebar-nav').containsText('Documentation');
         assert.dom('.sidebar-nav a:first-child ').hasClass('active');
@@ -345,7 +346,7 @@ module('Acceptance | authentication', function (hooks) {
           await visit('/');
 
           // then
-          assert.dom('.sidebar-nav a').exists({ count: 3 });
+          assert.dom('.sidebar-nav a').exists({ count: 4 });
           assert.dom('.sidebar-nav').containsText('Campagnes');
           assert.dom('.sidebar-nav').containsText('Élèves');
           assert.dom('.sidebar-nav a:first-child ').hasClass('active');

--- a/orga/tests/acceptance/team-list_test.js
+++ b/orga/tests/acceptance/team-list_test.js
@@ -26,32 +26,48 @@ module('Acceptance | Team List', function (hooks) {
   });
 
   module('When prescriber is logged in', function () {
-    module('When prescriber is a member', function (hooks) {
-      hooks.beforeEach(async () => {
+    module('When prescriber is a member', function () {
+      test('it should show title of team page', async function (assert) {
+        // given
         user = createUserMembershipWithRole('MEMBER');
         createPrescriberByUser(user);
 
         await authenticateSession(user.id);
-      });
 
-      test('it should not be accessible', async function (assert) {
         // when
         await visit('/equipe');
 
         // then
-        assert.equal(currentURL(), '/campagnes');
+        assert.contains('Mon équipe');
+      });
+
+      test('it should be possible to see only members list', async function (assert) {
+        // given
+        user = createUserMembershipWithRole('MEMBER');
+        createPrescriberByUser(user);
+
+        await authenticateSession(user.id);
+
+        // when
+        await visit('/equipe');
+
+        // then
+        assert.equal(currentURL(), '/equipe/membres');
+        assert.notContains('Membres');
+        assert.notContains('Invitations');
+        assert.notContains('Inviter un membre');
+        assert.contains('Rôle');
       });
     });
 
-    module('When prescriber is an admin', function (hooks) {
-      hooks.beforeEach(async () => {
+    module('When prescriber is an admin', function () {
+      test('it should be accessible', async function (assert) {
+        // given
         user = createUserMembershipWithRole('ADMIN');
         createPrescriberByUser(user);
 
         await authenticateSession(user.id);
-      });
 
-      test('it should be accessible', async function (assert) {
         // when
         await visit('/equipe/membres');
 
@@ -60,25 +76,44 @@ module('Acceptance | Team List', function (hooks) {
       });
 
       test('it should show title of team page', async function (assert) {
+        // given
+        user = createUserMembershipWithRole('ADMIN');
+        createPrescriberByUser(user);
+
+        await authenticateSession(user.id);
+
         // when
         await visit('/equipe');
 
         // then
-        assert.dom('.page-title').hasText('Mon équipe');
+        assert.contains('Mon équipe');
+      });
+
+      test('it should show members list, invitations list and add an invitation button', async function (assert) {
+        // given
+        user = createUserMembershipWithRole('ADMIN');
+        createPrescriberByUser(user);
+
+        await authenticateSession(user.id);
+
+        // when
+        await visit('/equipe');
+
+        // then
+        assert.contains('Membres');
+        assert.contains('Invitations');
+        assert.contains('Inviter un membre');
       });
     });
   });
 
-  module('When the prescriber comes back to this route', function (hooks) {
-    hooks.beforeEach(async () => {
-      user = createUserMembershipWithRole('ADMIN');
-      createPrescriberByUser(user);
-
-      await authenticateSession(user.id);
-    });
-
+  module('When the prescriber comes back to this route', function () {
     test('it should land on first page', async function (assert) {
       // given
+      user = createUserMembershipWithRole('ADMIN');
+      createPrescriberByUser(user);
+      await authenticateSession(user.id);
+
       const organizationId = server.db.organizations[0].id;
       times(10, () => {
         server.create('membership', {

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -140,6 +140,21 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       // then
       assert.dom('.sidebar-menu__documentation-item').doesNotExist();
     });
+
+    test('it should display the team for all organisation members', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 1, isPro: true });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const intl = this.owner.lookup('service:intl');
+      intl.setLocale(['fr', 'fr']);
+
+      // when
+      await render(hbs`<Layout::Sidebar />`);
+
+      // then
+      assert.contains('Équipe');
+    });
   });
 
   module('when the user is authenticated on orga.pix.org', function (hooks) {

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -3,6 +3,24 @@ import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import { clickByText, render, clickByName, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import Service from '@ember/service';
+
+class CurrentUserAdminStub extends Service {
+  isAdminInOrganization = true;
+  prescriber = {
+    id: 344535,
+  };
+  organization = {
+    credit: 10000,
+  };
+}
+
+class CurrentUserMemberStub extends Service {
+  isAdminInOrganization = false;
+  organization = {
+    credit: 10000,
+  };
+}
 
 module('Integration | Component | Team::MembersListItem', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -18,197 +36,238 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         id: 111,
         firstName: 'Gigi',
         lastName: 'La Terreur',
+        get: sinon.stub().returns(111),
       },
       save: sinon.stub(),
     };
 
     memberMembership = {
-      id: 1,
+      id: 2,
       displayRole: 'Membre',
       organizationRole: 'MEMBER',
       user: {
-        id: 111,
+        id: 112,
         firstName: 'Jojo',
         lastName: 'La Panique',
+        get: sinon.stub().returns(112),
       },
       save: sinon.stub(),
     };
   });
 
-  test('it should display an administrator firstName, lastName, role and edit button', async function (assert) {
-    // given
-    this.set('membership', adminMembership);
-
-    // when
-    await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
-
-    // then
-    assert.contains('La Terreur');
-    assert.contains('Gigi');
-    assert.contains('Administrateur');
-    assert.dom('button[aria-label="Gérer"]').exists;
-  });
-
-  module('When edit organization role button is clicked', function () {
-    test('it should show update and save button, and show the drop down to select role to update', async function (assert) {
+  module('when user is a member', function () {
+    test('it should display a member, firstName, lastName and role', async function (assert) {
       // given
       this.set('membership', memberMembership);
-
-      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+      this.owner.register('service:current-user', CurrentUserMemberStub);
 
       // when
-      await clickByName('Gérer');
-      await clickByText('Modifier le rôle');
+      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
 
       // then
-      assert.dom('.zone-save-cancel-role').exists({ count: 1 });
-      assert.dom('#save-organization-role').exists({ count: 1 });
-      assert.dom('#cancel-update-organization-role').exists({ count: 1 });
+      assert.contains('La Panique');
+      assert.contains('Jojo');
+      assert.contains('Membre');
     });
 
-    test('it should cancel the update if using the cancel button', async function (assert) {
+    test('it should not display the edit button', async function (assert) {
       // given
       this.set('membership', memberMembership);
-
-      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
-
-      await clickByName('Gérer');
-      await clickByText('Modifier le rôle');
+      this.owner.register('service:current-user', CurrentUserMemberStub);
 
       // when
-      await clickByName('Annuler');
+      const screen = await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
 
       // then
-      assert.equal(memberMembership.organizationRole, 'MEMBER');
-      sinon.assert.notCalled(memberMembership.save);
-    });
-
-    test('it should change the value of the drop down to Administrateur and display the modified role', async function (assert) {
-      // given
-      this.set('membership', memberMembership);
-
-      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
-      await clickByName('Gérer');
-      await clickByText('Modifier le rôle');
-
-      // when
-      await selectByLabelAndOption('Sélectionner un rôle', 'ADMIN');
-      await clickByText('Enregistrer');
-
-      // then
-      assert.equal(memberMembership.organizationRole, 'ADMIN');
-      sinon.assert.called(memberMembership.save);
-    });
-
-    test('it should change the value of the drop down to Membre and display the modified role', async function (assert) {
-      // given
-      this.set('membership', adminMembership);
-
-      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
-      await clickByName('Gérer');
-      await clickByText('Modifier le rôle');
-
-      // when
-      await selectByLabelAndOption('Sélectionner un rôle', 'MEMBER');
-      await clickByText('Enregistrer');
-
-      // then
-      assert.equal(adminMembership.organizationRole, 'MEMBER');
-      sinon.assert.called(adminMembership.save);
-    });
-
-    test('it should display success message when updating a member role', async function (assert) {
-      // given
-      const notifications = this.owner.lookup('service:notifications');
-      sinon.stub(notifications, 'success');
-      this.set('membership', adminMembership);
-
-      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
-      await clickByName('Gérer');
-      await clickByText('Modifier le rôle');
-
-      // when
-      await selectByLabelAndOption('Sélectionner un rôle', 'MEMBER');
-      await clickByText('Enregistrer');
-
-      // then
-      sinon.assert.calledWith(
-        notifications.success,
-        this.intl.t('pages.team-members.notifications.change-member-role.success')
-      );
-      assert.ok(true);
-    });
-
-    test('it should display error message when updating a member role fails', async function (assert) {
-      // given
-      adminMembership.save.rejects();
-      this.set('membership', adminMembership);
-      const notifications = this.owner.lookup('service:notifications');
-      sinon.stub(notifications, 'error');
-
-      await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
-      await clickByName('Gérer');
-      await clickByText('Modifier le rôle');
-
-      // when
-      await selectByLabelAndOption('Sélectionner un rôle', 'MEMBER');
-      await clickByText('Enregistrer');
-
-      // then
-      sinon.assert.calledWith(
-        notifications.error,
-        this.intl.t('pages.team-members.notifications.change-member-role.error')
-      );
-      assert.ok(true);
+      assert.dom(screen.queryByLabelText('Gérer')).doesNotExist();
     });
   });
 
-  module('When remove member button is clicked', (hooks) => {
-    let removeMembershipStub;
-
-    hooks.beforeEach(async function () {
+  module('when current user is an administrator', function () {
+    test('it should display a member firstName, lastName, role and edit button', async function (assert) {
       // given
-      removeMembershipStub = sinon.stub();
-      memberMembership.user.get = (attr) => {
-        return attr === 'firstName' ? memberMembership.user.firstName : memberMembership.user.lastName;
-      };
       this.set('membership', memberMembership);
-      this.set('removeMembership', removeMembershipStub);
+      this.owner.register('service:current-user', CurrentUserAdminStub);
 
       // when
-      await render(hbs`<Team::MembersListItem @membership={{membership}} @onRemoveMember={{removeMembership}} />`);
-      await clickByName('Gérer');
-      await clickByText('Supprimer');
-    });
-
-    test('should display a confirmation modal', function (assert) {
-      // then
-      assert.contains('Confirmez-vous la suppression ?');
-      assert.contains('Annuler');
-      assert.contains('Supprimer');
-    });
-
-    test('should display the membership first name and last name in the modal', function (assert) {
-      // then
-      assert.contains(memberMembership.user.firstName);
-      assert.contains(memberMembership.user.lastName);
-    });
-
-    test('should close the modal by clicking on cancel button', async function (assert) {
-      // when
-      await clickByName('Annuler');
+      const screen = await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
 
       // then
-      assert.notContains("Supprimer de l'équipe");
+
+      assert.contains('La Panique');
+      assert.contains('Jojo');
+      assert.contains('Membre');
+      assert.dom(screen.getByLabelText('Gérer')).exists();
     });
 
-    test('should call removeMembership and close modal by clicking on remove button', async function (assert) {
-      // when
-      await clickByText('Oui, supprimer le membre');
+    module('When edit organization role button is clicked', function () {
+      test('it should show update and save button, and show the drop down to select role to update', async function (assert) {
+        // given
+        this.set('membership', adminMembership);
+        this.owner.register('service:current-user', CurrentUserAdminStub);
 
-      // then
-      sinon.assert.calledWith(removeMembershipStub, memberMembership);
-      assert.notContains("Supprimer de l'équipe");
+        const screen = await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+
+        // when
+        await clickByName('Gérer');
+        await clickByText('Modifier le rôle');
+
+        // then
+        assert.dom('.zone-save-cancel-role').exists({ count: 1 });
+        assert.dom(screen.queryByLabelText('Annuler')).exists();
+        assert.dom(screen.queryByLabelText('Enregistrer')).exists();
+      });
+
+      test('it should cancel the update if using the cancel button', async function (assert) {
+        // given
+        this.set('membership', adminMembership);
+        this.owner.register('service:current-user', CurrentUserAdminStub);
+
+        await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+
+        await clickByName('Gérer');
+        await clickByText('Modifier le rôle');
+
+        // when
+        await clickByName('Annuler');
+
+        // then
+        assert.equal(memberMembership.organizationRole, 'MEMBER');
+        sinon.assert.notCalled(memberMembership.save);
+      });
+
+      test('it should change the value of the drop down to Administrateur and display the modified role', async function (assert) {
+        // given
+        this.owner.register('service:current-user', CurrentUserAdminStub);
+        this.set('membership', memberMembership);
+
+        await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+        await clickByName('Gérer');
+        await clickByText('Modifier le rôle');
+
+        // when
+        await selectByLabelAndOption('Sélectionner un rôle', 'ADMIN');
+        await clickByText('Enregistrer');
+
+        // then
+        assert.equal(memberMembership.organizationRole, 'ADMIN');
+        sinon.assert.called(memberMembership.save);
+      });
+
+      test('it should change the value of the drop down to Membre and display the modified role', async function (assert) {
+        // given
+        this.set('membership', adminMembership);
+        this.owner.register('service:current-user', CurrentUserAdminStub);
+
+        await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+        await clickByName('Gérer');
+        await clickByText('Modifier le rôle');
+
+        // when
+        await selectByLabelAndOption('Sélectionner un rôle', 'MEMBER');
+        await clickByText('Enregistrer');
+
+        // then
+        assert.equal(adminMembership.organizationRole, 'MEMBER');
+        sinon.assert.called(adminMembership.save);
+      });
+
+      test('it should display success message when updating a member role', async function (assert) {
+        // given
+        const notifications = this.owner.lookup('service:notifications');
+        sinon.stub(notifications, 'success');
+        this.set('membership', adminMembership);
+        this.owner.register('service:current-user', CurrentUserAdminStub);
+
+        await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+        await clickByName('Gérer');
+        await clickByText('Modifier le rôle');
+
+        // when
+        await selectByLabelAndOption('Sélectionner un rôle', 'MEMBER');
+        await clickByText('Enregistrer');
+
+        // then
+        sinon.assert.calledWith(
+          notifications.success,
+          this.intl.t('pages.team-members.notifications.change-member-role.success')
+        );
+        assert.ok(true);
+      });
+
+      test('it should display error message when updating a member role fails', async function (assert) {
+        // given
+        adminMembership.save.rejects();
+        this.set('membership', adminMembership);
+        this.owner.register('service:current-user', CurrentUserAdminStub);
+        const notifications = this.owner.lookup('service:notifications');
+        sinon.stub(notifications, 'error');
+
+        await render(hbs`<Team::MembersListItem @membership={{membership}}/>`);
+        await clickByName('Gérer');
+        await clickByText('Modifier le rôle');
+
+        // when
+        await selectByLabelAndOption('Sélectionner un rôle', 'MEMBER');
+        await clickByText('Enregistrer');
+
+        // then
+        sinon.assert.calledWith(
+          notifications.error,
+          this.intl.t('pages.team-members.notifications.change-member-role.error')
+        );
+        assert.ok(true);
+      });
+    });
+
+    module('When remove member button is clicked', (hooks) => {
+      let removeMembershipStub;
+
+      hooks.beforeEach(async function () {
+        // given
+        this.owner.register('service:current-user', CurrentUserAdminStub);
+        removeMembershipStub = sinon.stub();
+        memberMembership.user.get = (attr) => {
+          return attr === 'firstName' ? memberMembership.user.firstName : memberMembership.user.lastName;
+        };
+        this.set('membership', memberMembership);
+        this.set('removeMembership', removeMembershipStub);
+
+        // when
+        await render(hbs`<Team::MembersListItem @membership={{membership}} @onRemoveMember={{removeMembership}} />`);
+        await clickByName('Gérer');
+        await clickByText('Supprimer');
+      });
+
+      test('should display a confirmation modal', function (assert) {
+        // then
+        assert.contains('Confirmez-vous la suppression ?');
+        assert.contains('Annuler');
+        assert.contains('Supprimer');
+      });
+
+      test('should display the membership first name and last name in the modal', function (assert) {
+        // then
+        assert.contains(memberMembership.user.firstName);
+        assert.contains(memberMembership.user.lastName);
+      });
+
+      test('should close the modal by clicking on cancel button', async function (assert) {
+        // when
+        await clickByName('Annuler');
+
+        // then
+        assert.notContains("Supprimer de l'équipe");
+      });
+
+      test('should call removeMembership and close modal by clicking on remove button', async function (assert) {
+        // when
+        await clickByText('Oui, supprimer le membre');
+
+        // then
+        sinon.assert.calledWith(removeMembershipStub, memberMembership);
+        assert.notContains("Supprimer de l'équipe");
+      });
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Jusqu'à présent il n'était pas possible pour un membre d'une organisation d'accéder à la page membres. C'est désormais possible, cependant il n'a pas accès à toutes les options disponibles pour un admin. Cet utilisateur ne voit qu'une liste de membres, sans possibilité de les éditer. Les invitations ne sont pas visibles non plus.

## :gift: Solution
Le lien vers la page membre est visible dans la sidebar.
La page Equipe affiche certaines options suivant si le membre est administrateur ou pas.

## :star2: Remarques
Effet de bord en donnant accès à tous les rôles pour la route `/team` (voir fichier `orga/app/routes/authenticated/team.js`) afin que les membres avec un rôle membre puissent accéder à la route `equipe/membres` : un test qui vérifiait que lorsqu'un membre essayer d'aller sur http://localhost:4201/equipe/creation il est redirigé vers campagne était au rouge, j'ai donc mis à jour la route `/equipe/creation`

## :santa: Pour tester
- se connecter en tant qu'admin et vérifier que l'admin a bien accès à toutes les options : liste des membres, liste des invitations, picto pour éditer un membre et bouton pour inviter un membre. 
- se connecter en tant que membre et vérifier que le membre ne voit que les membres de l'orga
- aller sur l'url `http://localhost:4201/equipe/creation` et vérifier que le membre n'a pas accès à cette page et est redirigé vers `http://localhost:4201/campagnes`

