### PR TITLE
[TECH] Faire échouer la CI sur le set recommended de eslint-mocha sur l'API.

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -26,4 +26,8 @@ rules:
       message: Use only faker.internet.exampleEmail()
   knex/avoid-injections: error
   i18n-json/valid-message-syntax: warn
+  # Set all recommended rules as blocking for CI
   mocha/no-exclusive-tests: error
+  mocha/no-pending-tests: error
+  mocha/no-skipped-tests: error
+  mocha/no-top-level-hooks: error


### PR DESCRIPTION
## :christmas_tree: Problème
Les règles `recommended` ne causent pas toutes la sortie en erreur de la CI, voir [la documentation](https://github.com/lo1tuma/eslint-plugin-mocha/pull/317), ce qui n'est pas évident à comprendre au premier abord.

## :gift: Solution
Forcer la sortie en erreur en passant le niveau de celles en `warning`  à `error`

## :star2: Remarques
Cette PR étend la solution de la PR https://github.com/1024pix/pix/pull/3887

Il serait intéressant de la rajouter dans les autres utilisations de mocha (mon-pix) https://github.com/1024pix/pix/issues/3894

## :santa: Pour tester
Ajouter un test en skip et vérifie que `npm run lint` renvoie un code retour <> 0
