### PR TITLE
[FEATURE] Ajouter la catégorie d'un profil cible dans PixAdmin (PIX-3756).

### DIFF
--- a/admin/app/components/target-profiles/category.hbs
+++ b/admin/app/components/target-profiles/category.hbs
@@ -1,0 +1,3 @@
+<PixTag @compact="true" @color="blue-light">
+  {{this.category}}
+</PixTag>

--- a/admin/app/components/target-profiles/category.js
+++ b/admin/app/components/target-profiles/category.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+export default class Category extends Component {
+  get category() {
+    const { category } = this.args;
+    switch (category) {
+      case 'COMPETENCES':
+        return 'Compétences Pix';
+      case 'SUBJECT':
+        return 'Thématique';
+      case 'DISCIPLINE':
+        return 'Disciplinaire';
+      case 'CUSTOM':
+        return 'Sur-mesure';
+      case 'PREDEFINED':
+        return 'Prédéfinie';
+      default:
+        return 'Autre';
+    }
+  }
+}

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -10,6 +10,7 @@ export default class TargetProfile extends Model {
   @attr('string') description;
   @attr('string') comment;
   @attr('string') ownerOrganizationId;
+  @attr('string') category;
 
   @attr('array') skillsId;
 

--- a/admin/app/styles/components/target-profiles/target-profile.scss
+++ b/admin/app/styles/components/target-profiles/target-profile.scss
@@ -19,3 +19,7 @@
     margin-bottom: 24px;
   }
 }
+
+.target-profile_title {
+  margin-right: 8px;
+}

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -15,7 +15,8 @@
   {{else}}
     <section class="page-section">
       <div class="page-section__header">
-        <h1 class="page-section__title">{{@model.name}}</h1>
+        <h1 class="page-section__title target-profile_title">{{@model.name}}</h1>
+        <TargetProfiles::Category @category={{@model.category}} />
       </div>
       <div class="page-section__container">
         <div class="page-section__content">

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
@@ -50,6 +50,7 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
         ownerOrganizationId: 456,
         description: 'Top profil cible.',
         comment: 'Commentaire Privé.',
+        category: 'SUBJECT',
       });
 
       // when
@@ -57,6 +58,7 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
 
       // then
       assert.contains('Profil Cible Fantastix');
+      assert.contains('Thématique');
       assert.dom('section').containsText('ID : 1');
       assert.dom('section').containsText('Public : Oui');
       assert.dom('section').containsText('Obsolète : Non');

--- a/admin/tests/integration/components/target-profiles/category_test.js
+++ b/admin/tests/integration/components/target-profiles/category_test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | TargetProfiles::Category', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should display the tag for type COMPETENCES', async function (assert) {
+    // when
+    await render(hbs`<TargetProfiles::Category @category="COMPETENCES"/>`);
+
+    // then
+    assert.contains('Compétences Pix');
+  });
+
+  test('it should display the tag for type SUBJECT', async function (assert) {
+    // when
+    await render(hbs`<TargetProfiles::Category @category="SUBJECT"/>`);
+
+    // then
+    assert.contains('Thématique');
+  });
+
+  test('it should display the tag for type DISCIPLINE', async function (assert) {
+    // when
+    await render(hbs`<TargetProfiles::Category @category="DISCIPLINE"/>`);
+
+    // then
+    assert.contains('Disciplinaire');
+  });
+
+  test('it should display the tag for type CUSTOM', async function (assert) {
+    // when
+    await render(hbs`<TargetProfiles::Category @category="CUSTOM"/>`);
+
+    // then
+    assert.contains('Sur-mesure');
+  });
+
+  test('it should display the tag for type PREDEFINED', async function (assert) {
+    // when
+    await render(hbs`<TargetProfiles::Category @category="PREDEFINED"/>`);
+
+    // then
+    assert.contains('Prédéfinie');
+  });
+
+  test('it should display the tag for type OTHER', async function (assert) {
+    // when
+    await render(hbs`<TargetProfiles::Category @category="OTHER"/>`);
+
+    // then
+    assert.contains('Autre');
+  });
+});

