### PR TITLE
[BUGFIX] Retourner sur la liste des campagnes lorsque l'on clique sur annuler lors de la création d'une campagne (PIX-4045)

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class NewController extends Controller {
+  @service router;
   @service store;
   @service notifications;
   @service intl;
@@ -14,6 +15,7 @@ export default class NewController extends Controller {
   @action
   async createCampaign(campaignAttributes) {
     this.notifications.clearAll();
+
     try {
       this.model.campaign.setProperties(campaignAttributes);
       await this.model.campaign.save();
@@ -26,7 +28,12 @@ export default class NewController extends Controller {
       this.errors = this.model.campaign.errors;
     }
     if (!this.errors) {
-      this.transitionToRoute('authenticated.campaigns.campaign.settings', this.model.campaign.id);
+      this.router.transitionTo('authenticated.campaigns.campaign.settings', this.model.campaign.id);
     }
+  }
+
+  @action
+  cancel() {
+    this.router.transitionTo('authenticated.campaigns');
   }
 }

--- a/orga/tests/unit/controllers/authenticated/campaigns/new_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/new_test.js
@@ -1,11 +1,48 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Unit | Controller | authenticated/campaigns/new', function (hooks) {
-  setupTest(hooks);
+  setupIntlRenderingTest(hooks);
+  let controller;
 
-  test('it exists', function (assert) {
-    const controller = this.owner.lookup('controller:authenticated/campaigns/new');
-    assert.ok(controller);
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/campaigns/new');
+  });
+
+  module('#action cancel', function () {
+    test('it should call transitionTo with appropriate arguments', function (assert) {
+      // given
+      controller.router = { transitionTo: sinon.stub() };
+
+      // when
+      controller.cancel();
+
+      // then
+      assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns'));
+    });
+  });
+
+  module('#action createCampaign', function () {
+    test('it should call transitionTo with appropriate arguments', async function (assert) {
+      // given
+      controller.router = { transitionTo: sinon.stub() };
+      controller.notifications = {
+        clearAll: sinon.stub(),
+      };
+      controller.model = {
+        campaign: {
+          id: 1,
+          save: sinon.stub().resolves(),
+          setProperties: sinon.stub(),
+        },
+      };
+
+      // when
+      await controller.createCampaign({ name: 'ma campagne' });
+
+      // then
+      assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns.campaign.settings', 1));
+    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Le bouton annuler ne fonctionne plus

## :gift: Solution
Refaire fonctionner le bouton annuler

## :star2: Remarques
RAS

## :santa: Pour tester
Aller sur Pix Orga, créer une campagne, cliquer sur annuler, vérifier que l'on retourne bien sur la liste des campagnes