### PR TITLE
[FEATURE] Bloquer le passage du test pour le candidat dont le test a été terminé par le Surveillant (PIX-4047)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -339,6 +339,12 @@ class CertificateVerificationCodeGenerationTooManyTrials extends DomainError {
   }
 }
 
+class CertificationEndedBySupervisorError extends DomainError {
+  constructor(message = 'Le surveillant a mis fin à votre test de certification.') {
+    super(message);
+  }
+}
+
 class CertificationCandidateAlreadyLinkedToUserError extends DomainError {
   constructor(message = 'Ce candidat de certification a déjà été lié à un utilisateur.') {
     super(message);
@@ -991,6 +997,7 @@ module.exports = {
   CertificationComputeError,
   CertificationCourseNotPublishableError,
   CertificationCourseUpdateError,
+  CertificationEndedBySupervisorError,
   ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,
   ChallengeToBeNeutralizedNotFoundError,

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -89,6 +89,10 @@ class Assessment {
     return this.state === Assessment.states.STARTED;
   }
 
+  isEndedBySupervisor() {
+    return this.state === Assessment.states.ENDED_BY_SUPERVISOR;
+  }
+
   setCompleted() {
     this.state = Assessment.states.COMPLETED;
   }

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -1,4 +1,4 @@
-const { ForbiddenAccess, ChallengeNotAskedError } = require('../errors');
+const { ForbiddenAccess, ChallengeNotAskedError, CertificationEndedBySupervisorError } = require('../errors');
 const Examiner = require('../models/Examiner');
 const KnowledgeElement = require('../models/KnowledgeElement');
 const logger = require('../../infrastructure/logger');
@@ -21,6 +21,9 @@ module.exports = async function correctAnswerThenUpdateAssessment({
   const assessment = await assessmentRepository.get(answer.assessmentId);
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+  }
+  if (assessment.isEndedBySupervisor()) {
+    throw new CertificationEndedBySupervisorError();
   }
   if (assessment.lastChallengeId && assessment.lastChallengeId != answer.challengeId) {
     throw new ChallengeNotAskedError();

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -37,6 +37,30 @@ describe('Unit | Domain | Models | Assessment', function () {
     });
   });
 
+  describe('#isEndedBySupervisor', function () {
+    it('should return true when its state is endedBySupervisor', function () {
+      // given
+      const assessment = new Assessment({ state: 'endedBySupervisor' });
+
+      // when
+      const isCompleted = assessment.isEndedBySupervisor();
+
+      // then
+      expect(isCompleted).to.be.true;
+    });
+
+    it('should return false when its state is not endedBySupervisor', function () {
+      // given
+      const assessment = new Assessment({ state: '' });
+
+      // when
+      const isCompleted = assessment.isEndedBySupervisor();
+
+      // then
+      expect(isCompleted).to.be.false;
+    });
+  });
+
   describe('#setCompleted', function () {
     it('should return the same object with state completed', function () {
       // given

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -96,6 +96,11 @@ export default class ChallengeRoute extends Route {
       this.transitionTo('assessments.resume', assessment.get('id'), queryParams);
     } catch (error) {
       answer.rollbackAttributes();
+
+      if (error?.errors?.[0]?.detail === 'Le surveillant a mis fin à votre test de certification.') {
+        return this.transitionTo('certifications.results', assessment.get('id'));
+      }
+
       return this.intermediateTransitionTo('error', error);
     }
   }

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -390,5 +390,33 @@ describe('Unit | Route | Assessments | Challenge', function () {
           });
       });
     });
+
+    context('when assessmnt has been ended by supervisor', function () {
+      it('should redirect candidate to end test screen when trying to answer', async function () {
+        // given
+        const error = {
+          errors: [
+            {
+              detail: 'Le surveillant a mis fin à votre test de certification.',
+            },
+          ],
+        };
+        answerToChallengeOne.save = sinon.stub().rejects(error);
+        const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
+
+        // when
+        await route.actions.saveAnswerAndNavigate.call(
+          route,
+          challengeOne,
+          assessment,
+          answerValue,
+          answerTimeout,
+          answerFocusedOut
+        );
+
+        // then
+        sinon.assert.calledWithExactly(route.transitionTo, 'certifications.results', assessment.get('id'));
+      });
+    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Le surveillant peut terminer le test d’un candidat depuis l’espace surveillant. 

Pour l'instant rien n'empêche le candidate de poursuivre son test.

Il faut maintenant bloquer l’accès au test du candidat qui est en train de passer son test.

## :gift: Solution
- bloquer le passage du test du candidat lorsque le surveillant a cliqué sur “terminer le test” depuis l’espace surveillant

- rediriger le candidat vers la page de fin de test actuelle (on redirigera vers la nouvelle page de FDT quand elle existera)

## :star2: Remarques
Suite du #3837

## :santa: Pour tester
- Commencer une certification avec un candidat
- Se rendre sur l'espace surveillant et cliquer sur le menu du candidat puis Terminer le test de certification
- Rafraichir pour constater que la certification du candidat n'est plus en cours.
- Essayer de poursuivre le test de certification  et constater que le candidat est redirigé vers la case de fin de test
