### PR TITLE
[FEATURE]  Afficher le macaron Pix+ Édu sur le certificat partagé (PIX-4066).

### DIFF
--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -3,6 +3,7 @@ const { knex } = require('../../../db/knex-database-connection');
 const ShareableCertificate = require('../../domain/models/ShareableCertificate');
 const AssessmentResult = require('../../domain/models/AssessmentResult');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
+const CertifiedBadgeImage = require('../../../lib/domain/read-models/CertifiedBadgeImage');
 const {
   badgeKey: pixPlusDroitExpertBadgeKey,
 } = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
@@ -93,7 +94,15 @@ async function _getCleaCertificationResult(certificationCourseId) {
 }
 
 async function _getCertifiedBadgeImages(certificationCourseId) {
-  const handledBadgeKeys = [pixPlusDroitExpertBadgeKey, pixPlusDroitMaitreBadgeKey];
+  const handledBadgeKeys = [
+    pixPlusDroitExpertBadgeKey,
+    pixPlusDroitMaitreBadgeKey,
+    PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+    PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+  ];
   const results = await knex
     .select('partnerKey')
     .from('partner-certifications')
@@ -104,9 +113,15 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
   return _.compact(
     _.map(results, (result) => {
       if (result.partnerKey === pixPlusDroitMaitreBadgeKey)
-        return 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg';
+        return new CertifiedBadgeImage({
+          path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+          isTemporaryBadge: false,
+        });
       if (result.partnerKey === pixPlusDroitExpertBadgeKey)
-        return 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg';
+        return new CertifiedBadgeImage({
+          path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
+          isTemporaryBadge: false,
+        });
       return null;
     })
   );

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -10,6 +10,13 @@ const {
 const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+const {
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../../domain/models/Badge').keys;
 const { NotFoundError } = require('../../../lib/domain/errors');
 const competenceTreeRepository = require('./competence-tree-repository');
 const ResultCompetenceTree = require('../../domain/models/ResultCompetenceTree');
@@ -121,6 +128,36 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
         return new CertifiedBadgeImage({
           path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
           isTemporaryBadge: false,
+        });
+      if (result.partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME)
+        return new CertifiedBadgeImage({
+          path: 'https://images.pix.fr/badges-certifies/pix-edu/autonome.svg',
+          isTemporaryBadge: true,
+          levelName: 'Autonome',
+        });
+      if (result.partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE)
+        return new CertifiedBadgeImage({
+          path: 'https://images.pix.fr/badges-certifies/pix-edu/avance.svg',
+          isTemporaryBadge: true,
+          levelName: 'Avancé',
+        });
+      if (result.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE)
+        return new CertifiedBadgeImage({
+          path: 'https://images.pix.fr/badges-certifies/pix-edu/avance.svg',
+          isTemporaryBadge: true,
+          levelName: 'Avancé',
+        });
+      if (result.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT)
+        return new CertifiedBadgeImage({
+          path: 'https://images.pix.fr/badges-certifies/pix-edu/expert.svg',
+          isTemporaryBadge: true,
+          levelName: 'Expert',
+        });
+      if (result.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR)
+        return new CertifiedBadgeImage({
+          path: 'https://images.pix.fr/badges-certifies/pix-edu/formateur.svg',
+          isTemporaryBadge: true,
+          levelName: 'Formateur',
         });
       return null;
     })

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -18,6 +18,13 @@ const {
 const {
   badgeKey: pixPlusDroitExpertBadgeKey,
 } = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+const {
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Shareable Certificate', function () {
   const minimalLearningContent = [
@@ -447,6 +454,241 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
           shareableCertificateData,
           acquiredBadges: [pixPlusDroitExpertBadgeKey, pixPlusDroitMaitreBadgeKey],
+          notAcquiredBadges: [],
+        });
+
+        // when
+        const shareableCertificate = await shareableCertificateRepository.getByVerificationCode('P-SOMECODE');
+
+        // then
+        const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
+          id: certificateId,
+          ...shareableCertificateData,
+        });
+        expect(shareableCertificate).to.deepEqualInstanceOmitting(expectedShareableCertificate, [
+          'resultCompetenceTree',
+        ]);
+      });
+
+      it('should get the certified badge images of PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME when those certifications were acquired', async function () {
+        // given
+        const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+        mockLearningContent(learningContentObjects);
+        const userId = databaseBuilder.factory.buildUser().id;
+        const shareableCertificateData = {
+          id: 123,
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId,
+          date: new Date('2020-01-01'),
+          verificationCode: 'P-SOMECODE',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: 51,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          certifiedBadgeImages: [
+            domainBuilder.buildCertifiedBadgeImage.temporary({
+              path: 'https://images.pix.fr/badges-certifies/pix-edu/autonome.svg',
+              levelName: 'Autonome',
+            }),
+          ],
+        };
+
+        const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
+          shareableCertificateData,
+          acquiredBadges: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME],
+          notAcquiredBadges: [],
+        });
+
+        // when
+        const shareableCertificate = await shareableCertificateRepository.getByVerificationCode('P-SOMECODE');
+
+        // then
+        const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
+          id: certificateId,
+          ...shareableCertificateData,
+        });
+        expect(shareableCertificate).to.deepEqualInstanceOmitting(expectedShareableCertificate, [
+          'resultCompetenceTree',
+        ]);
+      });
+
+      it('should get the certified badge images of PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE when those certifications were acquired', async function () {
+        // given
+        const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+        mockLearningContent(learningContentObjects);
+        const userId = databaseBuilder.factory.buildUser().id;
+        const shareableCertificateData = {
+          id: 123,
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId,
+          date: new Date('2020-01-01'),
+          verificationCode: 'P-SOMECODE',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: 51,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          certifiedBadgeImages: [
+            domainBuilder.buildCertifiedBadgeImage.temporary({
+              path: 'https://images.pix.fr/badges-certifies/pix-edu/avance.svg',
+              levelName: 'Avancé',
+            }),
+          ],
+        };
+
+        const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
+          shareableCertificateData,
+          acquiredBadges: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE],
+          notAcquiredBadges: [],
+        });
+
+        // when
+        const shareableCertificate = await shareableCertificateRepository.getByVerificationCode('P-SOMECODE');
+
+        // then
+        const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
+          id: certificateId,
+          ...shareableCertificateData,
+        });
+        expect(shareableCertificate).to.deepEqualInstanceOmitting(expectedShareableCertificate, [
+          'resultCompetenceTree',
+        ]);
+      });
+
+      it('should get the certified badge images of PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE when those certifications were acquired', async function () {
+        // given
+        const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+        mockLearningContent(learningContentObjects);
+        const userId = databaseBuilder.factory.buildUser().id;
+        const shareableCertificateData = {
+          id: 123,
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId,
+          date: new Date('2020-01-01'),
+          verificationCode: 'P-SOMECODE',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: 51,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          certifiedBadgeImages: [
+            domainBuilder.buildCertifiedBadgeImage.temporary({
+              path: 'https://images.pix.fr/badges-certifies/pix-edu/avance.svg',
+              levelName: 'Avancé',
+            }),
+          ],
+        };
+
+        const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
+          shareableCertificateData,
+          acquiredBadges: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE],
+          notAcquiredBadges: [],
+        });
+
+        // when
+        const shareableCertificate = await shareableCertificateRepository.getByVerificationCode('P-SOMECODE');
+
+        // then
+        const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
+          id: certificateId,
+          ...shareableCertificateData,
+        });
+        expect(shareableCertificate).to.deepEqualInstanceOmitting(expectedShareableCertificate, [
+          'resultCompetenceTree',
+        ]);
+      });
+
+      it('should get the certified badge images of PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT when those certifications were acquired', async function () {
+        // given
+        const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+        mockLearningContent(learningContentObjects);
+        const userId = databaseBuilder.factory.buildUser().id;
+        const shareableCertificateData = {
+          id: 123,
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId,
+          date: new Date('2020-01-01'),
+          verificationCode: 'P-SOMECODE',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: 51,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          certifiedBadgeImages: [
+            domainBuilder.buildCertifiedBadgeImage.temporary({
+              path: 'https://images.pix.fr/badges-certifies/pix-edu/expert.svg',
+              levelName: 'Expert',
+            }),
+          ],
+        };
+
+        const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
+          shareableCertificateData,
+          acquiredBadges: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT],
+          notAcquiredBadges: [],
+        });
+
+        // when
+        const shareableCertificate = await shareableCertificateRepository.getByVerificationCode('P-SOMECODE');
+
+        // then
+        const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
+          id: certificateId,
+          ...shareableCertificateData,
+        });
+        expect(shareableCertificate).to.deepEqualInstanceOmitting(expectedShareableCertificate, [
+          'resultCompetenceTree',
+        ]);
+      });
+
+      it('should get the certified badge images of PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR when those certifications were acquired', async function () {
+        // given
+        const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+        mockLearningContent(learningContentObjects);
+        const userId = databaseBuilder.factory.buildUser().id;
+        const shareableCertificateData = {
+          id: 123,
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId,
+          date: new Date('2020-01-01'),
+          verificationCode: 'P-SOMECODE',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: 51,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          certifiedBadgeImages: [
+            domainBuilder.buildCertifiedBadgeImage.temporary({
+              path: 'https://images.pix.fr/badges-certifies/pix-edu/formateur.svg',
+              levelName: 'Formateur',
+            }),
+          ],
+        };
+
+        const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
+          shareableCertificateData,
+          acquiredBadges: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR],
           notAcquiredBadges: [],
         });
 

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -427,8 +427,12 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           pixScore: 51,
           cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
           certifiedBadgeImages: [
-            'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
-            'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+            domainBuilder.buildCertifiedBadgeImage.notTemporary({
+              path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
+            }),
+            domainBuilder.buildCertifiedBadgeImage.notTemporary({
+              path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+            }),
           ],
         };
 
@@ -469,7 +473,11 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           certificationCenter: 'Centre des poules bien dodues',
           pixScore: 51,
           cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          certifiedBadgeImages: ['https://images.pix.fr/badges-certifies/pix-droit/expert.svg'],
+          certifiedBadgeImages: [
+            domainBuilder.buildCertifiedBadgeImage.notTemporary({
+              path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
+            }),
+          ],
         };
 
         const { certificateId } = await _buildValidShareableCertificateWithOneAcquiredPixPlusDroitBadge(


### PR DESCRIPTION
## :christmas_tree: Problème
Les macarons Pix+ Édu s'affichent sur le certificat du candidat mais pas sur le certificat partagé.

## :gift: Solution
Afficher le macaron Pix+ Édu sur le certificat partagé.

## :santa: Pour tester
- Aller sur https://app-pr3872.review.pix.fr/verification-certificat
- Entrer le code `P-QCM3Q7XM`
- Vérifier que le macaron est bien affiché

- Aller sur https://app-pr3872.review.pix.fr/verification-certificat
- Entrer le code `P-7D827XD7`
- Vérifier que le macaron est bien affiché