### PR TITLE
[TECH] Migrer la colonne answers.id de INTEGER en BIG INTEGER avec downtime.

### DIFF
--- a/api/scripts/bigint/change-answers-id-type-to-bigint-with-downtime.js
+++ b/api/scripts/bigint/change-answers-id-type-to-bigint-with-downtime.js
@@ -1,0 +1,34 @@
+require('dotenv').config();
+const { knex } = require('../../db/knex-database-connection');
+const logger = require('../../lib/infrastructure/logger');
+
+const changeAnswerIdTypeToBigint = async () => {
+  logger.info('Altering knowledge-elements.answerId type to BIGINT - In progress');
+  await knex.raw(`ALTER TABLE "knowledge-elements" ALTER COLUMN "answerId" TYPE BIGINT`);
+  logger.info('Altering knowledge-elements.answerId type to BIGINT - Done');
+
+  logger.info('Altering answers.id type to BIGINT - In progress');
+  await knex.raw(`ALTER TABLE "answers" ALTER COLUMN "id" TYPE BIGINT`);
+  logger.info('Altering answers.id type to BIGINT - Done');
+
+  logger.info('Altering answers_id_seq type to BIGINT - In progress');
+  await knex.raw(`ALTER SEQUENCE "answers_id_seq" AS BIGINT`);
+  logger.info('Altering answers_id_seq type to BIGINT - Done');
+};
+
+const preventOneOffContainerTimeout = () => {
+  setInterval(() => {
+    logger.info('alive');
+  }, 1000);
+};
+
+(async () => {
+  try {
+    preventOneOffContainerTimeout();
+    await changeAnswerIdTypeToBigint();
+    process.exit(0);
+  } catch (error) {
+    logger.fatal(error);
+    process.exit(1);
+  }
+})();

--- a/api/scripts/bigint/change-answers-id-type-to-bigint-with-downtime.js
+++ b/api/scripts/bigint/change-answers-id-type-to-bigint-with-downtime.js
@@ -7,6 +7,10 @@ const changeAnswerIdTypeToBigint = async () => {
   await knex.raw(`ALTER TABLE "knowledge-elements" ALTER COLUMN "answerId" TYPE BIGINT`);
   logger.info('Altering knowledge-elements.answerId type to BIGINT - Done');
 
+  logger.info('Altering flash-assessment-results.answerId type to BIGINT - In progress');
+  await knex.raw(`ALTER TABLE "flash-assessment-results" ALTER COLUMN "answerId" TYPE BIGINT`);
+  logger.info('Altering flash-assessment-results.answerId type to BIGINT - Done');
+
   logger.info('Altering answers.id type to BIGINT - In progress');
   await knex.raw(`ALTER TABLE "answers" ALTER COLUMN "id" TYPE BIGINT`);
   logger.info('Altering answers.id type to BIGINT - Done');

--- a/api/scripts/bigint/change-answers-id-type-to-bigint-with-downtime.js
+++ b/api/scripts/bigint/change-answers-id-type-to-bigint-with-downtime.js
@@ -3,21 +3,23 @@ const { knex } = require('../../db/knex-database-connection');
 const logger = require('../../lib/infrastructure/logger');
 
 const changeAnswerIdTypeToBigint = async () => {
-  logger.info('Altering knowledge-elements.answerId type to BIGINT - In progress');
-  await knex.raw(`ALTER TABLE "knowledge-elements" ALTER COLUMN "answerId" TYPE BIGINT`);
-  logger.info('Altering knowledge-elements.answerId type to BIGINT - Done');
+  await knex.transaction(async (trx) => {
+    logger.info('Altering knowledge-elements.answerId type to BIGINT - In progress');
+    await knex.raw(`ALTER TABLE "knowledge-elements" ALTER COLUMN "answerId" TYPE BIGINT`).transacting(trx);
+    logger.info('Altering knowledge-elements.answerId type to BIGINT - Done');
 
-  logger.info('Altering flash-assessment-results.answerId type to BIGINT - In progress');
-  await knex.raw(`ALTER TABLE "flash-assessment-results" ALTER COLUMN "answerId" TYPE BIGINT`);
-  logger.info('Altering flash-assessment-results.answerId type to BIGINT - Done');
+    logger.info('Altering flash-assessment-results.answerId type to BIGINT - In progress');
+    await knex.raw(`ALTER TABLE "flash-assessment-results" ALTER COLUMN "answerId" TYPE BIGINT`).transacting(trx);
+    logger.info('Altering flash-assessment-results.answerId type to BIGINT - Done');
 
-  logger.info('Altering answers.id type to BIGINT - In progress');
-  await knex.raw(`ALTER TABLE "answers" ALTER COLUMN "id" TYPE BIGINT`);
-  logger.info('Altering answers.id type to BIGINT - Done');
+    logger.info('Altering answers.id type to BIGINT - In progress');
+    await knex.raw(`ALTER TABLE "answers" ALTER COLUMN "id" TYPE BIGINT`).transacting(trx);
+    logger.info('Altering answers.id type to BIGINT - Done');
 
-  logger.info('Altering answers_id_seq type to BIGINT - In progress');
-  await knex.raw(`ALTER SEQUENCE "answers_id_seq" AS BIGINT`);
-  logger.info('Altering answers_id_seq type to BIGINT - Done');
+    logger.info('Altering answers_id_seq type to BIGINT - In progress');
+    await knex.raw(`ALTER SEQUENCE "answers_id_seq" AS BIGINT`).transacting(trx);
+    logger.info('Altering answers_id_seq type to BIGINT - Done');
+  });
 };
 
 const preventOneOffContainerTimeout = () => {
@@ -36,3 +38,5 @@ const preventOneOffContainerTimeout = () => {
     process.exit(1);
   }
 })();
