### PR TITLE
[FEATURE] Terminer un test de certification depuis le portail surveillant partie 1(Pix-4055)

### DIFF
--- a/api/db/database-builder/factory/build-supervisor-access.js
+++ b/api/db/database-builder/factory/build-supervisor-access.js
@@ -1,0 +1,24 @@
+const databaseBuffer = require('../database-buffer');
+const _ = require('lodash');
+const buildUser = require('./build-user');
+const buildSession = require('./build-session');
+
+module.exports = function buildSupervisorAccess({
+  id = databaseBuffer.getNextId(),
+  sessionId,
+  userId,
+  authorizedAt = new Date('2020-01-01'),
+} = {}) {
+  userId = _.isUndefined(userId) ? buildUser().id : userId;
+  sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
+  const values = {
+    id,
+    userId,
+    sessionId,
+    authorizedAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'supervisor-accesses',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -50,6 +50,7 @@ module.exports = {
   buildSchoolingRegistration: require('./build-schooling-registration'),
   buildSchoolingRegistrationWithUser: require('./build-schooling-registration-with-user'),
   buildStage: require('./build-stage'),
+  buildSupervisorAccess: require('./build-supervisor-access'),
   buildTag: require('./build-tag'),
   buildTargetProfile: require('./build-target-profile'),
   buildTargetProfileSkill: require('./build-target-profile-skill'),

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -106,6 +106,14 @@ module.exports = {
     return null;
   },
 
+  async endAssessmentBySupervisor(request) {
+    const assessmentId = request.params.id;
+
+    await usecases.endAssessmentBySupervisor({ assessmentId });
+
+    return null;
+  },
+
   async updateLastChallengeState(request) {
     const assessmentId = request.params.id;
     const lastQuestionState = request.params.state;

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 const assessmentController = require('./assessment-controller');
 const securityPreHandlers = require('../security-pre-handlers');
 const assessmentAuthorization = require('../preHandlers/assessment-authorization');
+const assessmentSupervisorAuthorization = require('../preHandlers/assessment-supervisor-authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
@@ -115,6 +116,26 @@ exports.register = async (server) => {
           }),
         },
         handler: assessmentController.completeAssessment,
+        tags: ['api'],
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/assessments/{id}/end-assessment-by-supervisor',
+      config: {
+        auth: false,
+        pre: [
+          {
+            method: assessmentSupervisorAuthorization.verify,
+            assign: 'authorizationCheck',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.assessmentId,
+          }),
+        },
+        handler: assessmentController.endAssessmentBySupervisor,
         tags: ['api'],
       },
     },

--- a/api/lib/application/preHandlers/assessment-supervisor-authorization.js
+++ b/api/lib/application/preHandlers/assessment-supervisor-authorization.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-restricted-syntax */
+
+const assessmentRepository = require('../../infrastructure/repositories/assessment-repository');
+const certificationCourseRepository = require('../../infrastructure/repositories/certification-course-repository');
+const supervisorAccessRepository = require('../../infrastructure/repositories/supervisor-access-repository');
+const validationErrorSerializer = require('../../infrastructure/serializers/jsonapi/validation-error-serializer');
+const { extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
+
+module.exports = {
+  async verify(request, h) {
+    const userId = extractUserIdFromRequest(request);
+    const assessmentId = parseInt(request.params.id);
+    const assessment = await assessmentRepository.get(assessmentId);
+    const certificationCourse = await certificationCourseRepository.get(assessment.certificationCourseId);
+    const isSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSession({
+      sessionId: certificationCourse.getSessionId(),
+      userId,
+    });
+
+    if (!isSupervisorForSession) {
+      const buildError = _handleWhenInvalidAuthorization(
+        'Vous n’êtes pas autorisé à terminer ce test de certification.'
+      );
+      return h.response(validationErrorSerializer.serialize(buildError)).code(401).takeover();
+    }
+
+    return true;
+  },
+};
+
+function _handleWhenInvalidAuthorization(errorMessage) {
+  return {
+    data: {
+      authorization: [errorMessage],
+    },
+  };
+}

--- a/api/lib/domain/usecases/end-assessment-by-supervisor.js
+++ b/api/lib/domain/usecases/end-assessment-by-supervisor.js
@@ -1,0 +1,9 @@
+module.exports = async function endAssessmentBySupervisor({ assessmentId, assessmentRepository }) {
+  const assessment = await assessmentRepository.get(assessmentId);
+
+  if (assessment.isCompleted()) {
+    return;
+  }
+
+  await assessmentRepository.endBySupervisorByAssessmentId(assessmentId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -202,6 +202,7 @@ module.exports = injectDependencies(
     disableCertificationCenterMembership: require('./disable-certification-center-membership'),
     dissociateUserFromSchoolingRegistration: require('./dissociate-user-from-schooling-registration'),
     dissociateSchoolingRegistrations: require('./dissociate-schooling-registrations'),
+    endAssessmentBySupervisor: require('./end-assessment-by-supervisor'),
     enrollStudentsToSession: require('./enroll-students-to-session'),
     finalizeSession: require('./finalize-session'),
     findAllTags: require('./find-all-tags'),

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -118,6 +118,10 @@ module.exports = {
     );
   },
 
+  endBySupervisorByAssessmentId(assessmentId) {
+    return this._updateStateById({ id: assessmentId, state: Assessment.states.ENDED_BY_SUPERVISOR });
+  },
+
   async ownedByUser({ id, userId = null }) {
     const assessment = await knex('assessments').select('userId').where({ id }).first();
 

--- a/api/lib/infrastructure/repositories/supervisor-access-repository.js
+++ b/api/lib/infrastructure/repositories/supervisor-access-repository.js
@@ -4,4 +4,9 @@ module.exports = {
   async create({ sessionId, userId }) {
     await knex('supervisor-accesses').insert({ sessionId, userId });
   },
+
+  async isUserSupervisorForSession({ sessionId, userId }) {
+    const result = await knex.select(1).from('supervisor-accesses').where({ sessionId, userId }).first();
+    return Boolean(result);
+  },
 };

--- a/api/tests/acceptance/application/assessments/assessment-controller-end-by-supervisor-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-end-by-supervisor-assessment_test.js
@@ -1,0 +1,66 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | assessment-controller-end-assessment-by-supervisor', function () {
+  let options;
+  let server;
+  let user, assessment, certificationCourse;
+
+  beforeEach(async function () {
+    server = await createServer();
+
+    user = databaseBuilder.factory.buildUser({});
+
+    certificationCourse = databaseBuilder.factory.buildCertificationCourse();
+
+    assessment = databaseBuilder.factory.buildAssessment({
+      state: Assessment.states.STARTED,
+      certificationCourseId: certificationCourse.id,
+    });
+
+    databaseBuilder.factory.buildSupervisorAccess({
+      userId: user.id,
+      sessionId: certificationCourse.sessionId,
+    });
+
+    await databaseBuilder.commit();
+
+    options = {
+      method: 'PATCH',
+      url: `/api/assessments/${assessment.id}/end-assessment-by-supervisor`,
+      headers: {
+        authorization: generateValidRequestAuthorizationHeader(user.id),
+      },
+    };
+  });
+
+  afterEach(async function () {
+    return knex('assessment-results').delete();
+  });
+
+  describe('PATCH /assessments/{id}/end-assessment-by-supervisor', function () {
+    context('when user is not the supervisor of the assessment session', function () {
+      it('should return a 401 HTTP status code', async function () {
+        // given
+        options.headers.authorization = generateValidRequestAuthorizationHeader(user.id + 1);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+
+    context('when user is the supervisor of the assessment session', function () {
+      it('should end the assessment by supervisor ', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+  });
+});

--- a/api/tests/integration/application/assessments/assessment-controller_test.js
+++ b/api/tests/integration/application/assessments/assessment-controller_test.js
@@ -4,9 +4,7 @@ const assessmentAuthorization = require('../../../../lib/application/preHandlers
 const moduleUnderTest = require('../../../../lib/application/assessments');
 
 describe('Integration | Application | Assessments | assessment-controller', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const assessment = domainBuilder.buildAssessment({ id: 1234 });
+  let assessment;
 
   let httpTestServer;
 
@@ -15,6 +13,7 @@ describe('Integration | Application | Assessments | assessment-controller', func
     sinon.stub(assessmentAuthorization, 'verify');
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
+    assessment = domainBuilder.buildAssessment();
   });
 
   describe('#get', function () {

--- a/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
@@ -22,4 +22,43 @@ describe('Integration | Repository | supervisor-access-repository', function () 
       expect(supervisorAccessInDB.userId).to.equal(userId);
     });
   });
+  describe('#isUserSupervisorForSession', function () {
+    afterEach(function () {
+      return knex('supervisor-accesses').delete();
+    });
+
+    it('should return true if user is supervising the session', async function () {
+      // given
+      const sessionId = databaseBuilder.factory.buildSession().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId });
+      await databaseBuilder.commit();
+
+      // when
+      const isUserSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSession({
+        sessionId,
+        userId,
+      });
+
+      // then
+      expect(isUserSupervisorForSession).to.be.true;
+    });
+
+    it('should return false if user is not supervising the session', async function () {
+      // given
+      const sessionId = databaseBuilder.factory.buildSession().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId });
+      await databaseBuilder.commit();
+
+      // when
+      const isUserSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSession({
+        sessionId: 123,
+        userId: 456,
+      });
+
+      // then
+      expect(isUserSupervisorForSession).to.be.false;
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment.js
@@ -153,4 +153,6 @@ buildAssessment.ofTypeCompetenceEvaluation = function ({
   });
 };
 
+buildAssessment.ofTypeCertification = buildAssessment;
+
 module.exports = buildAssessment;

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -180,6 +180,25 @@ describe('Unit | Controller | assessment-controller', function () {
     });
   });
 
+  describe('#endAssessmentBySupervisor', function () {
+    const assessmentId = 2;
+    const assessmentCompletedEvent = new AssessmentCompleted();
+
+    beforeEach(function () {});
+
+    it('should call the endAssessmentBySupervisor use case', async function () {
+      // given
+      sinon.stub(usecases, 'endAssessmentBySupervisor');
+      usecases.endAssessmentBySupervisor.resolves(assessmentCompletedEvent);
+
+      // when
+      await assessmentController.endAssessmentBySupervisor({ params: { id: assessmentId } });
+
+      // then
+      expect(usecases.endAssessmentBySupervisor).to.have.been.calledWithExactly({ assessmentId });
+    });
+  });
+
   describe('#findCompetenceEvaluations', function () {
     it('should return the competence evaluations', async function () {
       // given

--- a/api/tests/unit/application/preHandlers/assessment-supervisor-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/assessment-supervisor-authorization_test.js
@@ -1,0 +1,80 @@
+const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
+const AssessmentSupervisorAuthorization = require('../../../../lib/application/preHandlers/assessment-supervisor-authorization');
+const tokenService = require('../../../../lib/domain/services/token-service');
+const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
+const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
+const supervisorAccessRepository = require('../../../../lib/infrastructure/repositories/supervisor-access-repository');
+
+describe('Unit | Pre-handler | Assessment Supervisor Authorization', function () {
+  describe('#verify', function () {
+    const request = {
+      headers: { authorization: 'VALID_TOKEN' },
+      params: {
+        id: 8,
+      },
+    };
+
+    beforeEach(function () {
+      sinon.stub(tokenService, 'extractTokenFromAuthChain');
+      sinon.stub(tokenService, 'extractUserId');
+      sinon.stub(assessmentRepository, 'get');
+      sinon.stub(certificationCourseRepository, 'get');
+      sinon.stub(supervisorAccessRepository, 'isUserSupervisorForSession');
+    });
+
+    describe('When user is the supervisor of the assessment session', function () {
+      it('should return true', async function () {
+        // given
+        const extractedUserId = 'userId';
+        tokenService.extractUserId.returns(extractedUserId);
+        const certificationCourse = domainBuilder.buildCertificationCourse({ sessionId: 5467 });
+        const assessement = domainBuilder.buildAssessment({ courseId: certificationCourse.id });
+        tokenService.extractTokenFromAuthChain.returns('VALID_TOKEN');
+        tokenService.extractUserId.returns('userId');
+        assessmentRepository.get.resolves(assessement);
+        certificationCourseRepository.get.resolves(certificationCourse);
+        supervisorAccessRepository.isUserSupervisorForSession.resolves(true);
+
+        // when
+        const response = await AssessmentSupervisorAuthorization.verify(request, hFake);
+
+        // then
+        sinon.assert.calledOnce(assessmentRepository.get);
+        sinon.assert.calledWith(supervisorAccessRepository.isUserSupervisorForSession, {
+          sessionId: certificationCourse.getSessionId(),
+          userId: extractedUserId,
+        });
+        expect(response).to.be.true;
+      });
+    });
+
+    describe('When user is not the supervisor of the assessment session', function () {
+      it('should return status code 401 and the error message', async function () {
+        // given
+        const extractedUserId = 'userId';
+        tokenService.extractUserId.returns(extractedUserId);
+        const certificationCourse = domainBuilder.buildCertificationCourse({ sessionId: 5467 });
+        const assessement = domainBuilder.buildAssessment({ courseId: certificationCourse.id });
+        tokenService.extractTokenFromAuthChain.returns('VALID_TOKEN');
+        tokenService.extractUserId.returns('userId');
+        assessmentRepository.get.resolves(assessement);
+        certificationCourseRepository.get.resolves(certificationCourse);
+        supervisorAccessRepository.isUserSupervisorForSession.resolves(false);
+
+        // when
+        const response = await AssessmentSupervisorAuthorization.verify(request, hFake);
+
+        // then
+        sinon.assert.calledOnce(assessmentRepository.get);
+        sinon.assert.calledWith(supervisorAccessRepository.isUserSupervisorForSession, {
+          sessionId: certificationCourse.getSessionId(),
+          userId: extractedUserId,
+        });
+        expect(response.statusCode).to.equal(401);
+        expect(response.source.errors[0].detail).to.equal(
+          'Vous n’êtes pas autorisé à terminer ce test de certification.'
+        );
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/end-assessment-by-supervisor_test.js
+++ b/api/tests/unit/domain/usecases/end-assessment-by-supervisor_test.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const endAssessmentBySupervisor = require('../../../../lib/domain/usecases/end-assessment-by-supervisor');
 
-describe('Unit | UseCase | end-by-supervisor-assessment', function () {
+describe('Unit | UseCase | end-assessment-by-supervisor', function () {
   let assessmentRepository;
 
   beforeEach(function () {

--- a/api/tests/unit/domain/usecases/end-assessment-by-supervisor_test.js
+++ b/api/tests/unit/domain/usecases/end-assessment-by-supervisor_test.js
@@ -1,0 +1,58 @@
+const _ = require('lodash');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const endAssessmentBySupervisor = require('../../../../lib/domain/usecases/end-assessment-by-supervisor');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+
+describe('Unit | UseCase | end-by-supervisor-assessment', function () {
+  let assessmentRepository;
+
+  beforeEach(function () {
+    assessmentRepository = {
+      get: _.noop,
+      endBySupervisorByAssessmentId: _.noop,
+    };
+  });
+
+  context('when assessment is already completed', function () {
+    it('should not end the assessment', async function () {
+      // when
+      const completedAssessment = _buildCertificationAssessment({ state: 'completed' });
+      sinon.stub(assessmentRepository, 'endBySupervisorByAssessmentId').resolves();
+      sinon.stub(assessmentRepository, 'get').withArgs(completedAssessment.id).resolves(completedAssessment);
+
+      await endAssessmentBySupervisor({
+        assessmentId: completedAssessment.id,
+        assessmentRepository,
+      });
+
+      // then
+      expect(assessmentRepository.endBySupervisorByAssessmentId).not.to.have.been.called;
+    });
+  });
+
+  context('when assessment is not completed', function () {
+    it('should end the assessment', async function () {
+      // when
+      const assessment = _buildCertificationAssessment({ state: 'started' });
+      sinon.stub(assessmentRepository, 'endBySupervisorByAssessmentId').resolves();
+      sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
+
+      await endAssessmentBySupervisor({
+        assessmentId: assessment.id,
+        assessmentRepository,
+      });
+
+      // then
+      expect(assessmentRepository.endBySupervisorByAssessmentId).to.have.been.calledWithExactly(assessment.id);
+    });
+  });
+});
+
+function _buildCertificationAssessment({ state }) {
+  return domainBuilder.buildAssessment({
+    id: Symbol('assessmentId'),
+    certificationCourseId: Symbol('certificationCourseId'),
+    state,
+    type: Assessment.types.CERTIFICATION,
+  });
+}

--- a/api/tests/unit/domain/usecases/end-assessment-by-supervisor_test.js
+++ b/api/tests/unit/domain/usecases/end-assessment-by-supervisor_test.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const endAssessmentBySupervisor = require('../../../../lib/domain/usecases/end-assessment-by-supervisor');
-const Assessment = require('../../../../lib/domain/models/Assessment');
 
 describe('Unit | UseCase | end-by-supervisor-assessment', function () {
   let assessmentRepository;
@@ -16,7 +15,7 @@ describe('Unit | UseCase | end-by-supervisor-assessment', function () {
   context('when assessment is already completed', function () {
     it('should not end the assessment', async function () {
       // when
-      const completedAssessment = _buildCertificationAssessment({ state: 'completed' });
+      const completedAssessment = domainBuilder.buildAssessment.ofTypeCertification({ state: 'completed' });
       sinon.stub(assessmentRepository, 'endBySupervisorByAssessmentId').resolves();
       sinon.stub(assessmentRepository, 'get').withArgs(completedAssessment.id).resolves(completedAssessment);
 
@@ -33,7 +32,7 @@ describe('Unit | UseCase | end-by-supervisor-assessment', function () {
   context('when assessment is not completed', function () {
     it('should end the assessment', async function () {
       // when
-      const assessment = _buildCertificationAssessment({ state: 'started' });
+      const assessment = domainBuilder.buildAssessment.ofTypeCertification({ state: 'started' });
       sinon.stub(assessmentRepository, 'endBySupervisorByAssessmentId').resolves();
       sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
 
@@ -47,12 +46,3 @@ describe('Unit | UseCase | end-by-supervisor-assessment', function () {
     });
   });
 });
-
-function _buildCertificationAssessment({ state }) {
-  return domainBuilder.buildAssessment({
-    id: Symbol('assessmentId'),
-    certificationCourseId: Symbol('certificationCourseId'),
-    state,
-    type: Assessment.types.CERTIFICATION,
-  });
-}

--- a/certif/app/adapters/certification-candidate-for-supervising.js
+++ b/certif/app/adapters/certification-candidate-for-supervising.js
@@ -11,6 +11,10 @@ export default class CertificationCandidateForSupervisingAdapter extends Applica
       return `${this.host}/${this.namespace}/certification-candidates/${id}/authorize-to-resume`;
     }
 
+    if (requestType === 'endAssessmentBySupervisor') {
+      return `${this.host}/${this.namespace}/assessments/${id}/end-assessment-by-supervisor`;
+    }
+
     return super.buildURL(modelName, id, snapshot, requestType, query);
   }
 }

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -46,6 +46,9 @@
         <Dropdown::Item @onClick={{this.askUserToConfirmTestResume}}>
           Autoriser la reprise du test
         </Dropdown::Item>
+        <Dropdown::Item @onClick={{this.askUserToConfirmTestEnd}}>
+          Terminer le test
+        </Dropdown::Item>
       </Dropdown::Content>
     </div>
   {{/if}}
@@ -53,13 +56,18 @@
   {{#if this.isConfirmationModalDisplayed}}
     <SessionSupervising::ConfirmationModal
       @closeConfirmationModal={{this.closeConfirmationModal}}
-      @actionOnConfirmation={{this.actionOnConfirmation}}
+      @actionOnConfirmation={{this.actionMethod}}
       @candidate={{this.candidate}}
-      @modalDescriptionText={{this.modalDescriptionText}}
-      @modalInstructionText={{this.modalInstructionText}}
       @modalCancelText={{this.modalCancelText}}
       @modalConfirmationButtonText={{this.modalConfirmationText}}
-    />
+    >
+      <:instruction>
+        {{this.modalInstructionText}}
+      </:instruction>
+      <:description>
+        {{this.modalDescriptionText}}
+      </:description>
+    </SessionSupervising::ConfirmationModal>
 
   {{/if}}
 

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -51,54 +51,16 @@
   {{/if}}
 
   {{#if this.isConfirmationModalDisplayed}}
-    <AppModal @containerClass="pix-modal-dialog" @onClose={{this.closeConfirmationModal}}>
+    <SessionSupervising::ConfirmationModal
+      @closeConfirmationModal={{this.closeConfirmationModal}}
+      @actionOnConfirmation={{this.actionOnConfirmation}}
+      @candidate={{this.candidate}}
+      @modalDescriptionText={{this.modalDescriptionText}}
+      @modalInstructionText={{this.modalInstructionText}}
+      @modalCancelText={{this.modalCancelText}}
+      @modalConfirmationButtonText={{this.modalConfirmationText}}
+    />
 
-      <div class="pix-modal__close-button">
-        <button
-          type="button"
-          data-test-id="finalize-session-modal__close-cross"
-          {{on "click" this.closeConfirmationModal}}
-          aria-label="Fermer la fenêtre de confirmation"
-        >
-          Fermer
-          <img src="/icons/icon-close-modal.svg" alt="" role="presentation" width="24" height="24">
-        </button>
-      </div>
-
-      <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
-        <div class="pix-modal-body pix-modal-body--with-padding">
-          <div class="app-modal-body__attention">
-            Autoriser {{@candidate.firstName}} {{@candidate.lastName}} à reprendre son test ?
-          </div>
-          <div class="app-modal-body__warning">
-            <p>
-              Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème
-              technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test
-              à l'endroit où il l'avait quitté.
-            </p>
-          </div>
-        </div>
-
-        <div class="pix-modal-footer">
-          <PixButton
-            data-test-id="finalize-session-modal__confirm-button"
-            @triggerAction={{fn this.authorizeTestResume @candidate}}
-            @backgroundColor="yellow"
-          >
-            Je confirme l'autorisation
-          </PixButton>
-          <PixButton
-            data-test-id="finalize-session-modal__cancel-button"
-            @triggerAction={{this.closeConfirmationModal}}
-            @backgroundColor="transparent-light"
-            @isBorderVisible={{true}}
-            aria-label="Annuler et fermer la fenêtre de confirmation"
-          >
-            Annuler
-          </PixButton>
-        </div>
-      </div>
-    </AppModal>
   {{/if}}
 
 </li>

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -8,6 +8,10 @@ export default class CandidateInList extends Component {
 
   @tracked isMenuOpen = false;
   @tracked isConfirmationModalDisplayed = false;
+  @tracked modalDescriptionText;
+  @tracked modalCancelText;
+  @tracked modalConfirmationText;
+  @tracked modalInstructionText;
 
   get isCheckboxToBeDisplayed() {
     return !this.args.candidate.hasStarted && !this.args.candidate.hasCompleted;
@@ -34,6 +38,11 @@ export default class CandidateInList extends Component {
 
   @action
   askUserToConfirmTestResume() {
+    this.modalDescriptionText = 'Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d\'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l\'endroit où il l\'avait quitté.';
+    this.modalCancelText = 'Fermer';
+    this.modalConfirmationText = 'Je confirme l\'autorisation';
+    this.modalInstructionText = `Autoriser ${this.args.candidate.firstName} ${this.args.candidate.lastName} à reprendre son test ?`;
+    this.actionOnConfirmation = this.authorizeTestResume.bind(this);
     this.isConfirmationModalDisplayed = true;
   }
 
@@ -43,10 +52,10 @@ export default class CandidateInList extends Component {
   }
 
   @action
-  async authorizeTestResume(candidate) {
+  async authorizeTestResume() {
     this.closeConfirmationModal();
     try {
-      await this.args.onCandidateTestResumeAuthorization(candidate);
+      await this.args.onCandidateTestResumeAuthorization(this.args.candidate);
       this.notifications.success(
         `Succès ! ${this.args.candidate.firstName} ${this.args.candidate.lastName} peut reprendre son test de certification.`,
       );

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -9,6 +9,7 @@
             @candidate={{candidate}}
             @toggleCandidate={{this.toggleCandidate}}
             @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
+            @onSupervisorEndAssessment={{this.endAssessmentBySupervisor}}
           />
         {{/each}}
       </ul>

--- a/certif/app/components/session-supervising/candidate-list.js
+++ b/certif/app/components/session-supervising/candidate-list.js
@@ -12,4 +12,9 @@ export default class CandidateList extends Component {
   async authorizeTestResume(candidate) {
     await this.args.authorizeTestResume(candidate);
   }
+
+  @action
+  async endAssessmentBySupervisor(candidate) {
+    await this.args.endAssessmentBySupervisor(candidate);
+  }
 }

--- a/certif/app/components/session-supervising/confirmation-modal.hbs
+++ b/certif/app/components/session-supervising/confirmation-modal.hbs
@@ -15,11 +15,11 @@
   <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
     <div class="pix-modal-body pix-modal-body--with-padding">
       <div class="app-modal-body__attention">
-        {{@modalInstructionText}}
+        {{yield to="instruction"}}
       </div>
       <div class="app-modal-body__warning">
         <p>
-          {{@modalDescriptionText}}
+          {{yield to="description"}}
         </p>
       </div>
     </div>

--- a/certif/app/components/session-supervising/confirmation-modal.hbs
+++ b/certif/app/components/session-supervising/confirmation-modal.hbs
@@ -1,0 +1,46 @@
+<AppModal @containerClass="pix-modal-dialog" @onClose={{@closeConfirmationModal}}>
+
+  <div class="pix-modal__close-button">
+    <button
+      type="button"
+      data-test-id="finalize-session-modal__close-cross"
+      {{on "click" @closeConfirmationModal}}
+      aria-label="Fermer la fenêtre de confirmation"
+    >
+      Fermer
+      <img src="/icons/icon-close-modal.svg" alt="" role="presentation" width="24" height="24">
+    </button>
+  </div>
+
+  <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
+    <div class="pix-modal-body pix-modal-body--with-padding">
+      <div class="app-modal-body__attention">
+        {{@modalInstructionText}}
+      </div>
+      <div class="app-modal-body__warning">
+        <p>
+          {{@modalDescriptionText}}
+        </p>
+      </div>
+    </div>
+
+    <div class="pix-modal-footer">
+      <PixButton
+        data-test-id="finalize-session-modal__confirm-button"
+        @triggerAction={{@actionOnConfirmation}}
+        @backgroundColor="yellow"
+      >
+        {{@modalConfirmationButtonText}}
+      </PixButton>
+      <PixButton
+        data-test-id="finalize-session-modal__cancel-button"
+        @triggerAction={{@closeConfirmationModal}}
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        aria-label="Annuler et fermer la fenêtre de confirmation"
+      >
+        {{@modalCancelText}}
+      </PixButton>
+    </div>
+  </div>
+</AppModal>

--- a/certif/app/controllers/session-supervising.js
+++ b/certif/app/controllers/session-supervising.js
@@ -12,4 +12,9 @@ export default class SessionSupervisingController extends Controller {
   async authorizeTestResume(candidate) {
     await candidate.authorizeTestResume();
   }
+
+  @action
+  async endAssessmentBySupervisor(candidate) {
+    await candidate.endAssessmentBySupervisor();
+  }
 }

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -39,4 +39,9 @@ export default class CertificationCandidateForSupervising extends Model {
     type: 'post',
     urlType: 'authorizeToResume',
   });
+
+  endAssessmentBySupervisor = memberAction({
+    type: 'patch',
+    urlType: 'endAssessmentBySupervisor',
+  });
 }

--- a/certif/app/templates/session-supervising.hbs
+++ b/certif/app/templates/session-supervising.hbs
@@ -3,7 +3,7 @@
 <div class="app">
   <div class="session-supervising-page">
     <SessionSupervising::Header @session={{@model}}/>
-    <SessionSupervising::CandidateList @authorizeTestResume={{this.authorizeTestResume}} @toggleCandidate={{this.toggleCandidate}} @candidates={{@model.certificationCandidates}}/>
+    <SessionSupervising::CandidateList @authorizeTestResume={{this.authorizeTestResume}} @endAssessmentBySupervisor={{this.endAssessmentBySupervisor}} @toggleCandidate={{this.toggleCandidate}} @candidates={{@model.certificationCandidates}}/>
   </div>
 
   <NotificationContainer @position="bottom-right" />


### PR DESCRIPTION
## :christmas_tree: Problème
L’espace surveillant permet de s’assurer, sans avoir à constater la fin de test d’un candidat, que ce dernier a bien fait la totalité de son test sous surveillance puisqu’il n’est plus autonome pour la reprise de son test.

Un candidat ayant apporté son propre matériel, ou pour les candidats passant la certification à distance, il est plus compliqué de s’assurer que le candidat ait bien quitté la fenêtre de son test avant de quitter la salle/quitter le logiciel de surveillance à distance, et donc qu’il ne puisse pas continuer son test en dehors de toute surveillance. Il faudrait donc que le surveillant puisse s’assurer que le candidat ait bien terminé son test avant de le laisser quitter la salle/le logiciel.

## :gift: Solution
Permettre au surveillant depuis l’espace surveillant de terminer le test d’un candidat : 

dans le menu avec les 3 dots, ajouter une option “Terminer le test”

cliquer sur cette option affiche une pop-up de confirmation 

Wording : 

Terminer le test de Prénom Nom?Attention : cette action entraine la fin de son test de certification et est irréversible.

Boutons “Annuler” / “Terminer le test”

cliquer sur “Terminer le test” : 

passe le test du candidat au statut “Test terminé” sur l’espace surveillant

bloque le passage du test du candidat mais ATTENTION, ne modifie pas le statut de ses questions non répondues (ça se passera au moment de la finalisation de la session en fonction de la raison de l’abandon sélectionnée)

redirige le candidat sur l'écran de fin de test, avec un message spécifique : Votre surveillant a terminé votre test de certification. Vous ne pouvez plus continuer de répondre aux questions. 

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Commencer une certification avec un candidat
- Se rendre sur l'espace surveillant et cliquer sur le menu du candidat puis Terminer le test de certification
- Rafraichir pour constater que la certification du candidat n'est plus en cours.
