### PR TITLE
[BUGFIX] Passer le certificationCourseId au lieu de l'assessmentId pour la page de fin de test (PIX-4075)

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -98,7 +98,7 @@ export default class ChallengeRoute extends Route {
       answer.rollbackAttributes();
 
       if (error?.errors?.[0]?.detail === 'Le surveillant a mis fin à votre test de certification.') {
-        return this.transitionTo('certifications.results', assessment.get('id'));
+        return this.transitionTo('certifications.results', assessment.certificationCourse.get('id'));
       }
 
       return this.intermediateTransitionTo('error', error);

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -402,7 +402,8 @@ describe('Unit | Route | Assessments | Challenge', function () {
           ],
         };
         answerToChallengeOne.save = sinon.stub().rejects(error);
-        const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
+        const certificationCourse = EmberObject.create({});
+        const assessment = EmberObject.create({ answers: [answerToChallengeOne], certificationCourse });
 
         // when
         await route.actions.saveAnswerAndNavigate.call(
@@ -415,7 +416,11 @@ describe('Unit | Route | Assessments | Challenge', function () {
         );
 
         // then
-        sinon.assert.calledWithExactly(route.transitionTo, 'certifications.results', assessment.get('id'));
+        sinon.assert.calledWithExactly(
+          route.transitionTo,
+          'certifications.results',
+          assessment.certificationCourse.get('id')
+        );
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'on arrive sur la page de fin de test depuis une certification terminée par un surveillant, le numéro de certification affiché en haut à gauche de la page est erroné car on a transmis l'assessmentId au lieu de transmettre le certificationCourseId. 

## :gift: Solution
Passer le certificationCourseId. 

## :santa: Pour tester

Etapes : 
- Lancer un test de certification
- Ne pas répondre à toutes les questions
- Clique sur “Terminer le test” depuis l’espace surveillant
- Retourner sur le test de certification et rafraichir la page

Résultat obtenu : le numéro de certification en haut à droite est erroné

Résultat attendu : le numéro de certification devrait être le bon
