### PR TITLE
[TECH] Utiliser un ID de compétence spécifique au profil utilisateur dans les tests de charge.

### DIFF
--- a/high-level-tests/load-testing/scenarios/signup-and-competence-evaluation.yml
+++ b/high-level-tests/load-testing/scenarios/signup-and-competence-evaluation.yml
@@ -8,9 +8,6 @@ config:
       rampTo: 50
       name: Ramp up load
 
-  variables:
-    competenceId: "recsvLz0W2ShyfD63"
-
 scenarios:
   - name: "Inscription et évaluation"
     flow:
@@ -50,6 +47,18 @@ scenarios:
           headers:
             Authorization: "Bearer {{ accessToken }}"
 
+      # Fetch competence-id from user profile
+      - get:
+          url: "/api/users/{{ userId }}/profile"
+          headers:
+            Authorization: "Bearer {{ accessToken }}"
+          capture:
+            json: "$.included[?(@.type == 'scorecards')].attributes['competence-id']"
+            as: "competenceId"
+          expect:
+            - statusCode: 200
+            - contentType: json
+
       # Fetch campaign participations
       - get:
           url: "/api/users/{{ userId }}/campaign-participations"
@@ -70,6 +79,9 @@ scenarios:
           capture:
             json: "$.data.relationships.assessment.data.id"
             as: "assessmentId"
+          expect: 
+            - statusCode: 201
+
 
       # Fetch assessment
       - get:


### PR DESCRIPTION
## :christmas_tree: Problème
Les tests de charge utilisent un ID de compétence fixe pour s'exécuter. 
Lors de l'utilisation d'une nouvelle source de données pour le référentiel pédagogique, les tests ne fonctionnent plus.

## :gift: Solution
Récupérer un des ID de compétence proposés à l'utilisateur via le endpoint `/profile`

## :star2: Remarques
Ajout de tests sur les codes de retours des requêtes HTTP

## :santa: Pour tester
Lancer l'API, puis exécuter le scénario de test en local
```shell
npm run arti:cmd
```

Pendant l'exécution, se connecter à la BDD, et vérifier que le nombre de réponses augmente : 
```sql
select count(*) FROM answers; \watch 1
```
