### PR TITLE
[FEATURE] Algo flash : Enregistrer le niveau estimé et le taux d'erreur (PIX-4039)

### DIFF
--- a/api/db/database-builder/factory/build-flash-assessment-result.js
+++ b/api/db/database-builder/factory/build-flash-assessment-result.js
@@ -1,0 +1,20 @@
+const databaseBuffer = require('../database-buffer');
+const buildAssessment = require('./build-assessment');
+
+module.exports = function buildFlashAssessmentResult({
+  id = databaseBuffer.getNextId(),
+  assessmentId,
+  estimatedLevel = 2.64,
+  errorRate = 0.391,
+} = {}) {
+  if (!assessmentId) assessmentId = buildAssessment({ method: 'FLASH' }).id;
+  return databaseBuffer.pushInsertable({
+    tableName: 'flash-assessment-results',
+    values: {
+      id,
+      assessmentId,
+      estimatedLevel,
+      errorRate,
+    },
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -38,6 +38,7 @@ module.exports = {
   buildCorrectAnswersAndKnowledgeElementsForLearningContent: require('./build-correct-answers-and-knowledge-elements-for-learning-content'),
   buildCorrectAnswerAndKnowledgeElement: require('./build-correct-answer-and-knowledge-element'),
   buildFinalizedSession: require('./build-finalized-session'),
+  buildFlashAssessmentResult: require('./build-flash-assessment-result'),
   buildKnowledgeElement: require('./build-knowledge-element'),
   buildKnowledgeElementSnapshot: require('./build-knowledge-element-snapshot'),
   buildOrganization: require('./build-organization'),

--- a/api/db/migrations/20211223092838_create-flash-assessment-results.js
+++ b/api/db/migrations/20211223092838_create-flash-assessment-results.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'flash-assessment-results';
+
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('assessmentId').references('assessments.id').notNullable().unique();
+    t.double('estimatedLevel').notNullable();
+    t.double('errorRate').notNullable();
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -88,8 +88,7 @@ async function fetchForFlashCampaigns({ assessment, answerRepository, challengeR
 
 async function fetchForFlashLevelEstimation({ assessment, answerRepository, challengeRepository }) {
   const allAnswers = await answerRepository.findByAssessment(assessment.id);
-  // FIXME might need optimization, add a getMany on challengeRepository?
-  const challenges = await Promise.all(allAnswers.map(({ challengeId }) => challengeRepository.get(challengeId)));
+  const challenges = await challengeRepository.getMany(allAnswers.map(({ challengeId }) => challengeId));
 
   return {
     allAnswers,

--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -86,8 +86,20 @@ async function fetchForFlashCampaigns({ assessment, answerRepository, challengeR
   };
 }
 
+async function fetchForFlashLevelEstimation({ assessment, answerRepository, challengeRepository }) {
+  const allAnswers = await answerRepository.findByAssessment(assessment.id);
+  // FIXME might need optimization, add a getMany on challengeRepository?
+  const challenges = await Promise.all(allAnswers.map(({ challengeId }) => challengeRepository.get(challengeId)));
+
+  return {
+    allAnswers,
+    challenges,
+  };
+}
+
 module.exports = {
   fetchForCampaigns,
   fetchForCompetenceEvaluations,
   fetchForFlashCampaigns,
+  fetchForFlashLevelEstimation,
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,5 +1,6 @@
 const dependencies = {
   accountRecoveryDemandRepository: require('../../infrastructure/repositories/account-recovery-demand-repository'),
+  algorithmDataFetcherService: require('../../domain/services/algorithm-methods/data-fetcher'),
   answerRepository: require('../../infrastructure/repositories/answer-repository'),
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
@@ -65,6 +66,8 @@ const dependencies = {
   courseRepository: require('../../infrastructure/repositories/course-repository'),
   divisionRepository: require('../../infrastructure/repositories/division-repository'),
   encryptionService: require('../../domain/services/encryption-service'),
+  flashAssessmentResultRepository: require('../../infrastructure/repositories/flash-assessment-result-repository'),
+  flashAlgorithmService: require('../../domain/services/algorithm-methods/flash'),
   getCompetenceLevel: require('../../domain/services/get-competence-level'),
   groupRepository: require('../../infrastructure/repositories/group-repository'),
   finalizedSessionRepository: require('../../infrastructure/repositories/sessions/finalized-session-repository'),

--- a/api/lib/infrastructure/datasources/learning-content/datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/datasource.js
@@ -15,6 +15,20 @@ const _DatasourcePrototype = {
     return foundObject;
   },
 
+  async getMany(ids) {
+    const modelObjects = await this.list();
+
+    return ids.map((id) => {
+      const foundObject = _.find(modelObjects, { id });
+
+      if (!foundObject) {
+        throw new LearningContentResourceNotFound();
+      }
+
+      return foundObject;
+    });
+  },
+
   async list() {
     const learningContent = await this._getLearningContent();
     return learningContent[this.modelName];

--- a/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
@@ -1,0 +1,24 @@
+const { knex } = require('../../../db/knex-database-connection');
+const DomainTransaction = require('../DomainTransaction');
+
+const TABLE_NAME = 'flash-assessment-results';
+
+module.exports = {
+  async updateEstimatedLevelAndErrorRate({
+    assessmentId,
+    estimatedLevel,
+    errorRate,
+    domainTransaction: { knexTransaction } = DomainTransaction.emptyTransaction(),
+  }) {
+    const query = knex(TABLE_NAME)
+      .insert({
+        assessmentId,
+        estimatedLevel,
+        errorRate,
+      })
+      .onConflict('assessmentId')
+      .merge();
+    if (knexTransaction) query.transacting(knexTransaction);
+    return query;
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
@@ -1,0 +1,57 @@
+const { expect, knex, databaseBuilder } = require('../../../test-helper');
+const flashAssessmentResultRepository = require('../../../../lib/infrastructure/repositories/flash-assessment-result-repository');
+
+describe('Integration | Infrastructure | Repository | FlashAssessmentResultRepository', function () {
+  describe('#updateEstimatedLevelAndErrorRate', function () {
+    let assessmentWithoutResultId;
+    let assessmentWithResultId;
+
+    beforeEach(async function () {
+      assessmentWithoutResultId = databaseBuilder.factory.buildAssessment({ method: 'FLASH' }).id;
+      assessmentWithResultId = databaseBuilder.factory.buildFlashAssessmentResult().assessmentId;
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('flash-assessment-results').delete();
+    });
+
+    context("if a result doesn't already exist for assessment", function () {
+      it('should create a result with estimated level and error rate', async function () {
+        // given
+        const assessmentId = assessmentWithoutResultId;
+
+        // when
+        await flashAssessmentResultRepository.updateEstimatedLevelAndErrorRate({
+          assessmentId,
+          estimatedLevel: 1.9,
+          errorRate: 1.3,
+        });
+
+        // then
+        const createdResult = await knex('flash-assessment-results').select().where({ assessmentId }).first();
+        expect(createdResult.estimatedLevel).to.equal(1.9);
+        expect(createdResult.errorRate).to.equal(1.3);
+      });
+    });
+
+    context('if a result already exists for assessment', function () {
+      it("should update the result's estimated level and error rate", async function () {
+        // given
+        const assessmentId = assessmentWithResultId;
+
+        // when
+        await flashAssessmentResultRepository.updateEstimatedLevelAndErrorRate({
+          assessmentId,
+          estimatedLevel: -2.8,
+          errorRate: 0.44,
+        });
+
+        // then
+        const updatedResult = await knex('flash-assessment-results').select().where({ assessmentId }).first();
+        expect(updatedResult.estimatedLevel).to.equal(-2.8);
+        expect(updatedResult.errorRate).to.equal(0.44);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -189,4 +189,44 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       expect(data.challenges).to.deep.equal(challenges);
     });
   });
+
+  describe('#fetchForFlashLevelEstimation', function () {
+    let answerRepository;
+    let challengeRepository;
+
+    beforeEach(function () {
+      answerRepository = {
+        findByAssessment: sinon.stub(),
+      };
+      challengeRepository = {
+        getMany: sinon.stub(),
+      };
+    });
+
+    it('fetches answers and challenges', async function () {
+      // given
+      const assessment = domainBuilder.buildAssessment.ofTypeCampaign({
+        state: 'started',
+        method: 'FLASH',
+        campaignParticipationId: 1,
+        userId: 5678899,
+      });
+      const answer = Symbol('answer');
+      const challenges = Symbol('challenge');
+
+      answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
+      challengeRepository.getMany.withArgs().resolves(challenges);
+
+      // when
+      const data = await dataFetcher.fetchForFlashLevelEstimation({
+        assessment,
+        answerRepository,
+        challengeRepository,
+      });
+
+      // then
+      expect(data.allAnswers).to.deep.equal([answer]);
+      expect(data.challenges).to.deep.equal(challenges);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -34,14 +34,19 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
   const competenceEvaluationRepository = {};
   const targetProfileRepository = { getByCampaignParticipationId: () => undefined };
   const skillRepository = { findActiveByCompetenceId: () => undefined };
+  const flashAssessmentResultRepository = { updateEstimatedLevelAndErrorRate: () => undefined };
   const scorecardService = { computeScorecard: () => undefined };
   const knowledgeElementRepository = {
     findUniqByUserIdAndAssessmentId: () => undefined,
   };
+  const flashAlgorithmService = { getEstimatedLevelAndErrorRate: () => undefined };
+  const algorithmDataFetcherService = { fetchForFlashLevelEstimation: () => undefined };
   const nowDate = new Date('2021-03-11T11:00:04Z');
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line mocha/no-setup-in-describe
   nowDate.setMilliseconds(1);
+
+  let dependencies;
 
   beforeEach(function () {
     sinon.stub(answerRepository, 'findByChallengeAndAssessment');
@@ -50,10 +55,13 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     sinon.stub(challengeRepository, 'get');
     sinon.stub(skillRepository, 'findActiveByCompetenceId');
     sinon.stub(targetProfileRepository, 'getByCampaignParticipationId');
+    sinon.stub(flashAssessmentResultRepository, 'updateEstimatedLevelAndErrorRate');
     sinon.stub(scorecardService, 'computeScorecard');
     sinon.stub(knowledgeElementRepository, 'findUniqByUserIdAndAssessmentId');
     sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer');
     sinon.stub(dateUtils, 'getNowDate');
+    sinon.stub(flashAlgorithmService, 'getEstimatedLevelAndErrorRate');
+    sinon.stub(algorithmDataFetcherService, 'fetchForFlashLevelEstimation');
 
     const challengeId = 'oneChallengeId';
     assessment = domainBuilder.buildAssessment({ userId, lastQuestionDate: nowDate });
@@ -68,6 +76,20 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     challengeRepository.get.resolves(challenge);
 
     dateUtils.getNowDate.returns(nowDate);
+
+    dependencies = {
+      answerRepository,
+      assessmentRepository,
+      challengeRepository,
+      competenceEvaluationRepository,
+      skillRepository,
+      targetProfileRepository,
+      knowledgeElementRepository,
+      flashAssessmentResultRepository,
+      scorecardService,
+      flashAlgorithmService,
+      algorithmDataFetcherService,
+    };
   });
 
   context('when an answer for that challenge is not for an asked challenge', function () {
@@ -86,12 +108,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       const error = await catchErr(correctAnswerThenUpdateAssessment)({
         answer,
         userId,
-        answerRepository,
-        assessmentRepository,
-        challengeRepository,
-        targetProfileRepository,
-        knowledgeElementRepository,
-        scorecardService,
+        ...dependencies,
       });
 
       // then
@@ -112,12 +129,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       const error = await catchErr(correctAnswerThenUpdateAssessment)({
         answer,
         userId,
-        answerRepository,
-        assessmentRepository,
-        challengeRepository,
-        targetProfileRepository,
-        knowledgeElementRepository,
-        scorecardService,
+        ...dependencies,
       });
 
       // then
@@ -174,14 +186,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -193,14 +198,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -216,14 +214,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         const result = await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -251,14 +242,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           const result = await correctAnswerThenUpdateAssessment({
             answer,
             userId,
-            answerRepository,
-            assessmentRepository,
-            challengeRepository,
-            competenceEvaluationRepository,
-            skillRepository,
-            targetProfileRepository,
-            knowledgeElementRepository,
-            scorecardService,
+            ...dependencies,
           });
 
           // then
@@ -276,14 +260,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           const result = await correctAnswerThenUpdateAssessment({
             answer,
             userId,
-            answerRepository,
-            assessmentRepository,
-            challengeRepository,
-            competenceEvaluationRepository,
-            skillRepository,
-            targetProfileRepository,
-            knowledgeElementRepository,
-            scorecardService,
+            ...dependencies,
           });
 
           // then
@@ -303,14 +280,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           await correctAnswerThenUpdateAssessment({
             answer,
             userId,
-            answerRepository,
-            assessmentRepository,
-            challengeRepository,
-            competenceEvaluationRepository,
-            skillRepository,
-            targetProfileRepository,
-            knowledgeElementRepository,
-            scorecardService,
+            ...dependencies,
           });
 
           // then
@@ -369,14 +339,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
         // then
         const expectedArgs = [[completedAnswer, [firstKnowledgeElement, secondKnowledgeElement]]];
@@ -388,14 +351,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -408,14 +364,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -428,14 +377,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -457,14 +399,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         const result = await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -491,14 +426,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           const result = await correctAnswerThenUpdateAssessment({
             answer,
             userId,
-            answerRepository,
-            assessmentRepository,
-            challengeRepository,
-            competenceEvaluationRepository,
-            skillRepository,
-            targetProfileRepository,
-            knowledgeElementRepository,
-            scorecardService,
+            ...dependencies,
           });
 
           // then
@@ -517,14 +445,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           const result = await correctAnswerThenUpdateAssessment({
             answer,
             userId,
-            answerRepository,
-            assessmentRepository,
-            challengeRepository,
-            competenceEvaluationRepository,
-            skillRepository,
-            targetProfileRepository,
-            knowledgeElementRepository,
-            scorecardService,
+            ...dependencies,
           });
 
           // then
@@ -544,14 +465,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           await correctAnswerThenUpdateAssessment({
             answer,
             userId,
-            answerRepository,
-            assessmentRepository,
-            challengeRepository,
-            competenceEvaluationRepository,
-            skillRepository,
-            targetProfileRepository,
-            knowledgeElementRepository,
-            scorecardService,
+            ...dependencies,
           });
 
           // then
@@ -570,6 +484,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         challenge,
         skillAlreadyValidated,
         skillNotAlreadyValidated;
+      let flashData;
+      const estimatedLevel = 1.93274982;
+      const errorRate = 0.9127398127;
 
       beforeEach(function () {
         // given
@@ -603,6 +520,13 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         targetProfileRepository.getByCampaignParticipationId.resolves(targetProfile);
         KnowledgeElement.createKnowledgeElementsForAnswer.returns([firstKnowledgeElement, secondKnowledgeElement]);
         scorecardService.computeScorecard.resolves(scorecard);
+
+        flashData = Symbol('flashData');
+        algorithmDataFetcherService.fetchForFlashLevelEstimation.returns(flashData);
+        flashAlgorithmService.getEstimatedLevelAndErrorRate.returns({
+          estimatedLevel,
+          errorRate,
+        });
       });
 
       it('should call the answer repository to save the answer', async function () {
@@ -610,14 +534,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
         // then
         const expectedArgs = [[completedAnswer, []]];
@@ -629,14 +546,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -648,14 +558,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -668,14 +571,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -689,19 +585,53 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         const result = await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
         const expectedArgument = savedAnswer;
         expect(result).to.deep.equal(expectedArgument);
+      });
+
+      it('should call the algorithm data fetcher for level estimation', async function () {
+        // when
+        await correctAnswerThenUpdateAssessment({
+          answer,
+          userId,
+          ...dependencies,
+        });
+
+        expect(algorithmDataFetcherService.fetchForFlashLevelEstimation).to.have.been.calledWith({
+          assessment,
+          answerRepository,
+          challengeRepository,
+        });
+      });
+
+      it('should call the flash algorithm to estimate level and error rate', async function () {
+        // when
+        await correctAnswerThenUpdateAssessment({
+          answer,
+          userId,
+          ...dependencies,
+        });
+
+        expect(flashAlgorithmService.getEstimatedLevelAndErrorRate).to.have.been.calledWith(flashData);
+      });
+
+      it('should call the flash assessment result repository to save estimatedLevel and errorRate', async function () {
+        // when
+        await correctAnswerThenUpdateAssessment({
+          answer,
+          userId,
+          ...dependencies,
+        });
+
+        expect(flashAssessmentResultRepository.updateEstimatedLevelAndErrorRate).to.have.been.calledWith({
+          assessmentId: assessment.id,
+          estimatedLevel,
+          errorRate,
+        });
       });
 
       context('when the user responds correctly', function () {
@@ -710,14 +640,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           const result = await correctAnswerThenUpdateAssessment({
             answer,
             userId,
-            answerRepository,
-            assessmentRepository,
-            challengeRepository,
-            competenceEvaluationRepository,
-            skillRepository,
-            targetProfileRepository,
-            knowledgeElementRepository,
-            scorecardService,
+            ...dependencies,
           });
 
           // then
@@ -737,14 +660,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           await correctAnswerThenUpdateAssessment({
             answer,
             userId,
-            answerRepository,
-            assessmentRepository,
-            challengeRepository,
-            competenceEvaluationRepository,
-            skillRepository,
-            targetProfileRepository,
-            knowledgeElementRepository,
-            scorecardService,
+            ...dependencies,
           });
 
           // then
@@ -800,14 +716,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -820,14 +729,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -840,14 +742,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -859,14 +754,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         const result = await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          competenceEvaluationRepository,
-          skillRepository,
-          targetProfileRepository,
-          knowledgeElementRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         // then
@@ -891,9 +779,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       const result = correctAnswerThenUpdateAssessment({
         answer,
         userId,
-        answerRepository,
-        assessmentRepository,
-        scorecardService,
+        ...dependencies,
       });
 
       // then
@@ -924,10 +810,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       await correctAnswerThenUpdateAssessment({
         answer,
         userId,
-        answerRepository,
-        assessmentRepository,
-        challengeRepository,
-        scorecardService,
+        ...dependencies,
       });
 
       const expectedAnswer = domainBuilder.buildAnswer(answer);
@@ -953,10 +836,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         await correctAnswerThenUpdateAssessment({
           answer,
           userId,
-          answerRepository,
-          assessmentRepository,
-          challengeRepository,
-          scorecardService,
+          ...dependencies,
         });
 
         const expectedAnswer = domainBuilder.buildAnswer(answer);

--- a/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
@@ -5,14 +5,13 @@ const LearningContentResourceNotFound = require('../../../../../lib/infrastructu
 const cache = require('../../../../../lib/infrastructure/caches/learning-content-cache');
 
 describe('Unit | Infrastructure | Datasource | Learning Content | datasource', function () {
+  let someDatasource;
+
   beforeEach(function () {
     sinon.stub(cache, 'get');
-  });
-
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const someDatasource = dataSource.extend({
-    modelName: 'learningContentModel',
+    someDatasource = dataSource.extend({
+      modelName: 'learningContentModel',
+    });
   });
 
   describe('#get', function () {
@@ -90,6 +89,42 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
         // then
         return expect(promise).to.have.been.rejectedWith(err);
       });
+    });
+  });
+
+  describe('#getMany', function () {
+    let learningContent;
+
+    beforeEach(function () {
+      cache.get.callsFake((generator) => generator());
+
+      learningContent = {
+        learningContentModel: [
+          { id: 'rec1', property: 'value1' },
+          { id: 'rec2', property: 'value2' },
+          { id: 'rec3', property: 'value3' },
+        ],
+      };
+      sinon.stub(lcms, 'getLatestRelease').resolves(learningContent);
+    });
+
+    it('should fetch all records from LCMS API corresponfing to the ids passed', async function () {
+      // when
+      const result = await someDatasource.getMany(['rec1', 'rec2']);
+
+      // then
+      expect(result).to.deep.equal([
+        { id: 'rec1', property: 'value1' },
+        { id: 'rec2', property: 'value2' },
+      ]);
+    });
+
+    it('should throw an LearningContentResourceNotFound if no record was found', function () {
+      // when
+      const promise = someDatasource.getMany(['UNKNOWN_RECORD_ID']);
+
+      // then
+      return expect(promise).to.have.been.rejectedWith(LearningContentResourceNotFound);
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Le niveau estimé et le taux d'erreur de l'utilisateur sont recalculé à la volée à chaque fois que l'on souhaite récupérer la prochaine question d'une campagne flash.

## :gift: Solution
Stocker le niveau estimé et le taux d'erreur en BdD à chaque fois que l'utilisateur répond à une question.

## :star2: Remarques
À faire dans une PR : utiliser le niveau estimé stocké dans `flash.getPossibleNextChallenges()`

## :santa: Pour tester
Démarrer la campagne flash (FLASH1234), vérifier que le niveau estimé et le taux d'erreur sont mis à jour en BdD (table `users`) à chaque fois qu'on répond à une question.