--- a/api/db/database-builder/factory/build-target-profile.js
+++ b/api/db/database-builder/factory/build-target-profile.js
@@ -13,6 +13,7 @@ module.exports = function buildTargetProfile({
   outdated = false,
   description = null,
   comment = null,
+  category = 'OTHER',
 } = {}) {
   ownerOrganizationId = _.isUndefined(ownerOrganizationId) ? buildOrganization().id : ownerOrganizationId;
 
@@ -27,6 +28,7 @@ module.exports = function buildTargetProfile({
     outdated,
     description,
     comment,
+    category,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'target-profiles',

--- a/api/db/migrations/20211223110017_add-category-to-target-profiles.js
+++ b/api/db/migrations/20211223110017_add-category-to-target-profiles.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'target-profiles';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string('category').defaultTo('OTHER');
+  });
+  //does not work locally because the DB is empty during migration
+  await knex(TABLE_NAME).where({ isPublic: true }).update({ category: 'COMPETENCES' });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('category');
+  });
+};

--- a/api/db/seeds/data/target-profiles-builder.js
+++ b/api/db/seeds/data/target-profiles-builder.js
@@ -95,6 +95,7 @@ function _buildTargetProfilePICDiagnosticInitial(databaseBuilder) {
     id: TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
     name: 'PIC - Diagnostic Initial',
     isPublic: false,
+    category: 'OTHER',
     ownerOrganizationId: PRO_MED_NUM_ID,
   });
 
@@ -124,6 +125,7 @@ function _buildTargetProfileOnCompetence(databaseBuilder) {
     name: 'Résoudre des problèmes techniques (compétence 5.1)',
     imageUrl: 'https://images.pix.fr/profil-cible/Illu_classe2.svg',
     isPublic: false,
+    category: 'COMPETENCES',
     ownerOrganizationId: PRO_COMPANY_ID,
     description: 'Ce profil cible permet d\'**évaluer** sur la compétence 5.1. Le résultat est exprimé en ***pourcentage***',
     comment: 'Privé : Contient la ***compétence 5.1***.',
@@ -147,6 +149,7 @@ function _buildTargetProfileWithStagesAndBadges(databaseBuilder) {
     id: TARGET_PROFILE_STAGES_BADGES_ID,
     name: 'Parcours avec paliers & résultats thématiques',
     isPublic: true,
+    category: 'COMPETENCES',
     ownerOrganizationId: null,
     imageUrl: 'https://images.pix.fr/profil-cible/Illu_classe2.svg',
   });
@@ -166,6 +169,7 @@ function _buildTargetProfileWithSimplifiedAccess(databaseBuilder) {
     id: TARGET_PROFILE_SIMPLIFIED_ACCESS_ID,
     name: 'Accès simplifié',
     isPublic: true,
+    category: 'SUBJECT',
     ownerOrganizationId: PRO_MED_NUM_ID,
     isSimplifiedAccess: true,
   });
@@ -182,6 +186,7 @@ function _buildTargetProfilePixEmploiClea(databaseBuilder) {
     id: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
     name: 'Pix emploi - Parcours complet',
     isPublic: false,
+    category: 'CUSTOM',
     ownerOrganizationId: PRO_POLE_EMPLOI_ID,
   });
 
@@ -201,6 +206,7 @@ function _buildTargetProfilePixEmploiCleaV2(databaseBuilder) {
     id: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V2,
     name: 'Parcours complet CléA numérique (2021)',
     isPublic: false,
+    category: 'CUSTOM',
     ownerOrganizationId: PRO_POLE_EMPLOI_ID,
   });
 
@@ -220,6 +226,7 @@ function _buildTargetProfilePixDroit(databaseBuilder) {
     id: TARGET_PROFILE_PIX_DROIT_ID,
     name: 'Pix+ Droit - Parcours complet',
     isPublic: false,
+    category: 'SUBJECT',
     ownerOrganizationId: PRO_POLE_EMPLOI_ID,
   });
 
@@ -279,6 +286,7 @@ function _buildTargetProfilePixEduFormationInitiale(databaseBuilder) {
     id: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
     name: 'Pix+ Édu - Formation Initiale 2nd degré',
     isPublic: false,
+    category: 'SUBJECT',
     ownerOrganizationId: PRO_POLE_EMPLOI_ID,
   });
 
