### PR TITLE
[FEATURE] Ajouter la possibilité de modifier la catégorie d'un profile cible dans Pix Admin(PIX-3759)

### DIFF
--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -25,6 +25,19 @@
           @value={{this.form.name}}
           required={{true}}
         />
+
+        <PixSelect
+          class="form-control"
+          @id="targetProfileCategory"
+          @label={{"Catégorie :"}}
+          @onChange={{this.onCategoryChange}}
+          @selectedOption={{@model.category}}
+          @options={{this.optionsList}}
+          @emptyOptionLabel={{"-"}}
+          @emptyOptionNotSelectable={{true}}
+          required={{true}}
+        />
+
         <label for="targetProfileDescription" class="form-field__label">
           Description
         </label>

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -36,12 +36,20 @@ const Validations = buildValidations({
       }),
     ],
   },
+  category: {
+    validators: [
+      validator('presence', {
+        presence: true,
+      }),
+    ],
+  },
 });
 
 class Form extends Object.extend(Validations) {
   @tracked name;
   @tracked description;
   @tracked comment;
+  @tracked category;
 }
 
 export default class UpdateTargetProfile extends Component {
@@ -53,6 +61,34 @@ export default class UpdateTargetProfile extends Component {
     this.form.name = this.args.model.name;
     this.form.description = this.args.model.description || null;
     this.form.comment = this.args.model.comment || null;
+    this.form.category = this.args.model.category || null;
+
+    this.optionsList = [
+      {
+        value: 'COMPETENCES',
+        label: 'Compétences Pix',
+      },
+      {
+        value: 'CUSTOM',
+        label: 'Sur-mesure',
+      },
+      {
+        value: 'DISCIPLINE',
+        label: 'Disciplinaire',
+      },
+      {
+        value: 'OTHER',
+        label: 'Autre',
+      },
+      {
+        value: 'PREDEFINED',
+        label: 'Prédéfini',
+      },
+      {
+        value: 'SUBJECT',
+        label: 'Thématique',
+      },
+    ];
   }
 
   async _checkFormValidation() {
@@ -60,11 +96,18 @@ export default class UpdateTargetProfile extends Component {
     return validations.isValid;
   }
 
+  @action
+  onCategoryChange(event) {
+    this.form.category = event.target.value;
+  }
+
   async _updateTargetProfile() {
     const model = this.args.model;
     model.name = this.form.name.trim();
     model.description = this.form.description ? this.form.description.trim() : null;
     model.comment = this.form.comment ? this.form.comment.trim() : null;
+    model.category = this.form.category;
+
     try {
       await model.save();
       await this.notifications.success('Le profil cible a bien été mis à jour.');

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
@@ -185,6 +185,7 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
         isPublic: true,
         outdated: false,
         ownerOrganizationId: 456,
+        category: 'OTHER',
       });
 
       // when
@@ -195,6 +196,28 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
 
       // then
       assert.contains('Profil Cible Fantastix Edited');
+      assert.dom('Enregistrer').doesNotExist();
+    });
+
+    test('it should edit target profile category', async function (assert) {
+      // given
+      server.create('target-profile', {
+        id: 1,
+        name: 'Profil Cible Fantastix',
+        isPublic: true,
+        outdated: false,
+        ownerOrganizationId: 456,
+        category: 'OTHER',
+      });
+
+      // when
+      await visit('/target-profiles/1');
+      await click('button[type=button]');
+      await fillIn('#targetProfileCategory', 'CUSTOM');
+      await click('button[type=submit]');
+
+      // then
+      assert.contains('Sur-mesure');
       assert.dom('Enregistrer').doesNotExist();
     });
   });

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
@@ -21,6 +21,7 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
       ownerOrganizationId: '',
       isPublic: false,
       comment: '',
+      category: 'OTHER',
     };
 
     isFileInvalid = false;

