### PR TITLE
[FEATURE] Téléchargement des sujets sélectionnés dans la page sur Pix Orga (PIX-3954)

### DIFF
--- a/orga/app/components/tube/list.hbs
+++ b/orga/app/components/tube/list.hbs
@@ -1,5 +1,15 @@
 <section>
   <div class="panel">
+    <div class="download-file">
+      <PixButtonLink
+        class="download-file__button"
+        @href={{this.downloadURL}}
+        @isDisabled={{this.haveNoTubeSelected}}
+        download={{t "pages.preselect-target-profile.download-filename"}}
+      >
+        {{t "pages.preselect-target-profile.download" fileSize=this.fileSize}}
+      </PixButtonLink>
+    </div>
     <table class="table content-text content-text--small">
       <caption>{{t "pages.preselect-target-profile.table.caption"}}</caption>
       <thead>
@@ -21,7 +31,7 @@
             aria-label={{t "pages.preselect-target-profile.table.row-title"}}
           >
             <td class="table__column--center">
-              <Input id="tube-{{tube.id}}" @type="checkbox" />
+              <Input {{on "input" (fn this.updateSelectedTubes tube.id)}} id="tube-{{tube.id}}" @type="checkbox" />
             </td>
             <td>
               <label for="tube-{{tube.id}}">

--- a/orga/app/components/tube/list.js
+++ b/orga/app/components/tube/list.js
@@ -1,10 +1,46 @@
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
 import Component from '@glimmer/component';
 
 export default class TubeList extends Component {
+  @tracked tubesSelected = A();
+
+  get haveNoTubeSelected() {
+    return this.tubesSelected.length === 0;
+  }
+
+  get file() {
+    const json = JSON.stringify(this.tubesSelected);
+    return new Blob([json], { type: 'application/json' });
+  }
+
+  get fileSize() {
+    return (this.file.size / 1024).toFixed(2);
+  }
+
+  get downloadURL() {
+    return URL.createObjectURL(this.file);
+  }
+
   @action
   toggleInput(event) {
-    const el = event.currentTarget.querySelector('input');
-    el.checked = !el.checked;
+    const checkbox = event.currentTarget.querySelector('input');
+    if (event.target.nodeName === 'TD') {
+      checkbox.checked = !checkbox.checked;
+      const evt = document.createEvent('HTMLEvents');
+      evt.initEvent('input', false, true);
+      checkbox.dispatchEvent(evt);
+    }
+  }
+
+  @action
+  updateSelectedTubes(tubeId, event) {
+    const el = event.currentTarget;
+    if (el.checked) {
+      this.tubesSelected.pushObject(tubeId);
+    } else {
+      this.tubesSelected.removeObject(tubeId);
+    }
   }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -62,6 +62,7 @@
 @import "pages/authenticated/campaigns/details/participants/participant/results";
 @import "pages/authenticated/campaigns/participant-profile";
 @import "pages/authenticated/certifications";
+@import "pages/authenticated/preselect-target-profile";
 @import "pages/authenticated/team";
 @import "pages/authenticated/team/list";
 @import "pages/authenticated/team/new";

--- a/orga/app/styles/pages/authenticated/preselect-target-profile.scss
+++ b/orga/app/styles/pages/authenticated/preselect-target-profile.scss
@@ -1,0 +1,11 @@
+.download-file {
+  position: sticky;
+  padding: 0.5em;
+  top: 0;
+  z-index: 1;
+  background: white;
+
+  &__button {
+    width: fit-content;
+  }
+}

--- a/orga/tests/integration/components/tube/list_test.js
+++ b/orga/tests/integration/components/tube/list_test.js
@@ -2,13 +2,14 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { clickByName } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | tube:list', function (hooks) {
   setupRenderingTest(hooks);
+  let tubes;
 
-  test('it should display a list of tubes', async function (assert) {
-    // given
-    const tubes = [
+  hooks.beforeEach(() => {
+    tubes = [
       {
         id: 'tubeId1',
         practicalTitle: 'Titre 1',
@@ -20,6 +21,10 @@ module('Integration | Component | tube:list', function (hooks) {
         practicalDescription: 'Description 2',
       },
     ];
+  });
+
+  test('it should display a list of tubes', async function (assert) {
+    // given
     this.set('tubes', tubes);
 
     // when
@@ -28,5 +33,28 @@ module('Integration | Component | tube:list', function (hooks) {
     // then
     assert.dom('.row-tube').exists({ count: 2 });
     assert.dom(this.element.querySelector('.row-tube')).hasText('Titre 1 : Description 1');
+  });
+
+  test('Disable the download button if not tube is selected', async function (assert) {
+    // given
+    this.set('tubes', tubes);
+
+    // when
+    await render(hbs`<Tube::list @tubes={{this.tubes}}/>`);
+
+    // then
+    assert.dom('.download-file__button').hasClass('pix-button--disabled');
+  });
+
+  test('Enabled the download button if a tube is selected', async function (assert) {
+    // given
+    this.set('tubes', tubes);
+
+    // when
+    await render(hbs`<Tube::list @tubes={{this.tubes}}/>`);
+    await clickByName('Titre 1 : Description 1');
+
+    // then
+    assert.dom('.download-file__button').doesNotHaveClass('pix-button--disabled');
   });
 });

--- a/orga/tests/unit/components/tube/list_test.js
+++ b/orga/tests/unit/components/tube/list_test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Component | Tube::List', function (hooks) {
+  setupTest(hooks);
+
+  test('should generate a file with selected tubes', async function (assert) {
+    // given
+    const component = await createGlimmerComponent('component:tube/list');
+    const expectedFile = JSON.stringify(['tubeId1']);
+
+    // when
+    component.tubesSelected = ['tubeId1'];
+
+    // then
+    const text = await component.file.text();
+    assert.equal(text, expectedFile);
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -576,6 +576,8 @@
       }
     },
     "preselect-target-profile": {
+      "download": "Download topics selection (JSON, { fileSize }kb)",
+      "download-filename": "topic-selection.json",
       "title": "Topic selection",
       "table": {
         "caption": "Topic selection",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -569,6 +569,8 @@
       }
     },
     "preselect-target-profile": {
+      "download": "Télécharger la sélection des sujets (JSON, { fileSize }ko)",
+      "download-filename": "selection-sujets.json",
       "title": "Sélection des sujets",
       "table": {
         "caption": "Sélection des sujets",


### PR DESCRIPTION
## :christmas_tree: Problème
Nous affichons actuellement la liste des sujets sur référentiel Pix, mais on ne peut rien en faire. 

## :gift: Solution
Prise en compte de la sélection des sujets pour permettre le téléchargement du fichier json nécessaire pour la création du profil cible.


## :santa: Pour tester
1. Se connecter sur Pix Orga
2. Aller sur /selection-sujets
3. Sélectionner au moins 1 sujet
4. Cliquer sur le bouton télécharger en tête de page
5. Vérifier que le fichier n'est pas vide.