### PR TITLE
[TECH] Eviter les faux négatifs dus aux séquences de seeds (PIX-4065).

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -35,7 +35,7 @@ const {
 const computeParticipationsResults = require('../../scripts/prod/compute-participation-results');
 
 const poleEmploisSendingsBuilder = require('./data/pole-emploi-sendings-builder');
-const SEQUENCE_RESTART_AT_NUMBER = 10000000;
+const SEQUENCE_RESTART_AT_NUMBER = 10000;
 
 exports.seed = async (knex) => {
 
@@ -96,9 +96,11 @@ exports.seed = async (knex) => {
  * (time being enough for dev ou review apps - seed are not run on staging or prod)
  */
 async function alterSequenceIfPG(knex) {
+  let sequenceRestartAtNumber = SEQUENCE_RESTART_AT_NUMBER;
   const sequenceNameQueryResult = await knex.raw('SELECT sequence_name FROM information_schema.sequences;');
   const sequenceNames = sequenceNameQueryResult.rows.map((row) => row.sequence_name);
   return bluebird.mapSeries(sequenceNames, async (sequenceName) => {
-    await knex.raw(`ALTER SEQUENCE "${sequenceName}" RESTART WITH ${SEQUENCE_RESTART_AT_NUMBER};`);
+    await knex.raw(`ALTER SEQUENCE "${sequenceName}" RESTART WITH ${sequenceRestartAtNumber};`);
+    sequenceRestartAtNumber += (SEQUENCE_RESTART_AT_NUMBER / 10);
   });
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Sur les Review App (et l'integration), les sequences des tables postgres commencent toutes à 10 000 000. Cela peut amener de la confusion et donner des faux positifs sur des tests func 
(exemple: on croit utiliser l'id d'un table alors que c'est une autre mais les sequence en sont au meme niveau donc c'est un faux positif).

## :gift: Solution
- démarrer les sequences à 10 000 (10 000 000 c'est galère à taper dans les inputs)
- mettre un depart de sequence different pour chaque table (10000, 11000, 12000, 13000)

## :star2: Remarques
❓Plutôt que de mettre les valeurs en dur, on pourrais aussi mettre chaque sequence à la valeur du max d'index + 1 pour la table associé

## :santa: Pour tester
Sur certif, se connecter avec certifpro@example.net
Creer une session et y ajouter un candidat. Verifier que la session et le candidat n'on pas le même id