### PR TITLE
[TECH] Générer des tests conformes aux conventions avec le CLI Ember.

### DIFF
--- a/admin/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/admin/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | <%= dasherizedModuleName %>', function(hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /<%= dasherizedModuleName %>', async function(assert) {
-    await visit('/<%= dasherizedModuleName %>');
+    await visitScreen('/<%= dasherizedModuleName %>');
 
     assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
   });

--- a/admin/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/admin/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | <%= dasherizedModuleName %>', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /<%= dasherizedModuleName %>', async function(assert) {
+    await visit('/<%= dasherizedModuleName %>');
+
+    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
+  });
+});

--- a/admin/blueprints/adapter-test/files/tests/unit/adapters/__name___test.js
+++ b/admin/blueprints/adapter-test/files/tests/unit/adapters/__name___test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | <%= dasherizedModuleName %>', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    const adapter = this.owner.lookup('adapter:<%= dasherizedModuleName %>');
+    assert.ok(adapter);
+  });
+});

--- a/admin/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/admin/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component |  <%= dasherizedModuleName %>', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('replace this by your real test', async function(assert) {
+    // given
+
+    //  when
+    await render(hbs`<<%= classifiedModuleName %> />`);
+
+    // then
+    assert.ok(true);
+  });
+});

--- a/admin/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/admin/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component |  <%= dasherizedModuleName %>', function(hooks) {
   setupRenderingTest(hooks);
@@ -10,7 +10,7 @@ module('Integration | Component |  <%= dasherizedModuleName %>', function(hooks)
     // given
 
     //  when
-    await render(hbs`<<%= classifiedModuleName %> />`);
+    await renderScreen(hbs`<<%= classifiedModuleName %> />`);
 
     // then
     assert.ok(true);

--- a/admin/blueprints/route-test/files/tests/unit/routes/__name___test.js
+++ b/admin/blueprints/route-test/files/tests/unit/routes/__name___test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | <%= dasherizedModuleName %>', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:<%= classifiedModuleName %>');
+    assert.ok(route);
+  });
+});

--- a/certif/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/certif/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | <%= dasherizedModuleName %>', function(hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /<%= dasherizedModuleName %>', async function(assert) {
-    await visit('/<%= dasherizedModuleName %>');
+    await visitScreen('/<%= dasherizedModuleName %>');
 
     assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
   });

--- a/certif/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/certif/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | <%= dasherizedModuleName %>', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /<%= dasherizedModuleName %>', async function(assert) {
+    await visit('/<%= dasherizedModuleName %>');
+
+    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
+  });
+});

--- a/certif/blueprints/adapter-test/files/tests/unit/adapters/__name___test.js
+++ b/certif/blueprints/adapter-test/files/tests/unit/adapters/__name___test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | <%= dasherizedModuleName %>', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const adapter = this.owner.lookup('adapter:<%= dasherizedModuleName %>');
+    assert.ok(adapter);
+  });
+});

--- a/certif/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/certif/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component |  <%= dasherizedModuleName %>', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('replace this by your real test', async function(assert) {
+    // given
+
+    //  when
+    await render(hbs`<<%= classifiedModuleName %> />`);
+
+    // then
+    assert.ok(true);
+  });
+});

--- a/certif/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/certif/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component |  <%= dasherizedModuleName %>', function(hooks) {
@@ -10,7 +10,7 @@ module('Integration | Component |  <%= dasherizedModuleName %>', function(hooks)
     // given
 
     //  when
-    await render(hbs`<<%= classifiedModuleName %> />`);
+    await renderScreen(hbs`<<%= classifiedModuleName %> />`);
 
     // then
     assert.ok(true);

--- a/certif/blueprints/route-test/files/tests/unit/routes/__name___test.js
+++ b/certif/blueprints/route-test/files/tests/unit/routes/__name___test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | <%= dasherizedModuleName %>', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const route = this.owner.lookup('route:<%= classifiedModuleName %>');
+    assert.ok(route);
+  });
+});

--- a/mon-pix/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/mon-pix/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -1,0 +1,13 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { visit, currentURL } from '@ember/test-helpers';
+
+describe('Acceptance | <%= dasherizedModuleName %>', function() {
+  setupApplicationTest();
+
+  it('can visit /<%= dasherizedModuleName %>', async function() {
+    await visit('/<%= dasherizedModuleName %>');
+    expect(currentURL()).to.equal('/<%= dasherizedModuleName %>');
+  });
+});

