### PR TITLE
[FEATURE] Afficher dans l'espace surveillant quand un candidat a terminé son test (PIX-3659)

### DIFF
--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -52,7 +52,7 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   // A candidate that is authorized to start
   databaseBuilder.factory.buildCertificationCandidate({
     firstName: 'Jean-François',
-    lastName: 'Ananas',
+    lastName: 'Apascommencé',
     sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
     userId: null,
     authorizedToStart: true,
@@ -62,7 +62,7 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   const userId = databaseBuilder.factory.buildUser().id;
   const candidateWithStartedTest = {
     firstName: 'Jean-Pierre',
-    lastName: 'Arbuste',
+    lastName: 'Acommencé',
     userId,
     sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
   };
@@ -77,6 +77,9 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
     certificationCourseId: certificationCourse.id,
     state: Assessment.states.STARTED,
   });
+
+  _addCandidateWithTestCompleted({ sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, databaseBuilder });
+  _addCandidateWithTestEndedBySupervisor({ sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, databaseBuilder });
 
   let sessionId;
   const candidateDataSuccessWithUser = { ...CANDIDATE_DATA_SUCCESS, userId: CERTIF_SUCCESS_USER_ID };
@@ -176,4 +179,46 @@ function _convertToRoman(num) {
       return roman + _convertToRoman(num - pivot);
     }
   }
