### PR TITLE
[BUGFIX] Ne plus avoir de bug quand l'utilisateur a deux competence-eval(PIX-3944).

### DIFF
--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -44,6 +44,7 @@ module.exports = {
 
   getByAssessmentId(assessmentId) {
     return BookshelfCompetenceEvaluation.where({ assessmentId })
+      .orderBy('createdAt', 'asc')
       .fetch({ withRelated: ['assessment'] })
       .then((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, result))
       .catch((bookshelfError) => {
@@ -56,6 +57,7 @@ module.exports = {
 
   getByCompetenceIdAndUserId({ competenceId, userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
     return BookshelfCompetenceEvaluation.where({ competenceId, userId })
+      .orderBy('createdAt', 'asc')
       .fetch({ withRelated: ['assessment'], transacting: domainTransaction.knexTransaction })
       .then((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, result))
       .catch((bookshelfError) => {
@@ -68,14 +70,15 @@ module.exports = {
 
   findByUserId(userId) {
     return BookshelfCompetenceEvaluation.where({ userId })
-      .orderBy('createdAt', 'desc')
+      .orderBy('createdAt', 'asc')
       .fetchAll({ withRelated: ['assessment'] })
-      .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfCompetenceEvaluation, results));
+      .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfCompetenceEvaluation, results))
+      .then(_selectOnlyOneCompetenceEvaluationByCompetence);
   },
 
   findByAssessmentId(assessmentId) {
     return BookshelfCompetenceEvaluation.where({ assessmentId })
-      .orderBy('createdAt', 'desc')
+      .orderBy('createdAt', 'asc')
       .fetchAll()
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfCompetenceEvaluation, results));
   },
@@ -95,3 +98,8 @@ module.exports = {
     return isCompetenceEvaluationExists;
   },
 };
+
+function _selectOnlyOneCompetenceEvaluationByCompetence(competenceEvaluations) {
+  const assessmentsGroupedByCompetence = _.groupBy(competenceEvaluations, 'competenceId');
+  return _.map(assessmentsGroupedByCompetence, _.head);
+}

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -170,6 +170,33 @@ describe('Integration | Repository | Competence Evaluation', function () {
         expect(error).to.be.instanceof(NotFoundError);
       });
     });
+
+    it('should return only one competence evaluation linked to the competence id', async function () {
+      // given
+      const anotherAssessment = databaseBuilder.factory.buildAssessment({
+        userId: user.id,
+        type: Assessment.types.COMPETENCE_EVALUATION,
+      });
+
+      databaseBuilder.factory.buildCompetenceEvaluation({
+        userId: user.id,
+        competenceId: '1',
+        assessmentId: anotherAssessment.id,
+        status: STARTED,
+      });
+
+      // when
+      const result = await competenceEvaluationRepository.getByCompetenceIdAndUserId({
+        competenceId: 1,
+        userId: user.id,
+      });
+
+      // then
+      expect(_.omit(result, ['assessment', 'scorecard'])).to.deep.equal(
+        _.omit(competenceEvaluationExpected, ['assessment'])
+      );
+      expect(result.assessment.id).to.deep.equal(assessmentExpected.id);
+    });
   });
 
   describe('#findByUserId', function () {
@@ -193,6 +220,13 @@ describe('Integration | Repository | Competence Evaluation', function () {
         createdAt: new Date('2018-01-01'),
         status: STARTED,
       });
+      databaseBuilder.factory.buildCompetenceEvaluation({
+        userId: user.id,
+        competenceId: '1',
+        createdAt: new Date('2018-01-02'),
+        status: STARTED,
+      });
+
       databaseBuilder.factory.buildCompetenceEvaluation({
         userId: user.id,
         competenceId: '2',


### PR DESCRIPTION
## :christmas_tree: Problème
La table  `competence-evaluations` doit avoir une ligne unique par `userId` et `competenceId`. Suite à des soucis et des bugs, il peut arriver qu'il y ait 2 lignes voir plus.
Cela pose problème à la reprise ou autre d'une compétence, où l'une des lignes est prise à la place de celle qu'il faudrait

## :gift: Solution
- S'assurer de remonter toujours la même ligne entre les différentes méthodes du repository.
- Ajout d'une vérification lors de la création pour éviter les doublons

## :star2: Remarques
Toujours pas réussit à reproduire à la main, uniquement en ajoutant un double appel coté front.

## :santa: Pour tester
Vérifier qu'on puisse correctement : 
- Commencer/Reprendre une compétence
- Remettre à zéro une compétence et la reprendre
- Retenter une compétence