### PR TITLE
[BUGFIX] Retourner sur la page paramètres après avoir créé une campagne (Pix-4089).

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -15,6 +15,7 @@ export default class NewController extends Controller {
   @action
   async createCampaign(campaignAttributes) {
     this.notifications.clearAll();
+    this.errors = null;
 
     try {
       this.model.campaign.setProperties(campaignAttributes);
@@ -27,6 +28,7 @@ export default class NewController extends Controller {
       });
       this.errors = this.model.campaign.errors;
     }
+
     if (!this.errors) {
       this.router.transitionTo('authenticated.campaigns.campaign.settings', this.model.campaign.id);
     }


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l'on rempli un formulaire avec erreur, nous restons sur la page de création de campagne

## :gift: Solution
Réinitialiser les erreurs à chaque nouvel soumission du formulaire

## :star2: Remarques
RAS
## :santa: Pour tester
Se connecter sur Pix Orga et vérifier que lors d'une création de campagne avec une mauvaise saisie, nous arrivons tout de même sur la page de création de campagne