### PR TITLE
[FEATURE] Afficher l'éligibilité d'un candidat aux certifications Pix+ Édu (PIX-3995).

### DIFF
--- a/api/lib/domain/read-models/CertificationEligibility.js
+++ b/api/lib/domain/read-models/CertificationEligibility.js
@@ -1,9 +1,3 @@
-const { keys } = require('../models/Badge');
-const cleaBadgeKey = keys.PIX_EMPLOI_CLEA;
-const cleaBadgeKeyV2 = keys.PIX_EMPLOI_CLEA_V2;
-const pixPlusDroitMaitreBadgeKey = keys.PIX_DROIT_MAITRE_CERTIF;
-const pixPlusDroitExpertBadgeKey = keys.PIX_DROIT_EXPERT_CERTIF;
-
 class CertificationEligibility {
   constructor({
     id,
@@ -20,8 +14,4 @@ class CertificationEligibility {
   }
 }
 
-CertificationEligibility.cleaBadgeKey = cleaBadgeKey;
-CertificationEligibility.cleaBadgeKeyV2 = cleaBadgeKeyV2;
-CertificationEligibility.pixPlusDroitMaitreBadgeKey = pixPlusDroitMaitreBadgeKey;
-CertificationEligibility.pixPlusDroitExpertBadgeKey = pixPlusDroitExpertBadgeKey;
 module.exports = CertificationEligibility;

--- a/api/lib/domain/read-models/CertificationEligibility.js
+++ b/api/lib/domain/read-models/CertificationEligibility.js
@@ -5,12 +5,20 @@ class CertificationEligibility {
     cleaCertificationEligible,
     pixPlusDroitMaitreCertificationEligible,
     pixPlusDroitExpertCertificationEligible,
+    pixPlusEduAutonomeCertificationEligible,
+    pixPlusEduAvanceCertificationEligible,
+    pixPlusEduExpertCertificationEligible,
+    pixPlusEduFormateurCertificationEligible,
   }) {
     this.id = id;
     this.pixCertificationEligible = pixCertificationEligible;
     this.cleaCertificationEligible = cleaCertificationEligible;
     this.pixPlusDroitMaitreCertificationEligible = pixPlusDroitMaitreCertificationEligible;
     this.pixPlusDroitExpertCertificationEligible = pixPlusDroitExpertCertificationEligible;
+    this.pixPlusEduAutonomeCertificationEligible = pixPlusEduAutonomeCertificationEligible;
+    this.pixPlusEduAvanceCertificationEligible = pixPlusEduAvanceCertificationEligible;
+    this.pixPlusEduExpertCertificationEligible = pixPlusEduExpertCertificationEligible;
+    this.pixPlusEduFormateurCertificationEligible = pixPlusEduFormateurCertificationEligible;
   }
 }
 

--- a/api/lib/domain/usecases/get-user-certification-eligibility.js
+++ b/api/lib/domain/usecases/get-user-certification-eligibility.js
@@ -1,6 +1,14 @@
 const _ = require('lodash');
 const CertificationEligibility = require('../read-models/CertificationEligibility');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../models/Badge').keys;