+}
+
+function _addCandidateWithTestCompleted({ sessionId, databaseBuilder }) {
+  const user = databaseBuilder.factory.buildUser();
+  const candidate = {
+    firstName: 'Jean-Claude',
+    lastName: 'Afini',
+    userId: user.id,
+    sessionId,
+  };
+  databaseBuilder.factory.buildCertificationCandidate({
+    ...candidate,
+    authorizedToStart: true,
+  });
+  const certificationCourseWithCompletedTest = databaseBuilder.factory.buildCertificationCourse({
+    ...candidate,
+  });
+  databaseBuilder.factory.buildAssessment({
+    certificationCourseId: certificationCourseWithCompletedTest.id,
+    state: Assessment.states.COMPLETED,
+  });
+}
+
+function _addCandidateWithTestEndedBySupervisor({ sessionId, databaseBuilder }) {
+  const user = databaseBuilder.factory.buildUser();
+  const candidate = {
+    firstName: 'Jean-Michel',
+    lastName: 'Avusontestterminéparlesurveillant',
+    userId: user.id,
+    sessionId,
+  };
+  databaseBuilder.factory.buildCertificationCandidate({
+    ...candidate,
+    authorizedToStart: true,
+  });
+  const certificationCourseWithCompletedTest = databaseBuilder.factory.buildCertificationCourse({
+    ...candidate,
+  });
+  databaseBuilder.factory.buildAssessment({
+    certificationCourseId: certificationCourseWithCompletedTest.id,
+    state: Assessment.states.ENDED_BY_SUPERVISOR,
+  });
 }

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -9,6 +9,7 @@ const states = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ABORTED: 'aborted',
+  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
 };
 
 const types = {

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -1,5 +1,5 @@
 <li class="session-supervising-candidate-in-list">
-  {{#unless @candidate.hasStarted}}
+  {{#if this.isCheckboxToBeDisplayed}}
     <PixInput
       @id={{concat "candidate-checkbox-" @candidate.id}}
       class="session-supervising-candidate-in-list__checkbox"
@@ -7,7 +7,7 @@
       checked={{@candidate.authorizedToStart}}
       {{on 'click' (fn this.toggleCandidate @candidate)}}
     />
-  {{/unless}}
+  {{/if}}
   <div class="session-supervising-candidate-in-list__candidate-data">
     <div class="session-supervising-candidate-in-list__full-name">
       {{#if @candidate.hasStarted}}
@@ -29,8 +29,13 @@
         En cours
       </span>
     {{/if}}
+    {{#if @candidate.hasCompleted}}
+      <span class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--completed">
+        Terminé
+      </span>
+    {{/if}}
   </div>
-  {{#if @candidate.hasStarted}}
+  {{#if this.optionsMenuShouldBeDisplayed}}
     <div class="session-supervising-candidate-in-list__menu">
       <PixIconButton
         @icon="ellipsis-v"

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -9,6 +9,14 @@ export default class CandidateInList extends Component {
   @tracked isMenuOpen = false;
   @tracked isConfirmationModalDisplayed = false;
 
+  get isCheckboxToBeDisplayed() {
+    return !this.args.candidate.hasStarted && !this.args.candidate.hasCompleted;
+  }
+
+  get optionsMenuShouldBeDisplayed() {
+    return this.args.candidate.hasStarted;
+  }
+
   @action
   async toggleCandidate(candidate) {
     await this.args.toggleCandidate(candidate);

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -1,6 +1,13 @@
 import Model, { attr } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
 
+const assessmentStates = {
+  COMPLETED: 'completed',
+  STARTED: 'started',
+  ABORTED: 'aborted',
+  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+};
+
 export default class CertificationCandidateForSupervising extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
@@ -11,6 +18,11 @@ export default class CertificationCandidateForSupervising extends Model {
 
   get hasStarted() {
     return this.assessmentStatus === 'started';
+  }
+
+  get hasCompleted() {
+    return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_SUPERVISOR]
+      .includes(this.assessmentStatus);
   }
 
   updateAuthorizedToStart = memberAction({

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -42,6 +42,11 @@ $green-70: #006134;
       background-color: $green-0;
       color: $green-70;
     }
+
+    &--completed {
+      background-color: $blue-alert-light;
+      color: $blue-alert-dark;
+    }
   }
 
   &__menu {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -306,6 +306,62 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
     });
   });
 
+  module('when the candidate has completed the test', function() {
+    test('it displays the "terminé" label and no options menu', async function(assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        firstName: 'Martinex',
+        lastName: 'T\'Naga',
+        birthdate: '1979-08-27',
+        extraTimePercentage: null,
+        authorizedToStart: true,
+        assessmentStatus: 'completed',
+      });
+      this.toggleCandidate = sinon.spy();
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList
+          @candidate={{this.candidate}}
+          @toggleCandidate={{this.toggleCandidate}}
+        />
+      `);
+
+      // then
+      assert.dom('.session-supervising-candidate-in-list').hasText('T\'Naga Martinex 27/08/1979 Terminé');
+      assert.dom(screen.queryByRole('checkbox', { name: 'T\'Naga Martinex' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).doesNotExist();
+    });
+  });
+
+  module('when the candidate\'s test has been ended by supervisor', function() {
+    test('it displays the "terminé" label and no options menu', async function(assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        firstName: 'Stakar',
+        lastName: 'Ogord',
+        birthdate: '1976-09-26',
+        extraTimePercentage: null,
+        authorizedToStart: true,
+        assessmentStatus: 'endedBySupervisor',
+      });
+      this.toggleCandidate = sinon.spy();
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList
+          @candidate={{this.candidate}}
+          @toggleCandidate={{this.toggleCandidate}}
+        />
+      `);
+
+      // then
+      assert.dom('.session-supervising-candidate-in-list').hasText('Ogord Stakar 26/09/1976 Terminé');
+      assert.dom(screen.queryByRole('checkbox', { name: 'Ogord Stakar' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).doesNotExist();
+    });
+  });
+
   module('when the checkbox is clicked', function() {
     module('when the candidate is already authorized', function() {
       test('it calls the argument callback with candidate and false', async function(assert) {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -26,14 +26,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       authorizedToStart: false,
       assessmentStatus: null,
     });
-    this.toggleCandidate = sinon.spy();
 
     // when
     const screen = await renderScreen(hbs`
-      <SessionSupervising::CandidateInList
-        @candidate={{this.candidate}}
-        @toggleCandidate={{this.toggleCandidate}}
-      />
+      <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
     `);
 
     // then
@@ -53,14 +49,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         authorizedToStart: true,
         assessmentStatus: null,
       });
-      this.toggleCandidate = sinon.spy();
 
       // when
       const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList
-          @candidate={{this.candidate}}
-          @toggleCandidate={{this.toggleCandidate}}
-        />
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
       `);
 
       // then
@@ -78,14 +70,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         authorizedToStart: true,
         assessmentStatus: null,
       });
-      this.toggleCandidate = sinon.spy();
 
       // when
       const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList
-          @candidate={{this.candidate}}
-          @toggleCandidate={{this.toggleCandidate}}
-        />
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
       `);
 
       // then
@@ -106,14 +94,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         authorizedToStart: true,
         assessmentStatus: 'started',
       });
-      this.toggleCandidate = sinon.spy();
 
       // when
       const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList
-          @candidate={{this.candidate}}
-          @toggleCandidate={{this.toggleCandidate}}
-        />
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
       `);
 
       // then
@@ -134,12 +118,9 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           authorizedToStart: true,
           assessmentStatus: 'started',
         });
-        this.toggleCandidate = sinon.spy();
+
         const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
+          <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
         `);
 
         // when
@@ -161,13 +142,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             authorizedToStart: true,
             assessmentStatus: 'started',
           });
-          this.toggleCandidate = sinon.spy();
+
           const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
-        `);
+            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+          `);
 
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
@@ -189,13 +167,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               authorizedToStart: true,
               assessmentStatus: 'started',
             });
-            this.toggleCandidate = sinon.spy();
+
             const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
-        `);
+              <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+            `);
 
             // when
             await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
@@ -219,13 +194,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               authorizedToStart: true,
               assessmentStatus: 'started',
             });
-            this.toggleCandidate = sinon.spy();
+
             const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
-        `);
+              <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+            `);
 
             // when
             await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