@@ -306,6 +314,7 @@ function _buildTargetProfilePixEduFormationContinue(databaseBuilder) {
     id: TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE,
     name: 'Pix+ Édu - Formation Continue 2nd degré',
     isPublic: false,
+    category: 'DISCIPLINE',
     ownerOrganizationId: PRO_POLE_EMPLOI_ID,
   });
 

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -17,6 +17,7 @@ class TargetProfileWithLearningContent {
     badges = [],
     stages = [],
     imageUrl,
+    category,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -33,6 +34,7 @@ class TargetProfileWithLearningContent {
     this.badges = badges;
     this.stages = _.sortBy(stages, 'threshold');
     this.imageUrl = imageUrl;
+    this.category = category;
   }
 
   get skillNames() {

--- a/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
@@ -49,6 +49,7 @@ async function _get(whereClauseFnc, locale) {
       'target-profiles.description',
       'target-profiles.comment',
       'target-profiles.ownerOrganizationId',
+      'target-profiles.category',
       'target-profiles_skills.skillId'
     )
     .leftJoin('target-profiles_skills', 'target-profiles_skills.targetProfileId', 'target-profiles.id');
@@ -78,6 +79,7 @@ async function _toDomain(results, badges, stages, locale) {
     imageUrl: results[0].imageUrl,
     description: results[0].description,
     comment: results[0].comment,
+    category: results[0].category,
     skills,
     tubes,
     competences,

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
@@ -18,6 +18,7 @@ module.exports = {
         'competences',
         'areas',
         'imageUrl',
+        'category',
       ],
       skills: {
         ref: 'id',

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -57,6 +57,29 @@ const checkBadge = (actual, expected) => {
 
 describe('Integration | Repository | Target-profile-with-learning-content', function () {
   describe('#get', function () {
+    it('return target profile category', async function () {
+      // given
+      const skillId = 'skillId';
+      const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile({ category: 'COMPETENCES' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId });
+
+      const learningContent = {
+        areas: [{ id: 'area1', competenceIds: ['competence1'] }],
+        competences: [{ id: 'competence1', skillIds: [skillId], origin: 'Pix' }],
+        tubes: [{ id: 'tube1', competenceId: 'competence1' }],
+        skills: [{ id: skillId, tubeId: 'tube1', status: 'actif' }],
+      };
+
+      mockLearningContent(learningContent);
+      await databaseBuilder.commit();
+
+      // when
+      const targetProfile = await targetProfileWithLearningContentRepository.get({ id: targetProfileId });
+
+      // then
+      expect(targetProfile.category).to.equal('COMPETENCES');
+    });
+
     it('should return target profile with learning content', async function () {
       // given
       const skill1_1_1_2 = domainBuilder.buildTargetedSkill({

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
@@ -20,6 +20,7 @@ const buildTargetProfileWithLearningContent = function buildTargetProfileWithLea
   badges = [],
   stages = [],
   imageUrl,
+  category = 'OTHER',
 } = {}) {
   return new TargetProfileWithLearningContent({
     id,
@@ -37,6 +38,7 @@ const buildTargetProfileWithLearningContent = function buildTargetProfileWithLea
     badges,
     stages,
     imageUrl,
+    category,
   });
 };
 
@@ -52,6 +54,7 @@ buildTargetProfileWithLearningContent.withSimpleLearningContent = function withS
   comment = null,
   badges = [],
   stages = [],
+  category = 'OTHER',
 } = {}) {
   const skill = buildTargetedSkill({ id: 'skillId', tubeId: 'tubeId' });
   const tube = buildTargetedTube({ id: 'tubeId', competenceId: 'competenceId', skills: [skill] });
@@ -73,6 +76,7 @@ buildTargetProfileWithLearningContent.withSimpleLearningContent = function withS
     areas: [area],
     badges,
     stages,
+    category,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
@@ -21,6 +21,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
         competences: [{ id: 'rec3', name: 'Comprendre', areaId: 'rec4', index: '1.1' }],
         areas: [{ id: 'rec4', title: 'Connaître', color: 'blue' }],
         organizations: [{ id: 42 }],
+        category: 'OTHER',
       });
 
       const expectedTargetProfile = {
@@ -35,6 +36,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
             'is-public': targetProfileWithLearningContent.isPublic,
             'owner-organization-id': targetProfileWithLearningContent.ownerOrganizationId,
             'image-url': targetProfileWithLearningContent.imageUrl,
+            category: targetProfileWithLearningContent.category,
             'created-at': targetProfileWithLearningContent.createdAt,
           },
           relationships: {


### PR DESCRIPTION
## :christmas_tree: Problème
Une création de campagne comprend le choix du profil cible, cependant il peut y avoir jusqu'au 70 profils cibles (PC) dans la drop down.
Le choix d'un profile cible peut être compliqué avec autant d'options possible.

## :gift: Solution
Rajouter des catégories sur les profiles cibles pour faire un premier tri simple.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Aller sur Pix Admin et afficher un profile cible.
La catégorie du profile doit apparaître à la suite des informations sur le profil cible.
