### PR TITLE
[FEATURE] Ameliorer le rendu des certifications complementaires (PIX-3867)

### DIFF
--- a/admin/app/components/certification-centers/form.hbs
+++ b/admin/app/components/certification-centers/form.hbs
@@ -66,23 +66,21 @@
 
     <section>
       <h1 class="habilitations-title">Habilitations aux certifications complémentaires</h1>
-      <div class="form-field habilitations-checkbox-list">
-        <ul>
-          {{#each @habilitations as |habilitation index|}}
-            <li>
-              <label class="form-field__label" for={{concat "habilitation_" index}}>
-                <Input
-                  @type="checkbox"
-                  id={{concat "habilitation_" index}}
-                  @checked={{contains habilitation @certificationCenter.habilitations}}
-                  {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
-                />
-                {{habilitation.name}}
-              </label>
-            </li>
-          {{/each}}
-        </ul>
-      </div>
+      <ul class="form-field habilitations-checkbox-list">
+        {{#each @habilitations as |habilitation index|}}
+          <li class="habilitation-entry">
+            <Input
+              @type="checkbox"
+              id={{concat "habilitation_" index}}
+              @checked={{contains habilitation @certificationCenter.habilitations}}
+              {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
+            />
+            <label class="form-field__label" for={{concat "habilitation_" index}}>
+              {{habilitation.name}}
+            </label>
+          </li>
+        {{/each}}
+      </ul>
     </section>
   </section>
 

--- a/admin/app/components/certification-centers/information.hbs
+++ b/admin/app/components/certification-centers/information.hbs
@@ -55,26 +55,22 @@
               @value={{this.form.externalId}}
             />
           </div>
-          <div class="form-field certification-center-information__edit-form__habilitations-checkbox-list">
-            <h2 class="field__label">Habilitations aux certifications complémentaires</h2>
-            <ul class="habilitations-list-ul">
-              {{#each this.availableHabilitations as |habilitation|}}
-                <li>
-                  <div class="habilitation-entry">
-                    <Input
-                      id="habilitation-checkbox__{{habilitation.id}}"
-                      @type="checkbox"
-                      @checked={{contains habilitation @certificationCenter.habilitations}}
-                      {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
-                    />
-                    <label class="field__label" for="habilitation-checkbox__{{habilitation.id}}">
-                      {{habilitation.name}}
-                    </label>
-                  </div>
-                </li>
-              {{/each}}
-            </ul>
-          </div>
+          <h2 class="field__label">Habilitations aux certifications complémentaires</h2>
+          <ul class="form-field certification-center-information__edit-form__habilitations-checkbox-list">
+            {{#each this.availableHabilitations as |habilitation|}}
+              <li class="habilitation-entry">
+                <Input
+                  id="habilitation-checkbox__{{habilitation.id}}"
+                  @type="checkbox"
+                  @checked={{contains habilitation @certificationCenter.habilitations}}
+                  {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
+                />
+                <label class="field__label" for="habilitation-checkbox__{{habilitation.id}}">
+                  {{habilitation.name}}
+                </label>
+              </li>
+            {{/each}}
+          </ul>
           <div class="form-actions justify-content-end">
             <PixButton
               @size="small"
@@ -100,30 +96,28 @@
         </div>
         <div class="property">
           <h2 class="field__label">Habilitations aux certifications complémentaires</h2>
-          <div class="certification-center-information__display__habilitations-list">
-            <ul class="habilitations-list-ul">
-              {{#each this.availableHabilitations as |habilitation|}}
-                {{#if (contains habilitation @certificationCenter.habilitations)}}
-                  <li aria-label={{concat "Habilité pour " habilitation.name}}>
-                    <FaIcon class="granted-habilitation-icon" @icon="check-circle" />
-                    {{habilitation.name}}
-                  </li>
-                {{else}}
-                  <li aria-label={{concat "Non-habilité pour " habilitation.name}}>
-                    <FaIcon class="not-granted-habilitation-icon" @icon="times-circle" />
-                    {{habilitation.name}}
-                  </li>
-                {{/if}}
-              {{/each}}
-            </ul>
-          </div>
+          <ul class="certification-center-information__display__habilitations-list">
+            {{#each this.availableHabilitations as |habilitation|}}
+              {{#if (contains habilitation @certificationCenter.habilitations)}}
+                <li aria-label={{concat "Habilité pour " habilitation.name}}>
+                  <FaIcon class="granted-habilitation-icon" @icon="check-circle" />
+                  {{habilitation.name}}
+                </li>
+              {{else}}
+                <li aria-label={{concat "Non-habilité pour " habilitation.name}}>
+                  <FaIcon class="not-granted-habilitation-icon" @icon="times-circle" />
+                  {{habilitation.name}}
+                </li>
+              {{/if}}
+            {{/each}}
+          </ul>
           <PixButton
             @backgroundColor="transparent-light"
             @isBorderVisible={{true}}
             @size="small"
             @triggerAction={{this.enterEditMode}}
             aria-label="Editer"
-          >Editer
+          >Editer les informations
           </PixButton>
         </div>
       </div>

--- a/admin/app/styles/authenticated/sessions/session/informations.scss
+++ b/admin/app/styles/authenticated/sessions/session/informations.scss
@@ -37,7 +37,7 @@
 
     p {
       background-color: $black;
-      border-radius: 5px;
+      border-radius: 6px;
       color: $white;
       padding: 5px 10px;
       position: absolute;

--- a/admin/app/styles/components/certification-center-form.scss
+++ b/admin/app/styles/components/certification-center-form.scss
@@ -19,11 +19,26 @@
 
   .habilitations-checkbox-list {
     display: flex;
+    flex-direction: column;
+    list-style-type: none;
+    margin: 8px 0;
+    padding: 0;
 
-    ul {
-      list-style-type: none;
-      margin: 8px;
-      padding: 0;
+    .habilitation-entry {
+      display: flex;
+      flex-direction: row;
+      gap: 0.5rem;
+      padding-bottom: 8px;
+
+      * {
+        margin-bottom: 0;
+        align-self: center;
+      }
+
+      input[type=checkbox] {
+        width: 1rem;
+        height: 1rem;
+      }
     }
   }
 }

--- a/admin/app/styles/components/certification-centers/information.scss
+++ b/admin/app/styles/components/certification-centers/information.scss
@@ -1,29 +1,15 @@
 .certification-center-information {
 
+  h1 {
+    padding-bottom: 16px;
+  }
+
   &__display {
 
     &__name {
       font-size: 1.5rem;
       font-weight: 600;
       margin-bottom: 20px;
-    }
-
-    &__habilitations-list {
-      background-color: #F4F5F7;
-      border-radius: 16px;
-      padding: 8px;
-
-      li {
-        width: 200px;
-      }
-
-      .granted-habilitation-icon {
-        color: $green;
-      }
-
-      .not-granted-habilitation-icon {
-        color: $grey-35;
-      }
     }
 
     .property {
@@ -43,19 +29,6 @@
 
   &__edit-form {
     width: 500px;
-
-    .habilitations-list-ul {
-      flex-direction: column;
-    }
-
-    &__habilitations-checkboxes {
-      display: flex;
-    }
-
-    .habilitation-entry {
-      display: block;
-      padding-bottom: 8px;
-    }
   }
 
   .field__label {
@@ -70,10 +43,50 @@
     font-size: 0.85rem;
   }
 
-  .habilitations-list-ul {
+  &__display__habilitations-list,
+  &__edit-form__habilitations-checkbox-list {
     list-style-type: none;
-    display: flex;
     margin: 8px 0;
     padding: 0;
+  }
+
+  &__edit-form__habilitations-checkbox-list {
+    flex-direction: column;
+    display: flex;
+
+    .habilitation-entry {
+      display: flex;
+      flex-direction: row;
+      gap: 0.5rem;
+      padding-bottom: 8px;
+
+      * {
+        margin-bottom: 0;
+        align-self: center;
+      }
+
+      input[type=checkbox] {
+        width: 1rem;
+        height: 1rem;
+      }
+    }
+  }
+
+  &__display__habilitations-list {
+    background-color: #F4F5F7;
+    border-radius: 8px;
+    align-items: flex-start;
+    gap: 24px;
+    display: inline-flex;
+    flex-direction: row;
+    padding: 8px 16px;
+
+    .granted-habilitation-icon {
+      color: $green;
+    }
+
+    .not-granted-habilitation-icon {
+      color: $grey-35;
+    }
   }
 }

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -25,40 +25,46 @@
   font-size: 0.875rem;
   margin-bottom: 32px;
 
-  &__eligible {
+  &-container {
     background-color: $grey-10;
     padding: 16px 0;
     text-align: center;
-  }
 
-  &__eligible-title {
-    font-size: 1rem;
-  }
+    &-title {
+      font-size: 1rem;
+    }
 
-  &__eligible-item,
-  &__non-eligible-item {
-    font-weight: 500;
-  }
+    &-items {
+      display: flex;
+      justify-content: center;
+      gap: 8px;
 
-  &__eligible-icon {
-    color: $green;
-  }
+      &__eligible-item,
+      &__non-eligible-item {
+        font-weight: 500;
+      }
 
-  &__non-eligible-item,
-  &__non-eligible-icon {
-    color: $grey-50;
-  }
+      &__eligible-icon {
+        color: $green;
+      }
 
-  &__non-eligible {
-    align-items: center;
-    background-color: $yellow-alert-light;
-    color: $yellow-alert-dark;
-    display: flex;
-    padding: 10px 16px;
-  }
+      &__non-eligible-item,
+      &__non-eligible-icon {
+        color: $grey-50;
+      }
+    }
 
-  &__info-icon {
-    margin-right: 10px;
+    &__non-eligible {
+      align-items: center;
+      background-color: $yellow-alert-light;
+      color: $yellow-alert-dark;
+      display: flex;
+      padding: 10px 16px;
+    }
+
+    &__info-icon {
+      margin-right: 10px;
+    }
   }
 }
 

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -5,29 +5,37 @@
   {{#if @certificationCandidateSubscription.hasSubscriptions}}
     <div class="certification-starter-subscriptions">
       {{#if (gt this.allComplementaryCertificationsLength 0)}}
-        <div class="certification-starter-subscriptions__eligible" data-test-id="eligible-subscriptions">
-          <p class="certification-starter-subscriptions__eligible-title">{{t
-              "pages.certification-start.eligible-subscriptions"
-              itemCount=this.allComplementaryCertificationsLength
-            }}</p>
-          {{#each @certificationCandidateSubscription.eligibleSubscriptions as |eligibleSubscription|}}
-            <span class="certification-starter-subscriptions__eligible-item">
-              <FaIcon @icon="check-circle" class="certification-starter-subscriptions__eligible-icon" />
-              {{eligibleSubscription.name}}
-            </span>
-          {{/each}}
-          {{#each @certificationCandidateSubscription.nonEligibleSubscriptions as |nonEligibleSubscription|}}
-            <span class="certification-starter-subscriptions__non-eligible-item">
-              <FaIcon @icon="check-circle" class="certification-starter-subscriptions__non-eligible-icon" />
-              {{nonEligibleSubscription.name}}
-            </span>
-          {{/each}}
+        <div class="certification-starter-subscriptions-container">
+          <p class="certification-starter-subscriptions-container-title">
+            {{t "pages.certification-start.eligible-subscriptions" itemCount=this.allComplementaryCertificationsLength}}
+          </p>
+          <div class="certification-starter-subscriptions-container-items">
+            {{#each @certificationCandidateSubscription.eligibleSubscriptions as |eligibleSubscription|}}
+              <span class="certification-starter-subscriptions-container-items__eligible-item">
+                <FaIcon
+                  @icon="check-circle"
+                  class="certification-starter-subscriptions-container-items__eligible-icon"
+                />
+                {{eligibleSubscription.name}}
+              </span>
+            {{/each}}
+            {{#each @certificationCandidateSubscription.nonEligibleSubscriptions as |nonEligibleSubscription|}}
+              <span class="certification-starter-subscriptions-container-items__non-eligible-item">
+                <FaIcon
+                  @icon="check-circle"
+                  class="certification-starter-subscriptions-container-items__non-eligible-icon"
+                />
+                {{nonEligibleSubscription.name}}
+              </span>
+            {{/each}}
+          </div>
         </div>
       {{/if}}
       {{#if this.nonEligibleSubscriptionNames.length}}
-        <div class="certification-starter-subscriptions__non-eligible" data-test-id="non-eligible-subscriptions">
-          <FaIcon @icon="exclamation-circle" class="certification-starter-subscriptions__info-icon" />
-          <span>{{t
+        <div class="certification-starter-subscriptions-container__non-eligible">
+          <FaIcon @icon="exclamation-circle" class="certification-starter-subscriptions-container__info-icon" />
+          <span>
+            {{t
               "pages.certification-start.non-eligible-subscriptions"
               nonEligibleSubscription=this.nonEligibleSubscriptionNames
               eligibleSubscription=this.eligibleSubscriptionNames

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -63,10 +63,11 @@ describe('Integration | Component | certification-starter', function () {
 
         // then
         expect(
-          contains(
-            'Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :\n\n Certif complémentaire 1  Certif complémentaire 2'
-          )
+          contains('Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :'),
+          'Vous êtes inscrit...'
         ).to.exist;
+        expect(contains('Certif complémentaire 1'), 'Certif complémentaire 1').to.exist;
+        expect(contains('Certif complémentaire 2'), 'Certif complémentaire 2').to.exist;
       });
 
       it('should not display subscription non eligible panel', async function () {
@@ -101,7 +102,7 @@ describe('Integration | Component | certification-starter', function () {
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscriptions: [],
+            eligibleSubscriptions: [{ name: 'Certif complémentaire 2' }],
             nonEligibleSubscriptions: [{ name: 'Certif complémentaire 1' }],
           })
         );
@@ -114,7 +115,7 @@ describe('Integration | Component | certification-starter', function () {
         // expect
         expect(
           contains(
-            'Vous n’êtes pas éligible à Certif complémentaire 1. Vous pouvez néanmoins passer votre certification Pix'
+            'Vous n’êtes pas éligible à Certif complémentaire 1. Vous pouvez néanmoins passer votre certification Pix et Certif complémentaire 2'
           )
         ).to.exist;
       });


### PR DESCRIPTION
## :christmas_tree: Problème
Dans Pix Admin, les habilitations complémentaires ne sont pas positionnées de la même manière sur le page de création de centre et sur la page d'édition.

Dans Pix Admin, l'affichage des certifications complémentaires d'un centre est améliorable.

## :gift: Solution
### Harmoniser les cases à cocher sur les pages de création et d'édition de centre de la manière suivante :
- Aligner verticalement les checkboxes sur la base du texte du label
- Aligner horizontalement les checkboxes à gauche sur la gauche des champs de formulaire
- Ajouter un peu d'espace entre la checkbox et le label

### Améliorer l'affichage du bloc des certifications complémentaire sur la page d'un centre
- Faire en sorte que le bloc s'adapte au contenu plutôt que d'occuper la largeur de la page
- Ajouter 16px de marge intérieur horizontale (`padding`)
- Espacer les certifications complémentaires de 24px

### Ajouter de l'espace entre les certif complementaires sur la page d'acces aux certifications dans mon-pix
![image](https://user-images.githubusercontent.com/3769147/146905050-435fe080-1e99-42e9-a595-ecd788619d77.png)


## :star2: Remarques
/

## :santa: Pour tester
Pour mon-pix, 
lancer `update "certification-candidates" set "userId"=null where id=10000000;` et aller sur la page de demarrage d'une certification avec les infos en se connectant avec `certifdroit@example.net`
numero de session `10000000`, prenom `a`, nom `a`, date de naissance `01/01/2000`

Pour pix-admin, comparer la page de creation/edition/vue d'un centre de certification