@@ -247,12 +219,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
                 authorizedToStart: true,
                 assessmentStatus: 'started',
               });
-              this.toggleCandidate = sinon.spy();
               this.authorizeTestResume = sinon.stub().resolves();
               const screen = await renderScreen(hbs`
                 <SessionSupervising::CandidateInList
                   @candidate={{this.candidate}}
-                  @toggleCandidate={{this.toggleCandidate}}
                   @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
                 />
                 <NotificationContainer @position="bottom-right" />
@@ -279,12 +249,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
                 authorizedToStart: true,
                 assessmentStatus: 'started',
               });
-              this.toggleCandidate = sinon.spy();
               this.authorizeTestResume = sinon.stub().rejects();
               const screen = await renderScreen(hbs`
                 <SessionSupervising::CandidateInList
                   @candidate={{this.candidate}}
-                  @toggleCandidate={{this.toggleCandidate}}
                   @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
                 />
                 <NotificationContainer @position="bottom-right" />
@@ -317,14 +285,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         authorizedToStart: true,
         assessmentStatus: 'completed',
       });
-      this.toggleCandidate = sinon.spy();
 
       // when
       const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList
-          @candidate={{this.candidate}}
-          @toggleCandidate={{this.toggleCandidate}}
-        />
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
       `);
 
       // then
@@ -345,14 +309,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         authorizedToStart: true,
         assessmentStatus: 'endedBySupervisor',
       });
-      this.toggleCandidate = sinon.spy();
 
       // when
       const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList
-          @candidate={{this.candidate}}
-          @toggleCandidate={{this.toggleCandidate}}
-        />
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
       `);
 
       // then
@@ -377,10 +337,12 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         });
         this.toggleCandidate = sinon.spy();
 
