### PR TITLE
[FEATURE] Créer un script pour migrer les URL de documentations (PIX-3974).

### DIFF
--- a/api/scripts/prod/update-documentation-url.js
+++ b/api/scripts/prod/update-documentation-url.js
@@ -1,0 +1,106 @@
+const { knex } = require('../../db/knex-database-connection');
+
+async function updateDocumentationUrl() {
+  await _updateProOrganizations();
+
+  await _updateMedNumOrganizations();
+
+  await _updateSUPOrganizations();
+
+  await _updateSCOOrganizations();
+
+  await _updateAEFEOrganizations();
+
+  await _updateMLFOrganizations();
+
+  await _updateAGRIOrganizations();
+}
+
+const URL = {
+  PRO: 'https://cloud.pix.fr/s/cwZN2GAbqSPGnw4',
+  SUP: 'https://cloud.pix.fr/s/DTTo7Lp7p6Ktceo',
+  AEFE: 'https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8',
+  MLF: 'https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8',
+  MEDNUM: 'https://view.genial.ly/6048a0d3757f980dc010d6d4',
+  SCO: 'https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f',
+  AGRI: 'https://view.genial.ly/5f85a0b87812e90d12b7b593',
+};
+
+module.exports = {
+  updateDocumentationUrl,
+  URL,
+};
+
+async function _updateProOrganizations() {
+  await knex('organizations').where('type', 'PRO').update({ documentationUrl: URL.PRO });
+}
+
+async function _updateMedNumOrganizations() {
+  const ids = await knex
+    .select('organizations.id')
+    .from('organizations')
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ type: 'PRO', 'tags.name': 'MEDNUM' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.MEDNUM });
+}
+
+async function _updateSUPOrganizations() {
+  await knex('organizations').where('type', 'SUP').update({ documentationUrl: URL.SUP });
+}
+
+async function _updateSCOOrganizations() {
+  const ids = await knex
+    .from('organizations')
+    .where({ type: 'SCO', isManagingStudents: true })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.SCO });
+}
+
+async function _updateAEFEOrganizations() {
+  const ids = await knex
+    .from('organizations')
+    .where({ type: 'SCO' })
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ 'tags.name': 'AEFE' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.AEFE });
+}
+
+async function _updateMLFOrganizations() {
+  const ids = await knex
+    .from('organizations')
+    .where({ type: 'SCO' })
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ 'tags.name': 'MLF' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.MLF });
+}
+
+async function _updateAGRIOrganizations() {
+  const ids = await knex
+    .from('organizations')
+    .where({ type: 'SCO', isManagingStudents: true })
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ 'tags.name': 'AGRICULTURE' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.AGRI });
+}
+
+if (require.main === module) {
+  updateDocumentationUrl()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/api/tests/integration/scripts/prod/update-documentation-url_test.js
+++ b/api/tests/integration/scripts/prod/update-documentation-url_test.js
@@ -1,0 +1,170 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { updateDocumentationUrl, URL } = require('../../../../scripts/prod/update-documentation-url');
+
+describe.only('updateDocumentationUrl', function () {
+  context('when the organization is PRO', function () {
+    it('uses the PRO documentation', async function () {
+      databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.PRO);
+    });
+  });
+
+  context('when the organization is MEDNUM', function () {
+    it('uses the MEDNUM documentation', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'MEDNUM' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.MEDNUM);
+    });
+
+    context('when the organization is not PRO', function () {
+      it('does not the MEDNUM documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'MEDNUM' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.not.equal(URL.MEDNUM);
+      });
+    });
+  });
+
+  context('when the organization is SUP', function () {
+    it('uses the SUP documentation', async function () {
+      databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.SUP);
+    });
+  });
+
+  context('when the organization is SCO', function () {
+    it('uses the SCO documentation', async function () {
+      databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.SCO);
+    });
+
+    context('when the organization does not manage students', function () {
+      it('does not update documentation', async function () {
+        databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          isManagingStudents: false,
+          documentationUrl: 'toto',
+        });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal('toto');
+      });
+    });
+
+    context('when the organization is AEFE', function () {
+      it('uses the AEFE documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AEFE' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.AEFE);
+      });
+    });
+
+    context('when the organization is MLF', function () {
+      it('uses the MLF documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'MLF' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.MLF);
+      });
+    });
+
+    context('when the organization is AGRI', function () {
+      it('uses the AGRI documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          isManagingStudents: true,
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.AGRI);
+      });
+
+      context('when the organization is not managing students', function () {
+        it('does not update documentation', async function () {
+          const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+            type: 'SCO',
+            isManagingStudents: false,
+            documentationUrl: 'toto',
+          });
+          const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
+          databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+          await databaseBuilder.commit();
+
+          await updateDocumentationUrl();
+
+          const { documentationUrl } = await knex('organizations').first();
+
+          expect(documentationUrl).equal('toto');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Les liens de documentation ne sont pas présents en base.

## :gift: Solution
Utiliser un script pour ajouter ce lien à toutes les organisations existantes.

## :star2: Remarques
C'est dommage de ne pas utiliser les tags pour pouvoir faire ce genre de modifications.

## :santa: Pour tester
Vérifier que les orga : Pro, Pro MedNum,  Sup, Sco, Sco AEFE, SCO Agri, Sco MLF ont toutes accès à la bonne documentation.