### PR TITLE
[ORGA] Rendre non lisible les liens des tutoriels via lecteur d'écran lorsque le menu déroulant n'est pas afficher (PIX-3897)

### DIFF
--- a/orga/app/components/campaign/analysis/tube-recommendation-row.hbs
+++ b/orga/app/components/campaign/analysis/tube-recommendation-row.hbs
@@ -52,7 +52,13 @@
           {{#each @tubeRecommendation.tutorials as |tutorial|}}
             <tr aria-label={{t "pages.campaign-review.sub-table.row-title"}} class="table__row--small">
               <td class="tube-recommendation-tutorial-table__row">
-                <a href={{tutorial.link}} class="link" target="_blank" rel="noopener noreferrer">{{tutorial.title}}</a>
+                <a
+                  href={{tutorial.link}}
+                  class="link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  tabindex="{{if this.isOpen "0" "-1"}}"
+                >{{tutorial.title}}</a>
                 <span class="tube-recommendation-tutorial-table__details">
                   <strong>·</strong>
                   {{t "pages.campaign-review.sub-table.column.source.value" source=tutorial.source}}

--- a/orga/tests/integration/components/campaign/analysis/tube-recommendation-row_test.js
+++ b/orga/tests/integration/components/campaign/analysis/tube-recommendation-row_test.js
@@ -61,12 +61,27 @@ module('Integration | Component | Campaign::Analysis::TubeRecommendationRow', fu
     await click('[data-icon="chevron-down"]');
 
     // then
-    assert.dom('[aria-hidden="false"]').containsText('1 tuto recommandé par la communauté Pix');
-    assert.dom('[aria-label="Tutoriel"]:first-child').containsText('tutorial1');
+    assert.dom('tr[aria-hidden="false"]').containsText('1 tuto recommandé par la communauté Pix');
+    assert.dom('a[tabindex="0"]:first-child').containsText('tutorial1');
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('Vidéo');
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('10 minutes');
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('Par Youtube');
-    assert.dom('[aria-expanded="true"]').exists();
+    assert.dom('button[aria-expanded="true"]').exists();
+    assert.contains('Tube Desc A');
+  });
+
+  test('it should hide element to screen reader', async function (assert) {
+    // given
+    this.tubeRecommendation.tutorials = [tutorial1];
+
+    await render(hbs`<Campaign::Analysis::TubeRecommendationRow
+      @tubeRecommendation={{tubeRecommendation}}
+    />`);
+
+    // then
+    assert.dom('tr[aria-hidden="true"]').containsText('1 tuto recommandé par la communauté Pix');
+    assert.dom('a[tabindex="-1"]:first-child').containsText('tutorial1');
+    assert.dom('button[aria-expanded="false"]').exists();
     assert.contains('Tube Desc A');
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Au tab sur le clavier nous arririons sur les lien du tutoriel alors que nous n'affichons pas le lien possible

## :gift: Solution
Rendre non cliquable le lien du tutoriel tant que nous n'avons pas cliquer sur la dropdown

## :star2: Remarques
RAS
## :santa: Pour tester
Se connecter sur Pix Orga, vérifier que l'on passe bien d'une dropdown a l'autre sans passer par les liens des tutoriels