### PR TITLE
[A11Y] Ajout d'instructions pour les QCU et QCM (PIX-3916).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -40,6 +40,11 @@
     }
   }
 
+  &__instructions {
+    font-size: 1rem;
+    font-weight: $font-normal;
+  }
+
   &__proposal {
     font-size: 1.25rem;
     color: $grey-80;

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -1,6 +1,7 @@
 <form {{on "submit" this.validateAnswer}}>
 
   <div class="rounded-panel__row challenge-response {{if @answer "challenge-response--locked"}}">
+    <h2 class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcm"}}</h2>
     <h2 class="sr-only">{{t "pages.challenge.parts.answer-input"}}</h2>
     <div class="challenge-proposals">
       <QcmProposals

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -1,6 +1,7 @@
 <form {{on "submit" this.validateAnswer}}>
 
   <div class="rounded-panel__row challenge-response {{if @answer "challenge-response--locked"}}">
+    <h2 class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcu"}}</h2>
     <h2 class="sr-only">{{t "pages.challenge.parts.answer-input"}}</h2>
     <div class="challenge-proposals">
       <QcuProposals

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -465,6 +465,10 @@
       },
       "parts": {
         "answer-input": "Your answer",
+        "answer-instructions": {
+          "qcm": "Select one or more possible answers",
+          "qcu": "Select the right answer"
+        },
         "feedback": "Report a problem",
         "instruction": "Instructions to answer the question",
         "progress": "Your progression",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -465,6 +465,10 @@
       },
       "parts": {
         "answer-input": "Votre réponse",
+        "answer-instructions": {
+          "qcm": "Choisissez la ou les réponses possibles.",
+          "qcu": "Choisissez la bonne réponse."
+        },
         "feedback": "Signaler un problème",
         "instruction": "Consigne de l'épreuve",
         "progress": "Votre progression",


### PR DESCRIPTION
## :christmas_tree: Problème

Il n'est pas forcément clair pour certaines personnes de faire la différence entre les QCU et QCM au niveau du nombre de possibles réponses à sélectionner.

## :gift: Solution

Ajout d'une instruction visible pour tous en haut de chaque bloc de réponses pour ces types de questions.

## :star2: Remarques
N/A

## :santa: Pour tester

Sur pix-app, aller sur des épreuves QCU et QCM et constater la présence des instructions.
