### PR TITLE
[FEATURE] Ajout de la description du profile cible lors de la création de celui ci (PIX-4032)

### DIFF
--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -57,8 +57,19 @@
     </div>
 
     <div class="form-field form-group">
+      <label class="form-field__label" for="description">Description : </label>
+      <PixTextarea
+        class="form-control"
+        id="description"
+        @maxlength="500"
+        rows="4"
+        @value={{@targetProfile.description}}
+      />
+    </div>
+
+    <div class="form-field form-group">
       <label class="form-field__label" for="comment">Commentaire (usage interne) : </label>
-      <PixTextarea class="form-control" id="comment" @maxlength="500" row="4" @value={{@targetProfile.comment}} />
+      <PixTextarea class="form-control" id="comment" @maxlength="500" rows="4" @value={{@targetProfile.comment}} />
     </div>
   </section>
 

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -138,6 +138,7 @@ exports.register = async (server) => {
                 'image-url': Joi.string().uri().empty('').allow(null).optional(),
                 'skills-id': Joi.array().required(),
                 comment: Joi.string().optional().allow(null).max(500).empty(''),
+                description: Joi.string().optional().allow(null).max(500).empty(''),
               },
             },
           }),

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -18,6 +18,7 @@ module.exports = {
       'imageUrl',
       'ownerOrganizationId',
       'comment',
+      'description',
     ]);
 
     const trx = await knex.transaction();

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -20,13 +20,14 @@ describe('Integration | Repository | Target-profile', function () {
         isPublic: true,
         ownerOrganizationId: null,
         skillsId: [],
+        description: 'public description of target profile',
         comment: 'This is a high level target profile',
       };
       // when
       const targetProfileId = await targetProfileRepository.create(targetProfileData);
 
       const [targetProfile] = await knex('target-profiles')
-        .select(['name', 'imageUrl', 'outdated', 'isPublic', 'ownerOrganizationId', 'comment'])
+        .select(['name', 'imageUrl', 'outdated', 'isPublic', 'ownerOrganizationId', 'comment', 'description'])
         .where({ id: targetProfileId });
 
       // then
@@ -36,6 +37,7 @@ describe('Integration | Repository | Target-profile', function () {
       expect(targetProfile.isPublic).to.equal(targetProfileData.isPublic);
       expect(targetProfile.ownerOrganizationId).to.equal(targetProfileData.ownerOrganizationId);
       expect(targetProfile.comment).to.equal(targetProfileData.comment);
+      expect(targetProfile.description).to.equal(targetProfileData.description);
     });
 
     it('should attached each skillId once to target profile', async function () {
@@ -58,11 +60,7 @@ describe('Integration | Repository | Target-profile', function () {
     it('should throw exception given wrong insert', async function () {
       const targetProfileData = {
         name: 'myFirstTargetProfile',
-        imageUrl: 'someUrl',
-        isPublic: true,
-        ownerOrganizationId: null,
         skillsId: [null],
-        comment: 'This is a high level target profile',
       };
       // when
       const error = await catchErr(targetProfileRepository.create)(targetProfileData);


### PR DESCRIPTION
## :christmas_tree: Problème
Nous ne pouvions pas ajouter de description au profil cible à la création

## :gift: Solution
Rajouter un champ textearea qui permet de saisir une description du profil cible à destination du prescripteur

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Se connecter sur Pix Admin, vérifier que lors de la création d'un nouveau profile cible le description est bien ajouté.