### PR TITLE
[BUGFIX] Corriger la suppression des méthodes de connexion

### DIFF
--- a/api/lib/domain/usecases/remove-authentication-method.js
+++ b/api/lib/domain/usecases/remove-authentication-method.js
@@ -9,8 +9,13 @@ module.exports = async function removeAuthenticationMethod({
 }) {
   const user = await userRepository.get(userId);
 
+  const authenticationMethods = await authenticationMethodRepository.findByUserId({ userId });
+  if (authenticationMethods.length === 1) {
+    throw new UserNotAuthorizedToRemoveAuthenticationMethod();
+  }
+
   if (type === 'EMAIL') {
-    if (!user.username) {
+    if (user.username) {
       await _removeAuthenticationMethod(
         userId,
         AuthenticationMethod.identityProviders.PIX,
@@ -21,7 +26,7 @@ module.exports = async function removeAuthenticationMethod({
   }
 
   if (type === 'USERNAME') {
-    if (!user.email) {
+    if (user.email) {
       await _removeAuthenticationMethod(
         userId,
         AuthenticationMethod.identityProviders.PIX,
@@ -49,11 +54,5 @@ module.exports = async function removeAuthenticationMethod({
 };
 
 async function _removeAuthenticationMethod(userId, identityProvider, authenticationMethodRepository) {
-  const authenticationMethods = await authenticationMethodRepository.findByUserId({ userId });
-
-  if (authenticationMethods.length === 1) {
-    throw new UserNotAuthorizedToRemoveAuthenticationMethod();
-  }
-
   await authenticationMethodRepository.removeByUserIdAndIdentityProvider({ userId, identityProvider });
 }

--- a/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
+++ b/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
@@ -9,46 +9,60 @@ const createServer = require('../../../../server');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 
 describe('Acceptance | Controller | users-controller-remove-authentication-method', function () {
-  let server;
-  let user;
-  let options;
+  describe.only('POST /admin/users/:id/remove-authentication', function () {
+    it('should return 204', async function () {
+      // given
+      const server = await createServer();
+      const user = databaseBuilder.factory.buildUser({ username: 'jhn.doe0101', email: 'john.doe@example.net' });
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+        userId: user.id,
+      });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
+      const pixMaster = await insertUserWithRolePixMaster();
+      await databaseBuilder.commit();
 
-  beforeEach(async function () {
-    server = await createServer();
-    user = databaseBuilder.factory.buildUser({ username: 'jhn.doe0101', email: null });
-    databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
-      userId: user.id,
-    });
-    databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
-
-    const pixMaster = await insertUserWithRolePixMaster();
-    options = {
-      method: 'POST',
-      url: `/api/admin/users/${user.id}/remove-authentication`,
-      payload: {
-        data: {
-          attributes: {
-            type: 'USERNAME',
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/admin/users/${user.id}/remove-authentication`,
+        payload: {
+          data: {
+            attributes: {
+              type: 'USERNAME',
+            },
           },
         },
-      },
-      headers: { authorization: generateValidRequestAuthorizationHeader(pixMaster.id) },
-    };
-    return databaseBuilder.commit();
-  });
-
-  describe('POST /admin/users/:id/remove-authentication', function () {
-    it('should return 204', async function () {
-      // when
-      const response = await server.inject(options);
+        headers: { authorization: generateValidRequestAuthorizationHeader(pixMaster.id) },
+      });
 
       // then
       expect(response.statusCode).to.equal(204);
     });
 
     it('should set the username to null', async function () {
+      // given
+      const server = await createServer();
+      const user = databaseBuilder.factory.buildUser({ username: 'jhn.doe0101', email: 'john.doe@example.net' });
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+        userId: user.id,
+      });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
+      const pixMaster = await insertUserWithRolePixMaster();
+      await databaseBuilder.commit();
+
       // when
-      await server.inject(options);
+      await server.inject({
+        method: 'POST',
+        url: `/api/admin/users/${user.id}/remove-authentication`,
+        payload: {
+          data: {
+            attributes: {
+              type: 'USERNAME',
+            },
+          },
+        },
+        headers: { authorization: generateValidRequestAuthorizationHeader(pixMaster.id) },
+      });
 
       // then
       const updatedUser = await knex('users').where({ id: user.id }).first();
@@ -56,8 +70,29 @@ describe('Acceptance | Controller | users-controller-remove-authentication-metho
     });
 
     it('should remove PIX authenticationMethod', async function () {
+      // given
+      const server = await createServer();
+      const user = databaseBuilder.factory.buildUser({ username: 'jhn.doe0101', email: 'john.doe@example.net' });
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+        userId: user.id,
+      });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: user.id });
+      const pixMaster = await insertUserWithRolePixMaster();
+      await databaseBuilder.commit();
+
       // when
-      await server.inject(options);
+      await server.inject({
+        method: 'POST',
+        url: `/api/admin/users/${user.id}/remove-authentication`,
+        payload: {
+          data: {
+            attributes: {
+              type: 'USERNAME',
+            },
+          },
+        },
+        headers: { authorization: generateValidRequestAuthorizationHeader(pixMaster.id) },
+      });
 
       // then
       const pixAuthenticationMethod = await knex('authentication-methods')

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
     };
   });
 
-  function buildPIXAndGARAndPoleEmploiAuthenticationMethod(userId) {
+  function _buildPIXAndGARAndPoleEmploiAuthenticationMethod(userId) {
     return [
       domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId }),
       domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId }),
@@ -28,32 +28,61 @@ describe('Unit | UseCase | remove-authentication-method', function () {
   }
 
   context('When type is EMAIL', function () {
-    const type = 'EMAIL';
-
     it('should set the email to null', async function () {
       // given
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
-      const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+      const authenticationMethods = _buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
       authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
 
       // when
-      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+      await removeAuthenticationMethod({
+        userId: user.id,
+        type: 'EMAIL',
+        userRepository,
+        authenticationMethodRepository,
+      });
 
       // then
       expect(userRepository.updateEmail).to.have.been.calledWith({ id: user.id, email: null });
     });
 
     context('When user does not have a username', function () {
-      it('should remove PIX authentication method', async function () {
+      it('should NOT remove PIX authentication method', async function () {
         // given
         const user = domainBuilder.buildUser({ username: null });
         userRepository.get.resolves(user);
-        const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+        const authenticationMethods = _buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
         authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
 
         // when
-        await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+        await removeAuthenticationMethod({
+          userId: user.id,
+          type: 'EMAIL',
+          userRepository,
+          authenticationMethodRepository,
+        });
+
+        // then
+        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.not.have.been.called;
+      });
+    });
+
+    context('When user has a username', function () {
+      it('should remove PIX authentication method', async function () {
+        // given
+        const user = domainBuilder.buildUser({ username: 'john.doe0101' });
+        userRepository.get.resolves(user);
+        const authenticationMethods = _buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+        authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+        // when
+        await removeAuthenticationMethod({
+          userId: user.id,
+          type: 'EMAIL',
+          userRepository,
+          authenticationMethodRepository,
+        });
 
         // then
         expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
@@ -62,51 +91,64 @@ describe('Unit | UseCase | remove-authentication-method', function () {
         });
       });
     });
-
-    context('When user has a username', function () {
-      it('should not remove PIX authentication method', async function () {
-        // given
-        const user = domainBuilder.buildUser({ username: 'john.doe0101' });
-        userRepository.get.resolves(user);
-        const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
-        authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
-
-        // when
-        await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
-
-        // then
-        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.not.have.been.called;
-      });
-    });
   });
 
   context('When type is USERNAME', function () {
-    const type = 'USERNAME';
-
     it('should set the username to null', async function () {
       // given
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
-      const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+      const authenticationMethods = _buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
       authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
 
       // when
-      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+      await removeAuthenticationMethod({
+        userId: user.id,
+        type: 'USERNAME',
+        userRepository,
+        authenticationMethodRepository,
+      });
 
       // then
       expect(userRepository.updateUsername).to.have.been.calledWith({ id: user.id, username: null });
     });
 
     context('When user does not have an email', function () {
-      it('should remove PIX authentication method', async function () {
+      it('should NOT remove PIX authentication method', async function () {
         // given
         const user = domainBuilder.buildUser({ email: null });
         userRepository.get.resolves(user);
-        const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+        const authenticationMethods = _buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
         authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
 
         // when
-        await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+        await removeAuthenticationMethod({
+          userId: user.id,
+          type: 'USERNAME',
+          userRepository,
+          authenticationMethodRepository,
+        });
+
+        // then
+        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.not.have.been.called;
+      });
+    });
+
+    context('When user has an email', function () {
+      it('should remove PIX authentication method', async function () {
+        // given
+        const user = domainBuilder.buildUser({ email: 'john.doe@example.net' });
+        userRepository.get.resolves(user);
+        const authenticationMethods = _buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+        authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+        // when
+        await removeAuthenticationMethod({
+          userId: user.id,
+          type: 'USERNAME',
+          userRepository,
+          authenticationMethodRepository,
+        });
 
         // then
         expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
@@ -115,36 +157,23 @@ describe('Unit | UseCase | remove-authentication-method', function () {
         });
       });
     });
-
-    context('When user has an email', function () {
-      it('should not remove PIX authentication method', async function () {
-        // given
-        const user = domainBuilder.buildUser({ email: 'john.doe@example.net' });
-        userRepository.get.resolves(user);
-        const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
-        authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
-
-        // when
-        await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
-
-        // then
-        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.not.have.been.called;
-      });
-    });
   });
 
   context('When type is GAR', function () {
-    const type = 'GAR';
-
     it('should remove GAR authentication method', async function () {
       // given
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
-      const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+      const authenticationMethods = _buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
       authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
 
       // when
-      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+      await removeAuthenticationMethod({
+        userId: user.id,
+        type: 'GAR',
+        userRepository,
+        authenticationMethodRepository,
+      });
 
       // then
       expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
@@ -155,17 +184,20 @@ describe('Unit | UseCase | remove-authentication-method', function () {
   });
 
   context('When type is POLE_EMPLOI', function () {
-    const type = 'POLE_EMPLOI';
-
     it('should remove POLE_EMPLOI authentication method', async function () {
       // given
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
-      const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+      const authenticationMethods = _buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
       authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
 
       // when
-      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+      await removeAuthenticationMethod({
+        userId: user.id,
+        type: 'POLE_EMPLOI',
+        userRepository,
+        authenticationMethodRepository,
+      });
 
       // then
       expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
@@ -178,7 +210,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
   context('When there is only one remaining authentication method', function () {
     it('should throw a UserNotAuthorizedToRemoveAuthenticationMethod', async function () {
       // given
-      const user = domainBuilder.buildUser();
+      const user = domainBuilder.buildUser({ email: 'toto@example.net', username: null });
       userRepository.get.resolves(user);
       const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         userId: user.id,


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix Admin lorsqu'on cliquer sur "SUPPRIMER" sur une méthode de connexion Pix d'un utilisateur ayant la connexion Pix et identifiant, cette dernière n'est pas supprimée en base.

## :gift: Solution
Corriger la suppression en base de l'authentication method Pix ou identifiant lorsqu'on souhaite les supprimer.

## :star2: Remarques
Ce soucis est en lien avec la PR https://github.com/1024pix/pix/pull/2807 

## :santa: Pour tester
- Lancer Pix Admin
- Aller sur le profil de George De Cambridge par exemple (il faut que l'utilisateur ait la méthode de connexion avec email ET identifiant)
- Cliquer sur Supprimer (de la méthode de connexion de votre choix)
- Vérifier en BDD que la méthode de connexion choisie n'existe plus dans la table Authentification-methods
