### PR TITLE
[FEATURE]  Modifier l'url de documentation dans le détail d'une orga sur pix admin (Pix-3973).

### DIFF
--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -28,7 +28,7 @@
               Nom
             </label>
             {{#if (v-get this.form "name" "isInvalid")}}
-              <div class="form-field__error" aria-label="Message d'erreur du champ nom">
+              <div class="form-field__error">
                 {{v-get this.form "name" "message"}}
               </div>
             {{/if}}
@@ -43,7 +43,7 @@
           <div class="form-field">
             <label for="externalId" class="form-field__label">Identifiant externe</label>
             {{#if (v-get this.form "externalId" "isInvalid")}}
-              <div class="form-field__error" aria-label="Message d'erreur du champ identifiant externe">
+              <div class="form-field__error">
                 {{v-get this.form "externalId" "message"}}
               </div>
             {{/if}}
@@ -57,7 +57,7 @@
           <div class="form-field">
             <label for="provinceCode" class="form-field__label">Département (en 3 chiffres)</label>
             {{#if (v-get this.form "provinceCode" "isInvalid")}}
-              <div class="form-field__error" aria-label="Message d'erreur du champ département">
+              <div class="form-field__error">
                 {{v-get this.form "provinceCode" "message"}}
               </div>
             {{/if}}
@@ -71,7 +71,7 @@
           <div class="form-field">
             <label for="email" class="form-field__label">Adresse e-mail (SCO)</label>
             {{#if (v-get this.form "email" "isInvalid")}}
-              <div class="form-field__error" aria-label="Message d'erreur du champ adresse email">
+              <div class="form-field__error">
                 {{v-get this.form "email" "message"}}
               </div>
             {{/if}}
@@ -94,6 +94,20 @@
               @type="number"
               class={{if (v-get this.form "credit" "isInvalid") "form-control is-invalid" "form-control"}}
               @value={{this.form.credit}}
+            />
+          </div>
+          <div class="form-field">
+            <label for="documentationUrl" class="form-field__label">Lien vers la documentation</label>
+            {{#if (v-get this.form "documentationUrl" "isInvalid")}}
+              <div class="form-field__error">
+                {{v-get this.form "documentationUrl" "message"}}
+              </div>
+            {{/if}}
+            <Input
+              id="documentationUrl"
+              @type="text"
+              class={{if (v-get this.form "documentationUrl" "isInvalid") "form-control is-invalid" "form-control"}}
+              @value={{this.form.documentationUrl}}
             />
           </div>
           {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
@@ -213,7 +227,6 @@
               @isBorderVisible={{true}}
               @size="small"
               @triggerAction={{this.toggleEditMode}}
-              aria-label="Editer"
             >Editer</PixButton>
           </div>
           <div>

--- a/admin/app/components/organizations/information-section.js
+++ b/admin/app/components/organizations/information-section.js
@@ -75,6 +75,14 @@ const Validations = buildValidations({
       }),
     ],
   },
+  documentationUrl: {
+    validators: [
+      validator('absolute-url', {
+        allowBlank: true,
+        message: "Le lien n'est pas valide.",
+      }),
+    ],
+  },
 });
 
 class Form extends Object.extend(Validations) {
@@ -85,6 +93,7 @@ class Form extends Object.extend(Validations) {
   @tracked credit;
   @tracked isManagingStudents;
   @tracked canCollectProfiles;
+  @tracked documentationUrl;
 }
 
 export default class OrganizationInformationSection extends Component {
@@ -136,6 +145,7 @@ export default class OrganizationInformationSection extends Component {
     this.args.organization.set('credit', !this.form.credit ? null : this.form.credit);
     this.args.organization.set('isManagingStudents', this.form.isManagingStudents);
     this.args.organization.set('canCollectProfiles', this.form.canCollectProfiles);
+    this.args.organization.set('documentationUrl', this.form.documentationUrl);
 
     this.isEditMode = false;
     return this.args.onSubmit();
@@ -149,5 +159,6 @@ export default class OrganizationInformationSection extends Component {
     this.form.credit = this.args.organization.credit;
     this.form.isManagingStudents = this.args.organization.isManagingStudents;
     this.form.canCollectProfiles = this.args.organization.canCollectProfiles;
+    this.form.documentationUrl = this.args.organization.documentationUrl;
   }
 }

--- a/admin/app/validators/absolute-url.js
+++ b/admin/app/validators/absolute-url.js
@@ -1,0 +1,30 @@
+import FormatValidator from 'ember-cp-validations/validators/format';
+
+const AbsoluteUrl = FormatValidator.extend({
+  validate(value, options, model, attribute) {
+    if (value && !(value.startsWith('http://') || value.startsWith('https://'))) {
+      return options.message;
+    }
+    return this._super(value, { ...options, type: 'url' }, model, attribute);
+  },
+});
+
+AbsoluteUrl.reopenClass({
+  /**
+   * Define attribute specific dependent keys for your validator
+   *
+   * [
+   * 	`model.array.@each.${attribute}` --> Dependent is created on the model's context
+   * 	`${attribute}.isValid` --> Dependent is created on the `model.validations.attrs` context
+   * ]
+   *
+   * @param {String}  attribute   The attribute being evaluated
+   * @param {Unknown} options     Options passed into your validator
+   * @return {Array}
+   */
+  getDependentsFor(/* attribute, options */) {
+    return [];
+  },
+});
+
+export default AbsoluteUrl;

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render, fillIn } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
@@ -101,6 +101,7 @@ module('Integration | Component | organizations/information-section', function (
         isOrganizationSCO: true,
         isManagingStudents: false,
         credit: 0,
+        documentationUrl: 'https://pix.fr/',
       });
       this.set('organization', organization);
     });
@@ -110,7 +111,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // then
-      assert.dom("button[aria-label='Editer']").exists();
+      assert.contains('Editer');
     });
 
     test('it should toggle edition mode on click to edit button', async function (assert) {
@@ -118,7 +119,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
 
       // then
       assert.dom('.organization__edit-form').exists();
@@ -129,7 +130,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
 
       // then
       assert.dom('input#name').hasValue(organization.name);
@@ -139,6 +140,7 @@ module('Integration | Component | organizations/information-section', function (
       assert.dom('input#credit').hasValue(organization.credit.toString());
       assert.dom('input#canCollectProfiles').isNotChecked();
       assert.dom('input#isManagingStudents').isNotChecked();
+      assert.dom('input#documentationUrl').hasValue(organization.documentationUrl);
     });
 
     test("it should show error message if organization's name is empty", async function (assert) {
@@ -146,11 +148,11 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
       await fillIn('#name', '');
 
       // then
-      assert.dom('div[aria-label="Message d\'erreur du champ nom"]').hasText('Le nom ne peut pas être vide');
+      assert.contains('Le nom ne peut pas être vide');
     });
 
     test("it should show error message if organization's name is longer than 255 characters", async function (assert) {
@@ -158,13 +160,11 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
       await fillIn('#name', 'a'.repeat(256));
 
       // then
-      assert
-        .dom('div[aria-label="Message d\'erreur du champ nom"]')
-        .hasText('La longueur du nom ne doit pas excéder 255 caractères');
+      assert.contains('La longueur du nom ne doit pas excéder 255 caractères');
     });
 
     test("it should show error message if organization's external id is longer than 255 characters", async function (assert) {
@@ -172,13 +172,11 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
       await fillIn('#externalId', 'a'.repeat(256));
 
       // then
-      assert
-        .dom('div[aria-label="Message d\'erreur du champ identifiant externe"]')
-        .hasText("La longueur de l'identifiant externe ne doit pas excéder 255 caractères");
+      assert.contains("La longueur de l'identifiant externe ne doit pas excéder 255 caractères");
     });
 
     test("it should show error message if organization's province code is longer than 255 characters", async function (assert) {
@@ -186,13 +184,11 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
       await fillIn('#provinceCode', 'a'.repeat(256));
 
       // then
-      assert
-        .dom('div[aria-label="Message d\'erreur du champ département"]')
-        .hasText('La longueur du département ne doit pas excéder 255 caractères');
+      assert.contains('La longueur du département ne doit pas excéder 255 caractères');
     });
 
     test("it should show error message if organization's email is longer than 255 characters", async function (assert) {
@@ -200,13 +196,11 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
       await fillIn('#email', 'a'.repeat(256));
 
       // then
-      assert
-        .dom('div[aria-label="Message d\'erreur du champ adresse email"]')
-        .hasText("La longueur de l'email ne doit pas excéder 255 caractères.");
+      assert.contains("La longueur de l'email ne doit pas excéder 255 caractères.");
     });
 
     test("it should show error message if organization's email is not valid", async function (assert) {
@@ -214,13 +208,11 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
       await fillIn('#email', 'not-valid-email-format');
 
       // then
-      assert
-        .dom('div[aria-label="Message d\'erreur du champ adresse email"]')
-        .hasText("L'e-mail n'a pas le bon format.");
+      assert.contains("L'e-mail n'a pas le bon format.");
     });
 
     test("it should show error message if organization's credit is not valid", async function (assert) {
@@ -228,7 +220,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await click("button[aria-label='Editer']");
+      await clickByLabel('Editer');
       await fillIn('#credit', 'credit');
 
       // then
@@ -247,6 +239,18 @@ module('Integration | Component | organizations/information-section', function (
       assert.dom('.organization__data').exists();
     });
 
+    test("it should show error message if organization's documentationUrl is not valid", async function (assert) {
+      // given
+      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+
+      // when
+      await clickByLabel('Editer');
+      await fillIn('#documentationUrl', 'not-valid-url-format');
+
+      // then
+      assert.contains("Le lien n'est pas valide.");
+    });
+
     test('it should revert changes on click to cancel button', async function (assert) {
       // given
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
@@ -257,6 +261,7 @@ module('Integration | Component | organizations/information-section', function (
       await fillIn('input#provinceCode', 'new provinceCode');
       await clickByLabel('Gestion d’élèves/étudiants');
       await clickByLabel('Collecte de profils');
+      await fillIn('input#documentationUrl', 'new documentationUrl');
 
       // when
       await clickByLabel('Annuler');
@@ -267,6 +272,7 @@ module('Integration | Component | organizations/information-section', function (
       assert.contains(organization.provinceCode);
       assert.dom('.organization__isManagingStudents').hasText('Non');
       assert.dom('.organization__canCollectProfiles').hasText('Non');
+      assert.contains(organization.documentationUrl);
     });
 
     test('it should submit the form if there is no error', async function (assert) {
@@ -283,6 +289,7 @@ module('Integration | Component | organizations/information-section', function (
       await fillIn('input#credit', 50);
       await clickByLabel('Gestion d’élèves/étudiants');
       await clickByLabel('Collecte de profils');
+      await fillIn('input#documentationUrl', 'https://pix.fr/');
 
       // when
       await clickByLabel('Enregistrer');
@@ -294,6 +301,7 @@ module('Integration | Component | organizations/information-section', function (
       assert.contains('50');
       assert.dom('.organization__canCollectProfiles').hasText('Oui');
       assert.dom('.organization__isManagingStudents').hasText('Oui');
+      assert.contains('https://pix.fr/');
     });
   });
 

--- a/admin/tests/unit/validators/absolute-url-test.js
+++ b/admin/tests/unit/validators/absolute-url-test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Validator | absolute-url', function (hooks) {
+  setupTest(hooks);
+
+  const options = { message: "Le lien n'est pas valide." };
+
+  test('it does not returns an error message when url is empty', async function (assert) {
+    const validator = this.owner.lookup('validator:absolute-url');
+    const emptyUrl = '';
+
+    const message = await validator.validate(emptyUrl, { ...options, allowBlank: true });
+
+    assert.true(message);
+  });
+
+  test('it returns an error message when url does not start with http(s)://', async function (assert) {
+    const validator = this.owner.lookup('validator:absolute-url');
+    const badUrl = 'google.com';
+
+    const message = await validator.validate(badUrl, options);
+
+    assert.equal(message, options.message);
+  });
+
+  test('it does not return an error message when url starts with http://', async function (assert) {
+    const validator = this.owner.lookup('validator:absolute-url');
+    const goodUrl = 'http://google.com';
+
+    const message = await validator.validate(goodUrl, options);
+
+    assert.true(message);
+  });
+
+  test('it does not return an error message when url starts with https://', async function (assert) {
+    const validator = this.owner.lookup('validator:absolute-url');
+    const goodUrl = 'https://google.com';
+
+    const message = await validator.validate(goodUrl, options);
+
+    assert.true(message);
+  });
+
+  test('it returns an error message when url does not end with domain extension', async function (assert) {
+    const validator = this.owner.lookup('validator:absolute-url');
+    const badUrl = 'http://google';
+
+    const message = await validator.validate(badUrl, options);
+
+    assert.equal(message, options.message);
+  });
+});

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -25,6 +25,7 @@ module.exports = async function updateOrganizationInformation({
   existingOrganization.provinceCode = organization.provinceCode;
   existingOrganization.isManagingStudents = organization.isManagingStudents;
   existingOrganization.canCollectProfiles = organization.canCollectProfiles;
+  existingOrganization.documentationUrl = organization.documentationUrl;
 
   return organizationRepository.update(existingOrganization);
 };

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -100,6 +100,7 @@ module.exports = {
       'canCollectProfiles',
       'email',
       'credit',
+      'documentationUrl',
     ]);
 
     return new BookshelfOrganization({ id: organization.id })

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -83,6 +83,7 @@ module.exports = {
       isManagingStudents: attributes['is-managing-students'],
       canCollectProfiles: attributes['can-collect-profiles'],
       createdBy: attributes['created-by'],
+      documentationUrl: attributes['documentation-url'],
       tags,
     });
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -612,6 +612,7 @@ describe('Acceptance | Application | organization-controller', function () {
           credit: 666,
           email: 'sco.generic.account@example.net',
           createdBy: pixMasterUserId,
+          documentationUrl: 'https://pix.fr/',
         });
 
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -121,6 +121,7 @@ describe('Integration | Repository | Organization', function () {
         canCollectProfiles: true,
         credit: 50,
         email: 'email@example.net',
+        documentationUrl: 'https://pix.fr/',
       });
 
       // when
@@ -137,6 +138,7 @@ describe('Integration | Repository | Organization', function () {
       expect(organizationSaved.canCollectProfiles).to.equal(organization.canCollectProfiles);
       expect(organizationSaved.credit).to.equal(organization.credit);
       expect(organizationSaved.email).to.equal(organization.email);
+      expect(organizationSaved.documentationUrl).to.equal('https://pix.fr/');
     });
   });
 

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -246,6 +246,28 @@ describe('Unit | UseCase | update-organization-information', function () {
       });
     });
 
+    it('should allow to update the organization documentationUrl', async function () {
+      // given
+      const newDocumentationUrl = 'https://pix.fr/';
+      const organizationId = 7;
+      const givenOrganization = _buildOrganizationWithNullAttributes({
+        id: organizationId,
+        documentationUrl: newDocumentationUrl,
+      });
+      const originalOrganization = _buildOriginalOrganization(organizationId);
+
+      organizationRepository.get.resolves(originalOrganization);
+
+      // when
+      await updateOrganizationInformation({ organization: givenOrganization, organizationRepository });
+
+      // then
+      expect(organizationRepository.update).to.have.been.calledWithMatch({
+        ...originalOrganization,
+        documentationUrl: newDocumentationUrl,
+      });
+    });
+
     context('when updating tags', function () {
       it('should allow to assign a tag to organization', async function () {
         // given
@@ -349,6 +371,7 @@ function _buildOrganizationWithNullAttributes(attributes) {
     email: attributes.email,
     credit: attributes.credit,
     tags: attributes.tags,
+    documentationUrl: attributes.documentationUrl,
   });
 }
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -122,6 +122,7 @@ describe('Unit | Serializer | organization-serializer', function () {
         isManagingStudents: true,
         canCollectProfiles: true,
         createdBy: 10,
+        documentationUrl: 'https://pix.fr/',
       };
       const jsonApiOrganization = {
         data: {
@@ -138,6 +139,7 @@ describe('Unit | Serializer | organization-serializer', function () {
             'is-managing-students': organizationAttributes.isManagingStudents,
             'can-collect-profiles': organizationAttributes.canCollectProfiles,
             'created-by': organizationAttributes.createdBy,
+            'documentation-url': organizationAttributes.documentationUrl,
           },
         },
       };
@@ -158,6 +160,7 @@ describe('Unit | Serializer | organization-serializer', function () {
         isManagingStudents: organizationAttributes.isManagingStudents,
         canCollectProfiles: organizationAttributes.canCollectProfiles,
         createdBy: organizationAttributes.createdBy,
+        documentationUrl: organizationAttributes.documentationUrl,
       });
       expect(organization).to.be.instanceOf(Organization);
       expect(organization).to.deep.equal(expectedOrganization);


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à l'ajout du champs documentationUrl dans la BDD #3807  puis afficher le URL depuis pix admin dans la page de détail d'une orga #3810 , maintenant nous avons besoin de le modifie dans pix Admin pour faciliter la gestion sur l’information d'une orga en interne.

## :gift: Solution
Ajoutez la possibilité de modifier le lien vers la documentation depuis pix Admin dans la page de détail d'une orga.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- Se connecter à Pix Admin
- Aller dans l'organisation "Collège The Night Watch"
- Constater la présence de lien de documentation à modifier https://pix.fr/ qui s'ouvre dans un nouvel onglet lorsqu'on clique dessus.
- Cliquez sur 'Editer' pour modifier les information de l'orga , puis constatez que le champ  'Lien vers la documentation existe'
- Changer/effacez le lien vers la documentation puis sauvegardez.
- Verifier aussi la validation du lien dans le champ, un message d'erreur doit apparaître si le format saisi n'est correct.
- Constater que le lien vers la documentation à été changé.