### PR TITLE
[FEATURE] Permettre de scorer une certification Pix+ Édu (PIX-3991).

### DIFF
--- a/api/lib/domain/events/handle-pix-plus-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-certifications-scoring.js
@@ -1,4 +1,5 @@
 const { checkEventTypes } = require('./check-event-types');
+const bluebird = require('bluebird');
 const CertificationScoringCompleted = require('./CertificationScoringCompleted');
 const CertificationRescoringCompleted = require('./CertificationRescoringCompleted');
 const PixPlusCertificationScoring = require('../models/PixPlusCertificationScoring');
@@ -6,8 +7,58 @@ const { ReproducibilityRate } = require('../models/ReproducibilityRate');
 const AnswerCollectionForScoring = require('../models/AnswerCollectionForScoring');
 const { PIX_PLUS_DROIT } = require('../models/ComplementaryCertification');
 const { featureToggles } = require('../../config');
+const {
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../models/Badge').keys;
 
 const eventTypes = [CertificationScoringCompleted, CertificationRescoringCompleted];
+
+async function _isAllowedToBeScored({
+  certifiableBadgeKey,
+  certificationCourseId,
+  complementaryCertificationCourseRepository,
+}) {
+  if (featureToggles.isComplementaryCertificationSubscriptionEnabled) {
+    if (certifiableBadgeKey === PIX_DROIT_MAITRE_CERTIF || certifiableBadgeKey === PIX_DROIT_EXPERT_CERTIF) {
+      return await complementaryCertificationCourseRepository.hasComplementaryCertification({
+        certificationCourseId,
+        complementaryCertificationName: PIX_PLUS_DROIT,
+      });
+    } else if (
+      certifiableBadgeKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME ||
+      certifiableBadgeKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE ||
+      certifiableBadgeKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE ||
+      certifiableBadgeKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT ||
+      certifiableBadgeKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+async function _allowedToBeScoredBadgeKeys({
+  certifiableBadgeKeys,
+  certificationCourseId,
+  complementaryCertificationCourseRepository,
+}) {
+  return bluebird.filter(certifiableBadgeKeys, async (certifiableBadgeKey) =>
+    _isAllowedToBeScored({
+      certifiableBadgeKey,
+      certificationCourseId,
+      complementaryCertificationCourseRepository,
+    })
+  );
+}
 
 async function handlePixPlusCertificationsScoring({
   event,
@@ -18,21 +69,16 @@ async function handlePixPlusCertificationsScoring({
 }) {
   checkEventTypes(event, eventTypes);
   const certificationCourseId = event.certificationCourseId;
-  if (featureToggles.isComplementaryCertificationSubscriptionEnabled) {
-    const hasRunPixPlus = await complementaryCertificationCourseRepository.hasComplementaryCertification({
-      certificationCourseId,
-      complementaryCertificationName: PIX_PLUS_DROIT,
-    });
-    if (!hasRunPixPlus) {
-      return;
-    }
-  }
-
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({
     certificationCourseId,
   });
   const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgePixPlusKeysTaken();
-  for (const certifiableBadgeKey of certifiableBadgeKeys) {
+  const allowedToBeScoredBadgeKeys = await _allowedToBeScoredBadgeKeys({
+    certifiableBadgeKeys,
+    certificationCourseId,
+    complementaryCertificationCourseRepository,
+  });
+  for (const certifiableBadgeKey of allowedToBeScoredBadgeKeys) {
     const { certificationChallenges: pixPlusChallenges, certificationAnswers: pixPlusAnswers } =
       certificationAssessment.findAnswersAndChallengesForCertifiableBadgeKey(certifiableBadgeKey);
     const assessmentResult = await assessmentResultRepository.getByCertificationCourseId({ certificationCourseId });


### PR DESCRIPTION
## :christmas_tree: Problème
Il est théoriquement déjà possible de scorer une certification complémentaire Pix+. Néanmoins, avec les développements récents relatifs aux certifications complémentaires et à l'impossibilité de scorer une certification Pix+ Droit dans un certain nombre de cas, c'est n'est plus possible.

## :gift: Solution
Modifier le code relatif au scoring de certifications complémentaires afin de permettre de scorer une certification Pix+ Édu.

## :santa: Pour tester
- Vérifier que le feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED est activé.
- Créer une session de certification sur Pix Certif et y ajouter un candidat.
- Se connecter sur Pix App avec le compte `certifedu.initiale@example.net` et passer la certification.
- Aller en base et vérifier que la table `partner-certifications` a bien été alimentée avec le résultat du scoring.