-        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList
-          @candidate={{this.candidate}}
-          @toggleCandidate={{this.toggleCandidate}}
-        />`);
+        const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList
+            @candidate={{this.candidate}}
+            @toggleCandidate={{this.toggleCandidate}}
+          />`,
+        );
         const checkbox = screen.getByRole('checkbox');
 
         // when
@@ -406,10 +368,12 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         });
         this.toggleCandidate = sinon.spy();
 
-        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList
+        const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList
             @candidate={{this.candidate}}
             @toggleCandidate={{this.toggleCandidate}}
-        />`);
+          />
+        `);
         const checkbox = screen.getByRole('checkbox');
 
         // when

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -339,7 +339,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
     module('when the candidate is not authorized', function() {
       test('it calls the argument callback with candidate', async function(assert) {
         // given
-        const candidate = store.createRecord('certification-candidate-for-supervising', {
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
           id: 123,
           firstName: 'Toto',
           lastName: 'Tutu',
@@ -348,13 +348,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           authorizedToStart: false,
           assessmentResult: null,
         });
-        this.sessionForSupervising = store.createRecord('session-for-supervising', {
-          certificationCandidates: [candidate],
-        });
         this.toggleCandidate = sinon.spy();
 
         const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList
-            @candidates={{this.sessionForSupervising.certificationCandidates}}
+            @candidate={{this.candidate}}
             @toggleCandidate={{this.toggleCandidate}}
         />`);
         const checkbox = screen.getByRole('checkbox');

--- a/certif/tests/unit/models/certification-candidate-for-supervising_test.js
+++ b/certif/tests/unit/models/certification-candidate-for-supervising_test.js
@@ -50,6 +50,44 @@ module('Unit | Model | certification-candidate-for-supervising', function(hooks)
     });
   });
 
+  module('#get hasCompleted', () => {
+    test('returns false if assessmentStatus is started', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: 'started' };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.false(model.hasCompleted);
+    });
+
+    test('returns true if assessmentStatus is completed', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: 'completed' };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.true(model.hasCompleted);
+    });
+
+    test('returns true if assessmentStatus is endedBySupervisor', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: 'endedBySupervisor' };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.true(model.hasCompleted);
+    });
+  });
+
   function _pickModelData(certificationCandidate) {
     return pick(certificationCandidate, [
       'firstName',


### PR DESCRIPTION
## :christmas_tree: Problème

Si on limite beaucoup le risque qu’un candidat puisse faire son test en dehors de toute surveillance en lui retirant son autonomie sur la reprise de son test, un candidat quittant la salle sans avoir fermé la page de son test de certification, et donc ne nécessitant pas de reprendre son test, pourrait quitter la salle et terminer son test sans surveillance (a priori cas rare puisque signifierait que le candidat est venu avec son propre matériel).

## :gift: Solution

- afficher le statut “Test terminé” pour les candidats ayant terminé leur test dans le portail surveillant
- cacher le bouton qui permet d’autoriser la reprise de test du candidat et de terminer son test (les 3 dots)

## :star2: Remarques

- Un commit ajoutant le statut d'assessment "endedBySupervisor" a été cherry-pické de la PR #3824

## :santa: Pour tester

1. Se connecter à Pix Certif
2. Créer une session *
3. Ajouter au moins deux candidat·e·s
4. Se rendre dans l'espace surveillant
5. Autoriser les deux candidat·e·s à démarrer
6. Aller au bout du test avec le candidat 1 (passer toutes les question est OK)
7. Commencer le test avec la candidate 2 mais ne pas aller au bout
8. Depuis l'espace surveillant, terminer le test de la candidate 2 (ou si la PR qui va bien n'est pas encore mergée, le faire dans la base en mettant son assessment.state à "endedBySupervisor")
8. Recharger l'espace surveillant
9. Constater pour les deux candidats que le label "Terminé" apparaît, et que le bouton du menu d'options n'apparaît pas

\* dans les seeds, la session 3 a déjà les candidats dont on a besoin pour les tests, on peut passer directement à l'étape 8
