### PR TITLE
[BUGFIX] Bug d'affichage de l'onglet "Détails" et "Neutralisation" (PIX-4078)

### DIFF
--- a/admin/app/components/certifications/status.js
+++ b/admin/app/components/certifications/status.js
@@ -1,10 +1,11 @@
 import Component from '@glimmer/component';
 import includes from 'lodash/includes';
 import { STARTED, ERROR } from 'pix-admin/models/certification';
+import { ENDED_BY_SUPERVISOR } from 'pix-admin/models/jury-certification-summary';
 
 export default class CertificationStatusComponent extends Component {
   get isStatusBlocking() {
-    const blokingStatuses = [STARTED, ERROR];
+    const blokingStatuses = [STARTED, ERROR, ENDED_BY_SUPERVISOR];
     return includes(blokingStatuses, this.args.record.status) || this.args.record.isFlaggedAborted;
   }
 }

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -6,7 +6,10 @@ import find from 'lodash/find';
 import { certificationStatuses } from 'pix-admin/models/certification';
 
 const NOT_TAKEN = 'not_taken';
+export const ENDED_BY_SUPERVISOR = 'endedBySupervisor';
+export const juryCertificationSummaryStatuses = [{ value: ENDED_BY_SUPERVISOR, label: 'Terminée par le surveillant' }];
 
+const statuses = [...certificationStatuses, ...juryCertificationSummaryStatuses];
 export default class JuryCertificationSummary extends Model {
   @attr() firstName;
   @attr() lastName;
@@ -56,10 +59,7 @@ export default class JuryCertificationSummary extends Model {
 
   @computed('status')
   get statusLabel() {
-    const statusWithLabel = find(
-      certificationStatuses,
-      (certificationStatus) => certificationStatus.value === this.status
-    );
+    const statusWithLabel = find(statuses, { value: this.status });
     return statusWithLabel?.label;
   }
 

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -8,6 +8,7 @@ const NeutralizationAttempt = require('./NeutralizationAttempt');
 const states = {
   COMPLETED: 'completed',
   STARTED: 'started',
+  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
 };
 
 const certificationAssessmentSchema = Joi.object({
@@ -16,7 +17,7 @@ const certificationAssessmentSchema = Joi.object({
   certificationCourseId: Joi.number().integer().required(),
   createdAt: Joi.date().required(),
   completedAt: Joi.date().allow(null),
-  state: Joi.string().valid(states.COMPLETED, states.STARTED).required(),
+  state: Joi.string().valid(states.COMPLETED, states.STARTED, states.ENDED_BY_SUPERVISOR).required(),
   isV2Certification: Joi.boolean().required(),
   certificationChallenges: Joi.array().min(1).required(),
   certificationAnswersByDate: Joi.array().min(0).required(),

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -2,6 +2,7 @@ const { status: assessmentResultStatuses } = require('../models/AssessmentResult
 
 const STARTED = 'started';
 const CANCELLED = 'cancelled';
+const ENDED_BY_SUPERVISOR = 'endedBySupervisor';
 
 class JuryCertificationSummary {
   constructor({
@@ -15,6 +16,7 @@ class JuryCertificationSummary {
     abortReason,
     isPublished,
     isCourseCancelled,
+    isEndedBySupervisor,
     hasSeenEndTestScreen,
     cleaCertificationResult,
     pixPlusDroitMaitreCertificationResult,
@@ -24,7 +26,7 @@ class JuryCertificationSummary {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
-    this.status = _getStatus(status, isCourseCancelled);
+    this.status = _getStatus(status, isCourseCancelled, isEndedBySupervisor);
     this.pixScore = pixScore;
     this.isFlaggedAborted = Boolean(abortReason) && !completedAt;
     this.cleaCertificationResult = cleaCertificationResult;
@@ -50,9 +52,13 @@ class JuryCertificationSummary {
   }
 }
 
-function _getStatus(status, isCourseCancelled) {
+function _getStatus(status, isCourseCancelled, isEndedBySupervisor) {
   if (isCourseCancelled) {
     return CANCELLED;
+  }
+
+  if (isEndedBySupervisor) {
+    return ENDED_BY_SUPERVISOR;
   }
 
   if (!Object.values(assessmentResultStatuses).includes(status)) {
@@ -63,4 +69,4 @@ function _getStatus(status, isCourseCancelled) {
 }
 
 module.exports = JuryCertificationSummary;
-module.exports.statuses = { ...assessmentResultStatuses, STARTED };
+module.exports.statuses = { ...assessmentResultStatuses, STARTED, ENDED_BY_SUPERVISOR };

--- a/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -18,6 +18,26 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
       });
     });
 
+    context('when course is cancelled', function () {
+      it(`should returns "cancelled" status`, function () {
+        // when
+        const juryCertificationSummary = new JuryCertificationSummary({ isCourseCancelled: true });
+
+        // then
+        expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses['CANCELLED']);
+      });
+    });
+
+    context('when assessment is ended by supervisor', function () {
+      it(`should returns "endedBySupervisor" status`, function () {
+        // when
+        const juryCertificationSummary = new JuryCertificationSummary({ isEndedBySupervisor: true });
+
+        // then
+        expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses['ENDED_BY_SUPERVISOR']);
+      });
+    });
+
     context('when no status is given', function () {
       it('should return "started"', function () {
         // when


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à l'ajout du nouveau statut endedBySupervisor, l'affichage du détail d'une certification et de l'onglet neutralisation sont cassés sur Admin.

## :gift: Solution
Réparer l'affichage de ces 2 vues

## :star2: Remarques
Bonus: Ajouter le status "Terminée par le surveillant" dans la liste des certification d'une session

![image](https://user-images.githubusercontent.com/37305474/147269696-6464d5eb-8bfa-4419-950f-e906f2daa385.png)


## :santa: Pour tester
- Créer une session de certification
- Ajouter un candidate
- Commencer le test de certification du candidat
- Dans l'espace surveillant terminer le test du candidat
- Dans admin, consulter le détail de la certification du candidat, constater que la vue n'est pas cassée

![image](https://user-images.githubusercontent.com/37305474/147269941-70a678f2-ab90-4dc3-b8b1-eeb489d83b48.png)

- Dans admin, consulter la page de neutralisation de la certification du candidat, constater que la vue n'est pas cassée

![image](https://user-images.githubusercontent.com/37305474/147270052-0c6a832d-14e0-4739-98a2-a848758c8621.png)

- Constater que dans la liste des certifications de la session, le statut "Terminée par le candidat" est bien affiché

![image](https://user-images.githubusercontent.com/37305474/147270169-dd92479e-2533-4610-89ef-965be45dd6f0.png)

