### PR TITLE
[A11Y] Rendre la navigation au niveau de la campagne accessible lors d'une zoom 200% en mode texte sur Firefox (PIX-3895)

### DIFF
--- a/orga/app/styles/components/indicator-card.scss
+++ b/orga/app/styles/components/indicator-card.scss
@@ -9,7 +9,7 @@
   background-color: $white;
   border-radius: 8px;
   box-shadow: $shadow-base;
-  height: 112px;
+  min-height: 112px;
   padding: 0;
 
   &__icon {

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -114,13 +114,14 @@
 
 .navbar {
   display: flex;
-  height: 60px;
+  width: 100%;
+  min-height: 60px;
   border: none;
-  padding: 0 10px;
+  padding: 0 8px;
   display: flex;
 
   &-item {
-    width: 150px;
+    padding: 0 24px;
     align-items: center;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## :christmas_tree: Problème
Lors du zoom texte  200% sur Firefox, beaucoup d'élement était tronqué

## :gift: Solution
Modifier le css afin de rendre les élements visible même lors d'un zoom texte (disponible seulement sur FireFox)

## :star2: Remarques
Il y a un modification à faire sur pix-ui au niveau des PixButton (le nowrap empêche le button de passer à la ligne du dessous en mode texte 200%)

## :santa: Pour tester
Allez sur une campagne dans Pix Orga, faire un zoom texte 200% (alt + affichage > zoom > texte seulement) faire le zoom a 200%, vérifier que les élements ne sont plus tronqué