### PR TITLE
[FEATURE] Supprimer l'icone du type de résultat lors de l'affichage des informations sur le profile cible(PIX-4068).

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -81,6 +81,7 @@
           @options={{this.targetProfilesOptions}}
           @emptyOptionLabel=""
           aria-describedby="target-profile-info"
+          placeholder={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
           @isSearchable={{true}}
         />
         {{#if @errors.targetProfile}}

--- a/orga/app/components/campaign/target-profile-details.hbs
+++ b/orga/app/components/campaign/target-profile-details.hbs
@@ -14,7 +14,6 @@
       </li>
     {{/if}}
     <li class="target-profile-details__specificity__row target-profile-details__specificity__row--break-line">
-      <FaIcon @fixedWidth={{true}} @icon={{this.displayResultInfo.icon}} />
       {{t "common.target-profile-details.results.common"}}
       <FaIcon
         @fixedWidth={{true}}

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -312,6 +312,7 @@
         "result": "Success rate in "
       },
       "target-profile-informations": "If you want more information, see <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> the corresponding documentation</a>.",
+      "target-profiles-search-placeholder": "Search by name",
       "test-title": {
         "label": "Title of the customised test"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -305,6 +305,7 @@
       },
       "target-profiles-list-label": "Que souhaitez-vous tester ?",
       "target-profile-informations": "Si vous souhaitez avoir plus d'information, consulter <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> la documentation correspondante</a>.",
+      "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {
         "label": "Titre du parcours"
       },


### PR DESCRIPTION
## :christmas_tree: Problème
On affiche deux fois l’icône associé au type de résultats d'un profil cible sur la même ligne.
Ce que rend la lecture étrange.

## :gift: Solution
Supprimer l'icône qui n'a pas de sémantique.

## :star2: Remarques
BONUS: Rajout d'un petit placeholder pour l'input de recherche de profil cible.

## :santa: Pour tester
Aller sur la page de création de campagne
Choisir le type :
Dans l'input pour chercher un profil cible il y a placeholder (en anglais aussi)
Quand on sélectionne un profil cible il n'y plus qu'une seul fois l'icône en fonction du type de résultats.
