### PR TITLE
[FEATURE] Ajout de la case à cocher de sélection de sujets (PIX-3953)

### DIFF
--- a/admin/app/styles/globals/tables.scss
+++ b/admin/app/styles/globals/tables.scss
@@ -8,16 +8,6 @@ table {
 
 thead {
   width: 100%;
-
-  caption {
-    text-align: left;
-    display: table-cell;
-    vertical-align: inherit;
-    height: 60px;
-    padding-left: 30px;
-    font-weight: bold;
-    font-size: 0.9rem;
-  }
 }
 
 tbody {

--- a/orga/app/components/tube/list.hbs
+++ b/orga/app/components/tube/list.hbs
@@ -1,19 +1,34 @@
 <section>
   <div class="panel">
     <table class="table content-text content-text--small">
+      <caption>{{t "pages.preselect-target-profile.table.caption"}}</caption>
       <thead>
         <tr>
-          <Table::Header @size="wide">{{t "pages.preselect-target-profile.table.column.name"}}</Table::Header>
+          <Table::Header @size="x-small" @align="center" scope="col">
+            {{t "pages.preselect-target-profile.table.column.action"}}
+          </Table::Header>
+          <Table::Header @size="wide" scope="col">
+            {{t "pages.preselect-target-profile.table.column.name"}}
+          </Table::Header>
         </tr>
       </thead>
 
       <tbody>
         {{#each @tubes as |tube|}}
-          <tr class="row-tube" aria-label={{t "pages.preselect-target-profile.table.row-title"}}>
-            <td class="table__column">
-              {{tube.practicalTitle}}
-              :
-              {{tube.practicalDescription}}
+          <tr
+            {{on "click" this.toggleInput}}
+            class="row-tube tr--clickable"
+            aria-label={{t "pages.preselect-target-profile.table.row-title"}}
+          >
+            <td class="table__column--center">
+              <Input id="tube-{{tube.id}}" @type="checkbox" />
+            </td>
+            <td>
+              <label for="tube-{{tube.id}}">
+                {{tube.practicalTitle}}
+                :
+                {{tube.practicalDescription}}
+              </label>
             </td>
           </tr>
         {{/each}}

--- a/orga/app/components/tube/list.js
+++ b/orga/app/components/tube/list.js
@@ -1,0 +1,10 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class TubeList extends Component {
+  @action
+  toggleInput(event) {
+    const el = event.currentTarget.querySelector('input');
+    el.checked = !el.checked;
+  }
+}

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -26,16 +26,13 @@ thead {
     font-size: 0.875rem;
     font-weight: 500;
   }
+}
 
-  caption {
-    text-align: left;
-    display: table-cell;
-    vertical-align: inherit;
-    height: 60px;
-    padding-left: 30px;
-    font-weight: bold;
-    font-size: 0.9rem;
-  }
+caption {
+  text-align: center;
+  padding: 1rem 24px;
+  font-weight: bold;
+  font-size: 0.9rem;
 }
 
 tbody {
@@ -98,6 +95,11 @@ th::first-letter {
   &--center {
     text-align: center;
   }
+
+  &--x-small {
+    width: 3%;
+  }
+
 
   &--small {
     width: 6%;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -564,7 +564,9 @@
     "preselect-target-profile": {
       "title": "Topic selection",
       "table": {
+        "caption": "Topic selection",
         "column" : {
+          "action": "Select",
           "name": "Topic name"
         },
         "row-title": "Topic"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -565,7 +565,9 @@
     "preselect-target-profile": {
       "title": "Sélection des sujets",
       "table": {
+        "caption": "Sélection des sujets",
         "column" : {
+          "action": "Sélection",
           "name": "Nom du sujet"
         },
         "row-title": "Sujet"


### PR DESCRIPTION
## :christmas_tree: Problème  (PIX-3953)
La sélection de sujets pour un profil cible demande de sélectionner les dit-sujets (il y en a plus que 10 en plus).

## :gift: Solution
Rajouter une cache à cocher pour sélectionner un sujet

## :star2: Remarques
Nous avons corrigé le style de `<caption>` qui n'était pas correcte (il devait être descendant d'un `<thead>` alors qu'il faut qu'il soit le premier descendant d'un `<table>`).

## :santa: Pour tester
1. Aller sur /selection-sujets dans pix orga
2. Cliquer sur une ligne
3. Voir la cache à cocher changer d'état
![Screenshot 2021-12-13 at 17-35-11 Sélection des sujets Pix Orga](https://user-images.githubusercontent.com/86659/145851613-8e1ddfa2-37d8-4874-a211-2087d36ac873.png)

