### PR TITLE
[TECH] Corriger l'URL cible de l'API dans la documentation des tests de charge.

### DIFF
--- a/high-level-tests/load-testing/sample.env
+++ b/high-level-tests/load-testing/sample.env
@@ -16,5 +16,5 @@
 # presence: required
 # type: URL
 # default: none
-# exemple: https://pix-api-review-pr2125.osc-fr1.scalingo.io/api
+# exemple: https://pix-api-review-pr2125.osc-fr1.scalingo.io
 TARGET_DEV_API_URL=


### PR DESCRIPTION
## :christmas_tree: Problème
L'exemple de `TARGET_URL` contient un segment de trop

## :gift: Solution
Le remplacer par une valeur correcte

## :santa: Pour tester
Essayer en local
