### PR TITLE
[BUGFIX] Permettre la récupération de compte avec un INE en minuscule (PIX-3997).

### DIFF
--- a/api/lib/domain/services/sco-account-recovery-service.js
+++ b/api/lib/domain/services/sco-account-recovery-service.js
@@ -15,7 +15,7 @@ async function retrieveSchoolingRegistration({
 }) {
   const latestSchoolingRegistration = await schoolingRegistrationRepository.getLatestSchoolingRegistration({
     birthdate: studentInformation.birthdate,
-    nationalStudentId: studentInformation.ineIna,
+    nationalStudentId: studentInformation.ineIna.toUpperCase(),
   });
 
   const userId = await _getUserIdByMatchingStudentInformationWithSchoolingRegistration({

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route_test.js
@@ -15,7 +15,7 @@ describe('Acceptance | Route | Account-recovery', function () {
     });
 
     const studentInformation = {
-      ineIna: '123456789AA',
+      ineIna: '123456789aa',
       firstName: 'Jude',
       lastName: 'Law',
       birthdate: '2016-06-01',
@@ -40,14 +40,14 @@ describe('Acceptance | Route | Account-recovery', function () {
       databaseBuilder.factory.buildSchoolingRegistration({
         userId: user.id,
         ...studentInformation,
-        nationalStudentId: studentInformation.ineIna,
+        nationalStudentId: studentInformation.ineIna.toUpperCase(),
         organizationId: organization.id,
         updatedAt: new Date('2005-01-01T15:00:00Z'),
       });
       databaseBuilder.factory.buildSchoolingRegistration({
         userId: user.id,
         ...studentInformation,
-        nationalStudentId: studentInformation.ineIna,
+        nationalStudentId: studentInformation.ineIna.toUpperCase(),
         organizationId: latestOrganization.id,
         updatedAt: new Date('2010-01-01T15:00:00Z'),
       });


### PR DESCRIPTION
## :christmas_tree: Problème
Quand un utilisateur fait une récupération de compte et indique son INE en minuscule, son compte n'est pas trouvé.

## :gift: Solution
Rendre le match case-insensitive

## :santa: Pour tester
Aller sur [Récupérer mon compte](https://app-pr3997.review.pix.fr/recuperer-mon-compte)
Remplir le formulaire :
- 123456789bb
- george
- decambridge
- 22/07/2013
Vérifier que le compte de George est bien trouvé