+
+module.exports = { changeAnswerIdTypeToBigint };

--- a/api/tests/acceptance/scripts/bigint/change-answers-id-type-to-bigint-with-downtime_test.js
+++ b/api/tests/acceptance/scripts/bigint/change-answers-id-type-to-bigint-with-downtime_test.js
@@ -1,0 +1,64 @@
+const {
+  changeAnswerIdTypeToBigint,
+} = require('../../../../scripts/bigint/change-answers-id-type-to-bigint-with-downtime');
+const { expect, knex } = require('../../../test-helper');
+const DatabaseBuilder = require('../../../../db/database-builder/database-builder');
+const databaseBuilder = new DatabaseBuilder({ knex });
+
+describe('#changeAnswerIdTypeToBigint', function () {
+  let answerIdInsertedBeforeSwitch;
+
+  it('should insert answer with an id bigger than the maximum integer type value', async function () {
+    // when
+    await changeAnswerIdTypeToBigint();
+    const maxValueBigIntType = '9223372036854775807';
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment();
+    const { id: answerId } = databaseBuilder.factory.buildAnswer({ id: maxValueBigIntType, assessmentId });
+    databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId });
+    await databaseBuilder.commit();
+
+    // then
+    expect(answerId).to.be.equal(maxValueBigIntType);
+  });
+
+  it('should change type of answer sequence from integer to bigint', async function () {
+    // when
+    await changeAnswerIdTypeToBigint();
+
+    // then
+    const { rows: sequenceDataType } = await knex.raw(
+      `SELECT data_type FROM information_schema.sequences WHERE sequence_name = 'answers_id_seq'`
+    );
+    expect(sequenceDataType[0]['data_type']).to.equal('bigint');
+  });
+
+  it('should sequence are correctly reassigned', async function () {
+    // given
+    await changeAnswerIdTypeToBigint();
+
+    // when
+    const [{ id: answerIdInsertedAfterSwitch }] = await knex('answers')
+      .insert({
+        value: 'Some value for answer',
+        result: 'Some result for answer',
+        challengeId: 'rec123ABC',
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2020-01-02'),
+        resultDetails: 'Some result details for answer.',
+        timeSpent: 30,
+      })
+      .returning('id');
+
+    // then
+    expect(answerIdInsertedAfterSwitch).to.equal(answerIdInsertedBeforeSwitch + 1);
+  });
+
+  afterEach(async function () {
+    await knex.transaction(async (trx) => {
+      await knex.raw(`ALTER TABLE "knowledge-elements" ALTER COLUMN "answerId" TYPE INTEGER`).transacting(trx);
+      await knex.raw(`ALTER TABLE "flash-assessment-results" ALTER COLUMN "answerId" TYPE INTEGER`).transacting(trx);
+      await knex.raw(`ALTER TABLE "answers" ALTER COLUMN "id" TYPE INTEGER`).transacting(trx);
+      await knex.raw(`ALTER SEQUENCE "answers_id_seq" AS INTEGER`).transacting(trx);
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Le type `Integer` de l’identifiant de la table answer est limité à `2 147 483 647`. 
Au 15 mai 2022, `849 079 160` enregistrements sont présents.
Il reste `1 298 404 487` enregistrements libres.

Le maximum d'enregistrements insérés par jour du 1er au 15 mai est `3 009 644`.
A ce rythme, il reste approximativement 431 jours pour atteindre cette limite.

## :gift: Solution
La valeur maximale du type BigInt est `9 223 372 036 854 775 807`.
Migrer le type de l'identifiant vers ce type.

## :star2: Remarques
Les temps de traitement constatés sur une infratstructure comparable sont:
-  avec Postgresql 12: 16h;
-  avec Postgresql 13: 15h.

## :santa: Pour tester

### Environnement de test
Ajouter le repo Scalingo en tant que remote 
```js
git remote add bigint-test-scalingo git@ssh.osc-secnum-fr1.scalingo.com:pix-int-to-bigint-test.git 
```
Pusher la branche sur le repo scalingo 
```shell
git push --force bigint-test-scalingo tech-migrate-answers-id-bigint-with-downtime:master
```
Lancer le script
``` shell
scalingo --region osc-secnum-fr1 --app pix-int-to-bigint-test run --detached node ./scripts/bigint/change-answers-id-type-to-bigint-with-downtime.js
```

Suivre sa progression
```shell
scalingo --region osc-secnum-fr1 --app pix-int-to-bigint-test ps
scalingo --region osc-secnum-fr1 --app pix-int-to-bigint-test logs --follow --filter one-off-9441
scalingo --region osc-secnum-fr1 --app pix-int-to-bigint-test logs --filter one-off-9441 --lines 100000 | grep -v "alive" | sort
```

