### PR TITLE
[FEATURE] Changer les dates d'ouverture des certifications dans la bannière d'informations pour les SCO (PIX-4081)

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -52,7 +52,7 @@
         <PixBanner
         @actionLabel= "En savoir plus"
         @actionUrl= "https://view.genial.ly/6077017b8b37870d98620200"
-      >La certification Pix se déroulera du 29/11/21 au 04/03/22 pour les lycées et du 07/03/22 au 20/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées.</PixBanner>
+      >La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées.</PixBanner>
 
     {{/if}}
 

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -112,11 +112,11 @@ module('Acceptance | authenticated', function(hooks) {
       await authenticateSession(certificationPointOfContact.id);
 
       // when
-      await visit('/sessions/liste');
+      const screen = await visitScreen('/sessions/liste');
 
       // then
-      assert.dom('.pix-banner--information').exists();
-      assert.dom('.pix-banner--information').hasText('La certification Pix se déroulera du 29/11/21 au 04/03/22 pour les lycées et du 07/03/22 au 20/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées. En savoir plus');
+      assert.dom(screen.getByText('La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées.')).exists();
+      assert.dom(screen.getByRole('link', { name: 'En savoir plus' })).exists();
     });
 
     test('it should not display the banner when User is NOT SCO isManagingStudent', async function(assert) {
@@ -125,10 +125,11 @@ module('Acceptance | authenticated', function(hooks) {
       await authenticateSession(certificationPointOfContact.id);
 
       // when
-      await visit('/sessions/liste');
+      const screen = await visitScreen('/sessions/liste');
 
       // then
-      assert.dom('.pix-banner--information').doesNotExist();
+      const certificationBannerMessage = screen.queryByText('La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées.');
+      assert.dom(certificationBannerMessage).doesNotExist();
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Les scolaires (collèges, terminales et associés) ont des créneaux d'ouverture de la certification. Les utilisateurs certif gérant ces établissements ont actuellement une bannière les informant de ces dates. Les dates ayant changé, il faut changer la bannière avec les dates en question.

## :gift: Solution
Modifier les dates dans la bannière sur Pix Certif pour les utilisateurs SCO qui gèrent des élèves. 

## :santa: Pour tester
- Se connecter à Pix Certif avec un utilisateur membre d'un établissement SCO isManagingStudent (du genre certifsco@example.net, en s'assurant que l'établissement sélectionné en haut à droite est bien celui pour lequel il est ManagingStudent).
- Vérifier la présence du bandeau et que les dates soient correctes (Collège : 07/03/22 au 27/05/22 ; Lycées : 29/11/21 au 07/04/22)
- Changer d'établissement pour un où on n'est pas ScoManagingStudent, ou se connecter avec d'autres utilisateurs (certifsup@example.net, certifpro@example.net), chercher la bannière et constater (_qu'absence de preuve n'est pas preuve d'absence_) que la bannière est absente car elle ne doit s'afficher que pour les SCO gérant des élèves. 