--- a/admin/tests/unit/components/update-target-profile_test.js
+++ b/admin/tests/unit/components/update-target-profile_test.js
@@ -12,6 +12,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       const component = createGlimmerComponent('component:target-profiles/update-target-profile', {
         model: {
           name: 'Karam',
+          category: 'OTHER',
           save: sinon.stub(),
           rollbackAttributes: sinon.stub(),
         },
@@ -23,6 +24,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       component.form.name = 'Edited name';
       component.args.model = {
         name: 'Karam',
+        category: 'OTHER',
         save: sinon.stub(),
         rollbackAttributes: sinon.stub(),
       };
@@ -40,6 +42,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       const component = createGlimmerComponent('component:target-profiles/update-target-profile', {
         model: {
           name: 'Karam',
+          category: 'OTHER',
           save: sinon.stub(),
           rollbackAttributes: sinon.stub(),
         },
@@ -50,6 +53,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       component.form.name = 'Edited name';
       component.args.model = {
         name: 'Karam',
+        category: 'OTHER',
         save: sinon.stub(),
         rollbackAttributes: sinon.stub(),
       };
@@ -68,6 +72,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       const component = createGlimmerComponent('component:target-profiles/update-target-profile', {
         model: {
           name: 'Karam',
+          category: 'OTHER',
           description: null,
           save: sinon.stub(),
           rollbackAttributes: sinon.stub(),
@@ -79,6 +84,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       component.form.description = 'Edited description';
       component.args.model = {
         name: 'Karam',
+        category: 'OTHER',
         description: null,
         save: sinon.stub(),
         rollbackAttributes: sinon.stub(),
@@ -96,6 +102,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       const component = createGlimmerComponent('component:target-profiles/update-target-profile', {
         model: {
           name: 'Karam',
+          category: 'OTHER',
           comment: null,
           save: sinon.stub(),
           rollbackAttributes: sinon.stub(),
@@ -107,6 +114,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       component.form.comment = 'Edited comment';
       component.args.model = {
         name: 'Karam',
+        category: 'OTHER',
         comment: null,
         save: sinon.stub(),
         rollbackAttributes: sinon.stub(),
@@ -124,6 +132,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       const component = createGlimmerComponent('component:target-profiles/update-target-profile', {
         model: {
           name: 'Karam',
+          category: 'OTHER',
           save: sinon.stub(),
           rollbackAttributes: sinon.stub(),
         },
@@ -146,6 +155,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       const component = createGlimmerComponent('component:target-profiles/update-target-profile', {
         model: {
           name: 'Karam',
+          category: 'OTHER',
           save: sinon.stub(),
           rollbackAttributes: sinon.stub(),
         },

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -228,6 +228,7 @@ exports.register = async (server) => {
                 name: Joi.string().required().min(1),
                 description: Joi.string().required().allow(null).max(500),
                 comment: Joi.string().required().allow(null).max(500),
+                category: Joi.string().required(),
               },
             },
           }).options({ allowUnknown: true }),

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -60,8 +60,8 @@ module.exports = {
 
   async updateTargetProfile(request, h) {
     const id = request.params.id;
-    const { name, description, comment } = request.payload.data.attributes;
-    await usecases.updateTargetProfile({ id, name, description, comment });
+    const { name, description, comment, category } = request.payload.data.attributes;
+    await usecases.updateTargetProfile({ id, name, description, comment, category });
     return h.response({}).code(204);
   },
 

--- a/api/lib/domain/models/TargetProfile.js
+++ b/api/lib/domain/models/TargetProfile.js
@@ -1,3 +1,12 @@
+const categories = {
+  OTHER: 'OTHER',
+  COMPETENCES: 'COMPETENCES',
+  SUBJECT: 'SUBJECT',
+  DISCPLINE: 'DISCPLINE',
+  CUSTOM: 'CUSTOM',
+  PREDEFINED: 'PREDEFINED',
+};
+
 class TargetProfile {
   constructor({
     id,
@@ -69,5 +78,7 @@ function _addUniqueOrganization(organizations) {
     }
   };
 }
+
+TargetProfile.categories = categories;
 
 module.exports = TargetProfile;

--- a/api/lib/domain/models/TargetProfileForUpdate.js
+++ b/api/lib/domain/models/TargetProfileForUpdate.js
@@ -1,0 +1,20 @@
+const { validate } = require('../validators/target-profile-validator');
+class TargetProfileForUpdate {
+  constructor({ id, name, description, comment, category }) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.comment = comment;
+    this.category = category;
+  }
+
+  update({ name, description, comment, category }) {
+    this.name = name;
+    this.description = description;
+    this.comment = comment;
+    this.category = category;
+    validate(this);
+  }
+}
+
+module.exports = TargetProfileForUpdate;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -116,6 +116,7 @@ const dependencies = {
   tagRepository: require('../../infrastructure/repositories/tag-repository'),
   TargetProfileForSpecifierRepository: require('../../infrastructure/repositories/campaign/target-profile-for-specifier-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),
+  targetProfileForUpdateRepository: require('../../infrastructure/repositories/target-profile-for-update-repository'),
   targetProfileShareRepository: require('../../infrastructure/repositories/target-profile-share-repository'),
   targetProfileWithLearningContentRepository: require('../../infrastructure/repositories/target-profile-with-learning-content-repository'),
   tokenService: require('../../domain/services/token-service'),

--- a/api/lib/domain/usecases/update-target-profile.js
+++ b/api/lib/domain/usecases/update-target-profile.js
@@ -1,3 +1,12 @@
-module.exports = async function updateTargetProfile({ id, name, description, comment, targetProfileRepository }) {
-  await targetProfileRepository.update({ id, name, description, comment });
+module.exports = async function updateTargetProfile({
+  id,
+  name,
+  description,
+  comment,
+  category,
+  targetProfileForUpdateRepository,
+}) {
+  const targetProfileForUpdate = await targetProfileForUpdateRepository.get(id);
+  targetProfileForUpdate.update({ name, description, comment, category });
+  await targetProfileForUpdateRepository.update(targetProfileForUpdate);
 };

--- a/api/lib/domain/validators/target-profile-validator.js
+++ b/api/lib/domain/validators/target-profile-validator.js
@@ -1,0 +1,42 @@
+const Joi = require('joi');
+const { first } = require('lodash');
+const { EntityValidationError } = require('../errors');
+const TargetProfile = require('../models/TargetProfile');
+
+const categories = TargetProfile.categories;
+
+const schema = Joi.object({
+  category: Joi.string()
+    .valid(
+      categories.COMPETENCES,
+      categories.CUSTOM,
+      categories.DISCPLINE,
+      categories.OTHER,
+      categories.PREDEFINED,
+      categories.SUBJECT
+    )
+    .required()
+    .error((errors) => first(errors))
+    .messages({
+      'any.required': 'CATEGORY_IS_REQUIRED',
+      'string.base': 'CATEGORY_IS_REQUIRED',
+      'any.only': 'CATEGORY_IS_REQUIRED',
+    }),
+
+  name: Joi.string().required().messages({
+    'string.base': 'NAME_IS_REQUIRED',
+    'string.empty': 'NAME_IS_REQUIRED',
+  }),
+});
+
+function validate(targetProfile) {
+  const { error } = schema.validate(targetProfile, { abortEarly: false, allowUnknown: true });
+  if (error) {
+    throw EntityValidationError.fromJoiErrors(error.details);
+  }
+  return true;
+}
+
+module.exports = {
+  validate,
+};

--- a/api/lib/infrastructure/repositories/target-profile-for-update-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-for-update-repository.js
@@ -1,0 +1,22 @@
+const targetProfileForUpdate = require('../../domain/models/TargetProfileForUpdate');
+const { knex } = require('../../../db/knex-database-connection');
+const { NotFoundError } = require('../../domain/errors');
+
+module.exports = {
+  async get(id) {
+    const row = await knex('target-profiles')
+      .select('id', 'name', 'description', 'comment', 'category')
+      .where({ id })
+      .first();
+
+    if (!row) {
+      throw new NotFoundError(`Le profil cible avec l'id ${id} n'existe pas`);
+    }
+
+    return new targetProfileForUpdate(row);
+  },
+
+  async update(targetProfile) {
+    return await knex('target-profiles').where({ id: targetProfile.id }).update(targetProfile);
+  },
+};

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -274,6 +274,7 @@ describe('Acceptance | Controller | target-profile-controller', function () {
               name: 'CoolPixer',
               description: 'Amazing description',
               comment: 'Amazing comment',
+              category: 'OTHER',
             },
           },
         },

--- a/api/tests/integration/infrastructure/repositories/target-profile-for-update-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-for-update-repository_test.js
@@ -1,0 +1,134 @@
+const { expect, databaseBuilder, catchErr, knex } = require('../../../test-helper');
+const TargetProfileForUpdate = require('../../../../lib/domain/models/TargetProfileForUpdate');
+const { categories } = require('../../../../lib/domain/models/TargetProfile');
+const targetProfileForUpdateRepository = require('../../../../lib/infrastructure/repositories/target-profile-for-update-repository');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Integration | Repository | Target-profile-for-update', function () {
+  describe('#get', function () {
+    let targetProfileForUpdate;
+
+    beforeEach(async function () {
+      targetProfileForUpdate = new TargetProfileForUpdate({
+        id: 4,
+        name: 'name',
+        description: 'description',
+        comment: 'comment',
+        category: categories.OTHER,
+      });
+      databaseBuilder.factory.buildTargetProfile(targetProfileForUpdate);
+      await databaseBuilder.commit();
+    });
+
+    it('should return the target profile', async function () {
+      // when
+      const result = await targetProfileForUpdateRepository.get(targetProfileForUpdate.id);
+
+      expect(result).to.deep.eq(targetProfileForUpdate);
+    });
+
+    context('when the targetProfile does not exist', function () {
+      it('throws an error', async function () {
+        const error = await catchErr(targetProfileForUpdateRepository.get)(1);
+
+        expect(error).to.be.an.instanceOf(NotFoundError);
+        expect(error.message).to.have.string("Le profil cible avec l'id 1 n'existe pas");
+      });
+    });
+  });
+
+  describe('#update', function () {
+    it('should update the target profile name', async function () {
+      // given
+      const targetProfileForUpdate = new TargetProfileForUpdate({
+        id: 4,
+        name: 'name',
+        description: 'description',
+        comment: 'comment',
+        categories: categories.OTHER,
+      });
+      databaseBuilder.factory.buildTargetProfile(targetProfileForUpdate);
+      await databaseBuilder.commit();
+
+      // when
+      targetProfileForUpdate.name = 'Karam';
+      await targetProfileForUpdateRepository.update(targetProfileForUpdate);
+
+      // then
+      const { name } = await knex('target-profiles').select('name').where('id', targetProfileForUpdate.id).first();
+      expect(name).to.equal(targetProfileForUpdate.name);
+    });
+
+    it('should update the target profile description', async function () {
+      // given
+      const targetProfileForUpdate = new TargetProfileForUpdate({
+        id: 4,
+        name: 'name',
+        description: 'description',
+        comment: 'comment',
+        categories: categories.OTHER,
+      });
+      databaseBuilder.factory.buildTargetProfile(targetProfileForUpdate);
+      await databaseBuilder.commit();
+
+      // when
+      targetProfileForUpdate.description = 'Je change la description';
+      await targetProfileForUpdateRepository.update(targetProfileForUpdate);
+
+      // then
+      const { description } = await knex('target-profiles')
+        .select('description')
+        .where('id', targetProfileForUpdate.id)
+        .first();
+      expect(description).to.equal(targetProfileForUpdate.description);
+    });
+
+    it('should update the target profile comment', async function () {
+      // given
+      const targetProfileForUpdate = new TargetProfileForUpdate({
+        id: 4,
+        name: 'name',
+        description: 'description',
+        comment: 'comment',
+        categories: categories.OTHER,
+      });
+      databaseBuilder.factory.buildTargetProfile(targetProfileForUpdate);
+      await databaseBuilder.commit();
+
+      // when
+      targetProfileForUpdate.comment = 'Je change le commentaire';
+      await targetProfileForUpdateRepository.update(targetProfileForUpdate);
+
+      // then
+      const { comment } = await knex('target-profiles')
+        .select('comment')
+        .where('id', targetProfileForUpdate.id)
+        .first();
+      expect(comment).to.equal(targetProfileForUpdate.comment);
+    });
+
+    it('should update the target profile category', async function () {
+      // given
+      const targetProfileForUpdate = new TargetProfileForUpdate({
+        id: 4,
+        name: 'name',
+        description: 'description',
+        comment: 'comment',
+        categories: categories.OTHER,
+      });
+      databaseBuilder.factory.buildTargetProfile(targetProfileForUpdate);
+      await databaseBuilder.commit();
+
+      // when
+      targetProfileForUpdate.category = categories.PREDEFINED;
+      await targetProfileForUpdateRepository.update(targetProfileForUpdate);
+
+      // then
+      const { category } = await knex('target-profiles')
+        .select('category')
+        .where('id', targetProfileForUpdate.id)
+        .first();
+      expect(category).to.equal(targetProfileForUpdate.category);
+    });
+  });
+});

--- a/api/tests/integration/scripts/prod/update-documentation-url_test.js
+++ b/api/tests/integration/scripts/prod/update-documentation-url_test.js
@@ -1,7 +1,7 @@
 const { expect, databaseBuilder, knex } = require('../../../test-helper');
 const { updateDocumentationUrl, URL } = require('../../../../scripts/prod/update-documentation-url');
 
-describe.only('updateDocumentationUrl', function () {
+describe('updateDocumentationUrl', function () {
   context('when the organization is PRO', function () {
     it('uses the PRO documentation', async function () {
       databaseBuilder.factory.buildOrganization({ type: 'PRO' });

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -472,6 +472,7 @@ describe('Integration | Application | Target Profiles | Routes', function () {
             name: 'test',
             description: 'description changée.',
             comment: 'commentaire changé.',
+            category: 'OTHER',
           },
         },
       };
@@ -564,6 +565,7 @@ describe('Integration | Application | Target Profiles | Routes', function () {
             name: 'Not Pix Admin',
             description: null,
             comment: null,
+            category: 'OTHER',
           },
         },
       };

--- a/api/tests/unit/domain/models/TargetProfileForUpdate_test.js
+++ b/api/tests/unit/domain/models/TargetProfileForUpdate_test.js
@@ -1,0 +1,59 @@
+const { expect, catchErr } = require('../../../test-helper');
+const TargetProfileForUpdate = require('../../../../lib/domain/models/TargetProfileForUpdate');
+const TargetProfile = require('../../../../lib/domain/models/TargetProfile');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+
+describe('Unit | Domain | Models | TargetProfileForUpdate', function () {
+  describe('#update', function () {
+    it('should update attributes', function () {
+      const targetProfile = new TargetProfileForUpdate({
+        name: 'name',
+        description: 'description',
+        comment: 'commment',
+        category: TargetProfile.categories.OTHER,
+      });
+
+      targetProfile.update({
+        name: 'changedName',
+        description: 'changedDescription',
+        comment: 'changedComment',
+        category: TargetProfile.categories.COMPETENCES,
+      });
+
+      expect(targetProfile.name).to.eq('changedName');
+      expect(targetProfile.description).to.eq('changedDescription');
+      expect(targetProfile.comment).to.eq('changedComment');
+      expect(targetProfile.category).to.eq(TargetProfile.categories.COMPETENCES);
+    });
+
+    it('should throw error when name is null', async function () {
+      const targetProfile = new TargetProfileForUpdate({ name: 'name', category: TargetProfile.categories.OTHER });
+      const error = await catchErr(
+        targetProfile.update,
+        targetProfile
+      )({
+        name: null,
+        category: TargetProfile.categories.OTHER,
+      });
+
+      expect(error).to.be.an.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.eq('name');
+      expect(error.invalidAttributes[0].message).to.eq('NAME_IS_REQUIRED');
+    });
+
+    it('should throw error when category no match', async function () {
+      const targetProfile = new TargetProfileForUpdate({ name: 'name', category: TargetProfile.categories.OTHER });
+      const error = await catchErr(
+        targetProfile.update,
+        targetProfile
+      )({
+        name: 'Godzilla',
+        category: null,
+      });
+
+      expect(error).to.be.an.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.eq('category');
+      expect(error.invalidAttributes[0].message).to.eq('CATEGORY_IS_REQUIRED');
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/update-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/update-target-profile_test.js
@@ -1,12 +1,31 @@
 const { expect, sinon } = require('../../../test-helper');
 const { updateTargetProfile } = require('../../../../lib/domain/usecases');
+const TargetProfileForUpdate = require('../../../../lib/domain/models/TargetProfileForUpdate');
 
 describe('Unit | UseCase | update-target-profile', function () {
   it('should call repository method to update a target profile', async function () {
     //given
-    const targetProfileRepository = {
+    const targetProfileForUpdateRepository = {
+      get: sinon.stub(),
       update: sinon.stub(),
     };
+
+    const targetProfileToUpdate = new TargetProfileForUpdate({
+      id: 123,
+      name: 'name',
+      description: 'description',
+      comment: 'comment',
+    });
+
+    const expectedTargetProfile = new TargetProfileForUpdate({
+      id: 123,
+      name: 'Tom',
+      description: 'description changée',
+      comment: 'commentaire changé',
+      category: 'OTHER',
+    });
+
+    await targetProfileForUpdateRepository.get.withArgs(123).resolves(targetProfileToUpdate);
 
     //when
     await updateTargetProfile({
@@ -14,15 +33,11 @@ describe('Unit | UseCase | update-target-profile', function () {
       name: 'Tom',
       description: 'description changée',
       comment: 'commentaire changé',
-      targetProfileRepository,
+      category: 'OTHER',
+      targetProfileForUpdateRepository,
     });
 
     //then
-    expect(targetProfileRepository.update).to.have.been.calledOnceWithExactly({
-      id: 123,
-      name: 'Tom',
-      description: 'description changée',
-      comment: 'commentaire changé',
-    });
+    expect(targetProfileForUpdateRepository.update).to.have.been.calledOnceWithExactly(expectedTargetProfile);
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Nous avons ajouter une catégorie pour chaque profil cible, mais nous n'avons pas la possibilité de le modifier

## :gift: Solution
Ajouter dans Pix Admin la possibilité de modifier une catégorie dans le cas ou elle ne serait pas bien positionné

## :star2: Remarques
RAS

## :santa: Pour tester
Allez sur pix admin, modifier une categorie de profile cible et vérifier que c'est bien à jour.