### PR TITLE
[TECH Ajouter la règle de lint  mocha/no-exclusive-tests (PIX-4085).

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -26,3 +26,4 @@ rules:
       message: Use only faker.internet.exampleEmail()
   knex/avoid-injections: error
   i18n-json/valid-message-syntax: warn
+  mocha/no-exclusive-tests: error


### PR DESCRIPTION
## :christmas_tree: Problème
Les tests avec un .only ne cassent pas la CI
Régression suite à https://github.com/1024pix/pix/pull/3651

## :gift: Solution
Rajouter la règle de lint : mocha/no-exclusive-tests

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Mettre un only sur un test et lancer le linter