--- a/mon-pix/blueprints/adapter-test/files/tests/unit/adapters/__name___test.js
+++ b/mon-pix/blueprints/adapter-test/files/tests/unit/adapters/__name___test.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapter | <%= dasherizedModuleName %>', function () {
+  setupTest();
+
+  // Replace this with your real tests.
+  it('exists', function () {
+    const adapter = this.owner.lookup('adapter:<%= classifiedModuleName %>');
+    expect(adapter).to.be.ok;
+  });
+});

--- a/mon-pix/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/mon-pix/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+describe('Integration | Component |  <%= dasherizedModuleName %>', function() {
+  setupRenderingTest();
+
+  it('replace this by your real test', async function() {
+    // given
+
+    //  when
+    await render(hbs`<<%= classifiedModuleName %> />`);
+
+    // then
+    expect(true).to.be.true;
+  });
+});

--- a/mon-pix/blueprints/route-test/files/tests/unit/routes/__name___test.js
+++ b/mon-pix/blueprints/route-test/files/tests/unit/routes/__name___test.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Route | <%= dasherizedModuleName %>', function () {
+  setupTest();
+
+  it('exists', function () {
+    const route = this.owner.lookup('route:<%= classifiedModuleName %>');
+    expect(route).to.be.ok;
+  });
+});

--- a/orga/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/orga/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | <%= dasherizedModuleName %>', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /<%= dasherizedModuleName %>', async function (assert) {
+    await visit('/<%= dasherizedModuleName %>');
+
+    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
+  });
+});

--- a/orga/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/orga/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | <%= dasherizedModuleName %>', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /<%= dasherizedModuleName %>', async function (assert) {
-    await visit('/<%= dasherizedModuleName %>');
+    await visitScreen('/<%= dasherizedModuleName %>');
 
     assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
   });

--- a/orga/blueprints/adapter-test/files/tests/unit/adapters/__name___test.js
+++ b/orga/blueprints/adapter-test/files/tests/unit/adapters/__name___test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | <%= dasherizedModuleName %>', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    const adapter = this.owner.lookup('adapter:<%= dasherizedModuleName %>');
+    assert.ok(adapter);
+  });
+});

--- a/orga/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/orga/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component |  <%= dasherizedModuleName %>', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('replace this by your real test', async function (assert) {
+    // given
+
+    //  when
+    await render(hbs`<<%= classifiedModuleName %> />`);
+
+    // then
+    assert.ok(true);
+  });
+});

--- a/orga/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/orga/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component |  <%= dasherizedModuleName %>', function (hooks) {
   setupRenderingTest(hooks);
@@ -10,7 +10,7 @@ module('Integration | Component |  <%= dasherizedModuleName %>', function (hooks
     // given
 
     //  when
-    await render(hbs`<<%= classifiedModuleName %> />`);
+    await renderScreen(hbs`<<%= classifiedModuleName %> />`);
 
     // then
     assert.ok(true);

--- a/orga/blueprints/route-test/files/tests/unit/routes/__name___test.js
+++ b/orga/blueprints/route-test/files/tests/unit/routes/__name___test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | <%= dasherizedModuleName %>', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:<%= classifiedModuleName %>');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Ember aime beaucoup qu'on suive ses conventions. Entre autre, une bonne pratique est donc de générer les nouveaux composants / routes / adapters etc. via les commandes ember (`ember generate`).
Lorsqu'on créé des composants , des routes etc. avec le cli-ember ce dernier créer les fichiers de tests associés avec l'extension `-test.js`. Or dans nos conventions de nommage nous suffixons les tests par `_test.js`. 
Du coup, il faut à chaque fois faire le renommage du fichier de test créé.

## :gift: Solution
Créer des blueprints pour ne plus à avoir à s'occuper du nommage des tests.

## :star2: Remarques
J'en ai profité pour changer le `let` en `const` dans les tests unitaires que créé ember et qu'on changeait aussi à la main.

## :santa: Pour tester
Lancer les commandes suivantes dans chacune des différentes app et vérifier qu'elles génèrent bien les bons fichiers et surtout que le nom des tests finit par `_test.js` et non `-test.js` : 
- `ember generate route une-route`
- `ember generate test-acceptance un-test`
- `ember generate component un-composant`
- `ember generate adapter un-adapter`
