### PR TITLE
[FEATURE] Ne donner accès à l'espace surveillant qu'à certains centres de certification (PIX-3770).

### DIFF
--- a/api/lib/application/certification-candidates/certification-candidates-controller.js
+++ b/api/lib/application/certification-candidates/certification-candidates-controller.js
@@ -1,18 +1,9 @@
 const usecases = require('../../domain/usecases');
-const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
-const { NotFoundError } = require('../http-errors');
 const certificationCandidateSubscriptionSerializer = require('../../infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer');
 
 module.exports = {
   async authorizeToStart(request, h) {
     const certificationCandidateForSupervisingId = request.params.id;
-
-    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId(
-      certificationCandidateForSupervisingId
-    );
-    if (!isEndTestScreenRemovalEnabled) {
-      throw new NotFoundError();
-    }
 
     const authorizedToStart = request.payload['authorized-to-start'];
     await usecases.authorizeCertificationCandidateToStart({
@@ -25,13 +16,6 @@ module.exports = {
 
   async authorizeToResume(request, h) {
     const certificationCandidateId = request.params.id;
-
-    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId(
-      certificationCandidateId
-    );
-    if (!isEndTestScreenRemovalEnabled) {
-      throw new NotFoundError();
-    }
 
     await usecases.authorizeCertificationCandidateToResume({
       certificationCandidateId,

--- a/api/lib/application/certification-candidates/certification-candidates-controller.js
+++ b/api/lib/application/certification-candidates/certification-candidates-controller.js
@@ -1,16 +1,20 @@
 const usecases = require('../../domain/usecases');
-const { featureToggles } = require('../../config');
+const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
 const { NotFoundError } = require('../http-errors');
 const certificationCandidateSubscriptionSerializer = require('../../infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer');
 
 module.exports = {
   async authorizeToStart(request, h) {
-    if (!featureToggles.isEndTestScreenRemovalEnabled) {
+    const certificationCandidateForSupervisingId = request.params.id;
+
+    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId(
+      certificationCandidateForSupervisingId
+    );
+    if (!isEndTestScreenRemovalEnabled) {
       throw new NotFoundError();
     }
 
     const authorizedToStart = request.payload['authorized-to-start'];
-    const certificationCandidateForSupervisingId = request.params.id;
     await usecases.authorizeCertificationCandidateToStart({
       certificationCandidateForSupervisingId,
       authorizedToStart,
@@ -20,11 +24,15 @@ module.exports = {
   },
 
   async authorizeToResume(request, h) {
-    if (!featureToggles.isEndTestScreenRemovalEnabled) {
+    const certificationCandidateId = request.params.id;
+
+    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId(
+      certificationCandidateId
+    );
+    if (!isEndTestScreenRemovalEnabled) {
       throw new NotFoundError();
     }
 
-    const certificationCandidateId = request.params.id;
     await usecases.authorizeCertificationCandidateToResume({
       certificationCandidateId,
     });

--- a/api/lib/application/certification-candidates/index.js
+++ b/api/lib/application/certification-candidates/index.js
@@ -1,5 +1,6 @@
 const certificationCandidatesController = require('./certification-candidates-controller');
 const assessmentSupervisorAuthorization = require('../preHandlers/assessment-supervisor-authorization');
+const endTestScreenRemovalEnabled = require('../preHandlers/end-test-screen-removal-enabled');
 const Joi = require('joi');
 const identifiersType = require('../../domain/types/identifiers-type');
 
@@ -17,6 +18,12 @@ exports.register = async function (server) {
             'authorized-to-start': Joi.boolean().required(),
           }),
         },
+        pre: [
+          {
+            method: endTestScreenRemovalEnabled.verifyByCertificationCandidateId,
+            assign: 'endTestScreenRemovalEnabledCheck',
+          },
+        ],
         handler: certificationCandidatesController.authorizeToStart,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -34,6 +41,12 @@ exports.register = async function (server) {
             id: identifiersType.certificationCandidateId,
           }),
         },
+        pre: [
+          {
+            method: endTestScreenRemovalEnabled.verifyByCertificationCandidateId,
+            assign: 'endTestScreenRemovalEnabledCheck',
+          },
+        ],
         handler: certificationCandidatesController.authorizeToResume,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -48,6 +61,10 @@ exports.register = async function (server) {
       config: {
         auth: false,
         pre: [
+          {
+            method: endTestScreenRemovalEnabled.verifyByCertificationCandidateId,
+            assign: 'endTestScreenRemovalEnabledCheck',
+          },
           {
             method: assessmentSupervisorAuthorization.verify,
             assign: 'authorizationCheck',

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -171,6 +171,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CancelledOrganizationInvitationError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.SupervisorAccessNotAuthorizedError) {
+    return new HttpErrors.UnauthorizedError(error.message);
+  }
   if (error instanceof DomainErrors.SendingEmailToResultRecipientError) {
     return new HttpErrors.ServiceUnavailableError(error.message);
   }

--- a/api/lib/application/preHandlers/end-test-screen-removal-enabled.js
+++ b/api/lib/application/preHandlers/end-test-screen-removal-enabled.js
@@ -2,7 +2,7 @@ const { SupervisorAccessNotAuthorizedError } = require('../../domain/errors');
 const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
 
 module.exports = {
-  async verifyBySessionId(request, h) {
+  async verifyBySessionId(request) {
     let sessionId = request.params?.id;
     if (!sessionId) {
       sessionId = request.payload.data.attributes['session-id'];

--- a/api/lib/application/preHandlers/end-test-screen-removal-enabled.js
+++ b/api/lib/application/preHandlers/end-test-screen-removal-enabled.js
@@ -1,0 +1,33 @@
+const { SupervisorAccessNotAuthorizedError } = require('../../domain/errors');
+const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
+
+module.exports = {
+  async verifyBySessionId(request, h) {
+    let sessionId = request.params?.id;
+    if (!sessionId) {
+      sessionId = request.payload.data.attributes['session-id'];
+    }
+
+    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
+      sessionId
+    );
+    if (!isEndTestScreenRemovalEnabled) {
+      throw new SupervisorAccessNotAuthorizedError();
+    }
+
+    return true;
+  },
+
+  async verifyByCertificationCandidateId(request, h) {
+    const candidateId = request.params.id;
+
+    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId(
+      candidateId
+    );
+    if (!isEndTestScreenRemovalEnabled) {
+      return h.response().code(404).takeover();
+    }
+
+    return true;
+  },
+};

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -6,6 +6,7 @@ const finalizedSessionController = require('./finalized-session-controller');
 const authorization = require('../preHandlers/authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
 const { sendJsonApiError, UnprocessableEntityError } = require('../http-errors');
+const endTestScreenRemovalEnabled = require('../preHandlers/end-test-screen-removal-enabled');
 
 exports.register = async (server) => {
   server.route([
@@ -354,6 +355,12 @@ exports.register = async (server) => {
             id: identifiersType.sessionId,
           }),
         },
+        pre: [
+          {
+            method: endTestScreenRemovalEnabled.verifyBySessionId,
+            assign: 'endTestScreenRemovalEnabledCheck',
+          },
+        ],
         handler: sessionForSupervisingController.get,
         tags: ['api', 'sessions', 'supervising'],
         notes: [
@@ -381,6 +388,12 @@ exports.register = async (server) => {
             return sendJsonApiError(new UnprocessableEntityError('Un des champs saisis n’est pas valide.'), h);
           },
         },
+        pre: [
+          {
+            method: endTestScreenRemovalEnabled.verifyBySessionId,
+            assign: 'endTestScreenRemovalEnabledCheck',
+          },
+        ],
         handler: sessionForSupervisingController.supervise,
         tags: ['api', 'sessions', 'supervising'],
         notes: [

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -1,7 +1,7 @@
 const Joi = require('joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
-const sessionForMonitoringController = require('./session-for-supervising-controller');
+const sessionForSupervisingController = require('./session-for-supervising-controller');
 const finalizedSessionController = require('./finalized-session-controller');
 const authorization = require('../preHandlers/authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
@@ -354,7 +354,7 @@ exports.register = async (server) => {
             id: identifiersType.sessionId,
           }),
         },
-        handler: sessionForMonitoringController.get,
+        handler: sessionForSupervisingController.get,
         tags: ['api', 'sessions', 'supervising'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',
@@ -381,7 +381,7 @@ exports.register = async (server) => {
             return sendJsonApiError(new UnprocessableEntityError('Un des champs saisis n’est pas valide.'), h);
           },
         },
-        handler: sessionForMonitoringController.supervise,
+        handler: sessionForSupervisingController.supervise,
         tags: ['api', 'sessions', 'supervising'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -20,6 +20,7 @@ const fillCandidatesImportSheet = require('../../infrastructure/files/candidates
 const trim = require('lodash/trim');
 const UserLinkedToCertificationCandidate = require('../../domain/events/UserLinkedToCertificationCandidate');
 const logger = require('../../infrastructure/logger');
+const endTestScreenRemovalEnabled = require('../../domain/services/end-test-screen-removal-service');
 
 module.exports = {
   async findPaginatedFilteredJurySessions(request) {
@@ -43,8 +44,13 @@ module.exports = {
   async get(request) {
     const sessionId = request.params.id;
     const session = await usecases.getSession({ sessionId });
-
-    return sessionSerializer.serialize(session);
+    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalEnabled.isEndTestScreenRemovalEnabledBySessionId(
+      sessionId
+    );
+    if (!isEndTestScreenRemovalEnabled) {
+      session.supervisorPassword = undefined;
+    }
+    return sessionSerializer.serialize(session, true);
   },
 
   async save(request) {

--- a/api/lib/application/sessions/session-for-supervising-controller.js
+++ b/api/lib/application/sessions/session-for-supervising-controller.js
@@ -1,26 +1,32 @@
 const usecases = require('../../domain/usecases');
 const sessionForSupervisingSerializer = require('../../infrastructure/serializers/jsonapi/session-for-supervising-serializer');
-const { featureToggles } = require('../../config');
 const { NotFoundError } = require('../http-errors');
+const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
 
 module.exports = {
   async get(request) {
-    if (!featureToggles.isEndTestScreenRemovalEnabled) {
+    const sessionId = request.params.id;
+    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
+      sessionId
+    );
+    if (!isEndTestScreenRemovalEnabled) {
       throw new NotFoundError();
     }
 
-    const sessionId = request.params.id;
     const session = await usecases.getSessionForSupervising({ sessionId });
     return sessionForSupervisingSerializer.serialize(session);
   },
 
   async supervise(request, h) {
-    if (!featureToggles.isEndTestScreenRemovalEnabled) {
+    const { 'supervisor-password': supervisorPassword, 'session-id': sessionId } = request.payload.data.attributes;
+    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
+      // eslint-disable-next-line no-restricted-syntax
+      parseInt(sessionId, 10)
+    );
+    if (!isEndTestScreenRemovalEnabled) {
       throw new NotFoundError();
     }
-
     const { userId } = request.auth.credentials;
-    const { 'supervisor-password': supervisorPassword, 'session-id': sessionId } = request.payload.data.attributes;
     await usecases.superviseSession({ sessionId, userId, supervisorPassword });
     return h.response().code(204);
   },

--- a/api/lib/application/sessions/session-for-supervising-controller.js
+++ b/api/lib/application/sessions/session-for-supervising-controller.js
@@ -1,31 +1,15 @@
 const usecases = require('../../domain/usecases');
 const sessionForSupervisingSerializer = require('../../infrastructure/serializers/jsonapi/session-for-supervising-serializer');
-const { NotFoundError } = require('../http-errors');
-const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
 
 module.exports = {
   async get(request) {
     const sessionId = request.params.id;
-    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
-      sessionId
-    );
-    if (!isEndTestScreenRemovalEnabled) {
-      throw new NotFoundError();
-    }
-
     const session = await usecases.getSessionForSupervising({ sessionId });
     return sessionForSupervisingSerializer.serialize(session);
   },
 
   async supervise(request, h) {
     const { 'supervisor-password': supervisorPassword, 'session-id': sessionId } = request.payload.data.attributes;
-    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
-      // eslint-disable-next-line no-restricted-syntax
-      parseInt(sessionId, 10)
-    );
-    if (!isEndTestScreenRemovalEnabled) {
-      throw new NotFoundError();
-    }
     const { userId } = request.auth.credentials;
     await usecases.superviseSession({ sessionId, userId, supervisorPassword });
     return h.response().code(204);

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -162,6 +162,9 @@ module.exports = (function () {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
       isEndTestScreenRemovalEnabled: isFeatureEnabled(process.env.FT_END_TEST_SCREEN_REMOVAL_ENABLED),
+      allowedCertificationCenterIdsForEndTestScreenRemoval: _getArrayOfStrings(
+        process.env.FT_ALLOWED_CERTIFICATION_CENTER_IDS_FOR_END_TEST_SCREEN_REMOVAL
+      ),
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
       ),

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -159,7 +159,7 @@ module.exports = (function () {
     featureToggles: {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
-      isEndTestScreenRemovalEnabled: isFeatureEnabled(process.env.FT_END_TEST_SCREEN_REMOVAL_ENABLED),
+      isEndTestScreenRemovalEnabled: Boolean(getArrayOfStrings(process.env.END_TEST_SCREEN_REMOVAL_WHITELIST).length),
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
       ),

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,6 +1,7 @@
-const _ = require('lodash');
 const path = require('path');
 const moment = require('moment');
+
+const { getArrayOfStrings } = require('../lib/infrastructure/utils/string-utils');
 
 function parseJSONEnv(varName) {
   if (process.env[varName]) {
@@ -11,10 +12,6 @@ function parseJSONEnv(varName) {
 
 function isFeatureEnabled(environmentVariable) {
   return environmentVariable === 'true';
-}
-
-function _getArrayOfStrings(commaSeparatedStrings) {
-  return _(commaSeparatedStrings).split(',').map(_.trim).map(_.toUpper).value();
 }
 
 function _getNumber(numberAsString, defaultIntNumber) {
@@ -153,7 +150,7 @@ module.exports = (function () {
       maxReachableLevel: _getNumber(process.env.MAX_REACHABLE_LEVEL, 5),
       newYearSchoolingRegistrationsImportDate: _getDate(process.env.NEW_YEAR_SCHOOLING_REGISTRATIONS_IMPORT_DATE),
       numberOfChallengesForFlashMethod: _getNumber(process.env.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD),
-      pixCertifScoBlockedAccessWhitelist: _getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
+      pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
     },
@@ -162,7 +159,7 @@ module.exports = (function () {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
       isEndTestScreenRemovalEnabled: isFeatureEnabled(process.env.FT_END_TEST_SCREEN_REMOVAL_ENABLED),
-      allowedCertificationCenterIdsForEndTestScreenRemoval: _getArrayOfStrings(
+      allowedCertificationCenterIdsForEndTestScreenRemoval: getArrayOfStrings(
         process.env.FT_ALLOWED_CERTIFICATION_CENTER_IDS_FOR_END_TEST_SCREEN_REMOVAL
       ),
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -153,15 +153,13 @@ module.exports = (function () {
       pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
+      endTestScreenRemovalWhiteList: getArrayOfStrings(process.env.END_TEST_SCREEN_REMOVAL_WHITELIST),
     },
 
     featureToggles: {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
       isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
       isEndTestScreenRemovalEnabled: isFeatureEnabled(process.env.FT_END_TEST_SCREEN_REMOVAL_ENABLED),
-      allowedCertificationCenterIdsForEndTestScreenRemoval: getArrayOfStrings(
-        process.env.FT_ALLOWED_CERTIFICATION_CENTER_IDS_FOR_END_TEST_SCREEN_REMOVAL
-      ),
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
       ),

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -351,6 +351,14 @@ class CertificationEndedBySupervisorError extends DomainError {
   }
 }
 
+class SupervisorAccessNotAuthorizedError extends DomainError {
+  constructor(
+    message = "Cette session est organisée dans un centre de certification pour lequel l'espace surveillant n'a pas été activé par Pix."
+  ) {
+    super(message);
+  }
+}
+
 class CertificationCandidateAlreadyLinkedToUserError extends DomainError {
   constructor(message = 'Ce candidat de certification a déjà été lié à un utilisateur.') {
     super(message);
@@ -1072,6 +1080,7 @@ module.exports = {
   SessionAlreadyPublishedError,
   SessionNotAccessible,
   SiecleXmlImportError,
+  SupervisorAccessNotAuthorizedError,
   TargetProfileInvalidError,
   TargetProfileCannotBeCreated,
   TooManyRows,

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -24,6 +24,7 @@ const dependencies = {
   competenceRepository: require('../../infrastructure/repositories/competence-repository'),
   complementaryCertificationCourseRepository: require('../../infrastructure/repositories/complementary-certification-course-repository'),
   knowledgeElementRepository: require('../../infrastructure/repositories/knowledge-element-repository'),
+  endTestScreenRemovalService: require('../services/end-test-screen-removal-service'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
   poleEmploiSendingRepository: require('../../infrastructure/repositories/pole-emploi-sending-repository'),
   scoringCertificationService: require('../services/scoring/scoring-certification-service'),

--- a/api/lib/domain/services/end-test-screen-removal-service.js
+++ b/api/lib/domain/services/end-test-screen-removal-service.js
@@ -7,4 +7,9 @@ module.exports = {
     );
     return isEndTestScreenRemovalEnabled;
   },
+  isEndTestScreenRemovalEnabledByCandidateId: async function (candidateId) {
+    const isEndTestScreenRemovalEnabled =
+      await endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledByCandidateId(candidateId);
+    return isEndTestScreenRemovalEnabled;
+  },
 };

--- a/api/lib/domain/services/end-test-screen-removal-service.js
+++ b/api/lib/domain/services/end-test-screen-removal-service.js
@@ -1,0 +1,10 @@
+const endTestScreenRemovalRepository = require('../../infrastructure/repositories/end-test-screen-removal-repository');
+
+module.exports = {
+  isEndTestScreenRemovalEnabledBySessionId: async function (sessionId) {
+    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledBySessionId(
+      sessionId
+    );
+    return isEndTestScreenRemovalEnabled;
+  },
+};

--- a/api/lib/domain/services/end-test-screen-removal-service.js
+++ b/api/lib/domain/services/end-test-screen-removal-service.js
@@ -12,4 +12,12 @@ module.exports = {
       await endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledByCandidateId(candidateId);
     return isEndTestScreenRemovalEnabled;
   },
+
+  isEndTestScreenRemovalEnabledByCertificationCenterId: function (certificationCenterId) {
+    return endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledByCertificationCenterId(certificationCenterId);
+  },
+
+  isEndTestScreenRemovalEnabledForSomeCertificationCenter: function () {
+    return endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledForSomeCertificationCenter();
+  },
 };

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -1,5 +1,4 @@
 const get = require('lodash/get');
-const { featureToggles } = require('../../config');
 
 const {
   ForbiddenAccess,
@@ -9,6 +8,7 @@ const {
 
 const apps = require('../constants');
 const authenticationService = require('../../domain/services/authentication-service');
+const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
 
 function _checkUserAccessScope(scope, user) {
   if (scope === apps.PIX_ORGA.SCOPE && !user.isLinkedToOrganizations()) {
@@ -20,7 +20,9 @@ function _checkUserAccessScope(scope, user) {
   }
 
   if (scope === apps.PIX_CERTIF.SCOPE && !user.isLinkedToCertificationCenters()) {
-    if (!featureToggles.isEndTestScreenRemovalEnabled) {
+    const isEndTestScreenRemovalEnabled =
+      endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter();
+    if (!isEndTestScreenRemovalEnabled) {
       throw new ForbiddenAccess(apps.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG);
     }
   }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -67,6 +67,7 @@ const dependencies = {
   courseRepository: require('../../infrastructure/repositories/course-repository'),
   divisionRepository: require('../../infrastructure/repositories/division-repository'),
   encryptionService: require('../../domain/services/encryption-service'),
+  endTestScreenRemovalService: require('../services/end-test-screen-removal-service'),
   flashAssessmentResultRepository: require('../../infrastructure/repositories/flash-assessment-result-repository'),
   flashAlgorithmService: require('../../domain/services/algorithm-methods/flash'),
   getCompetenceLevel: require('../../domain/services/get-competence-level'),

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -27,6 +27,7 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   placementProfileService,
   certificationBadgesService,
   verifyCertificateCodeService,
+  endTestScreenRemovalService,
 }) {
   const session = await sessionRepository.get(sessionId);
   if (session.accessCode !== accessCode) {
@@ -41,7 +42,10 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     sessionId,
   });
 
-  if (featureToggles.isEndTestScreenRemovalEnabled) {
+  const isEndTestRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
+    session.id
+  );
+  if (isEndTestRemovalEnabled) {
     if (!certificationCandidate.isAuthorizedToStart()) {
       throw new CandidateNotAuthorizedToJoinSessionError();
     }

--- a/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
+++ b/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
@@ -1,0 +1,22 @@
+const { featureToggles } = require('../../config');
+const { knex } = require('../../../db/knex-database-connection');
+
+async function isEndTestScreenRemovalEnabledBySessionId(sessionId) {
+  const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
+
+  if (allowedCertificationCenterIdsForEndTestScreenRemoval.length === 0) return false;
+
+  const [{ count }] = await knex
+    .select(1)
+    .from('sessions')
+    .innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
+    .where({ 'sessions.id': sessionId })
+    .whereIn('certification-centers.id', allowedCertificationCenterIdsForEndTestScreenRemoval)
+    .count();
+
+  return Boolean(count);
+}
+
+module.exports = {
+  isEndTestScreenRemovalEnabledBySessionId,
+};

--- a/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
+++ b/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
@@ -14,9 +14,8 @@ async function isEndTestScreenRemovalEnabledBySessionId(sessionId) {
   const [{ count }] = await knex
     .select(1)
     .from('sessions')
-    .innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
-    .where({ 'sessions.id': sessionId })
-    .whereIn('certification-centers.id', endTestScreenRemovalWhiteList)
+    .where({ id: sessionId })
+    .whereIn('certificationCenterId', endTestScreenRemovalWhiteList)
     .count();
 
   return Boolean(count);
@@ -31,9 +30,8 @@ async function isEndTestScreenRemovalEnabledByCandidateId(certificationCandidate
     .select(1)
     .from('sessions')
     .innerJoin('certification-candidates', 'certification-candidates.sessionId', 'sessions.id')
-    .innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
     .where({ 'certification-candidates.id': certificationCandidateId })
-    .whereIn('certification-centers.id', endTestScreenRemovalWhiteList)
+    .whereIn('sessions.certificationCenterId', endTestScreenRemovalWhiteList)
     .count();
 
   return Boolean(count);

--- a/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
+++ b/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
@@ -17,6 +17,24 @@ async function isEndTestScreenRemovalEnabledBySessionId(sessionId) {
   return Boolean(count);
 }
 
+async function isEndTestScreenRemovalEnabledByCandidateId(certificationCandidateId) {
+  const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
+
+  if (allowedCertificationCenterIdsForEndTestScreenRemoval.length === 0) return false;
+
+  const [{ count }] = await knex
+    .select(1)
+    .from('sessions')
+    .innerJoin('certification-candidates', 'certification-candidates.sessionId', 'sessions.id')
+    .innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
+    .where({ 'certification-candidates.id': certificationCandidateId })
+    .whereIn('certification-centers.id', allowedCertificationCenterIdsForEndTestScreenRemoval)
+    .count();
+
+  return Boolean(count);
+}
+
 module.exports = {
   isEndTestScreenRemovalEnabledBySessionId,
+  isEndTestScreenRemovalEnabledByCandidateId,
 };

--- a/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
+++ b/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
@@ -1,6 +1,11 @@
 const { featureToggles } = require('../../config');
 const { knex } = require('../../../db/knex-database-connection');
 
+function isEndTestScreenRemovalEnabledByCertificationCenterId(certificationCenterId) {
+  const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
+  return allowedCertificationCenterIdsForEndTestScreenRemoval.includes(certificationCenterId);
+}
+
 async function isEndTestScreenRemovalEnabledBySessionId(sessionId) {
   const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
 
@@ -34,7 +39,14 @@ async function isEndTestScreenRemovalEnabledByCandidateId(certificationCandidate
   return Boolean(count);
 }
 
+function isEndTestScreenRemovalEnabledForSomeCertificationCenter() {
+  const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
+  return allowedCertificationCenterIdsForEndTestScreenRemoval.length > 0;
+}
+
 module.exports = {
   isEndTestScreenRemovalEnabledBySessionId,
   isEndTestScreenRemovalEnabledByCandidateId,
+  isEndTestScreenRemovalEnabledByCertificationCenterId,
+  isEndTestScreenRemovalEnabledForSomeCertificationCenter,
 };

--- a/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
+++ b/api/lib/infrastructure/repositories/end-test-screen-removal-repository.js
@@ -1,31 +1,31 @@
-const { featureToggles } = require('../../config');
+const { features } = require('../../config');
 const { knex } = require('../../../db/knex-database-connection');
 
 function isEndTestScreenRemovalEnabledByCertificationCenterId(certificationCenterId) {
-  const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
-  return allowedCertificationCenterIdsForEndTestScreenRemoval.includes(certificationCenterId);
+  const { endTestScreenRemovalWhiteList } = features;
+  return endTestScreenRemovalWhiteList.includes(certificationCenterId);
 }
 
 async function isEndTestScreenRemovalEnabledBySessionId(sessionId) {
-  const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
+  const { endTestScreenRemovalWhiteList } = features;
 
-  if (allowedCertificationCenterIdsForEndTestScreenRemoval.length === 0) return false;
+  if (endTestScreenRemovalWhiteList.length === 0) return false;
 
   const [{ count }] = await knex
     .select(1)
     .from('sessions')
     .innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
     .where({ 'sessions.id': sessionId })
-    .whereIn('certification-centers.id', allowedCertificationCenterIdsForEndTestScreenRemoval)
+    .whereIn('certification-centers.id', endTestScreenRemovalWhiteList)
     .count();
 
   return Boolean(count);
 }
 
 async function isEndTestScreenRemovalEnabledByCandidateId(certificationCandidateId) {
-  const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
+  const { endTestScreenRemovalWhiteList } = features;
 
-  if (allowedCertificationCenterIdsForEndTestScreenRemoval.length === 0) return false;
+  if (endTestScreenRemovalWhiteList.length === 0) return false;
 
   const [{ count }] = await knex
     .select(1)
@@ -33,15 +33,15 @@ async function isEndTestScreenRemovalEnabledByCandidateId(certificationCandidate
     .innerJoin('certification-candidates', 'certification-candidates.sessionId', 'sessions.id')
     .innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
     .where({ 'certification-candidates.id': certificationCandidateId })
-    .whereIn('certification-centers.id', allowedCertificationCenterIdsForEndTestScreenRemoval)
+    .whereIn('certification-centers.id', endTestScreenRemovalWhiteList)
     .count();
 
   return Boolean(count);
 }
 
 function isEndTestScreenRemovalEnabledForSomeCertificationCenter() {
-  const { allowedCertificationCenterIdsForEndTestScreenRemoval } = featureToggles;
-  return allowedCertificationCenterIdsForEndTestScreenRemoval.length > 0;
+  const { endTestScreenRemovalWhiteList } = features;
+  return endTestScreenRemovalWhiteList.length > 0;
 }
 
 module.exports = {

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -5,7 +5,6 @@ const { WrongDateFormatError } = require('../../../domain/errors');
 const { isValidDate } = require('../../utils/date-utils');
 
 const Session = require('../../../domain/models/Session');
-const { featureToggles } = require('../../../config');
 
 module.exports = {
   serialize(sessions) {
@@ -25,10 +24,8 @@ module.exports = {
       'certificationCenterId',
       'certificationCandidates',
       'certificationReports',
+      'supervisorPassword',
     ];
-    if (featureToggles.isEndTestScreenRemovalEnabled) {
-      attributes.push('supervisorPassword');
-    }
     return new Serializer('session', {
       attributes,
       certificationCandidates: {

--- a/api/lib/infrastructure/utils/string-utils.js
+++ b/api/lib/infrastructure/utils/string-utils.js
@@ -1,5 +1,10 @@
 const _ = require('../../infrastructure/utils/lodash-utils');
 
+function getArrayOfStrings(commaSeparatedStrings) {
+  if (!commaSeparatedStrings) return [];
+  return _(commaSeparatedStrings).split(',').map(_.trim).map(_.toUpper).value();
+}
+
 function isNumeric(string) {
   if (typeof string != 'string') {
     return false;
@@ -47,6 +52,7 @@ module.exports = {
   isNumeric,
   splitIntoWordsAndRemoveBackspaces,
   cleanStringAndParseFloat,
+  getArrayOfStrings,
   normalizeAndSortChars,
   normalize,
 };

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -31,6 +31,7 @@ const schema = Joi.object({
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
   FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
   FT_END_TEST_SCREEN_REMOVAL_ENABLED: Joi.string().optional().valid('true', 'false'),
+  FT_ALLOWED_CERTIFICATION_CENTER_IDS_FOR_END_TEST_SCREEN_REMOVAL: Joi.string().optional(),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -18,6 +18,7 @@ const PoleEmploiTokens = require('../../../lib/domain/models/PoleEmploiTokens');
 const poleEmploiTokensRepository = require('../../../lib/infrastructure/repositories/pole-emploi-tokens-repository');
 
 const createServer = require('../../../server');
+const { featureToggles } = require('../../../lib/config');
 
 describe('Acceptance | Controller | authentication-controller', function () {
   const orgaRoleInDB = { id: 1, name: 'ADMIN' };
@@ -41,31 +42,15 @@ describe('Acceptance | Controller | authentication-controller', function () {
   });
 
   describe('POST /api/token', function () {
-    let options;
-
     beforeEach(async function () {
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildMembership({ userId, organizationId, organizationRoleId: orgaRoleInDB.id });
-
-      options = {
-        method: 'POST',
-        url: '/api/token',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: querystring.stringify({
-          grant_type: 'password',
-          username: userEmailAddress,
-          password: userPassword,
-          scope: 'pix-orga',
-        }),
-      };
-
       await databaseBuilder.commit();
     });
 
     it('should return an 200 with accessToken when authentication is ok', async function () {
       // when
+      const options = _getOptions({ scope: 'pix-orga', username: userEmailAddress, password: userPassword });
       const response = await server.inject(options);
 
       // then
@@ -81,6 +66,8 @@ describe('Acceptance | Controller | authentication-controller', function () {
       // given
       const username = 'username123';
       const shouldChangePassword = true;
+
+      const options = _getOptions({ scope: 'pix-orga', username, password: userPassword });
 
       databaseBuilder.factory.buildUser.withRawPassword({
         username,
@@ -100,12 +87,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
         ],
       };
 
-      options.payload = querystring.stringify({
-        grant_type: 'password',
-        username,
-        password: userPassword,
-      });
-
       await databaseBuilder.commit();
 
       // when
@@ -114,6 +95,50 @@ describe('Acceptance | Controller | authentication-controller', function () {
       // then
       expect(response.statusCode).to.equal(401);
       expect(response.result).to.deep.equal(expectedResponseError);
+    });
+
+    context('when scope is pix-certif', function () {
+      context('when FT allowedCertificationCenterIdsForEndTestScreenRemoval is not empty', function () {
+        it('should return http code 200 with accessToken when authentication is ok', async function () {
+          //given
+          const options = _getOptions({ scope: 'pix-certif', username: userEmailAddress, password: userPassword });
+          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([1]);
+
+          await databaseBuilder.commit();
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+
+          const result = response.result;
+          expect(result.token_type).to.equal('bearer');
+          expect(result.access_token).to.exist;
+          expect(result.user_id).to.equal(userId);
+        });
+      });
+
+      context('when FT allowedCertificationCenterIdsForEndTestScreenRemoval is empty', function () {
+        it('should return http code 403 ', async function () {
+          //given
+          databaseBuilder.factory.buildUser.withRawPassword({
+            email: 'email@without.mb',
+            rawPassword: userPassword,
+            cgu: true,
+          });
+
+          await databaseBuilder.commit();
+          const options = _getOptions({ scope: 'pix-certif', username: 'email@without.mb', password: userPassword });
+
+          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+
+          // when
+          const { statusCode } = await server.inject(options);
+
+          // then
+          expect(statusCode).to.equal(403);
+        });
+      });
     });
   });
 
@@ -717,4 +742,20 @@ describe('Acceptance | Controller | authentication-controller', function () {
       });
     });
   });
+
+  function _getOptions({ scope, password, username }) {
+    return {
+      method: 'POST',
+      url: '/api/token',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      payload: querystring.stringify({
+        grant_type: 'password',
+        username,
+        password,
+        scope,
+      }),
+    };
+  }
 });

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -18,7 +18,7 @@ const PoleEmploiTokens = require('../../../lib/domain/models/PoleEmploiTokens');
 const poleEmploiTokensRepository = require('../../../lib/infrastructure/repositories/pole-emploi-tokens-repository');
 
 const createServer = require('../../../server');
-const { featureToggles } = require('../../../lib/config');
+const { features } = require('../../../lib/config');
 
 describe('Acceptance | Controller | authentication-controller', function () {
   const orgaRoleInDB = { id: 1, name: 'ADMIN' };
@@ -98,11 +98,11 @@ describe('Acceptance | Controller | authentication-controller', function () {
     });
 
     context('when scope is pix-certif', function () {
-      context('when FT allowedCertificationCenterIdsForEndTestScreenRemoval is not empty', function () {
+      context('when FT endTestScreenRemovalWhiteList is not empty', function () {
         it('should return http code 200 with accessToken when authentication is ok', async function () {
           //given
           const options = _getOptions({ scope: 'pix-certif', username: userEmailAddress, password: userPassword });
-          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([1]);
+          sinon.stub(features, 'endTestScreenRemovalWhiteList').value([1]);
 
           await databaseBuilder.commit();
           // when
@@ -118,7 +118,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
         });
       });
 
-      context('when FT allowedCertificationCenterIdsForEndTestScreenRemoval is empty', function () {
+      context('when FT endTestScreenRemovalWhiteList is empty', function () {
         it('should return http code 403 ', async function () {
           //given
           databaseBuilder.factory.buildUser.withRawPassword({
@@ -130,7 +130,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
           await databaseBuilder.commit();
           const options = _getOptions({ scope: 'pix-certif', username: 'email@without.mb', password: userPassword });
 
-          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+          sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
 
           // when
           const { statusCode } = await server.inject(options);

--- a/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
@@ -1,6 +1,6 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, sinon } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const { featureToggles } = require('../../../../lib/config');
+const { features } = require('../../../../lib/config');
 const ComplementaryCertification = require('../../../../lib/domain/models/ComplementaryCertification');
 
 describe('Acceptance | API | Certifications candidates', function () {
@@ -20,9 +20,7 @@ describe('Acceptance | API | Certifications candidates', function () {
             sessionId: session.id,
           });
           await databaseBuilder.commit();
-          sinon
-            .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-            .value([certificationCenter.id]);
+          sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenter.id]);
 
           const options = {
             method: 'POST',
@@ -57,9 +55,7 @@ describe('Acceptance | API | Certifications candidates', function () {
             sessionId: session.id,
           });
           await databaseBuilder.commit();
-          sinon
-            .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-            .value([certificationCenter.id]);
+          sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenter.id]);
 
           const options = {
             method: 'POST',
@@ -110,9 +106,7 @@ describe('Acceptance | API | Certifications candidates', function () {
               userId: supervisorUserId,
               sessionId,
             });
-            sinon
-              .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-              .value([certificationCenter.id]);
+            sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenter.id]);
 
             await databaseBuilder.commit();
             const options = {
@@ -128,6 +122,7 @@ describe('Acceptance | API | Certifications candidates', function () {
             expect(response.statusCode).to.equal(204);
           });
         });
+
         describe('when user is not the supervisor of the assessment session', function () {
           it('should return a 401 HTTP status code', async function () {
             // given
@@ -160,9 +155,7 @@ describe('Acceptance | API | Certifications candidates', function () {
               sessionId,
             });
 
-            sinon
-              .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-              .value([certificationCenter.id]);
+            sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenter.id]);
 
             await databaseBuilder.commit();
             const options = {
@@ -210,10 +203,6 @@ describe('Acceptance | API | Certifications candidates', function () {
         complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
       });
       await databaseBuilder.commit();
-
-      sinon
-        .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-        .value([certificationCenter.id]);
 
       const options = {
         method: 'GET',

--- a/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
@@ -6,18 +6,24 @@ const ComplementaryCertification = require('../../../../lib/domain/models/Comple
 describe('Acceptance | API | Certifications candidates', function () {
   describe('POST /api/certification-candidates/:id/authorize-to-start', function () {
     context('when user is authenticated', function () {
-      describe('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+      describe('when FT_ALLOWED_CERTIFICATION_CENTER_IDS_FOR_END_TEST_SCREEN_REMOVAL is enabled for the certification center', function () {
         it('should return a 204 status code', async function () {
           // given
-          sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
-
           const server = await createServer();
           const userId = databaseBuilder.factory.buildUser().id;
-          const session = databaseBuilder.factory.buildSession({ publishedAt: null });
+          const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+          const session = databaseBuilder.factory.buildSession({
+            publishedAt: null,
+            certificationCenterId: certificationCenter.id,
+          });
           const candidate = databaseBuilder.factory.buildCertificationCandidate({
             sessionId: session.id,
           });
           await databaseBuilder.commit();
+          sinon
+            .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
+            .value([certificationCenter.id]);
+
           const options = {
             method: 'POST',
             url: `/api/certification-candidates/${candidate.id}/authorize-to-start`,
@@ -37,18 +43,24 @@ describe('Acceptance | API | Certifications candidates', function () {
 
   describe('POST /api/certification-candidates/:id/authorize-to-resume', function () {
     context('when user is authenticated', function () {
-      describe('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+      describe('when FT_ALLOWED_CERTIFICATION_CENTER_IDS_FOR_END_TEST_SCREEN_REMOVAL is enabled for the certification center', function () {
         it('should return a 204 status code', async function () {
           // given
-          sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
-
           const server = await createServer();
           const userId = databaseBuilder.factory.buildUser().id;
-          const session = databaseBuilder.factory.buildSession({ publishedAt: null });
+          const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+          const session = databaseBuilder.factory.buildSession({
+            publishedAt: null,
+            certificationCenterId: certificationCenter.id,
+          });
           const candidate = databaseBuilder.factory.buildCertificationCandidate({
             sessionId: session.id,
           });
           await databaseBuilder.commit();
+          sinon
+            .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
+            .value([certificationCenter.id]);
+
           const options = {
             method: 'POST',
             url: `/api/certification-candidates/${candidate.id}/authorize-to-resume`,
@@ -67,15 +79,16 @@ describe('Acceptance | API | Certifications candidates', function () {
 
   describe('PATCH /api/certification-candidates/{id}/end-assessment-by-supervisor', function () {
     context('when user is authenticated', function () {
-      describe('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+      describe('when FT_ALLOWED_CERTIFICATION_CENTER_IDS_FOR_END_TEST_SCREEN_REMOVAL is enabled for the certification center', function () {
         context('when the user is the supervisor of the session', function () {
           it('should return a 204 status code', async function () {
             // given
-            sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
-
             const server = await createServer();
             const candidateUserId = databaseBuilder.factory.buildUser({}).id;
-            const sessionId = databaseBuilder.factory.buildSession().id;
+            const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+            const sessionId = databaseBuilder.factory.buildSession({
+              certificationCenterId: certificationCenter.id,
+            }).id;
             const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
               sessionId,
               userId: candidateUserId,
@@ -97,6 +110,9 @@ describe('Acceptance | API | Certifications candidates', function () {
               userId: supervisorUserId,
               sessionId,
             });
+            sinon
+              .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
+              .value([certificationCenter.id]);
 
             await databaseBuilder.commit();
             const options = {
@@ -115,11 +131,13 @@ describe('Acceptance | API | Certifications candidates', function () {
         describe('when user is not the supervisor of the assessment session', function () {
           it('should return a 401 HTTP status code', async function () {
             // given
-            sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
-
             const server = await createServer();
             const candidateUserId = databaseBuilder.factory.buildUser({}).id;
-            const sessionId = databaseBuilder.factory.buildSession().id;
+            const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+            const sessionId = databaseBuilder.factory.buildSession({
+              certificationCenterId: certificationCenter.id,
+            }).id;
+
             const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
               sessionId,
               userId: candidateUserId,
@@ -141,6 +159,10 @@ describe('Acceptance | API | Certifications candidates', function () {
               userId: supervisorUserId,
               sessionId,
             });
+
+            sinon
+              .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
+              .value([certificationCenter.id]);
 
             await databaseBuilder.commit();
             const options = {
@@ -165,8 +187,10 @@ describe('Acceptance | API | Certifications candidates', function () {
       // given
       const server = await createServer();
       const userId = databaseBuilder.factory.buildUser().id;
-
-      const session = databaseBuilder.factory.buildSession();
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const session = databaseBuilder.factory.buildSession({
+        certificationCenterId: certificationCenter.id,
+      });
       const candidate = databaseBuilder.factory.buildCertificationCandidate({
         sessionId: session.id,
       });
@@ -186,6 +210,10 @@ describe('Acceptance | API | Certifications candidates', function () {
         complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
       });
       await databaseBuilder.commit();
+
+      sinon
+        .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
+        .value([certificationCenter.id]);
 
       const options = {
         method: 'GET',

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -12,7 +12,7 @@ const createServer = require('../../../server');
 const { CertificationIssueReportCategories } = require('../../../lib/domain/models/CertificationIssueReportCategory');
 const CertificationAssessment = require('../../../lib/domain/models/CertificationAssessment');
 const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
-const { featureToggles } = require('../../../lib/config');
+const { features } = require('../../../lib/config');
 
 describe('Acceptance | API | Certification Course', function () {
   let server;
@@ -462,7 +462,7 @@ describe('Acceptance | API | Certification Course', function () {
       };
       await databaseBuilder.commit();
 
-      sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+      sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
     });
 
     context('when the given access code does not correspond to the session', function () {

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -6,11 +6,13 @@ const {
   mockLearningContent,
   generateValidRequestAuthorizationHeader,
   insertUserWithRolePixMaster,
+  sinon,
 } = require('../../test-helper');
 const createServer = require('../../../server');
 const { CertificationIssueReportCategories } = require('../../../lib/domain/models/CertificationIssueReportCategory');
 const CertificationAssessment = require('../../../lib/domain/models/CertificationAssessment');
 const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
+const { featureToggles } = require('../../../lib/config');
 
 describe('Acceptance | API | Certification Course', function () {
   let server;
@@ -435,10 +437,12 @@ describe('Acceptance | API | Certification Course', function () {
     let response;
     let userId;
     let sessionId;
+    let certificationCenterId;
 
     beforeEach(async function () {
       userId = databaseBuilder.factory.buildUser().id;
-      sessionId = databaseBuilder.factory.buildSession({ accessCode: '123' }).id;
+      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      sessionId = databaseBuilder.factory.buildSession({ accessCode: '123', certificationCenterId }).id;
       const payload = {
         data: {
           attributes: {
@@ -456,7 +460,9 @@ describe('Acceptance | API | Certification Course', function () {
         },
         payload,
       };
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
+
+      sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
     });
 
     context('when the given access code does not correspond to the session', function () {

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,7 +24,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-manage-uncompleted-certif-enabled': false,
             'is-email-validation-enabled': false,
             'is-end-test-screen-removal-enabled': false,
-            'allowed-certification-center-ids-for-end-test-screen-removal': [],
             'is-complementary-certification-subscription-enabled': false,
           },
           type: 'feature-toggles',

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,6 +24,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-manage-uncompleted-certif-enabled': false,
             'is-email-validation-enabled': false,
             'is-end-test-screen-removal-enabled': false,
+            'allowed-certification-center-ids-for-end-test-screen-removal': [],
             'is-complementary-certification-subscription-enabled': false,
           },
           type: 'feature-toggles',

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
@@ -1,6 +1,6 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, sinon } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const { featureToggles } = require('../../../../lib/config');
+const { features } = require('../../../../lib/config');
 
 describe('Acceptance | Controller | session-for-supervising-controller-get', function () {
   let server;
@@ -12,7 +12,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
   context('when en test screen removal is enabled', function () {
     it('should return OK and a sessionForSupervisings type', async function () {
       // given
-      sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([345]);
+      sinon.stub(features, 'endTestScreenRemovalWhiteList').value([345]);
       databaseBuilder.factory.buildCertificationCenter({ id: 345 });
       databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
       databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
@@ -45,7 +45,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
         payload: {},
       };
       options.headers = { authorization: generateValidRequestAuthorizationHeader(1111) };
-      sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+      sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
 
       // when
       const response = await server.inject(options);

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
@@ -38,7 +38,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
   });
 
   context('when end test screen removal is not enabled', function () {
-    it('should return 404 HTTP status code ', async function () {
+    it('should return 401 HTTP status code ', async function () {
       const options = {
         method: 'GET',
         url: '/api/sessions/121/supervising',
@@ -51,7 +51,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(404);
+      expect(response.statusCode).to.equal(401);
     });
   });
 });

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
@@ -9,10 +9,10 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
     server = await createServer();
   });
 
-  context('when FT_IS_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+  context('when en test screen removal is enabled', function () {
     it('should return OK and a sessionForSupervisings type', async function () {
       // given
-      sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+      sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([345]);
       databaseBuilder.factory.buildCertificationCenter({ id: 345 });
       databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
       databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
@@ -37,7 +37,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
     });
   });
 
-  context('when FT_IS_END_TEST_SCREEN_REMOVAL_ENABLED is not enabled', function () {
+  context('when end test screen removal is not enabled', function () {
     it('should return 404 HTTP status code ', async function () {
       const options = {
         method: 'GET',
@@ -45,7 +45,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
         payload: {},
       };
       options.headers = { authorization: generateValidRequestAuthorizationHeader(1111) };
-      sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(false);
+      sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
 
       // when
       const response = await server.inject(options);

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
@@ -7,7 +7,7 @@ const {
   knex,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const { featureToggles } = require('../../../../lib/config');
+const { features } = require('../../../../lib/config');
 
 describe('Acceptance | Controller | session-for-supervising-controller-supervise', function () {
   let server;
@@ -31,9 +31,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-supervise
     databaseBuilder.factory.buildSession(session);
     await databaseBuilder.commit();
 
-    sinon
-      .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-      .value([0, certificationCenter.id, 1]);
+    sinon.stub(features, 'endTestScreenRemovalWhiteList').value([0, certificationCenter.id, 1]);
     const headers = { authorization: generateValidRequestAuthorizationHeader(3456, 'pix-certif') };
 
     const options = {

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
@@ -22,15 +22,18 @@ describe('Acceptance | Controller | session-for-supervising-controller-supervise
 
   it('should return a HTTP 204 No Content', async function () {
     // given
-    sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
-    const session = domainBuilder.buildSession({ id: 121 });
+
+    const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+    const session = domainBuilder.buildSession({ id: 121, certificationCenterId: certificationCenter.id });
     session.generateSupervisorPassword();
     const supervisorPassword = session.supervisorPassword;
-
-    databaseBuilder.factory.buildSession(session);
     databaseBuilder.factory.buildUser({ id: 3456 });
+    databaseBuilder.factory.buildSession(session);
     await databaseBuilder.commit();
 
+    sinon
+      .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
+      .value([0, certificationCenter.id, 1]);
     const headers = { authorization: generateValidRequestAuthorizationHeader(3456, 'pix-certif') };
 
     const options = {

--- a/api/tests/integration/infrastructure/repositories/end-test-screen-removal-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/end-test-screen-removal-repository_test.js
@@ -1,6 +1,7 @@
 const { expect, databaseBuilder, sinon } = require('../../../test-helper');
 const {
   isEndTestScreenRemovalEnabledBySessionId,
+  isEndTestScreenRemovalEnabledByCandidateId,
 } = require('../../../../lib/infrastructure/repositories/end-test-screen-removal-repository');
 const { featureToggles } = require('../../../../lib/config');
 
@@ -75,6 +76,86 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
 
         // when
         const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
+
+        // then
+        expect(isEndTestScreenRemovalEnabled).to.be.true;
+      });
+    });
+  });
+  describe('#isEndTestScreenRemovalEnabledByCandidatesId', function () {
+    context('isEndTestScreenRemovalEnabledCertificationCenterIds is empty', function () {
+      context('the given candidates does not exist', function () {
+        it('returns false if feature toggle end screen certification center ids is empty', async function () {
+          // given
+          const candidateId = 0;
+          sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabledCertificationCenterIds').value([]);
+
+          // when
+          const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledByCandidateId(candidateId);
+
+          // then
+          expect(isEndTestScreenRemovalEnabled).to.be.false;
+        });
+      });
+      context('the given candidate does exist', function () {
+        it('returns false', async function () {
+          // given
+          const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+          const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+          const candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
+          await databaseBuilder.commit();
+          sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabledCertificationCenterIds').value([]);
+
+          // when
+          const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledByCandidateId(candidateId);
+
+          // then
+          expect(isEndTestScreenRemovalEnabled).to.be.false;
+        });
+      });
+    });
+
+    context('isEndTestScreenRemovalEnabledCertificationCenterIds is not empty', function () {
+      context(
+        'the feature is not enabled for the certification center associated with the given candidate id',
+        function () {
+          it('returns false', async function () {
+            // given
+            const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+            const otherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+            const sessionId = databaseBuilder.factory.buildSession({
+              certificationCenterId: otherCertificationCenterId,
+            }).id;
+            const candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
+
+            await databaseBuilder.commit();
+            sinon
+              .stub(featureToggles, 'isEndTestScreenRemovalEnabledCertificationCenterIds')
+              .value([certificationCenterId]);
+
+            // when
+            const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledByCandidateId(candidateId);
+
+            // then
+            expect(isEndTestScreenRemovalEnabled).to.be.false;
+          });
+        }
+      );
+    });
+
+    context('the feature is enabled for the certification center associated with the given session id', function () {
+      it('returns true if isEndTestScreenRemovalEnabledCertificationCenterIds contains the id associated with given session id', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+        const candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
+        await databaseBuilder.commit();
+        sinon
+          .stub(featureToggles, 'isEndTestScreenRemovalEnabledCertificationCenterIds')
+          .value([certificationCenterId]);
+
+        // when
+        const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledByCandidateId(candidateId);
 
         // then
         expect(isEndTestScreenRemovalEnabled).to.be.true;

--- a/api/tests/integration/infrastructure/repositories/end-test-screen-removal-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/end-test-screen-removal-repository_test.js
@@ -5,16 +5,16 @@ const {
   isEndTestScreenRemovalEnabledByCertificationCenterId,
   isEndTestScreenRemovalEnabledForSomeCertificationCenter,
 } = require('../../../../lib/infrastructure/repositories/end-test-screen-removal-repository');
-const { featureToggles } = require('../../../../lib/config');
+const { features } = require('../../../../lib/config');
 
 describe('Integration | Repository | EndTestScreenRemovalRepository', function () {
   describe('#isEndTestScreenRemovalEnabledBySessionId', function () {
-    context('allowedCertificationCenterIdsForEndTestScreenRemoval is empty', function () {
+    context('endTestScreenRemovalWhiteList is empty', function () {
       context('the given session does not exist', function () {
         it('returns false if feature toggle end screen certification center ids is empty', async function () {
           // given
           const sessionId = 0;
-          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+          sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
 
           // when
           const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
@@ -29,7 +29,7 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
           const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
           const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
           await databaseBuilder.commit();
-          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+          sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
 
           // when
           const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
@@ -40,7 +40,7 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
       });
     });
 
-    context('allowedCertificationCenterIdsForEndTestScreenRemoval is not empty', function () {
+    context('endTestScreenRemovalWhiteList is not empty', function () {
       context(
         'the feature is not enabled for the certification center associated with the given session id',
         function () {
@@ -52,9 +52,7 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
               certificationCenterId: otherCertificationCenterId,
             }).id;
             await databaseBuilder.commit();
-            sinon
-              .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-              .value([certificationCenterId]);
+            sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenterId]);
 
             // when
             const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
@@ -67,14 +65,12 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
     });
 
     context('the feature is enabled for the certification center associated with the given session id', function () {
-      it('returns true if allowedCertificationCenterIdsForEndTestScreenRemoval contains the id associated with given session id', async function () {
+      it('returns true if endTestScreenRemovalWhiteList contains the id associated with given session id', async function () {
         // given
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
         const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
         await databaseBuilder.commit();
-        sinon
-          .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-          .value([certificationCenterId]);
+        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenterId]);
 
         // when
         const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
@@ -90,7 +86,7 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
         it('returns false if feature toggle end screen certification center ids is empty', async function () {
           // given
           const candidateId = 0;
-          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+          sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
 
           // when
           const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledByCandidateId(candidateId);
@@ -106,7 +102,7 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
           const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
           const candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
           await databaseBuilder.commit();
-          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+          sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
 
           // when
           const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledByCandidateId(candidateId);
@@ -117,7 +113,7 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
       });
     });
 
-    context('allowedCertificationCenterIdsForEndTestScreenRemoval is not empty', function () {
+    context('endTestScreenRemovalWhiteList is not empty', function () {
       context(
         'the feature is not enabled for the certification center associated with the given candidate id',
         function () {
@@ -131,9 +127,7 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
             const candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
 
             await databaseBuilder.commit();
-            sinon
-              .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-              .value([certificationCenterId]);
+            sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenterId]);
 
             // when
             const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledByCandidateId(candidateId);
@@ -146,15 +140,13 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
     });
 
     context('the feature is enabled for the certification center associated with the given session id', function () {
-      it('returns true if allowedCertificationCenterIdsForEndTestScreenRemoval contains the id associated with given session id', async function () {
+      it("returns true if the session's certification center is whitelisted", async function () {
         // given
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
         const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
         const candidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
         await databaseBuilder.commit();
-        sinon
-          .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
-          .value([certificationCenterId]);
+        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenterId]);
 
         // when
         const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledByCandidateId(candidateId);
@@ -166,10 +158,10 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
   });
 
   describe('#isEndTestScreenRemovalEnabledByCertificationCenterId', function () {
-    context('when allowedCertificationCenterIdsForEndTestScreenRemoval contains the given id', function () {
+    context('when endTestScreenRemovalWhiteList contains the given id', function () {
       it('returns true', function () {
         //given
-        sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([9, 99, 999]);
+        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([9, 99, 999]);
 
         //when
         const isEndTestScreenRemovalEnabled = isEndTestScreenRemovalEnabledByCertificationCenterId(99);
@@ -179,10 +171,10 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
       });
     });
 
-    context('when allowedCertificationCenterIdsForEndTestScreenRemoval does not contains the given id', function () {
+    context('when endTestScreenRemovalWhiteList does not contains the given id', function () {
       it('returns true', function () {
         //given
-        sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
 
         //when
         const isEndTestScreenRemovalEnabled = isEndTestScreenRemovalEnabledByCertificationCenterId(99);
@@ -194,10 +186,10 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
   });
 
   describe('#isEndTestScreenRemovalEnabledForSomeCertificationCenter', function () {
-    context('when allowedCertificationCenterIdsForEndTestScreenRemoval is not empty', function () {
+    context('when endTestScreenRemovalWhiteList is not empty', function () {
       it('returns true', function () {
         //given
-        sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([9, 99, 999]);
+        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([9, 99, 999]);
 
         //when
         const isEndTestScreenRemovalEnabled = isEndTestScreenRemovalEnabledForSomeCertificationCenter();
@@ -207,10 +199,10 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
       });
     });
 
-    context('when allowedCertificationCenterIdsForEndTestScreenRemoval is empty', function () {
+    context('when endTestScreenRemovalWhiteList is empty', function () {
       it('returns false', function () {
         // given
-        sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
 
         // when
         const isEndTestScreenRemovalEnabled = isEndTestScreenRemovalEnabledForSomeCertificationCenter();

--- a/api/tests/integration/infrastructure/repositories/end-test-screen-removal-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/end-test-screen-removal-repository_test.js
@@ -1,0 +1,84 @@
+const { expect, databaseBuilder, sinon } = require('../../../test-helper');
+const {
+  isEndTestScreenRemovalEnabledBySessionId,
+} = require('../../../../lib/infrastructure/repositories/end-test-screen-removal-repository');
+const { featureToggles } = require('../../../../lib/config');
+
+describe('Integration | Repository | EndTestScreenRemovalRepository', function () {
+  describe('#isEndTestScreenRemovalEnabledBySessionId', function () {
+    context('allowedCertificationCenterIdsForEndTestScreenRemoval is empty', function () {
+      context('the given session does not exist', function () {
+        it('returns false if feature toggle end screen certification center ids is empty', async function () {
+          // given
+          const sessionId = 0;
+          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+
+          // when
+          const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
+
+          // then
+          expect(isEndTestScreenRemovalEnabled).to.be.false;
+        });
+      });
+      context('the given session does exist', function () {
+        it('returns false', async function () {
+          // given
+          const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+          const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+          await databaseBuilder.commit();
+          sinon.stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval').value([]);
+
+          // when
+          const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
+
+          // then
+          expect(isEndTestScreenRemovalEnabled).to.be.false;
+        });
+      });
+    });
+
+    context('allowedCertificationCenterIdsForEndTestScreenRemoval is not empty', function () {
+      context(
+        'the feature is not enabled for the certification center associated with the given session id',
+        function () {
+          it('returns false', async function () {
+            // given
+            const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+            const otherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+            const sessionId = databaseBuilder.factory.buildSession({
+              certificationCenterId: otherCertificationCenterId,
+            }).id;
+            await databaseBuilder.commit();
+            sinon
+              .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
+              .value([certificationCenterId]);
+
+            // when
+            const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
+
+            // then
+            expect(isEndTestScreenRemovalEnabled).to.be.false;
+          });
+        }
+      );
+    });
+
+    context('the feature is enabled for the certification center associated with the given session id', function () {
+      it('returns true if allowedCertificationCenterIdsForEndTestScreenRemoval contains the id associated with given session id', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+        await databaseBuilder.commit();
+        sinon
+          .stub(featureToggles, 'allowedCertificationCenterIdsForEndTestScreenRemoval')
+          .value([certificationCenterId]);
+
+        // when
+        const isEndTestScreenRemovalEnabled = await isEndTestScreenRemovalEnabledBySessionId(sessionId);
+
+        // then
+        expect(isEndTestScreenRemovalEnabled).to.be.true;
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -63,8 +63,9 @@ describe('Integration | Repository | SCOCertificationCandidate', function () {
       const candidates = await knex('certification-candidates').select();
       const actualCandidates = candidatesToBeCompared(candidates);
       const expectedCandidates = candidatesToBeCompared(scoCandidates);
-      expect(actualCandidates).to.deep.equal(expectedCandidates);
+      expect(actualCandidates).to.exactlyContain(expectedCandidates);
     });
+
     it('does nothing when no candidate is given', async function () {
       // when
       await scoCertificationCandidateRepository.addNonEnrolledCandidatesToSession({

--- a/api/tests/unit/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/unit/application/certification-candidates/certification-candidates-controller_test.js
@@ -1,143 +1,86 @@
-const { expect, sinon, catchErr, hFake } = require('../../../test-helper');
+const { expect, sinon, hFake } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 const certificationCandidateController = require('../../../../lib/application/certification-candidates/certification-candidates-controller');
 const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
-const { NotFoundError } = require('../../../../lib/application/http-errors');
 
 describe('Unit | Controller | certifications-candidate-controller', function () {
   describe('#authorizeToStart', function () {
-    describe('when end screen removal is enabled', function () {
-      it('should return a 204 status code', async function () {
-        // given
-        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(99).resolves(true);
-        const request = {
-          auth: {
-            credentials: { userId: '111' },
-          },
-          params: {
-            id: 99,
-          },
-          payload: { 'authorized-to-start': true },
-        };
+    it('should return a 204 status code', async function () {
+      // given
+      const request = {
+        auth: {
+          credentials: { userId: '111' },
+        },
+        params: {
+          id: 99,
+        },
+        payload: { 'authorized-to-start': true },
+      };
 
-        usecases.authorizeCertificationCandidateToStart = sinon.stub().rejects();
-        usecases.authorizeCertificationCandidateToStart
-          .withArgs({
-            certificationCandidateForSupervisingId: 99,
-            authorizedToStart: true,
-          })
-          .resolves();
+      usecases.authorizeCertificationCandidateToStart = sinon.stub().rejects();
+      usecases.authorizeCertificationCandidateToStart
+        .withArgs({
+          certificationCandidateForSupervisingId: 99,
+          authorizedToStart: true,
+        })
+        .resolves();
 
-        // when
-        const response = await certificationCandidateController.authorizeToStart(request, hFake);
+      // when
+      const response = await certificationCandidateController.authorizeToStart(request, hFake);
 
-        // then
-        expect(response.statusCode).to.equal(204);
-      });
-    });
-
-    describe('when end test screen removal is not enabled', function () {
-      it('should return a 404 status code', async function () {
-        // given
-        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId
-          //   .withArgs(99)
-          .resolves(false);
-
-        const request = {
-          auth: {
-            credentials: { userId: '111' },
-          },
-          params: {
-            id: 99,
-          },
-          payload: { 'authorized-to-start': true },
-        };
-
-        // when
-        const error = await catchErr(certificationCandidateController.authorizeToStart)(request, hFake);
-        certificationCandidateController.authorizeToStart(request, hFake);
-
-        // then
-        expect(error).to.be.an.instanceOf(NotFoundError);
-      });
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 
   describe('#authorizeToResume', function () {
-    describe('when end test screen removal is enabled', function () {
-      it('should return a 204 status code', async function () {
-        // given
-        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(99).resolves(true);
-        const request = {
-          auth: {
-            credentials: { userId: '111' },
-          },
-          params: {
-            id: 99,
-          },
-        };
-
-        usecases.authorizeCertificationCandidateToResume = sinon.stub().rejects();
-        usecases.authorizeCertificationCandidateToResume
-          .withArgs({
-            certificationCandidateId: 99,
-          })
-          .resolves();
-
-        // when
-        const response = await certificationCandidateController.authorizeToResume(request, hFake);
-
-        // then
-        expect(response.statusCode).to.equal(204);
-      });
-    });
-
-    describe('when end test screen removal is not enabled', function () {
-      it('should return a 404 status code', async function () {
-        // given
-        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(99).resolves(false);
-
-        const request = {
-          auth: {
-            credentials: { userId: '111' },
-          },
-          params: {
-            id: 99,
-          },
-        };
-
-        // when
-        const error = await catchErr(certificationCandidateController.authorizeToResume)(request, hFake);
-
-        // then
-        expect(error).to.be.an.instanceOf(NotFoundError);
-      });
-    });
-  });
-
-  describe('#endAssessmentBySupervisor', function () {
-    const certificationCandidateId = 2;
-
-    beforeEach(function () {});
-
-    it('should call the endAssessmentBySupervisor use case', async function () {
+    it('should return a 204 status code', async function () {
       // given
-      sinon.stub(usecases, 'endAssessmentBySupervisor');
-      usecases.endAssessmentBySupervisor.resolves();
+      sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
+      endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(99).resolves(true);
+      const request = {
+        auth: {
+          credentials: { userId: '111' },
+        },
+        params: {
+          id: 99,
+        },
+      };
+
+      usecases.authorizeCertificationCandidateToResume = sinon.stub().rejects();
+      usecases.authorizeCertificationCandidateToResume
+        .withArgs({
+          certificationCandidateId: 99,
+        })
+        .resolves();
 
       // when
-      await certificationCandidateController.endAssessmentBySupervisor({
-        params: { id: certificationCandidateId },
-      });
+      const response = await certificationCandidateController.authorizeToResume(request, hFake);
 
       // then
-      expect(usecases.endAssessmentBySupervisor).to.have.been.calledWithExactly({
-        certificationCandidateId,
-      });
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});
+
+describe('#endAssessmentBySupervisor', function () {
+  const certificationCandidateId = 2;
+
+  beforeEach(function () {});
+
+  it('should call the endAssessmentBySupervisor use case', async function () {
+    // given
+    sinon.stub(usecases, 'endAssessmentBySupervisor');
+    usecases.endAssessmentBySupervisor.resolves();
+
+    // when
+    await certificationCandidateController.endAssessmentBySupervisor({
+      params: { id: certificationCandidateId },
+    });
+
+    // then
+    expect(usecases.endAssessmentBySupervisor).to.have.been.calledWithExactly({
+      certificationCandidateId,
     });
   });
 });

--- a/api/tests/unit/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/unit/application/certification-candidates/certification-candidates-controller_test.js
@@ -1,15 +1,16 @@
 const { expect, sinon, catchErr, hFake } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 const certificationCandidateController = require('../../../../lib/application/certification-candidates/certification-candidates-controller');
-const { featureToggles } = require('../../../../lib/config');
+const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
 const { NotFoundError } = require('../../../../lib/application/http-errors');
 
 describe('Unit | Controller | certifications-candidate-controller', function () {
   describe('#authorizeToStart', function () {
-    describe('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+    describe('when end screen removal is enabled', function () {
       it('should return a 204 status code', async function () {
         // given
-        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(99).resolves(true);
         const request = {
           auth: {
             credentials: { userId: '111' },
@@ -36,10 +37,13 @@ describe('Unit | Controller | certifications-candidate-controller', function () 
       });
     });
 
-    describe('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is not enabled', function () {
+    describe('when end test screen removal is not enabled', function () {
       it('should return a 404 status code', async function () {
         // given
-        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(false);
+        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId
+          //   .withArgs(99)
+          .resolves(false);
 
         const request = {
           auth: {
@@ -53,6 +57,7 @@ describe('Unit | Controller | certifications-candidate-controller', function () 
 
         // when
         const error = await catchErr(certificationCandidateController.authorizeToStart)(request, hFake);
+        certificationCandidateController.authorizeToStart(request, hFake);
 
         // then
         expect(error).to.be.an.instanceOf(NotFoundError);
@@ -61,10 +66,11 @@ describe('Unit | Controller | certifications-candidate-controller', function () 
   });
 
   describe('#authorizeToResume', function () {
-    describe('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+    describe('when end test screen removal is enabled', function () {
       it('should return a 204 status code', async function () {
         // given
-        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(99).resolves(true);
         const request = {
           auth: {
             credentials: { userId: '111' },
@@ -89,10 +95,11 @@ describe('Unit | Controller | certifications-candidate-controller', function () 
       });
     });
 
-    describe('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is not enabled', function () {
+    describe('when end test screen removal is not enabled', function () {
       it('should return a 404 status code', async function () {
         // given
-        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(false);
+        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(99).resolves(false);
 
         const request = {
           auth: {

--- a/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
+++ b/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
@@ -1,6 +1,7 @@
-const { expect, sinon, hFake } = require('../../../test-helper');
+const { catchErr, expect, sinon, hFake } = require('../../../test-helper');
 const endTestScreenRemovalEnabled = require('../../../../lib/application/preHandlers/end-test-screen-removal-enabled');
 const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
+const { SupervisorAccessNotAuthorizedError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Pre-handler | end test screen removal', function () {
   describe('#verifyBySessionId', function () {
@@ -28,7 +29,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
       });
 
       describe('When session certification center is not in the whitelist', function () {
-        it('should return a 404 status code', async function () {
+        it('should throw', async function () {
           // given
           const request = {
             payload: {
@@ -38,10 +39,10 @@ describe('Unit | Pre-handler | end test screen removal', function () {
           endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(false);
 
           // when
-          const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
+          const error = await catchErr(endTestScreenRemovalEnabled.verifyBySessionId)(request, hFake);
 
           // then
-          expect(response.statusCode).to.equal(404);
+          expect(error).to.be.instanceOf(SupervisorAccessNotAuthorizedError);
         });
       });
     });
@@ -65,7 +66,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
       });
 
       describe('When session certification center is not in the whitelist', function () {
-        it('should return a 404 status code', async function () {
+        it('should throw', async function () {
           // given
           const request = {
             params: {
@@ -75,10 +76,10 @@ describe('Unit | Pre-handler | end test screen removal', function () {
           endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(false);
 
           // when
-          const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
+          const error = await catchErr(endTestScreenRemovalEnabled.verifyBySessionId)(request, hFake);
 
           // then
-          expect(response.statusCode).to.equal(404);
+          expect(error).to.be.instanceOf(SupervisorAccessNotAuthorizedError);
         });
       });
     });

--- a/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
+++ b/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
@@ -4,39 +4,82 @@ const endTestScreenRemovalService = require('../../../../lib/domain/services/end
 
 describe('Unit | Pre-handler | end test screen removal', function () {
   describe('#verifyBySessionId', function () {
-    const request = {
-      params: {
-        id: 8,
-      },
-    };
-
     beforeEach(function () {
       sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
     });
 
-    describe('When session certification center is in the whitelist', function () {
-      it('should return true', async function () {
-        // given
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(true);
+    context('When POST', function () {
+      describe('When session certification center is in the whitelist', function () {
+        it('should return true', async function () {
+          // given
+          const request = {
+            payload: {
+              data: { attributes: { 'session-id': 8 } },
+            },
+          };
+          endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(true);
 
-        // when
-        const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
+          // when
+          const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
 
-        // then
-        expect(response).to.be.true;
+          // then
+          expect(response).to.be.true;
+        });
+      });
+
+      describe('When session certification center is not in the whitelist', function () {
+        it('should return a 404 status code', async function () {
+          // given
+          const request = {
+            payload: {
+              data: { attributes: { 'session-id': 8 } },
+            },
+          };
+          endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(false);
+
+          // when
+          const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
       });
     });
+    context('When GET', function () {
+      describe('When session certification center is in the whitelist', function () {
+        it('should return true', async function () {
+          // given
+          const request = {
+            params: {
+              id: 8,
+            },
+          };
+          endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(true);
 
-    describe('When session certification center is not in the whitelist', function () {
-      it('should return a 404 status code', async function () {
-        // given
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(false);
+          // when
+          const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
 
-        // when
-        const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
+          // then
+          expect(response).to.be.true;
+        });
+      });
 
-        // then
-        expect(response.statusCode).to.equal(404);
+      describe('When session certification center is not in the whitelist', function () {
+        it('should return a 404 status code', async function () {
+          // given
+          const request = {
+            params: {
+              id: 8,
+            },
+          };
+          endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(false);
+
+          // when
+          const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
       });
     });
   });

--- a/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
+++ b/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
@@ -1,0 +1,81 @@
+const { expect, sinon, hFake } = require('../../../test-helper');
+const endTestScreenRemovalEnabled = require('../../../../lib/application/preHandlers/end-test-screen-removal-enabled');
+const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
+
+describe('Unit | Pre-handler | end test screen removal', function () {
+  describe('#verifyBySessionId', function () {
+    const request = {
+      params: {
+        id: 8,
+      },
+    };
+
+    beforeEach(function () {
+      sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
+    });
+
+    describe('When session certification center is in the whitelist', function () {
+      it('should return true', async function () {
+        // given
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(true);
+
+        // when
+        const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
+
+        // then
+        expect(response).to.be.true;
+      });
+    });
+
+    describe('When session certification center is not in the whitelist', function () {
+      it('should return a 404 status code', async function () {
+        // given
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(false);
+
+        // when
+        const response = await endTestScreenRemovalEnabled.verifyBySessionId(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+  });
+
+  describe('#verifyByCertificationCandidateId', function () {
+    const request = {
+      params: {
+        id: 5,
+      },
+    };
+
+    beforeEach(function () {
+      sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCandidateId');
+    });
+
+    describe("When candidate's certification center is in the whitelist", function () {
+      it('should return true', async function () {
+        // given
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(5).resolves(true);
+
+        // when
+        const response = await endTestScreenRemovalEnabled.verifyByCertificationCandidateId(request, hFake);
+
+        // then
+        expect(response).to.be.true;
+      });
+    });
+
+    describe("When candidate's certification center is not in the whitelist", function () {
+      it('should return a 404 status code', async function () {
+        // given
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId.withArgs(5).resolves(false);
+
+        // when
+        const response = await endTestScreenRemovalEnabled.verifyByCertificationCandidateId(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/session/session-for-supervising-controller_test.js
+++ b/api/tests/unit/application/session/session-for-supervising-controller_test.js
@@ -2,15 +2,16 @@ const { expect, sinon, hFake, domainBuilder, catchErr } = require('../../../test
 const sessionForSupervisingController = require('../../../../lib/application/sessions/session-for-supervising-controller');
 const usecases = require('../../../../lib/domain/usecases');
 const sessionForSupervisingSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer');
-const { featureToggles } = require('../../../../lib/config');
 const { NotFoundError } = require('../../../../lib/application/http-errors');
+const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
 
 describe('Unit | Controller | session-for-supervising', function () {
   describe('#get', function () {
-    context('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+    context('when end screen removal is enabled', function () {
       it('should return a session for supervising', async function () {
         // given
-        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(123).resolves(true);
         const request = {
           params: {
             id: 123,
@@ -34,10 +35,11 @@ describe('Unit | Controller | session-for-supervising', function () {
       });
     });
 
-    context('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is disabled', function () {
+    context('when end screen removal is disabled', function () {
       it('should throw a NotFoundError', async function () {
         // given
-        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(false);
+        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(123).resolves(false);
         const request = {
           params: {
             id: 123,
@@ -59,10 +61,11 @@ describe('Unit | Controller | session-for-supervising', function () {
   });
 
   describe('#supervise', function () {
-    context('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+    context('when end screen removal is enabled for the session', function () {
       it('should return a HTTP 204 No Content', async function () {
         // given
-        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(123).resolves(true);
         const request = {
           auth: {
             credentials: {
@@ -91,10 +94,11 @@ describe('Unit | Controller | session-for-supervising', function () {
       });
     });
 
-    context('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is disabled', function () {
+    context('when end screen removal is disabled', function () {
       it('should throw a NotFoundError', async function () {
         // given
-        sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(false);
+        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(123).resolves(false);
         const request = {
           auth: {
             credentials: {

--- a/api/tests/unit/application/session/session-for-supervising-controller_test.js
+++ b/api/tests/unit/application/session/session-for-supervising-controller_test.js
@@ -1,126 +1,61 @@
-const { expect, sinon, hFake, domainBuilder, catchErr } = require('../../../test-helper');
+const { expect, sinon, hFake, domainBuilder } = require('../../../test-helper');
 const sessionForSupervisingController = require('../../../../lib/application/sessions/session-for-supervising-controller');
 const usecases = require('../../../../lib/domain/usecases');
 const sessionForSupervisingSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer');
-const { NotFoundError } = require('../../../../lib/application/http-errors');
-const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
 
 describe('Unit | Controller | session-for-supervising', function () {
   describe('#get', function () {
-    context('when end screen removal is enabled', function () {
-      it('should return a session for supervising', async function () {
-        // given
-        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(123).resolves(true);
-        const request = {
-          params: {
-            id: 123,
+    it('should return a session for supervising', async function () {
+      // given
+      const request = {
+        params: {
+          id: 123,
+        },
+        auth: {
+          credentials: {
+            userId: 274939274,
           },
-          auth: {
-            credentials: {
-              userId: 274939274,
-            },
-          },
-        };
-        const foundSession = domainBuilder.buildSessionForSupervising({ id: 123 });
-        const serializedSession = sessionForSupervisingSerializer.serialize(foundSession);
-        sinon.stub(usecases, 'getSessionForSupervising');
-        usecases.getSessionForSupervising.withArgs({ sessionId: 123 }).resolves(foundSession);
+        },
+      };
+      const foundSession = domainBuilder.buildSessionForSupervising({ id: 123 });
+      const serializedSession = sessionForSupervisingSerializer.serialize(foundSession);
+      sinon.stub(usecases, 'getSessionForSupervising');
+      usecases.getSessionForSupervising.withArgs({ sessionId: 123 }).resolves(foundSession);
 
-        // when
-        const response = await sessionForSupervisingController.get(request, hFake);
+      // when
+      const response = await sessionForSupervisingController.get(request, hFake);
 
-        // then
-        expect(response).to.deep.equal(serializedSession);
-      });
-    });
-
-    context('when end screen removal is disabled', function () {
-      it('should throw a NotFoundError', async function () {
-        // given
-        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(123).resolves(false);
-        const request = {
-          params: {
-            id: 123,
-          },
-          auth: {
-            credentials: {
-              userId: 274939274,
-            },
-          },
-        };
-
-        // when
-        const error = await catchErr(sessionForSupervisingController.get)(request);
-
-        // then
-        expect(error).to.be.instanceof(NotFoundError);
-      });
+      // then
+      expect(response).to.deep.equal(serializedSession);
     });
   });
 
   describe('#supervise', function () {
-    context('when end screen removal is enabled for the session', function () {
-      it('should return a HTTP 204 No Content', async function () {
-        // given
-        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(123).resolves(true);
-        const request = {
-          auth: {
-            credentials: {
-              userId: 274939274,
+    it('should return a HTTP 204 No Content', async function () {
+      // given
+      const request = {
+        auth: {
+          credentials: {
+            userId: 274939274,
+          },
+        },
+        payload: {
+          data: {
+            attributes: {
+              'session-id': '123',
+              'supervisor-password': '567',
             },
           },
-          payload: {
-            data: {
-              attributes: {
-                'session-id': '123',
-                'supervisor-password': '567',
-              },
-            },
-          },
-        };
-        sinon.stub(usecases, 'superviseSession');
-        usecases.superviseSession
-          .withArgs({ sessionId: '123', userId: 274939274, supervisorPassword: '567' })
-          .resolves();
+        },
+      };
+      sinon.stub(usecases, 'superviseSession');
+      usecases.superviseSession.withArgs({ sessionId: '123', userId: 274939274, supervisorPassword: '567' }).resolves();
 
-        // when
-        const response = await sessionForSupervisingController.supervise(request, hFake);
+      // when
+      const response = await sessionForSupervisingController.supervise(request, hFake);
 
-        // then
-        expect(response.statusCode).to.equal(204);
-      });
-    });
-
-    context('when end screen removal is disabled', function () {
-      it('should throw a NotFoundError', async function () {
-        // given
-        sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(123).resolves(false);
-        const request = {
-          auth: {
-            credentials: {
-              userId: 274939274,
-            },
-          },
-          payload: {
-            data: {
-              attributes: {
-                'session-id': '123',
-                'supervisor-password': '567',
-              },
-            },
-          },
-        };
-
-        // when
-        const error = await catchErr(sessionForSupervisingController.supervise)(request);
-
-        // then
-        expect(error).to.be.instanceof(NotFoundError);
-      });
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/unit/domain/services/end-test-screen-removal-service_test.js
+++ b/api/tests/unit/domain/services/end-test-screen-removal-service_test.js
@@ -16,4 +16,20 @@ describe('Unit | Domain | Service | EndTestScreenRemoval', function () {
       expect(endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledBySessionId).to.be.calledWith(sessionId);
     });
   });
+
+  describe('#isEndTestScreenRemovalEnabledByCandidateId', function () {
+    it('should return value from repository', async function () {
+      // given
+      const candidateId = Symbol('candidateId');
+      sinon.stub(endTestScreenRemovalRepository, 'isEndTestScreenRemovalEnabledByCandidateId');
+      endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledByCandidateId.withArgs(candidateId).resolves(false);
+
+      // when
+      const isEndTestScreenRemovalEnabled =
+        await endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCandidateId(candidateId);
+
+      // then
+      expect(isEndTestScreenRemovalEnabled).to.equals(false);
+    });
+  });
 });

--- a/api/tests/unit/domain/services/end-test-screen-removal-service_test.js
+++ b/api/tests/unit/domain/services/end-test-screen-removal-service_test.js
@@ -31,5 +31,38 @@ describe('Unit | Domain | Service | EndTestScreenRemoval', function () {
       // then
       expect(isEndTestScreenRemovalEnabled).to.equals(false);
     });
+
+    describe('#isEndTestScreenRemovalEnabledByCertificationCenterId', function () {
+      it('should return value from repository', async function () {
+        // given
+        const certificationCenterId = Symbol('certificationCenterId');
+        sinon.stub(endTestScreenRemovalRepository, 'isEndTestScreenRemovalEnabledByCertificationCenterId');
+        endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledByCertificationCenterId
+          .withArgs(certificationCenterId)
+          .resolves(false);
+
+        // when
+        const isEndTestScreenRemovalEnabled =
+          await endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCertificationCenterId(certificationCenterId);
+
+        // then
+        expect(isEndTestScreenRemovalEnabled).to.equals(false);
+      });
+    });
+
+    describe('#isEndTestScreenRemovalEnabledForSomeCertificationCenter', function () {
+      it('should return value from repository', async function () {
+        // given
+        sinon.stub(endTestScreenRemovalRepository, 'isEndTestScreenRemovalEnabledForSomeCertificationCenter');
+        endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledForSomeCertificationCenter.resolves(false);
+
+        // when
+        const isEndTestScreenRemovalEnabled =
+          await endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter();
+
+        // then
+        expect(isEndTestScreenRemovalEnabled).to.equals(false);
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/services/end-test-screen-removal-service_test.js
+++ b/api/tests/unit/domain/services/end-test-screen-removal-service_test.js
@@ -1,0 +1,19 @@
+const { expect, sinon } = require('../../../test-helper');
+const endTestScreenRemovalRepository = require('../../../../lib/infrastructure/repositories/end-test-screen-removal-repository');
+const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
+
+describe('Unit | Domain | Service | EndTestScreenRemoval', function () {
+  describe('#isEndTestScreenRemovalEnabledBySessionId', function () {
+    it('should call repository with sessionId', async function () {
+      // given
+      const sessionId = Symbol('sessionId');
+      sinon.spy(endTestScreenRemovalRepository, 'isEndTestScreenRemovalEnabledBySessionId');
+
+      // when
+      await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(sessionId);
+
+      // then
+      expect(endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledBySessionId).to.be.calledWith(sessionId);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -31,6 +31,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
   const placementProfileService = {};
   const verifyCertificateCodeService = {};
   const complementaryCertificationRepository = {};
+  const endTestScreenRemovalService = {};
 
   const injectables = {
     assessmentRepository,
@@ -45,6 +46,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     placementProfileService,
     verifyCertificateCodeService,
     complementaryCertificationRepository,
+    endTestScreenRemovalService,
   };
 
   beforeEach(function () {
@@ -66,6 +68,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     certificationCourseRepository.save = sinon.stub();
     sessionRepository.get = sinon.stub();
     placementProfileService.getPlacementProfile = sinon.stub();
+    endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId = sinon.stub();
+
     verifyCertificateCodeService.generateCertificateVerificationCode = sinon.stub().resolves(verificationCode);
     certificationCenterRepository.getBySessionId = sinon.stub();
     complementaryCertificationRepository.findAll = sinon.stub();
@@ -124,10 +128,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
     context('when session is accessible', function () {
       context(
-        'when the feature toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED is active and the candidate IS NOT authorized',
+        'when FT_END_TEST_SCREEN_REMOVAL_ENABLED_CERTIFICATION_CENTER_IDS is enabled for the session and the candidate IS NOT authorized',
         function () {
           beforeEach(function () {
-            sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+            endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(1).resolves(true);
           });
 
           context('when the user joins the session', function () {
@@ -163,10 +167,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
       );
 
       context(
-        'when the feature toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED is active and when the certification candidate is authorized',
+        'when FT_END_TEST_SCREEN_REMOVAL_ENABLED_CERTIFICATION_CENTER_IDS is enabled for the session and when the certification candidate is authorized',
         function () {
           beforeEach(function () {
-            sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
+            endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(1).resolves(true);
           });
 
           context('when a certification course with provided userId and sessionId already exists', function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -1,9 +1,8 @@
-const { expect, EMPTY_BLANK_AND_NULL, sinon } = require('../../../../test-helper');
+const { expect, EMPTY_BLANK_AND_NULL } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
 
 const Session = require('../../../../../lib/domain/models/Session');
 const { statuses } = require('../../../../../lib/domain/models/Session');
-const { featureToggles } = require('../../../../../lib/config');
 
 describe('Unit | Serializer | JSONAPI | session-serializer', function () {
   describe('#serialize()', function () {
@@ -63,31 +62,18 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function () {
     });
 
     context('when session does not have a link to an existing certification center', function () {
-      context('when feature toggle FT_IS_END_TEST_SCREEN_REMOVAL_ENABLED is disabled', function () {
-        it('should convert a Session model object into JSON API data without supervisor password', function () {
-          // when
-          const json = serializer.serialize(modelSession);
+      it('should convert a Session model object into JSON API data including supervisor password', function () {
+        // given
+        const expectedJsonApiIncludingSupervisorPassword = {
+          ...expectedJsonApi,
+        };
+        expectedJsonApiIncludingSupervisorPassword.data.attributes['supervisor-password'] = 'SOWHAT';
 
-          // then
-          expect(json).to.deep.equal(expectedJsonApi);
-        });
-      });
+        // when
+        const json = serializer.serialize(modelSession);
 
-      context('when feature toggle FT_IS_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
-        it('should convert a Session model object into JSON API data including supervisor password', function () {
-          // given
-          sinon.stub(featureToggles, 'isEndTestScreenRemovalEnabled').value(true);
-          const expectedJsonApiIncludingSupervisorPassword = {
-            ...expectedJsonApi,
-          };
-          expectedJsonApiIncludingSupervisorPassword.data.attributes['supervisor-password'] = 'SOWHAT';
-
-          // when
-          const json = serializer.serialize(modelSession);
-
-          // then
-          expect(json).to.deep.equal(expectedJsonApiIncludingSupervisorPassword);
-        });
+        // then
+        expect(json).to.deep.equal(expectedJsonApiIncludingSupervisorPassword);
       });
     });
   });

--- a/api/tests/unit/infrastructure/utils/string-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/string-utils_test.js
@@ -2,6 +2,7 @@ const { expect } = require('../../../test-helper');
 const {
   isNumeric,
   cleanStringAndParseFloat,
+  getArrayOfStrings,
   splitIntoWordsAndRemoveBackspaces,
   normalizeAndSortChars,
   normalize,
@@ -10,7 +11,7 @@ const {
 describe('Unit | Utils | string-utils', function () {
   const zeroWidthSpaceChar = '​';
 
-  describe('isNumeric', function () {
+  describe('#isNumeric', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { case: 'abc', expectedResult: false },
@@ -35,7 +36,7 @@ describe('Unit | Utils | string-utils', function () {
     });
   });
 
-  describe('cleanStringAndParseFloat', function () {
+  describe('#cleanStringAndParseFloat', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { case: '0123', expectedResult: 123 },
@@ -55,7 +56,7 @@ describe('Unit | Utils | string-utils', function () {
     });
   });
 
-  describe('splitIntoWordsAndRemoveBackspaces', function () {
+  describe('#splitIntoWordsAndRemoveBackspaces', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { case: 'abc', expectedResult: ['abc'] },
@@ -82,6 +83,38 @@ describe('Unit | Utils | string-utils', function () {
   describe('#normalize', function () {
     it(`should normalize chars of a string with non canonical, zero-width and special characters: "Féd '. 4àBç - 2 (îHg)K${zeroWidthSpaceChar}J"`, function () {
       expect(normalize("Féd '. 4àBç - 2 (îHg)K​J")).to.equal('FED4ABC2IHGKJ');
+    });
+  });
+
+  describe('#getArrayOfStrings', function () {
+    context('given value is undefined', function () {
+      it('should return an empty array', function () {
+        // when
+        const array = getArrayOfStrings(undefined);
+
+        // then
+        expect(array).to.be.empty;
+      });
+    });
+
+    context('given value has only one string', function () {
+      it('should return array of 1', function () {
+        // when
+        const array = getArrayOfStrings('un');
+
+        // then
+        expect(array).to.deep.equal(['UN']);
+      });
+    });
+
+    context('given value has more than one string', function () {
+      it('should return an array containing the strings, trimmed and uppercase', function () {
+        // when
+        const array = getArrayOfStrings('un, dos');
+
+        // then
+        expect(array).to.deep.equal(['UN', 'DOS']);
+      });
     });
   });
 });

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -21,7 +21,7 @@ export default class SessionParametersController extends Controller {
   }
 
   get supervisorPasswordShouldBeDisplayed() {
-    return this.featureToggles.featureToggles.isEndTestScreenRemovalEnabled;
+    return Boolean(this.session.supervisorPassword);
   }
 
   @action

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -49,7 +49,7 @@ module('Acceptance | authenticated', function (hooks) {
       assert.equal(currentURL(), '/sessions/liste');
     });
 
-    module('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+    module('when end test screen removal is enabled', function () {
       test('it should show a "Espace surveillant" button', async function (assert) {
         // given
         server.create('feature-toggle', {
@@ -84,7 +84,7 @@ module('Acceptance | authenticated', function (hooks) {
       });
     });
 
-    module('when FT_END_TEST_SCREEN_REMOVAL_ENABLED is not enabled', function () {
+    module('when end test screen removal is not enabled', function () {
       test('it should not show a "Espace surveillant" button', async function (assert) {
         // given
         server.create('feature-toggle', {

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -80,15 +80,11 @@ module('Acceptance | Session Details Parameters', function (hooks) {
             assert.equal(currentURL(), `/sessions/${sessionCreatedAndStarted.id}/finalisation`);
           });
 
-          module('when the feature toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED is disabled', function () {
+          module('when the the supervisorPassword is unset meaning the FT is disabled for this session', function () {
             test('it should not display supervisor password', async function (assert) {
               // given
-              server.create('feature-toggle', {
-                id: 0,
-                isEndTestScreenRemovalEnabled: false,
-              });
               const sessionWithSupervisorPassword = server.create('session', {
-                supervisorPassword: 'SOWHAT',
+                supervisorPassword: undefined,
                 status: CREATED,
               });
 
@@ -96,7 +92,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
               const screen = await visit(`/sessions/${sessionWithSupervisorPassword.id}`);
 
               // then
-              const supervisorPasswordElement = screen.queryByText('C-SOWHAT');
+              const supervisorPasswordElement = screen.queryByText('Mot de passe de session');
               assert.dom(supervisorPasswordElement).doesNotExist();
             });
           });

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -241,7 +241,7 @@ module('Unit | Controller | authenticated', function (hooks) {
   });
 
   module('#get isEndTestScreenRemovalEnabled', function () {
-    test('should return true when FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function (assert) {
+    test('should return true when end test screen removal is enabled', function (assert) {
       // given
       class FeatureTogglesStub extends Service {
         featureToggles = {
@@ -260,7 +260,7 @@ module('Unit | Controller | authenticated', function (hooks) {
       assert.true(isEndTestScreenRemovalEnabled);
     });
 
-    test('should return false when FT_END_TEST_SCREEN_REMOVAL_ENABLED is not enbaled', function (assert) {
+    test('should return false when end test screen removal is not enabled', function (assert) {
       // given
       class FeatureTogglesStub extends Service {
         featureToggles = {


### PR DESCRIPTION
## :christmas_tree: Problème
Le toggle de fin de test se fait pour tout PIX, hors on souhaiterais pouvoir le faire uniquement pour certains centre de certification

## :gift: Solution
Ajouter une variable d'environnement FT_ALLOWED_CERTIFICATION_CENTER_IDS_FOR_END_TEST_SCREEN_REMOVAL qui renseigne une liste d'id de centre de certification.
Mettre le toggle en fonction d'un centre certification donné (a partir de session.certificationCenterId)

TODO voir ce qui doit être géré coté front:
- affichage de la page de fin de test: on peut utiliser les [meta de json-api](https://jsonapi.org/format/#document-meta)
- Affichage du mot de passe surveillant coté certif supervisorPasswordShouldBeDisplayed

## :star2: Remarques
Il y a 122 centres de certification sans external id en prod.

Dans une autre PR:
- gestion du lien en menu certif en fonction du centre de l'utilisateur
- ecran de fin de test (fin de certification)

## :santa: Pour tester
Tester pour toutes ces routes que la feature n'est pas activée si END_TEST_SCREEN_REMOVAL_WHITELIST ne contient pas l'identifiant du certification center
- POST /api/certification-candidates/:id/authorize-to-start
- POST /api/certification-candidates/:id/authorize-to-resume
- PATCH /api/certification-candidates/{id}/end-assessment-by-supervisor
- GET /api/sessions/121/supervising
- POST /api/sessions/supervise
- POST /api/certification-courses (save)
- /api/token (login in certif)

