### PR TITLE
[FEATURE] Remettre la poubelle du bouton "Effacer les filtres" (PIX-4051).

### DIFF
--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -32,6 +32,6 @@ module.exports = function () {
       'users',
       'trash-alt',
     ],
-    'free-regular-svg-icons': ['check-circle', 'copy'],
+    'free-regular-svg-icons': ['check-circle', 'copy', 'trash-alt'],
   };
 };


### PR DESCRIPTION
## :christmas_tree: Problème
L'icône de poubelle dans le bouton "Effacer les filtres" n'est plus visible.

## :gift: Solution
Il s'avère que le composant PixFilterBanner de pix-ui utilise l'icône **trash-alt** en version **regular** (cf [code](https://github.com/1024pix/pix-ui/blob/dev/addon/components/pix-filter-banner.hbs#L20)). Dans ce [commit](https://github.com/1024pix/pix/commit/c6b5c2d638194c1c202e5d2bb8d46657ec2955fc#diff-461647db7f0f0036980bcfd0968d73b28525f02cd193e1df10aa39ac59851bb9) l'icône a été supprimé de la configuration sûrement par erreur. On ajoute à nouveau l'icône dans sa variante regular au niveau de la configuration.

## :star2: Remarques
Côté applications on utilise le mécanisme proposé par ember-fontawesome pour limiter le nombre d'icône présente dans le bundle. Cependant on a pas forcément connaissance des icônes utilisé dans **pix-ui**. Il serait bien d'avoir un mécanisme d'extension de la configuration de pix-ui afin d'éviter ce type d'erreur à l'avenir.

## :santa: Pour tester
- Se connecter à Pix Orga
- Aller sur les détails d'une campagne qui a des participations
- Constater la présence de la poubelle dans le bouton "Effacer les filtres" au niveau de la barre de filtres de la liste des participations
