### PR TITLE
[FEATURE] Afficher le NPS après l'envoi des résultats d'une campagne (PIX-4061).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -123,7 +123,11 @@ export default class SkillReview extends Component {
   }
 
   get showNPS() {
-    return this.featureToggles.featureToggles.isNetPromoterScoreEnabled && this.args.model.campaign.organizationShowNPS;
+    return (
+      this.featureToggles.featureToggles.isNetPromoterScoreEnabled &&
+      this.args.model.campaign.organizationShowNPS &&
+      this.isShared
+    );
   }
 
   _buildUrl(baseUrl, params) {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -393,6 +393,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         };
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
+          isShared: true,
         };
         this.set('model', { campaign, campaignParticipationResult });
 


### PR DESCRIPTION
## :christmas_tree: Problème

A l'heure actuelle, le NPS s'affiche avant l'envoi des résultats d'une campagne.

## :gift: Solution

Amélioration de la condition d'affichage du bloc.

## :star2: Remarques
N/A

## :santa: Pour tester

Réaliser une campagne marquée comme ayant un NPS et constater de l'affichage du bloc uniquement après envoi des résultats.
