### PR TITLE
[A11Y] Ajouter des formes dans les repartitions du graphique camembert sur la page Activité de Pix Orga (PIX-3893)

### DIFF
--- a/orga/app/components/campaign/charts/participants-by-status.hbs
+++ b/orga/app/components/campaign/charts/participants-by-status.hbs
@@ -12,8 +12,8 @@
 
     <ul class="participants-by-status__legend" aria-hidden="true">
       {{#each this.datasets as |dataset|}}
-        <li class="participants-by-status__legend--{{dataset.key}}">
-          <p>{{dataset.legend}}</p>
+        <li {{did-insert this.setCanvas dataset.canvas}}>
+          <span>{{dataset.legend}}</span>
           <PixTooltip @id="legend-tooltip-{{dataset.key}}" @isWide="true" @position="top-left">
             <:triggerElement>
               <FaIcon

--- a/orga/app/components/campaign/charts/participants-by-status.js
+++ b/orga/app/components/campaign/charts/participants-by-status.js
@@ -1,8 +1,9 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import sumBy from 'lodash/sumBy';
 import { TOOLTIP_CONFIG } from '../../ui/chart';
-
+import pattern from 'patternomaly';
 export default class ParticipantsByStatus extends Component {
   @service store;
   @service intl;
@@ -19,12 +20,24 @@ export default class ParticipantsByStatus extends Component {
   }
 
   get data() {
+    const dataInfos = {
+      labels: [],
+      data: [],
+      backgroundColor: [],
+    };
+
+    this.datasets.forEach((data) => {
+      dataInfos.labels.push(data.tooltip);
+      dataInfos.data.push(data.count);
+      dataInfos.backgroundColor.push(data.canvas);
+    });
+
     return {
-      labels: this.datasets.map((data) => data.tooltip),
+      labels: dataInfos.labels,
       datasets: [
         {
-          data: this.datasets.map((data) => data.count),
-          backgroundColor: this.datasets.map((data) => data.color),
+          data: dataInfos.data,
+          backgroundColor: dataInfos.backgroundColor,
         },
       ],
     };
@@ -45,16 +58,31 @@ export default class ParticipantsByStatus extends Component {
     };
   }
 
+  @action
+  setCanvas(element, params) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 14;
+    canvas.height = 14;
+    canvas.className = 'participants-by-status__legend-view';
+    const ctx = canvas.getContext('2d');
+
+    ctx.fillStyle = params[0];
+    ctx.fillRect(0, 0, 14, 14);
+
+    element.insertBefore(canvas, element.firstChild);
+  }
+
   getDatasetLabels(key, count, isTypeAssessment) {
     const datasetLabels = isTypeAssessment ? LABELS_ASSESSMENT[key] : LABELS_PROFILE_COLLECTIONS[key];
     const percentage = this.total !== 0 ? count / this.total : 0;
+    const canvas = pattern.draw(datasetLabels.shape, datasetLabels.color);
 
     return {
       tooltip: this.intl.t(datasetLabels.tooltip, { percentage }),
       legend: this.intl.t(datasetLabels.legend, { count }),
       legendTooltip: this.intl.t(datasetLabels.legendTooltip, { count }),
       a11y: this.intl.t(datasetLabels.a11y, { count }),
-      color: datasetLabels.color,
+      canvas,
     };
   }
 }
@@ -65,7 +93,8 @@ const LABELS_ASSESSMENT = {
     legend: 'charts.participants-by-status.labels-legend.started',
     legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.started',
-    color: '#FFBE00',
+    color: '#ffbe00',
+    shape: 'diamond-box',
   },
   completed: {
     tooltip: 'charts.participants-by-status.labels-tooltip.completed-assessment',
@@ -73,6 +102,7 @@ const LABELS_ASSESSMENT = {
     legendTooltip: 'charts.participants-by-status.labels-legend.completed-assessment-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.completed',
     color: '#8a49ff',
+    shape: 'zigzag',
   },
   shared: {
     tooltip: 'charts.participants-by-status.labels-tooltip.shared',
@@ -80,6 +110,7 @@ const LABELS_ASSESSMENT = {
     legendTooltip: 'charts.participants-by-status.labels-legend.shared-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.shared',
     color: '#038a25',
+    shape: 'weave',
   },
 };
 
@@ -89,7 +120,8 @@ const LABELS_PROFILE_COLLECTIONS = {
     legend: 'charts.participants-by-status.labels-legend.started',
     legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.started',
-    color: '#FFBE00',
+    color: '#ffbe00',
+    shape: 'diamond-box',
   },
   completed: {
     tooltip: 'charts.participants-by-status.labels-tooltip.completed-profile',
@@ -97,6 +129,7 @@ const LABELS_PROFILE_COLLECTIONS = {
     legendTooltip: 'charts.participants-by-status.labels-legend.completed-profile-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.completed',
     color: '#8a49ff',
+    shape: 'zigzag',
   },
   shared: {
     tooltip: 'charts.participants-by-status.labels-tooltip.shared-profile',
@@ -104,5 +137,6 @@ const LABELS_PROFILE_COLLECTIONS = {
     legendTooltip: 'charts.participants-by-status.labels-legend.shared-profile-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.shared-profile',
     color: '#038a25',
+    shape: 'weave',
   },
 };

--- a/orga/app/styles/components/campaign/charts/participants-by-status.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-status.scss
@@ -3,52 +3,21 @@
 
   &__legend {
     list-style: none;
-    padding-left: 8px;
+    padding-left: 0;
     padding-top: 16px;
+    margin: 0;
     font-size: 0.875rem;
 
     > li {
       display: flex;
+      align-items: center;
       position: relative;
       padding-bottom: 8px;
       padding-left: 24px;
       color: $grey-70;
 
-      &::before {
-        position: absolute;
-        left: 0px;
-        top: 2px;
-        display: block;
-        width: 0.875rem;
-        height: 0.875rem;
-        border-radius: 50%;
-        content: ' ';
-      }
-
-      > p {
-        margin: 0;
-      }
-    }
-
-    > li:last-child {
-      padding-bottom: 0px;
-    }
-
-    &--started {
-      &::before {
-        background-color: $yellow;
-      }
-    }
-
-    &--completed {
-      &::before {
-        background-color: $purple;
-      }
-    }
-
-    &--shared {
-      &::before {
-        background-color: $green;
+      &:last-child {
+        padding-bottom: 0px;
       }
     }
   }
@@ -56,6 +25,11 @@
   &__legend-tooltip {
     margin-left: 8px;
     color: $grey-30;
+  }
+
+  &__legend-view {
+    border-radius: 14px;
+    margin: 0 8px;
   }
 
   &__loader {

--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -37,5 +37,9 @@ module.exports = function (defaults) {
     using: [{ transformation: 'amd', as: 'chartjs-adapter-date-fns.js' }],
   });
 
+  app.import('node_modules/patternomaly/dist/patternomaly.js', {
+    using: [{ transformation: 'amd', as: 'patternomaly.js' }],
+  });
+
   return app.toTree();
 };

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26631,6 +26631,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "patternomaly": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/patternomaly/-/patternomaly-1.3.2.tgz",
+      "integrity": "sha512-70UhA5+ZrnNgdfDBKXIGbMHpP+naTzfx9vPT4KwIdhtWWs0x6FWZRJQMXXhV2jcK0mxl28FA/2LPAKArNG058Q==",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",

--- a/orga/package.json
+++ b/orga/package.json
@@ -100,6 +100,7 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
+    "patternomaly": "^1.3.2",
     "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.0.0",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",


### PR DESCRIPTION
## :christmas_tree: Problème
Actullement, les couleurs différentes sur le graphique donut ne sont pas suffisant pour permettre aux personne dans une situation de handicap (colorblind) de différencier les différentes zones.

## :gift: Solution
Ajouter des formes différentes et identifiable dans chaque repartitions

## :star2: Remarques
RAS
## :santa: Pour tester
Se connecter sur Pix Orga et vérifier que nous avons bien des formes dans le graphique camembert sur la page activité