### PR TITLE
[FEATURE] Afficher le mot de passe surveillant sur la page de session de Pix Certif (PIX-3730)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -5,27 +5,32 @@ const { WrongDateFormatError } = require('../../../domain/errors');
 const { isValidDate } = require('../../utils/date-utils');
 
 const Session = require('../../../domain/models/Session');
+const { featureToggles } = require('../../../config');
 
 module.exports = {
   serialize(sessions) {
+    const attributes = [
+      'address',
+      'room',
+      'examiner',
+      'date',
+      'time',
+      'status',
+      'description',
+      'accessCode',
+      'examinerGlobalComment',
+      'finalizedAt',
+      'resultsSentToPrescriberAt',
+      'publishedAt',
+      'certificationCenterId',
+      'certificationCandidates',
+      'certificationReports',
+    ];
+    if (featureToggles.isEndTestScreenRemovalEnabled) {
+      attributes.push('supervisorPassword');
+    }
     return new Serializer('session', {
-      attributes: [
-        'address',
-        'room',
-        'examiner',
-        'date',
-        'time',
-        'status',
-        'description',
-        'accessCode',
-        'examinerGlobalComment',
-        'finalizedAt',
-        'resultsSentToPrescriberAt',
-        'publishedAt',
-        'certificationCenterId',
-        'certificationCandidates',
-        'certificationReports',
-      ],
+      attributes,
       certificationCandidates: {
         ref: 'id',
         ignoreRelationshipData: true,

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -10,11 +10,24 @@ export default class SessionParametersController extends Controller {
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
+  @tracked sessionNumberTooltipText = '';
   @tracked accessCodeTooltipText = '';
 
   @computed('certificationCandidates.@each.isLinked')
   get sessionHasStarted() {
     return this.certificationCandidates.isAny('isLinked');
+  }
+
+  @action
+  async showSessionIdTooltip() {
+    this.sessionNumberTooltipText = 'Copié !';
+    await _waitForSeconds(2);
+    this.removeSessionNumberTooltip();
+  }
+
+  @action
+  removeSessionNumberTooltip() {
+    this.sessionNumberTooltipText = '';
   }
 
   @action

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class SessionParametersController extends Controller {
 
@@ -12,10 +13,16 @@ export default class SessionParametersController extends Controller {
   @alias('model.certificationCandidates') certificationCandidates;
   @tracked sessionNumberTooltipText = '';
   @tracked accessCodeTooltipText = '';
+  @tracked supervisorPasswordTooltipText = '';
+  @service featureToggles;
 
   @computed('certificationCandidates.@each.isLinked')
   get sessionHasStarted() {
     return this.certificationCandidates.isAny('isLinked');
+  }
+
+  get supervisorPasswordShouldBeDisplayed() {
+    return this.featureToggles.featureToggles.isEndTestScreenRemovalEnabled;
   }
 
   @action
@@ -40,6 +47,18 @@ export default class SessionParametersController extends Controller {
   @action
   removeAccessCodeTooltip() {
     this.accessCodeTooltipText = '';
+  }
+
+  @action
+  async showSupervisorPasswordTooltip() {
+    this.supervisorPasswordTooltipText = 'Copié !';
+    await _waitForSeconds(2);
+    this.removeSupervisorPasswordTooltip();
+  }
+
+  @action
+  removeSupervisorPasswordTooltip() {
+    this.supervisorPasswordTooltipText = '';
   }
 }
 

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -10,7 +10,7 @@ export default class SessionParametersController extends Controller {
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
-  @tracked tooltipText = 'Copier le lien direct';
+  @tracked accessCodeTooltipText = '';
 
   @computed('certificationCandidates.@each.isLinked')
   get sessionHasStarted() {
@@ -18,12 +18,19 @@ export default class SessionParametersController extends Controller {
   }
 
   @action
-  clipboardSuccess() {
-    this.tooltipText = 'Copié !';
+  async showAccessCodeTooltip() {
+    this.accessCodeTooltipText = 'Copié !';
+    await _waitForSeconds(2);
+    this.removeAccessCodeTooltip();
   }
 
   @action
-  clipboardOut() {
-    this.tooltipText = 'Copier le code d\'accès';
+  removeAccessCodeTooltip() {
+    this.accessCodeTooltipText = '';
   }
+}
+
+async function _waitForSeconds(timeoutInSeconds) {
+  const timeoutInMiliseconds = timeoutInSeconds * 1000;
+  return new Promise((resolve) => window.setTimeout(resolve, timeoutInMiliseconds));
 }

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -29,6 +29,7 @@ export default class Session extends Model {
   @attr('string') room;
   @attr('string') status;
   @attr('string') examinerGlobalComment;
+  @attr('string') supervisorPassword;
   @attr() certificationCenterId;
   @hasMany('certificationReport') certificationReports;
 

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -14,6 +14,7 @@
 }
 
 .session-details-header {
+
   &__title {
     display: flex;
     align-items: center;
@@ -32,6 +33,7 @@
 }
 
 .session-details-header-datetime {
+
   &__date {
     padding-right: 40px;
     margin-right: 40px;
@@ -47,56 +49,61 @@
 .session-details-row {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
+  padding: 0 8px;
 
   &:not(:last-child) {
     border-bottom: 1px solid $grey-20;
   }
 }
 
+$details-content-padding: 8px;
+$details-content-margin: 8px;
+
 .session-details-content {
   display: flex;
   flex-direction: column;
-  padding: 22px 30px;
+  padding: 16px;
 
   &--multiple {
-    &:first-child {
-      width: 10%;
-    }
+    border-right: 1px solid $grey-20;
+    padding: $details-content-padding + $details-content-margin;
+    white-space: nowrap;
+  }
 
-    &:nth-child(2) {
-      width: 25%;
-    }
-
-    &:nth-child(3) {
-      width: 25%;
-    }
-
-    &:nth-child(4) {
-      width: 25%;
-    }
-
-    &:last-child {
-      width: 10%;
-      white-space: nowrap;
-    }
+  &--copyable {
+    background: $grey-5;
+    margin: $details-content-margin;
+    padding: $details-content-padding 16px;
+    border-radius: 4px;
+    border: 0;
   }
 
   &--single {
-    &:first-child {
-      width: 55%;
-    }
-  }
-
-  &:not(:last-child) {
-    border-right: 1px solid $grey-20;
+    width: 100%;
   }
 
   &__label {
-    margin: 0 0 10px;
+    margin: 0;
+    min-height: 32px;
+    font-weight: 500;
+    font-size: 0.875rem;
+    color: $grey-90;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  &__sub-label {
+    color: $grey-50;
+    font-weight: normal;
+    font-size: 0.813rem;
   }
 
   &__text {
+    font-size: 0.875rem;
     margin: 0;
+    padding: 8px 0;
   }
 
   &__clipboard {
@@ -110,7 +117,7 @@
   }
 
   &__clipboard-button {
-    margin-left: 6px;
+    margin-left: 4px;
   }
 }
 

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -48,6 +48,36 @@
       </div>
     </div>
 
+    {{#if this.supervisorPasswordShouldBeDisplayed}}
+      <div class="session-details-content session-details-content--multiple session-details-content--copyable">
+        <h4 class="label-text session-details-content__label">
+          Mot de passe de session
+          <div class="session-details-content__sub-label">Surveillant</div>
+        </h4>
+        <div class="session-details-content__clipboard" {{on 'mouseout' this.removeSupervisorPasswordTooltip}}>
+          <span class="content-text content-text--bold session-details-content__text">
+            C-{{this.session.supervisorPassword}}
+          </span>
+          {{#if (is-clipboard-supported)}}
+            <PixTooltip
+              @id="tooltip-clipboard-button"
+              @text={{this.supervisorPasswordTooltipText}}
+              @isInline={{true}}
+            >
+              <CopyButton
+                @clipboardText={{this.session.supervisorPassword}}
+                @success={{this.showSupervisorPasswordTooltip}}
+                @classNames="icon-button session-details-content__clipboard-button"
+                aria-label="Copier le code d'accès"
+              >
+                <FaIcon @icon='copy' prefix='fas' />
+              </CopyButton>
+            </PixTooltip>
+          {{/if}}
+        </div>
+      </div>
+    {{/if}}
+
     <div class="session-details-content session-details-content--multiple">
       <h4 class="label-text session-details-content__label">Nom du site</h4>
       <span class="content-text session-details-content__text">{{this.session.address}}</span>

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -1,12 +1,14 @@
 <div class="panel session-details-container">
   <div class="session-details-row">
-    <div class="session-details-content session-details-content--multiple">
+    <div class="session-details-content session-details-content--multiple session-details-content--copyable">
       <h4 class="label-text session-details-content__label">Numéro de session</h4>
-      <span class="content-text session-details-content__text">{{this.session.id}}</span>
+      <span class="content-text content-text--bold session-details-content__text">{{this.session.id}}</span>
     </div>
 
-    <div class="session-details-content session-details-content--multiple">
-      <h4 class="label-text session-details-content__label">Code d'accès</h4>
+    <div class="session-details-content session-details-content--multiple session-details-content--copyable">
+      <h4 class="label-text session-details-content__label">Code d'accès
+        <div class="session-details-content__sub-label">Candidat</div>
+      </h4>
       <div class="session-details-content__clipboard">
         <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>
         {{#if (is-clipboard-supported)}}

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -2,7 +2,25 @@
   <div class="session-details-row">
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">
       <h4 class="label-text session-details-content__label">Numéro de session</h4>
-      <span class="content-text content-text--bold session-details-content__text">{{this.session.id}}</span>
+      <div class="session-details-content__clipboard" {{on 'mouseout' this.removeSessionNumberTooltip}}>
+        <span class="content-text content-text--bold session-details-content__text">{{this.session.id}}</span>
+        {{#if (is-clipboard-supported)}}
+          <PixTooltip
+            @id="tooltip-clipboard-button"
+            @text={{this.sessionNumberTooltipText}}
+            @isInline={{true}}
+          >
+            <CopyButton
+              @clipboardText={{this.session.id}}
+              @success={{this.showSessionIdTooltip}}
+              @classNames="icon-button session-details-content__clipboard-button"
+              aria-label="Copier le code d'accès"
+            >
+              <FaIcon @icon='copy' prefix='fas' />
+            </CopyButton>
+          </PixTooltip>
+        {{/if}}
+      </div>
     </div>
 
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -1,23 +1,8 @@
 <div class="panel session-details-container">
   <div class="session-details-row">
     <div class="session-details-content session-details-content--multiple">
-      <h4 class="label-text session-details-content__label">ID session</h4>
+      <h4 class="label-text session-details-content__label">Numéro de session</h4>
       <span class="content-text session-details-content__text">{{this.session.id}}</span>
-    </div>
-
-    <div class="session-details-content session-details-content--multiple">
-      <h4 class="label-text session-details-content__label">Nom du site</h4>
-      <span class="content-text session-details-content__text">{{this.session.address}}</span>
-    </div>
-
-    <div class="session-details-content session-details-content--multiple">
-      <h4 class="label-text session-details-content__label">Salle</h4>
-      <span class="content-text session-details-content__text">{{this.session.room}}</span>
-    </div>
-
-    <div class="session-details-content session-details-content--multiple">
-      <h4 class="label-text session-details-content__label">Surveillant(s)</h4>
-      <span class="content-text session-details-content__text">{{this.session.examiner}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
@@ -41,6 +26,23 @@
         {{/if}}
       </div>
     </div>
+
+    <div class="session-details-content session-details-content--multiple">
+      <h4 class="label-text session-details-content__label">Nom du site</h4>
+      <span class="content-text session-details-content__text">{{this.session.address}}</span>
+    </div>
+
+    <div class="session-details-content session-details-content--multiple">
+      <h4 class="label-text session-details-content__label">Salle</h4>
+      <span class="content-text session-details-content__text">{{this.session.room}}</span>
+    </div>
+
+    <div class="session-details-content session-details-content--multiple">
+      <h4 class="label-text session-details-content__label">Surveillant(s)</h4>
+      <span class="content-text session-details-content__text">{{this.session.examiner}}</span>
+    </div>
+
+
   </div>
 
   <div class="session-details-row">

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -9,20 +9,21 @@
       <h4 class="label-text session-details-content__label">Code d'accès
         <div class="session-details-content__sub-label">Candidat</div>
       </h4>
-      <div class="session-details-content__clipboard">
+      <div class="session-details-content__clipboard" {{on 'mouseout' this.removeAccessCodeTooltip}}>
         <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>
         {{#if (is-clipboard-supported)}}
           <PixTooltip
             @id="tooltip-clipboard-button"
-            @text={{this.tooltipText}}
+            @text={{this.accessCodeTooltipText}}
+            @isInline={{true}}
           >
             <CopyButton
               @clipboardText={{this.session.accessCode}}
-              @success={{this.clipboardSuccess}} {{on 'mouseLeave' this.clipboardOut}}
+              @success={{this.showAccessCodeTooltip}}
               @classNames="icon-button session-details-content__clipboard-button"
-              aria-labelledby="tooltip-clipboard-button"
+              aria-label="Copier le code d'accès"
             >
-              <FaIcon @icon='copy' prefix='far' />
+              <FaIcon @icon='copy' prefix='fas' />
             </CopyButton>
           </PixTooltip>
         {{/if}}

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -4,6 +4,94 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@1024pix/ember-testing-library": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/ember-testing-library/-/ember-testing-library-0.5.0.tgz",
+      "integrity": "sha512-CGlNllnB1TUW+MSjp9B1NT78cI4zha2eUtMWx9TptH4rvNxuP7tplUXHgkNYpqp+M+lhhv7jgr4UkpcOYE2sbg==",
+      "dev": true,
+      "requires": {
+        "@testing-library/dom": "^8.9.0",
+        "broccoli-funnel": "^3.0.8",
+        "ember-auto-import": "^1.11.3",
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fs-merger": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.2.1.tgz",
+          "integrity": "sha512-AN6sX12liy0JE7C2evclwoo0aCG3PFulLjrTLsJpWh/2mM+DinhpSGqYLbHBBbIW1PLRNcFhJG8Axtz8mQW3ug==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-node-info": "^2.1.0",
+            "fs-extra": "^8.0.1",
+            "fs-tree-diff": "^2.0.1",
+            "walk-sync": "^2.2.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "promise-map-series": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -3770,121 +3858,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@pix/ember-testing-library": {
-      "version": "https://github.com/1024pix/ember-testing-library/tarball/v0.1.0",
-      "integrity": "sha512-EkzLKV3+P3mRR2BTGf5dTd5MGTqMqjMsqtJGX4aD7RdyvaFrxAn4yI7dy93OCtfmZpJlK7wxjWXRKrvr/LLZ9g==",
-      "dev": true,
-      "requires": {
-        "@testing-library/dom": "^8.9.0",
-        "broccoli-funnel": "^3.0.8",
-        "ember-auto-import": "^1.11.3",
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.7.1"
-      },
-      "dependencies": {
-        "@testing-library/dom": {
-          "version": "8.10.1",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.10.1.tgz",
-          "integrity": "sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^4.2.0",
-            "aria-query": "^5.0.0",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^27.0.2"
-          }
-        },
-        "aria-query": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
-          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
-          "dev": true
-        },
-        "broccoli-funnel": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
-          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "broccoli-plugin": "^4.0.7",
-            "debug": "^4.1.1",
-            "fs-tree-diff": "^2.0.1",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "walk-sync": "^2.0.2"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
-          }
-        },
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "dom-accessibility-api": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz",
-          "integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==",
-          "dev": true
-        },
-        "fs-merger": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.2.1.tgz",
-          "integrity": "sha512-AN6sX12liy0JE7C2evclwoo0aCG3PFulLjrTLsJpWh/2mM+DinhpSGqYLbHBBbIW1PLRNcFhJG8Axtz8mQW3ug==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-node-info": "^2.1.0",
-            "fs-extra": "^8.0.1",
-            "fs-tree-diff": "^2.0.1",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "promise-map-series": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
     "@simple-dom/interface": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
@@ -3953,6 +3926,22 @@
       "requires": {
         "remark": "^13.0.0",
         "unist-util-find-all-after": "^3.0.2"
+      }
+    },
+    "@testing-library/dom": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+      "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
       }
     },
     "@types/acorn": {
@@ -4651,6 +4640,12 @@
           "dev": true
         }
       }
+    },
+    "aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -9370,6 +9365,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "0.2.2",

--- a/certif/package.json
+++ b/certif/package.json
@@ -38,6 +38,7 @@
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
+    "@1024pix/ember-testing-library": "^0.5.0",
     "@ember/optional-features": "^2.0.0",
     "@fortawesome/ember-fontawesome": "^0.2.3",
     "@fortawesome/free-brands-svg-icons": "^5.15.3",
@@ -45,7 +46,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@pix/ember-testing-library": "https://github.com/1024pix/ember-testing-library/tarball/v0.1.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.12.0",

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -8,7 +8,7 @@ import {
   authenticateSession,
 } from '../helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { visit as visitScreen } from '@pix/ember-testing-library';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | authenticated', function(hooks) {
 

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { authenticateSession } from '../helpers/test-init';
 import { upload } from 'ember-file-upload/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { visit as visitScreen } from '@pix/ember-testing-library';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Session Details Certification Candidates', function(hooks) {
 

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   authenticateSession,
 } from '../helpers/test-init';
+import { visit } from '@1024pix/ember-testing-library';
 
 import config from 'pix-certif/config/environment';
 
@@ -96,20 +97,25 @@ module('Acceptance | Session Details', function(hooks) {
 
       test('it should display session details', async function(assert) {
         // given
-        const session = server.create('session', {
+        server.create('session', {
+          id: 123,
           date: '2019-02-18',
           time: '14:00',
+          address: '123 rue des peupliers',
+          room: 'Salle 101',
+          examiner: 'Winston',
+          accessCode: 'ABC123',
         });
 
         // when
-        await visit(`/sessions/${session.id}`);
+        const screen = await visit('/sessions/123');
 
         // then
-        assert.dom('.session-details-header__title h1').hasText(`Session ${session.id}`);
-        assert.dom('.session-details-container .session-details-row:first-child div:nth-child(2) span').hasText(`${session.address}`);
-        assert.dom('.session-details-container .session-details-row:first-child div:nth-child(3) span').hasText(`${session.room}`);
-        assert.dom('.session-details-container .session-details-row:first-child div:nth-child(4) span').hasText(`${session.examiner}`);
-        assert.dom('.session-details-container .session-details-row:first-child div:nth-child(5) span:first-child').hasText(`${session.accessCode}`);
+        assert.dom('.session-details-header__title h1').hasText('Session 123');
+        assert.dom(screen.getByText('123 rue des peupliers')).exists();
+        assert.dom(screen.getByText('Salle 101')).exists();
+        assert.dom(screen.getByText('Winston')).exists();
+        assert.dom(screen.getByText('ABC123')).exists();
         assert.dom('.session-details-header-datetime__date .content-text').hasText('lundi 18 févr. 2019');
         assert.contains('14:00');
       });

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, fillIn, find } from '@ember/test-helpers';
-import { visit as visitScreen } from '@pix/ember-testing-library';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { authenticateSession } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';

--- a/certif/tests/acceptance/supervisor-portal-access_test.js
+++ b/certif/tests/acceptance/supervisor-portal-access_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { fillIn, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit as visitScreen } from '@pix/ember-testing-library';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { authenticateSession } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';

--- a/certif/tests/acceptance/terms-of-service_test.js
+++ b/certif/tests/acceptance/terms-of-service_test.js
@@ -7,7 +7,7 @@ import {
   createCertificationPointOfContactWithTermsOfServiceAccepted,
   authenticateSession,
 } from '../helpers/test-init';
-import { visit as visitScreen } from '@pix/ember-testing-library';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 

--- a/certif/tests/helpers/extended-ember-test-helpers/click-by-label.js
+++ b/certif/tests/helpers/extended-ember-test-helpers/click-by-label.js
@@ -1,4 +1,4 @@
-import { getScreen } from '@pix/ember-testing-library';
+import { getScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 
 export default function clickByLabel(labelText) {

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | certification-candidate-details-modal', function(hooks) {
   setupRenderingTest(hooks);

--- a/certif/tests/integration/components/issue-report-modal/issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/issue-report-modal_test.js
@@ -4,7 +4,7 @@ import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | issue-report-modal', function(hooks) {
   setupRenderingTest(hooks);

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn } from '@ember/test-helpers';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 
 import hbs from 'htmlbars-inline-precompile';

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -4,7 +4,7 @@ import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 
 module('Integration | Component | new-certification-candidate-modal', function(hooks) {

--- a/certif/tests/integration/components/pagination-control_test.js
+++ b/certif/tests/integration/components/pagination-control_test.js
@@ -4,7 +4,7 @@ import { render, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import Service from '@ember/service';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 function getMetaForPage(pageNumber) {
   const rowCount = 50;

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -6,7 +6,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | SessionFinalization::CompletedReportsInformationStep', function(hooks) {
   setupRenderingTest(hooks);

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -7,7 +7,7 @@ import { run } from '@ember/runloop';
 import sinon from 'sinon';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | SessionFinalization::UncompletedReportsInformationStep', function(hooks) {
   setupRenderingTest(hooks);

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 
 import hbs from 'htmlbars-inline-precompile';

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render as renderScreen } from '@pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 import hbs from 'htmlbars-inline-precompile';
 

--- a/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
@@ -25,7 +25,7 @@ Then(`je vois le formulaire de modification de session de certification`, () => 
 });
 
 Then(`je lis la valeur {string} à l'emplacement de l'adresse de la session`, (sessionAddress) => {
-  cy.get('.session-details-row div:nth-child(2)').should('contain', sessionAddress);
+  cy.get('.session-details-row .session-details-content:nth-child(3) .session-details-content__text').should('contain', sessionAddress);
 });
 
 Then('je vois {int} candidat(s) dans le tableau de candidats', (candidateCount) => {


### PR DESCRIPTION
## :christmas_tree: Problème

Un surveillant souhaitant accéder à l’espace surveillant pour administrer une session de certification doit entrer le mot de passe de la session généré à la création de la session. Le surveillant n'étant pas forcément un membre de l’espace Pix Certif, il faut permettre à la personne ayant créé la session de communiquer ce mot de passe au(x) surveillant(s) de la session.

## :gift: Solution

Afficher le mot de passe de la session sur la page de détails de la session dans Pix Certif, pour TOUS les centres de certification  
- Maquette : https://share.goabstract.com/03a9e902-b390-407f-92e9-5b9bd4afaf6e mode=design&sha=d3d87eef8965a0e64d0c17d760a50e02ac0099d5
- Ne prendre en compte que les modifications de la ligne avec les infos de la session

## :star2: Remarques

Ajout du "copier dans le presse-papier" pour le numero de session quelque soit la valeur du toggle

## :santa: Pour tester

### Avec le toggle `FT_END_TEST_SCREEN_REMOVAL_ENABLED` **désactivé**

1. Se connecter à Pix Certif
2. Créer une session
3. Constater la nouvelle présentation des informations de session
4. Constater que le mot de passe surveillant n'apparaît pas
5. Cliquer sur le bouton copier en regard du numéro de session
6. Constater l'apparition du tooltip "Copié !" et sa disparition après deux secondes
7. Constater que le numéro de session a été copié dans le presse-papiers

### Avec le toggle `FT_END_TEST_SCREEN_REMOVAL_ENABLED` **activé**

1. Se connecter à Pix Certif
2. Créer une session
3. Constater la nouvelle présentation des informations de session
4. Constater que le mot de passe surveillant apparaît bien, préfixé par C-
5. Cliquer sur le bouton copier en regard du mot de passe surveillant
6. Constater l'apparition du tooltip "Copié !" et sa disparition après deux secondes