+const {
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../models/Badge').keys;
 
 module.exports = async function getUserCertificationEligibility({
   userId,
@@ -15,12 +23,18 @@ module.exports = async function getUserCertificationEligibility({
     pixCertificationEligible,
     certificationBadgesService,
   });
-  const { pixPlusDroitMaitreCertificationEligible, pixPlusDroitExpertCertificationEligible } =
-    await _computePixPlusCertificationEligibility({
-      userId,
-      pixCertificationEligible,
-      certificationBadgesService,
-    });
+  const {
+    pixPlusDroitMaitreCertificationEligible,
+    pixPlusDroitExpertCertificationEligible,
+    pixPlusEduAutonomeCertificationEligible,
+    pixPlusEduAvanceCertificationEligible,
+    pixPlusEduExpertCertificationEligible,
+    pixPlusEduFormateurCertificationEligible,
+  } = await _computePixPlusCertificationEligibility({
+    userId,
+    pixCertificationEligible,
+    certificationBadgesService,
+  });
 
   return new CertificationEligibility({
     id: userId,
@@ -28,6 +42,10 @@ module.exports = async function getUserCertificationEligibility({
     cleaCertificationEligible,
     pixPlusDroitMaitreCertificationEligible,
     pixPlusDroitExpertCertificationEligible,
+    pixPlusEduAutonomeCertificationEligible,
+    pixPlusEduAvanceCertificationEligible,
+    pixPlusEduExpertCertificationEligible,
+    pixPlusEduFormateurCertificationEligible,
   });
 };
 
@@ -36,7 +54,7 @@ async function _computeCleaCertificationEligibility({ userId, pixCertificationEl
   return certificationBadgesService.hasStillValidCleaBadgeAcquisition({ userId });
 }
 
-async function _computePixPlusDroitCertificationEligibility({
+async function _computePixPlusCertificationEligibility({
   userId,
   pixCertificationEligible,
   certificationBadgesService,
@@ -45,6 +63,10 @@ async function _computePixPlusDroitCertificationEligibility({
     return {
       pixPlusDroitMaitreCertificationEligible: false,
       pixPlusDroitExpertCertificationEligible: false,
+      pixPlusEduAutonomeCertificationEligible: false,
+      pixPlusEduAvanceCertificationEligible: false,
+      pixPlusEduExpertCertificationEligible: false,
+      pixPlusEduFormateurCertificationEligible: false,
     };
   }
   const stillValidCertifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
@@ -56,10 +78,34 @@ async function _computePixPlusDroitCertificationEligibility({
   const pixPlusDroitExpertBadgeAcquisition = _.find(stillValidCertifiableBadgeAcquisitions, {
     badgeKey: PIX_DROIT_EXPERT_CERTIF,
   });
+  const pixPlusEduAutonomeBadgeAcquisition = _.find(stillValidCertifiableBadgeAcquisitions, {
+    badgeKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  });
+  const pixPlusEduAvanceBadgeAcquisition = _.find(stillValidCertifiableBadgeAcquisitions, (badgeAcquisition) => {
+    return (
+      badgeAcquisition.badgeKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE ||
+      badgeAcquisition.badgeKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
+    );
+  });
+  const pixPlusEduExpertBadgeAcquisition = _.find(stillValidCertifiableBadgeAcquisitions, {
+    badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  });
+  const pixPlusEduFormateurBadgeAcquisition = _.find(stillValidCertifiableBadgeAcquisitions, {
+    badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+  });
+
   const pixPlusDroitMaitreCertificationEligible = Boolean(pixPlusDroitMaitreBadgeAcquisition);
   const pixPlusDroitExpertCertificationEligible = Boolean(pixPlusDroitExpertBadgeAcquisition);
+  const pixPlusEduAutonomeCertificationEligible = Boolean(pixPlusEduAutonomeBadgeAcquisition);
+  const pixPlusEduAvanceCertificationEligible = Boolean(pixPlusEduAvanceBadgeAcquisition);
+  const pixPlusEduExpertCertificationEligible = Boolean(pixPlusEduExpertBadgeAcquisition);
+  const pixPlusEduFormateurCertificationEligible = Boolean(pixPlusEduFormateurBadgeAcquisition);
   return {
     pixPlusDroitMaitreCertificationEligible,
     pixPlusDroitExpertCertificationEligible,
+    pixPlusEduAutonomeCertificationEligible,
+    pixPlusEduAvanceCertificationEligible,
+    pixPlusEduExpertCertificationEligible,
+    pixPlusEduFormateurCertificationEligible,
   };
 }

--- a/api/lib/domain/usecases/get-user-certification-eligibility.js
+++ b/api/lib/domain/usecases/get-user-certification-eligibility.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const CertificationEligibility = require('../read-models/CertificationEligibility');
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../models/Badge').keys;
 
 module.exports = async function getUserCertificationEligibility({
   userId,
@@ -15,7 +16,7 @@ module.exports = async function getUserCertificationEligibility({
     certificationBadgesService,
   });
   const { pixPlusDroitMaitreCertificationEligible, pixPlusDroitExpertCertificationEligible } =
-    await _computePixPlusDroitCertificationEligibility({
+    await _computePixPlusCertificationEligibility({
       userId,
       pixCertificationEligible,
       certificationBadgesService,
@@ -50,10 +51,10 @@ async function _computePixPlusDroitCertificationEligibility({
     userId,
   });
   const pixPlusDroitMaitreBadgeAcquisition = _.find(stillValidCertifiableBadgeAcquisitions, {
-    badgeKey: CertificationEligibility.pixPlusDroitMaitreBadgeKey,
+    badgeKey: PIX_DROIT_MAITRE_CERTIF,
   });
   const pixPlusDroitExpertBadgeAcquisition = _.find(stillValidCertifiableBadgeAcquisitions, {
-    badgeKey: CertificationEligibility.pixPlusDroitExpertBadgeKey,
+    badgeKey: PIX_DROIT_EXPERT_CERTIF,
   });
   const pixPlusDroitMaitreCertificationEligible = Boolean(pixPlusDroitMaitreBadgeAcquisition);
   const pixPlusDroitExpertCertificationEligible = Boolean(pixPlusDroitExpertBadgeAcquisition);

--- a/api/lib/infrastructure/serializers/jsonapi/certification-eligibility-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-eligibility-serializer.js
@@ -13,6 +13,10 @@ module.exports = {
         'cleaCertificationEligible',
         'pixPlusDroitMaitreCertificationEligible',
         'pixPlusDroitExpertCertificationEligible',
+        'pixPlusEduAutonomeCertificationEligible',
+        'pixPlusEduAvanceCertificationEligible',
+        'pixPlusEduExpertCertificationEligible',
+        'pixPlusEduFormateurCertificationEligible',
       ],
     }).serialize(certificationEligibility);
   },

--- a/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
+++ b/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
@@ -99,6 +99,10 @@ describe('Acceptance | users-controller-is-certifiable', function () {
               'clea-certification-eligible': false,
               'pix-plus-droit-maitre-certification-eligible': false,
               'pix-plus-droit-expert-certification-eligible': false,
+              'pix-plus-edu-autonome-certification-eligible': false,
+              'pix-plus-edu-avance-certification-eligible': false,
+              'pix-plus-edu-expert-certification-eligible': false,
+              'pix-plus-edu-formateur-certification-eligible': false,
             },
           },
         };

--- a/api/tests/tooling/domain-builder/factory/build-certification-eligibility.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-eligibility.js
@@ -6,6 +6,10 @@ module.exports = function buildCertificationEligibility({
   cleaCertificationEligible = false,
   pixPlusDroitMaitreCertificationEligible = false,
   pixPlusDroitExpertCertificationEligible = true,
+  pixPlusEduAutonomeCertificationEligible = false,
+  pixPlusEduAvanceCertificationEligible = false,
+  pixPlusEduExpertCertificationEligible = false,
+  pixPlusEduFormateurCertificationEligible = false,
 } = {}) {
   return new CertificationEligibility({
     id,
@@ -13,5 +17,9 @@ module.exports = function buildCertificationEligibility({
     cleaCertificationEligible,
     pixPlusDroitMaitreCertificationEligible,
     pixPlusDroitExpertCertificationEligible,
+    pixPlusEduAutonomeCertificationEligible,
+    pixPlusEduAvanceCertificationEligible,
+    pixPlusEduExpertCertificationEligible,
+    pixPlusEduFormateurCertificationEligible,
   });
 };

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -696,6 +696,10 @@ describe('Unit | Controller | user-controller', function () {
         cleaCertificationEligible: false,
         pixPlusDroitMaitreCertificationEligible: true,
         pixPlusDroitExpertCertificationEligible: false,
+        pixPlusEduAutonomeCertificationEligible: false,
+        pixPlusEduAvanceCertificationEligible: false,
+        pixPlusEduExpertCertificationEligible: true,
+        pixPlusEduFormateurCertificationEligible: false,
       });
       sinon
         .stub(usecases, 'getUserCertificationEligibility')
@@ -722,6 +726,10 @@ describe('Unit | Controller | user-controller', function () {
             'clea-certification-eligible': false,
             'pix-plus-droit-maitre-certification-eligible': true,
             'pix-plus-droit-expert-certification-eligible': false,
+            'pix-plus-edu-autonome-certification-eligible': false,
+            'pix-plus-edu-avance-certification-eligible': false,
+            'pix-plus-edu-expert-certification-eligible': true,
+            'pix-plus-edu-formateur-certification-eligible': false,
           },
         },
       });

--- a/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -76,115 +76,64 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
     });
   });
 
-  context('when pix plus droit maitre badge is not acquired', function () {
-    it('should return the user certification eligibility with not eligible pix plus droit maitre', async function () {
-      // given
-      const placementProfile = {
-        isCertifiable: () => true,
-      };
-      placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-      certificationBadgesService.hasStillValidCleaBadgeAcquisition.resolves(false);
-      const someOtherBadge = domainBuilder.buildBadge({
-        key: 'someKey',
-      });
-      const someOtherBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
-        badge: someOtherBadge,
-      });
-      certificationBadgesService.findStillValidBadgeAcquisitions.resolves([someOtherBadgeAcquisition]);
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  [
+    { badgeKey: PIX_DROIT_MAITRE_CERTIF, certificationEligibilityAttribute: 'pixPlusDroitMaitreCertificationEligible' },
+    { badgeKey: PIX_DROIT_EXPERT_CERTIF, certificationEligibilityAttribute: 'pixPlusDroitExpertCertificationEligible' },
+  ].forEach(({ badgeKey, certificationEligibilityAttribute }) => {
+    context(`when ${badgeKey} badge is not acquired`, function () {
+      it(`should return the user certification eligibility with not eligible ${badgeKey}`, async function () {
+        // given
+        const placementProfile = {
+          isCertifiable: () => true,
+        };
+        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
+        certificationBadgesService.hasStillValidCleaBadgeAcquisition.resolves(false);
+        const someOtherBadge = domainBuilder.buildBadge({
+          key: 'someKey',
+        });
+        const someOtherBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
+          badge: someOtherBadge,
+        });
+        certificationBadgesService.findStillValidBadgeAcquisitions.resolves([someOtherBadgeAcquisition]);
 
-      // when
-      const certificationEligibility = await getUserCertificationEligibility({
-        userId: 2,
-        placementProfileService,
-        certificationBadgesService,
-      });
+        // when
+        const certificationEligibility = await getUserCertificationEligibility({
+          userId: 2,
+          placementProfileService,
+          certificationBadgesService,
+        });
 
-      // then
-      expect(certificationEligibility.pixPlusDroitMaitreCertificationEligible).to.be.false;
+        // then
+        expect(certificationEligibility[certificationEligibilityAttribute]).to.be.false;
+      });
     });
-  });
 
-  context('when pix plus droit maitre badge is acquired', function () {
-    it('should return the user certification eligibility with eligible pix plus droit maitre', async function () {
-      // given
-      const placementProfile = {
-        isCertifiable: () => true,
-      };
-      placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-      certificationBadgesService.hasStillValidCleaBadgeAcquisition.resolves(false);
-      const maitreBadge = domainBuilder.buildBadge({
-        key: PIX_DROIT_MAITRE_CERTIF,
-      });
-      const maitreBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
-        badge: maitreBadge,
-      });
-      certificationBadgesService.findStillValidBadgeAcquisitions.resolves([maitreBadgeAcquisition]);
+    context(`when ${badgeKey} badge is acquired`, function () {
+      it(`should return the user certification eligibility with eligible ${badgeKey}`, async function () {
+        // given
+        const placementProfile = {
+          isCertifiable: () => true,
+        };
+        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
+        certificationBadgesService.hasStillValidCleaBadgeAcquisition.resolves(false);
+        const maitreBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
+          badge: domainBuilder.buildBadge({
+            key: badgeKey,
+          }),
+        });
+        certificationBadgesService.findStillValidBadgeAcquisitions.resolves([maitreBadgeAcquisition]);
 
-      // when
-      const certificationEligibility = await getUserCertificationEligibility({
-        userId: 2,
-        placementProfileService,
-        certificationBadgesService,
-      });
+        // when
+        const certificationEligibility = await getUserCertificationEligibility({
+          userId: 2,
+          placementProfileService,
+          certificationBadgesService,
+        });
 
-      // then
-      expect(certificationEligibility.pixPlusDroitMaitreCertificationEligible).to.be.true;
-    });
-  });
-
-  context('when pix plus droit expert badge is not acquired', function () {
-    it('should return the user certification eligibility with not eligible pix plus droit expert', async function () {
-      // given
-      const placementProfile = {
-        isCertifiable: () => true,
-      };
-      placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-      certificationBadgesService.hasStillValidCleaBadgeAcquisition.resolves(false);
-      const someOtherBadge = domainBuilder.buildBadge({
-        key: 'someKey',
+        // then
+        expect(certificationEligibility[certificationEligibilityAttribute]).to.be.true;
       });
-      const someOtherBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
-        badge: someOtherBadge,
-      });
-      certificationBadgesService.findStillValidBadgeAcquisitions.resolves([someOtherBadgeAcquisition]);
-
-      // when
-      const certificationEligibility = await getUserCertificationEligibility({
-        userId: 2,
-        placementProfileService,
-        certificationBadgesService,
-      });
-
-      // then
-      expect(certificationEligibility.pixPlusDroitExpertCertificationEligible).to.be.false;
-    });
-  });
-
-  context('when pix plus droit expert badge is acquired', function () {
-    it('should return the user certification eligibility with eligible pix plus droit expert', async function () {
-      // given
-      const placementProfile = {
-        isCertifiable: () => true,
-      };
-      placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-      certificationBadgesService.hasStillValidCleaBadgeAcquisition.resolves(false);
-      const expertBadge = domainBuilder.buildBadge({
-        key: PIX_DROIT_EXPERT_CERTIF,
-      });
-      const expertBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
-        badge: expertBadge,
-      });
-      certificationBadgesService.findStillValidBadgeAcquisitions.resolves([expertBadgeAcquisition]);
-
-      // when
-      const certificationEligibility = await getUserCertificationEligibility({
-        userId: 2,
-        placementProfileService,
-        certificationBadgesService,
-      });
-
-      // then
-      expect(certificationEligibility.pixPlusDroitExpertCertificationEligible).to.be.true;
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -1,16 +1,11 @@
 const { sinon, expect, domainBuilder } = require('../../../test-helper');
 const getUserCertificationEligibility = require('../../../../lib/domain/usecases/get-user-certification-eligibility');
-const CertificationEligibility = require('../../../../lib/domain/read-models/CertificationEligibility');
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | UseCase | get-user-certification-eligibility', function () {
   let clock;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const pixPlusDroitMaitreBadgeKey = CertificationEligibility.pixPlusDroitMaitreBadgeKey;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const pixPlusDroitExpertBadgeKey = CertificationEligibility.pixPlusDroitExpertBadgeKey;
   const now = new Date(2020, 1, 1);
+
   const placementProfileService = {
     getPlacementProfile: () => undefined,
   };
@@ -118,7 +113,7 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
       placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
       certificationBadgesService.hasStillValidCleaBadgeAcquisition.resolves(false);
       const maitreBadge = domainBuilder.buildBadge({
-        key: pixPlusDroitMaitreBadgeKey,
+        key: PIX_DROIT_MAITRE_CERTIF,
       });
       const maitreBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
         badge: maitreBadge,
@@ -174,7 +169,7 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
       placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
       certificationBadgesService.hasStillValidCleaBadgeAcquisition.resolves(false);
       const expertBadge = domainBuilder.buildBadge({
-        key: pixPlusDroitExpertBadgeKey,
+        key: PIX_DROIT_EXPERT_CERTIF,
       });
       const expertBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
         badge: expertBadge,

--- a/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -1,6 +1,14 @@
 const { sinon, expect, domainBuilder } = require('../../../test-helper');
 const getUserCertificationEligibility = require('../../../../lib/domain/usecases/get-user-certification-eligibility');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const {
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | UseCase | get-user-certification-eligibility', function () {
   let clock;
@@ -80,6 +88,26 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
   [
     { badgeKey: PIX_DROIT_MAITRE_CERTIF, certificationEligibilityAttribute: 'pixPlusDroitMaitreCertificationEligible' },
     { badgeKey: PIX_DROIT_EXPERT_CERTIF, certificationEligibilityAttribute: 'pixPlusDroitExpertCertificationEligible' },
+    {
+      badgeKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+      certificationEligibilityAttribute: 'pixPlusEduAutonomeCertificationEligible',
+    },
+    {
+      badgeKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+      certificationEligibilityAttribute: 'pixPlusEduAvanceCertificationEligible',
+    },
+    {
+      badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+      certificationEligibilityAttribute: 'pixPlusEduAvanceCertificationEligible',
+    },
+    {
+      badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+      certificationEligibilityAttribute: 'pixPlusEduExpertCertificationEligible',
+    },
+    {
+      badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+      certificationEligibilityAttribute: 'pixPlusEduFormateurCertificationEligible',
+    },
   ].forEach(({ badgeKey, certificationEligibilityAttribute }) => {
     context(`when ${badgeKey} badge is not acquired`, function () {
       it(`should return the user certification eligibility with not eligible ${badgeKey}`, async function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-eligibility-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-eligibility-serializer_test.js
@@ -11,6 +11,10 @@ describe('Unit | Serializer | JSONAPI | certification-eligibility-serializer', f
         cleaCertificationEligible: true,
         pixPlusDroitMaitreCertificationEligible: false,
         pixPlusDroitExpertCertificationEligible: true,
+        pixPlusEduAutonomeCertificationEligible: false,
+        pixPlusEduAvanceCertificationEligible: false,
+        pixPlusEduExpertCertificationEligible: true,
+        pixPlusEduFormateurCertificationEligible: false,
       });
 
       // when
@@ -26,6 +30,10 @@ describe('Unit | Serializer | JSONAPI | certification-eligibility-serializer', f
             'clea-certification-eligible': true,
             'pix-plus-droit-maitre-certification-eligible': false,
             'pix-plus-droit-expert-certification-eligible': true,
+            'pix-plus-edu-autonome-certification-eligible': false,
+            'pix-plus-edu-avance-certification-eligible': false,
+            'pix-plus-edu-expert-certification-eligible': true,
+            'pix-plus-edu-formateur-certification-eligible': false,
           },
         },
       });

--- a/mon-pix/app/models/is-certifiable.js
+++ b/mon-pix/app/models/is-certifiable.js
@@ -5,4 +5,8 @@ export default class IsCertifiable extends Model {
   @attr() cleaCertificationEligible;
   @attr() pixPlusDroitMaitreCertificationEligible;
   @attr() pixPlusDroitExpertCertificationEligible;
+  @attr() pixPlusEduAutonomeCertificationEligible;
+  @attr() pixPlusEduAvanceCertificationEligible;
+  @attr() pixPlusEduExpertCertificationEligible;
+  @attr() pixPlusEduFormateurCertificationEligible;
 }

--- a/mon-pix/app/templates/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/templates/components/congratulations-certification-banner.hbs
@@ -19,6 +19,19 @@
   {{#if @certificationEligibility.pixPlusDroitExpertCertificationEligible}}
     <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-droit-expert-eligibility"}}</p>
   {{/if}}
+  {{#if @certificationEligibility.pixPlusEduAutonomeCertificationEligible}}
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-autonome-eligibility"}}</p>
+  {{/if}}
+  {{#if @certificationEligibility.pixPlusEduAvanceCertificationEligible}}
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-avance-eligibility"}}</p>
+  {{/if}}
+  {{#if @certificationEligibility.pixPlusEduExpertCertificationEligible}}
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-expert-eligibility"}}</p>
+  {{/if}}
+  {{#if @certificationEligibility.pixPlusEduFormateurCertificationEligible}}
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-formateur-eligibility"}}</p>
+  {{/if}}
+
   <a
     href={{t "pages.certification-joiner.congratulation-banner.link.url"}}
     class="congratulations-banner__link"

--- a/mon-pix/app/templates/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/templates/components/congratulations-certification-banner.hbs
@@ -11,17 +11,13 @@
     {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}
   </p>
   {{#if @certificationEligibility.cleaCertificationEligible}}
-    <p data-test-eligible-clea>{{t "pages.certification-joiner.congratulation-banner.clea-eligibility"}}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.clea-eligibility"}}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusDroitMaitreCertificationEligible}}
-    <p data-test-eligible-pix-plus-droit-maitre>{{t
-        "pages.certification-joiner.congratulation-banner.pix-plus-droit-maitre-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-droit-maitre-eligibility"}}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusDroitExpertCertificationEligible}}
-    <p data-test-eligible-pix-plus-droit-expert>{{t
-        "pages.certification-joiner.congratulation-banner.pix-plus-droit-expert-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-droit-expert-eligibility"}}</p>
   {{/if}}
   <a
     href={{t "pages.certification-joiner.congratulation-banner.link.url"}}

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -98,4 +98,84 @@ describe('Integration | Component | Congratulations Certification Banner', funct
     // then
     expect(contains('Vous êtes également éligible à la certification Pix+ Droit Expert.')).to.exist;
   });
+
+  it('renders specific Pix+ Édu Autonome text when eligible Pix+ Édu Autonome certification', async function () {
+    // given
+    const store = this.owner.lookup('service:store');
+    const certificationEligibility = run(() =>
+      store.createRecord('is-certifiable', {
+        pixPlusEduAutonomeCertificationEligible: true,
+      })
+    );
+    this.set('certificationEligibility', certificationEligibility);
+    this.set('fullName', 'Fifi Brindacier');
+
+    // when
+    await render(
+      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+    );
+
+    // then
+    expect(contains('Vous êtes également éligible à la certification Pix+ Édu Autonome.')).to.exist;
+  });
+
+  it('renders specific Pix+ Édu Avancé text when eligible Pix+ Édu Avancé certification', async function () {
+    // given
+    const store = this.owner.lookup('service:store');
+    const certificationEligibility = run(() =>
+      store.createRecord('is-certifiable', {
+        pixPlusEduAvanceCertificationEligible: true,
+      })
+    );
+    this.set('certificationEligibility', certificationEligibility);
+    this.set('fullName', 'Fifi Brindacier');
+
+    // when
+    await render(
+      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+    );
+
+    // then
+    expect(contains('Vous êtes également éligible à la certification Pix+ Édu Avancé.')).to.exist;
+  });
+
+  it('renders specific Pix+ Édu Expert text when eligible Pix+ Édu Expert certification', async function () {
+    // given
+    const store = this.owner.lookup('service:store');
+    const certificationEligibility = run(() =>
+      store.createRecord('is-certifiable', {
+        pixPlusEduExpertCertificationEligible: true,
+      })
+    );
+    this.set('certificationEligibility', certificationEligibility);
+    this.set('fullName', 'Fifi Brindacier');
+
+    // when
+    await render(
+      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+    );
+
+    // then
+    expect(contains('Vous êtes également éligible à la certification Pix+ Édu Expert.')).to.exist;
+  });
+
+  it('renders specific Pix+ Édu Formateur text when eligible Pix+ Édu Formateur certification', async function () {
+    // given
+    const store = this.owner.lookup('service:store');
+    const certificationEligibility = run(() =>
+      store.createRecord('is-certifiable', {
+        pixPlusEduFormateurCertificationEligible: true,
+      })
+    );
+    this.set('certificationEligibility', certificationEligibility);
+    this.set('fullName', 'Fifi Brindacier');
+
+    // when
+    await render(
+      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+    );
+
+    // then
+    expect(contains('Vous êtes également éligible à la certification Pix+ Édu Formateur.')).to.exist;
+  });
 });

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -39,143 +39,50 @@ describe('Integration | Component | Congratulations Certification Banner', funct
     sinon.assert.calledOnce(closeBannerStub);
   });
 
-  it('renders specific Clea text when eligible Clea certification', async function () {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationEligibility = run(() =>
-      store.createRecord('is-certifiable', {
-        cleaCertificationEligible: true,
-      })
-    );
-    this.set('certificationEligibility', certificationEligibility);
-    this.set('fullName', 'Fifi Brindacier');
+  [
+    {
+      record: { cleaCertificationEligible: true },
+      expectedMessage: 'Vous êtes également éligible à la certification CléA numérique.',
+    },
+    {
+      record: { pixPlusDroitMaitreCertificationEligible: true },
+      expectedMessage: 'Vous êtes également éligible à la certification Pix+ Droit Maître.',
+    },
+    {
+      record: { pixPlusDroitExpertCertificationEligible: true },
+      expectedMessage: 'Vous êtes également éligible à la certification Pix+ Droit Expert.',
+    },
+    {
+      record: { pixPlusEduAutonomeCertificationEligible: true },
+      expectedMessage: 'Vous êtes également éligible à la certification Pix+ Édu Autonome.',
+    },
+    {
+      record: { pixPlusEduAvanceCertificationEligible: true },
+      expectedMessage: 'Vous êtes également éligible à la certification Pix+ Édu Avancé.',
+    },
+    {
+      record: { pixPlusEduExpertCertificationEligible: true },
+      expectedMessage: 'Vous êtes également éligible à la certification Pix+ Édu Expert.',
+    },
+    {
+      record: { pixPlusEduFormateurCertificationEligible: true },
+      expectedMessage: 'Vous êtes également éligible à la certification Pix+ Édu Formateur.',
+    },
+  ].forEach(({ record, expectedMessage }) => {
+    it(`renders "${expectedMessage}" when ${Object.keys(record)[0]} is ${Object.values(record)[0]}`, async function () {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationEligibility = run(() => store.createRecord('is-certifiable', record));
+      this.set('certificationEligibility', certificationEligibility);
+      this.set('fullName', 'Fifi Brindacier');
 
-    // when
-    await render(
-      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
-    );
+      // when
+      await render(
+        hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+      );
 
-    // then
-    expect(contains('Vous êtes également éligible à la certification CléA numérique.')).to.exist;
-  });
-
-  it('renders specific Pix+ Droit Maitre text when eligible Pix+ Droit maitre certification', async function () {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationEligibility = run(() =>
-      store.createRecord('is-certifiable', {
-        pixPlusDroitMaitreCertificationEligible: true,
-      })
-    );
-    this.set('certificationEligibility', certificationEligibility);
-    this.set('fullName', 'Fifi Brindacier');
-
-    // when
-    await render(
-      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
-    );
-
-    // then
-    expect(contains('Vous êtes également éligible à la certification Pix+ Droit Maître.')).to.exist;
-  });
-
-  it('renders specific Pix+ Droit Expert text when eligible Pix+ Droit expert certification', async function () {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationEligibility = run(() =>
-      store.createRecord('is-certifiable', {
-        pixPlusDroitExpertCertificationEligible: true,
-      })
-    );
-    this.set('certificationEligibility', certificationEligibility);
-    this.set('fullName', 'Fifi Brindacier');
-
-    // when
-    await render(
-      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
-    );
-
-    // then
-    expect(contains('Vous êtes également éligible à la certification Pix+ Droit Expert.')).to.exist;
-  });
-
-  it('renders specific Pix+ Édu Autonome text when eligible Pix+ Édu Autonome certification', async function () {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationEligibility = run(() =>
-      store.createRecord('is-certifiable', {
-        pixPlusEduAutonomeCertificationEligible: true,
-      })
-    );
-    this.set('certificationEligibility', certificationEligibility);
-    this.set('fullName', 'Fifi Brindacier');
-
-    // when
-    await render(
-      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
-    );
-
-    // then
-    expect(contains('Vous êtes également éligible à la certification Pix+ Édu Autonome.')).to.exist;
-  });
-
-  it('renders specific Pix+ Édu Avancé text when eligible Pix+ Édu Avancé certification', async function () {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationEligibility = run(() =>
-      store.createRecord('is-certifiable', {
-        pixPlusEduAvanceCertificationEligible: true,
-      })
-    );
-    this.set('certificationEligibility', certificationEligibility);
-    this.set('fullName', 'Fifi Brindacier');
-
-    // when
-    await render(
-      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
-    );
-
-    // then
-    expect(contains('Vous êtes également éligible à la certification Pix+ Édu Avancé.')).to.exist;
-  });
-
-  it('renders specific Pix+ Édu Expert text when eligible Pix+ Édu Expert certification', async function () {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationEligibility = run(() =>
-      store.createRecord('is-certifiable', {
-        pixPlusEduExpertCertificationEligible: true,
-      })
-    );
-    this.set('certificationEligibility', certificationEligibility);
-    this.set('fullName', 'Fifi Brindacier');
-
-    // when
-    await render(
-      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
-    );
-
-    // then
-    expect(contains('Vous êtes également éligible à la certification Pix+ Édu Expert.')).to.exist;
-  });
-
-  it('renders specific Pix+ Édu Formateur text when eligible Pix+ Édu Formateur certification', async function () {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certificationEligibility = run(() =>
-      store.createRecord('is-certifiable', {
-        pixPlusEduFormateurCertificationEligible: true,
-      })
-    );
-    this.set('certificationEligibility', certificationEligibility);
-    this.set('fullName', 'Fifi Brindacier');
-
-    // when
-    await render(
-      hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
-    );
-
-    // then
-    expect(contains('Vous êtes également éligible à la certification Pix+ Édu Formateur.')).to.exist;
+      // then
+      expect(contains(expectedMessage)).to.exist;
+    });
   });
 });

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { click, find, render } from '@ember/test-helpers';
+import { contains } from '../../helpers/contains';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Congratulations Certification Banner', function () {
@@ -55,9 +56,7 @@ describe('Integration | Component | Congratulations Certification Banner', funct
     );
 
     // then
-    expect(find('[data-test-eligible-clea]').textContent).to.contains(
-      'Vous êtes également éligible à la certification CléA numérique.'
-    );
+    expect(contains('Vous êtes également éligible à la certification CléA numérique.')).to.exist;
   });
 
   it('renders specific Pix+ Droit Maitre text when eligible Pix+ Droit maitre certification', async function () {
@@ -77,9 +76,7 @@ describe('Integration | Component | Congratulations Certification Banner', funct
     );
 
     // then
-    expect(find('[data-test-eligible-pix-plus-droit-maitre]').textContent).to.contains(
-      'Vous êtes également éligible à la certification Pix+ Droit Maître.'
-    );
+    expect(contains('Vous êtes également éligible à la certification Pix+ Droit Maître.')).to.exist;
   });
 
   it('renders specific Pix+ Droit Expert text when eligible Pix+ Droit expert certification', async function () {
@@ -99,8 +96,6 @@ describe('Integration | Component | Congratulations Certification Banner', funct
     );
 
     // then
-    expect(find('[data-test-eligible-pix-plus-droit-expert]').textContent).to.contains(
-      'Vous êtes également éligible à la certification Pix+ Droit Expert.'
-    );
+    expect(contains('Vous êtes également éligible à la certification Pix+ Droit Expert.')).to.exist;
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -214,6 +214,10 @@
           "url": "https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
         },
         "message": "Well done, {fullName},'<br>'your profile can now be certified.",
+        "pix-plus-edu-autonome-eligibility": "You are also eligible for the Pix+ Édu Autonome certification.",
+        "pix-plus-edu-avance-eligibility": "You are also eligible for the Pix+ Édu Avancé certification.",
+        "pix-plus-edu-expert-eligibility": "You are also eligible for the Pix+ Édu Expert certification.",
+        "pix-plus-edu-formateur-eligibility": "You are also eligible for the Pix+ Édu Formateur certification.",
         "pix-plus-droit-expert-eligibility": "You are also eligible for the Pix+ Droit Expert certification.",
         "pix-plus-droit-maitre-eligibility": "You are also eligible for the Pix+ Droit Maître certification."
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -214,6 +214,10 @@
           "url": "https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
         },
         "message": "Bravo {fullName},'<br>'votre profil est certifiable.",
+        "pix-plus-edu-autonome-eligibility": "Vous êtes également éligible à la certification Pix+ Édu Autonome.",
+        "pix-plus-edu-avance-eligibility": "Vous êtes également éligible à la certification Pix+ Édu Avancé.",
+        "pix-plus-edu-expert-eligibility": "Vous êtes également éligible à la certification Pix+ Édu Expert.",
+        "pix-plus-edu-formateur-eligibility": "Vous êtes également éligible à la certification Pix+ Édu Formateur.",
         "pix-plus-droit-expert-eligibility": "Vous êtes également éligible à la certification Pix+ Droit Expert.",
         "pix-plus-droit-maitre-eligibility": "Vous êtes également éligible à la certification Pix+ Droit Maître."
       },


### PR DESCRIPTION
## :christmas_tree: Problème
Il est dorénavant possible pour un candidat de passer une certification Pix+ Édu. Néanmoins, ce dernier n'est pas au courant de s'il est ou non éligible à passer cette certification complémentaire. 

## :gift: Solution
Afficher l'éligibilité d'un candidat à une certification Pix+ Édu.

## :santa: Pour tester
Se connecter aux comptes `certifedu.initiale@example.net` et `certifedu.continue@example.net` sur Pix App et vérifier, dans l'onglet Certifications, qu'ils sont bien éligibles à une certification Pix+ Édu.  
